### PR TITLE
[Music Lab] add exemplar modes

### DIFF
--- a/apps/src/lab2/constants.ts
+++ b/apps/src/lab2/constants.ts
@@ -16,6 +16,7 @@ export enum PERMISSIONS {
 
 export const START_SOURCES = 'start_sources';
 export const TOOLBOX_BLOCKS = 'toolbox_blocks';
+export const EDIT_EXEMPLAR = 'edit_exemplar';
 
 export const LABS_USING_NEW_SHARE_DIALOG = ['music', 'pythonlab'];
 
@@ -28,6 +29,8 @@ export enum WARNING_BANNER_MESSAGES {
   TEMPLATE = 'WARNING: You are editing start sources for a level with a template. Start sources should be defined on the template.',
   LOCK_FILES = 'Reminder: lock all start files your validation file references.',
   TOOLBOX_MODE = 'You are editing toolbox blocks.',
+  EXEMPLAR_MODE = 'You are editing exemplar sources.',
+  VIEWING_EXEMPLAR = 'You are viewing an example solution.',
 }
 
 // Default height of the predict question free response text area.

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -321,13 +321,15 @@ export const isLabLoading = (state: {lab: LabState}) =>
 // This may depend on more factors, such as share.
 export const isReadOnlyWorkspace = (state: RootState) => {
   const isEditMode = !!getAppOptionsEditBlocks();
-  const isEditingExemplarMode = getAppOptionsEditingExemplar();
+  const isEditingExemplar = getAppOptionsEditingExemplar();
+  const isViewingExemplar = getAppOptionsViewingExemplar();
 
   // Exemplar and block edit modes do not have a channel.
-  if (isEditMode || isEditingExemplarMode) {
+  if (isEditMode || isEditingExemplar) {
     return false;
+  } else if (isViewingExemplar) {
+    return true;
   }
-
   // Otherwise, we are in read only mode if we are not the owner of the channel,
   // the level is frozen, the level is a read only predict level, the level has been submitted.
   // or this is a lab that should be read only while running and the code is currently running.

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -2,7 +2,11 @@ import * as GoogleBlockly from 'blockly/core';
 
 import {BLOCK_TYPES, Renderers} from '@cdo/apps/blockly/constants';
 import CdoDarkTheme from '@cdo/apps/blockly/themes/cdoDark';
-import {ProcedureBlock, ExtendedBlock} from '@cdo/apps/blockly/types';
+import {
+  ProcedureBlock,
+  ExtendedBlock,
+  ExtendedWorkspaceSvg,
+} from '@cdo/apps/blockly/types';
 import {disableOrphanBlocks} from '@cdo/apps/blockly/utils';
 import {TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
@@ -648,6 +652,10 @@ export default class MusicBlocklyWorkspace {
   // For each function body in the current workspace, add a function call
   // block to the toolbox. Also add a function definition block, if required.
   generateFunctionBlocks() {
+    const workspace = this.workspace as ExtendedWorkspaceSvg;
+    if (workspace?.isReadOnly()) {
+      return;
+    }
     const blockList: GoogleBlockly.utils.toolbox.ToolboxItemInfo[] = [];
 
     if (this.toolbox?.addFunctionDefinition) {

--- a/apps/src/music/types.ts
+++ b/apps/src/music/types.ts
@@ -1,6 +1,6 @@
 import * as GoogleBlockly from 'blockly/core';
 
-import {ProjectLevelData, Source} from '../lab2/types';
+import {ProjectLevelData} from '../lab2/types';
 import {ValueOf} from '../types/utils';
 
 import {ToolboxData} from './blockly/toolbox/types';
@@ -19,7 +19,6 @@ export interface MusicLevelData extends ProjectLevelData {
   showAiGenerateAgainHelp?: boolean;
   allowChangeStartingPlayheadPosition?: boolean;
   toolboxDefinition?: GoogleBlockly.utils.toolbox.ToolboxInfo;
-  exemplarSources?: Source;
 }
 
 export type LoadFinishedCallback = (

--- a/apps/src/music/types.ts
+++ b/apps/src/music/types.ts
@@ -1,6 +1,6 @@
 import * as GoogleBlockly from 'blockly/core';
 
-import {ProjectLevelData} from '../lab2/types';
+import {ProjectLevelData, Source} from '../lab2/types';
 import {ValueOf} from '../types/utils';
 
 import {ToolboxData} from './blockly/toolbox/types';
@@ -19,6 +19,7 @@ export interface MusicLevelData extends ProjectLevelData {
   showAiGenerateAgainHelp?: boolean;
   allowChangeStartingPlayheadPosition?: boolean;
   toolboxDefinition?: GoogleBlockly.utils.toolbox.ToolboxInfo;
+  exemplarSources?: Source;
 }
 
 export type LoadFinishedCallback = (

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -10,7 +10,11 @@ import {
 } from '@cdo/apps/lab2/constants';
 import {isProjectTemplateLevel} from '@cdo/apps/lab2/lab2Redux';
 import {ProgressManagerContext} from '@cdo/apps/lab2/progress/ProgressContainer';
-import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
+import {
+  getAppOptionsEditBlocks,
+  getAppOptionsEditingExemplar,
+  getAppOptionsViewingExemplar,
+} from '@cdo/apps/lab2/projects/utils';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
@@ -109,9 +113,12 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
 
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
+  const isEditingExemplar = getAppOptionsEditingExemplar();
+  const isViewingExemplar = getAppOptionsViewingExemplar();
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
   const blockMode = useSelector(getBlockMode);
 
+  const levelId = useAppSelector(state => state.lab.levelProperties?.id);
   // Pass music validator to Progress Manager
   useEffect(() => {
     if (progressManager && appName === 'music') {
@@ -128,6 +135,12 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
         };
         return {level_data: updatedLevelData};
       });
+    } else if (isEditingExemplar) {
+      header.showLevelBuilderSaveButton(
+        () => ({exemplar_sources: blocklyWorkspace.getCode()}),
+        'Levelbuilder: Edit Exemplar',
+        `/levels/${levelId}/update_exemplar_code`
+      );
     } else if (isToolboxMode) {
       header.showLevelBuilderSaveButton(() => {
         const updatedLevelData = {
@@ -137,7 +150,14 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
         return {level_data: updatedLevelData};
       }, 'Levelbuilder: Edit toolbox blocks');
     }
-  }, [blocklyWorkspace, isStartMode, isToolboxMode, levelData]);
+  }, [
+    blocklyWorkspace,
+    isStartMode,
+    isEditingExemplar,
+    isToolboxMode,
+    levelData,
+    levelId,
+  ]);
 
   // Use the Lab2 generic prompt for Blockly prompt dialogs.
   const showGenericPrompt = useCallback(
@@ -369,6 +389,22 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 {projectTemplateLevel
                   ? WARNING_BANNER_MESSAGES.TEMPLATE
                   : WARNING_BANNER_MESSAGES.STANDARD}
+              </div>
+            )}
+            {isEditingExemplar && (
+              <div
+                id="toolboxModeWarningBanner"
+                className={moduleStyles.warningBanner}
+              >
+                {WARNING_BANNER_MESSAGES.EXEMPLAR_MODE}
+              </div>
+            )}
+            {isViewingExemplar && (
+              <div
+                id="toolboxModeWarningBanner"
+                className={moduleStyles.warningBanner}
+              >
+                {WARNING_BANNER_MESSAGES.VIEWING_EXEMPLAR}
               </div>
             )}
             {isToolboxMode && (

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -16,7 +16,11 @@ import {
   setPageError,
 } from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
+import {
+  getAppOptionsEditBlocks,
+  getAppOptionsEditingExemplar,
+  getAppOptionsViewingExemplar,
+} from '@cdo/apps/lab2/projects/utils';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {setExtraCopyrightContent} from '@cdo/apps/sharedComponents/footer/CopyrightDialog/index';
@@ -287,6 +291,8 @@ class UnconnectedMusicView extends React.Component {
     // In start mode, we always show the full toolbox for the given block mode.
     const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
     const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
+    const isEditingExemplar = getAppOptionsEditingExemplar();
+    const isViewingExemplar = getAppOptionsViewingExemplar();
 
     // Music Lab supports two types of toolbox configuration in levels:
     // The toolbox property is a simple list of block types and categories.
@@ -345,6 +351,8 @@ class UnconnectedMusicView extends React.Component {
         levelToolbox,
         levelToolboxDefinition
       );
+    } else if (isEditingExemplar || isViewingExemplar) {
+      this.loadCode(this.getExemplarSources() || this.getStartSources());
     } else if (this.getStartSources() || initialSources) {
       const startSources = this.getStartSources();
       let codeToLoad = startSources;
@@ -508,6 +516,10 @@ class UnconnectedMusicView extends React.Component {
     } else {
       return this.props.levelProperties?.levelData.startSources;
     }
+  };
+
+  getExemplarSources = () => {
+    return this.props.levelProperties?.exemplarSources;
   };
 
   onBlockSpaceChange = e => {

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -545,9 +545,7 @@ class LevelsController < ApplicationController
         links[@level.name] << {text: '[E]dit', url: edit_level_path(@level), access_key: 'e'}
         if [Javalab, Music, Pythonlab, Weblab2].include?(@level.class)
           links[@level.name] << {text: "[s]tart", url: edit_blocks_level_path(@level, :start_sources), access_key: 's'}
-          if @level.class != Music
-            links[@level.name] << {text: "e[x]emplar", url: edit_exemplar_level_path(@level), access_key: 'x'}
-          end
+          links[@level.name] << {text: "e[x]emplar", url: edit_exemplar_level_path(@level), access_key: 'x'}
           if [Music].include?(@level.class)
             links[@level.name] << {text: "[t]oolbox", url: edit_blocks_level_path(@level, :toolbox_blocks), access_key: 't'}
           end

--- a/dashboard/app/models/levels/music.rb
+++ b/dashboard/app/models/levels/music.rb
@@ -40,6 +40,7 @@ class Music < Blockly
     background
     level_data
     validations
+    encrypted_exemplar_sources
   )
 
   def self.create_from_level_builder(params, level_params)


### PR DESCRIPTION
This adds an exemplar editing mode levelbuilders and an exemplar viewing mode for teachers. Fortunately, the Code Bridge team has already provided much of the architecture needed for this feature.

<img width="649" alt="image" src="https://github.com/user-attachments/assets/5a07f298-480a-483b-b250-422014092ba8" />

In edit mode:
* A save button is added to the header
* A banner is added to the top of the workspace
* No project channel is used
* We will load blocks onto the workspace for an existing exemplar, or the level's start blocks.
* We use the level's toolbox, either one made in toolbox or the simpler allow list
* Starting over restores the level's start blocks

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/f4e7e820-3657-49ee-94d5-215ab430d183" />

When the workspace is saved, a top-level `encrypted_exemplar_sources` property is added to the level. Note that this is _not_ part of the Music Lab `level_data`. This aligns with how exemplars are saved in Code Bridge which makes it simple to maintain method for hooking them up to the teacher panel:
<img width="220" alt="image" src="https://github.com/user-attachments/assets/8085447a-69eb-4d2e-bae7-e027ecc74933" />

Clicking the Example Solution buttons opens the script level in a new tab with `?exemplar=true` appended to the URL. While in exemplar view mode:
* The workspace is read-only
* A banner is added to the top of the workspace

While testing this in a level with a flyout toolbox that included functions, I noticed that `generateFunctionBlocks` could cause a crash in a read-only workspace (due to the toolbox being missing). I added an early return to prevent this.

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/ba180f22-5c97-4173-afcf-5be984f7bedf" />

This branch does not introduce any other means of editing exemplar sources, although a JSON editor was discussed. Initially, I had a JSON editor working. However, when the decision was made to encrypt these sources was made (https://codedotorg.slack.com/archives/C07UT279KM1/p1739477320762509), it became more complicated to use the Raw JSON Editor component. @dancodedotorg advised that we could abandon this path in favor of encryption. He suggested that if more control is needed (e.g. bulk edits to blocks), that we could make this possible through new Blockly context menu options rather than manual JSON edits.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
