### PR TITLE
fix(workshops): use first session timezone when updating workshop

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_form_part.jsx
@@ -195,7 +195,7 @@ export default class SessionFormPart extends React.Component {
               componentClass="select"
               id="format"
               name="format"
-              value={this.props.session.format}
+              value={this.props.session.format ?? ''}
               onChange={this.handleFormatChange}
               disabled={this.props.readOnly}
               style={this.props.readOnly ? styles.readOnlyInput : undefined}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -280,11 +280,11 @@ export class WorkshopForm extends React.Component {
   // Convert from [date, startTime, endTime] to [start, end] and merge destroyedSessions
   prepareSessionsForApi(sessions, destroyedSessions) {
     const editing = Boolean(this.props.workshop);
+    const timeZone = editing
+      ? [...sessions, ...destroyedSessions].find(s => s.timeZone)?.timeZone
+      : Intl.DateTimeFormat().resolvedOptions().timeZone;
     return sessions
       .map(session => {
-        const timeZone = editing
-          ? session.timeZone
-          : Intl.DateTimeFormat().resolvedOptions().timeZone;
         return {
           id: session.id,
           session_format: session.format,

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -287,7 +287,7 @@ describe('WorkshopForm test', () => {
 
     expect(sessionsForApi[0].start).to.equal('2016-07-01T09:00:00.000Z');
     expect(sessionsForApi[0].end).to.equal('2016-07-01T17:00:00.000Z');
-    expect(sessionsForApi[0].time_zone).to.be.null;
+    expect(sessionsForApi[0].time_zone).to.be.undefined;
   });
 
   it('edits form and can save', () => {

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -53,7 +53,7 @@ class Pd::Session < ApplicationRecord
   end
 
   def set_default_time_zone
-    self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : 'UTC'
+    self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : nil
   end
 
   def prevent_time_zone_change

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -75,8 +75,12 @@ class Pd::Session < ApplicationRecord
   end
 
   def tz_abbreviation
-    return '' if time_zone.blank?
-    ActiveSupport::TimeZone[time_zone].tzinfo.current_period.abbreviation.to_s
+    return '' if time_zone.blank? || start.blank?
+
+    time_zone_obj = ActiveSupport::TimeZone[time_zone]
+    return '' unless time_zone_obj
+
+    time_zone_obj.tzinfo.period_for_utc(start).abbreviation.to_s
   end
 
   def formatted_date_with_start_and_end_times


### PR DESCRIPTION
when adding new sessions to an existing workshop using the edit form, the timezone was being set to UTC by the back end since no timezone was sent. this checks the first session for an existing timezone, since all workshops have at least one session created by default. I'm also removing validation that was setting a default time_zone of UTC, instead accepting that if a new session is created without a time_zone that they want the legacy functionality that did not support timezones

it also fixes a small bug in the formatting method on the back end where it was using the current day to determine the timezone abbreviation rather than the `start` datetime on the session

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
