### PR TITLE
Tab Navigability to Timeline Elements in MusicLab

### DIFF
--- a/apps/src/music/views/TimelineElement.tsx
+++ b/apps/src/music/views/TimelineElement.tsx
@@ -60,8 +60,13 @@ const TimelineElement: React.FunctionComponent<TimelineElementProps> = ({
     ? eventData.instrumentType
     : 'beat';
 
+  // The format of an id is "soundType/soundName" so parsing out the soundName
+  const friendlyLabel = eventData.id.split('/').pop();
+
   return (
-    <div
+    <button
+      type="button"
+      aria-label={friendlyLabel}
       className={classNames(
         'timeline-element',
         moduleStyles.timelineElement,
@@ -86,7 +91,7 @@ const TimelineElement: React.FunctionComponent<TimelineElementProps> = ({
       }}
     >
       &nbsp;
-    </div>
+    </button>
   );
 };
 

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -79,6 +79,12 @@
       border-width: 2px;
       border-style: solid;
 
+      &:focus-visible {
+        outline: 2px solid $light_white;
+        outline-offset: 2px;
+        border-radius: 0.375rem;
+      }
+
       &Playing {
         box-shadow: 0 0 10px rgba(255 255 255 / 0.5);
       }

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -71,6 +71,8 @@
     height: 100%;
 
     .timelineElement {
+      margin: 0;
+      padding: 0;
       position: absolute;
       box-sizing: border-box;
       border-radius: 8px;

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -80,7 +80,7 @@
       border-style: solid;
 
       &:focus-visible {
-        outline: 2px solid $light_white;
+        outline: 1px solid $light_white;
         outline-offset: 2px;
         border-radius: 0.375rem;
       }


### PR DESCRIPTION
There is a long thread [here](https://codedotorg.slack.com/archives/C9MB4CL07/p1739405232083519) about the long term plan for the MusicLab Timeline. In the short term, this PR resolves the WCAG violations of not having screen reader a11y here, and gives functionality of a user being able to scroll through the elements (that were previously entirely unreachable) and hear exactly which sounds they are, in order. I'm thinking of this as a space for iterative improvement, and feel this is a solid first step!


https://github.com/user-attachments/assets/85446316-7c63-44ba-98de-ab008baded39



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1003
- https://codedotorg.atlassian.net/browse/CT-998

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
