### PR TITLE
Lesson: background color

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -76,6 +76,7 @@ body.oceans-blue {
 
 body.music-black, body.background-dark {
   background-color: $dark_black;
+  color: $neutral_light;
 }
 
 body.background-dark, body.background-light {


### PR DESCRIPTION
This adds a default foreground color to the dark background, so that in the rare case that plain text is shown instead of a level, it's more legible.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/62905. 

### before

<img width="944" alt="Screenshot 2025-02-12 at 4 01 06 PM" src="https://github.com/user-attachments/assets/1c7473d9-b7b7-407a-b711-18dcd5897c24" />

### after

<img width="944" alt="Screenshot 2025-02-12 at 3 58 56 PM" src="https://github.com/user-attachments/assets/0f4efe87-bfb3-4bc8-9a5a-2f9c74f930bb" />
