### PR TITLE
Music: fix instruments with effects

### DIFF
--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -268,7 +268,7 @@ class ToneJSPlayer {
     Transport.bpm.value = bpm;
     // We need to regenerate all effect busses when BPM changes as some effects (e.g. delay) are BPM-dependent.
     this.generateEffectBusses();
-    // We also need to regenerate samplers so that they attach themselves to the new effects busses.
+    // We also need to regenerate samplers so that they connect themselves to the new effects busses.
     this.samplers = {};
   }
 

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -268,6 +268,8 @@ class ToneJSPlayer {
     Transport.bpm.value = bpm;
     // We need to regenerate all effect busses when BPM changes as some effects (e.g. delay) are BPM-dependent.
     this.generateEffectBusses();
+    // We also need to regenerate samplers so that they attach themselves to the new effects busses.
+    this.samplers = {};
   }
 
   scheduleSample(sample: SampleEvent, onSampleStart: (id: string) => void) {


### PR DESCRIPTION
This is a proposed fix for the following issue: if a song is loaded, then the song is changed to one with a different BPM, and then a `set effect` is followed by a `play drums` or `play notes` block, the drums or notes are not heard.  Reloading the page with this new configuration does work, though.

The issue appears to be that when the BPM is changed, we regenerate the effect busses, while the existing samplers (used for instruments) are referencing the previous effect busses. 