### PR TITLE
Disable applab_project failing scenario

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
@@ -95,7 +95,9 @@ Scenario: Save Project After Signing Out
   And I ensure droplet is in text mode
   Then ace editor code is equal to "// comment 1"
 
-@no_mobile
+# This test began failing, but the user experience is not broken.
+# Investigate whether we should remove or update this scenario. https://codedotorg.atlassian.net/browse/SL-1195
+@skip
 Scenario: Save Script Level After Signing Out
   Given I create a student named "Sally Student"
   Given I am assigned to unit "csp3-2017"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR skips the very flaky scenario in `applab_project.feature` ('Save Script Level After Signing Out').

## Links
[Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1739147342203359)


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Investigate and see if we should delete or update the skipped scenario - 
https://codedotorg.atlassian.net/browse/SL-1195

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
