### PR TITLE
Python Lab: include serializedMaze and labConfig in the exemplar

### DIFF
--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -1,6 +1,6 @@
 import {getNextFileId} from '@codebridge/codebridgeContext';
 import {DEFAULT_FOLDER_ID, MAZE_FILE_NAME} from '@codebridge/constants';
-import {combineStartSourcesAndValidation} from '@codebridge/utils';
+import {combineStartSourcesAndValidation, findFile} from '@codebridge/utils';
 import {useCallback, useMemo} from 'react';
 
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
@@ -10,6 +10,7 @@ import {
   getAppOptionsViewingExemplar,
 } from '@cdo/apps/lab2/projects/utils';
 import {
+  MazeCell,
   MultiFileSource,
   ProjectFileType,
   ProjectSources,
@@ -55,6 +56,17 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
     state => state.lab.levelProperties?.predictSettings?.isPredictLevel
   );
 
+  const generateMazeFile = (mazeContents: MazeCell[][], fileId: string) => {
+    return {
+      id: fileId,
+      name: MAZE_FILE_NAME,
+      contents: JSON.stringify(mazeContents),
+      type: ProjectFileType.SYSTEM_SUPPORT,
+      language: 'txt',
+      folderId: DEFAULT_FOLDER_ID,
+    };
+  };
+
   const generateProjectSourceFromStartSource = useCallback(
     (startCode: MultiFileSource) => {
       // If we have a serialized maze, we need to add it to the project sources so
@@ -62,14 +74,7 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
       // system support file.
       if (serializedMaze) {
         const mazeFileId = getNextFileId(Object.values(startCode.files));
-        const mazeFile = {
-          id: mazeFileId,
-          name: MAZE_FILE_NAME,
-          contents: JSON.stringify(serializedMaze),
-          type: ProjectFileType.SYSTEM_SUPPORT,
-          language: 'txt',
-          folderId: DEFAULT_FOLDER_ID,
-        };
+        const mazeFile = generateMazeFile(serializedMaze, mazeFileId);
         startCode = {
           ...startCode,
           files: {
@@ -130,12 +135,39 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
       return templateSources || startSources;
     }
     if (isEditingExemplar || isViewingExemplar) {
+      // Show the existing exemplar sources when editing or viewing exemplar sources,
+      // if they exist.
+      if (exemplarSource) {
+        const parsedExemplarSource: ProjectSources = {
+          source: exemplarSource,
+          labConfig: levelStartSources?.labConfig,
+        };
+        if (serializedMaze) {
+          // If there is an existing maze file, we will replace it with the current maze.
+          // Otherwise, we will create a new maze file.
+          const existingMazeFile = findFile(
+            exemplarSource,
+            MAZE_FILE_NAME,
+            DEFAULT_FOLDER_ID
+          );
+          const mazeFileId =
+            existingMazeFile?.id ||
+            getNextFileId(Object.values(exemplarSource.files));
+          const mazeFile = generateMazeFile(serializedMaze, mazeFileId);
+          parsedExemplarSource.source = {
+            ...exemplarSource,
+            files: {
+              ...exemplarSource.files,
+              [mazeFileId]: mazeFile,
+            },
+          };
+        }
+        return parsedExemplarSource;
+      }
       // If we are viewing exemplars sources and have no exemplar, we show a fallback
       // page from LabViewsRenderer. We fall back to template sources, if they exist,
       // or the level's start sources for editing.
-      return exemplarSource
-        ? {source: exemplarSource}
-        : templateSources || startSources;
+      return templateSources || startSources;
     }
 
     const projectSources = labInitialSources;
@@ -145,11 +177,12 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
     parsedDefaultSources,
     templateStartSources,
     isStartMode,
+    isPredictLevel,
     isEditingExemplar,
     isViewingExemplar,
     labInitialSources,
     exemplarSource,
-    isPredictLevel,
+    serializedMaze,
   ]);
 
   return {


### PR DESCRIPTION
Emma noticed that exemplar levels weren't properly showing the neighborhood. There were 2 fixes needed here:
- Include the labconfig in the exemplar initial sources so we will show the neighborhood preview
- Always use the serialized maze from the level in the exemplar sources (rather than the one from the exemplar, which could be out of date). I confirmed with curriculum that this was the desired behavior.


## Links

- jira ticket: [CT-1055](https://codedotorg.atlassian.net/browse/CT-1055)
- [slack discussion](https://codedotorg.slack.com/archives/C07GHHMNZ9D/p1739386080544289)

## Testing story
Tested locally that standard neighborhood levels still work, and when viewing or editing an exemplar you now see the neighborhood.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
