### PR TITLE
Use :eq instead of undocumented :nth in jQuery in UI tests

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -95,7 +95,7 @@ Feature: Curriculum Catalog Page
     And I click selector "[aria-label='Assign Computer Science Principles to your classroom']"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:nth(2)" is not checked
+    And element "input[type=checkbox]:eq(2)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is not selected
     And I click the "Section 2" checkbox in the dialog
@@ -127,7 +127,7 @@ Feature: Curriculum Catalog Page
     And I click selector "[aria-label='Assign Computer Science Principles to your classroom']"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:nth(2)" is not checked
+    And element "input[type=checkbox]:eq(2)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is selected
     And I click the "Section 2" checkbox in the dialog
@@ -226,7 +226,7 @@ Feature: Curriculum Catalog Page
     And I wait until current URL contains "/home"
     And I wait for jquery to load
     And I wait until element "h3:contains(Create a new section)" is visible
-  
+
   @no_mobile
   Scenario: On expanded card, Signed-in teacher with sections assigns and unassigns offerings to sections
     Given I am a teacher with student sections named Section 1 and Section 2
@@ -253,7 +253,7 @@ Feature: Curriculum Catalog Page
     And I click selector "button:contains(Assign to class sections)"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:nth(2)" is not checked
+    And element "input[type=checkbox]:eq(2)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is not selected
     And I click the "Section 2" checkbox in the dialog
@@ -289,7 +289,7 @@ Feature: Curriculum Catalog Page
     And I click selector "button:contains(Assign to class sections)"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:nth(2)" is not checked
+    And element "input[type=checkbox]:eq(2)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is selected
     And I click the "Section 2" checkbox in the dialog
@@ -302,7 +302,7 @@ Feature: Curriculum Catalog Page
     Then I am on "http://studio.code.org"
     And I see that "Section 1" is not assigned to "AI for Oceans" in the section table
     And I see that "Section 2" is not assigned to "Computer Science Principles" in the section table
-  
+
   @only_mobile
   Scenario: On mobile, Signed-out User sees the Learn More button on Catalog Cards
     Given I am on "http://studio.code.org/catalog"
@@ -310,7 +310,7 @@ Feature: Curriculum Catalog Page
     And I wait until element "h4:contains(AI for Oceans)" is visible
     And I click selector "[aria-label='Learn more about AI for Oceans']"
     And I wait until current URL contains "/oceans"
-  
+
   @only_mobile
   Scenario: On mobile, Signed-in teacher sees the Learn More button on Catalog Cards
     Given I create a teacher named "Teacher Tom"
@@ -319,7 +319,7 @@ Feature: Curriculum Catalog Page
     And I wait until element "h4:contains(AI for Oceans)" is visible
     And I click selector "[aria-label='Learn more about AI for Oceans']"
     And I wait until current URL contains "/oceans"
-  
+
   @only_mobile
   Scenario: On mobile, Signed-in student sees the Try Now button on Catalog Cards
     Given I create a student named "Student Sam"
@@ -328,9 +328,9 @@ Feature: Curriculum Catalog Page
     And I wait until element "h4:contains(AI for Oceans)" is visible
     And I click selector "[aria-label='Try AI for Oceans now']"
     And I wait until current URL contains "/oceans"
-  
+
   # Curriculum Catalog Filter tests
-  
+
   Scenario: User can Select all and Clear all in Curriculum Catalog filters
     Given I am on "http://studio.code.org/catalog"
     Then I wait until element "#grade-dropdown-button" is visible
@@ -365,8 +365,8 @@ Feature: Curriculum Catalog Page
     And the "Grade 10" checkbox is not selected
     And the "Grade 11" checkbox is not selected
     And the "Grade 12" checkbox is not selected
-  
-  
+
+
   Scenario: User can use Clear filters button to clear all selected filters
     Given I am on "http://studio.code.org/catalog"
     Then I wait until element "#grade-dropdown-button" is visible

--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -95,7 +95,7 @@ Feature: Curriculum Catalog Page
     And I click selector "[aria-label='Assign Computer Science Principles to your classroom']"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:nth-child(3)" is not checked
+    And element "input[type=checkbox]:eq(2)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is not selected
     And I click the "Section 2" checkbox in the dialog
@@ -127,7 +127,7 @@ Feature: Curriculum Catalog Page
     And I click selector "[aria-label='Assign Computer Science Principles to your classroom']"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:nth-child(3)" is not checked
+    And element "input[type=checkbox]:eq(2)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is selected
     And I click the "Section 2" checkbox in the dialog
@@ -253,7 +253,7 @@ Feature: Curriculum Catalog Page
     And I click selector "button:contains(Assign to class sections)"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:nth-child(3)" is not checked
+    And element "input[type=checkbox]:eq(2)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is not selected
     And I click the "Section 2" checkbox in the dialog
@@ -289,7 +289,7 @@ Feature: Curriculum Catalog Page
     And I click selector "button:contains(Assign to class sections)"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:nth-child(3)" is not checked
+    And element "input[type=checkbox]:eq(2)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is selected
     And I click the "Section 2" checkbox in the dialog

--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -95,7 +95,7 @@ Feature: Curriculum Catalog Page
     And I click selector "[aria-label='Assign Computer Science Principles to your classroom']"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:eq(2)" is not checked
+    And element "input[type=checkbox]:nth-child(3)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is not selected
     And I click the "Section 2" checkbox in the dialog
@@ -127,7 +127,7 @@ Feature: Curriculum Catalog Page
     And I click selector "[aria-label='Assign Computer Science Principles to your classroom']"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:eq(2)" is not checked
+    And element "input[type=checkbox]:nth-child(3)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is selected
     And I click the "Section 2" checkbox in the dialog
@@ -253,7 +253,7 @@ Feature: Curriculum Catalog Page
     And I click selector "button:contains(Assign to class sections)"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:eq(2)" is not checked
+    And element "input[type=checkbox]:nth-child(3)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is not selected
     And I click the "Section 2" checkbox in the dialog
@@ -289,7 +289,7 @@ Feature: Curriculum Catalog Page
     And I click selector "button:contains(Assign to class sections)"
     And element "span:contains(Section 1)" is visible
     And element "span:contains(Section 2)" is visible
-    And element "input[type=checkbox]:eq(2)" is not checked
+    And element "input[type=checkbox]:nth-child(3)" is not checked
     And the "Section 1" checkbox is not selected
     And the "Section 2" checkbox is selected
     And I click the "Section 2" checkbox in the dialog

--- a/dashboard/test/ui/features/javalab/javalab_submittable.feature
+++ b/dashboard/test/ui/features/javalab/javalab_submittable.feature
@@ -40,7 +40,7 @@ Scenario: Submit anything, teacher is able to unsubmit
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait to see "#teacher-panel-container"
   Then I wait until element "#unsubmit-button-uitest" is visible
   And I press "#unsubmit-button-uitest" using jQuery to load a new page

--- a/dashboard/test/ui/features/javalab/javalab_submittable.feature
+++ b/dashboard/test/ui/features/javalab/javalab_submittable.feature
@@ -40,7 +40,7 @@ Scenario: Submit anything, teacher is able to unsubmit
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait to see "#teacher-panel-container"
   Then I wait until element "#unsubmit-button-uitest" is visible
   And I press "#unsubmit-button-uitest" using jQuery to load a new page

--- a/dashboard/test/ui/features/javalab/javalab_submittable.feature
+++ b/dashboard/test/ui/features/javalab/javalab_submittable.feature
@@ -40,7 +40,7 @@ Scenario: Submit anything, teacher is able to unsubmit
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait to see "#teacher-panel-container"
   Then I wait until element "#unsubmit-button-uitest" is visible
   And I press "#unsubmit-button-uitest" using jQuery to load a new page

--- a/dashboard/test/ui/features/star_labs/applab/data_tab.feature
+++ b/dashboard/test/ui/features/star_labs/applab/data_tab.feature
@@ -17,7 +17,7 @@ Feature: App Lab Data Tab
     And I wait until element ".modal h1" is visible
     Then I save the table name from element ".modal h1"
     And I press "ui-test-import-table-btn"
-    Then I wait until element "#dataTablesBody table tr:eq(2) td:eq(0)" contains the saved table name
+    Then I wait until element "#dataTablesBody table tr:nth-child(3) td:nth-child(1)" contains the saved table name
 
   Scenario: Data Tables Tab
     # Create a new table
@@ -36,13 +36,13 @@ Feature: App Lab Data Tab
     And I click selector "#addDataTableRow input:first-of-type"
     And I press keys "2" for element "#addDataTableRow input:first-of-type"
     And I click selector "#addDataTableRow button:first-of-type"
-    Then I wait until element ".uitest-data-table-row:eq(0) td:nth-child(2)" contains text "2"
+    Then I wait until element ".uitest-data-table-row:nth-child(1) td:nth-child(2)" contains text "2"
 
     # Edit a row
-    And I click selector ".uitest-data-table-row:eq(0) td:nth-child(4) button:first-of-type"
-    Then I click selector ".uitest-data-table-row:eq(0) td:nth-child(2) input:first-of-type" once I see it
+    And I click selector ".uitest-data-table-row:nth-child(1) td:nth-child(4) button:first-of-type"
+    Then I click selector ".uitest-data-table-row:nth-child(1) td:nth-child(2) input:first-of-type" once I see it
     And I press keys "1" for element ".uitest-data-table-row td:nth-child(2) input"
-    And I click selector ".uitest-data-table-row:eq(0) td:nth-child(4) button:first-of-type"
+    And I click selector ".uitest-data-table-row:nth-child(1) td:nth-child(4) button:first-of-type"
     Then I wait until element ".uitest-data-table-content:first-of-type td:nth-child(2)" contains text "21"
 
   Scenario: Key/Value Pairs Tab

--- a/dashboard/test/ui/features/star_labs/applab/data_tab.feature
+++ b/dashboard/test/ui/features/star_labs/applab/data_tab.feature
@@ -17,7 +17,7 @@ Feature: App Lab Data Tab
     And I wait until element ".modal h1" is visible
     Then I save the table name from element ".modal h1"
     And I press "ui-test-import-table-btn"
-    Then I wait until element "#dataTablesBody table tr:nth-child(3) td:nth-child(1)" contains the saved table name
+    Then I wait until element "#dataTablesBody table tr:eq(2) td:eq(0)" contains the saved table name
 
   Scenario: Data Tables Tab
     # Create a new table
@@ -36,13 +36,13 @@ Feature: App Lab Data Tab
     And I click selector "#addDataTableRow input:first-of-type"
     And I press keys "2" for element "#addDataTableRow input:first-of-type"
     And I click selector "#addDataTableRow button:first-of-type"
-    Then I wait until element ".uitest-data-table-row:nth-child(1) td:nth-child(2)" contains text "2"
+    Then I wait until element ".uitest-data-table-row:eq(0) td:nth-child(2)" contains text "2"
 
     # Edit a row
-    And I click selector ".uitest-data-table-row:nth-child(1) td:nth-child(4) button:first-of-type"
-    Then I click selector ".uitest-data-table-row:nth-child(1) td:nth-child(2) input:first-of-type" once I see it
+    And I click selector ".uitest-data-table-row:eq(0) td:nth-child(4) button:first-of-type"
+    Then I click selector ".uitest-data-table-row:eq(0) td:nth-child(2) input:first-of-type" once I see it
     And I press keys "1" for element ".uitest-data-table-row td:nth-child(2) input"
-    And I click selector ".uitest-data-table-row:nth-child(1) td:nth-child(4) button:first-of-type"
+    And I click selector ".uitest-data-table-row:eq(0) td:nth-child(4) button:first-of-type"
     Then I wait until element ".uitest-data-table-content:first-of-type td:nth-child(2)" contains text "21"
 
   Scenario: Key/Value Pairs Tab

--- a/dashboard/test/ui/features/star_labs/applab/level_options.feature
+++ b/dashboard/test/ui/features/star_labs/applab/level_options.feature
@@ -28,6 +28,6 @@ Scenario: Level defaults to design mode, students see design mode and teachers s
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
   And I wait to see Applab code mode

--- a/dashboard/test/ui/features/star_labs/applab/level_options.feature
+++ b/dashboard/test/ui/features/star_labs/applab/level_options.feature
@@ -28,6 +28,6 @@ Scenario: Level defaults to design mode, students see design mode and teachers s
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
   And I wait to see Applab code mode

--- a/dashboard/test/ui/features/star_labs/applab/level_options.feature
+++ b/dashboard/test/ui/features/star_labs/applab/level_options.feature
@@ -28,6 +28,6 @@ Scenario: Level defaults to design mode, students see design mode and teachers s
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
   And I wait to see Applab code mode

--- a/dashboard/test/ui/features/star_labs/applab/libraries.feature
+++ b/dashboard/test/ui/features/star_labs/applab/libraries.feature
@@ -39,7 +39,7 @@ Feature: Libraries
     And I wait until element "a:contains('UntitledProject')" is visible
 
     # Remove Student1's library from Student2's project
-    And I click selector ".ui-test-remove-library:eq(0)" to load a new page
+    And I click selector ".ui-test-remove-library:nth-child(1)" to load a new page
     And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "div:contains('You have no libraries in your project')" is visible
@@ -55,7 +55,7 @@ Feature: Libraries
     And I click selector "#ui-test-manage-libraries" once I see it
     And I wait until element ".ui-test-sortable-table-select" is visible
     When I select the "Untitled Project" option in dropdown named "selectOption"
-    And I click selector ".ui-test-sortable-table-select table input:eq(0)"
+    And I click selector ".ui-test-sortable-table-select table input:nth-child(1)"
     And I click selector ".modal div:contains('Assign library'):last"
     And I wait until element "p:contains('This library is assigned to the following sections:')" is visible
     Then I sign out

--- a/dashboard/test/ui/features/star_labs/applab/libraries.feature
+++ b/dashboard/test/ui/features/star_labs/applab/libraries.feature
@@ -39,7 +39,7 @@ Feature: Libraries
     And I wait until element "a:contains('UntitledProject')" is visible
 
     # Remove Student1's library from Student2's project
-    And I click selector ".ui-test-remove-library:nth-child(1)" to load a new page
+    And I click selector ".ui-test-remove-library:eq(0)" to load a new page
     And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "div:contains('You have no libraries in your project')" is visible
@@ -55,7 +55,7 @@ Feature: Libraries
     And I click selector "#ui-test-manage-libraries" once I see it
     And I wait until element ".ui-test-sortable-table-select" is visible
     When I select the "Untitled Project" option in dropdown named "selectOption"
-    And I click selector ".ui-test-sortable-table-select table input:nth-child(1)"
+    And I click selector ".ui-test-sortable-table-select table input:eq(0)"
     And I click selector ".modal div:contains('Assign library'):last"
     And I wait until element "p:contains('This library is assigned to the following sections:')" is visible
     Then I sign out

--- a/dashboard/test/ui/features/star_labs/applab/versions.feature
+++ b/dashboard/test/ui/features/star_labs/applab/versions.feature
@@ -23,10 +23,10 @@ Scenario: Script Level Versions
   And element ".project_updated_at" eventually contains text "Saved"
 
   When I press "versions-header"
-  And I wait until element "button:contains(Restore):eq(0)" is visible
+  And I wait until element "button:contains(Restore):nth-child(1)" is visible
   And element "button.btn-info" is visible
   And I make all links open in the current tab
-  And I click selector "button.btn-info:eq(0)" to load a new page
+  And I click selector "button.btn-info:nth-child(1)" to load a new page
   And I wait for the lab page to fully load
   Then ace editor code is equal to "// comment 1"
   And element "#workspace-header-span" contains text "View only"
@@ -69,7 +69,7 @@ Scenario: Project Load and Reload
   Then ".versionRow:nth-child(2) p" contains the saved text
   And element ".versionRow:nth-child(2) .img-upload" contains text "Restore"
 
-  And element "#showVersionsModal tr:contains(a minute ago):contains(Restore):eq(1)" is not visible
+  And element "#showVersionsModal tr:contains(a minute ago):contains(Restore):nth-child(2)" is not visible
 
 @no_mobile
 Scenario: Project Version Checkpoints

