### PR TITLE
fix(workshops): move time zones to workshop

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -281,6 +281,7 @@
     "messageformat": "2.3.0",
     "ml-knn": "^3.0.0",
     "moment": "^2.29.4",
+    "moment-timezone": "^0.5.47",
     "object-fit-images": "^3.2.3",
     "papaparse": "^5.4.1",
     "path-browserify": "^1.0.1",

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
@@ -8,6 +8,7 @@ import ReactTooltip from 'react-tooltip';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
 
 import * as utils from '../../../utils';
+import {getSessionDate, getSessionTimes} from '../sessionDateUtils';
 import {workshopShape} from '../workshop_dashboard/types.js';
 import {
   DATE_FORMAT,
@@ -170,18 +171,23 @@ export default class LandingPageWorkshopsTable extends React.Component {
         </td>
         <td>
           {workshop.sessions.map((session, i) => {
-            return (
-              <p key={i}>{moment.utc(session.start).format(DATE_FORMAT)}</p>
-            );
+            const date = getSessionDate({
+              session,
+              format: DATE_FORMAT,
+              isLocal: !workshop.time_zone,
+            });
+            return <p key={i}>{date}</p>;
           })}
         </td>
         <td>
           {workshop.sessions.map((session, i) => {
+            const {startTime, endTime, tzAbbreviation} = getSessionTimes({
+              session,
+              format: TIME_FORMAT,
+              isLocal: !workshop.time_zone,
+            });
             return (
-              <p key={i}>
-                {`${moment.utc(session.start).format(TIME_FORMAT)} -
-                     ${moment.utc(session.end).format(TIME_FORMAT)}`}
-              </p>
+              <p key={i}>{`${startTime} - ${endTime} ${tzAbbreviation}`}</p>
             );
           })}
         </td>

--- a/apps/src/code-studio/pd/sessionDateUtils.js
+++ b/apps/src/code-studio/pd/sessionDateUtils.js
@@ -1,0 +1,25 @@
+import moment from 'moment-timezone';
+
+export const getSessionDate = ({session, format, isLocal = false}) =>
+  isLocal
+    ? moment.utc(session.start).format(format)
+    : moment
+        .utc(session.start)
+        .tz(Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC')
+        .format(format);
+
+export const getSessionTimes = ({session, format, isLocal = false}) => {
+  const userTimeZone =
+    Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  const tzAbbreviation = isLocal
+    ? 'local'
+    : moment.utc(session.start).tz(userTimeZone).format('z');
+  const startTime = isLocal
+    ? moment.utc(session.start).format(format)
+    : moment.utc(session.start).tz(userTimeZone).format(format);
+  const endTime = isLocal
+    ? moment.utc(session.end).format(format)
+    : moment.utc(session.end).tz(userTimeZone).format(format);
+
+  return {startTime, endTime, tzAbbreviation};
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_form_part.jsx
@@ -199,7 +199,7 @@ export default class SessionFormPart extends React.Component {
               componentClass="select"
               id="format"
               name="format"
-              value={this.props.session.format}
+              value={this.props.session.format ?? ''}
               onChange={this.handleFormatChange}
               disabled={this.props.readOnly}
               style={this.props.readOnly ? styles.readOnlyInput : undefined}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
@@ -1,7 +1,7 @@
 /**
  * Displays nicely-formatted session time for a workshop.
  */
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -12,14 +12,17 @@ export default class SessionTime extends React.Component {
     session: PropTypes.shape({
       start: PropTypes.string.isRequired,
       end: PropTypes.string.isRequired,
+      time_zone: PropTypes.string,
     }).isRequired,
   };
 
   render() {
+    const {session} = this.props;
+    const tz = session.time_zone || 'UTC';
     const formattedTime =
-      moment.utc(this.props.session.start).format(DATETIME_FORMAT) +
+      moment.utc(session.start).tz(tz).format(DATETIME_FORMAT) +
       '-' +
-      moment.utc(this.props.session.end).format(TIME_FORMAT);
+      moment.utc(session.end).tz(tz).format(TIME_FORMAT);
 
     return <div>{formattedTime}</div>;
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
@@ -18,11 +18,16 @@ export default class SessionTime extends React.Component {
 
   render() {
     const {session} = this.props;
-    const tz = session.time_zone || 'UTC';
-    const formattedTime =
-      moment.utc(session.start).tz(tz).format(DATETIME_FORMAT) +
-      '-' +
-      moment.utc(session.end).tz(tz).format(TIME_FORMAT);
+    const tzAbbreviation = session.time_zone
+      ? moment.utc(session.start).tz(session.time_zone).format('z')
+      : 'local';
+    const formattedTime = `${moment
+      .utc(session.start)
+      .tz(session.time_zone || 'UTC')
+      .format(DATETIME_FORMAT)}-${moment
+      .utc(session.end)
+      .tz(session.time_zone || 'UTC')
+      .format(TIME_FORMAT)} ${tzAbbreviation}`;
 
     return <div>{formattedTime}</div>;
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
@@ -1,33 +1,34 @@
 /**
  * Displays nicely-formatted session time for a workshop.
  */
-import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {TIME_FORMAT, DATETIME_FORMAT} from '../workshopConstants';
+import {getSessionDate, getSessionTimes} from '../../sessionDateUtils';
+import {DATE_FORMAT, TIME_FORMAT} from '../workshopConstants';
 
 export default class SessionTime extends React.Component {
   static propTypes = {
     session: PropTypes.shape({
       start: PropTypes.string.isRequired,
       end: PropTypes.string.isRequired,
-      time_zone: PropTypes.string,
+      is_local: PropTypes.string,
     }).isRequired,
   };
 
   render() {
     const {session} = this.props;
-    const tzAbbreviation = session.time_zone
-      ? moment.utc(session.start).tz(session.time_zone).format('z')
-      : 'local';
-    const formattedTime = `${moment
-      .utc(session.start)
-      .tz(session.time_zone || 'UTC')
-      .format(DATETIME_FORMAT)}-${moment
-      .utc(session.end)
-      .tz(session.time_zone || 'UTC')
-      .format(TIME_FORMAT)} ${tzAbbreviation}`;
+    const date = getSessionDate({
+      session,
+      format: DATE_FORMAT,
+      isLocal: session.is_local,
+    });
+    const {startTime, endTime, tzAbbreviation} = getSessionTimes({
+      session,
+      format: TIME_FORMAT,
+      isLocal: session.is_local,
+    });
+    const formattedTime = `${date} ${startTime}-${endTime} ${tzAbbreviation}`;
 
     return <div>{formattedTime}</div>;
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
@@ -12,7 +12,7 @@ export default class SessionTime extends React.Component {
     session: PropTypes.shape({
       start: PropTypes.string.isRequired,
       end: PropTypes.string.isRequired,
-      is_local: PropTypes.string,
+      is_local: PropTypes.bool.isRequired,
     }).isRequired,
   };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -116,6 +116,7 @@ export class WorkshopForm extends React.Component {
       module: PropTypes.string,
       course_offerings: PropTypes.array,
       participant_group_type: PropTypes.string,
+      time_zone: PropTypes.string,
     }),
     onSaved: PropTypes.func,
     today: PropTypes.instanceOf(Date),
@@ -252,17 +253,16 @@ export class WorkshopForm extends React.Component {
         format: session.session_format,
         date: moment
           .utc(session.start)
-          .tz(session.time_zone || 'UTC')
+          .tz(this.workshopTimezone || 'UTC')
           .format(DATE_FORMAT),
         startTime: moment
           .utc(session.start)
-          .tz(session.time_zone || 'UTC')
+          .tz(this.workshopTimezone || 'UTC')
           .format(TIME_FORMAT),
         endTime: moment
           .utc(session.end)
-          .tz(session.time_zone || 'UTC')
+          .tz(this.workshopTimezone || 'UTC')
           .format(TIME_FORMAT),
-        timeZone: session.time_zone,
       };
     });
   }
@@ -271,8 +271,6 @@ export class WorkshopForm extends React.Component {
   prepareSessionsForApi(sessions, destroyedSessions) {
     return sessions
       .map(session => {
-        const timeZone =
-          session.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
         return {
           id: session.id,
           session_format: session.format,
@@ -280,15 +278,18 @@ export class WorkshopForm extends React.Component {
             .tz(
               `${session.date} ${session.startTime}`,
               DATETIME_FORMAT,
-              timeZone
+              this.workshopTimezone
             )
             .utc()
             .toISOString(),
           end: moment
-            .tz(`${session.date} ${session.endTime}`, DATETIME_FORMAT, timeZone)
+            .tz(
+              `${session.date} ${session.endTime}`,
+              DATETIME_FORMAT,
+              this.workshopTimezone
+            )
             .utc()
             .toISOString(),
-          time_zone: timeZone,
         };
       })
       .concat(
@@ -302,14 +303,12 @@ export class WorkshopForm extends React.Component {
   }
 
   get workshopTimezone() {
-    // a new session is created using the user's local timezone
-    let sessionTz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-    const editing = Boolean(this.props.workshop);
-    if (editing) {
-      // handle legacy sessions stored without timezone offset
-      sessionTz = this.props.workshop.sessions?.[0]?.time_zone || 'UTC';
-    }
-    return moment.tz(sessionTz).format('z');
+    const {workshop} = this.props;
+    // if editing an existing workshop, use the existing time zone
+    // if creating a new workshop, use the user's current time zone
+    return workshop
+      ? workshop.time_zone
+      : Intl.DateTimeFormat().resolvedOptions().timeZone;
   }
 
   // Convert from [id, name, email] to an array of ids.
@@ -848,6 +847,7 @@ export class WorkshopForm extends React.Component {
       regional_partner_id: this.state.regional_partner_id,
       course_offerings: this.state.course_offerings,
       participant_group_type: this.state.participant_group_type,
+      time_zone: this.workshopTimezone,
     };
 
     if (this.state.organizer) {
@@ -1046,7 +1046,9 @@ export class WorkshopForm extends React.Component {
       <Grid>
         <form>
           <Row>
-            <Col sm={4}>All workshop times are {this.workshopTimezone}:</Col>
+            <Col sm={4}>
+              All workshop times are {this.workshopTimezone ?? 'local'}:
+            </Col>
           </Row>
           <SessionListFormPart
             sessions={this.state.sessions}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -4,7 +4,7 @@
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import $ from 'jquery';
 import _ from 'lodash';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 /* eslint-disable no-restricted-imports */
@@ -250,9 +250,19 @@ export class WorkshopForm extends React.Component {
       return {
         id: session.id,
         format: session.session_format,
-        date: moment.utc(session.start).format(DATE_FORMAT),
-        startTime: moment.utc(session.start).format(TIME_FORMAT),
-        endTime: moment.utc(session.end).format(TIME_FORMAT),
+        date: moment
+          .utc(session.start)
+          .tz(session.time_zone || 'UTC')
+          .format(DATE_FORMAT),
+        startTime: moment
+          .utc(session.start)
+          .tz(session.time_zone || 'UTC')
+          .format(TIME_FORMAT),
+        endTime: moment
+          .utc(session.end)
+          .tz(session.time_zone || 'UTC')
+          .format(TIME_FORMAT),
+        timeZone: session.time_zone,
       };
     });
   }
@@ -261,15 +271,24 @@ export class WorkshopForm extends React.Component {
   prepareSessionsForApi(sessions, destroyedSessions) {
     return sessions
       .map(session => {
+        const timeZone =
+          session.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
         return {
           id: session.id,
           session_format: session.format,
           start: moment
-            .utc(session.date + ' ' + session.startTime, DATETIME_FORMAT)
-            .format(),
+            .tz(
+              `${session.date} ${session.startTime}`,
+              DATETIME_FORMAT,
+              timeZone
+            )
+            .utc()
+            .toISOString(),
           end: moment
-            .utc(session.date + ' ' + session.endTime, DATETIME_FORMAT)
-            .format(),
+            .tz(`${session.date} ${session.endTime}`, DATETIME_FORMAT, timeZone)
+            .utc()
+            .toISOString(),
+          time_zone: timeZone,
         };
       })
       .concat(
@@ -280,6 +299,17 @@ export class WorkshopForm extends React.Component {
           };
         })
       );
+  }
+
+  get workshopTimezone() {
+    // a new session is created using the user's local timezone
+    let sessionTz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    const editing = Boolean(this.props.workshop);
+    if (editing) {
+      // handle legacy sessions stored without timezone offset
+      sessionTz = this.props.workshop.sessions?.[0]?.time_zone || 'UTC';
+    }
+    return moment.tz(sessionTz).format('z');
   }
 
   // Convert from [id, name, email] to an array of ids.
@@ -1016,7 +1046,7 @@ export class WorkshopForm extends React.Component {
       <Grid>
         <form>
           <Row>
-            <Col sm={4}>All workshop times are local:</Col>
+            <Col sm={4}>All workshop times are {this.workshopTimezone}:</Col>
           </Row>
           <SessionListFormPart
             sessions={this.state.sessions}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -329,7 +329,7 @@ export default class WorkshopTable extends React.Component {
           canDelete: row.can_delete,
           endDate: row.sessions[row.sessions.length - 1].end,
         },
-        sessions: row.sessions.map(s => ({...s, time_zone: row.time_zone})),
+        sessions: row.sessions.map(s => ({...s, is_local: !row.time_zone})),
       })
     );
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -329,6 +329,7 @@ export default class WorkshopTable extends React.Component {
           canDelete: row.can_delete,
           endDate: row.sessions[row.sessions.length - 1].end,
         },
+        sessions: row.sessions.map(s => ({...s, time_zone: row.time_zone})),
       })
     );
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
@@ -111,6 +111,7 @@ export class Workshop extends React.Component {
             'course_offerings',
             'module',
             'participant_group_type',
+            'time_zone',
           ]),
         });
       })

