### PR TITLE
[Python Lab] improved resize bar

### DIFF
--- a/apps/src/codebridge/components/ResizeBar.tsx
+++ b/apps/src/codebridge/components/ResizeBar.tsx
@@ -1,6 +1,5 @@
-import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect, useMemo} from 'react';
 import {SeparatorProps} from 'react-resizable-layout';
 
 import moduleStyles from './resizeBar.module.scss';
@@ -11,7 +10,8 @@ interface ResizeBarProps {
   separatorProps: SeparatorProps;
 }
 
-export const RESIZE_BAR_SIZE_PX = 13;
+export const RESIZE_BAR_SIZE_PX = 1;
+export const RESIZE_BAR_SIZE_PX_HOVERED = 3;
 
 const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
   isVertical,
@@ -22,26 +22,43 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
     ? moduleStyles.verticalBar
     : moduleStyles.horizontalBar;
   const [isFocused, setIsFocused] = React.useState(false);
-  const dragClass = isDragging || isFocused ? moduleStyles.dragging : undefined;
-  const iconClassName = isVertical
-    ? classNames(moduleStyles.resizeIcon, moduleStyles.resizeIconVertical)
-    : moduleStyles.resizeIcon;
+
+  useEffect(() => {
+    const isResizing = isDragging || isFocused;
+    const cursor = !isResizing
+      ? 'default'
+      : isVertical
+      ? 'col-resize'
+      : 'row-resize';
+    document.body.style.cursor = cursor;
+  }, [isDragging, isFocused, isVertical]);
+
+  const grabbableClass = useMemo(() => {
+    const className = [
+      isVertical
+        ? moduleStyles.verticalGrabbable
+        : moduleStyles.horizontalGrabbable,
+    ];
+    if (isDragging || isFocused) {
+      className.push(moduleStyles.visible);
+    }
+    return classNames(...className);
+  }, [isDragging, isFocused, isVertical]);
 
   return (
-    <div
-      className={classNames(moduleStyles.resizeBar, layoutClass, dragClass)}
-      {...separatorProps}
-      // TODO: the separator props are applying role "separator" as well as min/max/now aria values.
-      // Is it ok to ignore this warning?
-      // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      tabIndex={0}
-      onFocus={() => setIsFocused(true)}
-      onBlur={() => setIsFocused(false)}
-    >
-      <FontAwesomeV6Icon
-        className={iconClassName}
-        iconName={isVertical ? 'ellipsis-v' : 'ellipsis'}
+    <div className={classNames(moduleStyles.resizeBar, layoutClass)}>
+      <div
+        className={classNames(moduleStyles.grabbableDiv, grabbableClass)}
+        {...separatorProps}
+        // TODO: the separator props are applying role "separator" as well as min/max/now aria values.
+        // Is it ok to ignore this warning?
+        // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={0}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onMouseEnter={() => setIsFocused(true)}
+        onMouseLeave={() => setIsFocused(false)}
       />
     </div>
   );

--- a/apps/src/codebridge/components/ResizeBar.tsx
+++ b/apps/src/codebridge/components/ResizeBar.tsx
@@ -11,27 +11,29 @@ interface ResizeBarProps {
 }
 
 export const RESIZE_BAR_SIZE_PX = 1;
-export const RESIZE_BAR_SIZE_PX_HOVERED = 3;
 
+// A resize bar that can be dragged to resize two adjacent panels.
+// The bar is 1px wide, but when it is hovered/focused or being dragged, it
+// becomes 5px wide. The area that can be grabbed is also 5px wide.
+// The resize bar should be used with useResizable from react-resizable-layout.
 const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
   isVertical,
   isDragging,
   separatorProps,
 }) => {
-  const layoutClass = isVertical
-    ? moduleStyles.verticalBar
-    : moduleStyles.horizontalBar;
-  const [isFocused, setIsFocused] = React.useState(false);
+  const [isActive, setIsActive] = React.useState(false);
 
   useEffect(() => {
-    const isResizing = isDragging || isFocused;
+    // Ensure the cursor changes when the user is dragging or is hovered
+    // over/focused on the resize bar.
+    const isResizing = isDragging || isActive;
     const cursor = !isResizing
       ? 'default'
       : isVertical
       ? 'col-resize'
       : 'row-resize';
     document.body.style.cursor = cursor;
-  }, [isDragging, isFocused, isVertical]);
+  }, [isDragging, isActive, isVertical]);
 
   const grabbableClass = useMemo(() => {
     const className = [
@@ -39,11 +41,17 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
         ? moduleStyles.verticalGrabbable
         : moduleStyles.horizontalGrabbable,
     ];
-    if (isDragging || isFocused) {
+    if (isDragging || isActive) {
+      // When we are dragging or the resize bar is active, we show the wider
+      // grabbable bar.
       className.push(moduleStyles.visible);
     }
     return classNames(...className);
-  }, [isDragging, isFocused, isVertical]);
+  }, [isDragging, isActive, isVertical]);
+
+  const layoutClass = isVertical
+    ? moduleStyles.verticalBar
+    : moduleStyles.horizontalBar;
 
   return (
     <div className={classNames(moduleStyles.resizeBar, layoutClass)}>
@@ -55,10 +63,10 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
         // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
-        onMouseEnter={() => setIsFocused(true)}
-        onMouseLeave={() => setIsFocused(false)}
+        onFocus={() => setIsActive(true)}
+        onBlur={() => setIsActive(false)}
+        onMouseEnter={() => setIsActive(true)}
+        onMouseLeave={() => setIsActive(false)}
       />
     </div>
   );

