### PR TITLE
Utilities to Backup S3 Prefixes

### DIFF
--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -167,3 +167,19 @@ Resources:
               {
                 AWS: [!Sub "arn:aws:iam::${DeveloperAccount}:role/DroneWorker"],
               }
+  BackupsBucket:
+    Type: "AWS::S3::Bucket"
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: "cdo-backups"
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "AES256"
+      VersioningConfiguration:
+        Status: "Enabled"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true

--- a/bin/oneoff/backup_s3_bucket
+++ b/bin/oneoff/backup_s3_bucket
@@ -138,7 +138,8 @@ begin
     options[:source_bucket],
     # Begin filename with `_` so that it's more likely to be displayed at the beginning of the S3 Console listing.
     "#{options[:source_prefix]}/_#{options[:log_filename]}",
-    file_contents
+    file_contents,
+    {no_random: true} # Don't prefix log filename with a random unique identifier.
   )
   CDO.log.info "[BACKUP S3 BUCKET] Uploaded backup log CSV #{options[:log_filename]} to source bucket/prefix."
   # Log what was backed up to destination location
@@ -146,7 +147,8 @@ begin
     options[:destination_bucket],
     # Begin filename with `_` so that it's more likely to be displayed at the beginning of the S3 Console listing.
     "#{options[:destination_prefix]}/_#{options[:log_filename]}",
-    file_contents
+    file_contents,
+    {no_random: true} # Don't prefix log filename with a random unique identifier.
   )
   CDO.log.info "[BACKUP S3 BUCKET] Uploaded backup log CSV #{options[:log_filename]} to destination bucket/prefix."
 rescue Aws::Errors::ServiceError, StandardError => exception

--- a/bin/oneoff/backup_s3_bucket
+++ b/bin/oneoff/backup_s3_bucket
@@ -135,16 +135,20 @@ begin
   file_contents = File.read(options[:log_filename])
   # Log what was backed up to source location.
   AWS::S3.upload_to_bucket(
-    bucket: options[:source_bucket],
-    key: "#{options[:source_prefix]}/#{options[:log_filename]}",
-    body: file_contents
+    options[:source_bucket],
+    # Begin filename with `_` so that it's more likely to be displayed at the beginning of the S3 Console listing.
+    "_#{options[:source_prefix]}/#{options[:log_filename]}",
+    file_contents
   )
+  CDO.log.info "[BACKUP S3 BUCKET] Uploaded backup log CSV #{options[:log_filename]} to source bucket/prefix."
   # Log what was backed up to destination location
   AWS::S3.upload_to_bucket(
-    bucket: options[:destination_bucket],
-    key: "#{options[:destination_prefix]}/#{options[:log_filename]}",
-    body: file_contents
+    options[:destination_bucket],
+    # Begin filename with `_` so that it's more likely to be displayed at the beginning of the S3 Console listing.
+    "_#{options[:destination_prefix]}/#{options[:log_filename]}",
+    file_contents
   )
+  CDO.log.info "[BACKUP S3 BUCKET] Uploaded backup log CSV #{options[:log_filename]} to destination bucket/prefix."
 rescue Aws::Errors::ServiceError, StandardError => exception
   CDO.log.error "[BACKUP S3 BUCKET] Error uploading backup CSV log to source/destination buckets: #{exception.message}"
 end