--- a/dashboard/test/ui/features/star_labs/applab/versions.feature
+++ b/dashboard/test/ui/features/star_labs/applab/versions.feature
@@ -23,10 +23,10 @@ Scenario: Script Level Versions
   And element ".project_updated_at" eventually contains text "Saved"
 
   When I press "versions-header"
-  And I wait until element "button:contains(Restore):nth-child(1)" is visible
+  And I wait until element "button:contains(Restore):eq(0)" is visible
   And element "button.btn-info" is visible
   And I make all links open in the current tab
-  And I click selector "button.btn-info:nth-child(1)" to load a new page
+  And I click selector "button.btn-info:eq(0)" to load a new page
   And I wait for the lab page to fully load
   Then ace editor code is equal to "// comment 1"
   And element "#workspace-header-span" contains text "View only"
@@ -69,7 +69,7 @@ Scenario: Project Load and Reload
   Then ".versionRow:nth-child(2) p" contains the saved text
   And element ".versionRow:nth-child(2) .img-upload" contains text "Restore"
 
-  And element "#showVersionsModal tr:contains(a minute ago):contains(Restore):nth-child(2)" is not visible
+  And element "#showVersionsModal tr:contains(a minute ago):contains(Restore):eq(1)" is not visible
 
 @no_mobile
 Scenario: Project Version Checkpoints

--- a/dashboard/test/ui/features/star_labs/applab_submittable.feature
+++ b/dashboard/test/ui/features/star_labs/applab_submittable.feature
@@ -38,7 +38,7 @@ Scenario: Submit anything, teacher is able to unsubmit
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait to see "#teacher-panel-container"
   Then I wait until element "#unsubmit-button-uitest" is visible
   And I press "#unsubmit-button-uitest" using jQuery to load a new page

--- a/dashboard/test/ui/features/star_labs/applab_submittable.feature
+++ b/dashboard/test/ui/features/star_labs/applab_submittable.feature
@@ -38,7 +38,7 @@ Scenario: Submit anything, teacher is able to unsubmit
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait to see "#teacher-panel-container"
   Then I wait until element "#unsubmit-button-uitest" is visible
   And I press "#unsubmit-button-uitest" using jQuery to load a new page

--- a/dashboard/test/ui/features/star_labs/applab_submittable.feature
+++ b/dashboard/test/ui/features/star_labs/applab_submittable.feature
@@ -38,7 +38,7 @@ Scenario: Submit anything, teacher is able to unsubmit
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait to see "#teacher-panel-container"
   Then I wait until element "#unsubmit-button-uitest" is visible
   And I press "#unsubmit-button-uitest" using jQuery to load a new page

--- a/dashboard/test/ui/features/star_labs/gamelab/libraries.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/libraries.feature
@@ -39,7 +39,7 @@ Feature: Libraries
     And I wait until element "a:contains('UntitledProject')" is visible
 
     # Remove Student1's library from Student2's project
-    And I click selector ".ui-test-remove-library:eq(0)" to load a new page
+    And I click selector ".ui-test-remove-library:nth-child(1)" to load a new page
     And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "div:contains('You have no libraries in your project')" is visible
@@ -55,7 +55,7 @@ Feature: Libraries
     And I click selector "#ui-test-manage-libraries" once I see it
     And I wait until element ".ui-test-sortable-table-select" is visible
     When I select the "Untitled Project" option in dropdown named "selectOption"
-    And I click selector ".ui-test-sortable-table-select table input:eq(0)"
+    And I click selector ".ui-test-sortable-table-select table input:nth-child(1)"
     And I click selector ".modal div:contains('Assign library'):last"
     And I wait until element "p:contains('This library is assigned to the following sections:')" is visible
     Then I sign out

--- a/dashboard/test/ui/features/star_labs/gamelab/libraries.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/libraries.feature
@@ -39,7 +39,7 @@ Feature: Libraries
     And I wait until element "a:contains('UntitledProject')" is visible
 
     # Remove Student1's library from Student2's project
-    And I click selector ".ui-test-remove-library:nth-child(1)" to load a new page
+    And I click selector ".ui-test-remove-library:eq(0)" to load a new page
     And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "div:contains('You have no libraries in your project')" is visible
@@ -55,7 +55,7 @@ Feature: Libraries
     And I click selector "#ui-test-manage-libraries" once I see it
     And I wait until element ".ui-test-sortable-table-select" is visible
     When I select the "Untitled Project" option in dropdown named "selectOption"
-    And I click selector ".ui-test-sortable-table-select table input:nth-child(1)"
+    And I click selector ".ui-test-sortable-table-select table input:eq(0)"
     And I click selector ".modal div:contains('Assign library'):last"
     And I wait until element "p:contains('This library is assigned to the following sections:')" is visible
     Then I sign out

--- a/dashboard/test/ui/features/star_labs/netsim_lobby.feature
+++ b/dashboard/test/ui/features/star_labs/netsim_lobby.feature
@@ -45,7 +45,7 @@ Feature: Using the Internet Simulator Lobby
     Given I am on the 3rd NetSim test level
     And I wait up to 5 seconds for element ".modal" to be visible
     Then element ".modal" is visible
-    And element ".modal h1:nth-child(1)" contains text "Puzzle 3 of 5"
+    And element ".modal h1:eq(0)" contains text "Puzzle 3 of 5"
     And element ".instructions-markdown" contains text "Transfer your favicon to a partner"
 
     # We can close the instructions modal

--- a/dashboard/test/ui/features/star_labs/netsim_lobby.feature
+++ b/dashboard/test/ui/features/star_labs/netsim_lobby.feature
@@ -45,7 +45,7 @@ Feature: Using the Internet Simulator Lobby
     Given I am on the 3rd NetSim test level
     And I wait up to 5 seconds for element ".modal" to be visible
     Then element ".modal" is visible
-    And element ".modal h1:eq(0)" contains text "Puzzle 3 of 5"
+    And element ".modal h1:nth-child(1)" contains text "Puzzle 3 of 5"
     And element ".instructions-markdown" contains text "Transfer your favicon to a partner"
 
     # We can close the instructions modal

--- a/dashboard/test/ui/features/star_labs/weblab/versions.feature
+++ b/dashboard/test/ui/features/star_labs/weblab/versions.feature
@@ -28,9 +28,9 @@ Scenario: Weblab Versions
   And I close the dialog
   And I wait for 3 seconds
   Then I press "versions-header"
-  And I wait until element "button:contains(Restore):eq(0)" is visible
+  And I wait until element "button:contains(Restore):nth-child(1)" is visible
   And element "button.btn-info" is visible
-  And I click selector "button:contains(Restore):eq(0)"
+  And I click selector "button:contains(Restore):nth-child(1)"
   And I wait until element "#showVersionsModal" is gone
   And I wait for 3 seconds
   And I wait until element "#submitButton" is visible
@@ -42,5 +42,5 @@ Scenario: Weblab Versions
   # Instead, we simply verify that there are now 2 earlier versions that can be restored
   Then I press "versions-header"
   And I wait to see a dialog titled "Version History"
-  And I wait until element "button:contains(Restore):eq(1)" is visible
+  And I wait until element "button:contains(Restore):nth-child(2)" is visible
   And I close the dialog

--- a/dashboard/test/ui/features/star_labs/weblab/versions.feature
+++ b/dashboard/test/ui/features/star_labs/weblab/versions.feature
@@ -28,9 +28,9 @@ Scenario: Weblab Versions
   And I close the dialog
   And I wait for 3 seconds
   Then I press "versions-header"
-  And I wait until element "button:contains(Restore):nth-child(1)" is visible
+  And I wait until element "button:contains(Restore):eq(0)" is visible
   And element "button.btn-info" is visible
-  And I click selector "button:contains(Restore):nth-child(1)"
+  And I click selector "button:contains(Restore):eq(0)"
   And I wait until element "#showVersionsModal" is gone
   And I wait for 3 seconds
   And I wait until element "#submitButton" is visible
@@ -42,5 +42,5 @@ Scenario: Weblab Versions
   # Instead, we simply verify that there are now 2 earlier versions that can be restored
   Then I press "versions-header"
   And I wait to see a dialog titled "Version History"
-  And I wait until element "button:contains(Restore):nth-child(2)" is visible
+  And I wait until element "button:contains(Restore):eq(1)" is visible
   And I close the dialog

--- a/dashboard/test/ui/features/step_definitions/match_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/match_steps.rb
@@ -1,31 +1,31 @@
 And /^match level (\d+) question contains text "([^"]*)"$/ do |index, expected_text|
-  selector = ".match:nth(#{index}) .question"
+  selector = ".match:eq(#{index}) .question"
   actual_text = @browser.execute_script("return $(#{selector.dump}).text();")
   expect(actual_text).to include(expected_text)
 end
 
 And /^match level (\d+) contains (\d+) unplaced answers$/ do |index, expected_count|
-  selector = ".match:nth(#{index}) .match_answers .answer"
+  selector = ".match:eq(#{index}) .match_answers .answer"
   actual_count = @browser.execute_script("return $(#{selector.dump}).length;")
   expect(actual_count).to eq(expected_count.to_i)
 end
 
 And /^match level (\d+) contains (\d+) empty slots$/ do |index, expected_count|
-  selector = ".match:nth(#{index}) .match_slots .emptyslot"
+  selector = ".match:eq(#{index}) .match_slots .emptyslot"
   actual_count = @browser.execute_script("return $(#{selector.dump}).length;")
   expect(actual_count).to eq(expected_count.to_i)
 end
 
 And /^I drag match level (\d+) unplaced answer (\d+) to empty slot (\d+)$/ do |level, answer, slot|
-  level_selector = ".match:nth(#{level})"
-  answer_selector = "#{level_selector} .match_answers .answer:nth(#{answer})"
-  slot_selector = "#{level_selector} .match_slots .emptyslot:nth(#{slot})"
+  level_selector = ".match:eq(#{level})"
+  answer_selector = "#{level_selector} .match_answers .answer:eq(#{answer})"
+  slot_selector = "#{level_selector} .match_slots .emptyslot:eq(#{slot})"
   code = generate_selector_drag_code(answer_selector, slot_selector, 0, 0)
   @browser.execute_script code
 end
 
 And /^match placed answer (\d+) has original index (\d+)$/ do |answer, original_index|
-  selector = ".match_slots .answer:nth(#{answer})"
+  selector = ".match_slots .answer:eq(#{answer})"
   actual_index = @browser.execute_script("return $(#{selector.dump}).attr('originalIndex');")
   expect(actual_index.to_i).to eq(original_index)
 end

--- a/dashboard/test/ui/features/step_definitions/match_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/match_steps.rb
@@ -1,31 +1,31 @@
 And /^match level (\d+) question contains text "([^"]*)"$/ do |index, expected_text|
-  selector = ".match:eq(#{index}) .question"
+  selector = ".match:nth-child(#{index + 1}) .question"
   actual_text = @browser.execute_script("return $(#{selector.dump}).text();")
   expect(actual_text).to include(expected_text)
 end
 
 And /^match level (\d+) contains (\d+) unplaced answers$/ do |index, expected_count|
-  selector = ".match:eq(#{index}) .match_answers .answer"
+  selector = ".match:nth-child(#{index + 1}) .match_answers .answer"
   actual_count = @browser.execute_script("return $(#{selector.dump}).length;")
   expect(actual_count).to eq(expected_count.to_i)
 end
 
 And /^match level (\d+) contains (\d+) empty slots$/ do |index, expected_count|
-  selector = ".match:eq(#{index}) .match_slots .emptyslot"
+  selector = ".match:nth-child(#{index + 1}) .match_slots .emptyslot"
   actual_count = @browser.execute_script("return $(#{selector.dump}).length;")
   expect(actual_count).to eq(expected_count.to_i)
 end
 
 And /^I drag match level (\d+) unplaced answer (\d+) to empty slot (\d+)$/ do |level, answer, slot|
-  level_selector = ".match:eq(#{level})"
-  answer_selector = "#{level_selector} .match_answers .answer:eq(#{answer})"
-  slot_selector = "#{level_selector} .match_slots .emptyslot:eq(#{slot})"
+  level_selector = ".match:nth-child(#{level + 1})"
+  answer_selector = "#{level_selector} .match_answers .answer:nth-child(#{answer + 1})"
+  slot_selector = "#{level_selector} .match_slots .emptyslot:nth-child(#{slot + 1})"
   code = generate_selector_drag_code(answer_selector, slot_selector, 0, 0)
   @browser.execute_script code
 end
 
 And /^match placed answer (\d+) has original index (\d+)$/ do |answer, original_index|
-  selector = ".match_slots .answer:eq(#{answer})"
+  selector = ".match_slots .answer:nth-child(#{answer + 1})"
   actual_index = @browser.execute_script("return $(#{selector.dump}).attr('originalIndex');")
   expect(actual_index.to_i).to eq(original_index)
 end

--- a/dashboard/test/ui/features/step_definitions/match_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/match_steps.rb
@@ -1,31 +1,31 @@
 And /^match level (\d+) question contains text "([^"]*)"$/ do |index, expected_text|
-  selector = ".match:nth-child(#{index + 1}) .question"
+  selector = ".match:eq(#{index}) .question"
   actual_text = @browser.execute_script("return $(#{selector.dump}).text();")
   expect(actual_text).to include(expected_text)
 end
 
 And /^match level (\d+) contains (\d+) unplaced answers$/ do |index, expected_count|
-  selector = ".match:nth-child(#{index + 1}) .match_answers .answer"
+  selector = ".match:eq(#{index}) .match_answers .answer"
   actual_count = @browser.execute_script("return $(#{selector.dump}).length;")
   expect(actual_count).to eq(expected_count.to_i)
 end
 
 And /^match level (\d+) contains (\d+) empty slots$/ do |index, expected_count|
-  selector = ".match:nth-child(#{index + 1}) .match_slots .emptyslot"
+  selector = ".match:eq(#{index}) .match_slots .emptyslot"
   actual_count = @browser.execute_script("return $(#{selector.dump}).length;")
   expect(actual_count).to eq(expected_count.to_i)
 end
 
 And /^I drag match level (\d+) unplaced answer (\d+) to empty slot (\d+)$/ do |level, answer, slot|
-  level_selector = ".match:nth-child(#{level + 1})"
-  answer_selector = "#{level_selector} .match_answers .answer:nth-child(#{answer + 1})"
-  slot_selector = "#{level_selector} .match_slots .emptyslot:nth-child(#{slot + 1})"
+  level_selector = ".match:eq(#{level})"
+  answer_selector = "#{level_selector} .match_answers .answer:eq(#{answer})"
+  slot_selector = "#{level_selector} .match_slots .emptyslot:eq(#{slot})"
   code = generate_selector_drag_code(answer_selector, slot_selector, 0, 0)
   @browser.execute_script code
 end
 
 And /^match placed answer (\d+) has original index (\d+)$/ do |answer, original_index|
-  selector = ".match_slots .answer:nth-child(#{answer + 1})"
+  selector = ".match_slots .answer:eq(#{answer})"
   actual_index = @browser.execute_script("return $(#{selector.dump}).attr('originalIndex');")
   expect(actual_index.to_i).to eq(original_index)
 end

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -71,7 +71,7 @@ def verify_bubble_type(selector, type)
 end
 
 def header_bubble_selector(level_num)
-  ".header_level .react_stage a:nth(#{level_num - 1}) .progress-bubble"
+  ".header_level .react_stage a:eq(#{level_num - 1}) .progress-bubble"
 end
 
 Then /^I verify the bubble for level (\d+) is an? (concept|activity) bubble/ do |level, type|
@@ -93,14 +93,14 @@ Then /^I verify progress in the header of the current page is "([^"]*)" for leve
 end
 
 Then /^I verify progress in the drop down of the current page is "([^"]*)" for lesson (\d+) level (\d+)/ do |test_result, lesson, level|
-  selector = "tbody tr:nth(#{lesson.to_i - 1}) a:contains(#{level.to_i}) .progress-bubble"
+  selector = "tbody tr:eq(#{lesson.to_i - 1}) a:contains(#{level.to_i}) .progress-bubble"
   verify_progress(selector, test_result)
 end
 
 Then /^I verify progress for lesson (\d+) level (\d+)( in detail view)? is "([^"]*)"( without waiting)?/ do |lesson, level, detail_view, test_result, without_waiting|
   selector = detail_view.nil? ?
