### PR TITLE
feat(Section): refactor to use SpacingNoneToL type for padding

### DIFF
--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import {HTMLAttributes, ReactNode} from 'react';
 
-import {ComponentSizeXSToL} from '@/common/types';
+import {SpacingNoneToL} from '@/common/types';
 import moduleStyles from './section.module.scss';
 
 export type SectionBackground =
@@ -31,7 +31,7 @@ export interface SectionProps extends HTMLAttributes<HTMLElement> {
   /** Background image */
   backgroundImageUrl?: string;
   /** Vertical padding */
-  padding?: Exclude<ComponentSizeXSToL, 'xs' | 's'>;
+  padding?: Exclude<SpacingNoneToL, 'none' | 'xs' | 's'>;
   /** Section content */
   children?: ReactNode;
 }

--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import {HTMLAttributes, ReactNode} from 'react';
 
-import {SpacingNoneToL} from '@/common/types';
+import {SpacingNoneToS, SpacingNoneToL} from '@/common/types';
 import moduleStyles from './section.module.scss';
 
 export type SectionBackground =
@@ -31,7 +31,7 @@ export interface SectionProps extends HTMLAttributes<HTMLElement> {
   /** Background image */
   backgroundImageUrl?: string;
   /** Vertical padding */
-  padding?: Exclude<SpacingNoneToL, 'none' | 'xs' | 's'>;
+  padding?: Exclude<SpacingNoneToL, SpacingNoneToS>;
   /** Section content */
   children?: ReactNode;
 }

--- a/frontend/packages/component-library/src/common/types/index.ts
+++ b/frontend/packages/component-library/src/common/types/index.ts
@@ -8,7 +8,8 @@ export type ComponentSizeXSToL = 'xs' | 's' | 'm' | 'l';
 /**
  * Possible options for spacing related props in Design System components
  */
-export type SpacingNoneToM = 'none' | 'xs' | 's' | 'm';
+export type SpacingNoneToS = 'none' | 'xs' | 's';
+export type SpacingNoneToM = SpacingNoneToS | 'm';
 export type SpacingNoneToL = SpacingNoneToM | 'l';
 
 /**


### PR DESCRIPTION
Replaces the `ComponentSizeXSToL` type with `SpacingNoneToL` for padding to better reflect what this type is doing.

## Links
Jira ticket: [CMS-355](https://codedotorg.atlassian.net/browse/CMS-355)

## Testing story
Tested locally in Storybook and Contentful that padding still shows as expected

----

## Storybook

https://github.com/user-attachments/assets/8cae89ca-af49-412f-beec-89865b9b2732



## Contentful


https://github.com/user-attachments/assets/1f793b9a-ab2c-4b1c-9460-3491779d228c


