### PR TITLE
[Music] Nested loop condition

### DIFF
--- a/apps/src/music/progress/MusicConditions.ts
+++ b/apps/src/music/progress/MusicConditions.ts
@@ -48,7 +48,13 @@ export const MusicConditions: ConditionNames = {
     name: 'played_anything_in_same_loop',
     valueType: 'number',
     description:
-      'Checks if something is playing from within a repeat block, at least this many times. Ex. Value: 3',
+      'Checks if something is playing from within a loop, at least this many times. Ex. Value: 3',
+  },
+  PLAYED_ANYTHING_IN_SAME_NESTED_LOOP: {
+    name: 'played_anything_in_same_nested_loop',
+    valueType: 'number',
+    description:
+      'Checks if something is playing from within a nested loop, at least this many times. Ex. Value: 3',
   },
   PLAYED_SOUNDS: {
     name: 'played_sounds',

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -72,6 +72,9 @@ export default class MusicValidator extends Validator {
     // A map of ids for blocks in loops and the count of playback events associated with them.
     const blockIdLoopRepetitions: {[key: string]: number} = {};
 
+    // A map of ids for blocks in nested loops and the count of playback events associated with them.
+    const blockIdNestedLoopRepetitions: {[key: string]: number} = {};
+
     // Get number of patterns that have been started, separately counting those
     // that are empty and those with events.
     let playedNumberEmptyPatterns = 0;
@@ -187,9 +190,9 @@ export default class MusicValidator extends Validator {
         }
       }
 
-      // Check for a block nested within an if/else block causing something to play.
       const validationInfo = eventData.validationInfo;
       if (validationInfo) {
+        // Check for a block nested within an if/else block causing something to play.
         if (validationInfo.parentControlTypes?.includes(BlockTypes.IF_ELSE)) {
           this.conditionsChecker.addSatisfiedCondition({
             name: MusicConditions.PLAYED_ANYTHING_IN_CONDITIONAL.name,
@@ -227,6 +230,23 @@ export default class MusicValidator extends Validator {
           this.addPlayedConditions(
             MusicConditions.PLAYED_ANYTHING_IN_SAME_LOOP.name,
             Math.max(...Object.values(blockIdLoopRepetitions))
+          );
+        }
+
+        // Check for a block within a nested loop block causing something to play.
+        if (
+          validationInfo.parentControlTypes?.filter(type =>
+            LoopBlockTypes.includes(type)
+          ).length >= 2
+        ) {
+          if (!blockIdNestedLoopRepetitions[blockId]) {
+            blockIdNestedLoopRepetitions[blockId] = 1;
+          } else {
+            blockIdNestedLoopRepetitions[blockId]++;
+          }
+          this.addPlayedConditions(
+            MusicConditions.PLAYED_ANYTHING_IN_SAME_NESTED_LOOP.name,
+            Math.max(...Object.values(blockIdNestedLoopRepetitions))
           );
         }
       }


### PR DESCRIPTION
This adds a condition for Music Lab validations that allows for distinguishing between sounds that were played in a nested loop (vs. any loop).

Requested by @dancodedotorg:
> I can say with 100% confidence that we’re going to be emphasizing and validating nested loops in this unit. So if there’s work to make sure we can validate those, then I think that’s a worthwhile project.
> I’m not far enough in the weeds with validation/level design to know what specific things I’d want to check.

https://github.com/user-attachments/assets/6db6e700-3ec0-4a35-94fa-2e8fdf0554b8


![image](https://github.com/user-attachments/assets/a08fa434-8d6b-432a-b8d1-002e6e533346)


## Links

https://codedotorg.slack.com/archives/C07UT279KM1/p1738857867826279?thread_ts=1738854685.993949&cid=C07UT279KM1

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
