### PR TITLE
Music: fix selection

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -596,17 +596,17 @@ export default class MusicBlocklyWorkspace {
       return;
     }
 
-    if (blockId) {
-      (this.workspace as GoogleBlockly.WorkspaceSvg)
-        .getBlockById(blockId)
-        ?.select();
-    } else {
-      (this.workspace as GoogleBlockly.WorkspaceSvg)
-        .getAllBlocks()
-        .forEach(block => {
-          block.unselect();
-        });
-    }
+    const selectedBlock = blockId
+      ? ((this.workspace as GoogleBlockly.WorkspaceSvg).getBlockById(
+          blockId
+        ) as GoogleBlockly.Block)
+      : null;
+
+    (this.workspace as GoogleBlockly.WorkspaceSvg)
+      .getAllBlocks()
+      .forEach(block => {
+        block === selectedBlock ? block.select() : block.unselect();
+      });
   }
 
   getSelectedTriggerId(blockId: string) {

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -596,14 +596,10 @@ export default class MusicBlocklyWorkspace {
       return;
     }
 
-    const selectedBlock = blockId
-      ? (this.workspace as GoogleBlockly.WorkspaceSvg).getBlockById(blockId)
-      : null;
-
     (this.workspace as GoogleBlockly.WorkspaceSvg)
       .getAllBlocks()
       .forEach(block => {
-        block === selectedBlock ? block.select() : block.unselect();
+        block.id === blockId ? block.select() : block.unselect();
       });
   }
 

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -597,9 +597,7 @@ export default class MusicBlocklyWorkspace {
     }
 
     const selectedBlock = blockId
-      ? ((this.workspace as GoogleBlockly.WorkspaceSvg).getBlockById(
-          blockId
-        ) as GoogleBlockly.Block)
+      ? (this.workspace as GoogleBlockly.WorkspaceSvg).getBlockById(blockId)
       : null;
 
     (this.workspace as GoogleBlockly.WorkspaceSvg)


### PR DESCRIPTION
This fixes an issue in which clicking multiple timeline elements would select multiple blocks.  Now, only the block that correlates to the last-clicked timeline element remains selected.

### before

<img width="1512" alt="Screenshot 2025-02-10 at 9 20 59 PM" src="https://github.com/user-attachments/assets/338962c5-1d04-4bb6-9112-d0505c4ae979" />

### after

<img width="1512" alt="Screenshot 2025-02-10 at 9 20 21 PM" src="https://github.com/user-attachments/assets/9e79d641-e765-4f85-8687-6da946bae125" />