-    ".uitest-summary-progress-table .uitest-summary-progress-row:nth(#{lesson.to_i - 1}) .progress-bubble:nth(#{level.to_i - 1})" :
-    ".uitest-detail-progress-table .uitest-progress-lesson:nth(#{lesson.to_i - 1}) .progress-bubble:nth(#{level.to_i - 1})"
+    ".uitest-summary-progress-table .uitest-summary-progress-row:eq(#{lesson.to_i - 1}) .progress-bubble:eq(#{level.to_i - 1})" :
+    ".uitest-detail-progress-table .uitest-progress-lesson:eq(#{lesson.to_i - 1}) .progress-bubble:eq(#{level.to_i - 1})"
   verify_progress(selector, test_result, no_wait: !!without_waiting)
 end
 

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -71,7 +71,7 @@ def verify_bubble_type(selector, type)
 end
 
 def header_bubble_selector(level_num)
-  ".header_level .react_stage a:eq(#{level_num - 1}) .progress-bubble"
+  ".header_level .react_stage a:nth-child(#{level_num}) .progress-bubble"
 end
 
 Then /^I verify the bubble for level (\d+) is an? (concept|activity) bubble/ do |level, type|
@@ -93,14 +93,14 @@ Then /^I verify progress in the header of the current page is "([^"]*)" for leve
 end
 
 Then /^I verify progress in the drop down of the current page is "([^"]*)" for lesson (\d+) level (\d+)/ do |test_result, lesson, level|
-  selector = "tbody tr:eq(#{lesson.to_i - 1}) a:contains(#{level.to_i}) .progress-bubble"
+  selector = "tbody tr:nth-child(#{lesson.to_i}) a:contains(#{level.to_i}) .progress-bubble"
   verify_progress(selector, test_result)
 end
 
 Then /^I verify progress for lesson (\d+) level (\d+)( in detail view)? is "([^"]*)"( without waiting)?/ do |lesson, level, detail_view, test_result, without_waiting|
   selector = detail_view.nil? ?
-    ".uitest-summary-progress-table .uitest-summary-progress-row:eq(#{lesson.to_i - 1}) .progress-bubble:eq(#{level.to_i - 1})" :
-    ".uitest-detail-progress-table .uitest-progress-lesson:eq(#{lesson.to_i - 1}) .progress-bubble:eq(#{level.to_i - 1})"
+    ".uitest-summary-progress-table .uitest-summary-progress-row:nth-child(#{lesson.to_i}) .progress-bubble:nth-child(#{level.to_i})" :
+    ".uitest-detail-progress-table .uitest-progress-lesson:nth-child(#{lesson.to_i}) .progress-bubble:nth-child(#{level.to_i})"
   verify_progress(selector, test_result, no_wait: !!without_waiting)
 end
 

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -71,7 +71,7 @@ def verify_bubble_type(selector, type)
 end
 
 def header_bubble_selector(level_num)
-  ".header_level .react_stage a:nth-child(#{level_num}) .progress-bubble"
+  ".header_level .react_stage a:eq(#{level_num - 1}) .progress-bubble"
 end
 
 Then /^I verify the bubble for level (\d+) is an? (concept|activity) bubble/ do |level, type|
@@ -93,14 +93,14 @@ Then /^I verify progress in the header of the current page is "([^"]*)" for leve
 end
 
 Then /^I verify progress in the drop down of the current page is "([^"]*)" for lesson (\d+) level (\d+)/ do |test_result, lesson, level|
-  selector = "tbody tr:nth-child(#{lesson.to_i}) a:contains(#{level.to_i}) .progress-bubble"
+  selector = "tbody tr:eq(#{lesson.to_i - 1}) a:contains(#{level.to_i}) .progress-bubble"
   verify_progress(selector, test_result)
 end
 
 Then /^I verify progress for lesson (\d+) level (\d+)( in detail view)? is "([^"]*)"( without waiting)?/ do |lesson, level, detail_view, test_result, without_waiting|
   selector = detail_view.nil? ?
-    ".uitest-summary-progress-table .uitest-summary-progress-row:nth-child(#{lesson.to_i}) .progress-bubble:nth-child(#{level.to_i})" :
-    ".uitest-detail-progress-table .uitest-progress-lesson:nth-child(#{lesson.to_i}) .progress-bubble:nth-child(#{level.to_i})"
+    ".uitest-summary-progress-table .uitest-summary-progress-row:eq(#{lesson.to_i - 1}) .progress-bubble:eq(#{level.to_i - 1})" :
+    ".uitest-detail-progress-table .uitest-progress-lesson:eq(#{lesson.to_i - 1}) .progress-bubble:eq(#{level.to_i - 1})"
   verify_progress(selector, test_result, no_wait: !!without_waiting)
 end
 

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -269,7 +269,7 @@ Then /^the section table row at index (\d+) has (primary|secondary) assignment p
   # Wait until the link loads in the table
   href = nil
   wait_until do
-    href = @browser.execute_script("return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(3) a:eq(#{link_index})').attr('href');")
+    href = @browser.execute_script("return $('.uitest-owned-sections tbody tr:nth-child(#{row_index + 1}) td:nth-child(4) a:nth-child(#{link_index - 1})').attr('href');")
     !href.nil?
   end
 
@@ -356,7 +356,7 @@ def get_section_id_from_table(row_index)
   href = nil
   wait_until do
     href = @browser.execute_script(
-      "return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(1) a').attr('href')"
+      "return $('.uitest-owned-sections tbody tr:nth-child(#{row_index + 1}) td:nth-child(2) a').attr('href')"
     )
     !href.nil?
   end

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -269,7 +269,7 @@ Then /^the section table row at index (\d+) has (primary|secondary) assignment p
   # Wait until the link loads in the table
   href = nil
   wait_until do
-    href = @browser.execute_script("return $('.uitest-owned-sections tbody tr:nth-child(#{row_index + 1}) td:nth-child(4) a:nth-child(#{link_index - 1})').attr('href');")
+    href = @browser.execute_script("return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(3) a:eq(#{link_index})').attr('href');")
     !href.nil?
   end
 
