### PR TITLE
P20/do not require space in secret words

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1224,7 +1224,8 @@ class User < ApplicationRecord
       followers: {section: section}
     )
 
-    return if user.secret_words.delete(' ') != params[:secret_words].delete(' ')
+    return unless user&.valid_secret_words?(params[:secret_words])
+
     user
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1219,11 +1219,13 @@ class User < ApplicationRecord
     return if params[:secret_words].blank?
     return if section.login_type != Section::LOGIN_TYPE_WORD
 
-    User.joins(:sections_as_student).find_by(
+    user = User.joins(:sections_as_student).find_by(
       id: params[:user_id],
-      secret_words: params[:secret_words],
       followers: {section: section}
     )
+
+    return if user.secret_words.delete(' ') != params[:secret_words].delete(' ')
+    user
   end
 
   def self.authenticate_with_section_and_secret_picture(section:, params:)
@@ -1687,7 +1689,7 @@ class User < ApplicationRecord
   end
 
   def valid_secret_words?(words)
-    words == secret_words
+    words.delete(' ') == secret_words.delete(' ')
   end
 
   # override the default devise password to support old and new style hashed passwords

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -58,7 +58,7 @@ class SectionsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "valid log_in wih picture" do
+  test "valid log_in with picture" do
     assert_difference '@picture_user_1.reload.sign_in_count' do # devise Trackable fields are updated
       post :log_in, params: {
         id: @picture_section.code,
@@ -70,7 +70,7 @@ class SectionsControllerTest < ActionController::TestCase
     assert_redirected_to '/'
   end
 
-  test "invalid log_in wih picture" do
+  test "invalid log_in with picture" do
     assert_no_difference '@picture_user_1.reload.sign_in_count' do # devise Trackable fields are not updated
       post :log_in, params: {
         id: @picture_section.code,
@@ -98,7 +98,7 @@ class SectionsControllerTest < ActionController::TestCase
     assert_redirected_to section_path(id: @picture_section.code)
   end
 
-  test "valid log_in wih word" do
+  test "valid log_in with word" do
     assert_difference '@word_user_1.reload.sign_in_count' do # devise Trackable fields are updated
       post :log_in, params: {
         id: @word_section.code,
@@ -110,7 +110,19 @@ class SectionsControllerTest < ActionController::TestCase
     assert_redirected_to '/'
   end
 
-  test "invalid log_in wih word" do
+  test "valid log_in with word without spaces" do
+    assert_difference '@word_user_1.reload.sign_in_count' do # devise Trackable fields are updated
+      post :log_in, params: {
+        id: @word_section.code,
+        user_id: @word_user_1.id,
+        secret_words: @word_user_1.secret_words.delete(' ')
+      }
+    end
+
+    assert_redirected_to '/'
+  end
+
+  test "invalid log_in with word" do
     assert_no_difference '@word_user_1.reload.sign_in_count' do # devise Trackable fields are not updated
       post :log_in, params: {
         id: @word_section.code,


### PR DESCRIPTION
A North-Star classroom visit pointed out that the space in the set of secret words is a place where children can have trouble in the chaotic time where they are logging in. This gives some help by not requiring the space when using secret words.

## Links

- jira ticket: [P20-1409](https://codedotorg.atlassian.net/browse/P20-1409)

## Testing story

Added a controller test to show that logging into a section via valid secret words (without a space) works.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
