### PR TITLE
Revert "fix(workshops): session start and end times are the same across timezones"

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -279,7 +279,6 @@
     "messageformat": "2.3.0",
     "ml-knn": "^3.0.0",
     "moment": "^2.29.4",
-    "moment-timezone": "^0.5.47",
     "object-fit-images": "^3.2.3",
     "papaparse": "^5.4.1",
     "path-browserify": "^1.0.1",

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
@@ -1,7 +1,7 @@
 /**
  * Displays nicely-formatted session time for a workshop.
  */
-import moment from 'moment-timezone';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -12,17 +12,14 @@ export default class SessionTime extends React.Component {
     session: PropTypes.shape({
       start: PropTypes.string.isRequired,
       end: PropTypes.string.isRequired,
-      time_zone: PropTypes.string,
     }).isRequired,
   };
 
   render() {
-    const {session} = this.props;
-    const tz = session.time_zone || 'UTC';
     const formattedTime =
-      moment.utc(session.start).tz(tz).format(DATETIME_FORMAT) +
+      moment.utc(this.props.session.start).format(DATETIME_FORMAT) +
       '-' +
-      moment.utc(session.end).tz(tz).format(TIME_FORMAT);
+      moment.utc(this.props.session.end).format(TIME_FORMAT);
 
     return <div>{formattedTime}</div>;
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -4,7 +4,7 @@
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import $ from 'jquery';
 import _ from 'lodash';
-import moment from 'moment-timezone';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 /* eslint-disable no-restricted-imports */
@@ -260,19 +260,9 @@ export class WorkshopForm extends React.Component {
       return {
         id: session.id,
         format: session.session_format,
-        date: moment
-          .utc(session.start)
-          .tz(session.time_zone || 'UTC')
-          .format(DATE_FORMAT),
-        startTime: moment
-          .utc(session.start)
-          .tz(session.time_zone || 'UTC')
-          .format(TIME_FORMAT),
-        endTime: moment
-          .utc(session.end)
-          .tz(session.time_zone || 'UTC')
-          .format(TIME_FORMAT),
-        timeZone: session.time_zone,
+        date: moment.utc(session.start).format(DATE_FORMAT),
+        startTime: moment.utc(session.start).format(TIME_FORMAT),
+        endTime: moment.utc(session.end).format(TIME_FORMAT),
       };
     });
   }
@@ -281,24 +271,15 @@ export class WorkshopForm extends React.Component {
   prepareSessionsForApi(sessions, destroyedSessions) {
     return sessions
       .map(session => {
-        const timeZone =
-          session.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
         return {
           id: session.id,
           session_format: session.format,
           start: moment
-            .tz(
-              `${session.date} ${session.startTime}`,
-              DATETIME_FORMAT,
-              timeZone
-            )
-            .utc()
-            .toISOString(),
+            .utc(session.date + ' ' + session.startTime, DATETIME_FORMAT)
+            .format(),
           end: moment
-            .tz(`${session.date} ${session.endTime}`, DATETIME_FORMAT, timeZone)
-            .utc()
-            .toISOString(),
-          time_zone: timeZone,
+            .utc(session.date + ' ' + session.endTime, DATETIME_FORMAT)
+            .format(),
         };
       })
       .concat(
@@ -309,17 +290,6 @@ export class WorkshopForm extends React.Component {
           };
         })
       );
-  }
-
-  get workshopTimezone() {
-    // a new session is created using the user's local timezone
-    let sessionTz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-    const editing = Boolean(this.props.workshop);
-    if (editing) {
-      // handle legacy sessions stored without timezone offset
-      sessionTz = this.props.workshop.sessions?.[0]?.time_zone || 'UTC';
-    }
-    return moment.tz(sessionTz).format('z');
   }
 
   // Convert from [id, name, email] to an array of ids.
