### PR TITLE
Fix i18n build error when uncommitted changes

### DIFF
--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -20,16 +20,19 @@ HOME=/home/ubuntu
 
 # Run a CI Build to update the server from staging. We do this primarily to
 # make sure the server gets seeded with latest level content for the sync in.
+# - Scheduled for 4:00 AM PST (7:00 AM EST); run aproximately 4 hours after levelbuilder
+#   changes are committed to staging.
+# - Run it every day except Monday. So we don't conflict with the sync if it fails
+#   to commit changes, and we spend Monday verifiying the results of the full sync.
 # Note that the CI_ONLY_BUILD environment variable is necessary; the server is
 # not set up to actually serve a version of the website, and it will fail to
 # build correctly if not thus restricted.
-0 */4 * * * bash -l -c "cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1"
+0 12 * * SUN,TUE-SAT bash -l -c "cd /home/ubuntu/code-dot-org && git checkout -- . && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1 && git checkout -- ."
 
 # Run the I18n Sync!
-# Sync is scheduled for 12:30 AM PST every Monday; run around midnight so the
-# sync is hopefully finished by start of day on Monday, offset by 30 minutes so
-# we don't conflict with the ci_build which runs on the hour.
-30 8 * * MON bash -l -c "(cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1"
+# Sync is scheduled for 12:00 AM PST (3:00 AM EST) every Monday; run at midnight so the
+# sync is finished by start of day on Monday.
+0 8 * * MON bash -l -c "(cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1"
 
 # Run the sync down periodically throughout the week. Specifically:
 # - Run it every 4 hours. This is a somewhat arbitrarily-chosen frequency


### PR DESCRIPTION
## What:
This PR edits the i18n cronjobs in two ways:
1. Updating the cadence of cronjobs to once a day, TUE-SUN, at 4:00 AM PST (7:00 AM EST)
-  The build cronjob was running every 4 hours. The last time this cronjob frequency was edited was in 2020 when the i18n-dev server crontab was saved in [PR #35436](https://github.com/code-dot-org/code-dot-org/pull/35436).
- The purpose of building the i18n-server is to keep the database seeded with the latest level content, however, the content scoop happens automatically once a day. We would only need to seed the database once a day after Merging levelbuilder to staging (12:35 AM PT, Weekdays).
- The proposed cadence is, daily (except Mondays since the sync is executed), after the content scoop, before the start of the EST work day.
2. Move the i18n sync 30 minutes earlier.
- The original 30-minute offset was so a sync did not start at the same time as a build process, but now they are scheduled for different days.

## Why:
The build fails when the i18n-dev server has uncommitted changes in the current branch.
These are typically changes to the database schema, and we want to discard them before pulling the latest staging branch.
We need to automatically discard any changes in the i18n-dev server before starting the build process.

## Links

- jira ticket: [P20-1415](https://codedotorg.atlassian.net/browse/P20-1415)

## Deployment strategy

When this PR gets approved, I will manually update the `i18n-dev` crontab

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
