### PR TITLE
feat(marketing): add concurrency limit

### DIFF
--- a/.github/workflows/marketing-app-cicd.yml
+++ b/.github/workflows/marketing-app-cicd.yml
@@ -19,6 +19,14 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: code-dot-org/marketing
 
+concurrency:
+  # For pushes to staging, requests are grouped into the "deploy-marketing" concurrency group to queue them up
+  # For pull requests, there are no limits to concurrency
+  group: ${{ github.event_name == 'push' && 'deploy-marketing' || github.run_id }}
+  # For pushes to staging, multiple pushes are queued
+  # For pull requests, multiple pushes to the same PR cancels previous executions
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   # Job: build-and-push-image


### PR DESCRIPTION
This PR limits the concurrency of github actions for the marketing app. Currently, when multiple commits are pushed to `staging`, the Github Action is executed in parallel which results in an update to the stack while an update is already occurring. Additionally, it results in two docker builds which don't contain the other commit.

To mitigate this, pushes to staging are queued up while pull requests continue to run in parallel.