@@ -1150,7 +1120,7 @@ export class WorkshopForm extends React.Component {
       <Grid>
         <form>
           <Row>
-            <Col sm={4}>All workshop times are {this.workshopTimezone}:</Col>
+            <Col sm={4}>All workshop times are local:</Col>
           </Row>
           <SessionListFormPart
             sessions={this.state.sessions}

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -1,6 +1,5 @@
 import {assert, expect} from 'chai'; // eslint-disable-line no-restricted-imports
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
-import moment from 'moment-timezone';
 import React from 'react';
 import {FormControl} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import '../workshopFactory';
@@ -165,121 +164,6 @@ describe('WorkshopForm test', () => {
     // defaults to first session format option
     expect(sessionFormatDropdown.props().value).to.equal(
       PdSessionFormats[0].value
-    );
-  });
-
-  it("new workshop sessions are created with the user's local timezone", () => {
-    const easternTz = 'America/New_York';
-    jest
-      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
-      .mockReturnValueOnce({
-        timeZone: easternTz,
-      });
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([WorkshopAdmin])}
-            facilitatorCourses={[]}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const tzAbbreviation = moment.tz(easternTz).format('z');
-
-    expect(wrapper.find('WorkshopForm').find('Col').first().text()).to.equal(
-      `All workshop times are ${tzAbbreviation}:`
-    );
-  });
-
-  it('edits to workshop sessions are done in the original timezone', () => {
-    const easternTz = 'America/New_York';
-    jest
-      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
-      .mockReturnValueOnce({
-        timeZone: easternTz,
-      });
-
-    const workshop = Factory.build('workshop');
-    const [firstSession] = workshop.sessions;
-    const sessionTz = firstSession.time_zone; // America/Denver in workshop factory
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([WorkshopAdmin])}
-            facilitatorCourses={[]}
-            workshop={workshop}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const tzAbbreviation = moment.tz(sessionTz).format('z');
-
-    const workshopForm = wrapper.find('WorkshopForm');
-
-    const [formattedSessionData] = workshopForm
-      .instance()
-      .prepareSessionsForForm(workshop.sessions);
-
-    expect(formattedSessionData.startTime).to.equal('9:00am');
-    expect(formattedSessionData.endTime).to.equal('5:00pm');
-    expect(formattedSessionData.date).to.equal('2016-07-01');
-
-    expect(workshopForm.find('Col').first().text()).to.equal(
-      `All workshop times are ${tzAbbreviation}:`
-    );
-  });
-
-  it('edits to legacy workshop sessions without a timezone are done in UTC', () => {
-    const easternTz = 'America/New_York';
-    jest
-      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
-      .mockReturnValueOnce({
-        timeZone: easternTz,
-      });
-
-    const workshop = Factory.build('workshop');
-    const [firstSession] = workshop.sessions;
-    // remove time_zone and reset session time to 9-5 utc, like legacy sessions are in the db
-    firstSession.time_zone = null;
-    const start = new Date(firstSession.start);
-    const end = new Date(firstSession.end);
-    start.setHours(9);
-    end.setHours(17);
-    firstSession.start = start.toISOString();
-    firstSession.end = end.toISOString();
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([WorkshopAdmin])}
-            facilitatorCourses={[]}
-            workshop={workshop}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const tzAbbreviation = 'UTC';
-
-    const workshopForm = wrapper.find('WorkshopForm');
-
-    const [formattedSessionData] = workshopForm
-      .instance()
-      .prepareSessionsForForm(workshop.sessions);
-
-    expect(formattedSessionData.startTime).to.equal('9:00am');
-    expect(formattedSessionData.endTime).to.equal('5:00pm');
-    expect(formattedSessionData.date).to.equal('2016-07-01');
-
-    expect(workshopForm.find('Col').first().text()).to.equal(
-      `All workshop times are ${tzAbbreviation}:`
     );
   });
 

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
@@ -12,8 +12,7 @@ import {
  */
 
 // For testing average middle of the year dates.
-const middleOfYearFakeToday = new Date(2016, 6, 1, 15); // July 1st, 2016
-const middleOfYearFakeTodayEnd = new Date(2016, 6, 1, 23); // July 1st, 2016
+const middleOfYearFakeToday = new Date(2016, 6, 1); // July 1st, 2016
 // For testing cases when wrapping around from December of one year to January of the next.
 const endOfYearFakeToday = new Date(2016, 12, 30); // December 30th, 2016
 
@@ -114,8 +113,7 @@ Factory.define('session')
   .sequence('id')
   .attr('code', 'TEST')
   .attr('start', middleOfYearFakeToday.toISOString())
-  .attr('end', middleOfYearFakeTodayEnd.toISOString())
-  .attr('time_zone', 'America/Denver')
+  .attr('end', middleOfYearFakeToday.toISOString())
   .attr('attendance_count', 0)
   .attr('session_format', PdSessionFormats[0].value)
   .attr('show_link?', false);

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -10303,7 +10303,6 @@ __metadata:
     mocha: ^10.6.0
     mock-firmata: 0.2.0
     moment: ^2.29.4
-    moment-timezone: ^0.5.47
     object-fit-images: ^3.2.3
     papaparse: ^5.4.1
     path-browserify: ^1.0.1
@@ -20868,15 +20867,6 @@ es6-shim@latest:
   dependencies:
     board-io: ^3.0.5
   checksum: b6b95409b02f3e4d2248d34e80b1175870f6bfb34f4bd3764c31fef6e40915a1c5c7452d8fbd84731015721053ed37745953cc3601a377f1a100050a5332d103
-  languageName: node
-  linkType: hard
-
-"moment-timezone@npm:^0.5.47":
-  version: 0.5.47
-  resolution: "moment-timezone@npm:0.5.47"
-  dependencies:
-    moment: ^2.29.4
-  checksum: 6288a9d653b902bd913f1dca24426ad71e5a98cd98684139e3ed74e635289e6acde62450735364fd3758d6ac836a1eaab859c08d0252587a377192f25f0bda5a
   languageName: node
   linkType: hard
 

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -345,7 +345,7 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
       :virtual,
       :suppress_email,
       :third_party_provider,
-      {sessions_attributes: [:id, :start, :end, :time_zone, :session_format, :_destroy]},
+      {sessions_attributes: [:id, :start, :end, :session_format, :_destroy]},
       :module,
       :participant_group_type
     ]

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -30,17 +30,13 @@ class Pd::Session < ApplicationRecord
   belongs_to :workshop, class_name: 'Pd::Workshop', foreign_key: 'pd_workshop_id', optional: true
   has_many :attendances, class_name: 'Pd::Attendance', foreign_key: 'pd_session_id', dependent: :destroy
 
