### PR TITLE
Python Lab: log to statsig on resize

### DIFF
--- a/apps/src/codebridge/Workspace/Output.tsx
+++ b/apps/src/codebridge/Workspace/Output.tsx
@@ -54,7 +54,11 @@ const Output: React.FunctionComponent<OutputProps> = ({
     min: MIN_MINI_APP_SIZE,
     max: MAX_MINI_APP_SIZE,
     containerRef: resizeContainerRef,
-    onResizeStart: () => logOnResize(appName),
+    onResizeStart: () =>
+      logOnResize(appName, {
+        layout: config.activeLayout || '',
+        resizeBar: 'neighborhood',
+      }),
   });
 
   const [adjustedMiniAppSize, setAdjustedMiniAppSize] =

--- a/apps/src/codebridge/Workspace/Output.tsx
+++ b/apps/src/codebridge/Workspace/Output.tsx
@@ -8,6 +8,7 @@ import {useResizable} from 'react-resizable-layout';
 import Console from '@cdo/apps/codebridge/Console/Console';
 import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
 import ResizeBar from '@cdo/apps/lab2/views/components/ResizeBar';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import CodebridgeRegistry from '../CodebridgeRegistry';
 import {MiniApps} from '../constants';
@@ -41,6 +42,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
   // In vertical mode, consoleSize is the height of the console.
   // In horizontal mode, consoleSize is the width of the console.
   const [consoleSize, setConsoleSize] = useState<number | undefined>(undefined);
+  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   const {
     position: miniAppSize,
@@ -52,7 +54,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
     min: MIN_MINI_APP_SIZE,
     max: MAX_MINI_APP_SIZE,
     containerRef: resizeContainerRef,
-    onResizeStart: logOnResize,
+    onResizeStart: () => logOnResize(appName),
   });
 
   const [adjustedMiniAppSize, setAdjustedMiniAppSize] =

--- a/apps/src/codebridge/Workspace/Output.tsx
+++ b/apps/src/codebridge/Workspace/Output.tsx
@@ -6,6 +6,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
 import Console from '@cdo/apps/codebridge/Console/Console';
+import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
 import ResizeBar from '@cdo/apps/lab2/views/components/ResizeBar';
 
 import CodebridgeRegistry from '../CodebridgeRegistry';
@@ -51,6 +52,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
     min: MIN_MINI_APP_SIZE,
     max: MAX_MINI_APP_SIZE,
     containerRef: resizeContainerRef,
+    onResizeStart: logOnResize,
   });
 
   const [adjustedMiniAppSize, setAdjustedMiniAppSize] =

