### PR TITLE
Reorder when we log attendance

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
@@ -134,15 +134,15 @@ export class SessionAttendance extends React.Component {
       this.setState({
         attendance: clonedAttendance,
       });
-
-      if (value.attended) {
-        analyticsReporter.sendEvent(EVENTS.WORKSHOP_ATTENDANCE_MARKED_EVENT, {
-          user_logged_own_attendance: false,
-          session_id: this.props.sessionId,
-        });
-      }
     }
     this.props.onSaved(value);
+
+    if (!value.error && value.attended) {
+      analyticsReporter.sendEvent(EVENTS.WORKSHOP_ATTENDANCE_MARKED_EVENT, {
+        user_logged_own_attendance: false,
+        session_id: this.props.sessionId,
+      });
+    }
   };
 
   render() {


### PR DESCRIPTION
[Sam noticed](https://codedotorg.slack.com/archives/C04540KNGDQ/p1739293502495819) a teacher hitting an issue recently where when they tried to edit the attendance, it would cause a bunch of them to change unexpectedly. I was able to repro this issue on this workshop, but when looking at other workshops didn't see this issue. On the workshop that wasn't working, I was noticing an Amplitude error I didn't recognize:
![amp error](https://github.com/user-attachments/assets/a5bbe031-8355-47c3-979d-d8c8a7f7a29e)

I checked on the Amplitude site and confirmed this event was being logged on production, so it wasn't happening to all logs of the event.

Since I recently merged [this PR](https://github.com/code-dot-org/code-dot-org/pull/63673) that added logging to marking attendance, I figured it was related. My guess is that the Amplitude logging is causing an error, then it's not able to call [the `onSaved` function](https://github.com/code-dot-org/code-dot-org/pull/63870/files#diff-3367615e2befb117221165342f07905e1da2e051aecaf363102a32193717680bL145) after since an error is thrown, leading to the attendance object being in an inaccurate state.

This tentative fix switches the order so the `onSaved` function is called no matter what before we try to log. We'll then see if any other teachers report this issue or if the same teacher still has the issue once it's merged.

## Links
Slack thread discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1739293502495819)