### PR TITLE
P20-1406/add alternative help url for non-google classroom troubleshooting

### DIFF
--- a/apps/src/templates/teacherDashboard/RosterDialog.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.jsx
@@ -101,8 +101,10 @@ NoClassroomsFound.propTypes = {
   rosterProvider: PropTypes.oneOf(Object.keys(OAuthSectionTypes)),
 };
 
-const ROSTERED_SECTIONS_SUPPORT_URL =
+const GOOGLE_CLASSROOMS_SYNC_SUPPORT_URL =
   'https://support.code.org/hc/en-us/articles/115001319312';
+const ROSTERED_SECTIONS_SUPPORT_URL =
+  'https://support.code.org/hc/en-us/articles/6496495212557';
 
 const LoadError = ({rosterProvider, loginType}) => {
   switch (rosterProvider) {
@@ -113,7 +115,7 @@ const LoadError = ({rosterProvider, loginType}) => {
           <ReauthorizeGoogleClassroom />
           <p>
             <a
-              href={ROSTERED_SECTIONS_SUPPORT_URL}
+              href={GOOGLE_CLASSROOMS_SYNC_SUPPORT_URL}
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
We had a report that the troubleshooting link for syncing Clever sections pointed to our Google Classroom troubleshooting link. This PR adds a link pointing to the more general synced sections' troubleshooting.

Original link: https://support.code.org/hc/en-us/articles/115001319312-Setting-Up-Sections-with-Google-Classroom-Sync
New link for non-google classroom users: https://support.code.org/hc/en-us/articles/6496495212557-Troubleshooting-common-issues-with-Google-Classroom-Clever-sections

## Links
Jira: [P20-1406](https://codedotorg.atlassian.net/browse/P20-1406)

