### PR TITLE
Fix calendars automatically showing UTC time

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
@@ -41,8 +41,8 @@ const zeroPad = value => {
 const generateDateText = session => {
   const date = new Date(session.start);
   return `${
-    MonthNames[date.getMonth()]
-  } ${date.getDate()}, ${date.getFullYear()}`;
+    MonthNames[date.getUTCMonth()]
+  } ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
 };
 
 const generateTimeText = session => {
@@ -50,14 +50,16 @@ const generateTimeText = session => {
   const end = new Date(session.end);
 
   const startTimeText = start
-    .toLocaleString('utc', {
+    .toLocaleString('en-US', {
+      timeZone: 'utc',
       hour: 'numeric',
       minute: 'numeric',
       hour12: true,
     })
     .replaceAll(' ', '');
   const endTimeText = end
-    .toLocaleString('utc', {
+    .toLocaleString('en-US', {
+      timeZone: 'utc',
       hour: 'numeric',
       minute: 'numeric',
       hour12: true,
@@ -84,14 +86,14 @@ export const buildAppleCalendarLink = (
     const end = new Date(session.end);
     // Calendars parse a month of '01' as January, while Javascript's Date class parses a month of '00'
     // as January, so the month needs to be offset by 1.
-    const date = `${start.getFullYear()}${zeroPad(
-      start.getMonth() + 1
-    )}${zeroPad(start.getDate())}`;
-    const startTime = `${date}T${zeroPad(start.getHours())}${zeroPad(
-      start.getMinutes()
+    const date = `${start.getUTCFullYear()}${zeroPad(
+      start.getUTCMonth() + 1
+    )}${zeroPad(start.getUTCDate())}`;
+    const startTime = `${date}T${zeroPad(start.getUTCHours())}${zeroPad(
+      start.getUTCMinutes()
     )}00`;
-    const endTime = `${date}T${zeroPad(end.getHours())}${zeroPad(
-      end.getMinutes()
+    const endTime = `${date}T${zeroPad(end.getUTCHours())}${zeroPad(
+      end.getUTCMinutes()
     )}00`;
 
     icsFileContent.push(
@@ -124,14 +126,14 @@ export const buildGoogleCalendarLink = (
   const end = new Date(session.end);
   // Calendars parse a month of '01' as January, while Javascript's Date class parses a month of '00'
   // as January, so the month needs to be offset by 1.
-  const date = `${start.getFullYear()}${zeroPad(start.getMonth() + 1)}${zeroPad(
-    start.getDate()
-  )}`;
-  const startTime = `${date}T${zeroPad(start.getHours())}${zeroPad(
-    start.getMinutes()
+  const date = `${start.getUTCFullYear()}${zeroPad(
+    start.getUTCMonth() + 1
+  )}${zeroPad(start.getUTCDate())}`;
+  const startTime = `${date}T${zeroPad(start.getUTCHours())}${zeroPad(
+    start.getUTCMinutes()
   )}00`;
-  const endTime = `${date}T${zeroPad(end.getHours())}${zeroPad(
-    end.getMinutes()
+  const endTime = `${date}T${zeroPad(end.getUTCHours())}${zeroPad(
+    end.getUTCMinutes()
   )}00`;
 
   return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
@@ -150,14 +152,14 @@ export const buildOutlookCalendarLink = (
   const end = new Date(session.end);
   // Calendars parse a month of '01' as January, while Javascript's Date class parses a month of '00'
   // as January, so the month needs to be offset by 1.
-  const date = `${start.getFullYear()}-${zeroPad(
-    start.getMonth() + 1
-  )}-${zeroPad(start.getDate())}`;
-  const startTime = `${date}T${zeroPad(start.getHours())}:${zeroPad(
-    start.getMinutes()
+  const date = `${start.getUTCFullYear()}-${zeroPad(
+    start.getUTCMonth() + 1
+  )}-${zeroPad(start.getUTCDate())}`;
+  const startTime = `${date}T${zeroPad(start.getUTCHours())}:${zeroPad(
+    start.getUTCMinutes()
   )}:00`;
-  const endTime = `${date}T${zeroPad(end.getHours())}:${zeroPad(
-    end.getMinutes()
+  const endTime = `${date}T${zeroPad(end.getUTCHours())}:${zeroPad(
+    end.getUTCMinutes()
   )}:00`;
 
   return `https://outlook.live.com/calendar/action/compose?rru=addevent&subject=${encodeURIComponent(


### PR DESCRIPTION
Based on [this thread](https://codedotorg.slack.com/archives/C04540KNGDQ/p1739374569922769?thread_ts=1739293727.487089&cid=C04540KNGDQ), it looks like calendar times are assumed to be in UTC so they're not showing the wrong times:
![old time table](https://github.com/user-attachments/assets/26f4bac4-278c-45aa-a3f6-298931bb182f)
![non utc](https://github.com/user-attachments/assets/f64be10f-e5b0-45f5-b544-229b57f0a784)
![wrong outlook](https://github.com/user-attachments/assets/b82fd038-f62d-485b-9609-19e81a5a09dd)

In this PR, all the date times use the `getUTC` prefix rather than the `get` prefix to ensure the times are correct:
![fix time tables](https://github.com/user-attachments/assets/8d0026fe-768e-4663-962b-bd914ec8f85f)
![google claendar fix](https://github.com/user-attachments/assets/0f689cfa-e0db-407c-944c-5037af78a378)
![outlook fixed](https://github.com/user-attachments/assets/72fc2f94-57bd-42f7-b070-7f5b220ed177)

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1739374569922769?thread_ts=1739293727.487089&cid=C04540KNGDQ)

## Testing story
Local testing.
