### PR TITLE
Revert "Remove unused i18n lazy loading from test env config"

### DIFF
--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -19,6 +19,24 @@ Dashboard::Application.configure do
 
   is_ci = !!ENV.fetch('CI', nil)
 
+  # test environment should use precompiled, minified, digested assets like production,
+  # unless it's being used for unit tests.
+  ci_test = !!(ENV['UNIT_TEST'] || is_ci)
+
+  unless ci_test
+    # Compress JavaScripts and CSS.
+    # webpack handles js compression for us
+    # config.assets.js_compressor = :uglifier
+    # config.assets.css_compressor = :sass
+
+    # Version of your assets, change this if you want to expire all your assets.
+    config.assets.version = '1.0'
+
+    # Avoid loading all i18n files up front, which can significantly slow down initialization.
+    # Instead, it only loads i18n files that belong to the current locale.
+    config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
+  end
+
   # In CI environments (ie, Drone), stub relevant AWS services (currently just SageMaker)
   # so we can run UI tests for our AI Chat (ie, Generative AI) lab.
   if is_ci
@@ -32,8 +50,10 @@ Dashboard::Application.configure do
   config.action_controller.perform_caching = false
 
   # Disable Rails.cache when running unit tests.
-  # Also disabled in Drone, although unsure sure if this is strictly desired.
-  config.cache_store = :memory_store, {size: 64.megabytes} if ENV['UNIT_TEST'] || is_ci
+  config.cache_store = :memory_store, {size: 64.megabytes} if ci_test
+
+  # config.action_mailer.raise_delivery_errors = true
+  # config.action_mailer.delivery_method = :smtp
 
   # Show mail previews (rails/mailers).
   # See http://edgeguides.rubyonrails.org/action_mailer_basics.html#previewing-emails


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#63642

We (I) thought this lazy loading was not being used -- soon after merging this change, I noticed tests running slowly when I ran individual unit tests locally, which led me to dig in deeper.

ENV['UNIT_TEST'] (which partially controls whether we use lazy loading) is set in two places:
- `common_test_helper.rb`
https://github.com/code-dot-org/code-dot-org/blob/b1a39288084d349044a462a855e1d06d8addefa6/dashboard/test/test_helper.rb#L22
- the `dashboard_ci` Rake task (run as part of the `test:ci` Rake task):
https://github.com/code-dot-org/code-dot-org/blob/b1a39288084d349044a462a855e1d06d8addefa6/lib/rake/test.rake#L105

As far as I can tell, the check of `UNIT_TEST`'s value in the test env config typically happens _before_ the value is set in `test_helper`, so it always evaluates to false.

As a result, my understanding is that **lazy loading is currently used in non-CI test environments.**

## Testing story

I tested running individual unit tests (eg, `bundle exec spring testunit ./test/controllers/aichat_requests_controller_test`)
as well as the full rails test suite (`bundle exec rails test`) and printed out the value of `UNIT_TEST` and saw that is being read before it is set. There was a major performance difference between using lazy loading vs. not.

[Another developer also confirmed much faster](https://codedotorg.slack.com/archives/C08AMQ869QX/p1739312418292869) running of unit tests locally with this set (thanks Ryan!)