### PR TITLE
Remove user_id index in backpacks

### DIFF
--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -12,7 +12,6 @@
 # Indexes
 #
 #  index_backpacks_on_storage_app_id  (storage_app_id) UNIQUE
-#  index_backpacks_on_user_id         (user_id) UNIQUE
 #
 class Backpack < ApplicationRecord
   belongs_to :user, optional: true

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -12,6 +12,7 @@
 # Indexes
 #
 #  index_backpacks_on_storage_app_id  (storage_app_id) UNIQUE
+#  index_backpacks_on_user_id_and_game_id  (user_id,game_id) UNIQUE
 #
 class Backpack < ApplicationRecord
   belongs_to :user, optional: true

--- a/dashboard/db/migrate/20250213210703_remove_user_id_index.rb
+++ b/dashboard/db/migrate/20250213210703_remove_user_id_index.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdIndex < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :backpacks, name: "index_backpacks_on_user_id"
+  end
+end

--- a/dashboard/db/migrate/20250213210703_remove_user_id_index.rb
+++ b/dashboard/db/migrate/20250213210703_remove_user_id_index.rb
@@ -1,5 +1,6 @@
 class RemoveUserIdIndex < ActiveRecord::Migration[6.1]
   def change
     remove_index :backpacks, name: "index_backpacks_on_user_id"
+    add_index :backpacks, [:user_id, :game_id], unique: true
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -194,6 +194,7 @@ ActiveRecord::Schema.define(version: 2025_02_13_210703) do
     t.datetime "updated_at", null: false
     t.integer "game_id"
     t.index ["storage_app_id"], name: "index_backpacks_on_storage_app_id", unique: true
+    t.index ["user_id", "game_id"], name: "index_backpacks_on_user_id_and_game_id", unique: true
   end
 
   create_table "blocks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_07_175343) do
+ActiveRecord::Schema.define(version: 2025_02_13_210703) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -194,7 +194,6 @@ ActiveRecord::Schema.define(version: 2025_02_07_175343) do
     t.datetime "updated_at", null: false
     t.integer "game_id"
     t.index ["storage_app_id"], name: "index_backpacks_on_storage_app_id", unique: true
-    t.index ["user_id"], name: "index_backpacks_on_user_id", unique: true
   end
 
   create_table "blocks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/63832. Now that a user can have more than one backpack (one per app type), this PR removes the `user_id` index from the Backpacks table, and adds an index on `user_id` and `game_id` which is unique. This follows up https://github.com/code-dot-org/code-dot-org/pull/63832.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
