### PR TITLE
Improve "Unknown property not in defaults" Error Message

### DIFF
--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -34,10 +34,16 @@ module Cdo
         "#{root}/config.yml.erb"
       )
 
-      defaults = render("#{root}/config.yml.erb").first
-      to_h.each_key do |key|
-        raise "Unknown property not in defaults: #{key}" unless defaults.key?(key.to_sym)
+      configured_properties = to_h.keys.map(&:to_sym)
+      default_properties = render("#{root}/config.yml.erb").first.keys
+      unknown_properties = configured_properties - default_properties
+      unless unknown_properties.empty?
+        raise <<~ERROR
+          Property or properties "#{unknown_properties.join(', ')}" defined in the environment without a default specified in `config.yml.erb`.
+          Likely this is a former configuration value which has been removed from `config.yml.erb` but still exists in your `locals.yml`.
+        ERROR
       end
+
       raise "'#{rack_env}' is not known environment." unless rack_envs.include?(rack_env)
       freeze_config
     end


### PR DESCRIPTION
The bespoke error message we surface when an environment is using a configuration property not included in `config.yml.erb` is somewhat generic. Update it to be a bit more specific about the nature of the problem, and to provide a recommendation for resolution.

Also tweak it to handle multiple violations simultaneously.

## Testing story

Tested locally by adding some bogus values to my `locals.yml`:

```
[~/code-dot-org (elijah/improve-removed-config-error-message)]$ bin/dashboard-console
/home/elijah/projects/work/code-dot-org/lib/cdo.rb:41:in `initialize': Property or properties "foo, baz" defined in the environment without a default specified in `config.yml.erb`. (RuntimeError)
Likely this is a former configuration value which has been removed from `config.yml.erb` but still exists in your `locals.yml`.
        from /home/elijah/.rbenv/versions/3.0.5/lib/ruby/3.0.0/singleton.rb:127:in `new'
        from /home/elijah/.rbenv/versions/3.0.5/lib/ruby/3.0.0/singleton.rb:127:in `block in instance'
        from /home/elijah/.rbenv/versions/3.0.5/lib/ruby/3.0.0/singleton.rb:125:in `synchronize'
        from /home/elijah/.rbenv/versions/3.0.5/lib/ruby/3.0.0/singleton.rb:125:in `instance'
        from /home/elijah/projects/work/code-dot-org/lib/cdo.rb:363:in `<top (required)>'
        from /home/elijah/projects/work/code-dot-org/deployment.rb:10:in `require'
        from /home/elijah/projects/work/code-dot-org/deployment.rb:10:in `<top (required)>'
        from bin/dashboard-console:2:in `require_relative'
        from bin/dashboard-console:2:in `<main>'
```