--- a/bin/oneoff/backup_s3_bucket
+++ b/bin/oneoff/backup_s3_bucket
@@ -1,0 +1,155 @@
+#!/usr/bin/env ruby
+
+# Initialize Rails, which configures CDO.log to stream to syslog. On systems provisioned with Chef
+# CloudWatch Agent streams syslog to a CloudWatch Log.
+require_relative '../../dashboard/config/environment'
+require 'cdo/aws/s3'
+require 'optparse'
+require 'json'
+require 'uri'
+require 'date'
+require 'csv'
+require 'aws-sdk-sts'
+
+# TODO: Convert this to a method in `AWS::S3` with unit tests and provide a rake task to invoke it.
+# This script backs up a folder (prefix) of a source S3 bucket to a destination bucket/prefix, preserving Object keys
+# relative to the destination prefix.
+# USAGE:
+#   bin/oneoff/backup_s3_bucket --source-bucket my-important-bucket --source-prefix important/folder --destination-bucket save-stuff-here --destination-prefix backup-folder/my-important-bucket
+
+options = {}
+options[:actually_backup] = false
+options[:log_filename] = "s3_bucket_backup_log.#{Time.current.to_formatted_s(:number)}.csv"
+# Initialize to empty strings so that if prefix arguments are not provided we use the root of the source/destination buckets.
+options[:source_prefix] = ''
+options[:destination_prefix] = ''
+OptionParser.new do |parser|
+  parser.banner = "Usage: bin/oneoff/backup_s3_bucket [options]"
+  parser.on("-a", "--actually-backup", "Actually copy Objects") do
+    options[:actually_backup] = true
+  end
+  # TODO: add an option to specify that all versions of each Object should be backed up.
+  # TODO: add an option to conditionally upload the backup report to the source bucket source prefix
+  parser.on("-s", "--source-bucket SOURCE-BUCKET", "Source S3 Bucket") do |source_bucket|
+    options[:source_bucket] = source_bucket
+  end
+  parser.on("-p", "--source-prefix SOURCE-PREFIX", "The source S3 prefix, not including leading/trailing slashes.") do |source_prefix|
+    options[:source_prefix] = source_prefix.delete_prefix('/').delete_suffix('/')
+  end
+  parser.on("-d", "--destination-bucket DESTINATION-BUCKET", "Source S3 Bucket") do |destination_bucket|
+    options[:destination_bucket] = destination_bucket
+  end
+  parser.on("-q", "--destination-prefix DESTINATION-PREFIX", "The destination S3 prefix, not including leading/trailing slashes.") do |destination_prefix|
+    puts destination_prefix
+    options[:destination_prefix] = destination_prefix.delete_prefix('/').delete_suffix('/')
+  end
+  parser.on("-l", "--log-filename", "Set the log filename") do |log_filename|
+    options[:log_filename] = log_filename
+  end
+  parser.on("-h", "--help", "Displays this help message") do
+    puts parser
+    exit
+  end
+end.parse!
+
+puts "Called with options: #{options}"
+puts "Script logs are streaming to CloudWatch."
+
+class SkipBackupError < StandardError; end
+
+sts_client = Aws::STS::Client.new
+ACCOUNT_ID = sts_client.get_caller_identity.account
+s3_client = AWS::S3.create_client
+
+continuation_token = nil
+
+BackupStatus = Struct.new(
+  :source_object_uri,                  # S3 URI of source Object (`s3://[bucket-identifier]/[key]`)
+  :source_object_version,              # Version ID of source Object
+  :source_object_last_modified,        # Last modified date/time of source Object
+  :source_object_etag,                 # Source Object etag
+  :destination_object_uri,             # S3 URI of backup Object (`s3://[backup-bucket-identifier]/[backup-key]`)
+  :destination_object_version,         # Version ID of backup Object
+  :destination_object_last_modified,   # Last modified date/time of backup Object
+  :destination_object_etag,            # Backup Object etag
+  :backup_date_time,                   # Date/Time Object backup was attempted.
+  :backup_status,                      # true (successfully backed up) / false (not backed up)
+  :backup_status_reason                # Detailed error if backup failed.
+)
+
+objects_attempted = 0
+objects_backed_up = 0
+objects_failed = 0
+
+# Log each Object that we attempt to backup to a CSV file.
+CSV.open(options[:log_filename], 'a') do |backup_log_csv|
+  backup_log_csv << BackupStatus.members if File.empty?(options[:log_filename])
+  # List all Objects matching source prefix in batches until there are no more to list.
+  loop do
+    list_source_objects_response = s3_client.list_objects_v2(
+      bucket: options[:source_bucket],
+      prefix: options[:source_prefix],
+      continuation_token: continuation_token
+    )
+
+    # Iterate through each S3 Object within the current list request batch.
+    CDO.log.info "[BACKUP S3 OBJECTS] Retrieving #{list_source_objects_response.contents.length} Objects."
+    list_source_objects_response.contents.each do |source_object|
+      objects_attempted += 1
+      backup_status = BackupStatus.new
+      backup_status.source_object_uri = "s3://#{options[:source_bucket]}/#{source_object.key}"
+      backup_status.destination_object_uri = "s3://#{options[:destination_bucket]}/#{options[:destination_prefix]}/#{source_object.key}"
+      backup_status.source_object_last_modified = source_object.last_modified
+      backup_status.source_object_etag = source_object.etag
+      CDO.log.info "[BACKUP S3 BUCKET] Attempting to backup Object: #{backup_status.source_object_uri}"
+      raise SkipBackupError.new('Skipping backup. --actually-backup is set to false.') unless options[:actually_backup]
+      copy_object_output = AWS::S3.backup_object(
+        options[:source_bucket],
+        source_object.key,
+        options[:destination_bucket],
+        options[:destination_prefix]
+      )
+      objects_backed_up += 1
+      backup_status.backup_date_time = Time.now.to_formatted_s(:number)
+      backup_status.source_object_version = copy_object_output.copy_source_version_id
+      backup_status.destination_object_version = copy_object_output.version_id
+      backup_status.destination_object_last_modified = copy_object_output.copy_object_result.last_modified
+      backup_status.destination_object_etag = copy_object_output.copy_object_result.etag
+      backup_status.backup_status = true
+      CDO.log.info "[BACKUP S3 BUCKET] Successfully backed up #{backup_status.source_object_uri} to #{backup_status.destination_object_uri}"
+    rescue Aws::Errors::ServiceError, StandardError => exception
+      objects_failed += 1
+      CDO.log.error "[BACKUP S3 BUCKET] Error backing up: #{backup_status.source_object_uri} / #{exception.message}"
+      backup_status.backup_status = false
+      backup_status.backup_status_reason = exception.message
+    ensure
+      backup_log_csv << backup_status
+      backup_log_csv.flush
+    end
+    break unless list_source_objects_response.is_truncated
+    continuation_token = list_source_objects_response.next_continuation_token
+  end
+end
+
+begin
+  file_contents = File.read(options[:log_filename])
+  # Log what was backed up to source location.
+  AWS::S3.upload_to_bucket(
+    bucket: options[:source_bucket],
+    key: "#{options[:source_prefix]}/#{options[:log_filename]}",
+    body: file_contents
+  )
+  # Log what was backed up to destination location
+  AWS::S3.upload_to_bucket(
+    bucket: options[:destination_bucket],
+    key: "#{options[:destination_prefix]}/#{options[:log_filename]}",
+    body: file_contents
+  )
+rescue Aws::Errors::ServiceError, StandardError => exception
+  CDO.log.error "[BACKUP S3 BUCKET] Error uploading backup CSV log to source/destination buckets: #{exception.message}"
+end
+
+CDO.log.info "[BACKUP S3 BUCKET] Objects Attempted: #{objects_attempted}"
+CDO.log.info "[BACKUP S3 BUCKET] Objects Successfully Backed up: #{objects_backed_up}"
+CDO.log.info "[BACKUP S3 BUCKET] Objects Failed Backup: #{objects_failed}"
+puts "Script execution complete."

