### PR TITLE
fix(Tooltip): Center content in tooltip

### DIFF
--- a/frontend/packages/component-library/src/tooltip/tooltip.module.scss
+++ b/frontend/packages/component-library/src/tooltip/tooltip.module.scss
@@ -54,6 +54,7 @@ $tooltip-span-vertical-top-spacing: 2px;
   z-index: 10;
   display: flex;
   align-items: center;
+  justify-content: center;
   height: fit-content;
   background-color: $tooltip-background-color;
   box-sizing: border-box;


### PR DESCRIPTION
We observed short text tooltips being misaligned when using tooltips with size = "xs". This appears to fix it.

## Testing story

I repro'd via the design system Storybook, and confirmed that this fixed it. Consulted with @levadadenys, who also chatted with the design team.