### PR TITLE
feat(source-maps): add source maps to component library

### DIFF
--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -337,6 +337,13 @@ const WEBPACK_BASE_CONFIG = {
               use: ['source-map-loader'],
               enforce: 'pre',
             },
+            // Enable source maps for shared frontend packages
+            {
+              test: /\.js$/,
+              enforce: 'pre',
+              include: /frontend\/packages/,
+              use: ['source-map-loader'],
+            },
           ]
         : []),
     ],

--- a/frontend/packages/component-library/tsup.config.ts
+++ b/frontend/packages/component-library/tsup.config.ts
@@ -20,6 +20,7 @@ function createConfig(format: 'cjs' | 'esm'): Options {
     clean: true,
     target: 'es2019',
     format: [format],
+    sourcemap: true,
     external: [
       '/fonts/barlowSemiCondensed/BarlowSemiCondensed-Medium.ttf',
       '/fonts/barlowSemiCondensed/BarlowSemiCondensed-SemiBold.ttf',


### PR DESCRIPTION
This PR adds source maps to the component library. For `marketing`, source maps are automatically loaded by Next.js. For `apps`, source maps need to be loaded via the `source-map-loader`. While it might make sense to enable source maps for all node modules in development mode, `apps` is already fairly slow so this PR limits the scope of the source maps to just packages in `frontend/packages`.
