### PR TITLE
Lazy load i18n in development environment

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -376,13 +376,6 @@ If you want to make JavaScript changes and have them take effect locally, you'll
 
 This configures dashboard to rebuild apps whenever you run `bundle exec rake build` and to use the version that you built yourself.  See the documentation in that directory for faster ways to build and iterate.
 
-## Enabling internationalization(i18n) / translations
-If you want to enable the ability to switch Code.org to display different languages:
-1. Edit `locals.yml` and enable the following options:
-   ```
-   # code-dot-org/locals.yml
-   load_locales: true
-   ```
 ## Editor configuration
 
 We enforce linting rules for all our code, and we recommend you set up your editor to integrate with that linting.

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -390,9 +390,6 @@ optimize_rails_assets: true
 # Allows your local server to lazy load locales.
 lazy_load_i18n: false
 
-# (Deprecated: use +lazy_load_i18n+ config instead)
-load_locales:
-
 # Whether to skip the slow `rake seed:all` command during `rake build`.
 # Until you manually run `rake seed:all` or disable this flag, you won't
 # see changes to: videos, concepts, levels, scripts, trophies, prize providers,

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -387,10 +387,10 @@ optimize_webpack_assets: true
 
 optimize_rails_assets: true
 
-# Allows your local server to render non-English locales, defaults to false in development.
-# If false, choosing a locale other than English will have no effect.
-# Note: You may need to be in an incognito window to see changes
-# due to a difference in the language cookie between production and localhost.
+# Allows your local server to lazy load locales.
+lazy_load_i18n: false
+
+# (Deprecated: use +lazy_load_i18n+ config instead)
 load_locales:
 
 # Whether to skip the slow `rake seed:all` command during `rake build`.

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -387,7 +387,8 @@ optimize_webpack_assets: true
 
 optimize_rails_assets: true
 
-# Allows your local server to lazy load locales.
+# Improves local environment load time by loading only the i18n data for the current locale.
+# Note: Not intended for production use.
 lazy_load_i18n: false
 
 # Whether to skip the slow `rake seed:all` command during `rake build`.

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -82,3 +82,6 @@ active_job_queue_adapter: :async
 # Number of workers to start when running `rake build:start_active_job_workers`:
 active_job_backend_n_workers_to_start: 2
 active_job_backend_rolling_restart_in_n_batches: 1
+
+# Enables I18n lazy loading
+lazy_load_i18n: true

--- a/dashboard/config/initializers/fast_localization.rb
+++ b/dashboard/config/initializers/fast_localization.rb
@@ -1,12 +1,3 @@
-# Because loading YAML locales is super-slow, only load english yml locale files in development
-# To load all locales for testing, add "load_locales: true" to locals.yml config
-
-if (CDO.skip_locales || Rails.env.development?) && !CDO.load_locales
-  Dashboard::Application.config.i18n.railties_load_path.each do |path|
-    path.glob = "*{es-ES,en}.yml"
-  end
-end
-
 # Preload translations (before application fork, after i18n_railtie initializer)
 Dashboard::Application.config.after_initialize do |_|
   unless ENV['SKIP_I18N_INIT']

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -51,16 +51,10 @@ module Cdo
     end
 
     def i18n_backend
-      @i18n_backend ||= begin
+      @i18n_backend ||=
         # Because loading i18n files is super-slow, lazy load them in development.
         # To load all locales for testing, add "lazy_load_i18n: false" to +locals.yml+ config
-        lazy_load_i18n = CDO.lazy_load_i18n
-
-        # Uses deprecated configurations to determine if i18n were set to be fully loaded to disable the lazy loading.
-        lazy_load_i18n = !CDO.load_locales if lazy_load_i18n.nil? && (CDO.skip_locales || CDO.rack_env?(:development))
-
-        lazy_load_i18n ? Cdo::I18n::LazyLoadableBackend.new(lazy_load: true) : Cdo::I18n::SimpleBackend.new
-      end
+        CDO.lazy_load_i18n ? Cdo::I18n::LazyLoadableBackend.new(lazy_load: true) : Cdo::I18n::SimpleBackend.new
     end
 
     def canonical_hostname(domain)

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -51,7 +51,16 @@ module Cdo
     end
 
     def i18n_backend
