### PR TITLE
DIFF - get AI Diff TA button working on new dashboard 

### DIFF
--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -15,6 +15,7 @@ import Typography from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import SidebarOption from '@cdo/apps/templates/teacherNavigation/SidebarOption';
+import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {AiDiffContext} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
@@ -217,20 +218,22 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
         />
         {navbarComponents.map(component => component)}
       </div>
-      <AiDiffFloatingActionButton
-        context={
-          selectedSection.courseId || selectedSection.unitId
-            ? AiDiffContext.COURSE
-            : AiDiffContext.GENERAL
-        }
-        scriptId={
-          selectedSection.courseId
-            ? selectedSection.courseId
-            : selectedSection.unitId
-        }
-        scriptName={selectedSection.courseVersionName}
-        unitDisplayName={selectedSection.courseDisplayName}
-      />
+      {experiments.isEnabled('ai-differentiation') && (
+        <AiDiffFloatingActionButton
+          context={
+            selectedSection.courseId || selectedSection.unitId
+              ? AiDiffContext.COURSE
+              : AiDiffContext.GENERAL
+          }
+          scriptId={
+            selectedSection.courseId
+              ? selectedSection.courseId
+              : selectedSection.unitId
+          }
+          scriptName={selectedSection.courseVersionName}
+          unitDisplayName={selectedSection.courseDisplayName}
+        />
+      )}
     </nav>
   );
 };

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -192,6 +192,14 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
     }
   );
 
+  const aiContext = () => {
+    if (selectedSection?.courseId && selectedSection?.unitId)
+      return AiDiffContext.COURSE;
+    if (selectedSection?.courseId) return AiDiffContext.COURSE;
+    if (selectedSection?.unitId) return AiDiffContext.UNIT;
+    return AiDiffContext.GENERAL;
+  };
+
   return (
     <nav className={styles.sidebarContainer} id="ui-test-teacher-sidebar">
       <div className={styles.sidebarContent}>
@@ -220,11 +228,7 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
       </div>
       {experiments.isEnabled('ai-differentiation') && (
         <AiDiffFloatingActionButton
-          context={
-            selectedSection?.courseId || selectedSection?.unitId
-              ? AiDiffContext.COURSE
-              : AiDiffContext.GENERAL
-          }
+          context={aiContext()}
           scriptId={
             selectedSection?.courseId
               ? selectedSection?.courseId

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -221,17 +221,17 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
       {experiments.isEnabled('ai-differentiation') && (
         <AiDiffFloatingActionButton
           context={
-            selectedSection.courseId || selectedSection.unitId
+            selectedSection?.courseId || selectedSection?.unitId
               ? AiDiffContext.COURSE
               : AiDiffContext.GENERAL
           }
           scriptId={
-            selectedSection.courseId
-              ? selectedSection.courseId
-              : selectedSection.unitId
+            selectedSection?.courseId
+              ? selectedSection?.courseId
+              : selectedSection?.unitId
           }
-          scriptName={selectedSection.courseVersionName}
-          unitDisplayName={selectedSection.courseDisplayName}
+          scriptName={selectedSection?.courseVersionName}
+          unitDisplayName={selectedSection?.courseDisplayName}
         />
       )}
     </nav>

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -10,11 +10,13 @@ import {
   useParams,
 } from 'react-router-dom';
 
+import AiDiffFloatingActionButton from '@cdo/apps/aiDifferentiation/AiDiffFloatingActionButton';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import SidebarOption from '@cdo/apps/templates/teacherNavigation/SidebarOption';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {AiDiffContext} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import {selectedSectionSelector} from '../teacherDashboard/teacherSectionsReduxSelectors';
@@ -215,6 +217,20 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
         />
         {navbarComponents.map(component => component)}
       </div>
+      <AiDiffFloatingActionButton
+        context={
+          selectedSection.courseId || selectedSection.unitId
+            ? AiDiffContext.COURSE
+            : AiDiffContext.GENERAL
+        }
+        scriptId={
+          selectedSection.courseId
+            ? selectedSection.courseId
+            : selectedSection.unitId
+        }
+        scriptName={selectedSection.courseVersionName}
+        unitDisplayName={selectedSection.courseDisplayName}
+      />
     </nav>
   );
 };

--- a/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
+++ b/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
@@ -11,6 +11,9 @@ import {
 } from 'react-router-dom';
 
 import {getStore, registerReducers} from '@cdo/apps/redux';
+import currentUser, {
+  setInitialData,
+} from '@cdo/apps/templates/currentUserRedux';
 import teacherSections, {
   selectSection,
   setSections,
@@ -23,12 +26,21 @@ import {
   TEACHER_NAVIGATION_BASE_URL,
   TEACHER_NAVIGATION_SECTIONS_URL,
 } from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
+import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
 const LocationElement = () => {
   const location = useLocation();
   return <div>{location.pathname} path</div>;
 };
+
+// Needed to mock out the PDFDownloadLink component in the AiDiffContainer
+jest.mock('@react-pdf/renderer', () => ({
+  PDFDownloadLink: () => null,
+  StyleSheet: {
+    create: () => null,
+  },
+}));
 
 describe('TeacherNavigationBar', () => {
   const sections = [
@@ -77,8 +89,16 @@ describe('TeacherNavigationBar', () => {
     store = getStore();
     registerReducers({
       teacherSections,
+      currentUser,
     });
     store.dispatch(setSections(serverSections));
+    store.dispatch(
+      setInitialData({
+        id: 1,
+        name: 'test_user',
+        has_completed_ai_differentiation_welcome: true,
+      })
+    );
 
     loadSelectedSectionSpy = jest
       .spyOn(selectedSectionLoader, 'asyncLoadSelectedSection')
@@ -156,6 +176,10 @@ describe('TeacherNavigationBar', () => {
       </Provider>
     );
   };
+
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = () => {};
+  });
 
   afterEach(() => {
     jest.restoreAllMocks();
@@ -253,5 +277,27 @@ describe('TeacherNavigationBar', () => {
     const dropdownAfterClick = screen.getByRole('combobox');
     expect(dropdownAfterClick).toHaveValue('14');
     expect(loadSelectedSectionSpy).toHaveBeenCalledWith('14');
+  });
+
+  test('does not render AiDiffFloatingActionButton component when experiement is not enabled', async () => {
+    // mock experiment is enabled
+    experiments.isEnabled = jest.fn(() => false);
+    renderDefault(13, `/teacher_dashboard/sections/13/unit/csd3-2022`);
+
+    expect(
+      screen.queryByRole('button', {name: i18n.openOrCloseTeachingAssistant()})
+    ).toBeNull();
+  });
+
+  test('renders AiDiffFloatingActionButton component', async () => {
+    // mock experiment is enabled
+    experiments.isEnabled = jest.fn(() => true);
+    renderDefault(13, `/teacher_dashboard/sections/13/unit/csd3-2022`);
+
+    const chatButton = await screen.findByRole('button', {
+      name: i18n.openOrCloseTeachingAssistant(),
+    });
+    fireEvent.click(chatButton);
+    expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
   });
 });


### PR DESCRIPTION
Adds TA button for Differentiation on every page of the new dashboard. 

<img width="1360" alt="image" src="https://github.com/user-attachments/assets/663094cd-3355-45b5-a38b-0c91f0bade73" />


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?selectedIssue=AITT-913)



## Testing story

Added a Unit test.  Note that I limited how many tests I added to the `TeacherNavigationBar` test since the `AiDiffFloatingActionButton` already has a pretty comprehensive set of tests. 