### PR TITLE
Fix course overview highlight in navbar

### DIFF
--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -22,6 +22,7 @@ import {selectedSectionSelector} from '../teacherDashboard/teacherSectionsReduxS
 import {asyncLoadSelectedSection} from './selectedSectionLoader';
 import {
   LABELED_TEACHER_NAVIGATION_PATHS,
+  TEACHER_NAVIGATION_PATH_NAMES,
   TEACHER_NAVIGATION_PATHS,
 } from './TeacherNavigationPaths';
 
@@ -155,6 +156,19 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
     }
   };
 
+  const isOptionSelected = React.useCallback(
+    (key: string) => {
+      return (
+        currentPathName === key ||
+        (currentPathName === TEACHER_NAVIGATION_PATH_NAMES.courseOverview &&
+          key === TEACHER_NAVIGATION_PATH_NAMES.unitOverview) ||
+        (currentPathName === TEACHER_NAVIGATION_PATH_NAMES.unitOverview &&
+          key === TEACHER_NAVIGATION_PATH_NAMES.courseOverview)
+      );
+    },
+    [currentPathName]
+  );
+
   const getSidebarOptionsForSection = (
     sidebarKeys: (keyof typeof LABELED_TEACHER_NAVIGATION_PATHS)[]
   ) => {
@@ -164,7 +178,7 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
     return sidebarKeys.map(key => (
       <SidebarOption
         key={'ui-test-sidebar-' + key}
-        isSelected={currentPathName === key}
+        isSelected={isOptionSelected(key)}
         sectionId={selectedSection.id}
         courseVersionName={selectedSection.courseVersionName}
         unitName={selectedSection.unitName}

--- a/apps/src/templates/teacherNavigation/TeacherNavigationPaths.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationPaths.tsx
@@ -26,6 +26,10 @@ export const TEACHER_NAVIGATION_PATHS = {
 const getAbsolutePath = (name: string) =>
   `${TEACHER_NAVIGATION_SECTIONS_URL}/${SPECIFIC_SECTION_BASE_URL}/${name}`;
 
+export const TEACHER_NAVIGATION_PATH_NAMES = Object.fromEntries(
+  Object.keys(TEACHER_NAVIGATION_PATHS).map(key => [key, key])
+);
+
 export const LABELED_TEACHER_NAVIGATION_PATHS = {
   home: {
     url: TEACHER_NAVIGATION_PATHS.home,


### PR DESCRIPTION
This was caused by only checking if the url matched the selected section's assignment type (unit or course), however you can get to the unit from the course page and the course from the unit page.

This fixes the issue by adding additional logic for the unit/course pages.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1620
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
