### PR TITLE
Add projects route to disallow list in robots.txt

### DIFF
--- a/dashboard/public/robots.txt
+++ b/dashboard/public/robots.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:348bc2056f4c23bffbb10572a49f5e986da6af3f23475ae9b16553b7877af85b
+oid sha256:35ff3c001e18095979042cd5a8a0b8f858b9df6a08a19625aa61bd1230d3caff
 size 173

--- a/dashboard/public/robots.txt
+++ b/dashboard/public/robots.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17e8623580d8065ffb379f9500bd620e259cfc9eb95153ba50232c008358c129
-size 153
+oid sha256:348bc2056f4c23bffbb10572a49f5e986da6af3f23475ae9b16553b7877af85b
+size 173


### PR DESCRIPTION
Robots.txt files are very important for Search Engine Optimization. They make help robots find the right pages on our site to crawl and index. 

This PR suggests adding /projects/ routes to the disallow list in the robots.txt file which means bots trying to crawl the site should not look at any page with a /projects/ route. 

I'm proposing this change for a couple reasons:
- We should not have student projects showing up in search results. 
- These pages are some of the pages on our site marked as "poor performance" in the Google Search Console. [Example ](https://search.google.com/search-console/core-web-vitals/drilldown?resource_id=sc-domain%3Acode.org&item_key=CAMQARgD)
- There are no pages in this route which we need to have indexed to get people to our site. Instead of /projects/<lab>/new routes people would ideally end up on our marketing pages for those tools first such as code.org/applab

## Follow-up work

- I'm working on a follow up doc covering more SEO improvements which will have further suggested updates.


