### PR TITLE
Use shared OpenAI API key across student learning projects

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -628,11 +628,8 @@ jwks_data:
 jwk_private_key_data: !Secret
 
 # Credentials for OpenAI API
-openai_chat_completion_api_key: !Secret
-openai_chat_completion_org_id: !Secret
 openai_evaluate_rubric_api_key: !Secret
-openai_evaluate_rubric_org_id:
-openai_aichat_safety_api_key: !Secret
+openai_student_learning_api_key: !Secret
 
 # AI Proxy for OpenAI API
 ai_proxy_origin: https://aiproxy-test.code.org

--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -35,4 +35,4 @@ db_credential_admin: !StackSecret
 db_credential_writer: !StackSecret
 db_credential_reader: !StackSecret
 
-openai_aichat_safety_api_key: !Secret
+openai_student_learning_api_key: !Secret

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -62,9 +62,8 @@ slack_bot_token: !Secret
 jwks_data:
 jwk_private_key_data:
 
-openai_chat_completion_api_key: ''
 openai_evaluate_rubric_api_key:
-openai_aichat_safety_api_key: !Secret
+openai_student_learning_api_key: !Secret
 
 # Mapbox
 mapbox_upload_tileset:    'censustiles-dev'

--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -1,7 +1,7 @@
 class OpenaiChatController < ApplicationController
   authorize_resource class: false
 
-  API_KEY = CDO.openai_chat_completion_api_key
+  API_KEY = CDO.openai_student_learning_api_key
   MODEL = SharedConstants::AI_TUTOR_CHAT_MODEL_VERSION
 
   # POST /openai/chat_completion

--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -4,7 +4,7 @@
 # This module is structured very similarly to the AichatSagemakerHelper module,
 # which manages AI Chat lab's interaction with models that use AWS Sagemaker.
 module AichatOpenaiHelper
-  API_KEY = CDO.openai_chat_completion_api_key
+  API_KEY = CDO.openai_student_learning_api_key
   MODEL = SharedConstants::AICHAT_MODEL_VERSION
 
   def self.get_openai_assistant_response(aichat_model_customizations, stored_messages, new_message, level_id)

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -3,7 +3,7 @@ require 'cdo/aws/metrics'
 # Provides functionality to detect toxicity in user input and model output used in the AI Chat Lab.
 # Uses various services to check for profanity and toxicity based on DCDO settings.
 module AichatSafetyHelper
-  API_KEY = CDO.openai_aichat_safety_api_key
+  API_KEY = CDO.openai_student_learning_api_key
   MODEL = SharedConstants::AICHAT_MODEL_VERSION
 
   class ToxicityDetector

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -11,12 +11,10 @@ module OpenaiChatHelper
     end
 
     def request_chat_completion(messages, temperature = DEFAULT_TEMPERATURE)
-      # Set up the API endpoint URL and request headers
       headers = {
         "Content-Type" => "application/json",
         "Authorization" => "Bearer #{api_key}"
       }
-      headers["OpenAI-Organization"] = CDO.openai_chat_completion_org_id if CDO.openai_chat_completion_org_id
 
       data = {
         model: model,

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -7,7 +7,7 @@
 # errors accessing Secrets Manager.
 #slack_bot_token: localoverride
 #pardot_private_key: localoverride
-#openai_aichat_safety_api_key: localoverride
+#openai_student_learning_api_key: localoverride
 
 # Whether to prefix bundler commands with 'sudo'.
 # It may be useful to set this false when doing local development on Linux.


### PR DESCRIPTION
Uses a "new" `openai_student_learning_api_key` across AI Tutor and AI Chat interactions with OpenAI. The value of the key is actually just copied from the existing `openai_aichat_safety_api_key`. We decided that having a single key would be easiest to manage in the long term, and that we can track usage between projects via CloudWatch. [More discussion in this Slack thread.](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1739319271612899)

Prior to this change, AI Tutor and the "base model" usage of gpt-4o-mini were on a personal developer account -- now they (and the safety check usage) use keys owned by "service accounts" ([OpenAI docs](https://help.openai.com/en/articles/9186755-managing-projects-in-the-api-platform#h_f4f30ba612)), which allows for key management to be independent of any individual developer.

A couple of related things I did outside of this PR:
1. I created the new key in Secrets Manager (there's one for production, and one for non-production).
2. I updated the name of the existing Project in OpenAI from "GenAI Safety" to "Student Learning".

## Testing story

I tested manually that safety checks run when updating the system prompt were successful, and I was able to interact with gpt-4o-mini via normal chat. I also tested AI Tutor manually.

## Follow-up work

I can delete the unused keys (`openai_aichat_safety_api_key`, `openai_chat_completion_org_id`, `openai_aichat_safety_api_key`) in Secrets Manager once we've deployed this and seen no issues.

I also added a follow-up task to track token usage in CloudWatch. AI Tutor has very limited usage from what I understand, so maybe not important to differentiate at the moment, but something we should do down the line: https://codedotorg.atlassian.net/browse/LABS-1355