### PR TITLE
Project card: fix image

### DIFF
--- a/apps/src/templates/projects/project-card.module.scss
+++ b/apps/src/templates/projects/project-card.module.scss
@@ -41,7 +41,6 @@
 .image {
   flex-shrink: 0;
   width: 100%;
-  height: 100%;
 }
 
 .bold {


### PR DESCRIPTION
The work in https://github.com/code-dot-org/code-dot-org/pull/62999 (remerged in https://github.com/code-dot-org/code-dot-org/pull/63149) appears to have caused some of the project card images at https://studio.code.org/projects/public to be squished a bit.  This change proposes a restoration of the previous image appearance.

### before

<img width="1074" alt="Screenshot 2025-02-13 at 10 36 42 PM" src="https://github.com/user-attachments/assets/6ccfb1d4-b9c0-4cf9-b608-05907fac0f14" />

### after

<img width="1074" alt="Screenshot 2025-02-13 at 10 36 49 PM" src="https://github.com/user-attachments/assets/99bb088a-0303-4ded-9451-a945e01e37bd" />
