### PR TITLE
AI Chat: fix dropdown css specificity

### DIFF
--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -108,7 +108,7 @@ $default-spacing: 4px;
   padding: 10px 7px;
 }
 
-.selectedModelDropdown {
+label.selectedModelDropdown {
   @extend %full-width;
   padding-bottom: 10px;
   display: inline-block;


### PR DESCRIPTION
Fix css specificity for the select model dropdown so it takes up the full width.

Before:

<img width="790" alt="Screenshot 2025-02-14 at 10 24 42 AM" src="https://github.com/user-attachments/assets/a7dfe5be-ba08-46e7-bae9-e60871b46ceb" />


After:

<img width="789" alt="Screenshot 2025-02-14 at 10 28 49 AM" src="https://github.com/user-attachments/assets/eaf7a842-e98d-4556-b994-7160f16887d3" />