--- a/bin/oneoff/backup_s3_bucket
+++ b/bin/oneoff/backup_s3_bucket
@@ -137,7 +137,8 @@ begin
   AWS::S3.upload_to_bucket(
     options[:source_bucket],
     # Begin filename with `_` so that it's more likely to be displayed at the beginning of the S3 Console listing.
-    "#{options[:source_prefix]}/_#{options[:log_filename]}",
+    # Delete leading slash if optional source prefix was not provided.
+    "#{options[:source_prefix]}/_#{options[:log_filename]}".delete_prefix('/'),
     file_contents,
     {no_random: true} # Don't prefix log filename with a random unique identifier.
   )
@@ -146,7 +147,8 @@ begin
   AWS::S3.upload_to_bucket(
     options[:destination_bucket],
     # Begin filename with `_` so that it's more likely to be displayed at the beginning of the S3 Console listing.
-    "#{options[:destination_prefix]}/_#{options[:log_filename]}",
+    # # Delete leading slash if optional destination prefix was not provided.
+    "#{options[:destination_prefix]}/_#{options[:log_filename]}".delete_prefix('/'),
     file_contents,
     {no_random: true} # Don't prefix log filename with a random unique identifier.
   )

--- a/bin/oneoff/backup_s3_bucket
+++ b/bin/oneoff/backup_s3_bucket
@@ -137,7 +137,7 @@ begin
   AWS::S3.upload_to_bucket(
     options[:source_bucket],
     # Begin filename with `_` so that it's more likely to be displayed at the beginning of the S3 Console listing.
-    "_#{options[:source_prefix]}/#{options[:log_filename]}",
+    "#{options[:source_prefix]}/_#{options[:log_filename]}",
     file_contents
   )
   CDO.log.info "[BACKUP S3 BUCKET] Uploaded backup log CSV #{options[:log_filename]} to source bucket/prefix."
