### PR TITLE
fix(jest): limit max workers to 75% of cpu cores

### DIFF
--- a/apps/jest.config.js
+++ b/apps/jest.config.js
@@ -96,7 +96,7 @@ const config = {
   // globals: {},
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-  // maxWorkers: "50%",
+  maxWorkers: '75%',
 
   // An array of directory names to be searched recursively up from the requiring module's location
   // moduleDirectories: [


### PR DESCRIPTION
The Code.org CI environment is a shared machine which is subject to resource contention. When cron jobs, asynchronous jobs, and other tasks run while a jest suite executes, there is a possibility one of the cores are running other resource intensive tasks resulting in a lengthy delay before the core is returned to the worker, thus causing it to exceed the 5s timeout. Since the CI environment is shared, limit the maximum workers to 75% of cores to allow some to remain to be used by other processes.