### PR TITLE
Lesson: background color fix

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanelContainer.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanelContainer.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 
+import moduleStyles from './teacher-panel.module.scss';
+
 export default class TeacherPanelContainer extends React.Component {
   static propTypes = {
     children: PropTypes.node,
@@ -32,7 +34,13 @@ export default class TeacherPanelContainer extends React.Component {
 
   render() {
     return (
-      <div className={classNames('teacher-panel', {hidden: !this.state.open})}>
+      <div
+        className={classNames(
+          'teacher-panel',
+          moduleStyles.teacherPanelContainer,
+          {hidden: !this.state.open}
+        )}
+      >
         <div className="hide-handle">
           <FontAwesome icon="chevron-right" onClick={this.hide} />
         </div>

--- a/apps/src/code-studio/components/progress/teacherPanel/teacher-panel.module.scss
+++ b/apps/src/code-studio/components/progress/teacherPanel/teacher-panel.module.scss
@@ -1,3 +1,9 @@
+@import 'color.scss';
+
+.teacherPanelContainer {
+  color: $default_text;
+}
+
 .sortDropdown {
   display: block;
   text-align: center;


### PR DESCRIPTION
This follow-up to https://github.com/code-dot-org/code-dot-org/pull/63884 ensures that the teacher panel renders correctly over dark background lessons.

### before

<img width="995" alt="Screenshot 2025-02-14 at 7 25 26 AM" src="https://github.com/user-attachments/assets/be5b037c-0fe4-4041-a28f-eec465566002" />

### after

<img width="995" alt="Screenshot 2025-02-14 at 7 28 54 AM" src="https://github.com/user-attachments/assets/7f1ced04-732e-429e-b589-ff8286c634e7" />
