### PR TITLE
feat(workshops): require session format and add empty state option

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_form_part.jsx
@@ -149,6 +149,10 @@ export default class SessionFormPart extends React.Component {
       style.endTime = 'error';
       help.endTime = 'Must end after it starts.';
     }
+    if (!this.props.session.format) {
+      style.format = 'error';
+      help.format = 'Required.';
+    }
 
     return (
       <Row>
@@ -190,7 +194,7 @@ export default class SessionFormPart extends React.Component {
           </FormGroup>
         </Col>
         <Col sm={3}>
-          <FormGroup>
+          <FormGroup validationState={style.format}>
             <FormControl
               componentClass="select"
               id="format"
@@ -200,12 +204,14 @@ export default class SessionFormPart extends React.Component {
               disabled={this.props.readOnly}
               style={this.props.readOnly ? styles.readOnlyInput : undefined}
             >
+              <option value={''}>Select an option</option>
               {PdSessionFormats.map(({value, label}) => (
                 <option key={value} value={value}>
                   {label}
                 </option>
               ))}
             </FormControl>
+            <HelpBlock>{help.format}</HelpBlock>
           </FormGroup>
         </Col>
         <Col sm={2}>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_list_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_list_form_part.jsx
@@ -37,6 +37,7 @@ export default class SessionListFormPart extends React.Component {
         .format(DATE_FORMAT),
       startTime: lastSession.startTime,
       endTime: lastSession.endTime,
+      format: lastSession.format,
     };
 
     sessions.push(newSession);


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

this adds an empty state option for existing workshop sessions that don't have a session_format, and requires the session format to be set before submission. it also utilizes the last session's format when adding a new session similar to how the last session's start and end times are used.

![Screenshot 2025-02-11 at 5 35 45 PM](https://github.com/user-attachments/assets/7db6ff89-9023-4097-8fe6-f6f0202f5314)

![Screenshot 2025-02-11 at 5 35 37 PM](https://github.com/user-attachments/assets/2867e138-c469-4cc0-b4f2-1a1b363efce4)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
