### PR TITLE
feat(Divider): refactor to use SpacingNoneToL type for margin

### DIFF
--- a/frontend/packages/component-library/src/divider/Divider.tsx
+++ b/frontend/packages/component-library/src/divider/Divider.tsx
@@ -1,14 +1,14 @@
 import classNames from 'classnames';
 import {HTMLAttributes} from 'react';
 
-import {ComponentSizeXSToL} from './../common/types';
+import {SpacingNoneToL} from './../common/types';
 import moduleStyles from './divider.module.scss';
 
 export interface DividerProps extends HTMLAttributes<HTMLElement> {
   /** Divider Color */
   color?: 'primary' | 'strong';
   /** Divider Margin */
-  margin?: 'none' | ComponentSizeXSToL;
+  margin?: SpacingNoneToL;
   /** Divider custom className */
   className?: string;
 }

--- a/frontend/packages/component-library/src/divider/divider.module.scss
+++ b/frontend/packages/component-library/src/divider/divider.module.scss
@@ -4,7 +4,6 @@
 .divider {
   border: 0;
   border-top: 1px solid;
-  margin: 0;
   width: 100%;
 }
 
@@ -21,6 +20,10 @@
 
 // Divider margin
 .divider-margin {
+  &-none {
+    margin: 0;
+  }
+
   &-xs {
     margin: 0.5rem 0;
   }


### PR DESCRIPTION
Replaces the `ComponentSizeXSToL` type with `SpacingNoneToL` for margins to better reflect what this type is doing.

## Links
Jira ticket: [CMS-356](https://codedotorg.atlassian.net/browse/CMS-356)

## Testing story
Tested locally in Storybook and Contentful that margin still shows as expected

----

## Storybook
<img width="1034" alt="Screenshot 2025-02-14 at 8 43 53 AM" src="https://github.com/user-attachments/assets/753304bb-feb4-4c0f-b70d-0b04855a4bab" />

## Contentful

https://github.com/user-attachments/assets/d99ff7c3-dc0f-4f70-b611-ff156ddd6185


