### PR TITLE
feat(workshops): validate new session fields

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -345,7 +345,7 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
       :virtual,
       :suppress_email,
       :third_party_provider,
-      {sessions_attributes: [:id, :start, :end, :session_format, :_destroy]},
+      {sessions_attributes: [:id, :start, :end, :session_format, :meeting_link, :location_name, :location_address, :_destroy]},
       :module,
       :participant_group_type
     ]

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -36,6 +36,7 @@ class Pd::Session < ApplicationRecord
   validates_presence_of :start, :end
   validate :starts_and_ends_on_the_same_day
   validate :starts_before_ends
+  validate :valid_meeting_link_format, if: :meeting_link?
 
   def starts_and_ends_on_the_same_day
     return unless start && self.end
@@ -48,6 +49,12 @@ class Pd::Session < ApplicationRecord
     return unless start && self.end
     unless start < self.end
       errors.add(:end, 'must occur after the start.')
+    end
+  end
+
+  def valid_meeting_link_format
+    unless valid_url?(meeting_link)
+      errors.add(:meeting_link, "is not a valid URL")
     end
   end
 
@@ -120,6 +127,13 @@ class Pd::Session < ApplicationRecord
 
   def too_soon_for_link?
     workshop.started_at.nil? || start - 48.hours > Time.zone.now
+  end
+
+  def valid_url?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+  rescue URI::InvalidURIError
+    false
   end
 
   private def unused_random_code

--- a/dashboard/app/serializers/api/v1/pd/session_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/session_serializer.rb
@@ -15,7 +15,7 @@
 #
 
 class Api::V1::Pd::SessionSerializer < ActiveModel::Serializer
-  attributes :id, :start, :end, :code, :session_format, :show_link?, :attendance_count
+  attributes :id, :start, :end, :code, :session_format, :meeting_link, :location_name, :location_address, :show_link?, :attendance_count
 
   def attendance_count
     Pd::Attendance.where(session: object).count

--- a/dashboard/lib/pd/application/regional_partner_teachercon_mapping.rb
+++ b/dashboard/lib/pd/application/regional_partner_teachercon_mapping.rb
@@ -15,35 +15,5 @@ module Pd::Application
       return nil if regional_partner.nil?
       REGIONAL_PARTNER_TC_MAPPING[regional_partner.name]
     end
-
-    def find_teachercon_workshop(course:, city:, year: THIS_YEAR)
-      find_scheduled_workshop(
-        course: course,
-        subject: Pd::Workshop::SUBJECT_TEACHER_CON,
-        city: city,
-        year: year
-      )
-    end
-
-    def find_fit_workshop(course:, city:, year: THIS_YEAR)
-      find_scheduled_workshop(
-        course: course,
-        subject: Pd::Workshop::SUBJECT_FIT,
-        city: city,
-        year: year
-      )
-    end
-
-    def find_scheduled_workshop(course:, subject:, city:, year: THIS_YEAR)
-      Pd::Workshop.
-        in_year(year).
-        where(course: course, subject: subject).
-        joins(:sessions).
-        where(
-          'pd_workshops.location_address LIKE ? OR pd_sessions.location_address LIKE ?',
-          "%#{city}%",
-          "%#{city}%"  # Check both the workshop's location and the session's location
-        ).first
-    end
   end
 end

--- a/dashboard/lib/pd/application/regional_partner_teachercon_mapping.rb
+++ b/dashboard/lib/pd/application/regional_partner_teachercon_mapping.rb
@@ -38,8 +38,12 @@ module Pd::Application
       Pd::Workshop.
         in_year(year).
         where(course: course, subject: subject).
-        where('pd_workshops.location_address like ?', "%#{city}%").
-        first
+        joins(:sessions).
+        where(
+          'pd_workshops.location_address LIKE ? OR pd_sessions.location_address LIKE ?',
+          "%#{city}%",
+          "%#{city}%"  # Check both the workshop's location and the session's location
+        ).first
     end
   end
 end

--- a/dashboard/test/lib/pd/application/regional_partner_teachercon_mapping_test.rb
+++ b/dashboard/test/lib/pd/application/regional_partner_teachercon_mapping_test.rb
@@ -18,39 +18,5 @@ module Pd::Application
         build(:regional_partner, name: 'Mississippi State University')
       )
     end
-
-    test 'find_teachercon_workshop' do
-      Pd::Workshop.any_instance.stubs(:process_location)
-
-      create :workshop, course: Pd::Workshop::COURSE_CSD,
-        subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Phoenix, AZ',
-        num_sessions: 5, sessions_from: Time.new(2018, 7, 22, 9)
-
-      create :workshop, course: Pd::Workshop::COURSE_CSP,
-        subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Phoenix, AZ',
-        num_sessions: 5, sessions_from: Time.new(2018, 7, 22, 9)
-
-      create :workshop, course: Pd::Workshop::COURSE_CSD,
-        subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Atlanta, GA',
-        num_sessions: 5, sessions_from: Time.new(2018, 7, 22, 9)
-
-      create :workshop, course: Pd::Workshop::COURSE_CSP,
-        subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Atlanta, GA',
-        num_sessions: 5, sessions_from: Time.new(2018, 7, 22, 9)
-
-      # Last year, same city
-      create :workshop, course: Pd::Workshop::COURSE_CSD,
-        subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Phoenix, AZ',
-        num_sessions: 5, sessions_from: Time.new(2017, 7, 22, 9)
-
-      create :workshop, course: Pd::Workshop::COURSE_CSP,
-        subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Phoenix, AZ',
-        num_sessions: 5, sessions_from: Time.new(2017, 7, 22, 9)
-
-      assert_nil find_teachercon_workshop(course: Pd::Workshop::COURSE_CSD, city: 'Phoenix')
-      assert_nil find_teachercon_workshop(course: Pd::Workshop::COURSE_CSP, city: 'Phoenix')
-      assert_nil find_teachercon_workshop(course: Pd::Workshop::COURSE_CSD, city: 'Atlanta')
-      assert_nil find_teachercon_workshop(course: Pd::Workshop::COURSE_CSP, city: 'Atlanta')
-    end
   end
 end

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -22,6 +22,13 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert_equal 'End must occur after the start.', session.errors.full_messages[0]
   end
 
+  test 'valid_meeting_link_format validation error' do
+    session = build :pd_session, meeting_link: 'bad/url here'
+    refute session.valid?
+    assert_equal 1, session.errors.messages.count
+    assert_equal 'Meeting link is not a valid URL', session.errors.full_messages[0]
+  end
+
   test 'formatted_date' do
     session = build :pd_session, start: DateTime.new(2016, 3, 1, 9).in_time_zone
     assert_equal '2016-03-01', session.formatted_date


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

this adds some very basic validation for the meeting_link property added to the session model. I updated a query that tries to find workshops located in a given city by also searching the workshop's sessions. also includes the new fields in the session serializer and the allowed params in the workshop controller
## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3077)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
