### PR TITLE
feat(Divider): clean up Storybook docs

### DIFF
--- a/frontend/packages/component-library/src/divider/stories/Divider.story.tsx
+++ b/frontend/packages/component-library/src/divider/stories/Divider.story.tsx
@@ -36,13 +36,6 @@ const MultipleTemplate: StoryObj<{
 }> = {
   render: args => (
     <>
-      <p>
-        {args.components.some(componentArg => componentArg.margin)
-          ? '* Gray background exists to show spacing, it will not appear with component *'
-          : "* Margins on this screen do not represent Component's margins, and are only added to improve storybook view *"}
-      </p>
-
-      <p>Multiple Dividers:</p>
       <div style={{display: 'flex', flexDirection: 'column', gap: '20px'}}>
         {args.components?.map((componentArg, index) => (
           <div
@@ -92,6 +85,14 @@ export const GroupOfDividersWithMargin: StoryObj<{
       {color: 'primary', margin: 'm'},
       {color: 'primary', margin: 'l'},
     ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Gray background exists to show padding, it will not appear with component.',
+      },
+    },
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);

--- a/frontend/packages/component-library/src/divider/stories/Divider.story.tsx
+++ b/frontend/packages/component-library/src/divider/stories/Divider.story.tsx
@@ -90,7 +90,7 @@ export const GroupOfDividersWithMargin: StoryObj<{
     docs: {
       description: {
         story:
-          'Gray background exists to show padding, it will not appear with component.',
+          'Gray background exists to show margin, it will not appear with component.',
       },
     },
   },


### PR DESCRIPTION
Removes some extraneous documentation and moves other documentation on Storybook for the Divider component.

## Links
Jira ticket: [CMS-357](https://codedotorg.atlassian.net/browse/CMS-357)

## Testing story
Tested locally in Storybook

----

## Before
<img width="1053" alt="Screenshot 2025-02-14 at 9 06 15 AM" src="https://github.com/user-attachments/assets/ec036da7-82c2-43a1-b8fb-fb43e0cb96b5" />

## After
<img width="1053" alt="Screenshot 2025-02-14 at 9 04 49 AM" src="https://github.com/user-attachments/assets/c0b43f17-a02a-4afd-8a21-4869f3a84233" />