@@ -356,7 +356,7 @@ def get_section_id_from_table(row_index)
   href = nil
   wait_until do
     href = @browser.execute_script(
-      "return $('.uitest-owned-sections tbody tr:nth-child(#{row_index + 1}) td:nth-child(2) a').attr('href')"
+      "return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(1) a').attr('href')"
     )
     !href.nil?
   end

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -46,7 +46,7 @@ end
 Then /^I submit the assessment on "([^"]*)"$/ do |puzzle_url|
   steps %{
     And I am on "#{append_noautoplay(puzzle_url)}"
-    And I click selector ".answers:nth(0) .answerbutton[index=1]" once I see it
+    And I click selector ".answers:eq(0) .answerbutton[index=1]" once I see it
     And I wait for 5 seconds
     And I click selector ".submitButton" once I see it
     And I wait until element ".modal" is visible

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -46,7 +46,7 @@ end
 Then /^I submit the assessment on "([^"]*)"$/ do |puzzle_url|
   steps %{
     And I am on "#{append_noautoplay(puzzle_url)}"
-    And I click selector ".answers:eq(0) .answerbutton[index=1]" once I see it
+    And I click selector ".answers:nth-child(1) .answerbutton[index=1]" once I see it
     And I wait for 5 seconds
     And I click selector ".submitButton" once I see it
     And I wait until element ".modal" is visible

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -46,7 +46,7 @@ end
 Then /^I submit the assessment on "([^"]*)"$/ do |puzzle_url|
   steps %{
     And I am on "#{append_noautoplay(puzzle_url)}"
-    And I click selector ".answers:nth-child(1) .answerbutton[index=1]" once I see it
+    And I click selector ".answers:eq(0) .answerbutton[index=1]" once I see it
     And I wait for 5 seconds
     And I click selector ".submitButton" once I see it
     And I wait until element ".modal" is visible

--- a/dashboard/test/ui/features/step_definitions/studio.rb
+++ b/dashboard/test/ui/features/step_definitions/studio.rb
@@ -7,6 +7,6 @@ When /^I load student number (.*)'s project from the blue teacher panel$/ do |n|
     And I wait to see ".show-handle"
     And I click selector ".show-handle .fa-chevron-left"
     And I wait until element ".student-table" is visible
-    And I click selector "#teacher-panel-container tr:nth(#{n})" to load a new page
+    And I click selector "#teacher-panel-container tr:eq(#{n})" to load a new page
   STEPS
 end

--- a/dashboard/test/ui/features/step_definitions/studio.rb
+++ b/dashboard/test/ui/features/step_definitions/studio.rb
@@ -7,6 +7,6 @@ When /^I load student number (.*)'s project from the blue teacher panel$/ do |n|
     And I wait to see ".show-handle"
     And I click selector ".show-handle .fa-chevron-left"
     And I wait until element ".student-table" is visible
-    And I click selector "#teacher-panel-container tr:nth-child(#{n + 1})" to load a new page
+    And I click selector "#teacher-panel-container tr:eq(#{n})" to load a new page
   STEPS
 end

--- a/dashboard/test/ui/features/step_definitions/studio.rb
+++ b/dashboard/test/ui/features/step_definitions/studio.rb
@@ -7,6 +7,6 @@ When /^I load student number (.*)'s project from the blue teacher panel$/ do |n|
     And I wait to see ".show-handle"
     And I click selector ".show-handle .fa-chevron-left"
     And I wait until element ".student-table" is visible
-    And I click selector "#teacher-panel-container tr:eq(#{n})" to load a new page
+    And I click selector "#teacher-panel-container tr:nth-child(#{n + 1})" to load a new page
   STEPS
 end

--- a/dashboard/test/ui/features/step_definitions/top_instructions.rb
+++ b/dashboard/test/ui/features/step_definitions/top_instructions.rb
@@ -13,9 +13,9 @@ end
 # Updated: Check that image is still visible after pressing play
 Then /^I listen to the (\d+)(?:st|nd|rd|th) inline audio element$/ do |n|
   steps <<-STEPS
-    Then I click selector ".inline-audio:eq(#{n}) .playPause"
+    Then I click selector ".inline-audio:nth-child(#{n + 1}) .playPause"
     And I wait for 2 seconds
-    And element ".inline-audio:eq(#{n}) .playPause i" is visible
+    And element ".inline-audio:nth-child(#{n + 1}) .playPause i" is visible
   STEPS
 end
 

--- a/dashboard/test/ui/features/step_definitions/top_instructions.rb
+++ b/dashboard/test/ui/features/step_definitions/top_instructions.rb
@@ -13,9 +13,9 @@ end
 # Updated: Check that image is still visible after pressing play
 Then /^I listen to the (\d+)(?:st|nd|rd|th) inline audio element$/ do |n|
   steps <<-STEPS
-    Then I click selector ".inline-audio:nth-child(#{n + 1}) .playPause"
+    Then I click selector ".inline-audio:eq(#{n}) .playPause"
     And I wait for 2 seconds
-    And element ".inline-audio:nth-child(#{n + 1}) .playPause i" is visible
+    And element ".inline-audio:eq(#{n}) .playPause i" is visible
   STEPS
 end
 

--- a/dashboard/test/ui/features/student_learning/hour_of_code/ml_hoc.feature
+++ b/dashboard/test/ui/features/student_learning/hour_of_code/ml_hoc.feature
@@ -7,8 +7,8 @@ Feature: Oceans ML HoC
   Scenario: Fish vs. Trash
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/2?guide=off"
-    And I wait until element "button:contains(Fish):eq(1)" is visible
-    Then I click selector "button:contains(Fish):eq(1)" 5 times
+    And I wait until element "button:contains(Fish):nth-child(2)" is visible
+    Then I click selector "button:contains(Fish):nth-child(2)" 5 times
     Then I click selector "button:contains(Not Fish)" 5 times
     Then I click selector "button:contains(Continue)" once I see it
 
@@ -48,8 +48,8 @@ Feature: Oceans ML HoC
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/6?guide=off"
     Then I click selector "button:contains(Blue)" once I see it
-    And I wait until element "button:contains(Blue):eq(1)" is visible
-    Then I click selector "button:contains(Blue):eq(1)" 5 times
+    And I wait until element "button:contains(Blue):nth-child(2)" is visible
+    Then I click selector "button:contains(Blue):nth-child(2)" 5 times
     Then I click selector "button:contains(Not Blue)" 5 times
     Then I click selector "button:contains(Continue)" once I see it
 
@@ -66,8 +66,8 @@ Feature: Oceans ML HoC
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/8?guide=off"
     Then I click selector "button:contains(Fierce)" once I see it
-    And I wait until element "button:contains(Fierce):eq(1)" is visible
-    Then I click selector "button:contains(Fierce):eq(1)" 5 times
+    And I wait until element "button:contains(Fierce):nth-child(2)" is visible
+    Then I click selector "button:contains(Fierce):nth-child(2)" 5 times
     Then I click selector "button:contains(Not Fierce)" 5 times
     Then I click selector "button:contains(Continue)" once I see it
 

--- a/dashboard/test/ui/features/student_learning/hour_of_code/ml_hoc.feature
+++ b/dashboard/test/ui/features/student_learning/hour_of_code/ml_hoc.feature
@@ -7,8 +7,8 @@ Feature: Oceans ML HoC
   Scenario: Fish vs. Trash
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/2?guide=off"
-    And I wait until element "button:contains(Fish):nth-child(2)" is visible
-    Then I click selector "button:contains(Fish):nth-child(2)" 5 times
+    And I wait until element "button:contains(Fish):eq(1)" is visible
+    Then I click selector "button:contains(Fish):eq(1)" 5 times
     Then I click selector "button:contains(Not Fish)" 5 times
     Then I click selector "button:contains(Continue)" once I see it
 
@@ -48,8 +48,8 @@ Feature: Oceans ML HoC
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/6?guide=off"
     Then I click selector "button:contains(Blue)" once I see it
-    And I wait until element "button:contains(Blue):nth-child(2)" is visible
-    Then I click selector "button:contains(Blue):nth-child(2)" 5 times
+    And I wait until element "button:contains(Blue):eq(1)" is visible
+    Then I click selector "button:contains(Blue):eq(1)" 5 times
     Then I click selector "button:contains(Not Blue)" 5 times
     Then I click selector "button:contains(Continue)" once I see it
 
@@ -66,8 +66,8 @@ Feature: Oceans ML HoC
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/8?guide=off"
     Then I click selector "button:contains(Fierce)" once I see it
-    And I wait until element "button:contains(Fierce):nth-child(2)" is visible
-    Then I click selector "button:contains(Fierce):nth-child(2)" 5 times
+    And I wait until element "button:contains(Fierce):eq(1)" is visible
+    Then I click selector "button:contains(Fierce):eq(1)" 5 times
     Then I click selector "button:contains(Not Fierce)" 5 times
     Then I click selector "button:contains(Continue)" once I see it
 

--- a/dashboard/test/ui/features/support/blockly_helpers.rb
+++ b/dashboard/test/ui/features/support/blockly_helpers.rb
@@ -29,7 +29,7 @@ module BlocklyHelpers
   end
 
   def get_indexed_blockly_draggable_selector(index)
-    ".blocklyDraggable:visible:eq(#{index - 1})"
+    ".blocklyDraggable:visible:nth-child(#{index})"
   end
 
   def drag_indexed_block_to_offset(block_selector, dx, dy)

--- a/dashboard/test/ui/features/support/blockly_helpers.rb
+++ b/dashboard/test/ui/features/support/blockly_helpers.rb
@@ -29,7 +29,7 @@ module BlocklyHelpers
   end
 
   def get_indexed_blockly_draggable_selector(index)
-    ".blocklyDraggable:visible:nth-child(#{index})"
+    ".blocklyDraggable:visible:eq(#{index - 1})"
   end
 
   def drag_indexed_block_to_offset(block_selector, dx, dy)

--- a/dashboard/test/ui/features/teacher_tools/cached_level_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/cached_level_page.feature
@@ -14,5 +14,5 @@ Feature: Cached level page
     Given I sign in as "Teacher Monica"
     Then I navigate to the script "dance" lesson 1 level 13 for the section I saved
     And I wait until element "#teacher-panel-container" is visible
-    And I wait until element "td:nth-child(2)" contains text "Joey"
+    And I wait until element "td:eq(1)" contains text "Joey"
     And I wait for 20 seconds

--- a/dashboard/test/ui/features/teacher_tools/cached_level_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/cached_level_page.feature
@@ -14,5 +14,5 @@ Feature: Cached level page
     Given I sign in as "Teacher Monica"
     Then I navigate to the script "dance" lesson 1 level 13 for the section I saved
     And I wait until element "#teacher-panel-container" is visible
-    And I wait until element "td:eq(1)" contains text "Joey"
+    And I wait until element "td:nth-child(2)" contains text "Joey"
     And I wait for 20 seconds

--- a/dashboard/test/ui/features/teacher_tools/hidden_scripts_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/hidden_scripts_eyes.feature
@@ -7,7 +7,7 @@ Scenario: Hidden Scripts
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/courses/allthethingscourse"
   And I wait to see ".uitest-togglehidden"
-  Then I click selector ".uitest-togglehidden:nth(0) div:contains('Hidden')"
+  Then I click selector ".uitest-togglehidden:eq(0) div:contains('Hidden')"
   And I see no difference for "teacher overview with hidden script"
   Then I sign in as "bobby"
   And I am on "http://studio.code.org/courses/allthethingscourse"

--- a/dashboard/test/ui/features/teacher_tools/hidden_scripts_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/hidden_scripts_eyes.feature
@@ -7,7 +7,7 @@ Scenario: Hidden Scripts
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/courses/allthethingscourse"
   And I wait to see ".uitest-togglehidden"
-  Then I click selector ".uitest-togglehidden:eq(0) div:contains('Hidden')"
+  Then I click selector ".uitest-togglehidden:nth-child(1) div:contains('Hidden')"
   And I see no difference for "teacher overview with hidden script"
   Then I sign in as "bobby"
   And I am on "http://studio.code.org/courses/allthethingscourse"

--- a/dashboard/test/ui/features/teacher_tools/hidden_scripts_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/hidden_scripts_eyes.feature
@@ -7,7 +7,7 @@ Scenario: Hidden Scripts
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/courses/allthethingscourse"
   And I wait to see ".uitest-togglehidden"
-  Then I click selector ".uitest-togglehidden:nth-child(1) div:contains('Hidden')"
+  Then I click selector ".uitest-togglehidden:eq(0) div:contains('Hidden')"
   And I see no difference for "teacher overview with hidden script"
   Then I sign in as "bobby"
   And I am on "http://studio.code.org/courses/allthethingscourse"

--- a/dashboard/test/ui/features/teacher_tools/hidden_stages_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/hidden_stages_eyes.feature
@@ -7,7 +7,7 @@ Scenario: Hidden Stages
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/s/allthethings"
   And I wait to see ".uitest-togglehidden"
-  Then I click selector ".uitest-togglehidden:nth(1) div:contains('Hidden')"
+  Then I click selector ".uitest-togglehidden:eq(1) div:contains('Hidden')"
   And I see no difference for "teacher overview with hidden stage"
   Then I sign in as "bobby"
   And I am on "http://studio.code.org/s/allthethings"

--- a/dashboard/test/ui/features/teacher_tools/hidden_stages_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/hidden_stages_eyes.feature
@@ -7,7 +7,7 @@ Scenario: Hidden Stages
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/s/allthethings"
   And I wait to see ".uitest-togglehidden"
-  Then I click selector ".uitest-togglehidden:eq(1) div:contains('Hidden')"
+  Then I click selector ".uitest-togglehidden:nth-child(2) div:contains('Hidden')"
   And I see no difference for "teacher overview with hidden stage"
   Then I sign in as "bobby"
   And I am on "http://studio.code.org/s/allthethings"

--- a/dashboard/test/ui/features/teacher_tools/hidden_stages_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/hidden_stages_eyes.feature
@@ -7,7 +7,7 @@ Scenario: Hidden Stages
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/s/allthethings"
   And I wait to see ".uitest-togglehidden"
-  Then I click selector ".uitest-togglehidden:nth-child(2) div:contains('Hidden')"
+  Then I click selector ".uitest-togglehidden:eq(1) div:contains('Hidden')"
   And I see no difference for "teacher overview with hidden stage"
   Then I sign in as "bobby"
   And I am on "http://studio.code.org/s/allthethings"

--- a/dashboard/test/ui/features/teacher_tools/instructions/csp_top_instructions_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/csp_top_instructions_eyes.feature
@@ -41,7 +41,7 @@ Scenario: Resizing CSD and CSP Top Instructions
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   Then I see no difference for "teacher in feedback tab"

--- a/dashboard/test/ui/features/teacher_tools/instructions/csp_top_instructions_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/csp_top_instructions_eyes.feature
@@ -41,7 +41,7 @@ Scenario: Resizing CSD and CSP Top Instructions
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
 
   Then I see no difference for "teacher in feedback tab"

--- a/dashboard/test/ui/features/teacher_tools/instructions/csp_top_instructions_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/csp_top_instructions_eyes.feature
@@ -41,7 +41,7 @@ Scenario: Resizing CSD and CSP Top Instructions
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   Then I see no difference for "teacher in feedback tab"

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
@@ -57,7 +57,7 @@ Otherwise don't show feedback tab
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait to see ".editor-column"
   And I wait to see "#ui-test-submit-feedback"
   And element ".editor-column" contains text "This is the key concept for this mini rubric."

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
@@ -57,7 +57,7 @@ Otherwise don't show feedback tab
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait to see ".editor-column"
   And I wait to see "#ui-test-submit-feedback"
   And element ".editor-column" contains text "This is the key concept for this mini rubric."

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
@@ -57,7 +57,7 @@ Otherwise don't show feedback tab
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait to see ".editor-column"
   And I wait to see "#ui-test-submit-feedback"
   And element ".editor-column" contains text "This is the key concept for this mini rubric."

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
@@ -36,7 +36,7 @@ Feature: Feedback Tab Visibility
     And I wait to see ".show-handle"
     Then I click selector ".show-handle .fa-chevron-left"
     And I wait until element ".student-table" is visible
-    And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+    And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
     And I wait for the lab page to fully load
     Then I see no difference for "teacher giving feedback tab load"
 

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
@@ -36,7 +36,7 @@ Feature: Feedback Tab Visibility
     And I wait to see ".show-handle"
     Then I click selector ".show-handle .fa-chevron-left"
     And I wait until element ".student-table" is visible
-    And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+    And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
     And I wait for the lab page to fully load
     Then I see no difference for "teacher giving feedback tab load"
 

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
@@ -36,7 +36,7 @@ Feature: Feedback Tab Visibility
     And I wait to see ".show-handle"
     Then I click selector ".show-handle .fa-chevron-left"
     And I wait until element ".student-table" is visible
-    And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+    And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
     And I wait for the lab page to fully load
     Then I see no difference for "teacher giving feedback tab load"
 

--- a/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
+++ b/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
@@ -13,7 +13,7 @@ Feature: Lesson extras teacher panel
     And check that the URL contains "section_id="
     And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
     And I wait until element ".student-table" is visible
-    And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+    And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
 
     # Lesson extras individual puzzle page
     And I click selector ".sublevel-card-title-uitest" once I see it to load a new page

--- a/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
+++ b/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
@@ -13,7 +13,7 @@ Feature: Lesson extras teacher panel
     And check that the URL contains "section_id="
     And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
     And I wait until element ".student-table" is visible
-    And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+    And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
 
     # Lesson extras individual puzzle page
     And I click selector ".sublevel-card-title-uitest" once I see it to load a new page
@@ -22,4 +22,4 @@ Feature: Lesson extras teacher panel
     And check that the URL contains "section_id="
     And check that the URL contains "user_id="
     And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
-    And I wait until element "td:eq(1)" contains text "Sally"
+    And I wait until element "td:nth-child(2)" contains text "Sally"

--- a/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
+++ b/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
@@ -13,7 +13,7 @@ Feature: Lesson extras teacher panel
     And check that the URL contains "section_id="
     And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
     And I wait until element ".student-table" is visible
-    And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+    And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
 
     # Lesson extras individual puzzle page
     And I click selector ".sublevel-card-title-uitest" once I see it to load a new page
@@ -22,4 +22,4 @@ Feature: Lesson extras teacher panel
     And check that the URL contains "section_id="
     And check that the URL contains "user_id="
     And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
-    And I wait until element "td:nth-child(2)" contains text "Sally"
+    And I wait until element "td:eq(1)" contains text "Sally"

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -109,7 +109,7 @@ Feature: BubbleChoice
     And I wait until element "#ui-close-dialog" is not visible
 
     # Go to another Lab2 level (panels)
-    And I click selector ".progress-bubble:nth(5)"
+    And I click selector ".progress-bubble:eq(5)"
     And I wait until element "#lab2-panels" is visible
     And check that the url contains "/s/allthethings/lessons/52/levels/6"
 

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -12,10 +12,10 @@ Feature: BubbleChoice
     # Make sure you are taken back to the BubbleChoice activity page with progress
     And I wait until current URL contains "/lessons/40/levels/1"
     And I wait for jquery to load
-    And I wait until element ".uitest-bubble-choice:nth-child(1)" is visible
-    And element ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is visible
+    And I wait until element ".uitest-bubble-choice:eq(0)" is visible
+    And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
     And check that the url contains "/s/allthethings/lessons/40/levels/1"
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble" is "perfect"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble" is "perfect"
 
     And I sign out
 
@@ -35,10 +35,10 @@ Feature: BubbleChoice
     Given I am on "http://studio.code.org/s/allthethings/lessons/40/levels/1"
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is "not_tried"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
     And I wait for 4 seconds
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is "perfect"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
   @no_firefox
   Scenario: Lab2 BubbleChoice progress
@@ -57,10 +57,10 @@ Feature: BubbleChoice
     # Make sure you are taken back to the Lab2 BubbleChoice activity page with progress
     And I wait until current URL contains "/lessons/52/levels/8"
     And I wait for jquery to load
-    And I wait until element ".uitest-bubble-choice:nth-child(1)" is visible
-    And element ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is visible
+    And I wait until element ".uitest-bubble-choice:eq(0)" is visible
+    And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
     And check that the url contains "/s/allthethings/lessons/52/levels/8"
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble" is "perfect"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble" is "perfect"
 
     And I sign out
 
@@ -80,10 +80,10 @@ Feature: BubbleChoice
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8"
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is "not_tried"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
     And I wait for 4 seconds
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is "perfect"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
     # View progress from BubbleChoice sublevel activity page
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8/sublevel/1"
@@ -109,7 +109,7 @@ Feature: BubbleChoice
     And I wait until element "#ui-close-dialog" is not visible
 
     # Go to another Lab2 level (panels)
-    And I click selector ".progress-bubble:nth-child(6)"
+    And I click selector ".progress-bubble:eq(5)"
     And I wait until element "#lab2-panels" is visible
     And check that the url contains "/s/allthethings/lessons/52/levels/6"
 

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -12,10 +12,10 @@ Feature: BubbleChoice
     # Make sure you are taken back to the BubbleChoice activity page with progress
     And I wait until current URL contains "/lessons/40/levels/1"
     And I wait for jquery to load
-    And I wait until element ".uitest-bubble-choice:eq(0)" is visible
-    And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
+    And I wait until element ".uitest-bubble-choice:nth-child(1)" is visible
+    And element ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is visible
     And check that the url contains "/s/allthethings/lessons/40/levels/1"
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble" is "perfect"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble" is "perfect"
 
     And I sign out
 
@@ -35,10 +35,10 @@ Feature: BubbleChoice
     Given I am on "http://studio.code.org/s/allthethings/lessons/40/levels/1"
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
     And I wait for 4 seconds
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is "perfect"
 
   @no_firefox
   Scenario: Lab2 BubbleChoice progress
@@ -57,10 +57,10 @@ Feature: BubbleChoice
     # Make sure you are taken back to the Lab2 BubbleChoice activity page with progress
     And I wait until current URL contains "/lessons/52/levels/8"
     And I wait for jquery to load
-    And I wait until element ".uitest-bubble-choice:eq(0)" is visible
-    And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
+    And I wait until element ".uitest-bubble-choice:nth-child(1)" is visible
+    And element ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is visible
     And check that the url contains "/s/allthethings/lessons/52/levels/8"
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble" is "perfect"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble" is "perfect"
 
     And I sign out
 
@@ -80,10 +80,10 @@ Feature: BubbleChoice
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8"
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
     And I wait for 4 seconds
-    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:nth-child(1) .progress-bubble:first" is "perfect"
 
     # View progress from BubbleChoice sublevel activity page
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8/sublevel/1"
@@ -109,7 +109,7 @@ Feature: BubbleChoice
     And I wait until element "#ui-close-dialog" is not visible
 
     # Go to another Lab2 level (panels)
-    And I click selector ".progress-bubble:eq(5)"
+    And I click selector ".progress-bubble:nth-child(6)"
     And I wait until element "#lab2-panels" is visible
     And check that the url contains "/s/allthethings/lessons/52/levels/6"
 

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group.feature
@@ -7,16 +7,16 @@ Scenario: Submit three answers.
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
 
-  When element ".level-group-content:nth(1) .multi-question" contains text "The standard QWERTY keyboard has"
+  When element ".level-group-content:eq(1) .multi-question" contains text "The standard QWERTY keyboard has"
 
   # First, submit answers to all three multis.
-  And I press ".level-group-content:nth(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
 
   # Pressing 1, 2, 0 should result in 2, 0 being selected.
-  And I press ".level-group-content:nth(2) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
 
   And I press ".submitButton:first" using jQuery
   And I wait to see ".modal"
@@ -27,10 +27,10 @@ Scenario: Submit three answers.
 
   # Go back to the page to see that same options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/33/levels/1?noautoplay=true"
-  And element ".level-group-content:nth(0) #checked_2" is visible
-  And element ".level-group-content:nth(1) #checked_1" is visible
-  And element ".level-group-content:nth(2) #checked_2" is visible
-  And element ".level-group-content:nth(2) #checked_0" is visible
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_1" is visible
+  And element ".level-group-content:eq(2) #checked_2" is visible
+  And element ".level-group-content:eq(2) #checked_0" is visible
 
 Scenario: Match levels within level group
   Given I create a teacher-associated student named "Lilian"
@@ -64,7 +64,7 @@ Scenario: Match levels within level group
   And I wait to see ".submitButton"
 
   # Wait for moves reflecting lastAttempt to be made
-  And I wait until element ".match:nth(1) .match_slots .answer" is visible
+  And I wait until element ".match:eq(1) .match_slots .answer" is visible
 
   Then match level 0 contains 3 unplaced answers
   And match level 0 contains 3 empty slots
@@ -80,7 +80,7 @@ Scenario: Match levels within level group
   And I am on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
   And I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
 
   Then match level 0 contains 3 unplaced answers
   And match level 0 contains 3 empty slots
@@ -96,25 +96,25 @@ Scenario: Submit all answers, including match levels
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
 
-  When element ".level-group-content:nth(1) .multi-question" contains text "The standard QWERTY keyboard has"
+  When element ".level-group-content:eq(1) .multi-question" contains text "The standard QWERTY keyboard has"
 
   # Select answers to all three multis.
 
-  And I press ".level-group-content:nth(0) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth(1) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
 
   # Select answers to both match levels.
 
-  And I scroll the ".level-group-content:nth(3)" element into view
+  And I scroll the ".level-group-content:eq(3)" element into view
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And match level 0 contains 0 empty slots
 
-  And I scroll the ".level-group-content:nth(4)" element into view
+  And I scroll the ".level-group-content:eq(4)" element into view
   And I drag match level 1 unplaced answer 0 to empty slot 0
   And I drag match level 1 unplaced answer 0 to empty slot 0
   And I drag match level 1 unplaced answer 0 to empty slot 0

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group.feature
@@ -7,16 +7,16 @@ Scenario: Submit three answers.
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
 
-  When element ".level-group-content:nth-child(2) .multi-question" contains text "The standard QWERTY keyboard has"
+  When element ".level-group-content:eq(1) .multi-question" contains text "The standard QWERTY keyboard has"
 
   # First, submit answers to all three multis.
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
 
   # Pressing 1, 2, 0 should result in 2, 0 being selected.
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
 
   And I press ".submitButton:first" using jQuery
   And I wait to see ".modal"
@@ -27,10 +27,10 @@ Scenario: Submit three answers.
 
   # Go back to the page to see that same options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/33/levels/1?noautoplay=true"
-  And element ".level-group-content:nth-child(1) #checked_2" is visible
-  And element ".level-group-content:nth-child(2) #checked_1" is visible
-  And element ".level-group-content:nth-child(3) #checked_2" is visible
-  And element ".level-group-content:nth-child(3) #checked_0" is visible
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_1" is visible
+  And element ".level-group-content:eq(2) #checked_2" is visible
+  And element ".level-group-content:eq(2) #checked_0" is visible
 
 Scenario: Match levels within level group
   Given I create a teacher-associated student named "Lilian"
@@ -64,7 +64,7 @@ Scenario: Match levels within level group
   And I wait to see ".submitButton"
 
   # Wait for moves reflecting lastAttempt to be made
-  And I wait until element ".match:nth-child(2) .match_slots .answer" is visible
+  And I wait until element ".match:eq(1) .match_slots .answer" is visible
 
   Then match level 0 contains 3 unplaced answers
   And match level 0 contains 3 empty slots
@@ -80,7 +80,7 @@ Scenario: Match levels within level group
   And I am on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
   And I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
 
   Then match level 0 contains 3 unplaced answers
   And match level 0 contains 3 empty slots
@@ -96,25 +96,25 @@ Scenario: Submit all answers, including match levels
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
 
-  When element ".level-group-content:nth-child(2) .multi-question" contains text "The standard QWERTY keyboard has"
+  When element ".level-group-content:eq(1) .multi-question" contains text "The standard QWERTY keyboard has"
 
   # Select answers to all three multis.
 
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth-child(2) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
 
   # Select answers to both match levels.
 
-  And I scroll the ".level-group-content:nth-child(4)" element into view
+  And I scroll the ".level-group-content:eq(3)" element into view
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And match level 0 contains 0 empty slots
 
-  And I scroll the ".level-group-content:nth-child(5)" element into view
+  And I scroll the ".level-group-content:eq(4)" element into view
   And I drag match level 1 unplaced answer 0 to empty slot 0
   And I drag match level 1 unplaced answer 0 to empty slot 0
   And I drag match level 1 unplaced answer 0 to empty slot 0

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group.feature
@@ -7,16 +7,16 @@ Scenario: Submit three answers.
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
 
-  When element ".level-group-content:eq(1) .multi-question" contains text "The standard QWERTY keyboard has"
+  When element ".level-group-content:nth-child(2) .multi-question" contains text "The standard QWERTY keyboard has"
 
   # First, submit answers to all three multis.
-  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
 
   # Pressing 1, 2, 0 should result in 2, 0 being selected.
-  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
 
   And I press ".submitButton:first" using jQuery
   And I wait to see ".modal"
@@ -27,10 +27,10 @@ Scenario: Submit three answers.
 
   # Go back to the page to see that same options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/33/levels/1?noautoplay=true"
-  And element ".level-group-content:eq(0) #checked_2" is visible
-  And element ".level-group-content:eq(1) #checked_1" is visible
-  And element ".level-group-content:eq(2) #checked_2" is visible
-  And element ".level-group-content:eq(2) #checked_0" is visible
+  And element ".level-group-content:nth-child(1) #checked_2" is visible
+  And element ".level-group-content:nth-child(2) #checked_1" is visible
+  And element ".level-group-content:nth-child(3) #checked_2" is visible
+  And element ".level-group-content:nth-child(3) #checked_0" is visible
 
 Scenario: Match levels within level group
   Given I create a teacher-associated student named "Lilian"
@@ -64,7 +64,7 @@ Scenario: Match levels within level group
   And I wait to see ".submitButton"
 
   # Wait for moves reflecting lastAttempt to be made
-  And I wait until element ".match:eq(1) .match_slots .answer" is visible
+  And I wait until element ".match:nth-child(2) .match_slots .answer" is visible
 
   Then match level 0 contains 3 unplaced answers
   And match level 0 contains 3 empty slots
@@ -80,7 +80,7 @@ Scenario: Match levels within level group
   And I am on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
   And I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
 
   Then match level 0 contains 3 unplaced answers
   And match level 0 contains 3 empty slots
@@ -96,25 +96,25 @@ Scenario: Submit all answers, including match levels
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
 
-  When element ".level-group-content:eq(1) .multi-question" contains text "The standard QWERTY keyboard has"
+  When element ".level-group-content:nth-child(2) .multi-question" contains text "The standard QWERTY keyboard has"
 
   # Select answers to all three multis.
 
-  And I press ".level-group-content:eq(0) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:eq(1) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth-child(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
 
   # Select answers to both match levels.
 
-  And I scroll the ".level-group-content:eq(3)" element into view
+  And I scroll the ".level-group-content:nth-child(4)" element into view
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And I drag match level 0 unplaced answer 0 to empty slot 0
   And match level 0 contains 0 empty slots
 
-  And I scroll the ".level-group-content:eq(4)" element into view
+  And I scroll the ".level-group-content:nth-child(5)" element into view
   And I drag match level 1 unplaced answer 0 to empty slot 0
   And I drag match level 1 unplaced answer 0 to empty slot 0
   And I drag match level 1 unplaced answer 0 to empty slot 0

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page.feature
@@ -8,61 +8,61 @@ Background:
   And element ".nextPageButton" is visible
 
 Scenario: multi page level numbering
-  Then element ".level-group-number:nth(0)" contains text "1. "
-  And element ".level-group-content:nth(0) .multi-question" contains text "Which arrow gets"
+  Then element ".level-group-number:eq(0)" contains text "1. "
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
 
-  And element ".level-group-number:nth(1)" contains text "2. "
-  And element ".level-group-content:nth(1) .multi-question" contains text "The standard QWERTY keyboard has"
+  And element ".level-group-number:eq(1)" contains text "2. "
+  And element ".level-group-content:eq(1) .multi-question" contains text "The standard QWERTY keyboard has"
 
   When I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
 
-  Then element ".level-group-number:nth(0)" contains text "4. "
-  And element ".level-group-content:nth(0) .multi-question" contains text "go at the beginning"
+  Then element ".level-group-number:eq(0)" contains text "4. "
+  And element ".level-group-content:eq(0) .multi-question" contains text "go at the beginning"
 
-  And element ".level-group-number:nth(3)" contains text "7. "
-  And element ".level-group-content:nth(3)" contains text "Reflecting on the ECS Curriculum"
+  And element ".level-group-number:eq(3)" contains text "7. "
+  And element ".level-group-content:eq(3)" contains text "Reflecting on the ECS Curriculum"
 
   # External level is not numbered
-  And element ".level-group-content:nth(4)" contains text "Sample external 2"
+  And element ".level-group-content:eq(4)" contains text "Sample external 2"
 
-  And element ".level-group-number:nth(4)" contains text "8. "
-  And element ".level-group-content:nth(5)" contains text "What are your goals"
+  And element ".level-group-number:eq(4)" contains text "8. "
+  And element ".level-group-content:eq(5)" contains text "What are your goals"
 
 Scenario: Submit three pages.
-  When element ".level-group-content:nth(0) .multi-question" contains text "Which arrow gets"
+  When element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
-  And I press ".level-group-content:nth(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
   # Pressing 1, 2, 0 should result in 2, 0 being selected.
-  And I press ".level-group-content:nth(2) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
-  And element ".level-group-content:nth(0) .multi-question" contains text "Which step should go"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which step should go"
 
   # Enter answers to all three multis on the second page.
-  And I press ".level-group-content:nth(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(1) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
 
   # Also enter text into the text_match and the free_response on that page
-  And I type "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t" into "textarea:nth(0)"
-  And I type 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t' into "textarea:nth(1)"
+  And I type "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t" into "textarea:eq(0)"
+  And I type 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t' into "textarea:eq(1)"
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/3"
-  And element ".level-group-content:nth(0) .multi-question" contains text "Which repeat block"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which repeat block"
 
   # Enter answers to both multis on the third page.
-  And I press ".level-group-content:nth(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
 
   # Submit the long assessment
   And I press ".submitButton:first" using jQuery
@@ -71,21 +71,21 @@ Scenario: Submit three pages.
 
   # Go back to the first page to see that correct options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/1?noautoplay=true"
-  And element ".level-group-content:nth(0) #checked_2" is visible
-  And element ".level-group-content:nth(1) #checked_1" is visible
-  And element ".level-group-content:nth(2) #checked_2" is visible
-  And element ".level-group-content:nth(2) #checked_0" is visible
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_1" is visible
+  And element ".level-group-content:eq(2) #checked_2" is visible
+  And element ".level-group-content:eq(2) #checked_0" is visible
 
   # Go to the second page to see that correct answers are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/2?noautoplay=true"
-  And element ".level-group-content:nth(0) #checked_2" is visible
-  And element ".level-group-content:nth(1) #checked_0" is visible
-  And element ".level-group-content:nth(2) #checked_1" is visible
-  And element "textarea:nth(0)" has escaped value "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t"
-  And element "textarea:nth(1)" has escaped value 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t'
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_0" is visible
+  And element ".level-group-content:eq(2) #checked_1" is visible
+  And element "textarea:eq(0)" has escaped value "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t"
+  And element "textarea:eq(1)" has escaped value 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t'
 
   # Go to the third page to see that correct options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/3?noautoplay=true"
-  And element ".level-group-content:nth(0) #checked_2" is visible
-  And element ".level-group-content:nth(1) #checked_1" is visible
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_1" is visible
   And I wait for 2 seconds

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page.feature
@@ -8,61 +8,61 @@ Background:
   And element ".nextPageButton" is visible
 
 Scenario: multi page level numbering
-  Then element ".level-group-number:eq(0)" contains text "1. "
-  And element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
+  Then element ".level-group-number:nth-child(1)" contains text "1. "
+  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which arrow gets"
 
-  And element ".level-group-number:eq(1)" contains text "2. "
-  And element ".level-group-content:eq(1) .multi-question" contains text "The standard QWERTY keyboard has"
+  And element ".level-group-number:nth-child(2)" contains text "2. "
+  And element ".level-group-content:nth-child(2) .multi-question" contains text "The standard QWERTY keyboard has"
 
   When I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
 
-  Then element ".level-group-number:eq(0)" contains text "4. "
-  And element ".level-group-content:eq(0) .multi-question" contains text "go at the beginning"
+  Then element ".level-group-number:nth-child(1)" contains text "4. "
+  And element ".level-group-content:nth-child(1) .multi-question" contains text "go at the beginning"
 
-  And element ".level-group-number:eq(3)" contains text "7. "
-  And element ".level-group-content:eq(3)" contains text "Reflecting on the ECS Curriculum"
+  And element ".level-group-number:nth-child(4)" contains text "7. "
+  And element ".level-group-content:nth-child(4)" contains text "Reflecting on the ECS Curriculum"
 
   # External level is not numbered
-  And element ".level-group-content:eq(4)" contains text "Sample external 2"
+  And element ".level-group-content:nth-child(5)" contains text "Sample external 2"
 
-  And element ".level-group-number:eq(4)" contains text "8. "
-  And element ".level-group-content:eq(5)" contains text "What are your goals"
+  And element ".level-group-number:nth-child(5)" contains text "8. "
+  And element ".level-group-content:nth-child(6)" contains text "What are your goals"
 
 Scenario: Submit three pages.
-  When element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
+  When element ".level-group-content:nth-child(1) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
-  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
   # Pressing 1, 2, 0 should result in 2, 0 being selected.
-  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
-  And element ".level-group-content:eq(0) .multi-question" contains text "Which step should go"
+  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which step should go"
 
   # Enter answers to all three multis on the second page.
-  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(1) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
 
   # Also enter text into the text_match and the free_response on that page
-  And I type "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t" into "textarea:eq(0)"
-  And I type 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t' into "textarea:eq(1)"
+  And I type "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t" into "textarea:nth-child(1)"
+  And I type 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t' into "textarea:nth-child(2)"
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/3"
-  And element ".level-group-content:eq(0) .multi-question" contains text "Which repeat block"
+  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which repeat block"
 
   # Enter answers to both multis on the third page.
-  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
 
   # Submit the long assessment
   And I press ".submitButton:first" using jQuery
@@ -71,21 +71,21 @@ Scenario: Submit three pages.
 
   # Go back to the first page to see that correct options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/1?noautoplay=true"
-  And element ".level-group-content:eq(0) #checked_2" is visible
-  And element ".level-group-content:eq(1) #checked_1" is visible
-  And element ".level-group-content:eq(2) #checked_2" is visible
-  And element ".level-group-content:eq(2) #checked_0" is visible
+  And element ".level-group-content:nth-child(1) #checked_2" is visible
+  And element ".level-group-content:nth-child(2) #checked_1" is visible
+  And element ".level-group-content:nth-child(3) #checked_2" is visible
+  And element ".level-group-content:nth-child(3) #checked_0" is visible
 
   # Go to the second page to see that correct answers are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/2?noautoplay=true"
-  And element ".level-group-content:eq(0) #checked_2" is visible
-  And element ".level-group-content:eq(1) #checked_0" is visible
-  And element ".level-group-content:eq(2) #checked_1" is visible
-  And element "textarea:eq(0)" has escaped value "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t"
-  And element "textarea:eq(1)" has escaped value 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t'
+  And element ".level-group-content:nth-child(1) #checked_2" is visible
+  And element ".level-group-content:nth-child(2) #checked_0" is visible
+  And element ".level-group-content:nth-child(3) #checked_1" is visible
+  And element "textarea:nth-child(1)" has escaped value "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t"
+  And element "textarea:nth-child(2)" has escaped value 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t'
 
   # Go to the third page to see that correct options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/3?noautoplay=true"
-  And element ".level-group-content:eq(0) #checked_2" is visible
-  And element ".level-group-content:eq(1) #checked_1" is visible
+  And element ".level-group-content:nth-child(1) #checked_2" is visible
+  And element ".level-group-content:nth-child(2) #checked_1" is visible
   And I wait for 2 seconds

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page.feature
@@ -8,61 +8,61 @@ Background:
   And element ".nextPageButton" is visible
 
 Scenario: multi page level numbering
-  Then element ".level-group-number:nth-child(1)" contains text "1. "
-  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which arrow gets"
+  Then element ".level-group-number:eq(0)" contains text "1. "
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
 
-  And element ".level-group-number:nth-child(2)" contains text "2. "
-  And element ".level-group-content:nth-child(2) .multi-question" contains text "The standard QWERTY keyboard has"
+  And element ".level-group-number:eq(1)" contains text "2. "
+  And element ".level-group-content:eq(1) .multi-question" contains text "The standard QWERTY keyboard has"
 
   When I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
 
-  Then element ".level-group-number:nth-child(1)" contains text "4. "
-  And element ".level-group-content:nth-child(1) .multi-question" contains text "go at the beginning"
+  Then element ".level-group-number:eq(0)" contains text "4. "
+  And element ".level-group-content:eq(0) .multi-question" contains text "go at the beginning"
 
-  And element ".level-group-number:nth-child(4)" contains text "7. "
-  And element ".level-group-content:nth-child(4)" contains text "Reflecting on the ECS Curriculum"
+  And element ".level-group-number:eq(3)" contains text "7. "
+  And element ".level-group-content:eq(3)" contains text "Reflecting on the ECS Curriculum"
 
   # External level is not numbered
-  And element ".level-group-content:nth-child(5)" contains text "Sample external 2"
+  And element ".level-group-content:eq(4)" contains text "Sample external 2"
 
-  And element ".level-group-number:nth-child(5)" contains text "8. "
-  And element ".level-group-content:nth-child(6)" contains text "What are your goals"
+  And element ".level-group-number:eq(4)" contains text "8. "
+  And element ".level-group-content:eq(5)" contains text "What are your goals"
 
 Scenario: Submit three pages.
-  When element ".level-group-content:nth-child(1) .multi-question" contains text "Which arrow gets"
+  When element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
   # Pressing 1, 2, 0 should result in 2, 0 being selected.
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
-  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which step should go"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which step should go"
 
   # Enter answers to all three multis on the second page.
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(2) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
 
   # Also enter text into the text_match and the free_response on that page
-  And I type "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t" into "textarea:nth-child(1)"
-  And I type 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t' into "textarea:nth-child(2)"
+  And I type "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t" into "textarea:eq(0)"
+  And I type 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t' into "textarea:eq(1)"
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/3"
-  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which repeat block"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which repeat block"
 
   # Enter answers to both multis on the third page.
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
 
   # Submit the long assessment
   And I press ".submitButton:first" using jQuery
@@ -71,21 +71,21 @@ Scenario: Submit three pages.
 
   # Go back to the first page to see that correct options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/1?noautoplay=true"
-  And element ".level-group-content:nth-child(1) #checked_2" is visible
-  And element ".level-group-content:nth-child(2) #checked_1" is visible
-  And element ".level-group-content:nth-child(3) #checked_2" is visible
-  And element ".level-group-content:nth-child(3) #checked_0" is visible
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_1" is visible
+  And element ".level-group-content:eq(2) #checked_2" is visible
+  And element ".level-group-content:eq(2) #checked_0" is visible
 
   # Go to the second page to see that correct answers are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/2?noautoplay=true"
-  And element ".level-group-content:nth-child(1) #checked_2" is visible
-  And element ".level-group-content:nth-child(2) #checked_0" is visible
-  And element ".level-group-content:nth-child(3) #checked_1" is visible
-  And element "textarea:nth-child(1)" has escaped value "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t"
-  And element "textarea:nth-child(2)" has escaped value 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t'
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_0" is visible
+  And element ".level-group-content:eq(2) #checked_1" is visible
+  And element "textarea:eq(0)" has escaped value "First line \nsecond 'line'\n!@#$%^&*()_+-=~`\n\\ \\n \\t"
+  And element "textarea:eq(1)" has escaped value 'Another first line \nsecond "line"\n!@#$%^&*()_+-=~`\n\\ \\n \\t'
 
   # Go to the third page to see that correct options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/3?noautoplay=true"
-  And element ".level-group-content:nth-child(1) #checked_2" is visible
-  And element ".level-group-content:nth-child(2) #checked_1" is visible
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_1" is visible
   And I wait for 2 seconds

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page_dots.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page_dots.feature
@@ -8,39 +8,39 @@ Background:
   And element ".nextPageButton" is visible
 
 Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
-  When element ".level-group-content:nth(0) .multi-question" contains text "Which arrow gets"
+  When element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
-  And I press ".level-group-content:nth(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
   # Pressing 1, 2, 0 should result in 2, 0 being selected.
-  And I press ".level-group-content:nth(2) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
-  And element ".level-group-content:nth(0) .multi-question" contains text "Which step should go"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which step should go"
 
   # Enter no answers on the second page.
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/3"
-  And element ".level-group-content:nth(0) .multi-question" contains text "Which repeat block"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which repeat block"
 
   # Enter answers to only the first multi on the third page.
-  And I press ".level-group-content:nth(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
 
   And I wait until jQuery Ajax requests are finished
 
   # Go back to the first page to see that correct options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/1?noautoplay=true"
-  And element ".level-group-content:nth(0) #checked_2" is visible
-  And element ".level-group-content:nth(1) #checked_1" is visible
-  And element ".level-group-content:nth(2) #checked_2" is visible
-  And element ".level-group-content:nth(2) #checked_0" is visible
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_1" is visible
+  And element ".level-group-content:eq(2) #checked_2" is visible
+  And element ".level-group-content:eq(2) #checked_0" is visible
 
   Then I reload the page
   And I wait to see ".react_stage"
@@ -88,33 +88,33 @@ Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
   And I verify progress for lesson 23 level 4 is "attempted_assessment"
 
 Scenario: optional free play level
-  When element ".level-group-content:nth(0) .multi-question" contains text "Which arrow gets"
+  When element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
-  And I press ".level-group-content:nth(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
   # The last question requires 2 boxes to be checked.
-  And I press ".level-group-content:nth(2) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
-  And element ".level-group-content:nth(0) .multi-question" contains text "Which step should go"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which step should go"
 
   # Answer all three multis on page 2, but not the markdown or free response.
-  And I press ".level-group-content:nth(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(1) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:nth(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/3"
-  And element ".level-group-content:nth(0) .multi-question" contains text "Which repeat block"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which repeat block"
 
   # Answer both multis on page 3.
-  And I press ".level-group-content:nth(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
 
   # Verify the bubble status and submit dialog message show incomplete
 

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page_dots.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page_dots.feature
@@ -8,39 +8,39 @@ Background:
   And element ".nextPageButton" is visible
 
 Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
-  When element ".level-group-content:nth-child(1) .multi-question" contains text "Which arrow gets"
+  When element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
   # Pressing 1, 2, 0 should result in 2, 0 being selected.
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
-  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which step should go"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which step should go"
 
   # Enter no answers on the second page.
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/3"
-  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which repeat block"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which repeat block"
 
   # Enter answers to only the first multi on the third page.
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
 
   And I wait until jQuery Ajax requests are finished
 
   # Go back to the first page to see that correct options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/1?noautoplay=true"
-  And element ".level-group-content:nth-child(1) #checked_2" is visible
-  And element ".level-group-content:nth-child(2) #checked_1" is visible
-  And element ".level-group-content:nth-child(3) #checked_2" is visible
-  And element ".level-group-content:nth-child(3) #checked_0" is visible
+  And element ".level-group-content:eq(0) #checked_2" is visible
+  And element ".level-group-content:eq(1) #checked_1" is visible
+  And element ".level-group-content:eq(2) #checked_2" is visible
+  And element ".level-group-content:eq(2) #checked_0" is visible
 
   Then I reload the page
   And I wait to see ".react_stage"
@@ -88,33 +88,33 @@ Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
   And I verify progress for lesson 23 level 4 is "attempted_assessment"
 
 Scenario: optional free play level
-  When element ".level-group-content:nth-child(1) .multi-question" contains text "Which arrow gets"
+  When element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
   # The last question requires 2 boxes to be checked.
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
-  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which step should go"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which step should go"
 
   # Answer all three multis on page 2, but not the markdown or free response.
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/3"
-  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which repeat block"
+  And element ".level-group-content:eq(0) .multi-question" contains text "Which repeat block"
 
   # Answer both multis on page 3.
-  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
 
   # Verify the bubble status and submit dialog message show incomplete
 

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page_dots.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_multi_page_dots.feature
@@ -8,39 +8,39 @@ Background:
   And element ".nextPageButton" is visible
 
 Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
-  When element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
+  When element ".level-group-content:nth-child(1) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
-  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
   # Pressing 1, 2, 0 should result in 2, 0 being selected.
-  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
-  And element ".level-group-content:eq(0) .multi-question" contains text "Which step should go"
+  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which step should go"
 
   # Enter no answers on the second page.
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/3"
-  And element ".level-group-content:eq(0) .multi-question" contains text "Which repeat block"
+  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which repeat block"
 
   # Enter answers to only the first multi on the third page.
-  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
 
   And I wait until jQuery Ajax requests are finished
 
   # Go back to the first page to see that correct options are selected.
   Then I am on "http://studio.code.org/s/allthethings/lessons/23/levels/2/page/1?noautoplay=true"
-  And element ".level-group-content:eq(0) #checked_2" is visible
-  And element ".level-group-content:eq(1) #checked_1" is visible
-  And element ".level-group-content:eq(2) #checked_2" is visible
-  And element ".level-group-content:eq(2) #checked_0" is visible
+  And element ".level-group-content:nth-child(1) #checked_2" is visible
+  And element ".level-group-content:nth-child(2) #checked_1" is visible
+  And element ".level-group-content:nth-child(3) #checked_2" is visible
+  And element ".level-group-content:nth-child(3) #checked_0" is visible
 
   Then I reload the page
   And I wait to see ".react_stage"
@@ -88,33 +88,33 @@ Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
   And I verify progress for lesson 23 level 4 is "attempted_assessment"
 
 Scenario: optional free play level
-  When element ".level-group-content:eq(0) .multi-question" contains text "Which arrow gets"
+  When element ".level-group-content:nth-child(1) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
-  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
   # The last question requires 2 boxes to be checked.
-  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=1]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/2"
-  And element ".level-group-content:eq(0) .multi-question" contains text "Which step should go"
+  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which step should go"
 
   # Answer all three multis on page 2, but not the markdown or free response.
