### PR TITLE
Lab2: error reload button

### DIFF
--- a/apps/src/lab2/views/ErrorFallbackPage.tsx
+++ b/apps/src/lab2/views/ErrorFallbackPage.tsx
@@ -1,4 +1,7 @@
+import {Button} from '@code-dot-org/component-library/button';
 import React from 'react';
+
+import {commonI18n} from '@cdo/apps/types/locale';
 
 import moduleStyles from './Lab2Wrapper.module.scss';
 
@@ -20,6 +23,13 @@ export const ErrorUI: React.FunctionComponent<ErrorUIProps> = ({message}) => (
       {message && (
         <div className={moduleStyles.pageErrorMessage}>({message})</div>
       )}
+      <Button
+        text={commonI18n.reloadPage()}
+        onClick={() => {
+          location.reload();
+        }}
+        size="s"
+      />
     </div>
   </div>
 );

--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -23,20 +23,20 @@
     animation: fadein 0.5s;
 
     .pageError {
+      display: flex;
       background-color: $neutral_light;
+      flex-direction: column;
+      align-items: center;
       border-radius: 5px;
       padding: 20px;
-      text-align: center;
+      gap: 20px;
 
       &Image {
         width: 120px;
-        display: block;
-        margin: 2px auto 15px auto;
       }
 
       &Message {
         color: $neutral_dark70;
-        margin-top: 10px;
       }
     }
   }
@@ -58,5 +58,4 @@
     width: 100%;
     z-index: 80;
   }
-
 }


### PR DESCRIPTION
The Lab2 error UI now offers a button to reload the page.

<img width="1512" alt="Screenshot 2025-02-10 at 9 58 36 PM" src="https://github.com/user-attachments/assets/206fca0f-44a0-4175-b0e6-1a4760b68de7" />