--- a/apps/src/codebridge/components/resizeBar.module.scss
+++ b/apps/src/codebridge/components/resizeBar.module.scss
@@ -1,37 +1,56 @@
 @import 'color.scss';
 
+$bar-width: 1px;
+$bar-width-hovered: 4px;
+
 .resizeBar {
-  background-color: $light_gray_950;
+  background-color: $light_gray_800;
   color: $light-white;
   text-align: center;
   flex-shrink: 0;
   font-size: 24px;
   display: flex;
   justify-content: center;
+  position: relative;
 }
 
 .verticalBar {
-  width: 13px;
+  width: $bar-width;
   height: 100%;
-  cursor: col-resize;
 }
 
 .horizontalBar {
   width: 100%;
-  height: 13px;
+  height: $bar-width;
+}
+
+.grabbableDiv {
+  position: absolute;
+  background-color: $light_gray_800;
+  opacity: 0;
+  z-index: 3;
+}
+
+.verticalGrabbable {
+  width: 5px;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: -2px;
+  right: 2px;
+  cursor: col-resize;
+}
+
+.horizontalGrabbable {
+  height: 5px;
+  width: 100%;
+  left: 0;
+  right: 0;
+  top: -2px;
+  bottom: 2px;
   cursor: row-resize;
 }
 
