### PR TITLE
Python Lab: better error message if input fails

### DIFF
--- a/apps/i18n/pythonlab/en_us.json
+++ b/apps/i18n/pythonlab/en_us.json
@@ -1,0 +1,3 @@
+{
+  "inputFailed": "We're sorry, input is unavailable at this time. Input may not work in a private or incognito window. If you are in a standard browser window, please try refreshing the page. If the issue persists, contact support@code.org."
+}

--- a/apps/src/pythonlab/locale-do-not-import.js
+++ b/apps/src/pythonlab/locale-do-not-import.js
@@ -1,0 +1,15 @@
+/**
+ * DO NOT IMPORT THIS DIRECTLY. Instead do:
+ *   ```
+ *   import msg from '@cdo/apps/pythonlab/locale'.
+ *   ```
+ * This allows the webpack config to determine how locales should be loaded,
+ * which is important for making locale setup work seamlessly in tests.
+ */
+
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+
+let locale = safeLoadLocale('pythonlab_locale');
+locale = localeWithI18nStringTracker(locale, 'pythonlab');
+module.exports = locale;

--- a/apps/src/pythonlab/locale.ts
+++ b/apps/src/pythonlab/locale.ts
@@ -1,0 +1,9 @@
+/**
+ * A TypeScript wrapper for the PythonlabLocale object which casts
+ * it to the {@link Locale} type.
+ */
+import {Locale} from '@cdo/apps/types/locale';
+
+export default require('@cdo/pythonlab/locale') as Locale<
+  typeof import('@cdo/i18n/pythonlab/en_us.json')
+>;

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -94,7 +94,7 @@ initializePyodide();
 onmessage = async event => {
   // make sure loading is done
   await initializePyodide();
-  const {id, python, source, validationFile, canSupportInput} = event.data;
+  const {id, python, source, validationFile} = event.data;
   let results = undefined;
   let sourceToWrite = source;
   // Add the validation file to the source if it exists.
@@ -110,9 +110,7 @@ onmessage = async event => {
   try {
     writeSource(sourceToWrite, DEFAULT_FOLDER_ID, '', pyodide);
     await importPackagesFromFiles(sourceToWrite, pyodide);
-    if (canSupportInput) {
-      await patchInput(id);
-    }
+    await patchInput(id);
     results = await pyodide.runPythonAsync(python, {
       filename: `/${HOME_FOLDER}/${MAIN_PYTHON_FILE}`,
     });

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -4,6 +4,7 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {setAndSaveSource} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {setLoadedCodeEnvironment} from '@cdo/apps/lab2/redux/systemRedux';
 import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
+import pythonlabI18n from '@cdo/apps/pythonlab/locale';
 import {getStore} from '@cdo/apps/redux';
 import {createUuid} from '@cdo/apps/utils';
 
@@ -69,9 +70,7 @@ const setUpPyodideWorker = () => {
         break;
       case 'error':
         if (message.includes(MessageTag.INPUT_FAILED)) {
-          consoleManager?.writeErrorMessage(
-            "We're sorry, input is unavailable at this time. Input may not work in a private or incognito window. If you are in a standard browser window, please try refreshing the page. If the issue persists, contact support@code.org."
-          );
+          consoleManager?.writeErrorMessage(pythonlabI18n.inputFailed());
           break;
         }
         consoleManager?.writeErrorMessage(parseErrorMessage(message));

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -68,6 +68,12 @@ const setUpPyodideWorker = () => {
         getStore().dispatch(setAndSaveSource(message));
         break;
       case 'error':
+        if (message.includes(MessageTag.INPUT_FAILED)) {
+          consoleManager?.writeErrorMessage(
+            "We're sorry, input is unavailable at this time. Input may not work in a private or incognito window. If you are in a standard browser window, please try refreshing the page. If the issue persists, contact support@code.org."
+          );
+          break;
+        }
         consoleManager?.writeErrorMessage(parseErrorMessage(message));
         break;
       case 'system_error':
@@ -187,7 +193,6 @@ const asyncRun = (() => {
         id,
         source,
         validationFile,
-        canSupportInput: canSupportInput(),
       };
       pyodideWorker.postMessage(messageData);
     });

--- a/apps/src/pythonlab/pythonHelpers/patches.ts
+++ b/apps/src/pythonlab/pythonHelpers/patches.ts
@@ -4,6 +4,7 @@ export enum MessageTag {
   MATPLOTLIB_IMG = 'MATPLOTLIB_SHOW_IMG',
   NEIGHBORHOOD_SIGNAL = '[NEIGHBORHOOD]',
   INPUT_PROMPT = '[INPUT_PROMPT]',
+  INPUT_FAILED = '[INPUT_FAILED]',
 }
 
 export const TEARDOWN_CODE = `from pythonlab_setup import teardown_pythonlab
@@ -40,7 +41,7 @@ export const pythonlabInputModule = {
     );
     request.send(null);
     if (request.status !== 200) {
-      throw new Error('Failed to read input.');
+      throw new Error(MessageTag.INPUT_FAILED);
     }
     return request.responseText;
   },

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -206,6 +206,7 @@ const LOCALE_ALIASES = {
     localeDoNotImport('@cdo/lab2/locale'),
     localeDoNotImport('@cdo/music/locale'),
     localeDoNotImport('@cdo/netsim/locale'),
+    localeDoNotImport('@cdo/pythonlab/locale'),
     localeDoNotImport('@cdo/regionalPartnerMiniContact/locale'),
     localeDoNotImport('@cdo/regionalPartnerSearch/locale'),
     localeDoNotImport('@cdo/standaloneVideo/locale'),

--- a/dashboard/app/views/levels/_lab2.html.haml
+++ b/dashboard/app/views/levels/_lab2.html.haml
@@ -6,6 +6,7 @@
   %script{src: webpack_asset_path("js/#{js_locale}/aichat_locale.js")}
   %script{src: webpack_asset_path("js/#{js_locale}/codebridge_locale.js")}
   %script{src: webpack_asset_path("js/#{js_locale}/lab2_locale.js")}
+  %script{src: webpack_asset_path("js/#{js_locale}/pythonlab_locale.js")}
   %script{src: webpack_asset_path('js/googleblockly.js')}
   -# To use css linting in Web Lab 2, uncomment this line. This is commented out because this is a prototype
   -# feature and we aren't ready to have it imported for every lab2 lab yet.


### PR DESCRIPTION
There are a few places where input can fail to work in python lab. The user could be in a browser that doesn't support service workers (as far as I know, this is incognito Firefox only), or it could fail to register the service worker (this so far has only happened twice for a real user, with an empty error, so I'm not quite sure what's going on there). In either of those cases, this replaces a vague error message with a more actionable one for students:

![Screenshot 2025-02-12 at 12 12 05 PM](https://github.com/user-attachments/assets/eb95664b-ae1b-414a-88cf-fc93a1ea5371)

To do this, instead of only patching input when it is available, we always patch input, and if we fail to connect to the service worker we throw a specific error.

As part of this I also set up a translation file for python lab.

## Links
- jira ticket: [CT-1049](https://codedotorg.atlassian.net/browse/CT-1049)


## Testing story
Tested locally.


## Follow-up work
Now that there is a python lab translation file, translate the other python lab specific messages: [CT-1054](https://codedotorg.atlassian.net/browse/CT-1054)



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
