### PR TITLE
Lab2: fix header buttons

### DIFF
--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -4,6 +4,7 @@ import {
   WithTooltip,
 } from '@code-dot-org/component-library/tooltip';
 import {sendCodebridgeAnalyticsEvent} from '@codebridge/utils/analyticsReporterHelper';
+import classNames from 'classnames';
 import React, {useCallback} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
@@ -116,9 +117,12 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
           type={'tertiary'}
           color={buttonColors.white}
           text={commonI18n.skipToProject()}
-          className={darkModeStyles.tertiaryButton}
+          className={classNames(
+            darkModeStyles.tertiaryButton,
+            moduleStyles.buttonSkip
+          )}
         >
-          {commonI18n.skipToProject()}
+          <span>{commonI18n.skipToProject()}</span>
         </Button>
       )}
     </div>

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -76,3 +76,14 @@
   justify-content: flex-end;
   gap: 4px;
 }
+
+.buttonSkip {
+  flex-shrink: 1;
+  white-space: nowrap;
+  overflow: hidden;
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/apps/src/music/views/HeaderButtons.module.scss
+++ b/apps/src/music/views/HeaderButtons.module.scss
@@ -71,5 +71,13 @@
     width: initial;
     padding: 0 11px;
     gap: 9px;
+    flex-shrink: 1;
+    white-space: nowrap;
+    overflow: hidden;
+
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 }

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -241,7 +241,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
           type="button"
           className={classNames(moduleStyles.button, moduleStyles.buttonSkip)}
         >
-          {commonI18n.skipToProject()}
+          <span>{commonI18n.skipToProject()}</span>
           <FontAwesome
             title={commonI18n.skipToProject()}
             icon="arrow-right"


### PR DESCRIPTION
Fix the header buttons when the "Skip to project" button is present and the screen is narrow, in Music Lab and Codebridge.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/63419.

### Music Lab

#### before

<img width="508" alt="Screenshot 2025-02-11 at 7 58 13 PM" src="https://github.com/user-attachments/assets/9875ef2a-63d8-4f12-a03d-fb51ca226b9b" />

#### after

<img width="508" alt="Screenshot 2025-02-11 at 7 57 01 PM" src="https://github.com/user-attachments/assets/49230bf9-bb4c-4f54-b866-971d32cef391" />

### Codebridge

#### before

<img width="467" alt="Screenshot 2025-02-11 at 8 44 35 PM" src="https://github.com/user-attachments/assets/afbbdcfc-af3f-480c-a3b4-88a5ccbfb21d" />

#### after

<img width="467" alt="Screenshot 2025-02-11 at 8 42 59 PM" src="https://github.com/user-attachments/assets/e1c41d16-fcfe-4300-a2a6-a7da108a05f3" />
