### PR TITLE
Fix local nav blank on global edition

### DIFF
--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -337,13 +337,6 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
     () => window.location.pathname.split('/teacher_dashboard')[0] || ''
   );
 
-  console.log('lfm', {
-    baseUrlPrepend: baseUrlPrepend(),
-    path: window.location.pathname,
-    split: window.location.pathname.split('/teacher_dashboard'),
-    basename: baseUrlPrepend() + TEACHER_NAVIGATION_BASE_URL,
-  });
-
   return (
     <RouterProvider
       router={createBrowserRouter(createRoutesFromElements(routes), {

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React, {useEffect, useRef} from 'react';
 import {useDispatch} from 'react-redux';
 import {
@@ -332,10 +333,21 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
     ]
   );
 
+  const baseUrlPrepend = _.once(
+    () => window.location.pathname.split('/teacher_dashboard')[0] || ''
+  );
+
+  console.log('lfm', {
+    baseUrlPrepend: baseUrlPrepend(),
+    path: window.location.pathname,
+    split: window.location.pathname.split('/teacher_dashboard'),
+    basename: baseUrlPrepend() + TEACHER_NAVIGATION_BASE_URL,
+  });
+
   return (
     <RouterProvider
       router={createBrowserRouter(createRoutesFromElements(routes), {
-        basename: TEACHER_NAVIGATION_BASE_URL,
+        basename: baseUrlPrepend() + TEACHER_NAVIGATION_BASE_URL,
       })}
     />
   );


### PR DESCRIPTION
Fixes the global edition being completely blank with the new local navigation. This was caused by not appropriately handling anything PREPENDING teacher dashboard.
![image](https://github.com/user-attachments/assets/b2a7fa29-94bd-4b8e-a4ee-c8225e58034b)

## Links
[Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1739479229053549)
[Other debugging thread](https://codedotorg.slack.com/archives/C046G4TRLEN/p1739482862201839)
[Jira](https://codedotorg.atlassian.net/browse/TEACH-1636?atlOrigin=eyJpIjoiMTE3YmQ4MzM5NjBlNGQyNzk2ZjkxODdhOTc4OTFmYWEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
