### PR TITLE
Update backpack API due to recent Backpack model update

### DIFF
--- a/apps/src/code-studio/components/backpack/BackpackClientApi.js
+++ b/apps/src/code-studio/components/backpack/BackpackClientApi.js
@@ -3,8 +3,9 @@ import clientApi from '@cdo/apps/code-studio/initApp/clientApi';
 const REQUEST_RETRY_COUNT = 1;
 
 export default class BackpackClientApi {
-  constructor(channelId) {
+  constructor(appType, channelId) {
     this.backpackApi = clientApi.create('/v3/libraries');
+    this.appType = appType;
     this.channelId = channelId;
     this.uploadingFiles = false;
     this.fileUploadsInProgress = [];
@@ -19,7 +20,7 @@ export default class BackpackClientApi {
 
   fetchChannelId(callback) {
     $.ajax({
-      url: '/backpacks/channel',
+      url: `/backpacks/channel/${this.appType}`,
       type: 'get',
     }).done(response => {
       this.channelId = response.channel;

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -313,7 +313,7 @@ Javalab.prototype.init = function (config) {
 
   let backpackApi = null;
   if (backpackEnabled) {
-    backpackApi = new BackpackClientApi(config.backpackChannel);
+    backpackApi = new BackpackClientApi('javalab', config.backpackChannel);
   }
 
   // Used for some post requests made in Javalab, namely

--- a/apps/test/unit/code-studio/components/backpack/BackpackClientApiTest.js
+++ b/apps/test/unit/code-studio/components/backpack/BackpackClientApiTest.js
@@ -6,6 +6,7 @@ import {assert, expect} from '../../../../util/reconfiguredChai'; // eslint-disa
 
 describe('BackpackClientApi', () => {
   const channelId = 'fake_channel_id';
+  const appType = 'javalab';
   const sampleFileJson = {
     'test.java': {text: 'hello'},
     'test2.java': {text: 'hello'},
@@ -36,7 +37,7 @@ describe('BackpackClientApi', () => {
   describe('with provided channel id', () => {
     beforeEach(() => {
       server = sinon.fakeServer.create();
-      backpackClientApi = new BackpackClientApi(channelId);
+      backpackClientApi = new BackpackClientApi(appType, channelId);
       fetchChannelIdStub = sinon.stub(backpackClientApi, 'fetchChannelId');
       errorCallback = sinon.fake();
       successCallback = sinon.fake();
@@ -122,7 +123,7 @@ describe('BackpackClientApi', () => {
   describe('without provided channel id', () => {
     beforeEach(() => {
       server = sinon.fakeServer.create();
-      backpackClientApi = new BackpackClientApi();
+      backpackClientApi = new BackpackClientApi(appType);
       fetchChannelIdStub = sinon.stub(backpackClientApi, 'fetchChannelId');
       errorCallback = sinon.fake();
       successCallback = sinon.fake();

--- a/dashboard/app/controllers/backpacks_controller.rb
+++ b/dashboard/app/controllers/backpacks_controller.rb
@@ -1,11 +1,15 @@
 class BackpacksController < ApplicationController
   before_action :authenticate_user!
 
-  # GET /backpacks/channel
-  # Return the channel token for the backpack of the current user. If
-  # the current user does not have a backpack, create one.
+  # GET /backpacks/channel/:app_type
+  # Return the channel token for the backpack of the current user with the given app_type. If
+  # the current user does not have a backpack for the app_type, create one.
   def get_channel
-    backpack = Backpack.find_or_create(current_user.id, request.ip)
+    app_type = params[:app_type].capitalize
+    game_id = Game.by_name(app_type)
+    raise ActiveRecord::RecordNotFound, "Game not found for app_type name: #{app_type}" unless game_id
+
+    backpack = Backpack.find_or_create(current_user.id, game_id, request.ip)
     render json: {channel: backpack.channel}
   end
 end

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -261,8 +261,10 @@ module LevelsHelper
     view_options(backpack_enabled: backpack_enabled)
 
     if backpack_enabled
+      # Backpack is used in lab2 apps also but app_options is only used by legacy labs, i.e., Javalab.
+      game_id = Game.by_name('Javalab')
       user_id = @user&.id || current_user&.id
-      backpack = Backpack.find_by_user_id(user_id)
+      backpack = Backpack.find_by(user_id: user_id, game_id: game_id)
       view_options(backpack_channel: backpack&.channel)
     end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -253,7 +253,8 @@ module LevelsHelper
     )
 
     # Enable backpack for levels with a backpack option (currently all non-standalone Javalab),
-    # and get the backpack channel token if it exists
+    # and get the backpack channel token if it exists.
+    # Backpack is used in lab2 apps also but app_options is only used by legacy labs.
     backpack_enabled = !!(@level.is_a?(Javalab) &&
       (ProjectsController::STANDALONE_PROJECTS["javalab"]["name"] != @level.name) &&
       (@user || current_user))
@@ -261,10 +262,8 @@ module LevelsHelper
     view_options(backpack_enabled: backpack_enabled)
 
     if backpack_enabled
-      # Backpack is used in lab2 apps also but app_options is only used by legacy labs, i.e., Javalab.
-      game_id = Game.by_name('Javalab')
       user_id = @user&.id || current_user&.id
-      backpack = Backpack.find_by(user_id: user_id, game_id: game_id)
+      backpack = Backpack.find_by(user_id: user_id, game_id: @level.game_id)
       view_options(backpack_channel: backpack&.channel)
     end
 

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -25,7 +25,7 @@ class Backpack < ApplicationRecord
   def self.find_or_create(user_id, game_id, ip)
     backpack = find_by(user_id: user_id, game_id: game_id)
     unless backpack
-      # Create a project for this user's backpack in the app_type ('Javalab' or 'Pythonlab') determined by game_id
+      # Create a project for this user's backpack in the app determined by game_id
       project = Projects.new(storage_id_for_user_id(user_id))
       encrypted_id = project.create({hidden: true}, ip: ip, type: 'backpack')
       _, project_id = storage_decrypt_channel_id(encrypted_id)

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -16,19 +16,20 @@
 #
 class Backpack < ApplicationRecord
   belongs_to :user, optional: true
+  belongs_to :game, optional: true
 
   # The projects table used to be named storage_apps. This column has not been renamed
   # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
   alias_attribute :project_id, :storage_app_id
 
-  def self.find_or_create(user_id, ip)
-    backpack = find_by_user_id(user_id)
+  def self.find_or_create(user_id, game_id, ip)
+    backpack = find_by(user_id: user_id, game_id: game_id)
     unless backpack
-      # Create a project for this user's backpack
+      # Create a project for this user's backpack in the app_type ('Javalab' or 'Pythonlab') determined by game_id
       project = Projects.new(storage_id_for_user_id(user_id))
       encrypted_id = project.create({hidden: true}, ip: ip, type: 'backpack')
       _, project_id = storage_decrypt_channel_id(encrypted_id)
-      backpack = create!(user_id: user_id, project_id: project_id)
+      backpack = create!(user_id: user_id, game_id: game_id, project_id: project_id)
     end
     backpack
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1186,7 +1186,7 @@ Dashboard::Application.routes.draw do
       end
     end
 
-    get '/backpacks/channel', to: 'backpacks#get_channel'
+    get '/backpacks/channel/:app_type', to: 'backpacks#get_channel'
 
     resources :project_commits, only: [:create]
     get 'project_commits/get_token', to: 'project_commits#get_token'

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -4,19 +4,20 @@ class BackpacksControllerTest < ActionController::TestCase
   setup_all do
     @user = create :user
     @storage_id = fake_storage_id_for_user_id(@user.id)
+    @game_id = 68
   end
 
-  test_redirect_to_sign_in_for :get_channel
+  test_redirect_to_sign_in_for :get_channel, params: {app_type: "javalab"}
 
   test 'get_channel creates backpack if one does not exist' do
     sign_in @user
     Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     Backpack.any_instance.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
 
-    assert_nil Backpack.find_by_user_id(@user.id)
-    response = get :get_channel
+    assert_nil Backpack.find_by(user_id: @user.id, game_id: @game_id)
+    response = get :get_channel, params: {app_type: "javalab"}
     assert_response :success
-    refute_nil Backpack.find_by_user_id(@user.id)
+    refute_nil Backpack.find_by(user_id: @user.id, game_id: @game_id)
     body = JSON.parse(response.body)
     channel = body['channel']
     storage_id, project_id = storage_decrypt_channel_id(channel)
@@ -29,11 +30,11 @@ class BackpacksControllerTest < ActionController::TestCase
     Backpack.any_instance.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
 
     assert_nil Backpack.find_by_user_id(@user.id)
-    get :get_channel
-    first_backpack = Backpack.find_by_user_id(@user.id)
+    get :get_channel, params: {app_type: "javalab"}
+    first_backpack = Backpack.find_by(user_id: @user.id, game_id: @game_id)
     assert_response :success
-    get :get_channel
-    second_backpack = Backpack.find_by_user_id(@user.id)
+    get :get_channel, params: {app_type: "javalab"}
+    second_backpack = Backpack.find_by(user_id: @user.id, game_id: @game_id)
     assert_equal(first_backpack.project_id, second_backpack.project_id)
   end
 end

--- a/dashboard/test/models/backpack_test.rb
+++ b/dashboard/test/models/backpack_test.rb
@@ -9,28 +9,30 @@ class BackpackTest < ActiveSupport::TestCase
   setup_all do
     @user = create :user
     @storage_id = fake_storage_id_for_user_id(@user.id)
+    @game_id = 68
   end
 
   test 'find_or_create creates project if backpack does not exist' do
     Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
-    backpack = Backpack.find_or_create(@user.id, 'fake-ip')
+    backpack = Backpack.find_or_create(@user.id, @game_id, 'fake-ip')
     assert backpack.project_id > 0
     assert_equal @user.id, backpack.user_id
+    assert_equal @game_id, backpack.game_id
   end
 
   # projects with value hidden are hidden from a user's projects list
   test 'project that is created has value hidden = true' do
     Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     Backpack.any_instance.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
-    backpack = Backpack.find_or_create(@user.id, 'fake-ip')
+    backpack = Backpack.find_or_create(@user.id, @game_id, 'fake-ip')
     project = Projects.new(@storage_id).get(backpack.channel)
     assert project["hidden"]
   end
 
   test 'find_or_create returns existing backpack if it exists' do
     Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
-    backpack = Backpack.find_or_create(@user.id, 'fake-ip')
-    backpack2 = Backpack.find_or_create(@user.id, 'fake-ip')
+    backpack = Backpack.find_or_create(@user.id, @game_id, 'fake-ip')
+    backpack2 = Backpack.find_or_create(@user.id, @game_id, 'fake-ip')
     assert_equal(backpack, backpack2)
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR follows up a change in the `Backpack` model https://github.com/code-dot-org/code-dot-org/pull/63832 and includes:
- adding the association between the `Backpack` and `Game` models,
- an update to GET '/backpacks/channel' route to include an `app_type` param,
- update to `get_channel` in `backpack_controller` so that `app_type` is passed as a param and the channel id of the backpack for a given user and app type is returned along with corresponding changes in `backpack.rb`,
- small update to `levels_helper` to population backpack channel in `app_options`,
- on the frontend, updating `BackpackClientApi` so that `appType` is an instance variable and passed when fetching the channel id of the backpack,


## Links
[jira](https://codedotorg.atlassian.net/browse/CT-1041)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I updated unit tests in `BackpackClientApiTest.js`, in `backpacks_controller_test.rb`, and `backpack_test.rb`.
Locally:
- On a teacher account, I confirmed that I could add files to and delete files from the backpack.
- On a student account that previously didn't access the backpack yet, I confirmed that the backpack was added, and that I could add to and delete files from backpack.
- Confirmed that in the 'Backpacks' table, the two backpacks were stored as expected.
<img width="775" alt="Screenshot 2025-02-11 at 12 30 45 PM" src="https://github.com/user-attachments/assets/30c3afd0-dc45-4933-8d8f-2790f2c1ea5f" />


- Confirmed that `backpackChannel` was assigned in `appOptions` on the frontend.
<img width="399" alt="Screenshot 2025-02-12 at 7 29 52 AM" src="https://github.com/user-attachments/assets/0a62d09c-5f5d-4f55-b9d7-58e92f9316a0" />


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
- Move backpack-related files out of `javalab` directory
- Add `BackpackAPIContext` to `Codebridge.tsx`.
- Add frontend UI/functionality so that users can add files to and delete files from backpack in `pythonlab`.

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
