### PR TITLE
Revert "Revert "Add game_id column to Backpacks table and backfill entries""

### DIFF
--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -7,9 +7,11 @@
 #  storage_app_id :integer          not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  game_id        :integer
 #
 # Indexes
 #
+#  fk_rails_5ae7249531                (game_id)
 #  index_backpacks_on_storage_app_id  (storage_app_id) UNIQUE
 #  index_backpacks_on_user_id         (user_id) UNIQUE
 #

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -11,7 +11,6 @@
 #
 # Indexes
 #
-#  fk_rails_5ae7249531                (game_id)
 #  index_backpacks_on_storage_app_id  (storage_app_id) UNIQUE
 #  index_backpacks_on_user_id         (user_id) UNIQUE
 #

--- a/dashboard/db/migrate/20250207175343_add_foreign_key_from_games_to_backpacks_and_backfill.rb
+++ b/dashboard/db/migrate/20250207175343_add_foreign_key_from_games_to_backpacks_and_backfill.rb
@@ -1,0 +1,20 @@
+class AddForeignKeyFromGamesToBackpacksAndBackfill < ActiveRecord::Migration[6.1]
+  def change
+    add_column :backpacks, :game_id, :integer, index: true
+    add_foreign_key :backpacks, :games, column: :game_id
+
+    reversible do |dir|
+      dir.up do
+        game_id = Game.find_by(name: 'Javalab')&.id
+        if game_id
+          Backpack.where(game_id: nil).update_all(game_id: game_id)
+        else
+          Rails.logger.warn "Game 'Javalab' not found. No backfill performed."
+        end
+      end
+      dir.down do
+        Backpack.update_all(game_id: nil)
+      end
+    end
+  end
+end

--- a/dashboard/db/migrate/20250207175343_add_game_id_to_backpacks_and_backfill.rb
+++ b/dashboard/db/migrate/20250207175343_add_game_id_to_backpacks_and_backfill.rb
@@ -1,7 +1,6 @@
-class AddForeignKeyFromGamesToBackpacksAndBackfill < ActiveRecord::Migration[6.1]
+class AddGameIdToBackpacksAndBackfill < ActiveRecord::Migration[6.1]
   def change
     add_column :backpacks, :game_id, :integer, index: true
-    add_foreign_key :backpacks, :games, column: :game_id
 
     reversible do |dir|
       dir.up do

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_01_29_162309) do
+ActiveRecord::Schema.define(version: 2025_02_07_175343) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -192,6 +192,8 @@ ActiveRecord::Schema.define(version: 2025_01_29_162309) do
     t.integer "storage_app_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "game_id"
+    t.index ["game_id"], name: "fk_rails_5ae7249531"
     t.index ["storage_app_id"], name: "index_backpacks_on_storage_app_id", unique: true
     t.index ["user_id"], name: "index_backpacks_on_user_id", unique: true
   end
@@ -2514,6 +2516,7 @@ ActiveRecord::Schema.define(version: 2025_01_29_162309) do
   add_foreign_key "ai_tutor_interaction_feedbacks", "ai_tutor_interactions"
   add_foreign_key "ai_tutor_interaction_feedbacks", "users"
   add_foreign_key "aichat_events", "aichat_requests", column: "request_id"
+  add_foreign_key "backpacks", "games"
   add_foreign_key "cap_user_events", "users"
   add_foreign_key "census_submission_form_maps", "census_submissions"
   add_foreign_key "census_summaries", "schools"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -193,7 +193,6 @@ ActiveRecord::Schema.define(version: 2025_02_07_175343) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "game_id"
-    t.index ["game_id"], name: "fk_rails_5ae7249531"
     t.index ["storage_app_id"], name: "index_backpacks_on_storage_app_id", unique: true
     t.index ["user_id"], name: "index_backpacks_on_user_id", unique: true
   end
@@ -1738,7 +1737,7 @@ ActiveRecord::Schema.define(version: 2025_02_07_175343) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "projects", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "projects", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "storage_id"
     t.text "value", size: :medium
     t.datetime "updated_at", null: false
@@ -2516,7 +2515,6 @@ ActiveRecord::Schema.define(version: 2025_02_07_175343) do
   add_foreign_key "ai_tutor_interaction_feedbacks", "ai_tutor_interactions"
   add_foreign_key "ai_tutor_interaction_feedbacks", "users"
   add_foreign_key "aichat_events", "aichat_requests", column: "request_id"
-  add_foreign_key "backpacks", "games"
   add_foreign_key "cap_user_events", "users"
   add_foreign_key "census_submission_form_maps", "census_submissions"
   add_foreign_key "census_summaries", "schools"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1737,7 +1737,7 @@ ActiveRecord::Schema.define(version: 2025_02_07_175343) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "projects", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "projects", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "storage_id"
     t.text "value", size: :medium
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#63827 which reverted https://github.com/code-dot-org/code-dot-org/pull/63771.
This PR updates the original migration file by removing the foreign key constraint. When the original migration file was run, the following [error was reported](https://app.honeybadger.io/projects/3240/faults/117267698/01JKRM0DZWW1HJZBS85GTPYBZG):
```
ActiveRecord::InvalidForeignKey: Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`dashboard_staging`.`backpacks`, CONSTRAINT `fk_rails_5ae7249531` FOREIGN KEY (`game_id`) REFERENCES `games` (`id`))
```
The migration was executed successfully, however during the `staging` build DB seeding, we [reset the database](https://github.com/code-dot-org/code-dot-org/blob/1bc4c7b5fda7a9c613312f14cbd5fac871cee811/dashboard/app/models/concerns/seeded.rb#L6-L10) which includes [destroying and recreating the games table](https://github.com/code-dot-org/code-dot-org/blob/442e41f1cdae40da5380b263dcb94fdb4191fa21/dashboard/app/models/game.rb#L366). The order of the `Game` entries is set by the [constant `GAMES_BY_INDEX`](https://github.com/code-dot-org/code-dot-org/blob/442e41f1cdae40da5380b263dcb94fdb4191fa21/dashboard/app/models/game.rb#L286-L288). Noting that all level files have a `game_id` so the order of these games should not ever change.

However, the original migration was missing `ON DELETE` behavior so that when the `Game` entries were deleted, this caused an error.

After discussion with @sureshc and @cat5inthecradle, we are removing the foreign key constraint and after the migration and backfill is completed successfully, we can add the association between the two models.

```
class Backpack < ApplicationRecord
  belongs_to :game
end
```


## Testing
I reset my local DB, then ran the migration and confirmed that the `Backpacks` table has `game_id` column with value `68` (Javalab game_id).
<img width="634" alt="Screenshot 2025-02-11 at 7 51 32 AM" src="https://github.com/user-attachments/assets/8e323528-6bee-4f80-a516-c9dea4ecdb26" />