-  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
-  And I press ".level-group-content:eq(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(3) .answerbutton[index=0]" using jQuery
 
   And I press ".nextPageButton" using jQuery to load a new page
   And I wait to see ".level-group-content"
   And check that the URL contains "/page/3"
-  And element ".level-group-content:eq(0) .multi-question" contains text "Which repeat block"
+  And element ".level-group-content:nth-child(1) .multi-question" contains text "Which repeat block"
 
   # Answer both multis on page 3.
-  And I press ".level-group-content:eq(0) .answerbutton[index=2]" using jQuery
-  And I press ".level-group-content:eq(1) .answerbutton[index=1]" using jQuery
+  And I press ".level-group-content:nth-child(1) .answerbutton[index=2]" using jQuery
+  And I press ".level-group-content:nth-child(2) .answerbutton[index=1]" using jQuery
 
   # Verify the bubble status and submit dialog message show incomplete
 

--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
@@ -99,9 +99,9 @@ Feature: Using the Lesson Edit Page
     And element ".uitest-level-token-name" is visible
     And I press ".uitest-level-token-name" using jQuery
     And I wait until element ".level-token-checkboxes" is visible
-    And element ".level-token-checkboxes input[type=checkbox]:nth(1)" is not checked
-    And I press ".level-token-checkboxes input[type=checkbox]:nth(1)" using jQuery
-    And element ".level-token-checkboxes input[type=checkbox]:nth(1)" is checked
+    And element ".level-token-checkboxes input[type=checkbox]:eq(1)" is not checked
+    And I press ".level-token-checkboxes input[type=checkbox]:eq(1)" using jQuery
+    And element ".level-token-checkboxes input[type=checkbox]:eq(1)" is checked
 
     When I click "button[type='submit']" to load a new page
     And I wait until element "#show-container" is visible