-  before_validation :set_default_time_zone
-
-  before_update :prevent_time_zone_change
-
   validates_presence_of :start, :end
   validate :starts_and_ends_on_the_same_day
   validate :starts_before_ends
 
   def starts_and_ends_on_the_same_day
     return unless start && self.end
-    unless start_time.to_date == end_time.to_date
+    unless start.to_datetime.to_date == self.end.to_datetime.to_date
       errors.add(:end, 'must occur on the same day as the start.')
     end
   end
@@ -52,38 +48,15 @@ class Pd::Session < ApplicationRecord
     end
   end
 
-  def set_default_time_zone
-    self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : 'UTC'
-  end
-
-  def prevent_time_zone_change
-    if time_zone_changed?
-      self.time_zone = time_zone_was # Revert to the original time_zone
-    end
-  end
-
-  def start_time
-    start.in_time_zone(time_zone || 'UTC')
-  end
-
-  def end_time
-    self.end.in_time_zone(time_zone || 'UTC')
-  end
-
   def formatted_date
-    start_time.to_date.iso8601
-  end
-
-  def tz_abbreviation
-    return '' if time_zone.blank?
-    ActiveSupport::TimeZone[time_zone].tzinfo.current_period.abbreviation.to_s
+    start.to_date.iso8601
   end
 
   def formatted_date_with_start_and_end_times