--- a/apps/src/lab2/utils/logOnResize.ts
+++ b/apps/src/lab2/utils/logOnResize.ts
@@ -1,7 +1,10 @@
-import Lab2Registry from '../Lab2Registry';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 
-export const logOnResize = () => {
-  Lab2Registry.getInstance()
-    .getMetricsReporter()
-    .incrementCounter('Lab2.DragToResize');
+export const logOnResize = (labType?: string) => {
+  analyticsReporter.sendEvent(
+    EVENTS.LAB2_RESIZE_DRAG_START,
+    {labType},
+    PLATFORMS.STATSIG
+  );
 };

--- a/apps/src/lab2/utils/logOnResize.ts
+++ b/apps/src/lab2/utils/logOnResize.ts
@@ -1,10 +1,14 @@
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 
-export const logOnResize = (labType?: string) => {
+export const logOnResize = (
+  labType?: string,
+  payload?: Record<string, string>
+) => {
+  const fullPayload = payload ? {labType, ...payload} : {labType};
   analyticsReporter.sendEvent(
     EVENTS.LAB2_RESIZE_DRAG_START,
-    {labType},
+    fullPayload,
     PLATFORMS.STATSIG
   );
 };

--- a/apps/src/lab2/utils/logOnResize.ts
+++ b/apps/src/lab2/utils/logOnResize.ts
@@ -1,0 +1,7 @@
+import Lab2Registry from '../Lab2Registry';
+
+export const logOnResize = () => {
+  Lab2Registry.getInstance()
+    .getMetricsReporter()
+    .incrementCounter('Lab2.DragToResize');
+};

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -531,6 +531,9 @@ const EVENTS = {
 
   // Sign in callout on CSF and CSC levels
   LEVEL_SIGN_IN_CALLOUT_SHOWN: 'Level Sign In Callout Shown',
+
+  // Lab2
+  LAB2_RESIZE_DRAG_START: 'Resize bar dragged in lab2',
 };
 
 const EVENT_GROUP_NAMES = {

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -42,7 +42,11 @@ const HorizontalLayout: React.FunctionComponent = () => {
     axis: 'x',
     initial: INITIAL_INFO_PANEL_WIDTH,
     min: MIN_LEFT_PANEL_WIDTH,
-    onResizeStart: () => logOnResize('pythonlab'),
+    onResizeStart: () =>
+      logOnResize('pythonlab', {
+        layout: 'horizontal',
+        resizeBar: 'instructions',
+      }),
   });
   const {
     position: rawOutputHeight,
@@ -53,7 +57,8 @@ const HorizontalLayout: React.FunctionComponent = () => {
     initial: INITIAL_OUTPUT_HEIGHT,
     min: MIN_OUTPUT_HEIGHT,
     reverse: true,
-    onResizeStart: () => logOnResize('pythonlab'),
+    onResizeStart: () =>
+      logOnResize('pythonlab', {layout: 'horizontal', resizeBar: 'console'}),
   });
 
   const adjustRightPanelWidth = useCallback(() => {

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -5,6 +5,7 @@ import {throttle} from 'lodash';
 import React, {useCallback, useEffect, useMemo} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
+import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
 import ResizeBar, {
   RESIZE_BAR_SIZE_PX,
 } from '@cdo/apps/lab2/views/components/ResizeBar';
@@ -41,6 +42,7 @@ const HorizontalLayout: React.FunctionComponent = () => {
     axis: 'x',
     initial: INITIAL_INFO_PANEL_WIDTH,
     min: MIN_LEFT_PANEL_WIDTH,
+    onResizeStart: logOnResize,
   });
   const {
     position: rawOutputHeight,
@@ -51,6 +53,7 @@ const HorizontalLayout: React.FunctionComponent = () => {
     initial: INITIAL_OUTPUT_HEIGHT,
     min: MIN_OUTPUT_HEIGHT,
     reverse: true,
+    onResizeStart: logOnResize,
   });
 
   const adjustRightPanelWidth = useCallback(() => {

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -42,7 +42,7 @@ const HorizontalLayout: React.FunctionComponent = () => {
     axis: 'x',
     initial: INITIAL_INFO_PANEL_WIDTH,
     min: MIN_LEFT_PANEL_WIDTH,
-    onResizeStart: logOnResize,
+    onResizeStart: () => logOnResize('pythonlab'),
   });
   const {
     position: rawOutputHeight,
@@ -53,7 +53,7 @@ const HorizontalLayout: React.FunctionComponent = () => {
     initial: INITIAL_OUTPUT_HEIGHT,
     min: MIN_OUTPUT_HEIGHT,
     reverse: true,
-    onResizeStart: logOnResize,
+    onResizeStart: () => logOnResize('pythonlab'),
   });
 
   const adjustRightPanelWidth = useCallback(() => {

--- a/apps/src/pythonlab/layout/VerticalLayout.tsx
+++ b/apps/src/pythonlab/layout/VerticalLayout.tsx
@@ -4,6 +4,7 @@ import Output from '@codebridge/Workspace/Output';
 import React, {useCallback, useEffect} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
+import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
 import ResizeBar, {
   RESIZE_BAR_SIZE_PX,
 } from '@cdo/apps/lab2/views/components/ResizeBar';
@@ -32,6 +33,7 @@ const VerticalLayout: React.FunctionComponent = () => {
     axis: 'x',
     initial: INITIAL_INFO_PANEL_WIDTH,
     min: MIN_INFO_PANEL_WIDTH,
+    onResizeStart: logOnResize,
   });
   const {
     position: rawOutputWidth,
@@ -42,6 +44,7 @@ const VerticalLayout: React.FunctionComponent = () => {
     initial: INITIAL_OUTPUT_WIDTH,
     min: MIN_OUTPUT_WIDTH,
     reverse: true,
+    onResizeStart: logOnResize,
   });
 
   const adjustWidths = useCallback(() => {

--- a/apps/src/pythonlab/layout/VerticalLayout.tsx
+++ b/apps/src/pythonlab/layout/VerticalLayout.tsx
@@ -33,7 +33,8 @@ const VerticalLayout: React.FunctionComponent = () => {
     axis: 'x',
     initial: INITIAL_INFO_PANEL_WIDTH,
     min: MIN_INFO_PANEL_WIDTH,
-    onResizeStart: () => logOnResize('pythonlab'),
+    onResizeStart: () =>
+      logOnResize('pythonlab', {layout: 'vertical', resizeBar: 'instructions'}),
   });
   const {
     position: rawOutputWidth,
@@ -44,7 +45,8 @@ const VerticalLayout: React.FunctionComponent = () => {
     initial: INITIAL_OUTPUT_WIDTH,
     min: MIN_OUTPUT_WIDTH,
     reverse: true,
-    onResizeStart: () => logOnResize('pythonlab'),
+    onResizeStart: () =>
+      logOnResize('pythonlab', {layout: 'vertical', resizeBar: 'console'}),
   });
 
   const adjustWidths = useCallback(() => {

--- a/apps/src/pythonlab/layout/VerticalLayout.tsx
+++ b/apps/src/pythonlab/layout/VerticalLayout.tsx
@@ -33,7 +33,7 @@ const VerticalLayout: React.FunctionComponent = () => {
     axis: 'x',
     initial: INITIAL_INFO_PANEL_WIDTH,
     min: MIN_INFO_PANEL_WIDTH,
-    onResizeStart: logOnResize,
+    onResizeStart: () => logOnResize('pythonlab'),
   });
   const {
     position: rawOutputWidth,
@@ -44,7 +44,7 @@ const VerticalLayout: React.FunctionComponent = () => {
     initial: INITIAL_OUTPUT_WIDTH,
     min: MIN_OUTPUT_WIDTH,
     reverse: true,
-    onResizeStart: logOnResize,
+    onResizeStart: () => logOnResize('pythonlab'),
   });
 
   const adjustWidths = useCallback(() => {


### PR DESCRIPTION
Add logging to statsig when any of the resize bars in Python Lab are dragged (we log on drag start). I made a helper method so this logic can be reused if others want to use the `ResizeBar` component and also log on resize.

## Links

- jira ticket: [CT-1046](https://codedotorg.atlassian.net/browse/CT-1046)

## Testing story
Tested locally that the logs look correct.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
