### PR TITLE
Codebridge: tweak a panel container header

### DIFF
--- a/apps/src/codebridge/Console/console.module.scss
+++ b/apps/src/codebridge/Console/console.module.scss
@@ -34,6 +34,10 @@
 .consoleHeader {
   height: 40px;
   min-height: 40px;
+
+  & > div {
+    height: 40px;
+  }
 }
 
 .controlButton {


### PR DESCRIPTION
A quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/63419 to ensure that items in the Console panel container's header are vertically centered.  They were a tiny bit taller than the header itself.

### before

<img width="1011" alt="Screenshot 2025-02-14 at 10 45 20 AM" src="https://github.com/user-attachments/assets/25235477-6912-45d2-ad3b-64a1a07de273" />

### after

<img width="1011" alt="Screenshot 2025-02-14 at 10 45 05 AM" src="https://github.com/user-attachments/assets/8ccbfee5-dbb9-43d6-aad3-0fa681045c69" />


