### PR TITLE
fix(marketing): patch next to have a longer timeout for font downloads

### DIFF
--- a/frontend/apps/marketing/.yarnrc.yml
+++ b/frontend/apps/marketing/.yarnrc.yml
@@ -1,0 +1,1 @@
+patchFolder: patches

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -30,7 +30,7 @@
     "@code-dot-org/component-library": "workspace:*",
     "@contentful/experiences-sdk-react": "^1.30.3",
     "contentful": "^11.2.5",
-    "next": "^15.1.2",
+    "next": "patch:next@npm%3A15.1.4#~/apps/marketing/patches/next-npm-15.1.4-0932792742.patch",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/frontend/apps/marketing/patches/next-npm-15.1.4-0932792742.patch
+++ b/frontend/apps/marketing/patches/next-npm-15.1.4-0932792742.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/compiled/@next/font/dist/google/fetch-font-file.js b/dist/compiled/@next/font/dist/google/fetch-font-file.js
+index 8ece2fc4a2ea27ff7723e1c467ef6ddeacb1159a..2c4b389dbd68b525da85a4df6c62ca648781588a 100644
+--- a/dist/compiled/@next/font/dist/google/fetch-font-file.js
++++ b/dist/compiled/@next/font/dist/google/fetch-font-file.js
+@@ -23,7 +23,7 @@ async function fetchFontFile(url, isDev) {
+     }
+     return await (0, retry_1.retry)(async () => {
+         const controller = new AbortController();
+-        const timeoutId = setTimeout(() => controller.abort(), 3000);
++        const timeoutId = setTimeout(() => controller.abort(), 30_000);
+         const arrayBuffer = await (0, node_fetch_1.default)(url, {
+             agent: (0, get_proxy_agent_1.getProxyAgent)(),
+             // Add a timeout in dev

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1065,7 +1065,7 @@ __metadata:
     eslint-plugin-jest: "npm:^28.9.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
-    next: "npm:^15.1.2"
+    next: "patch:next@npm%3A15.1.4#~/apps/marketing/patches/next-npm-15.1.4-0932792742.patch"
     prettier: "npm:3.3.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -12659,7 +12659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^15.1.2":
+"next@npm:15.1.4":
   version: 15.1.4
   resolution: "next@npm:15.1.4"
   dependencies:
@@ -12717,6 +12717,67 @@ __metadata:
   bin:
     next: dist/bin/next
   checksum: 10c0/55325f95e1a8eb13de4ff0f7d7945c130226139bc308950e4fb9002bacae1b3a012bf1488e259027e606cdc460826fa91408e07c79d53c6f69b516b23a4741c5
+  languageName: node
+  linkType: hard
+
+"next@patch:next@npm%3A15.1.4#~/apps/marketing/patches/next-npm-15.1.4-0932792742.patch":
+  version: 15.1.4
+  resolution: "next@patch:next@npm%3A15.1.4#~/apps/marketing/patches/next-npm-15.1.4-0932792742.patch::version=15.1.4&hash=067edd"
+  dependencies:
+    "@next/env": "npm:15.1.4"
+    "@next/swc-darwin-arm64": "npm:15.1.4"
+    "@next/swc-darwin-x64": "npm:15.1.4"
+    "@next/swc-linux-arm64-gnu": "npm:15.1.4"
+    "@next/swc-linux-arm64-musl": "npm:15.1.4"
+    "@next/swc-linux-x64-gnu": "npm:15.1.4"
+    "@next/swc-linux-x64-musl": "npm:15.1.4"
+    "@next/swc-win32-arm64-msvc": "npm:15.1.4"
+    "@next/swc-win32-x64-msvc": "npm:15.1.4"
+    "@swc/counter": "npm:0.1.3"
+    "@swc/helpers": "npm:0.5.15"
+    busboy: "npm:1.6.0"
+    caniuse-lite: "npm:^1.0.30001579"
+    postcss: "npm:8.4.31"
+    sharp: "npm:^0.33.5"
+    styled-jsx: "npm:5.1.6"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
+    babel-plugin-react-compiler: "*"
+    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+    sharp:
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 10c0/f3d350c33485f367d5c15a61a5c79c21853ac0187258fe98fe9d132ff67bce8dafd839713036d981422760a4c6443041b7b82370b1a0046cc75f075cfce5f8e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Next.js has a default timeout for font downloads as 3 seconds. For slower computers or networks, this will cause a timeout leading to a failure to download the fonts. This PR patches next to have a longer time out.

Long term, we may consider hosting the fonts locally rather than downloading them from Google at bootstrap. Followup [task](https://codedotorg.atlassian.net/browse/CMS-328)