### PR TITLE
chore: release component library and component library styles

### DIFF
--- a/frontend/packages/component-library-styles/CHANGELOG.md
+++ b/frontend/packages/component-library-styles/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [0.0.0-alpha.1](https://github.com/code-dot-org/code-dot-org/compare/@code-dot-org/component-library-styles@0.0.0...${npm.name}@0.0.0-alpha.1) (2025-02-25)
+
+### Bug Fixes
+
+- **font.scss:** fixed barlowFont variables definitions ([fc554a1](https://github.com/code-dot-org/code-dot-org/commit/fc554a12ac6e70c0166592ea9796e2e3f31afccd))
+
+### Features
+
+- **Carousel:** DSCO - Add Carousel component ([3588bf6](https://github.com/code-dot-org/code-dot-org/commit/3588bf6c5724258fd833b1cc7d48b72d8e4d8353))
+- **dsco:** add support for conventional commits ([400a234](https://github.com/code-dot-org/code-dot-org/commit/400a2349fa5e329e1cc41adfb32c80daf467f4a9))
+- **marketing:** add support for font loading ([238525c](https://github.com/code-dot-org/code-dot-org/commit/238525c34b5133eeab587a18947b70a216bc3a97))
+- **stylelint:** add stylelint support ([f56981c](https://github.com/code-dot-org/code-dot-org/commit/f56981cf888b9b946524146453995aeabaf889ef))
+- **typography:** update default typography colors to use semantic colors instead of primitive colors ([5d68e0a](https://github.com/code-dot-org/code-dot-org/commit/5d68e0a596a7aa0cd4b582c6c41a6b3116bc832b))
+- **Video:** DSCO - Add Video component ([#63435](https://github.com/code-dot-org/code-dot-org/issues/63435)) ([06e6a71](https://github.com/code-dot-org/code-dot-org/commit/06e6a712637278f17d00a6a66ba0198b10aa6b47))
+
+### Chores
+
+- **colors:** Synced up Figma and FrontEnd Color variables values ([c1cb8a5](https://github.com/code-dot-org/code-dot-org/commit/c1cb8a5fe1feaa0604f1e656cba7f9e8baa75a50))
+- prettier auto fixes ([d3d7b24](https://github.com/code-dot-org/code-dot-org/commit/d3d7b24b00f44689dfb477e537f3a0ec96624ca9))

--- a/frontend/packages/component-library-styles/package.json
+++ b/frontend/packages/component-library-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/component-library-styles",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "homepage": "https://github.com/code-dot-org/code-dot-org/blob/staging/frontend/packages/component-library-styles/#readme",
   "repository": {
     "type": "git",

--- a/frontend/packages/component-library/CHANGELOG.md
+++ b/frontend/packages/component-library/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+## [0.1.0-alpha.1](https://github.com/code-dot-org/code-dot-org/compare/@code-dot-org/component-library@0.1.0-alpha.0...${npm.name}@0.1.0-alpha.1) (2025-02-25)
+
+### Bug Fixes
+
+- **Carousel:** wait for carousel load to complete ([bfdfac8](https://github.com/code-dot-org/code-dot-org/commit/bfdfac86c7444c5f707bd98d621fd26f2eea8ef2))
+- **component-library:** add dts to dev mode ([c1afdfa](https://github.com/code-dot-org/code-dot-org/commit/c1afdfa6589087a6fe1207c679f640e689cfa4ce))
+- **Link:** disable flaky test ([66ae793](https://github.com/code-dot-org/code-dot-org/commit/66ae7934fc5fc4c6c7e86eb84d99a786ff98f9ad))
+- **Video:** add ignore region for YT logo ([1ec463a](https://github.com/code-dot-org/code-dot-org/commit/1ec463a835abf7507e14239403f06a2512b185dc))
+
+### Features
+
+- **apps:** link `@code-dot-org/component-library` to `apps` ([60d46ef](https://github.com/code-dot-org/code-dot-org/commit/60d46eff827246cb6616acece63d268ded5295c5))
+- **Button:** added tertiary gray iconOnly Button support [Design2-269] ([#63661](https://github.com/code-dot-org/code-dot-org/issues/63661)) ([b8514d8](https://github.com/code-dot-org/code-dot-org/commit/b8514d8a1d715cba510345d88ae52d9866c5d9ae))
+- **Carousel:** DSCO - Add Carousel component ([3588bf6](https://github.com/code-dot-org/code-dot-org/commit/3588bf6c5724258fd833b1cc7d48b72d8e4d8353))
+- **component-library:** remove Stub and StubSection components ([#63409](https://github.com/code-dot-org/code-dot-org/issues/63409)) ([94199e6](https://github.com/code-dot-org/code-dot-org/commit/94199e6947ded834a9dd5eefa5a99f368433c953))
+- **component-library:** split esm/cjs outputs ([28c0212](https://github.com/code-dot-org/code-dot-org/commit/28c0212ea42e8637d43d5b3bfe972287b6daa8a8))
+- **componentLibrary:** Specify exports in package.json for all the existing dsco components ([#63395](https://github.com/code-dot-org/code-dot-org/issues/63395)) ([052a241](https://github.com/code-dot-org/code-dot-org/commit/052a2419cd6a66b73990ef4503818f8d3a8fbb4b))
+- **Divider:** clean up Storybook docs ([#63962](https://github.com/code-dot-org/code-dot-org/issues/63962)) ([0e5e4d7](https://github.com/code-dot-org/code-dot-org/commit/0e5e4d7bd1fba5bc6758b8e9eb1c143e54838789))
+- **Divider:** DSCO - Add Divider component ([60122e5](https://github.com/code-dot-org/code-dot-org/commit/60122e553c1ac8c7b85f0d025ce6ab9b0485e8d8))
+- **Divider:** refactor to use SpacingNoneToL type for margin ([#63960](https://github.com/code-dot-org/code-dot-org/issues/63960)) ([bc6991a](https://github.com/code-dot-org/code-dot-org/commit/bc6991a744e61bd72d437dd752de11becfed1a57))
+- **Divider:** update classNames to be more descriptive ([#63904](https://github.com/code-dot-org/code-dot-org/issues/63904)) ([2a69da1](https://github.com/code-dot-org/code-dot-org/commit/2a69da1f15e6b7a4d46dc391d9dd39bc32ee836a))
+- **dsco:** add support for conventional commits ([400a234](https://github.com/code-dot-org/code-dot-org/commit/400a2349fa5e329e1cc41adfb32c80daf467f4a9))
+- **frontend:** add precommit linting support ([4215635](https://github.com/code-dot-org/code-dot-org/commit/42156356dcd43ec6eba85c1008f67add9765291c))
+- **frontend:** add precommit linting support ([21f5e42](https://github.com/code-dot-org/code-dot-org/commit/21f5e428da3bd9ff92e0d21a6bfdcec889b0cb33))
+- implement ci/cd for the component library ([e18fb46](https://github.com/code-dot-org/code-dot-org/commit/e18fb460a6a1e611fffb641510cd7a6b9f9ac162))
+- **marketing/typography:** added Heading and Paragraph custom components ([0fdec2f](https://github.com/code-dot-org/code-dot-org/commit/0fdec2f2cb1cef43f7f112fc02d5bca847130d4e))
+- **Section:** add background pattern option ([#63824](https://github.com/code-dot-org/code-dot-org/issues/63824)) ([6d15a2b](https://github.com/code-dot-org/code-dot-org/commit/6d15a2baad864c4cf3e2dcd6f081e9cc3630bad9))
+- **Section:** add component definition for Contentful ([#63792](https://github.com/code-dot-org/code-dot-org/issues/63792)) ([c776202](https://github.com/code-dot-org/code-dot-org/commit/c7762024431bff29bea3ebbc3380bfd06d4378d6))
+- **Section:** DSCO - Add Section component ([#63706](https://github.com/code-dot-org/code-dot-org/issues/63706)) ([f63328b](https://github.com/code-dot-org/code-dot-org/commit/f63328b710e6ccc7e0b17747f7e86c9e884f81c7))
+- **Section:** refactor to use SpacingNoneToL type for padding ([#63961](https://github.com/code-dot-org/code-dot-org/issues/63961)) ([ec1ca40](https://github.com/code-dot-org/code-dot-org/commit/ec1ca40d63df5613fab2e7e18a89a59f75526e5f))
+- **Section:** update classNames to be more descriptive ([#63903](https://github.com/code-dot-org/code-dot-org/issues/63903)) ([58763ec](https://github.com/code-dot-org/code-dot-org/commit/58763ec9f730bf652bfe3f6b5dd426504d289ef8))
+- **source-maps:** add source maps to component library ([53c5412](https://github.com/code-dot-org/code-dot-org/commit/53c54126991d6ce78add49d6f9485820389db74d))
+- **stylelint:** add stylelint support ([f56981c](https://github.com/code-dot-org/code-dot-org/commit/f56981cf888b9b946524146453995aeabaf889ef))
+- **Video:** add component definition for Contentful ([#63646](https://github.com/code-dot-org/code-dot-org/issues/63646)) ([c4add80](https://github.com/code-dot-org/code-dot-org/commit/c4add804b8d65c7df75b6be2674df05f4c6b8663))
+- **Video:** DSCO - Add Video component ([#63435](https://github.com/code-dot-org/code-dot-org/issues/63435)) ([06e6a71](https://github.com/code-dot-org/code-dot-org/commit/06e6a712637278f17d00a6a66ba0198b10aa6b47))
+
+### Chores
+
+- **alert:** re-export alertTypes constant ([4ca1194](https://github.com/code-dot-org/code-dot-org/commit/4ca11947c0b05e524ca766855d6551852c547058))
+- **common:** create separate entrypoints for dsco common ([e985e59](https://github.com/code-dot-org/code-dot-org/commit/e985e59a5402a9cb3b3ea92fa744922dc40bf3a5))
+- **component-library:** move `classnames` to peer & dev dep. ([0660a45](https://github.com/code-dot-org/code-dot-org/commit/0660a451a43ad7ca664c19345a6222f045e536c1))
+- **component-library:** move common scss and css to `@code-dot-org/css` ([6f6a05a](https://github.com/code-dot-org/code-dot-org/commit/6f6a05abd1652e99b9893a03fa57f831dc613ed8))
+- **component-library:** remove dependency on react bootstrap ([5a2772c](https://github.com/code-dot-org/code-dot-org/commit/5a2772c09b4dea6555a3a739c740e4cafee0353e))
+- **component-library:** update exports to reflect cjs default ([b70f304](https://github.com/code-dot-org/code-dot-org/commit/b70f3049ff0e5470890bcfeced2e3ec8c5094d07))
+- **component-library:** use commonjs as default output ([de12933](https://github.com/code-dot-org/code-dot-org/commit/de1293385968ce1e71354850b11f8ed0594acf9e))
+- **Divider:** update export statements ([#63602](https://github.com/code-dot-org/code-dot-org/issues/63602)) ([6a20169](https://github.com/code-dot-org/code-dot-org/commit/6a20169e6eb34c1e011fba7c653d016da6ca290d))
+- fix `css` file imports in scss ([8928738](https://github.com/code-dot-org/code-dot-org/commit/8928738db17ba2e03cd2147658c21baf0de3106d))
+- **marketing:** use explicit imports for imported components ([8af7d1c](https://github.com/code-dot-org/code-dot-org/commit/8af7d1c20124a6cab09d0518a09cbcfd028d72fe))
+- remove monoweave ([7d9d773](https://github.com/code-dot-org/code-dot-org/commit/7d9d7736a20103b92948e14c8c93540b97d6fe90))
+- rename color & primitiveColors to scss extension ([34e50fe](https://github.com/code-dot-org/code-dot-org/commit/34e50fe9a0ebc5bf2b129fde3ab8f005ec903022))
+- **typography:** move typography module scss to `@code-dot-org/css` ([36a0441](https://github.com/code-dot-org/code-dot-org/commit/36a044105656f711df36bf99f996eb89b33fb65b))

--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/component-library",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "keywords": [
     "design-system",
     "code.org"


### PR DESCRIPTION
After running the following commands, two commits are produced with the associated change logs.

```
yarn workspace @code-dot-org/component-library release
yarn workspace @code-dot-org/component-library-styles release
```