### PR TITLE
DSCO Swap: update View Student Response button

### DIFF
--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import Button from '@cdo/apps/legacySharedComponents/Button';
+// import Button from '@cdo/apps/legacySharedComponents/Button';
+import {Button, buttonColors} from '@code-dot-org/component-library/button';
 import i18n from '@cdo/locale';
 
 import styles from './summary-entry-point.module.scss';
@@ -30,11 +31,13 @@ const SummaryEntryPoint = ({scriptData, students, selectedSection}) => {
   return (
     <div className={className}>
       <Button
-        color={Button.ButtonColor.neutralDark}
+        color={buttonColors.black}
+        type={'secondary'}
+        size={'s'}
         text={i18n.viewStudentResponses()}
         href={summaryUrl}
+        useAsLink={true}
         className={styles.button}
-        __useDeprecatedTag
       />
 
       {selectedSection && (

--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -1,10 +1,9 @@
+import {Button, buttonColors} from '@code-dot-org/component-library/button';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-// import Button from '@cdo/apps/legacySharedComponents/Button';
-import {Button, buttonColors} from '@code-dot-org/component-library/button';
 import i18n from '@cdo/locale';
 
 import styles from './summary-entry-point.module.scss';


### PR DESCRIPTION
A little tidying detour while I'm working on the level summary page. I updated the "View student responses" button to use the DSCO `Button` component. There are slight visual differences, but no functional changes. 

BEFORE 
![Screenshot 2025-02-11 at 5 03 52 PM](https://github.com/user-attachments/assets/fa8f019a-f35b-4e04-b1b9-0334ea50fe0b)

AFTER 
![Screenshot 2025-02-11 at 5 04 42 PM](https://github.com/user-attachments/assets/bbe85001-2df1-4b3f-9c55-2e15a8149116)

