### PR TITLE
Handle if temperature is provided as string to `gpt-4o-mini`

### DIFF
--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -17,7 +17,7 @@ module AichatOpenaiHelper
 
     request_chat_completion(
       messages,
-      aichat_model_customizations['temperature']
+      aichat_model_customizations['temperature'].to_f
     )
   end
 


### PR DESCRIPTION
We had a bug where levels are sometimes configured with a string as the temperature. Handle this edge case as a fallback.

Slack thread where this issue was observed: https://codedotorg.slack.com/archives/C06FELVTV0Q/p1739215780623479