### PR TITLE
fix(marketing): enable lfs for checkout

### DIFF
--- a/.github/workflows/marketing-app-cicd.yml
+++ b/.github/workflows/marketing-app-cicd.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: 'frontend'
+          lfs: true
 
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry


### PR DESCRIPTION
Images in Github Actions are marked as LFS. Therefore, enable LFS checkout.

Tested [here](https://github.com/code-dot-org/code-dot-org/actions/runs/13268063498/job/37040473261)