-    formatted_start = start_time.strftime('%l:%M%P').strip
-    formatted_end = end_time.strftime('%l:%M%P').strip
+    start_time = start.strftime('%l:%M%P').strip
+    end_time = self.end.strftime('%l:%M%P').strip
 
-    "#{formatted_date}, #{formatted_start}-#{formatted_end} #{tz_abbreviation}".strip
+    "#{formatted_date}, #{start_time}-#{end_time}"
   end
 
   def session_info_for_calendar
@@ -95,14 +68,14 @@ class Pd::Session < ApplicationRecord
   end
 
   def start_date_us_format
-    start_time.strftime('%b %d %Y').strip
+    start.strftime('%b %d %Y').strip
   end
 
   def start_date_with_start_and_end_times_us_format
-    formatted_start = start_time.strftime('%l:%M%P').strip
-    formatted_end = end_time.strftime('%l:%M%P').strip
+    start_time = start.strftime('%l:%M%P').strip
+    end_time = self.end.strftime('%l:%M%P').strip
 
-    "#{start_date_us_format}, #{formatted_start} - #{formatted_end} #{tz_abbreviation}".strip
+    "#{start_date_us_format}, #{start_time} - #{end_time}"
   end
 
   def hours

--- a/dashboard/app/serializers/api/v1/pd/session_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/session_serializer.rb
@@ -15,7 +15,7 @@
 #
 
 class Api::V1::Pd::SessionSerializer < ActiveModel::Serializer
-  attributes :id, :start, :end, :time_zone, :code, :session_format, :show_link?, :attendance_count
+  attributes :id, :start, :end, :code, :session_format, :show_link?, :attendance_count
 
   def attendance_count
     Pd::Attendance.where(session: object).count

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -22,19 +22,6 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert_equal 'End must occur after the start.', session.errors.full_messages[0]
   end
 
-  test 'prevent_time_zone_change' do
-    session = create(:pd_session, time_zone: 'America/Denver')
-    assert_equal 'America/Denver', session.time_zone
-
-    session.update!(time_zone: 'America/New_York')
-    assert_equal 'America/Denver', session.time_zone
-  end
-
-  test 'bad time_zone value results in UTC' do
-    session = create(:pd_session, time_zone: 'Bad/Zone')
-    assert_equal 'UTC', session.time_zone
-  end
-
   test 'formatted_date' do
     session = build :pd_session, start: DateTime.new(2016, 3, 1, 9).in_time_zone
     assert_equal '2016-03-01', session.formatted_date
@@ -43,26 +30,9 @@ class Pd::SessionTest < ActiveSupport::TestCase
   test 'formatted_date_with_start_and_end_times' do
     session = create(
       :pd_session,
-      time_zone: 'America/Denver',
-      start: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 9).utc.iso8601,
-      end: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
+      start: DateTime.new(2016, 3, 1, 9).in_time_zone,
+      end: DateTime.new(2016, 3, 1, 17).in_time_zone
     )
-
-    assert_equal '2016-03-01, 9:00am-5:00pm MST', session.formatted_date_with_start_and_end_times
-  end
-
-  test 'formatted_date_with_start_and_end_times no time_zone' do
-    session = create(
-      :pd_session,
-      start: Time.current.in_time_zone('UTC').change(year: 2016, month: 3, day: 1, hour: 9).utc.iso8601,
-      end: Time.current.in_time_zone('UTC').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
-    )
-
-    assert_equal 'UTC', session.time_zone
-
-    # override validation on create that defaults new sessions to UTC timezone if not provided
-    # to reproduce a legacy session with no time_zone
-    session.time_zone = nil
 
     assert_equal '2016-03-01, 9:00am-5:00pm', session.formatted_date_with_start_and_end_times
   end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#63598