### PR TITLE
Fix Teacher Panel styles

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -201,7 +201,10 @@ class TeacherPanel extends React.Component {
       hasSections && unitHasLockableLessons && viewAs === ViewType.Instructor;
 
     return (
-      <TeacherPanelContainer logToFirehose={this.logToFirehose}>
+      <TeacherPanelContainer
+        className={moduleStyles.teacherPanelContainer}
+        logToFirehose={this.logToFirehose}
+      >
         <h3>{i18n.teacherPanel()}</h3>
         <div style={styles.scrollable}>
           <ViewAsToggle

--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanelContainer.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanelContainer.jsx
@@ -5,11 +5,10 @@ import React from 'react';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 
-import moduleStyles from './teacher-panel.module.scss';
-
 export default class TeacherPanelContainer extends React.Component {
   static propTypes = {
     children: PropTypes.node,
+    className: PropTypes.string,
     logToFirehose: PropTypes.func,
   };
 
@@ -35,11 +34,9 @@ export default class TeacherPanelContainer extends React.Component {
   render() {
     return (
       <div
-        className={classNames(
-          'teacher-panel',
-          moduleStyles.teacherPanelContainer,
-          {hidden: !this.state.open}
-        )}
+        className={classNames('teacher-panel', this.props.className, {
+          hidden: !this.state.open,
+        })}
       >
         <div className="hide-handle">
           <FontAwesome icon="chevron-right" onClick={this.hide} />


### PR DESCRIPTION
It seems that importing styles in the `TeacherParentContainer` component causes them to be defined after other component styles, lowering their priority and breaking the overall component's styling.

 Before | After |
| ------ | ------ |
| <img alt="before" src="https://github.com/user-attachments/assets/8a70e1f1-0a88-42db-b427-9c31da41530c" /> | <img alt="after" src="https://github.com/user-attachments/assets/18de1c8a-60e9-4dc6-9309-7989dfa8a4aa" /> |

## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/63926