### PR TITLE
Another Timeline improvement for screen readers

### DIFF
--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -172,12 +172,14 @@ const Timeline: React.FunctionComponent = () => {
   return (
     <div
       id="timeline"
+      aria-label="Timeline"
       className={classNames(
         moduleStyles.timeline,
         isPlaying && moduleStyles.timelinePlaying
       )}
       onClick={onTimelineClick}
       ref={timelineRef}
+      tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
     >
       <div
         id="timeline-measures-background"


### PR DESCRIPTION
There is one more WCAG violation that says we need to announce the timeline because it is scrollable. I added a tabindex and aria-label here to fix the error. This is an improved experience also because it will alert the users that they are now moving into elements within the timeline (so will work in tandem with the updates in https://github.com/code-dot-org/code-dot-org/pull/63942).

https://github.com/user-attachments/assets/fa604e4d-b16f-4cfe-b539-bab229a6cda0


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1000

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