-      CDO_I18N_BACKEND
+      @i18n_backend ||= begin
+        # Because loading i18n files is super-slow, lazy load them in development.
+        # To load all locales for testing, add "lazy_load_i18n: false" to +locals.yml+ config
+        lazy_load_i18n = CDO.lazy_load_i18n
+
+        # Uses deprecated configurations to determine if i18n were set to be fully loaded to disable the lazy loading.
+        lazy_load_i18n = !CDO.load_locales if lazy_load_i18n.nil? && (CDO.skip_locales || CDO.rack_env?(:development))
+
+        lazy_load_i18n ? Cdo::I18n::LazyLoadableBackend.new(lazy_load: true) : Cdo::I18n::SimpleBackend.new
+      end
     end
 
     def canonical_hostname(domain)

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -277,5 +277,3 @@ module Cdo
     end
   end
 end
-
-CDO_I18N_BACKEND = Cdo::I18n::SimpleBackend.new

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -37,11 +37,12 @@ build_apps: true
 # If false, dashboard will try to use a prepackaged version from S3.
 use_my_apps: true
 
-# Allows your local server to render non-English locales, defaults to false.
-# If false, choosing a locale other than English will have no effect.
-# Note: You may need to be in an incognito window to see changes
-# due to a difference in the language cookie between production and localhost.
-#load_locales: true
+
+# Allows your local server to lazy load locales, defaults to true.
+# Note: You may need to be in an incognito window to see changes,
+#       as once the `language_` cookie is set in production (HTTPS),
+#       it becomes "Secure" and can't be rewritten in a local (HTTP) environment.
+#lazy_load_i18n: true
 
 
 # Whether to skip the slow `rake seed:all` command during `rake build`.

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -38,7 +38,8 @@ build_apps: true
 use_my_apps: true
 
 
-# Improves Rails server load time by delaying the loading of i18n files until the locale is changed; defaults to true.
+# Improves local environment load time by loading only the i18n data for the current locale.
+# Defaults to `true` in the development environment.
 # Note: You may need to be in an incognito window to see changes,
 #       as once the `language_` cookie is set in production (HTTPS),
 #       it becomes "Secure" and can't be rewritten in a local (HTTP) environment.

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -38,7 +38,7 @@ build_apps: true
 use_my_apps: true
 
 
-# Allows your local server to lazy load locales, defaults to true.
+# Improves Rails server load time by delaying the loading of i18n files until the locale is changed; defaults to true.
 # Note: You may need to be in an incognito window to see changes,
 #       as once the `language_` cookie is set in production (HTTPS),
 #       it becomes "Secure" and can't be rewritten in a local (HTTP) environment.

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -49,21 +49,8 @@ def load_pegasus_settings
   I18n.backend = CDO.i18n_backend
   I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
   I18n.fallbacks = I18n::Locale::Fallbacks.new(['en-US'])
-
-  # We don't load all translations in dev and test environment.
-  # Loading translations from files is slow, more than 60s sometimes. That can
-  # cause unrelated eyes tests to fail because of command timeout.
-  if rack_env?(:development) && !CDO.load_locales
-    I18n.load_path += Dir[cache_dir('i18n/en-US.json')]
-    I18n.load_path += Dir[cache_dir('i18n/es-ES.json')]
-    I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
-    I18n.load_path += Dir[hoc_dir('i18n/es.yml')]
-    I18n.load_path += Dir[hoc_dir('i18n/fr.yml')]
-    I18n.load_path += Dir[hoc_dir('i18n/pt.yml')]
-  else
-    I18n.load_path += Dir[cache_dir('i18n/*.json')]
-    I18n.load_path += Dir[hoc_dir('i18n/*.yml')]
-  end
+  I18n.load_path += Dir[cache_dir('i18n/*.json')]
+  I18n.load_path += Dir[hoc_dir('i18n/*.yml')]
   I18n.enforce_available_locales = false
   I18n.backend.load_translations
 end


### PR DESCRIPTION
## Issue
The Rails server takes several minutes to load due to the time spent loading i18n files during startup or when changes occur.

## Solution
Implement i18n lazy loading in the development environment. This ensures that the server initially loads only the default `en` locale at startup and dynamically loads additional locales when they are needed. This approach can make the server start up approximately three times faster.

## Rails server benchmark results:
| Desc  | Config | Load time |
| ------ | ------ | ---------- |
| With all locales loaded  | `load_locales: true` | 69 seconds |
| With `en` and `es` locales loaded  | `load_locales: false` | 24 seconds |
| With I18n lazy loading enabled  | `lazy_load_i18n: true` | 26 seconds |

## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/57661
