### PR TITLE
New teacher homepage section list component

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
 
 import {Heading4} from '@cdo/apps/componentLibrary/typography';
+import {SectionMap} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import styles from './teacherHomepage.module.scss';
 
 export const SectionList: React.FC = () => {
-  const sections = useAppSelector(state => state.teacherSections.sections);
-  console.log(sections);
+  const sections: SectionMap = useAppSelector(
+    state => state.teacherSections.sections
+  );
+
+  const getSectionList = (sections: SectionMap) => {
+    const sectionElementList: JSX.Element[] = [];
+    for (const [k, v] of Object.entries(sections)) {
+      sectionElementList.push(<p key={k}>{v.name}</p>);
+    }
+    return sectionElementList;
+  };
 
   return (
     <div className={styles.sectionList}>
       <Heading4>{i18n.classSections()}</Heading4>
+      {getSectionList(sections)}
     </div>
   );
 };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 
-import {Heading2} from '@cdo/apps/componentLibrary/typography';
+import {Heading4} from '@cdo/apps/componentLibrary/typography';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
-export interface SectionListProps {
-  headline: string;
-}
-export const SectionList: React.FC<SectionListProps> = ({headline}) => {
+import styles from './teacherHomepage.module.scss';
+
+export const SectionList: React.FC = () => {
+  const sections = useAppSelector(state => state.teacherSections.sections);
+  console.log(sections);
+
   return (
-    <div>
-      <Heading2>
-        {i18n.welcome()}
-        {headline}
-      </Heading2>
+    <div className={styles.sectionList}>
+      <Heading4>{i18n.classSections()}</Heading4>
     </div>
   );
 };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
@@ -3,12 +3,10 @@ import React from 'react';
 import {Heading2} from '@cdo/apps/componentLibrary/typography';
 import i18n from '@cdo/locale';
 
-export interface TeacherHomepageV2Props {
+export interface SectionListProps {
   headline: string;
 }
-export const TeacherHomepageV2: React.FC<TeacherHomepageV2Props> = ({
-  headline,
-}) => {
+export const SectionList: React.FC<SectionListProps> = ({headline}) => {
   return (
     <div>
       <Heading2>

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -7,7 +7,7 @@ import {SectionList} from './SectionList';
 
 import styles from './teacherHomepage.module.scss';
 
-export const TeacherHomepageV2: React.FC = () => {
+export const TeacherHomepage: React.FC = () => {
   return (
     <div className={styles.teacherHomepageBody}>
       <Heading2>{i18n.welcome()}</Heading2>

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageV2.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageV2.tsx
@@ -5,19 +5,13 @@ import i18n from '@cdo/locale';
 
 import {SectionList} from './SectionList';
 
-export interface TeacherHomepageV2Props {
-  headline: string;
-}
-export const TeacherHomepageV2: React.FC<TeacherHomepageV2Props> = ({
-  headline,
-}) => {
+import styles from './teacherHomepage.module.scss';
+
+export const TeacherHomepageV2: React.FC = () => {
   return (
-    <div>
-      <Heading2>
-        {i18n.welcome()}
-        {headline}
-      </Heading2>
-      <SectionList headline={headline} />
+    <div className={styles.teacherHomepageBody}>
+      <Heading2>{i18n.welcome()}</Heading2>
+      <SectionList />
     </div>
   );
 };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageV2.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageV2.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import {Heading2} from '@cdo/apps/componentLibrary/typography';
+import i18n from '@cdo/locale';
+
+import {SectionList} from './SectionList';
+
+export interface TeacherHomepageV2Props {
+  headline: string;
+}
+export const TeacherHomepageV2: React.FC<TeacherHomepageV2Props> = ({
+  headline,
+}) => {
+  return (
+    <div>
+      <Heading2>
+        {i18n.welcome()}
+        {headline}
+      </Heading2>
+      <SectionList headline={headline} />
+    </div>
+  );
+};

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -1,0 +1,1 @@
+// Styling goes here

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -1,1 +1,9 @@
-// Styling goes here
+@import 'color';
+
+.teacherHomepageBody {
+  padding: 24px 40px;
+}
+
+.sectionList {
+  padding: 12px 0;
+}

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -24,7 +24,7 @@ import SectionProjectsListWithData from '../projects/SectionProjectsListWithData
 import SectionAssessments from '../sectionAssessments/SectionAssessments';
 import StandardsReport from '../sectionProgress/standards/StandardsReport';
 import SectionProgressSelector from '../sectionProgressV2/SectionProgressSelector';
-import {TeacherHomepageV2} from '../studioHomepages/teacherHomepageV2/TeacherHomepageV2';
+import {TeacherHomepage} from '../studioHomepages/teacherHomepageV2/TeacherHomepage';
 import SectionLoginInfo from '../teacherDashboard/SectionLoginInfo';
 import StatsTableWithData from '../teacherDashboard/StatsTableWithData';
 import {
@@ -116,7 +116,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
                 needsReload={needsReload ? needsReload : false}
               />
               <div>
-                <TeacherHomepageV2 />
+                <TeacherHomepage />
               </div>
             </>
           }

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -116,7 +116,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
                 needsReload={needsReload ? needsReload : false}
               />
               <div>
-                <TeacherHomepageV2 headline={'Testing'} />
+                <TeacherHomepageV2 />
               </div>
             </>
           }

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -24,7 +24,7 @@ import SectionProjectsListWithData from '../projects/SectionProjectsListWithData
 import SectionAssessments from '../sectionAssessments/SectionAssessments';
 import StandardsReport from '../sectionProgress/standards/StandardsReport';
 import SectionProgressSelector from '../sectionProgressV2/SectionProgressSelector';
-import {TeacherHomepageV2} from '../studioHomepages/TeacherHomepageV2';
+import {TeacherHomepageV2} from '../studioHomepages/teacherHomepageV2/TeacherHomepageV2';
 import SectionLoginInfo from '../teacherDashboard/SectionLoginInfo';
 import StatsTableWithData from '../teacherDashboard/StatsTableWithData';
 import {

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionListTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionListTest.tsx
@@ -1,0 +1,73 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+import {Provider} from 'react-redux';
+import {Store} from 'redux';
+
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import {SectionList} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/SectionList';
+import teacherSections, {
+  setSections,
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {serverSectionFromSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+
+describe('SectionList', () => {
+  const sections = [
+    {
+      id: 11,
+      name: 'Period 1',
+      hidden: false,
+      courseVersionName: 'csd-2024',
+      unitName: null,
+    },
+    {
+      id: 12,
+      name: 'Period 2',
+      hidden: false,
+      courseVersionName: 'csd-2023',
+      unitName: null,
+    },
+    {
+      id: 13,
+      name: 'Period 3',
+      hidden: false,
+      courseVersionName: 'csd-2022',
+      unitName: 'csd3-2022',
+    },
+    {
+      id: 14,
+      name: 'Period 4',
+      hidden: false,
+      courseVersionName: 'csd-2022',
+      unitName: 'csd6-2022',
+    },
+    {
+      id: 15,
+      name: 'hidden',
+      hidden: true,
+      unitName: null,
+    },
+  ];
+
+  const serverSections = sections.map(serverSectionFromSection);
+
+  const store: Store = getStore();
+  registerReducers({teacherSections});
+  store.dispatch(setSections(serverSections));
+
+  function renderComponent() {
+    return render(
+      <Provider store={store}>
+        <SectionList />
+      </Provider>
+    );
+  }
+
+  it('renders list of teacher sections', async () => {
+    renderComponent();
+    await screen.findByText('Class Sections');
+    screen.getByText('Period 1');
+    screen.getByText('Period 2');
+    screen.getByText('Period 3');
+    screen.getByText('Period 4');
+  });
+});

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -1,0 +1,69 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+import {Provider} from 'react-redux';
+import {Store} from 'redux';
+
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import {TeacherHomepage} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/TeacherHomepage';
+import teacherSections, {
+  setSections,
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {serverSectionFromSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+
+describe('SectionList', () => {
+  const sections = [
+    {
+      id: 11,
+      name: 'Period 1',
+      hidden: false,
+      courseVersionName: 'csd-2024',
+      unitName: null,
+    },
+    {
+      id: 12,
+      name: 'Period 2',
+      hidden: false,
+      courseVersionName: 'csd-2023',
+      unitName: null,
+    },
+    {
+      id: 13,
+      name: 'Period 3',
+      hidden: false,
+      courseVersionName: 'csd-2022',
+      unitName: 'csd3-2022',
+    },
+    {
+      id: 14,
+      name: 'Period 4',
+      hidden: false,
+      courseVersionName: 'csd-2022',
+      unitName: 'csd6-2022',
+    },
+    {
+      id: 15,
+      name: 'hidden',
+      hidden: true,
+      unitName: null,
+    },
+  ];
+
+  const serverSections = sections.map(serverSectionFromSection);
+
+  const store: Store = getStore();
+  registerReducers({teacherSections});
+  store.dispatch(setSections(serverSections));
+
+  function renderComponent() {
+    return render(
+      <Provider store={store}>
+        <TeacherHomepage />
+      </Provider>
+    );
+  }
+  it('renders SectionList component', async () => {
+    renderComponent();
+    await screen.findByText('Welcome,');
+    screen.getByText('Class Sections');
+  });
+});


### PR DESCRIPTION
This update adds the SectionList wrapper component that will hold the section cards in the new teacher homepage

From figma:
![image](https://github.com/user-attachments/assets/7c24fcbc-ea9e-414e-ab17-ecebb68129cd)

## Links
[TEACH-1571](https://codedotorg.atlassian.net/browse/TEACH-1571)
[Figma](https://www.figma.com/design/5ILfiJkPQpjskBwksMDeZl/Teacher-Dashboard?node-id=6208-3713&t=0r4jugQunahP7UVz-0)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