@@ -111,6 +111,6 @@ Feature: Using the Lesson Edit Page
     And I wait until element ".uitest-activity-card" is visible
     And I press ".uitest-level-token-name" using jQuery
     And I wait until element ".level-token-checkboxes" is visible
-    Then element ".level-token-checkboxes input[type=checkbox]:nth(1)" is checked
+    Then element ".level-token-checkboxes input[type=checkbox]:eq(1)" is checked
 
     And I delete the temp unit with lessons

--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
@@ -99,9 +99,9 @@ Feature: Using the Lesson Edit Page
     And element ".uitest-level-token-name" is visible
     And I press ".uitest-level-token-name" using jQuery
     And I wait until element ".level-token-checkboxes" is visible
-    And element ".level-token-checkboxes input[type=checkbox]:nth-child(2)" is not checked
-    And I press ".level-token-checkboxes input[type=checkbox]:nth-child(2)" using jQuery
-    And element ".level-token-checkboxes input[type=checkbox]:nth-child(2)" is checked
+    And element ".level-token-checkboxes input[type=checkbox]:eq(1)" is not checked
+    And I press ".level-token-checkboxes input[type=checkbox]:eq(1)" using jQuery
+    And element ".level-token-checkboxes input[type=checkbox]:eq(1)" is checked
 
     When I click "button[type='submit']" to load a new page
     And I wait until element "#show-container" is visible
@@ -111,6 +111,6 @@ Feature: Using the Lesson Edit Page
     And I wait until element ".uitest-activity-card" is visible
     And I press ".uitest-level-token-name" using jQuery
     And I wait until element ".level-token-checkboxes" is visible
-    Then element ".level-token-checkboxes input[type=checkbox]:nth-child(2)" is checked
+    Then element ".level-token-checkboxes input[type=checkbox]:eq(1)" is checked
 
     And I delete the temp unit with lessons

--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
@@ -99,9 +99,9 @@ Feature: Using the Lesson Edit Page
     And element ".uitest-level-token-name" is visible
     And I press ".uitest-level-token-name" using jQuery
     And I wait until element ".level-token-checkboxes" is visible
-    And element ".level-token-checkboxes input[type=checkbox]:eq(1)" is not checked
-    And I press ".level-token-checkboxes input[type=checkbox]:eq(1)" using jQuery
-    And element ".level-token-checkboxes input[type=checkbox]:eq(1)" is checked
+    And element ".level-token-checkboxes input[type=checkbox]:nth-child(2)" is not checked
+    And I press ".level-token-checkboxes input[type=checkbox]:nth-child(2)" using jQuery
+    And element ".level-token-checkboxes input[type=checkbox]:nth-child(2)" is checked
 
     When I click "button[type='submit']" to load a new page
     And I wait until element "#show-container" is visible
@@ -111,6 +111,6 @@ Feature: Using the Lesson Edit Page
     And I wait until element ".uitest-activity-card" is visible
     And I press ".uitest-level-token-name" using jQuery
     And I wait until element ".level-token-checkboxes" is visible
-    Then element ".level-token-checkboxes input[type=checkbox]:eq(1)" is checked
+    Then element ".level-token-checkboxes input[type=checkbox]:nth-child(2)" is checked
 
     And I delete the temp unit with lessons

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -29,8 +29,8 @@ Feature: Evaluate student code against rubrics using AI
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
-    And element ".teacher-panel td:eq(1)" contains text "Aiden"
-    And I click selector ".teacher-panel td:eq(1)" to load a new page
+    And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
+    And I click selector ".teacher-panel td:nth-child(2)" to load a new page
     And I wait for the lab page to fully load
     And I wait until element "#ui-floatingActionButton" is visible
     And I click selector ".introjs-skipbutton" once I see it
@@ -75,8 +75,8 @@ Feature: Evaluate student code against rubrics using AI
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
-    And element ".teacher-panel td:eq(1)" contains text "Aiden"
-    And I click selector ".teacher-panel td:eq(1)" to load a new page
+    And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
+    And I click selector ".teacher-panel td:nth-child(2)" to load a new page
     And I wait for the lab page to fully load
     And I wait until element "#ui-floatingActionButton" is visible
     And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
@@ -127,8 +127,8 @@ Feature: Evaluate student code against rubrics using AI
     And I get debug info for the current user
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
-    And element ".teacher-panel td:eq(1)" contains text "Aiden"
-    And I click selector ".teacher-panel td:eq(1)" to load a new page
+    And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
+    And I click selector ".teacher-panel td:nth-child(2)" to load a new page
     And I wait for the lab page to fully load
     And I wait until element "#ui-floatingActionButton" is visible
     And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
@@ -184,8 +184,8 @@ Feature: Evaluate student code against rubrics using AI
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
-    And element ".teacher-panel td:eq(1)" contains text "Aiden"
-    And I click selector ".teacher-panel td:eq(1)" to load a new page
+    And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
+    And I click selector ".teacher-panel td:nth-child(2)" to load a new page
     And I wait for the lab page to fully load
     And I wait until element "#ui-floatingActionButton" is visible
     And I click selector ".introjs-skipbutton" once I see it

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -29,8 +29,8 @@ Feature: Evaluate student code against rubrics using AI
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
-    And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
-    And I click selector ".teacher-panel td:nth-child(2)" to load a new page
+    And element ".teacher-panel td:eq(1)" contains text "Aiden"
+    And I click selector ".teacher-panel td:eq(1)" to load a new page
     And I wait for the lab page to fully load
     And I wait until element "#ui-floatingActionButton" is visible
     And I click selector ".introjs-skipbutton" once I see it
@@ -75,8 +75,8 @@ Feature: Evaluate student code against rubrics using AI
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
-    And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
-    And I click selector ".teacher-panel td:nth-child(2)" to load a new page
+    And element ".teacher-panel td:eq(1)" contains text "Aiden"
+    And I click selector ".teacher-panel td:eq(1)" to load a new page
     And I wait for the lab page to fully load
     And I wait until element "#ui-floatingActionButton" is visible
     And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
@@ -127,8 +127,8 @@ Feature: Evaluate student code against rubrics using AI
     And I get debug info for the current user
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
-    And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
-    And I click selector ".teacher-panel td:nth-child(2)" to load a new page
+    And element ".teacher-panel td:eq(1)" contains text "Aiden"
+    And I click selector ".teacher-panel td:eq(1)" to load a new page
     And I wait for the lab page to fully load
     And I wait until element "#ui-floatingActionButton" is visible
     And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
