### PR TITLE
feat(marketing): add support for font awesome 6

### DIFF
--- a/frontend/apps/marketing/src/app/layout.tsx
+++ b/frontend/apps/marketing/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type {Metadata} from 'next';
 
 import './globals.css';
+import '@code-dot-org/component-library-styles/font-awesome.scss';
 
 export const metadata: Metadata = {
   title: 'Code.org',


### PR DESCRIPTION
This is a pretty quick PR to import the Code.org font awesome bootstrap code.

![image](https://github.com/user-attachments/assets/022ec65c-23fa-4436-bb9e-ae66d10199cb)
