### PR TITLE
Show workshop name as the enroll form title if available

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
@@ -46,7 +46,9 @@ export default class WorkshopEnroll extends React.Component {
   constructor(props) {
     super(props);
 
-    const workshopTitle = props.workshop.name ?? `a ${props.workshop.course}`;
+    const workshopTitle = props.workshop.name
+      ? props.workshop.name
+      : `a ${props.workshop.course}`;
     let workshopEnrollTitle = `Register for ${workshopTitle}`;
     if (!workshopTitle.toLowerCase().endsWith('workshop')) {
       workshopEnrollTitle += ' workshop';

--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
@@ -46,7 +46,14 @@ export default class WorkshopEnroll extends React.Component {
   constructor(props) {
     super(props);
 
+    const workshopTitle = props.workshop.name ?? `a ${props.workshop.course}`;
+    let workshopEnrollTitle = `Register for ${workshopTitle}`;
+    if (!workshopTitle.toLowerCase().endsWith('workshop')) {
+      workshopEnrollTitle += ' workshop';
+    }
+
     this.state = {
+      workshopEnrollTitle: workshopEnrollTitle,
       workshopEnrollmentStatus:
         this.props.workshop_enrollment_status ||
         SUBMISSION_STATUSES.UNSUBMITTED,
@@ -174,7 +181,7 @@ export default class WorkshopEnroll extends React.Component {
       default:
         return (
           <div>
-            <h1>{`Register for a ${this.props.workshop.course} workshop`}</h1>
+            <h1>{this.state.workshopEnrollTitle}</h1>
             <p>
               Taught by Code.org facilitators who are experienced computer
               science educators, our workshops will prepare you to teach the


### PR DESCRIPTION
Shows the workshop name if available as the enroll form title.

### Shows the workshop name when available
![NAME](https://github.com/user-attachments/assets/5fe435de-5c3b-44f3-a53e-cb52288562f2)

### Still shows the workshop course name if it has no  name
![CSF no name](https://github.com/user-attachments/assets/6216edb6-afdc-433e-addc-43a75e69b78e)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3097)

## Testing story
Local testing.