@@ -184,8 +184,8 @@ Feature: Evaluate student code against rubrics using AI
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
-    And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
-    And I click selector ".teacher-panel td:nth-child(2)" to load a new page
+    And element ".teacher-panel td:eq(1)" contains text "Aiden"
+    And I click selector ".teacher-panel td:eq(1)" to load a new page
     And I wait for the lab page to fully load
     And I wait until element "#ui-floatingActionButton" is visible
     And I click selector ".introjs-skipbutton" once I see it

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -17,7 +17,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I wait to see "#ui-floatingActionButton"
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".student-table" is visible
-  And I click selector ".student-table tr:nth(1)" to load a new page
+  And I click selector ".student-table tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
   And I click selector ".introjs-skipbutton" once I see it

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -17,7 +17,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I wait to see "#ui-floatingActionButton"
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".student-table" is visible
-  And I click selector ".student-table tr:nth-child(2)" to load a new page
+  And I click selector ".student-table tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
   And I click selector ".introjs-skipbutton" once I see it
@@ -58,8 +58,8 @@ Scenario: Teacher views rubric product tour
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait for the lab page to fully load
-  And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
-  And I click selector ".teacher-panel td:nth-child(2)" to load a new page
+  And element ".teacher-panel td:eq(1)" contains text "Aiden"
+  And I click selector ".teacher-panel td:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   # Teacher views product tour step 1
@@ -148,8 +148,8 @@ Scenario: Teacher views Rubric and Settings tabs
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait for the lab page to fully load
-  And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
-  And I click selector ".teacher-panel td:nth-child(2)" to load a new page
+  And element ".teacher-panel td:eq(1)" contains text "Aiden"
+  And I click selector ".teacher-panel td:eq(1)" to load a new page
   And I wait for the lab page to fully load
   And I click selector ".introjs-skipbutton" if it exists
 
@@ -181,8 +181,8 @@ Scenario: Teacher views product tour
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait for the lab page to fully load
-  And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
-  And I click selector ".teacher-panel td:nth-child(2)" to load a new page
+  And element ".teacher-panel td:eq(1)" contains text "Aiden"
+  And I click selector ".teacher-panel td:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   # Teacher views product tour step 1

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -17,7 +17,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I wait to see "#ui-floatingActionButton"
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".student-table" is visible
-  And I click selector ".student-table tr:eq(1)" to load a new page
+  And I click selector ".student-table tr:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
   And I click selector ".introjs-skipbutton" once I see it
@@ -58,8 +58,8 @@ Scenario: Teacher views rubric product tour
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait for the lab page to fully load
-  And element ".teacher-panel td:eq(1)" contains text "Aiden"
-  And I click selector ".teacher-panel td:eq(1)" to load a new page
+  And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
+  And I click selector ".teacher-panel td:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
 
   # Teacher views product tour step 1
@@ -148,8 +148,8 @@ Scenario: Teacher views Rubric and Settings tabs
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait for the lab page to fully load
-  And element ".teacher-panel td:eq(1)" contains text "Aiden"
-  And I click selector ".teacher-panel td:eq(1)" to load a new page
+  And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
+  And I click selector ".teacher-panel td:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
   And I click selector ".introjs-skipbutton" if it exists
 
@@ -181,8 +181,8 @@ Scenario: Teacher views product tour
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait for the lab page to fully load
-  And element ".teacher-panel td:eq(1)" contains text "Aiden"
-  And I click selector ".teacher-panel td:eq(1)" to load a new page
+  And element ".teacher-panel td:nth-child(2)" contains text "Aiden"
+  And I click selector ".teacher-panel td:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
 
   # Teacher views product tour step 1

--- a/dashboard/test/ui/features/teacher_tools/student_lesson_plan.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_lesson_plan.feature
@@ -37,17 +37,17 @@ Feature: Student Lesson Plan
     Then I wait until element ".announcement-notification:first" is visible
     And element ".announcement-notification:first" contains text matching "Information for Students"
 
-    Then I wait until element ".announcement-notification:nth(1)" is visible
-    And element ".announcement-notification:nth(1)" contains text matching "Information for Students and Teachers"
+    Then I wait until element ".announcement-notification:eq(1)" is visible
+    And element ".announcement-notification:eq(1)" contains text matching "Information for Students and Teachers"
 
     # Navigate between student lesson plans
     Then I wait until element ".uitest-lesson-dropdown-nav" is visible
     And I click ".uitest-lesson-dropdown-nav"
-    Then I wait until element "a.no-navigation:nth(1)" is visible
-    And I click selector "a.no-navigation:nth(1)"
+    Then I wait until element "a.no-navigation:eq(1)" is visible
+    And I click selector "a.no-navigation:eq(1)"
     And I wait until element "a.navigate:contains(2 - Second Lesson)" is visible
-    Then I wait until element "a.navigate:nth(0)" is visible
-    And I click selector "a.navigate:nth(0)"
+    Then I wait until element "a.navigate:eq(0)" is visible
+    And I click selector "a.navigate:eq(0)"
     Then I wait until I am on "http://studio.code.org/s/allthemigratedthings/lessons/2/student"
     And I wait until element "#show-container" is visible
     And I wait until element "h1:contains(Lesson 2: Second Lesson)" is visible

--- a/dashboard/test/ui/features/teacher_tools/student_lesson_plan.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_lesson_plan.feature
@@ -37,17 +37,17 @@ Feature: Student Lesson Plan
     Then I wait until element ".announcement-notification:first" is visible
     And element ".announcement-notification:first" contains text matching "Information for Students"
 
-    Then I wait until element ".announcement-notification:eq(1)" is visible
-    And element ".announcement-notification:eq(1)" contains text matching "Information for Students and Teachers"
+    Then I wait until element ".announcement-notification:nth-child(2)" is visible
+    And element ".announcement-notification:nth-child(2)" contains text matching "Information for Students and Teachers"
 
     # Navigate between student lesson plans
     Then I wait until element ".uitest-lesson-dropdown-nav" is visible
     And I click ".uitest-lesson-dropdown-nav"
-    Then I wait until element "a.no-navigation:eq(1)" is visible
-    And I click selector "a.no-navigation:eq(1)"
+    Then I wait until element "a.no-navigation:nth-child(2)" is visible
+    And I click selector "a.no-navigation:nth-child(2)"
     And I wait until element "a.navigate:contains(2 - Second Lesson)" is visible
-    Then I wait until element "a.navigate:eq(0)" is visible
-    And I click selector "a.navigate:eq(0)"
+    Then I wait until element "a.navigate:nth-child(1)" is visible
+    And I click selector "a.navigate:nth-child(1)"
     Then I wait until I am on "http://studio.code.org/s/allthemigratedthings/lessons/2/student"
     And I wait until element "#show-container" is visible
     And I wait until element "h1:contains(Lesson 2: Second Lesson)" is visible

--- a/dashboard/test/ui/features/teacher_tools/student_lesson_plan.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_lesson_plan.feature
@@ -37,17 +37,17 @@ Feature: Student Lesson Plan
     Then I wait until element ".announcement-notification:first" is visible
     And element ".announcement-notification:first" contains text matching "Information for Students"
 
-    Then I wait until element ".announcement-notification:nth-child(2)" is visible
-    And element ".announcement-notification:nth-child(2)" contains text matching "Information for Students and Teachers"
+    Then I wait until element ".announcement-notification:eq(1)" is visible
+    And element ".announcement-notification:eq(1)" contains text matching "Information for Students and Teachers"
 
     # Navigate between student lesson plans
     Then I wait until element ".uitest-lesson-dropdown-nav" is visible
     And I click ".uitest-lesson-dropdown-nav"
-    Then I wait until element "a.no-navigation:nth-child(2)" is visible
-    And I click selector "a.no-navigation:nth-child(2)"
+    Then I wait until element "a.no-navigation:eq(1)" is visible
+    And I click selector "a.no-navigation:eq(1)"
     And I wait until element "a.navigate:contains(2 - Second Lesson)" is visible
-    Then I wait until element "a.navigate:nth-child(1)" is visible
-    And I click selector "a.navigate:nth-child(1)"
+    Then I wait until element "a.navigate:eq(0)" is visible
+    And I click selector "a.navigate:eq(0)"
     Then I wait until I am on "http://studio.code.org/s/allthemigratedthings/lessons/2/student"
     And I wait until element "#show-container" is visible
     And I wait until element "h1:contains(Lesson 2: Second Lesson)" is visible

--- a/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
@@ -14,7 +14,7 @@ Scenario: Game lab level where student has not started
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" contains text "This student has not started the level."
@@ -31,7 +31,7 @@ Scenario: Maze level where student has not started
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" contains text "This student has not started the level."
@@ -48,7 +48,7 @@ Scenario: Contained level
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" does not contain text "This student has not started the level."

--- a/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
@@ -14,7 +14,7 @@ Scenario: Game lab level where student has not started
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" contains text "This student has not started the level."
@@ -31,7 +31,7 @@ Scenario: Maze level where student has not started
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" contains text "This student has not started the level."
@@ -48,7 +48,7 @@ Scenario: Contained level
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" does not contain text "This student has not started the level."

--- a/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
@@ -14,7 +14,7 @@ Scenario: Game lab level where student has not started
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" contains text "This student has not started the level."
@@ -31,7 +31,7 @@ Scenario: Maze level where student has not started
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" contains text "This student has not started the level."
@@ -48,7 +48,7 @@ Scenario: Contained level
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" does not contain text "This student has not started the level."

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -47,12 +47,12 @@ Feature: Using the teacher dashboard
     # Stats tab
     And I click selector "#uitest-teacher-dashboard-nav a:contains(Stats)" once I see it
     And I wait until element "#uitest-stats-table" is visible
-    And element "#uitest-stats-table tr:nth-child(2)" contains text "Sally"
+    And element "#uitest-stats-table tr:eq(1)" contains text "Sally"
 
     # Manage students tab
     And I click selector "#uitest-teacher-dashboard-nav a:contains(Manage Students)" once I see it
     And I wait until element "#uitest-manage-students-table" is visible
-    And element "#uitest-manage-students-table tr:nth-child(2)" contains text "Sally"
+    And element "#uitest-manage-students-table tr:eq(1)" contains text "Sally"
     And I wait until element "#uitest-privacy-text" is visible
     And element "#uitest-privacy-text" contains text "We encourage you to share this letter"
     And I wait until element "#uitest-privacy-link" is visible
@@ -78,7 +78,7 @@ Feature: Using the teacher dashboard
     # Assessments/Surveys tab: assessment
     And I select the "Lesson 33: Single page assessment" option in dropdown "assessment-selector"
     And I wait until element "#uitest-submission-status-table" is visible
-    And element "#uitest-submission-status-table tr:nth-child(2)" contains text "Sally"
+    And element "#uitest-submission-status-table tr:eq(1)" contains text "Sally"
 
   Scenario: Loading section projects
     Given I create a teacher-associated student named "Sally"
@@ -206,10 +206,10 @@ Feature: Using the teacher dashboard
     Then I navigate to teacher dashboard for the section I saved
     And I click selector "#uitest-teacher-dashboard-nav a:contains(Projects)" once I see it
     And I wait until element "#uitest-projects-table" is visible
-    And I wait until the image within element "tr:nth-child(2)" has loaded
-    And I wait until the image within element "tr:nth-child(3)" has loaded
-    And I wait until the image within element "tr:nth-child(4)" has loaded
-    And I wait until the image within element "tr:nth-child(5)" has loaded
+    And I wait until the image within element "tr:eq(1)" has loaded
+    And I wait until the image within element "tr:eq(2)" has loaded
+    And I wait until the image within element "tr:eq(3)" has loaded
+    And I wait until the image within element "tr:eq(4)" has loaded
 
     Then I see no difference for "projects list view"
     And I close my eyes
@@ -256,7 +256,7 @@ Feature: Using the teacher dashboard
     And I wait until element "#uitest-course-dropdown" is visible
     And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"
 
-  Scenario: Accept invitation to new progress view and see new view immediately.
+  Scenario: Accept invitation to new progress view and see new view immediately. 
     Given I am on "http://studio.code.org"
     When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
     Given I create an authorized teacher-associated student named "Sally"
@@ -274,7 +274,7 @@ Feature: Using the teacher dashboard
     And I wait until element "h6:contains(Icon Key)" is visible
     And I wait until element "#ui-test-progress-table-v2" is visible
 
-  Scenario: Delay responding to invitation to new progress view and see old view immediately.
+  Scenario: Delay responding to invitation to new progress view and see old view immediately. 
     Given I am on "http://studio.code.org"
     When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
     Given I create an authorized teacher-associated student named "Sally"
@@ -315,3 +315,4 @@ Feature: Using the teacher dashboard
     And I click selector "button:contains(View more)"
     And I see no difference for "all tiles visible"
     And I close my eyes
+    

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -47,12 +47,12 @@ Feature: Using the teacher dashboard
     # Stats tab
     And I click selector "#uitest-teacher-dashboard-nav a:contains(Stats)" once I see it
     And I wait until element "#uitest-stats-table" is visible
-    And element "#uitest-stats-table tr:eq(1)" contains text "Sally"
+    And element "#uitest-stats-table tr:nth-child(2)" contains text "Sally"
 
     # Manage students tab
     And I click selector "#uitest-teacher-dashboard-nav a:contains(Manage Students)" once I see it
     And I wait until element "#uitest-manage-students-table" is visible
-    And element "#uitest-manage-students-table tr:eq(1)" contains text "Sally"
+    And element "#uitest-manage-students-table tr:nth-child(2)" contains text "Sally"
     And I wait until element "#uitest-privacy-text" is visible
     And element "#uitest-privacy-text" contains text "We encourage you to share this letter"
     And I wait until element "#uitest-privacy-link" is visible
@@ -78,7 +78,7 @@ Feature: Using the teacher dashboard
     # Assessments/Surveys tab: assessment
     And I select the "Lesson 33: Single page assessment" option in dropdown "assessment-selector"
     And I wait until element "#uitest-submission-status-table" is visible
-    And element "#uitest-submission-status-table tr:eq(1)" contains text "Sally"
+    And element "#uitest-submission-status-table tr:nth-child(2)" contains text "Sally"
 
   Scenario: Loading section projects
     Given I create a teacher-associated student named "Sally"
@@ -206,10 +206,10 @@ Feature: Using the teacher dashboard
     Then I navigate to teacher dashboard for the section I saved
     And I click selector "#uitest-teacher-dashboard-nav a:contains(Projects)" once I see it
     And I wait until element "#uitest-projects-table" is visible
-    And I wait until the image within element "tr:eq(1)" has loaded
-    And I wait until the image within element "tr:eq(2)" has loaded
-    And I wait until the image within element "tr:eq(3)" has loaded
-    And I wait until the image within element "tr:eq(4)" has loaded
+    And I wait until the image within element "tr:nth-child(2)" has loaded
+    And I wait until the image within element "tr:nth-child(3)" has loaded
+    And I wait until the image within element "tr:nth-child(4)" has loaded
+    And I wait until the image within element "tr:nth-child(5)" has loaded
 
     Then I see no difference for "projects list view"
     And I close my eyes
@@ -256,7 +256,7 @@ Feature: Using the teacher dashboard
     And I wait until element "#uitest-course-dropdown" is visible
     And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"
 
-  Scenario: Accept invitation to new progress view and see new view immediately. 
+  Scenario: Accept invitation to new progress view and see new view immediately.
     Given I am on "http://studio.code.org"
     When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
     Given I create an authorized teacher-associated student named "Sally"
@@ -274,7 +274,7 @@ Feature: Using the teacher dashboard
     And I wait until element "h6:contains(Icon Key)" is visible
     And I wait until element "#ui-test-progress-table-v2" is visible
 
-  Scenario: Delay responding to invitation to new progress view and see old view immediately. 
+  Scenario: Delay responding to invitation to new progress view and see old view immediately.
     Given I am on "http://studio.code.org"
     When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
     Given I create an authorized teacher-associated student named "Sally"
@@ -315,4 +315,3 @@ Feature: Using the teacher dashboard
     And I click selector "button:contains(View more)"
     And I see no difference for "all tiles visible"
     And I close my eyes
-    

--- a/dashboard/test/ui/features/teacher_tools/teacher_lesson_plan.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_lesson_plan.feature
@@ -12,8 +12,8 @@ Feature: Teacher Lesson Plan
     Then I wait until element ".announcement-notification:first" is visible
     And element ".announcement-notification:first" contains text matching "Information for Teachers"
 