@@ -145,7 +145,7 @@ begin
   AWS::S3.upload_to_bucket(
     options[:destination_bucket],
     # Begin filename with `_` so that it's more likely to be displayed at the beginning of the S3 Console listing.
-    "_#{options[:destination_prefix]}/#{options[:log_filename]}",
+    "#{options[:destination_prefix]}/_#{options[:log_filename]}",
     file_contents
   )
   CDO.log.info "[BACKUP S3 BUCKET] Uploaded backup log CSV #{options[:log_filename]} to destination bucket/prefix."

--- a/bin/oneoff/backup_s3_bucket
+++ b/bin/oneoff/backup_s3_bucket
@@ -40,7 +40,6 @@ OptionParser.new do |parser|
     options[:destination_bucket] = destination_bucket
   end
   parser.on("-q", "--destination-prefix DESTINATION-PREFIX", "The destination S3 prefix, not including leading/trailing slashes.") do |destination_prefix|
-    puts destination_prefix
     options[:destination_prefix] = destination_prefix.delete_prefix('/').delete_suffix('/')
   end
   parser.on("-l", "--log-filename", "Set the log filename") do |log_filename|

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -239,6 +239,23 @@ module AWS
       object_keys
     end
 
+    # Back up an S3 Object by copying it. Preserve the source Object key while prefixing it with a destination (backup)
+    # folder name. For example, use this method to back up:
+    #  user-content-bucket://my/path/to/object_name.ext --> backup-bucket://backups/user-content/my/path/to/object_name.ext
+    # @params source_bucket [String] The source S3 bucket name.
+    # @params source_object_key [String] The object key to copy.
+    # @params destination_bucket [String] The destination bucket.
+    # @params destination_object_prefix [String] The destination (backup) directory name, NOT including trailing slash.
+    def self.backup_object(source_bucket, source_object_key, destination_bucket, destination_object_prefix)
+      create_client.copy_object(
+        {
+          bucket: destination_bucket,
+          copy_source: "/#{source_bucket}/#{source_object_key}",
+          key: "#{destination_object_prefix}/#{source_object_key}"
+        }
+      )
+    end
+
     # Renames an object by copying it and then deleting the old copy (S3 objects are immutable)
     # @params bucket [String] The S3 bucket name.
     # @params object_key [String] The object key to rename.

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -249,8 +249,8 @@ module AWS
     # @return [Aws::S3::Types::CopyObjectOutput]
     # @raise [Aws::S3::Errors::ServiceError]
     def self.backup_object(source_bucket, source_object_key, destination_bucket, destination_object_prefix)