-.resizeIcon {
-  line-height: 13px;
-}
-
-.resizeIconVertical {
-  top: 50%;
-  position: absolute;
-  transform: translateY(-50%);
-}
-
-.dragging {
-  background-color: $light_gray_800; 
+.visible {
+  opacity: 1;
 }

--- a/apps/src/codebridge/components/resizeBar.module.scss
+++ b/apps/src/codebridge/components/resizeBar.module.scss
@@ -1,16 +1,11 @@
 @import 'color.scss';
 
 $bar-width: 1px;
-$bar-width-hovered: 4px;
+$bar-width-hovered: 5px;
 
 .resizeBar {
   background-color: $light_gray_800;
-  color: $light-white;
-  text-align: center;
   flex-shrink: 0;
-  font-size: 24px;
-  display: flex;
-  justify-content: center;
   position: relative;
 }
 
@@ -32,7 +27,7 @@ $bar-width-hovered: 4px;
 }
 
 .verticalGrabbable {
-  width: 5px;
+  width: $bar-width-hovered;
   height: 100%;
   top: 0;
   bottom: 0;
@@ -42,7 +37,7 @@ $bar-width-hovered: 4px;
 }
 
 .horizontalGrabbable {
-  height: 5px;
+  height: $bar-width-hovered;
   width: 100%;
   left: 0;
   right: 0;

--- a/apps/src/lab2/views/components/ResizeBar.tsx
+++ b/apps/src/lab2/views/components/ResizeBar.tsx
@@ -13,8 +13,8 @@ interface ResizeBarProps {
 export const RESIZE_BAR_SIZE_PX = 1;
 
 // A resize bar that can be dragged to resize two adjacent panels.
-// The bar is 1px wide, but when it is hovered/focused or being dragged, it
-// becomes 5px wide. The area that can be grabbed is also 5px wide.
+// The visible bar starts out 1px wide. There is an absolutely-positioned 5px bar
+// that is used for grabbing, and becomes visible when it is hovered/focused or being dragged.
 // The resize bar should be used with useResizable from react-resizable-layout.
 const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
   isVertical,

--- a/apps/src/lab2/views/components/resizeBar.module.scss
+++ b/apps/src/lab2/views/components/resizeBar.module.scss
@@ -1,7 +1,10 @@
 @import 'color.scss';
 
 $bar-width: 1px;
-$bar-width-hovered: 5px;
+$bar-width-grab-area: 5px;
+
+$grab-area-offset: calc(($bar-width-grab-area - 1px)/2);
+$negative-grab-area-offset: calc(-1 * $grab-area-offset);
 
 .resizeBar {
   background-color: $light_gray_800;
@@ -24,25 +27,26 @@ $bar-width-hovered: 5px;
   background-color: $light_gray_800;
   opacity: 0;
   z-index: 3;
+  transition: opacity 0.1s ease-in;
 }
 
 .verticalGrabbable {
-  width: $bar-width-hovered;
+  width: $bar-width-grab-area;
   height: 100%;
   top: 0;
   bottom: 0;
-  left: -2px;
-  right: 2px;
+  left: $negative-grab-area-offset;
+  right: $grab-area-offset;
   cursor: col-resize;
 }
 
 .horizontalGrabbable {
-  height: $bar-width-hovered;
+  height: $bar-width-grab-area;
   width: 100%;
   left: 0;
   right: 0;
-  top: -2px;
-  bottom: 2px;
+  top: $negative-grab-area-offset;
+  bottom: $grab-area-offset;
   cursor: row-resize;
 }
 

--- a/apps/src/lab2/views/components/resizeBar.module.scss
+++ b/apps/src/lab2/views/components/resizeBar.module.scss
@@ -2,8 +2,7 @@
 
 $bar-width: 1px;
 $bar-width-grab-area: 5px;
-
-$grab-area-offset: calc(($bar-width-grab-area - 1px)/2);
+$grab-area-offset: calc(($bar-width-grab-area - 1px) / 2);
 $negative-grab-area-offset: calc(-1 * $grab-area-offset);
 
 .resizeBar {

--- a/apps/src/lab2/views/components/resizeBar.module.scss
+++ b/apps/src/lab2/views/components/resizeBar.module.scss
@@ -1,8 +1,8 @@
 @import 'color.scss';
 
 $bar-width: 1px;
-$bar-width-grab-area: 5px;
-$grab-area-offset: calc(($bar-width-grab-area - 1px) / 2);
+$bar-width-grab-area: 3px;
+$grab-area-offset: calc(($bar-width-grab-area - $bar-width) / 2);
 $negative-grab-area-offset: calc(-1 * $grab-area-offset);
 
 .resizeBar {

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -7,7 +7,7 @@ import {useResizable} from 'react-resizable-layout';
 
 import ResizeBar, {
   RESIZE_BAR_SIZE_PX,
-} from '@cdo/apps/codebridge/components/ResizeBar';
+} from '@cdo/apps/lab2/views/components/ResizeBar';
 
 import moduleStyles from './layout.module.scss';
 

--- a/apps/src/pythonlab/layout/VerticalLayout.tsx
+++ b/apps/src/pythonlab/layout/VerticalLayout.tsx
@@ -1,9 +1,12 @@
-import ResizeBar, {RESIZE_BAR_SIZE_PX} from '@codebridge/components/ResizeBar';
 import {InfoPanel} from '@codebridge/InfoPanel';
 import Workspace from '@codebridge/Workspace';
 import Output from '@codebridge/Workspace/Output';
 import React, {useEffect} from 'react';
 import {useResizable} from 'react-resizable-layout';
+
+import ResizeBar, {
+  RESIZE_BAR_SIZE_PX,
+} from '@cdo/apps/lab2/views/components/ResizeBar';
 
 import moduleStyles from './layout.module.scss';
 


### PR DESCRIPTION
Follow up to #63743
Improve the python lab resize bars to be a more modern style, which also fixes some slight jumping we were seeing with the previous version. See the linked pr for before videos.

Now the bar is a 1px line, but when hovered it becomes 3px. The hover/focus area is also 3px so it is easier to trigger the resize. I also improved the cursor logic, so when we are actively dragging the cursor is always the resize cursor.


https://github.com/user-attachments/assets/2821eae0-066e-43a0-bdb2-a5e66e6634e5


## Links
- jira tickets: [CT-1042](https://codedotorg.atlassian.net/browse/CT-1042), [CT-1043](https://codedotorg.atlassian.net/browse/CT-1043)

## Testing story
Tested locally on Chrome and Firefox.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
