### PR TITLE
fix(workshops): handle editing legacy timezones

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -279,10 +279,12 @@ export class WorkshopForm extends React.Component {
 
   // Convert from [date, startTime, endTime] to [start, end] and merge destroyedSessions
   prepareSessionsForApi(sessions, destroyedSessions) {
+    const editing = Boolean(this.props.workshop);
     return sessions
       .map(session => {
-        const timeZone =
-          session.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const timeZone = editing
+          ? session.timeZone
+          : Intl.DateTimeFormat().resolvedOptions().timeZone;
         return {
           id: session.id,
           session_format: session.format,
@@ -312,13 +314,17 @@ export class WorkshopForm extends React.Component {
   }
 
   get workshopTimezone() {
-    // a new session is created using the user's local timezone
-    let sessionTz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-    const editing = Boolean(this.props.workshop);
-    if (editing) {
-      // handle legacy sessions stored without timezone offset
-      sessionTz = this.props.workshop.sessions?.[0]?.time_zone || 'UTC';
+    const {workshop} = this.props;
+    const existingTimezone = workshop?.sessions?.[0]?.time_zone;
+    // handle editing legacy sessions stored without timezone offset
+    if (!existingTimezone && workshop) {
+      return 'local';
     }
+    // a new session is created using the user's local timezone
+    const sessionTz =
+      existingTimezone ||
+      Intl.DateTimeFormat().resolvedOptions().timeZone ||
+      'UTC';
     return moment.tz(sessionTz).format('z');
   }
 

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -266,21 +266,28 @@ describe('WorkshopForm test', () => {
       </Provider>
     );
 
-    const tzAbbreviation = 'UTC';
-
     const workshopForm = wrapper.find('WorkshopForm');
 
-    const [formattedSessionData] = workshopForm
+    expect(workshopForm.find('Col').first().text()).to.equal(
+      `All workshop times are local:`
+    );
+
+    const formSessions = workshopForm
       .instance()
       .prepareSessionsForForm(workshop.sessions);
 
-    expect(formattedSessionData.startTime).to.equal('9:00am');
-    expect(formattedSessionData.endTime).to.equal('5:00pm');
-    expect(formattedSessionData.date).to.equal('2016-07-01');
+    expect(formSessions[0].startTime).to.equal('9:00am');
+    expect(formSessions[0].endTime).to.equal('5:00pm');
+    expect(formSessions[0].date).to.equal('2016-07-01');
+    expect(formSessions[0].timeZone).to.be.null;
 
-    expect(workshopForm.find('Col').first().text()).to.equal(
-      `All workshop times are ${tzAbbreviation}:`
-    );
+    const sessionsForApi = workshopForm
+      .instance()
+      .prepareSessionsForApi(formSessions, []);
+
+    expect(sessionsForApi[0].start).to.equal('2016-07-01T09:00:00.000Z');
+    expect(sessionsForApi[0].end).to.equal('2016-07-01T17:00:00.000Z');
+    expect(sessionsForApi[0].time_zone).to.be.null;
   });
 
   it('edits form and can save', () => {


### PR DESCRIPTION
edits to legacy sessions without time_zone were using the user's local timezone to offset the value sent in the api patch request. checking for the existence of the workshop in the component props determines if the user is editing or creating a workshop. if editing, and the existing session doesn't have a timezone, then it is a legacy session and should not be offset. the timezone label was also misleading for legacy sessions saying the times were UTC, when really they're meant to be local to the timezone where the session was created. update the label to default to 'local'

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[slack](https://codedotorg.slack.com/archives/C04540KNGDQ/p1738934024244219?thread_ts=1738934024.244219&cid=C04540KNGDQ)
[[ACQ-3096] Times change when saving workshop (possibly expected?) - Code.org Jira](https://codedotorg.atlassian.net/browse/ACQ-3096)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