-    Then I wait until element ".announcement-notification:nth(1)" is visible
-    And element ".announcement-notification:nth(1)" contains text matching "Information for Students and Teachers"
+    Then I wait until element ".announcement-notification:eq(1)" is visible
+    And element ".announcement-notification:eq(1)" contains text matching "Information for Students and Teachers"
 
     # Check for name of lesson
     And I wait until element "h1:contains(Lesson 1: First Lesson)" is visible
@@ -75,11 +75,11 @@ Feature: Teacher Lesson Plan
     # Navigate between lesson plans
     Then I wait until element ".uitest-lesson-dropdown-nav" is visible
     And I click ".uitest-lesson-dropdown-nav"
-    Then I wait until element "a.no-navigation:nth(1)" is visible
-    And I click selector "a.no-navigation:nth(1)"
+    Then I wait until element "a.no-navigation:eq(1)" is visible
+    And I click selector "a.no-navigation:eq(1)"
     And I wait until element "a.navigate:contains(2 - Second Lesson)" is visible
-    Then I wait until element "a.navigate:nth(0)" is visible
-    And I click selector "a.navigate:nth(0)"
+    Then I wait until element "a.navigate:eq(0)" is visible
+    And I click selector "a.navigate:eq(0)"
     Then I wait until I am on "http://studio.code.org/s/allthemigratedthings/lessons/2"
     And I wait until element "#show-container" is visible
     And I wait until element "h1:contains(Lesson 2: Second Lesson)" is visible
@@ -96,7 +96,7 @@ Feature: Teacher Lesson Plan
     Given I create a teacher named "Prof_Dumbledore"
     And I am on "http://studio.code.org/s/allthemigratedthings/lessons/5"
     And I wait until element "#show-container" is visible
-    And I click selector ".uitest-ProgressPill:nth(0)"
+    And I click selector ".uitest-ProgressPill:eq(0)"
     And I wait until element ".modal" is visible
     And I wait until element ".modal-body button:contains(Dismiss)" is visible
     And I wait until element ".modal-backdrop" is visible
@@ -104,7 +104,7 @@ Feature: Teacher Lesson Plan
     And I click selector ".modal-body button:contains(Dismiss)"
     And I wait until element ".modal-backdrop" is gone
 
-    And I click selector ".uitest-ProgressPill:nth(1)"
+    And I click selector ".uitest-ProgressPill:eq(1)"
     And I wait until element ".modal" is visible
     And I wait until element ".modal-body button:contains(Dismiss)" is visible
     And I wait until element ".modal-backdrop" is visible
@@ -112,7 +112,7 @@ Feature: Teacher Lesson Plan
     And I click selector ".modal-body button:contains(Dismiss)"
     And I wait until element ".modal-backdrop" is gone
 
-    And I click selector ".uitest-ProgressPill:nth(2)"
+    And I click selector ".uitest-ProgressPill:eq(2)"
     And I wait until element ".modal" is visible
     And I wait until element ".modal-body button:contains(Dismiss)" is visible
     And I wait until element ".modal-backdrop" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_lesson_plan.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_lesson_plan.feature
@@ -12,8 +12,8 @@ Feature: Teacher Lesson Plan
     Then I wait until element ".announcement-notification:first" is visible
     And element ".announcement-notification:first" contains text matching "Information for Teachers"
 
-    Then I wait until element ".announcement-notification:nth-child(2)" is visible
-    And element ".announcement-notification:nth-child(2)" contains text matching "Information for Students and Teachers"
+    Then I wait until element ".announcement-notification:eq(1)" is visible
+    And element ".announcement-notification:eq(1)" contains text matching "Information for Students and Teachers"
 
     # Check for name of lesson
     And I wait until element "h1:contains(Lesson 1: First Lesson)" is visible
@@ -75,11 +75,11 @@ Feature: Teacher Lesson Plan
     # Navigate between lesson plans
     Then I wait until element ".uitest-lesson-dropdown-nav" is visible
     And I click ".uitest-lesson-dropdown-nav"
-    Then I wait until element "a.no-navigation:nth-child(2)" is visible
-    And I click selector "a.no-navigation:nth-child(2)"
+    Then I wait until element "a.no-navigation:eq(1)" is visible
+    And I click selector "a.no-navigation:eq(1)"
     And I wait until element "a.navigate:contains(2 - Second Lesson)" is visible
-    Then I wait until element "a.navigate:nth-child(1)" is visible
-    And I click selector "a.navigate:nth-child(1)"
+    Then I wait until element "a.navigate:eq(0)" is visible
+    And I click selector "a.navigate:eq(0)"
     Then I wait until I am on "http://studio.code.org/s/allthemigratedthings/lessons/2"
     And I wait until element "#show-container" is visible
     And I wait until element "h1:contains(Lesson 2: Second Lesson)" is visible
@@ -96,7 +96,7 @@ Feature: Teacher Lesson Plan
     Given I create a teacher named "Prof_Dumbledore"
     And I am on "http://studio.code.org/s/allthemigratedthings/lessons/5"
     And I wait until element "#show-container" is visible
-    And I click selector ".uitest-ProgressPill:nth-child(1)"
+    And I click selector ".uitest-ProgressPill:eq(0)"
     And I wait until element ".modal" is visible
     And I wait until element ".modal-body button:contains(Dismiss)" is visible
     And I wait until element ".modal-backdrop" is visible
@@ -104,7 +104,7 @@ Feature: Teacher Lesson Plan
     And I click selector ".modal-body button:contains(Dismiss)"
     And I wait until element ".modal-backdrop" is gone
 
-    And I click selector ".uitest-ProgressPill:nth-child(2)"
+    And I click selector ".uitest-ProgressPill:eq(1)"
     And I wait until element ".modal" is visible
     And I wait until element ".modal-body button:contains(Dismiss)" is visible
     And I wait until element ".modal-backdrop" is visible
@@ -112,7 +112,7 @@ Feature: Teacher Lesson Plan
     And I click selector ".modal-body button:contains(Dismiss)"
     And I wait until element ".modal-backdrop" is gone
 
-    And I click selector ".uitest-ProgressPill:nth-child(3)"
+    And I click selector ".uitest-ProgressPill:eq(2)"
     And I wait until element ".modal" is visible
     And I wait until element ".modal-body button:contains(Dismiss)" is visible
     And I wait until element ".modal-backdrop" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_lesson_plan.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_lesson_plan.feature
@@ -12,8 +12,8 @@ Feature: Teacher Lesson Plan
     Then I wait until element ".announcement-notification:first" is visible
     And element ".announcement-notification:first" contains text matching "Information for Teachers"
 
-    Then I wait until element ".announcement-notification:eq(1)" is visible
-    And element ".announcement-notification:eq(1)" contains text matching "Information for Students and Teachers"
+    Then I wait until element ".announcement-notification:nth-child(2)" is visible
+    And element ".announcement-notification:nth-child(2)" contains text matching "Information for Students and Teachers"
 
     # Check for name of lesson
     And I wait until element "h1:contains(Lesson 1: First Lesson)" is visible
@@ -75,11 +75,11 @@ Feature: Teacher Lesson Plan
     # Navigate between lesson plans
     Then I wait until element ".uitest-lesson-dropdown-nav" is visible
     And I click ".uitest-lesson-dropdown-nav"
-    Then I wait until element "a.no-navigation:eq(1)" is visible
-    And I click selector "a.no-navigation:eq(1)"
+    Then I wait until element "a.no-navigation:nth-child(2)" is visible
+    And I click selector "a.no-navigation:nth-child(2)"
     And I wait until element "a.navigate:contains(2 - Second Lesson)" is visible
-    Then I wait until element "a.navigate:eq(0)" is visible
-    And I click selector "a.navigate:eq(0)"
+    Then I wait until element "a.navigate:nth-child(1)" is visible
+    And I click selector "a.navigate:nth-child(1)"
     Then I wait until I am on "http://studio.code.org/s/allthemigratedthings/lessons/2"
     And I wait until element "#show-container" is visible
     And I wait until element "h1:contains(Lesson 2: Second Lesson)" is visible
@@ -96,7 +96,7 @@ Feature: Teacher Lesson Plan
     Given I create a teacher named "Prof_Dumbledore"
     And I am on "http://studio.code.org/s/allthemigratedthings/lessons/5"
     And I wait until element "#show-container" is visible
-    And I click selector ".uitest-ProgressPill:eq(0)"
+    And I click selector ".uitest-ProgressPill:nth-child(1)"
     And I wait until element ".modal" is visible
     And I wait until element ".modal-body button:contains(Dismiss)" is visible
     And I wait until element ".modal-backdrop" is visible
@@ -104,7 +104,7 @@ Feature: Teacher Lesson Plan
     And I click selector ".modal-body button:contains(Dismiss)"
     And I wait until element ".modal-backdrop" is gone
 
-    And I click selector ".uitest-ProgressPill:eq(1)"
+    And I click selector ".uitest-ProgressPill:nth-child(2)"
     And I wait until element ".modal" is visible
     And I wait until element ".modal-body button:contains(Dismiss)" is visible
     And I wait until element ".modal-backdrop" is visible
@@ -112,7 +112,7 @@ Feature: Teacher Lesson Plan
     And I click selector ".modal-body button:contains(Dismiss)"
     And I wait until element ".modal-backdrop" is gone
 
-    And I click selector ".uitest-ProgressPill:eq(2)"
+    And I click selector ".uitest-ProgressPill:nth-child(3)"
     And I wait until element ".modal" is visible
     And I wait until element ".modal-body button:contains(Dismiss)" is visible
     And I wait until element ".modal-backdrop" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_student_toggle.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_student_toggle.feature
@@ -15,7 +15,7 @@ Scenario: Toggle on Multi Level
   Then I open the progress drop down of the current page
   And I see no difference for "progress dropdown for teacher"
 
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait to see ".header_popup_link"
   Then I open the progress drop down of the current page
   And I wait until element ".user-stats-block:contains(Jigsaw)" is visible
@@ -29,7 +29,7 @@ Scenario: Toggle on Hidden Maze Level
   Then I sign in as "Teacher_Arya"
   Then I am on "http://studio.code.org/s/allthethings"
   And I wait to see ".uitest-togglehidden"
-  Then I click selector ".uitest-togglehidden:nth(1) div:contains('Hidden')"
+  Then I click selector ".uitest-togglehidden:eq(1) div:contains('Hidden')"
   Then I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1?noautoplay=true"
   And I wait for the lab page to fully load
   And I see no difference for "page load"
@@ -60,7 +60,7 @@ Scenario: Toggle on Lockable Level
   And I see no difference for "view as teacher while locked"
 
   # Click the first student
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait until element "#level-body" is visible
   And element "#level-body" contains text "This survey is anonymous"
   And element "#locked-lesson" is not visible
@@ -82,7 +82,7 @@ Scenario: Toggle on Lockable Level
   And element "#locked-lesson" is not visible
 
   # Click the first student
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait until element "#level-body" is visible
   And element "#level-body" contains text "This survey is anonymous"
   And element "#locked-lesson" is not visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_student_toggle.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_student_toggle.feature
@@ -15,7 +15,7 @@ Scenario: Toggle on Multi Level
   Then I open the progress drop down of the current page
   And I see no difference for "progress dropdown for teacher"
 
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait to see ".header_popup_link"
   Then I open the progress drop down of the current page
   And I wait until element ".user-stats-block:contains(Jigsaw)" is visible
@@ -29,7 +29,7 @@ Scenario: Toggle on Hidden Maze Level
   Then I sign in as "Teacher_Arya"
   Then I am on "http://studio.code.org/s/allthethings"
   And I wait to see ".uitest-togglehidden"
-  Then I click selector ".uitest-togglehidden:nth-child(2) div:contains('Hidden')"
+  Then I click selector ".uitest-togglehidden:eq(1) div:contains('Hidden')"
   Then I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1?noautoplay=true"
   And I wait for the lab page to fully load
   And I see no difference for "page load"
@@ -60,7 +60,7 @@ Scenario: Toggle on Lockable Level
   And I see no difference for "view as teacher while locked"
 
   # Click the first student
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait until element "#level-body" is visible
   And element "#level-body" contains text "This survey is anonymous"
   And element "#locked-lesson" is not visible
@@ -82,7 +82,7 @@ Scenario: Toggle on Lockable Level
   And element "#locked-lesson" is not visible
 
   # Click the first student
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait until element "#level-body" is visible
   And element "#level-body" contains text "This survey is anonymous"
   And element "#locked-lesson" is not visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_student_toggle.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_student_toggle.feature
@@ -15,7 +15,7 @@ Scenario: Toggle on Multi Level
   Then I open the progress drop down of the current page
   And I see no difference for "progress dropdown for teacher"
 
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait to see ".header_popup_link"
   Then I open the progress drop down of the current page
   And I wait until element ".user-stats-block:contains(Jigsaw)" is visible
@@ -29,7 +29,7 @@ Scenario: Toggle on Hidden Maze Level
   Then I sign in as "Teacher_Arya"
   Then I am on "http://studio.code.org/s/allthethings"
   And I wait to see ".uitest-togglehidden"
-  Then I click selector ".uitest-togglehidden:eq(1) div:contains('Hidden')"
+  Then I click selector ".uitest-togglehidden:nth-child(2) div:contains('Hidden')"
   Then I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1?noautoplay=true"
   And I wait for the lab page to fully load
   And I see no difference for "page load"
@@ -60,7 +60,7 @@ Scenario: Toggle on Lockable Level
   And I see no difference for "view as teacher while locked"
 
   # Click the first student
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait until element "#level-body" is visible
   And element "#level-body" contains text "This survey is anonymous"
   And element "#locked-lesson" is not visible
@@ -82,7 +82,7 @@ Scenario: Toggle on Lockable Level
   And element "#locked-lesson" is not visible
 
   # Click the first student
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait until element "#level-body" is visible
   And element "#level-body" contains text "This survey is anonymous"
   And element "#locked-lesson" is not visible

--- a/dashboard/test/ui/features/teacher_tools/version_history.feature
+++ b/dashboard/test/ui/features/teacher_tools/version_history.feature
@@ -14,7 +14,7 @@ Scenario: Teacher can view student versions
   And I press "versions-header"
   And I wait until element "div:contains(Latest Version)" is visible
   Then I save the text from ".versionRow:nth-child(1) p"
-  
+
   When I close the dialog
   And I set the project version interval to 1 second
   And I wait for 1.5 seconds
@@ -30,7 +30,7 @@ Scenario: Teacher can view student versions
   Then I sign in as "Teacher_Ron"
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
   And I dismiss the teacher panel
   And I press "versions-header"

--- a/dashboard/test/ui/features/teacher_tools/version_history.feature
+++ b/dashboard/test/ui/features/teacher_tools/version_history.feature
@@ -30,7 +30,7 @@ Scenario: Teacher can view student versions
   Then I sign in as "Teacher_Ron"
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
+  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
   And I wait for the lab page to fully load
   And I dismiss the teacher panel
   And I press "versions-header"

--- a/dashboard/test/ui/features/teacher_tools/version_history.feature
+++ b/dashboard/test/ui/features/teacher_tools/version_history.feature
@@ -30,7 +30,7 @@ Scenario: Teacher can view student versions
   Then I sign in as "Teacher_Ron"
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1"
   And I wait until element ".student-table" is visible
-  And I click selector "#teacher-panel-container tr:nth-child(2)" to load a new page
+  And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
   And I dismiss the teacher panel
   And I press "versions-header"


### PR DESCRIPTION
I was working on a UI test and saw this `:nth` selector being used in a step I was using, and was like, what is that? The Googles/ChatGPTs weirdly had nothing to offer, apart from this one Stack Overflow post, which said it is an undocumented alias for the selector `:eq`:

https://stackoverflow.com/questions/18052122/documentation-for-jquery-nth

This is a straight find and replace of `:nth(` with `:eq(` in the `ui` test directory. Appears tests are passing, so I'm inclined to believe this SO post 😆 . Admittedly I think `nth` is a little more readable, but I think I'd take documented over readable.

Also worth noting that jQuery has deprecated the `:eq(` selector, but we're on a very old version of jQuery and this still feels like a step in the right direction:

https://api.jquery.com/eq-selector/