### PR TITLE
Music: tweak panel container header

### DIFF
--- a/apps/src/music/views/HeaderButtons.module.scss
+++ b/apps/src/music/views/HeaderButtons.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   min-width: 190px;
   max-width: calc(100vw - 270px);
+  justify-content: end;
 }
 
 .button {


### PR DESCRIPTION
A quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/63419 to ensure that the Music Lab buttons are pushed all the way to the edge when they are at their narrowest.

### before

<img width="955" alt="Screenshot 2025-02-11 at 11 56 23 AM" src="https://github.com/user-attachments/assets/a7af9d89-a383-4fd1-809e-d2494ac4f500" />

### after

<img width="955" alt="Screenshot 2025-02-11 at 11 56 26 AM" src="https://github.com/user-attachments/assets/7842e6ea-bd2c-408c-af68-7ea845a558e0" />
