### PR TITLE
fix(workshops): use workshop.virtual to backfill session_format

### DIFF
--- a/bin/oneoff/backfill_pd_sessions_session_format.rb
+++ b/bin/oneoff/backfill_pd_sessions_session_format.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require_relative '../../dashboard/config/environment'
+
+Pd::Session.includes(:workshop).where(session_format: nil).where(deleted_at: nil).find_each(batch_size: 500) do |session|
+  workshop = session.workshop
+  next unless workshop
+
+  session.session_format = workshop.virtual ? 'virtual' : 'in_person'
+  session.save!
+end


### PR DESCRIPTION
this updates existing workshop sessions that have a null session_format to use the workshop's virtual serialized attribute to determine if the session is in person or virtual

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3099)
[slack](https://codedotorg.slack.com/archives/C04540KNGDQ/p1738937835983559)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
