### PR TITLE
Fix redirecting to teacher_dashboard and not newest script year

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -30,23 +30,6 @@ class CoursesController < ApplicationController
   end
 
   def show
-    if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.course_id == @unit_group.id} && (Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
-      section_id = params[:section_id] || current_user.sections_instructed.select {|s| s.course_id == @unit_group.id}.last.id
-      if section_id
-        if @unit_group.single_unit_course?
-          redirect_to "/teacher_dashboard/sections/#{section_id}/unit/#{@unit_group.default_units.first.name}"
-          return
-        else
-          redirect_to "/teacher_dashboard/sections/#{section_id}/courses/#{@unit_group.name}"
-          return
-        end
-      end
-    end
-    if (!params[:section_id] && current_user&.last_section_id) && !(Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
-      redirect_to "#{request.path}?section_id=#{current_user.last_section_id}"
-      return
-    end
-
     # Attempt to redirect user if we think they ended up on the wrong course overview page.
     override_redirect = VersionRedirectOverrider.override_course_redirect?(session, @unit_group)
     if !override_redirect && redirect_unit_group = redirect_unit_group(@unit_group)
@@ -57,6 +40,18 @@ class CoursesController < ApplicationController
     # If this is a single-unit course, redirect to the unit overview
     if @unit_group.single_unit_course?
       redirect_to script_path(@unit_group.default_units.first)
+      return
+    end
+
+    if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.course_id == @unit_group.id} && (Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
+      section_id = params[:section_id] || current_user.sections_instructed.select {|s| s.course_id == @unit_group.id}.last.id
+      if section_id
+        redirect_to "/teacher_dashboard/sections/#{section_id}/courses/#{@unit_group.name}"
+        return
+      end
+    end
+    if (!params[:section_id] && current_user&.last_section_id) && !(Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
+      redirect_to "#{request.path}?section_id=#{current_user.last_section_id}"
       return
     end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -16,6 +16,16 @@ class ScriptsController < ApplicationController
   use_reader_connection_for_route(:show)
 
   def show
+    if @script.is_deprecated
+      return render 'errors/deprecated_course'
+    end
+    if @script.redirect_to?
+      redirect_path = script_path(Unit.get_from_cache(@script.redirect_to))
+      redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
+      redirect_to "#{redirect_path}#{redirect_query_string}"
+      return
+    end
+
     if Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false)
       if request.query_parameters.include? "user_id"
         redirect_query_string = request.query_string.sub("user_id=#{request.query_parameters[:user_id]}", "").sub("&&", "&")
@@ -36,16 +46,6 @@ class ScriptsController < ApplicationController
           return
         end
       end
-    end
-
-    if @script.is_deprecated
-      return render 'errors/deprecated_course'
-    end
-    if @script.redirect_to?
-      redirect_path = script_path(Unit.get_from_cache(@script.redirect_to))
-      redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
-      redirect_to "#{redirect_path}#{redirect_query_string}"
-      return
     end
 
     if request.path != (canonical_path = script_path(@script))

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -384,18 +384,6 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to "/teacher_dashboard/sections/#{experiment_section.id}/courses/#{experiment_course.name}"
   end
 
-  test "show: teacher in teacher-local-nav-v2 experiment is redirected to teacher dashboard unit overview if single-unit course is in a section" do
-    experiment_single_unit_course = create :single_unit_course
-    experiment_teacher = create :teacher
-    experiment_section = create :section, user: experiment_teacher, unit_group: experiment_single_unit_course
-    SingleUserExperiment.find_or_create_by!(min_user_id: experiment_teacher.id, name: 'teacher-local-nav-v2')
-
-    sign_in experiment_teacher
-
-    get :show, params: {course_name: experiment_single_unit_course.name}
-    assert_redirected_to "/teacher_dashboard/sections/#{experiment_section.id}/unit/#{experiment_single_unit_course.default_units.first.name}"
-  end
-
   no_access_msg = "You don&#39;t have access to this course."
 
   test_user_gets_response_for :show, response: :redirect, user: nil,


### PR DESCRIPTION
Fixes issue found in [this](https://codedotorg.slack.com/archives/C039X1ZLX/p1739488088761409) slack thread
```
:fire:  Dev outage: Links to units while signed in spin forever :fire:
Start time: Yesterday's DTP
Description: Due to yesterday's release of the teacher local navigation bar, Links to units that have a redirect_to property will cause a signed in user to get a forever spinner instead of loading the unit overview page. These redirect_to units are usually to go from a generic course to the latest course year. e.g. /s/pre-express should go to /s/pre-express-2024
Effected workflows: Production
Users effected? Signed in teachers
```
## Links

https://github.com/user-attachments/assets/d1d8b5fc-d39d-400c-a99d-70433dde6421



## Testing story
Will add tests and better fail cases in a future PR. I want this to go out ASAP