-      # `copy_object` uses REST internally, so encode Object keys for safe transport via HTTP/REST.
-      encoded_source_object_key = source_object_key.ascii_only? ? source_object_key : selective_encode(source_object_key)
+      # `copy_object` uses REST internally, so encode UTF-8 characters in Object Key for safe transport via HTTP/REST.
+      encoded_source_object_key = source_object_key.chars.map {|char| char.ascii_only? ? char : URI.encode_www_form_component(char)}.join
       create_client.copy_object(
         {
           bucket: destination_bucket,
@@ -404,16 +404,6 @@ module AWS
           return upload_log(File.basename(filename), file, options)
         end
       end
-    end
-    # Only encode non-ASCII characters in an Object Key for safe transport via REST by the S3 SDK to the S3 service.
-    private def selective_encode(key)
-      key.chars.map do |char|
-        if char.ascii_only?
-          char  # Leave ASCII characters as-is
-        else
-          URI.encode_www_form_component(char)  # Only encode non-ASCII
-        end
-      end.join
     end
   end
 end

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -246,12 +246,16 @@ module AWS
     # @params source_object_key [String] The object key to copy.
     # @params destination_bucket [String] The destination bucket.
     # @params destination_object_prefix [String] The destination (backup) directory name, NOT including trailing slash.
+    # @return [Aws::S3::Types::CopyObjectOutput]
+    # @raise [Aws::S3::Errors::ServiceError]
     def self.backup_object(source_bucket, source_object_key, destination_bucket, destination_object_prefix)
+      encoded_source_object_key = source_object_key.ascii_only? ? source_object_key : URI.encode_www_form_component(source_object_key)
       create_client.copy_object(
         {
           bucket: destination_bucket,
-          copy_source: "/#{source_bucket}/#{source_object_key}",
-          key: "#{destination_object_prefix}/#{source_object_key}"
+          # `copy_object` uses REST internally, so encode Object keys for safe transport via HTTP/REST.
+          copy_source: "/#{source_bucket}/#{encoded_source_object_key}",
+          key: "#{destination_object_prefix}/#{encoded_source_object_key}"
         }
       )
     end

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -239,6 +239,28 @@ module AWS
       object_keys
     end
 
+    # Encodes an S3 Object Key for safe transport via HTTP/REST while preserving ASCII characters.
+    # Only encodes non-ASCII characters and converts trailing whitespace to %20.
+    # @param [String] object_key The S3 Object Key to encode
+    # @return [String] The encoded key
+    def self.encode_object_key_for_transport(object_key)
+      trailing_whitespace_count = object_key.length - object_key.rstrip.length
+      chars = object_key.chars
+
+      chars.map.with_index do |char, index|
+        if char.ascii_only?
+          # Convert trailing whitespace to %20, but keep other whitespace as-is
+          if char <= " " && index >= (chars.length - trailing_whitespace_count)
+            '%20'
+          else
+            char
+          end
+        else
+          URI.encode_www_form_component(char)
+        end
+      end.join
+    end
+
     # Back up an S3 Object by copying it. Preserve the source Object key while prefixing it with a destination (backup)
     # folder name. For example, use this method to back up:
     #  user-content-bucket://my/path/to/object_name.ext --> backup-bucket://backups/user-content/my/path/to/object_name.ext
@@ -249,8 +271,7 @@ module AWS
     # @return [Aws::S3::Types::CopyObjectOutput]
     # @raise [Aws::S3::Errors::ServiceError]
     def self.backup_object(source_bucket, source_object_key, destination_bucket, destination_object_prefix)
-      # `copy_object` uses REST internally, so encode UTF-8 characters in Object Key for safe transport via HTTP/REST.
-      encoded_source_object_key = source_object_key.chars.map {|char| char.ascii_only? ? char : URI.encode_www_form_component(char)}.join
+      encoded_source_object_key = encode_object_key_for_transport(source_object_key)
       create_client.copy_object(
         {
           bucket: destination_bucket,

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -249,11 +249,11 @@ module AWS
     # @return [Aws::S3::Types::CopyObjectOutput]
     # @raise [Aws::S3::Errors::ServiceError]
     def self.backup_object(source_bucket, source_object_key, destination_bucket, destination_object_prefix)
-      encoded_source_object_key = source_object_key.ascii_only? ? source_object_key : URI.encode_www_form_component(source_object_key)
+      # `copy_object` uses REST internally, so encode Object keys for safe transport via HTTP/REST.
+      encoded_source_object_key = source_object_key.ascii_only? ? source_object_key : selective_encode(source_object_key)
       create_client.copy_object(
         {
           bucket: destination_bucket,
-          # `copy_object` uses REST internally, so encode Object keys for safe transport via HTTP/REST.
           copy_source: "/#{source_bucket}/#{encoded_source_object_key}",
           key: "#{destination_object_prefix}/#{encoded_source_object_key}"
         }
@@ -404,6 +404,16 @@ module AWS
           return upload_log(File.basename(filename), file, options)
         end
       end
+    end
+    # Only encode non-ASCII characters in an Object Key for safe transport via REST by the S3 SDK to the S3 service.
+    private def selective_encode(key)
+      key.chars.map do |char|
+        if char.ascii_only?
+          char  # Leave ASCII characters as-is
+        else
+          URI.encode_www_form_component(char)  # Only encode non-ASCII
+        end
+      end.join
     end
   end
 end

--- a/lib/test/cdo/aws/s3.rb
+++ b/lib/test/cdo/aws/s3.rb
@@ -1,6 +1,7 @@
 require_relative '../../test_helper'
 
-BUCKET = 'test-bucket'
+TEST_BUCKET = 'test-bucket'
+TEST_DESTINATION_BUCKET = 'test-destination-bucket'
 
 class CdoAwsS3Test < Minitest::Test
   def setup
@@ -20,34 +21,34 @@ class CdoAwsS3Test < Minitest::Test
     ).once
 
     refute AWS::S3.instance_variable_get(:@cached_bucket_contents)
-    assert AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-object')
-    refute AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-nonexistent')
+    assert AWS::S3.cached_exists_in_bucket?(TEST_BUCKET, 'test-object')
+    refute AWS::S3.cached_exists_in_bucket?(TEST_BUCKET, 'test-nonexistent')
     assert AWS::S3.instance_variable_get(:@cached_bucket_contents)
 
     AWS::S3.s3.unstub(:list_objects_v2)
   end
 
   def test_upload_updates_cache
-    AWS::S3.instance_variable_set(:@cached_bucket_contents, {BUCKET => Set.new})
+    AWS::S3.instance_variable_set(:@cached_bucket_contents, {TEST_BUCKET => Set.new})
     AWS::S3.s3.stubs(:put_object)
 
-    refute AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-nonexistent')
-    AWS::S3.upload_to_bucket(BUCKET, 'test-nonexistent', '', {no_random: true})
-    assert AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-nonexistent')
+    refute AWS::S3.cached_exists_in_bucket?(TEST_BUCKET, 'test-nonexistent')
+    AWS::S3.upload_to_bucket(TEST_BUCKET, 'test-nonexistent', '', {no_random: true})
+    assert AWS::S3.cached_exists_in_bucket?(TEST_BUCKET, 'test-nonexistent')
 
     AWS::S3.s3.unstub(:put_object)
   end
 
   def test_delete_updates_cache
-    AWS::S3.instance_variable_set(:@cached_bucket_contents, {BUCKET => Set['test-object']})
+    AWS::S3.instance_variable_set(:@cached_bucket_contents, {TEST_BUCKET => Set['test-object']})
     mock = MiniTest::Mock.new
     def mock.delete_marker
     end
     AWS::S3.s3.stubs(:delete_object).returns(mock)
 
-    assert AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-object')
-    AWS::S3.delete_from_bucket(BUCKET, 'test-object')
-    refute AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-object')
+    assert AWS::S3.cached_exists_in_bucket?(TEST_BUCKET, 'test-object')
+    AWS::S3.delete_from_bucket(TEST_BUCKET, 'test-object')
+    refute AWS::S3.cached_exists_in_bucket?(TEST_BUCKET, 'test-object')
 
     AWS::S3.s3.unstub(:delete_object)
   end
@@ -62,5 +63,98 @@ class CdoAwsS3Test < Minitest::Test
     presigned_url = "https://cdo-build-logs.s3.amazonaws.com/test/20230222T200104%2B0000?versionId=AjeSMS0Eq2pkvljW7ohD2J6qMFMx_ykU&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAW5P5EEELIETSUTKS%2F20230222%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230222T204400Z&X-Amz-Expires=259200&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEEQaCXVzLWVhc3QtMSJGMEQCICuSp6dZ0WJeZ3K%2FEoM7yuEO32NgaByJP%2BiD05%2F%2BK2z%2FAiAOMioA0x2aO7J9gori13wBPCRjNn2QBWVFTOjHEgzfZSrWBAjd%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDQ3NTY2MTYwNzE5MCIMvVTdvqm2IsQmRZrpKqoEPcSC8vnFXU7DtHoHQZ3vDD83MgR1biwz9QvHEbZS3H1fia2%2FZfLPXELz%2BxVWO23NViPn%2B7XV2%2FKbZNdIFAiMvvuzpfdF2R31%2FmgfXcZP6W2NwUUNqrszxgtxM12V3%2BK%2BkBzcoDQshQPXtPeAKdP1EQuDNwL43oLrFrLZ6xK2n85TxGog5F6f0ZEN2IXZRASVtT41nN0GRWgVnhWqlJJWYigtS8eKN7S56cRI5x2264HKTuoHqb2%2BugTInqvM3sKScpRMcEoxbYe98CFa9N11s%2B8LWYxpkVAk2Qb8jEJ6fbN9FIaPK2FmhDdpsljHKfnl15i8wReuRL3v4ajZtok%2BjIkjtZIDNP6MTpEXm%2BwemjNmJzdpLAlYwud%2FUdClHL95GkBe%2FMyZKlicrjRwiSIPJnHSBBJpgSn9p%2FPWvBZgAs7H3C54lfKGLT5TiIodRgn1XrZg83EXmiMomxHloS9s38mVr5QhdyR742xZcfQQ%2BVMcEVxVntVz7xQdwCeWSL1ZV41s9b2fk9HpE9lTPjHvpxtTSoPTGOW8%2Bv2Yees7%2F%2FMyqrmuvY%2Fy0V%2FGE7NRDA5OXdEPXAm6QUmPWNyG%2BKVzE0FnonkpxfLK4KDCd7jcOZSDd3%2BBa%2Fy3%2F9qnppbuvXU3usv4m9vltmw8GDuHv5T3QivksxkuiVjjJ51qgfdEEOIn6o0jRDjhKo12w7Ce4zATW%2BeLR10hZlWZTomGvoYvLWiUCsWnubTO%2BfgwpeTZnwY6qgFp9%2F6%2B%2BVA%2F4dRfQyn%2FqmH%2BJzwYDj4SzTeTVdJ%2FN8FtRj%2BHBet09EBX7zgdBmmebRnSkqOWm0NuXf9cb9aSBAkclmluSP%2Bmk0by%2BJrYvVJSV6Iwv6yCG2de15XbkfQm46eb3c8EqJpI4CGTfyTwrZB7LednvfTVJrpW9iPcI97LmfIez7MlV1nMBANHRdxOiIm4jrwUkryN7EfBC4y9%2BsOQH5zXFlIiZ8vh%2BA%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=3117b23c8bda56230d2dc8c3fd3452b5b5576a2507dcd881fe40ec3bcd77ce70"
     expected_url = "https://s3.console.aws.amazon.com/s3/object/cdo-build-logs?prefix=test/20230222T200104%2B0000"
     assert_equal(expected_url, AWS::S3.get_console_link_from_presigned(presigned_url))
+  end
+
+  def test_backup_object_with_ascii_key
+    # Test with a simple ASCII key
+    source_key = "test/path/file.txt"
+    encoded_source_key = source_key  # No encoding needed for ASCII
+    destination_prefix = "backups/2024"
+
+    # Set up expectations for the copy_object call
+    AWS::S3.s3.expects(:copy_object).with(
+      bucket: TEST_DESTINATION_BUCKET,
+      copy_source: "/#{TEST_BUCKET}/#{encoded_source_key}",
+      key: "#{destination_prefix}/#{encoded_source_key}"
+    ).returns(true)
+
+    # Call the method and verify it succeeds
+    result = AWS::S3.backup_object(
+      TEST_BUCKET,
+      source_key,
+      TEST_DESTINATION_BUCKET,
+      destination_prefix
+    )
+    assert result
+  end
+
+  def test_backup_object_with_utf8_key
+    # Test with a key containing UTF-8 characters
+    source_key = "test/path/привет-世界.txt"
+    encoded_source_key = 'test/path/%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82-%E4%B8%96%E7%95%8C.txt'
+    destination_prefix = "backups/2024"
+
+    # Set up expectations for the copy_object call with encoded source
+    AWS::S3.s3.expects(:copy_object).with(
+      bucket: TEST_DESTINATION_BUCKET,
+      copy_source: "/#{TEST_BUCKET}/#{encoded_source_key}",
+      key: "#{destination_prefix}/#{encoded_source_key}"
+    ).returns(true)
+
+    # Call the method and verify it succeeds
+    result = AWS::S3.backup_object(
+      TEST_BUCKET,
+      source_key,
+      TEST_DESTINATION_BUCKET,
+      destination_prefix
+    )
+    assert result
+  end
+
+  def test_backup_object_with_mixed_utf8_and_ascii_key
+    # Test with a key containing both ASCII and UTF-8 characters
+    source_key = "test/path/hello-привет/file-文件.txt"
+    encoded_source_key = 'test/path/hello-%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82/file-%E6%96%87%E4%BB%B6.txt'
+    destination_prefix = "backups/2024"
+
+    # Set up expectations for the copy_object call with encoded source
+    AWS::S3.s3.expects(:copy_object).with(
+      bucket: TEST_DESTINATION_BUCKET,
+      copy_source: "/#{TEST_BUCKET}/#{encoded_source_key}",
+      key: "#{destination_prefix}/#{encoded_source_key}"
+    ).returns(true)
+
+    # Call the method and verify it succeeds
+    result = AWS::S3.backup_object(
+      TEST_BUCKET,
+      source_key,
+      TEST_DESTINATION_BUCKET,
+      destination_prefix
+    )
+    assert result
+  end
+
+  def test_backup_object_handles_s3_errors
+    # Test error handling with a simple ASCII key
+    source_key = "test/path/file.txt"
+    destination_prefix = "backups/2024"
+
+    # Simulate an S3 error
+    AWS::S3.s3.expects(:copy_object).raises(
+      Aws::S3::Errors::ServiceError.new(
+        stub(context: nil),
+        'Failed to copy object'
+      )
+    )
+
+    # Verify the error is propagated
+    assert_raises Aws::S3::Errors::ServiceError do
+      AWS::S3.backup_object(
+        TEST_BUCKET,
+        source_key,
+        TEST_DESTINATION_BUCKET,
+        destination_prefix
+      )
+    end
   end
 end

--- a/lib/test/cdo/aws/s3.rb
+++ b/lib/test/cdo/aws/s3.rb
@@ -134,6 +134,34 @@ class CdoAwsS3Test < Minitest::Test
     assert result
   end
 
+  def test_backup_object_with_trailing_whitespace_in_key
+    # Test with keys containing various trailing whitespace patterns
+    {
+      "test/path/file.txt   " => "test/path/file.txt%20%20%20",
+      "test/path/file.txt \t " => "test/path/file.txt%20%20%20",
+      "test/path/file with spaces.txt  " => "test/path/file with spaces.txt%20%20",
+      "test/path/привет.txt " => "test/path/%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82.txt%20"
+    }.each do |source_key, expected_encoded_key|
+      destination_prefix = "backups/2024"
+
+      # Set up expectations for the copy_object call
+      AWS::S3.s3.expects(:copy_object).with(
+        bucket: TEST_DESTINATION_BUCKET,
+        copy_source: "/#{TEST_BUCKET}/#{expected_encoded_key}",
+        key: "#{destination_prefix}/#{expected_encoded_key}"
+      ).returns(true)
+
+      # Call the method and verify it succeeds
+      result = AWS::S3.backup_object(
+        TEST_BUCKET,
+        source_key,
+        TEST_DESTINATION_BUCKET,
+        destination_prefix
+      )
+      assert result
+    end
+  end
+
   def test_backup_object_handles_s3_errors
     # Test error handling with a simple ASCII key
     source_key = "test/path/file.txt"


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1601

- Add a method to `AWS::S3` that backs up an Object and unit tests for the new method.
- Add a command line script that backs up a source prefix to a destination prefix and logs each Object it attempted to back up.
- Update the `cdo-backups` bucket to enable Versioning.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
