### PR TITLE
Musiclab measure lengths as fractions for clarity of screenreader experience

### DIFF
--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -41,12 +41,13 @@ const getLengthRepresentation = (length: number) => {
 const decimalToFraction = (decimal: number): string => {
   if (decimal % 1 === 0) return decimal.toString();
 
-  const gcd = (a: number, b: number): number => (b ? gcd(b, a % b) : a);
+  const greatestCommonDivisor = (a: number, b: number): number =>
+    b ? greatestCommonDivisor(b, a % b) : a;
 
   const len = decimal.toString().length - 2;
   const denominator = Math.pow(10, len);
   const numerator = decimal * denominator;
-  const divisor = gcd(numerator, denominator);
+  const divisor = greatestCommonDivisor(numerator, denominator);
 
   return `${numerator / divisor}/${denominator / divisor}`;
 };

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -38,20 +38,6 @@ const getLengthRepresentation = (length: number) => {
   return lengthToSymbol[length] || length;
 };
 
-const decimalToFraction = (decimal: number): string => {
-  if (decimal % 1 === 0) return decimal.toString();
-
-  const greatestCommonDivisor = (a: number, b: number): number =>
-    b ? greatestCommonDivisor(b, a % b) : a;
-
-  const len = decimal.toString().length - 2;
-  const denominator = Math.pow(10, len);
-  const numerator = decimal * denominator;
-  const divisor = greatestCommonDivisor(numerator, denominator);
-
-  return `${numerator / divisor}/${denominator / divisor}`;
-};
-
 interface FolderPanelRowProps {
   libraryGroupPath: string;
   playingPreview: string;
@@ -194,7 +180,9 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
       }}
       ref={isSelected ? currentSoundRefCallback : null}
       aria-label={
-        sound.name + musicI18n.measureLength() + decimalToFraction(sound.length)
+        sound.name +
+        musicI18n.measureLength() +
+        String(getLengthRepresentation(sound.length))
       }
       tabIndex={0}
       role="tabpanel"

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -38,6 +38,19 @@ const getLengthRepresentation = (length: number) => {
   return lengthToSymbol[length] || length;
 };
 
+const decimalToFraction = (decimal: number): string => {
+  if (decimal % 1 === 0) return decimal.toString();
+
+  const gcd = (a: number, b: number): number => (b ? gcd(b, a % b) : a);
+
+  const len = decimal.toString().length - 2;
+  const denominator = Math.pow(10, len);
+  const numerator = decimal * denominator;
+  const divisor = gcd(numerator, denominator);
+
+  return `${numerator / divisor}/${denominator / divisor}`;
+};
+
 interface FolderPanelRowProps {
   libraryGroupPath: string;
   playingPreview: string;
@@ -179,7 +192,9 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
         }
       }}
       ref={isSelected ? currentSoundRefCallback : null}
-      aria-label={sound.name + musicI18n.measureLength() + sound.length}
+      aria-label={
+        sound.name + musicI18n.measureLength() + decimalToFraction(sound.length)
+      }
       tabIndex={0}
       role="tabpanel"
     >


### PR DESCRIPTION
The screenreader experience for musiclab was not ideal- measure lengths are currently displayed as fractions (through a conversion function) but read by the screenreader as decimals. This ticket adds an additional helper function so the screen reader can read out the numbers as fractions, matching the sighted experience and more closely aligning with the way users discuss music and music beat lengths.

I used copilot for starter code for this, and feel the risk for this change is very low because I'm only using the function in the screen reader output.

Before:
https://github.com/user-attachments/assets/ae7b5d4f-e2bd-4c2b-b84d-a4cb0697eeed

After:
https://github.com/user-attachments/assets/f3442360-cddd-4b3f-b7bd-447a459e29b7


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1035

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