--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
@@ -7,6 +7,7 @@ import Typography, {
 } from '@code-dot-org/component-library/typography';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
+import moment from 'moment-timezone';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -18,27 +19,6 @@ import {getSessionDate, getSessionTimes} from '../sessionDateUtils';
 import style from '@cdo/apps/code-studio/pd/professional_learning_landing/landingPage.module.scss';
 
 const CelebrationImage = require('@cdo/static/pd/EnrollmentCelebration.png');
-
-const MonthNames = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
-
-// Ensures the given value is two digits long (padded with a '0' if necessary)
-// so that time intervals are always two digits long.
-const zeroPad = value => {
-  return value.toString().padStart(2, '0');
-};
 
 const generateDateText = session => {
   return getSessionDate({
@@ -58,6 +38,17 @@ const generateTimeText = session => {
   return `${startTime} - ${endTime}`;
 };
 
+export const getStartAndEndUTCStrings = ({session, format}) => {
+  // legacy sessions: stored in local time, format without 'Z'
+  // new sessions: already in UTC, format with 'Z'
+  const startTime = session.is_local
+    ? moment.utc(session.start).format(format)
+    : moment.utc(session.start).format(`${format}[Z]`);
+  const endTime = session.is_local
+    ? moment.utc(session.end).format(format)
+    : moment.utc(session.end).format(`${format}[Z]`);
+
+  return {startTime, endTime};
 };
 
 export const buildAppleCalendarLink = (
@@ -65,27 +56,24 @@ export const buildAppleCalendarLink = (
   workshopTitle,
   workshopLocation
 ) => {
+  const format = 'YYYYMMDDTHHmmss';
+  const [firstSession] = workshopSessions;
+  const {startTime: firstSessionStart} = getStartAndEndUTCStrings({
+    session: firstSession,
+    format,
+  });
   let icsFileContent = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
     'CALSCALE:GREGORIAN',
-    `PRODID:${workshopTitle}${workshopSessions[0].start}/ics`,
+    `PRODID:${workshopTitle} ${firstSessionStart}/ics`,
   ];
 
   workshopSessions.forEach(session => {
-    const start = new Date(session.start);
-    const end = new Date(session.end);
-    // Calendars parse a month of '01' as January, while Javascript's Date class parses a month of '00'
-    // as January, so the month needs to be offset by 1.
-    const date = `${start.getUTCFullYear()}${zeroPad(
-      start.getUTCMonth() + 1
-    )}${zeroPad(start.getUTCDate())}`;
-    const startTime = `${date}T${zeroPad(start.getUTCHours())}${zeroPad(
-      start.getUTCMinutes()
-    )}00`;
-    const endTime = `${date}T${zeroPad(end.getUTCHours())}${zeroPad(
-      end.getUTCMinutes()
-    )}00`;
+    const {startTime, endTime} = getStartAndEndUTCStrings({
+      session,
+      format,
+    });
 
     icsFileContent.push(
       'BEGIN:VEVENT',
@@ -113,25 +101,19 @@ export const buildGoogleCalendarLink = (
   workshopTitle,
   workshopLocation
 ) => {
-  const start = new Date(session.start);
-  const end = new Date(session.end);
-  // Calendars parse a month of '01' as January, while Javascript's Date class parses a month of '00'
-  // as January, so the month needs to be offset by 1.
-  const date = `${start.getUTCFullYear()}${zeroPad(
-    start.getUTCMonth() + 1
-  )}${zeroPad(start.getUTCDate())}`;
-  const startTime = `${date}T${zeroPad(start.getUTCHours())}${zeroPad(
-    start.getUTCMinutes()
-  )}00`;
-  const endTime = `${date}T${zeroPad(end.getUTCHours())}${zeroPad(
-    end.getUTCMinutes()
-  )}00`;
+  const baseUrl = 'https://www.google.com/calendar/render?action=TEMPLATE';
+  const format = 'YYYYMMDDTHHmmss';
+  const {startTime, endTime} = getStartAndEndUTCStrings({
+    session,
+    format,
+  });
+  const params = new URLSearchParams({
+    text: workshopTitle,
+    dates: `${startTime}/${endTime}`,
+    location: workshopLocation,
+  });
 
-  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
-    workshopTitle
-  )}&location=${encodeURIComponent(
-    workshopLocation
-  )}&dates=${encodeURIComponent(startTime)}/${encodeURIComponent(endTime)}`;
+  return `${baseUrl}&${params.toString()}`;
 };
 
 export const buildOutlookCalendarLink = (
@@ -139,27 +121,21 @@ export const buildOutlookCalendarLink = (
   workshopTitle,
   workshopLocation
 ) => {
-  const start = new Date(session.start);
-  const end = new Date(session.end);
-  // Calendars parse a month of '01' as January, while Javascript's Date class parses a month of '00'
-  // as January, so the month needs to be offset by 1.
-  const date = `${start.getUTCFullYear()}-${zeroPad(
-    start.getUTCMonth() + 1
-  )}-${zeroPad(start.getUTCDate())}`;
-  const startTime = `${date}T${zeroPad(start.getUTCHours())}:${zeroPad(
-    start.getUTCMinutes()
-  )}:00`;
-  const endTime = `${date}T${zeroPad(end.getUTCHours())}:${zeroPad(
-    end.getUTCMinutes()
-  )}:00`;
+  const baseUrl =
+    'https://outlook.live.com/calendar/action/compose?rru=addevent';
+  const format = 'YYYY-MM-DDTHH:mm:ss';
+  const {startTime, endTime} = getStartAndEndUTCStrings({
+    session,
+    format,
+  });
+  const params = new URLSearchParams({
+    subject: workshopTitle,
+    location: workshopLocation,
+    startdt: startTime,
+    enddt: endTime,
+  });
 
-  return `https://outlook.live.com/calendar/action/compose?rru=addevent&subject=${encodeURIComponent(
-    workshopTitle
-  )}&location=${encodeURIComponent(
-    workshopLocation
-  )}&startdt=${encodeURIComponent(startTime)}&enddt=${encodeURIComponent(
-    endTime
-  )}`;
+  return `${baseUrl}&${params.toString()}`;
 };
 
 export default function WorkshopEnrollmentCelebrationDialog({

--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
@@ -5,9 +5,9 @@ import Typography, {
   Heading6,
   BodyTwoText,
 } from '@code-dot-org/component-library/typography';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import moment from 'moment-timezone';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';

--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
@@ -13,6 +13,8 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import AccessibleDialog from '@cdo/apps/sharedComponents/AccessibleDialog';
 import i18n from '@cdo/locale';
 
+import {getSessionDate, getSessionTimes} from '../sessionDateUtils';
+
 import style from '@cdo/apps/code-studio/pd/professional_learning_landing/landingPage.module.scss';
 
 const CelebrationImage = require('@cdo/static/pd/EnrollmentCelebration.png');
@@ -39,34 +41,23 @@ const zeroPad = value => {
 };
 
 const generateDateText = session => {
-  const date = new Date(session.start);
-  return `${
-    MonthNames[date.getUTCMonth()]
-  } ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
+  return getSessionDate({
+    session,
+    format: 'MMMM D, YYYY',
+    isLocal: session.is_local,
+  });
 };
 
 const generateTimeText = session => {
-  const start = new Date(session.start);
-  const end = new Date(session.end);
+  const {startTime, endTime} = getSessionTimes({
+    session,
+    format: 'h:mmA',
+    isLocal: session.is_local,
+  });
 
-  const startTimeText = start
-    .toLocaleString('en-US', {
-      timeZone: 'utc',
-      hour: 'numeric',
-      minute: 'numeric',
-      hour12: true,
-    })
-    .replaceAll(' ', '');
-  const endTimeText = end
-    .toLocaleString('en-US', {
-      timeZone: 'utc',
-      hour: 'numeric',
-      minute: 'numeric',
-      hour12: true,
-    })
-    .replaceAll(' ', '');
+  return `${startTime} - ${endTime}`;
+};
 
-  return `${startTimeText} - ${endTimeText}`;
 };
 
 export const buildAppleCalendarLink = (

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -74,9 +74,25 @@ const DEFAULT_PROPS = {
 
 describe('LandingPage', () => {
   let store;
-  const defaultCreateObjectURL = window.URL.createObjectURL;
+  let defaultCreateObjectURL;
+  let blobContentPromise;
+  let workshopTitle = 'New Workshop';
+  let workshopLocation = '123 Main St';
+
+  beforeAll(() => {
+    defaultCreateObjectURL = window.URL.createObjectURL;
+  });
 
   beforeEach(() => {
+    let mockCreateObjectUrl = jest.fn().mockImplementation(blob => {
+      blobContentPromise = new Promise(res => {
+        const fileReader = new FileReader();
+        fileReader.onload = () => res(fileReader.result);
+        fileReader.readAsText(blob);
+      });
+      return 'testCreateObjectURL';
+    });
+    window.URL.createObjectURL = mockCreateObjectUrl;
     stubRedux();
     registerReducers({isRtl, teacherSections});
     store = getStore();
@@ -87,6 +103,7 @@ describe('LandingPage', () => {
     restoreRedux();
     window.URL.createObjectURL = defaultCreateObjectURL;
     jest.resetAllMocks();
+    blobContentPromise = undefined;
   });
 
   function renderDefault(propOverrides = {}) {
@@ -443,8 +460,6 @@ describe('LandingPage', () => {
   });
 
   it('page shows success dialog stating workshop course when redirected here from successful non-BYOW enrollment', () => {
-    window.URL.createObjectURL = () => 'testCreateObjectURL';
-
     const workshopCourse = 'TEST COURSE';
     sessionStorage.setItem('workshopCourse', workshopCourse);
     sessionStorage.setItem(
@@ -463,8 +478,6 @@ describe('LandingPage', () => {
   });
 
   it('page shows success dialog stating workshop name when redirected here from successful BYOW enrollment', () => {
-    window.URL.createObjectURL = () => 'testCreateObjectURL';
-
     const workshopCourse = 'TEST COURSE';
     const workshopName = 'TEST NAME';
     sessionStorage.setItem('workshopCourse', workshopCourse);
@@ -485,8 +498,6 @@ describe('LandingPage', () => {
   });
 
   it('enroll success dialog shows buttons with links to add session to calendar for workshops with one session', () => {
-    window.URL.createObjectURL = () => 'testCreateObjectURL';
-
     const workshopCourse = 'TEST COURSE';
     const workshopLocation = 'Seattle, WA';
     const workshopSession = TEST_WORKSHOP_SESSIONS[0];
@@ -574,8 +585,6 @@ describe('LandingPage', () => {
   });
 
   it('enroll success dialog shows buttons that open dialog to add multiple sessions to calendar for workshops with multiple sessions', () => {
-    window.URL.createObjectURL = () => 'testCreateObjectURL';
-
     const workshopCourse = 'TEST COURSE';
     const workshopLocation = 'Seattle, WA';
     sessionStorage.setItem('workshopCourse', workshopCourse);
@@ -680,6 +689,148 @@ describe('LandingPage', () => {
     ).toBe(null);
 
     sessionStorage.clear();
+  });
+
+  describe('buildGoogleCalendarLink', () => {
+    test('creates link with UTC datetime when session is not local', () => {
+      const session = {
+        start: '2025-02-11T16:00:00Z', // 9 AM MST
+        end: '2025-02-12T00:00:00Z', // 5 PM MST
+        is_local: false,
+      };
+
+      const result = buildGoogleCalendarLink(
+        session,
+        workshopTitle,
+        workshopLocation
+      );
+
+      expect(result).toContain(
+        `dates=${encodeURIComponent('20250211T160000Z/20250212T000000Z')}`
+      );
+    });
+
+    test('creates a link with local time for legacy sessions', () => {
+      const session = {
+        start: '2025-02-11T09:00:00Z',
+        end: '2025-02-11T17:00:00Z',
+        is_local: true,
+      };
+
+      const result = buildGoogleCalendarLink(
+        session,
+        workshopTitle,
+        workshopLocation
+      );
+
+      // datetime params do not have trailing 'Z' indicating user's local time
+      expect(result).toContain(
+        `dates=${encodeURIComponent('20250211T090000/20250211T170000')}`
+      );
+    });
+  });
+
+  describe('buildOutlookCalendarLink', () => {
+    test('creates link with UTC datetime when session is not local', () => {
+      const session = {
+        start: '2025-02-11T16:00:00Z',
+        end: '2025-02-12T00:00:00Z',
+        is_local: false,
+      };
+
+      const link = buildOutlookCalendarLink(
+        session,
+        workshopTitle,
+        workshopLocation
+      );
+
+      expect(link).toContain(
+        `startdt=${encodeURIComponent('2025-02-11T16:00:00Z')}`
+      );
+      expect(link).toContain(
+        `enddt=${encodeURIComponent('2025-02-12T00:00:00Z')}`
+      );
+    });
+
+    test('creates a link with local time for legacy sessions', () => {
+      const session = {
+        start: '2025-02-11T09:00:00Z',
+        end: '2025-02-11T17:00:00Z',
+        is_local: true,
+      };
+
+      const link = buildOutlookCalendarLink(
+        session,
+        workshopTitle,
+        workshopLocation
+      );
+
+      // datetime params do not have trailing 'Z' indicating user's local time
+      expect(link).toContain(
+        `startdt=${encodeURIComponent('2025-02-11T09:00:00')}`
+      );
+      expect(link).toContain(
+        `enddt=${encodeURIComponent('2025-02-11T17:00:00')}`
+      );
+    });
+  });
+
+  describe('buildAppleCalendarLink', () => {
+    const workshopSessions = [
+      {
+        start: '2025-02-11T16:00:00Z',
+        end: '2025-02-12T00:00:00Z',
+        is_local: false,
+      },
+      {
+        start: '2025-02-12T16:00:00Z',
+        end: '2025-02-13T00:00:00Z',
+        is_local: false,
+      },
+    ];
+
+    it('should generate a valid ics file content for sessions with time zones', async () => {
+      buildAppleCalendarLink(workshopSessions, workshopTitle, workshopLocation);
+
+      // wait for blob content to be read
+      const icsFileContent = await blobContentPromise;
+      expect(icsFileContent).toContain('BEGIN:VCALENDAR');
+      expect(icsFileContent).toContain('VERSION:2.0');
+      expect(icsFileContent).toContain(
+        `PRODID:${workshopTitle} 20250211T160000Z/ics`
+      );
+      expect(icsFileContent).toContain('DTSTART:20250211T160000Z');
+      expect(icsFileContent).toContain('DTEND:20250212T000000Z');
+      expect(icsFileContent).toContain('DTSTART:20250212T160000Z');
+      expect(icsFileContent).toContain('DTEND:20250213T000000Z');
+      expect(icsFileContent).toContain('SUMMARY:New Workshop');
+      expect(icsFileContent).toContain('LOCATION:123 Main St');
+      expect(icsFileContent).toContain('END:VCALENDAR');
+    });
+
+    it('should handle legacy sessions stored as local time without time zone', async () => {
+      const legacySessions = [
+        {
+          start: '2025-02-11T09:00:00Z',
+          end: '2025-02-11T17:00:00Z',
+          is_local: true,
+        },
+      ];
+
+      buildAppleCalendarLink(legacySessions, workshopTitle, workshopLocation);
+
+      const icsFileContent = await blobContentPromise;
+      expect(icsFileContent).toContain('BEGIN:VCALENDAR');
+      expect(icsFileContent).toContain('VERSION:2.0');
+      expect(icsFileContent).toContain(
+        `PRODID:${workshopTitle} 20250211T090000/ics`
+      );
+      expect(icsFileContent).toContain('DTSTART:20250211T090000');
+      expect(icsFileContent).toContain('DTEND:20250211T170000');
+      expect(icsFileContent).toContain('SUMMARY:New Workshop');
+      expect(icsFileContent).toContain('LOCATION:123 Main St');
+      expect(icsFileContent).toContain('END:VCALENDAR');
+    });
   });
 
   describe('Global Edition Configurations', () => {

--- a/apps/test/unit/code-studio/pd/sessionDateUtilsTest.js
+++ b/apps/test/unit/code-studio/pd/sessionDateUtilsTest.js
@@ -1,0 +1,142 @@
+import {
+  getSessionDate,
+  getSessionTimes,
+} from '@cdo/apps/code-studio/pd/sessionDateUtils';
+import {
+  DATE_FORMAT,
+  TIME_FORMAT,
+} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshopConstants';
+
+describe('getSessionDate', () => {
+  let mockTimeZoneResolvedOptions;
+
+  beforeEach(() => {
+    mockTimeZoneResolvedOptions = jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValue({
+        timeZone: 'America/Denver',
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should return the session date in the user's time zone", () => {
+    const session = {
+      start: '2025-02-10T16:00:00Z',
+    };
+
+    let result = getSessionDate({session, format: DATE_FORMAT, isLocal: false});
+
+    expect(result).toBe('2025-02-10');
+
+    mockTimeZoneResolvedOptions.mockReturnValueOnce({
+      timeZone: 'Australia/Sydney',
+    });
+
+    result = getSessionDate({session, format: DATE_FORMAT, isLocal: false});
+
+    expect(result).toBe('2025-02-11');
+  });
+
+  it('should return the legacy session date without offset timezone', () => {
+    const session = {
+      start: '2025-02-11T09:00:00Z',
+    };
+
+    let result = getSessionDate({
+      session,
+      format: DATE_FORMAT,
+      isLocal: true,
+    });
+
+    expect(result).toBe('2025-02-11');
+
+    mockTimeZoneResolvedOptions.mockReturnValueOnce({
+      timeZone: 'Australia/Sydney',
+    });
+
+    result = getSessionDate({session, format: DATE_FORMAT, isLocal: false});
+
+    expect(result).toBe('2025-02-11');
+  });
+});
+
+describe('getSessionTimes', () => {
+  let mockTimeZoneResolvedOptions;
+
+  beforeEach(() => {
+    mockTimeZoneResolvedOptions = jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValue({
+        timeZone: 'America/Denver',
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return start and end times in user time zone', () => {
+    const session = {
+      start: '2025-02-11T16:00:00Z',
+      end: '2025-02-12T00:00:00Z',
+    };
+
+    let result = getSessionTimes({
+      session,
+      format: TIME_FORMAT,
+      isLocal: false,
+    });
+
+    expect(result.startTime).toBe('9:00am');
+    expect(result.endTime).toBe('5:00pm');
+    expect(result.tzAbbreviation).toBe('MST');
+
+    mockTimeZoneResolvedOptions.mockReturnValueOnce({
+      timeZone: 'Australia/Sydney',
+    });
+
+    result = getSessionTimes({
+      session,
+      format: TIME_FORMAT,
+      isLocal: false,
+    });
+
+    expect(result.startTime).toBe('3:00am');
+    expect(result.endTime).toBe('11:00am');
+    expect(result.tzAbbreviation).toBe('AEDT');
+  });
+
+  it('should return start and end times without offset timezone if local', () => {
+    const session = {
+      start: '2025-02-11T09:00:00Z',
+      end: '2025-02-11T17:00:00Z',
+    };
+
+    let result = getSessionTimes({
+      session,
+      format: TIME_FORMAT,
+      isLocal: true,
+    });
+
+    expect(result.startTime).toBe('9:00am');
+    expect(result.endTime).toBe('5:00pm');
+    expect(result.tzAbbreviation).toBe('local');
+
+    mockTimeZoneResolvedOptions.mockReturnValueOnce({
+      timeZone: 'Australia/Sydney',
+    });
+
+    result = getSessionTimes({
+      session,
+      format: TIME_FORMAT,
+      isLocal: true,
+    });
+
+    expect(result.startTime).toBe('9:00am');
+    expect(result.endTime).toBe('5:00pm');
+    expect(result.tzAbbreviation).toBe('local');
+  });
+});

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -1,5 +1,6 @@
 import {assert, expect} from 'chai'; // eslint-disable-line no-restricted-imports
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import moment from 'moment-timezone';
 import React from 'react';
 import {FormControl} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import '../workshopFactory';
@@ -164,6 +165,121 @@ describe('WorkshopForm test', () => {
     // defaults to first session format option
     expect(sessionFormatDropdown.props().value).to.equal(
       PdSessionFormats[0].value
+    );
+  });
+
+  it("new workshop sessions are created with the user's local timezone", () => {
+    const easternTz = 'America/New_York';
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValueOnce({
+        timeZone: easternTz,
+      });
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const tzAbbreviation = moment.tz(easternTz).format('z');
+
+    expect(wrapper.find('WorkshopForm').find('Col').first().text()).to.equal(
+      `All workshop times are ${tzAbbreviation}:`
+    );
+  });
+
+  it('edits to workshop sessions are done in the original timezone', () => {
+    const easternTz = 'America/New_York';
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValueOnce({
+        timeZone: easternTz,
+      });
+
+    const workshop = Factory.build('workshop');
+    const [firstSession] = workshop.sessions;
+    const sessionTz = firstSession.time_zone; // America/Denver in workshop factory
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+            workshop={workshop}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const tzAbbreviation = moment.tz(sessionTz).format('z');
+
+    const workshopForm = wrapper.find('WorkshopForm');
+
+    const [formattedSessionData] = workshopForm
+      .instance()
+      .prepareSessionsForForm(workshop.sessions);
+
+    expect(formattedSessionData.startTime).to.equal('9:00am');
+    expect(formattedSessionData.endTime).to.equal('5:00pm');
+    expect(formattedSessionData.date).to.equal('2016-07-01');
+
+    expect(workshopForm.find('Col').first().text()).to.equal(
+      `All workshop times are ${tzAbbreviation}:`
+    );
+  });
+
+  it('edits to legacy workshop sessions without a timezone are done in UTC', () => {
+    const easternTz = 'America/New_York';
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValueOnce({
+        timeZone: easternTz,
+      });
+
+    const workshop = Factory.build('workshop');
+    const [firstSession] = workshop.sessions;
+    // remove time_zone and reset session time to 9-5 utc, like legacy sessions are in the db
+    firstSession.time_zone = null;
+    const start = new Date(firstSession.start);
+    const end = new Date(firstSession.end);
+    start.setHours(9);
+    end.setHours(17);
+    firstSession.start = start.toISOString();
+    firstSession.end = end.toISOString();
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+            workshop={workshop}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const tzAbbreviation = 'UTC';
+
+    const workshopForm = wrapper.find('WorkshopForm');
+
+    const [formattedSessionData] = workshopForm
+      .instance()
+      .prepareSessionsForForm(workshop.sessions);
+
+    expect(formattedSessionData.startTime).to.equal('9:00am');
+    expect(formattedSessionData.endTime).to.equal('5:00pm');
+    expect(formattedSessionData.date).to.equal('2016-07-01');
+
+    expect(workshopForm.find('Col').first().text()).to.equal(
+      `All workshop times are ${tzAbbreviation}:`
     );
   });
 

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -1,6 +1,5 @@
 import {assert, expect} from 'chai'; // eslint-disable-line no-restricted-imports
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
-import moment from 'moment-timezone';
 import React from 'react';
 import {FormControl} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import '../workshopFactory';
@@ -168,7 +167,7 @@ describe('WorkshopForm test', () => {
     );
   });
 
-  it("new workshop sessions are created with the user's local timezone", () => {
+  it("new workshops are created with the user's local timezone", () => {
     const easternTz = 'America/New_York';
     jest
       .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
@@ -187,10 +186,8 @@ describe('WorkshopForm test', () => {
       </Provider>
     );
 
-    const tzAbbreviation = moment.tz(easternTz).format('z');
-
     expect(wrapper.find('WorkshopForm').find('Col').first().text()).to.equal(
-      `All workshop times are ${tzAbbreviation}:`
+      `All workshop times are ${easternTz}:`
     );
   });
 
@@ -203,8 +200,7 @@ describe('WorkshopForm test', () => {
       });
 
     const workshop = Factory.build('workshop');
-    const [firstSession] = workshop.sessions;
-    const sessionTz = firstSession.time_zone; // America/Denver in workshop factory
+    const workshopTz = workshop.time_zone; // America/Denver in workshop factory
 
     const wrapper = mount(
       <Provider store={store}>
@@ -218,8 +214,6 @@ describe('WorkshopForm test', () => {
       </Provider>
     );
 
-    const tzAbbreviation = moment.tz(sessionTz).format('z');
-
     const workshopForm = wrapper.find('WorkshopForm');
 
     const [formattedSessionData] = workshopForm
@@ -231,11 +225,11 @@ describe('WorkshopForm test', () => {
     expect(formattedSessionData.date).to.equal('2016-07-01');
 
     expect(workshopForm.find('Col').first().text()).to.equal(
-      `All workshop times are ${tzAbbreviation}:`
+      `All workshop times are ${workshopTz}:`
     );
   });
 
-  it('edits to legacy workshop sessions without a timezone are done in UTC', () => {
+  it('edits to legacy workshop sessions without a timezone are done in local time', () => {
     const easternTz = 'America/New_York';
     jest
       .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
@@ -246,7 +240,7 @@ describe('WorkshopForm test', () => {
     const workshop = Factory.build('workshop');
     const [firstSession] = workshop.sessions;
     // remove time_zone and reset session time to 9-5 utc, like legacy sessions are in the db
-    firstSession.time_zone = null;
+    workshop.time_zone = null;
     const start = new Date(firstSession.start);
     const end = new Date(firstSession.end);
     start.setHours(9);
@@ -266,8 +260,6 @@ describe('WorkshopForm test', () => {
       </Provider>
     );
 
-    const tzAbbreviation = 'UTC';
-
     const workshopForm = wrapper.find('WorkshopForm');
 
     const [formattedSessionData] = workshopForm
@@ -279,7 +271,7 @@ describe('WorkshopForm test', () => {
     expect(formattedSessionData.date).to.equal('2016-07-01');
 
     expect(workshopForm.find('Col').first().text()).to.equal(
-      `All workshop times are ${tzAbbreviation}:`
+      `All workshop times are local:`
     );
   });
 

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
@@ -12,7 +12,8 @@ import {
  */
 
 // For testing average middle of the year dates.
-const middleOfYearFakeToday = new Date(2016, 6, 1); // July 1st, 2016
+const middleOfYearFakeToday = new Date(2016, 6, 1, 15); // July 1st, 2016
+const middleOfYearFakeTodayEnd = new Date(2016, 6, 1, 23); // July 1st, 2016
 // For testing cases when wrapping around from December of one year to January of the next.
 const endOfYearFakeToday = new Date(2016, 12, 30); // December 30th, 2016
 
@@ -113,7 +114,8 @@ Factory.define('session')
   .sequence('id')
   .attr('code', 'TEST')
   .attr('start', middleOfYearFakeToday.toISOString())
-  .attr('end', middleOfYearFakeToday.toISOString())
+  .attr('end', middleOfYearFakeTodayEnd.toISOString())
+  .attr('time_zone', 'America/Denver')
   .attr('attendance_count', 0)
   .attr('session_format', PdSessionFormats[0].value)
   .attr('show_link?', false);

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
@@ -36,7 +36,8 @@ Factory.define('workshop')
   .attr('funded', true)
   .attr('enrolled_teacher_count', 1)
   .attr('organizer', {name: 'Oscar Organzier', email: 'oscar@code.org'})
-  .attr('virtual', false);
+  .attr('virtual', false)
+  .attr('time_zone', 'America/Denver');
 
 Factory.define('workshop multiple sessions')
   .extend('workshop')
@@ -115,7 +116,6 @@ Factory.define('session')
   .attr('code', 'TEST')
   .attr('start', middleOfYearFakeToday.toISOString())
   .attr('end', middleOfYearFakeTodayEnd.toISOString())
-  .attr('time_zone', 'America/Denver')
   .attr('attendance_count', 0)
   .attr('session_format', PdSessionFormats[0].value)
   .attr('show_link?', false);

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -20895,6 +20895,15 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"moment-timezone@npm:^0.5.47":
+  version: 0.5.47
+  resolution: "moment-timezone@npm:0.5.47"
+  dependencies:
+    moment: ^2.29.4
+  checksum: 6288a9d653b902bd913f1dca24426ad71e5a98cd98684139e3ed74e635289e6acde62450735364fd3758d6ac836a1eaab859c08d0252587a377192f25f0bda5a
+  languageName: node
+  linkType: hard
+
 "moment@npm:^2.10.2, moment@npm:^2.29.4":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -10328,6 +10328,7 @@ __metadata:
     mocha: "npm:^10.6.0"
     mock-firmata: "npm:0.2.0"
     moment: "npm:^2.29.4"
+    moment-timezone: "npm:^0.5.47"
     object-fit-images: "npm:^3.2.3"
     papaparse: "npm:^5.4.1"
     path-browserify: "npm:^1.0.1"
@@ -20899,8 +20900,8 @@ canvg@gabelerner/canvg:
   version: 0.5.47
   resolution: "moment-timezone@npm:0.5.47"
   dependencies:
-    moment: ^2.29.4
-  checksum: 6288a9d653b902bd913f1dca24426ad71e5a98cd98684139e3ed74e635289e6acde62450735364fd3758d6ac836a1eaab859c08d0252587a377192f25f0bda5a
+    moment: "npm:^2.29.4"
+  checksum: 10/b2ad32e6b7ea4ce99756c9f571f8eb1bdd6592ecdc2bf3f7fb988ae980a49a7e87b986776090571b9608c8576205f839b736dc7589c180ce36c82fad4b8416c6
   languageName: node
   linkType: hard
 

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -338,7 +338,7 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
       :organizer_id,
       :suppress_email,
       :third_party_provider,
-      {sessions_attributes: [:id, :start, :end, :session_format, :meeting_link, :location_name, :location_address, :_destroy]},
+      {sessions_attributes: [:id, :start, :end, :time_zone, :session_format, :meeting_link, :location_name, :location_address, :_destroy]},
       :module,
       :participant_group_type,
       :description,

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -338,14 +338,15 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
       :organizer_id,
       :suppress_email,
       :third_party_provider,
-      {sessions_attributes: [:id, :start, :end, :time_zone, :session_format, :meeting_link, :location_name, :location_address, :_destroy]},
+      {sessions_attributes: [:id, :start, :end, :session_format, :meeting_link, :location_name, :location_address, :_destroy]},
       :module,
       :participant_group_type,
       :description,
       :registration_link,
       :prereq,
       :hidden,
-      :grades
+      :grades,
+      :time_zone
     ]
 
     allowed_params.delete :regional_partner_id unless can_update_regional_partner

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -30,7 +30,7 @@ class Pd::Session < ApplicationRecord
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 
-  belongs_to :workshop, class_name: 'Pd::Workshop', foreign_key: 'pd_workshop_id', optional: true, inverse_of: :sessions
+  belongs_to :workshop, class_name: 'Pd::Workshop', foreign_key: 'pd_workshop_id', optional: true
   has_many :attendances, class_name: 'Pd::Attendance', foreign_key: 'pd_session_id', dependent: :destroy
 
   validates_presence_of :start, :end

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -71,8 +71,12 @@ class Pd::Session < ApplicationRecord
   end
 
   def tz_abbreviation
-    return '' if workshop.time_zone.blank?
-    ActiveSupport::TimeZone[workshop.time_zone].tzinfo.current_period.abbreviation.to_s
+    return '' if workshop.time_zone.blank? || start.blank?
+
+    time_zone_obj = ActiveSupport::TimeZone[workshop.time_zone]
+    return '' unless time_zone_obj
+
+    time_zone_obj.tzinfo.period_for_utc(start).abbreviation.to_s
   end
 
   def formatted_date_with_start_and_end_times

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -89,8 +89,9 @@ class Pd::Session < ApplicationRecord
   def session_info_for_calendar
     {
       id: id,
-      start: start,
-      end: self.end
+      start: start_time.utc.iso8601,
+      end: end_time.utc.iso8601,
+      is_local: workshop.time_zone.blank?
     }
   end
 

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -33,6 +33,10 @@ class Pd::Session < ApplicationRecord
   belongs_to :workshop, class_name: 'Pd::Workshop', foreign_key: 'pd_workshop_id', optional: true
   has_many :attendances, class_name: 'Pd::Attendance', foreign_key: 'pd_session_id', dependent: :destroy
 
+  before_validation :set_default_time_zone
+
+  before_update :prevent_time_zone_change
+
   validates_presence_of :start, :end
   validate :starts_and_ends_on_the_same_day
   validate :starts_before_ends
@@ -40,7 +44,7 @@ class Pd::Session < ApplicationRecord
 
   def starts_and_ends_on_the_same_day
     return unless start && self.end
-    unless start.to_datetime.to_date == self.end.to_datetime.to_date
+    unless start_time.to_date == end_time.to_date
       errors.add(:end, 'must occur on the same day as the start.')
     end
   end
@@ -58,15 +62,38 @@ class Pd::Session < ApplicationRecord
     end
   end
 
+  def set_default_time_zone
+    self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : 'UTC'
+  end
+
+  def prevent_time_zone_change
+    if time_zone_changed?
+      self.time_zone = time_zone_was # Revert to the original time_zone
+    end
+  end
+
+  def start_time
+    start.in_time_zone(time_zone || 'UTC')
+  end
+
+  def end_time
+    self.end.in_time_zone(time_zone || 'UTC')
+  end
+
   def formatted_date
-    start.to_date.iso8601
+    start_time.to_date.iso8601
+  end
+
+  def tz_abbreviation
+    return '' if time_zone.blank?
+    ActiveSupport::TimeZone[time_zone].tzinfo.current_period.abbreviation.to_s
   end
 
   def formatted_date_with_start_and_end_times
-    start_time = start.strftime('%l:%M%P').strip
-    end_time = self.end.strftime('%l:%M%P').strip
+    formatted_start = start_time.strftime('%l:%M%P').strip
+    formatted_end = end_time.strftime('%l:%M%P').strip
 
-    "#{formatted_date}, #{start_time}-#{end_time}"
+    "#{formatted_date}, #{formatted_start}-#{formatted_end} #{tz_abbreviation}".strip
   end
 
   def session_info_for_calendar
@@ -78,14 +105,14 @@ class Pd::Session < ApplicationRecord
   end
 
   def start_date_us_format
-    start.strftime('%b %d %Y').strip
+    start_time.strftime('%b %d %Y').strip
   end
 
   def start_date_with_start_and_end_times_us_format
-    start_time = start.strftime('%l:%M%P').strip
-    end_time = self.end.strftime('%l:%M%P').strip
+    formatted_start = start_time.strftime('%l:%M%P').strip
+    formatted_end = end_time.strftime('%l:%M%P').strip
 
-    "#{start_date_us_format}, #{start_time} - #{end_time}"
+    "#{start_date_us_format}, #{formatted_start} - #{formatted_end} #{tz_abbreviation}".strip
   end
 
   def hours

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -30,7 +30,7 @@ class Pd::Session < ApplicationRecord
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 
-  belongs_to :workshop, class_name: 'Pd::Workshop', foreign_key: 'pd_workshop_id', optional: true
+  belongs_to :workshop, class_name: 'Pd::Workshop', foreign_key: 'pd_workshop_id', optional: true, inverse_of: :sessions
   has_many :attendances, class_name: 'Pd::Attendance', foreign_key: 'pd_session_id', dependent: :destroy
 
   validates_presence_of :start, :end

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -33,10 +33,6 @@ class Pd::Session < ApplicationRecord
   belongs_to :workshop, class_name: 'Pd::Workshop', foreign_key: 'pd_workshop_id', optional: true
   has_many :attendances, class_name: 'Pd::Attendance', foreign_key: 'pd_session_id', dependent: :destroy
 
-  before_validation :set_default_time_zone
-
-  before_update :prevent_time_zone_change
-
   validates_presence_of :start, :end
   validate :starts_and_ends_on_the_same_day
   validate :starts_before_ends
@@ -62,22 +58,12 @@ class Pd::Session < ApplicationRecord
     end
   end
 
-  def set_default_time_zone
-    self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : 'UTC'
-  end
-
-  def prevent_time_zone_change
-    if time_zone_changed?
-      self.time_zone = time_zone_was # Revert to the original time_zone
-    end
-  end
-
   def start_time
-    start.in_time_zone(time_zone || 'UTC')
+    start.in_time_zone(workshop.time_zone || 'UTC')
   end
 
   def end_time
-    self.end.in_time_zone(time_zone || 'UTC')
+    self.end.in_time_zone(workshop.time_zone || 'UTC')
   end
 
   def formatted_date
@@ -85,8 +71,8 @@ class Pd::Session < ApplicationRecord
   end
 
   def tz_abbreviation
-    return '' if time_zone.blank?
-    ActiveSupport::TimeZone[time_zone].tzinfo.current_period.abbreviation.to_s
+    return '' if workshop.time_zone.blank?
+    ActiveSupport::TimeZone[workshop.time_zone].tzinfo.current_period.abbreviation.to_s
   end
 
   def formatted_date_with_start_and_end_times

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -104,7 +104,7 @@ class Pd::Workshop < ApplicationRecord
 
   def sessions_must_start_on_separate_days
     if sessions.all(&:valid?)
-      unless sessions.map {|session| session.start.to_datetime.to_date}.uniq.length == sessions.length
+      unless sessions.map {|session| session.start_time.to_date}.uniq.length == sessions.length
         errors.add(:sessions, 'must start on separate days.')
       end
     else

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -46,7 +46,7 @@ class Pd::Workshop < ApplicationRecord
   belongs_to :organizer, class_name: 'User', optional: true
   has_and_belongs_to_many :facilitators, class_name: 'User', join_table: 'pd_workshops_facilitators', foreign_key: 'pd_workshop_id', association_foreign_key: 'user_id'
 
-  has_many :sessions, -> {order :start}, class_name: 'Pd::Session', dependent: :destroy, foreign_key: 'pd_workshop_id'
+  has_many :sessions, -> {order :start}, class_name: 'Pd::Session', dependent: :destroy, foreign_key: 'pd_workshop_id', inverse_of: :workshop
   accepts_nested_attributes_for :sessions, allow_destroy: true
 
   has_many :enrollments, class_name: 'Pd::Enrollment', dependent: :destroy, foreign_key: 'pd_workshop_id'

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -60,6 +60,7 @@ class Pd::Workshop < ApplicationRecord
     'fee',
     'grades',
     'prereq',
+    'time_zone',
 
     # Allows a workshop to be associated with a third party
     # organization.
@@ -74,6 +75,8 @@ class Pd::Workshop < ApplicationRecord
     # can be set to be true or false from the UI
     'suppress_email'
   ]
+
+  before_validation :sanitize_time_zone
 
   validates_inclusion_of :course, in: COURSES
   validates :capacity, numericality: {only_integer: true, greater_than: 0, less_than: 10000}
@@ -129,6 +132,10 @@ class Pd::Workshop < ApplicationRecord
 
   def virtual?
     sessions.any? {|session| session.session_format == "virtual"}
+  end
+
+  def sanitize_time_zone
+    self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : nil
   end
 
   # Whether enrollment in this workshop requires an application

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -5,7 +5,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrollment_code, :pre_workshop_survey_url, :attended, :on_map, :funded, :funding_type, :ready_to_close?,
     :workshop_starting_date, :date_and_location_name, :regional_partner_name, :regional_partner_id,
     :scholarship_workshop?, :can_delete, :created_at, :virtual?, :suppress_email, :third_party_provider, :course_offerings, :module,
-    :participant_group_type, :description, :registration_link, :prereq, :hidden, :grades
+    :participant_group_type, :description, :registration_link, :prereq, :hidden, :grades, :time_zone
 
   def sessions
     object.sessions.map do |session|

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -50,10 +50,6 @@ class Pd::SessionTest < ActiveSupport::TestCase
       end: Time.current.in_time_zone('UTC').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
     )
 
-    # override validation on create that defaults new sessions to UTC timezone if not provided
-    # to reproduce a legacy session with no time_zone
-    session.workshop.time_zone = nil
-
     assert_equal '2016-03-01, 9:00am-5:00pm', session.formatted_date_with_start_and_end_times
   end
 

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -29,6 +29,19 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert_equal 'Meeting link is not a valid URL', session.errors.full_messages[0]
   end
 
+  test 'prevent_time_zone_change' do
+    session = create(:pd_session, time_zone: 'America/Denver')
+    assert_equal 'America/Denver', session.time_zone
+
+    session.update!(time_zone: 'America/New_York')
+    assert_equal 'America/Denver', session.time_zone
+  end
+
+  test 'bad time_zone value results in UTC' do
+    session = create(:pd_session, time_zone: 'Bad/Zone')
+    assert_equal 'UTC', session.time_zone
+  end
+
   test 'formatted_date' do
     session = build :pd_session, start: DateTime.new(2016, 3, 1, 9).in_time_zone
     assert_equal '2016-03-01', session.formatted_date
@@ -37,9 +50,26 @@ class Pd::SessionTest < ActiveSupport::TestCase
   test 'formatted_date_with_start_and_end_times' do
     session = create(
       :pd_session,
-      start: DateTime.new(2016, 3, 1, 9).in_time_zone,
-      end: DateTime.new(2016, 3, 1, 17).in_time_zone
+      time_zone: 'America/Denver',
+      start: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 9).utc.iso8601,
+      end: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
     )
+
+    assert_equal '2016-03-01, 9:00am-5:00pm MST', session.formatted_date_with_start_and_end_times
+  end
+
+  test 'formatted_date_with_start_and_end_times no time_zone' do
+    session = create(
+      :pd_session,
+      start: Time.current.in_time_zone('UTC').change(year: 2016, month: 3, day: 1, hour: 9).utc.iso8601,
+      end: Time.current.in_time_zone('UTC').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
+    )
+
+    assert_equal 'UTC', session.time_zone
+
+    # override validation on create that defaults new sessions to UTC timezone if not provided
+    # to reproduce a legacy session with no time_zone
+    session.time_zone = nil
 
     assert_equal '2016-03-01, 9:00am-5:00pm', session.formatted_date_with_start_and_end_times
   end

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -29,31 +29,16 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert_equal 'Meeting link is not a valid URL', session.errors.full_messages[0]
   end
 
-  test 'prevent_time_zone_change' do
-    session = create(:pd_session, time_zone: 'America/Denver')
-    assert_equal 'America/Denver', session.time_zone
-
-    session.update!(time_zone: 'America/New_York')
-    assert_equal 'America/Denver', session.time_zone
-  end
-
-  test 'bad time_zone value results in UTC' do
-    session = create(:pd_session, time_zone: 'Bad/Zone')
-    assert_equal 'UTC', session.time_zone
-  end
-
   test 'formatted_date' do
     session = build :pd_session, start: DateTime.new(2016, 3, 1, 9).in_time_zone
     assert_equal '2016-03-01', session.formatted_date
   end
 
   test 'formatted_date_with_start_and_end_times' do
-    session = create(
-      :pd_session,
-      time_zone: 'America/Denver',
-      start: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 9).utc.iso8601,
-      end: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
-    )
+    session = build :pd_session
+    session.workshop.time_zone = 'America/Denver'
+    session.start = Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 9).utc.iso8601
+    session.end = Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
 
     assert_equal '2016-03-01, 9:00am-5:00pm MST', session.formatted_date_with_start_and_end_times
   end
@@ -65,11 +50,9 @@ class Pd::SessionTest < ActiveSupport::TestCase
       end: Time.current.in_time_zone('UTC').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
     )
 
-    assert_equal 'UTC', session.time_zone
-
     # override validation on create that defaults new sessions to UTC timezone if not provided
     # to reproduce a legacy session with no time_zone
-    session.time_zone = nil
+    session.workshop.time_zone = nil
 
     assert_equal '2016-03-01, 9:00am-5:00pm', session.formatted_date_with_start_and_end_times
   end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1636,6 +1636,11 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal 'N/A', workshop.workshop_date_range_string
   end
 
+  test 'bad time_zone value results in nil' do
+    workshop = create :workshop, time_zone: 'Bad/Zone'
+    assert_equal nil, workshop.time_zone
+  end
+
   private def session_on_day(day_offset)
     # 9am-5pm
     session_on(day_offset, 9.hours, 17.hours)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This stores the timezone on the workshop, rather than the workshop's sessions. it simplifies handling of legacy workshops without timezones, and it's safe to say a workshop will never need to display sessions in multiple timezones. moving the `time_zone` to the workshop model meant I needed to explicitly define the workshop's `sessions` as the inverse of the `workshop` in order to access the `workshop.time_zone` in the session validation methods. where the session dates and times are rendered, I'm appending the timezone abbreviation, for example `MST` or `MDT` for mountain time. when a timezone is created or edited, the user sees a label saying "All times are in America/Denver", pulling that from `Intl.DateTimeFormat` which detects the user's region.

### Handling legacy workshops and sessions:
legacy workshops do not have a `time_zone`, so the timezone abbreviations are either blank if formatted on the back end and the string "local" if formatted on the front end

Mix of legacy and workshops with time_zone in dashboard:
![Screenshot 2025-02-13 at 3 20 03 PM](https://github.com/user-attachments/assets/bb47d796-0f2c-4372-8cd0-9640a7892a2f)

Mix of legacy and workshops with time_zone in my professional learning page:
![Screenshot 2025-02-13 at 3 25 04 PM](https://github.com/user-attachments/assets/2e63336b-4f6b-4d9e-a88c-a6a870a7e8bb)


Workshop details with workshop time_zone:
![Screenshot 2025-02-13 at 3 21 02 PM](https://github.com/user-attachments/assets/33616d3f-0961-4985-9186-5d788821508e)

Workshop details of legacy workshop without time_zone:
![Screenshot 2025-02-13 at 3 21 19 PM](https://github.com/user-attachments/assets/feb58707-52d9-418f-a142-59ae367d7fc0)


Edit workshop with time_zone:
![Screenshot 2025-02-11 at 3 35 01 PM](https://github.com/user-attachments/assets/9b6c4b7c-202c-4ef9-862e-a7ad9e4a1a6c)


Edit workshop without time_zone:
![Screenshot 2025-02-11 at 3 34 44 PM](https://github.com/user-attachments/assets/c79fc7e4-dc5b-428e-8239-c1ce91d8142e)

Calendar modal add sessions with time_zone
![Screenshot 2025-02-13 at 3 23 32 PM](https://github.com/user-attachments/assets/d7ed112b-889b-42dc-aabd-be35b1b49471)

Calendar modal add legacy sessions without time_zone
![Screenshot 2025-02-13 at 3 27 21 PM](https://github.com/user-attachments/assets/92f37497-7139-4c2b-ac0d-f73a8ae17ae9)

Creating and updating a new workshop with user's time_zone:

https://github.com/user-attachments/assets/4dd28622-f3db-4c0e-be3c-0a76b04a11ba


Editing a legacy workshop without a time_zone, including adding new sessions:

https://github.com/user-attachments/assets/4aeba34a-7d7a-432b-879e-4dc098ad838a



## Links

[jira](https://codedotorg.atlassian.net/browse/ACQ-3052)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
