### PR TITLE
added crowdin workflow and configuration

### DIFF
--- a/.github/workflows/apps-crowdin-i18n-sync.yml
+++ b/.github/workflows/apps-crowdin-i18n-sync.yml
@@ -1,0 +1,60 @@
+name: Apps i18n Sync
+
+on:
+  push:
+    branches:
+      - staging
+    paths:
+      - "apps/i18n/**/en_us.json"
+  schedule:
+    - cron: '0 12 * * MON-FRI'  # Runs daily at 4 AM PST
+  workflow_dispatch:  # Allows manual trigger
+
+jobs:
+  sync_sources:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload source files to Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          config: "apps/crowdin.yml"
+          upload_sources: true
+          upload_translations: false
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+  download_translations:
+    runs-on: ubuntu-latest
+    needs: sync_sources
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get current date
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Download translations from Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          config: "apps/crowdin.yml"
+          upload_sources: false
+          download_translations: true
+          localization_branch_name: update-apps-translations-${{ env.DATE }}
+          create_pull_request: true
+          title: "i18n: update apps translations from Crowdin"
+          body: "This PR contains the latest apps translations from Crowdin."
+          pull_request_base_branch_name: staging
+          commit_message: "i18n: update apps translations from Crowdin"
+        env:
+          # Visit https://crowdin.com/settings#api-key to create this token
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/apps/crowdin.yml
+++ b/apps/crowdin.yml
@@ -1,0 +1,23 @@
+project_id: your_project_id
+api_token_env: CROWDIN_PERSONAL_TOKEN
+"base_path": "apps/i18n"
+"preserve_hierarchy": true
+
+# API Credentials must be loaded from a separate identity file. See
+# https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
+"api_key" : ""
+
+files: [
+  {
+    "source": "/**/en_us.json",
+    "translation": "/%original_path%/%locale_with_underscore%",
+    "ignore": [
+      "/calc/en_us.json",
+      "/eval/en_us.json",
+      "/netsim/en_us.json",
+      "/mlPlayground/en_us.json"
+      "/fish/en_us.json"
+    ],
+    "update_option" : "update_as_unapproved"
+  }
+]


### PR DESCRIPTION
### What:
Setting up the configuration files to enable Crowdin-GitHub actions on React i18n files.
- Decupling react strings from the i18n sync.
- Sync up to Crowding source files from `apps/i18n/**/en_us.json`
- Sync down from Crodin translations to `apps/i18n/**/*.json` and create a PR


### Why:
Our i18n sync pipeline is complex, handling content from diverse sources. Some of this content requires processing before being sent out for translation. Content used in react components is simpler and, if properly set up, does not require additional processing.
Since the i18n sync is scheduled once a week, it requires additional planning and coordination. Moreover, the i18n sync is occasionally blocked by other content that requires more oversight.
This block prevents a team from releasing features on time when feature owners want to ensure that it is translated before release. 
Most TMS offer a GitHub integration that allows for automatic source-translation updates between a GitHub repo, and the translation project associated, alleviating engineering time and and simplifying software localization.

## Links
- [GitHub Crowdin Action](https://github.com/marketplace/actions/crowdin-action)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
