### PR TITLE
Improve enrollment data integrity

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.tsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.tsx
@@ -13,6 +13,7 @@ import React, {Fragment, ReactNode, useMemo, useState} from 'react';
 
 import Typography from '@cdo/apps/componentLibrary/typography/Typography';
 import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {studio} from '@cdo/apps/lib/util/urlHelpers';
 import {useSchoolInfo} from '@cdo/apps/schoolInfo/hooks/useSchoolInfo';
 import {buildSchoolData} from '@cdo/apps/schoolInfo/utils/buildSchoolData';
 import {schoolInfoInvalid} from '@cdo/apps/schoolInfo/utils/schoolInfoInvalid';
@@ -20,7 +21,6 @@ import SchoolDataInputs, {
   SCHOOL_INFO_ID,
 } from '@cdo/apps/templates/SchoolDataInputs.jsx';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
-import {isEmail} from '@cdo/apps/util/formatValidation';
 
 import QuestionsTable from '../form_components/QuestionsTable';
 import {COURSE_BUILD_YOUR_OWN} from '../workshop_dashboard/workshopConstants';
@@ -57,13 +57,11 @@ interface SchoolInfoProps {
 
 interface EnrollFormState {
   attended_csf_intro_workshop: keyof typeof ATTENDED_CSF_COURSES_OPTIONS;
-  confirm_email: string;
   csf_course_experience: Partial<typeof CSF_COURSES>;
   csf_courses_planned: string[];
   csf_intro_intent: string;
   csf_intro_other_factors: string[];
   describe_role: string;
-  email: string;
   explain_csf_course_other: string;
   explain_not_teaching: string;
   explain_teaching_other: string;
@@ -95,7 +93,7 @@ type EnrollmentResponse = {
  */
 type EnrollFormProps = {
   collect_demographics?: boolean;
-  email?: string;
+  email: string;
   first_name?: string;
   last_name?: string;
   role?: string;
@@ -173,13 +171,11 @@ export default function EnrollForm(props: EnrollFormProps) {
 
   const [formState, setFormState] = useState<EnrollFormState>({
     attended_csf_intro_workshop: props.attended_csf_intro_workshop ?? '',
-    confirm_email: '',
     csf_course_experience: {},
     csf_courses_planned: [],
     csf_intro_intent: props.csf_intro_intent ?? '',
     csf_intro_other_factors: [],
     describe_role: '',
-    email: props.email ?? '',
     explain_csf_course_other: '',
     explain_not_teaching: '',
     explain_teaching_other: '',
@@ -335,7 +331,7 @@ export default function EnrollForm(props: EnrollFormProps) {
       user_id: props.user_id,
       first_name: formState.first_name,
       last_name: formState.last_name,
-      email: formState.email,
+      email: props.email,
       school_info: buildSchoolData({
         schoolId: schoolInfo.schoolId,
         country: schoolInfo.country,
@@ -392,15 +388,6 @@ export default function EnrollForm(props: EnrollFormProps) {
   const getAllErrors = () => {
     const errors: FormErrors = {};
 
-    if (formState.email) {
-      if (!isEmail(formState.email)) {
-        errors.email = 'Must be a valid email address';
-      }
-      if (!props.email && formState.email !== formState.confirm_email) {
-        errors.confirm_email = 'Email addresses do not match';
-      }
-    }
-
     if (
       schoolInfoInvalid({
         country: schoolInfo.country,
@@ -428,15 +415,7 @@ export default function EnrollForm(props: EnrollFormProps) {
   };
 
   const requiredFields: Array<keyof EnrollFormState> = useMemo(() => {
-    const fields: Array<keyof EnrollFormState> = [
-      'first_name',
-      'last_name',
-      'email',
-    ];
-
-    if (!props.email) {
-      fields.push('confirm_email');
-    }
+    const fields: Array<keyof EnrollFormState> = ['first_name', 'last_name'];
 
     if (props.workshop_course === CSF) {
       fields.push('role', 'grades_teaching');
@@ -489,7 +468,6 @@ export default function EnrollForm(props: EnrollFormProps) {
     formState.grades_teaching,
     formState.explain_teaching_other,
     formState.explain_not_teaching,
-    props.email,
     props.workshop_course,
     props.workshop_subject,
   ]);
@@ -562,7 +540,8 @@ export default function EnrollForm(props: EnrollFormProps) {
             className={styles.no_margin}
           >
             Fields marked with a<span className="form-required-field"> * </span>
-            are required.
+            are required. Make sure you are enrolling with the Code.org account
+            you will be using during the workshop.
           </Typography>
           <TextField
             id="first_name"
@@ -594,33 +573,25 @@ export default function EnrollForm(props: EnrollFormProps) {
             id="email"
             name="email"
             label="Email Address"
-            onChange={e =>
-              handleChange({
-                email: e.target.value,
-              })
-            }
-            value={formState.email}
-            title={
-              props.email ? 'Email can be changed in account settings' : ''
-            }
-            errorMessage={formErrors.email}
-            className={getRequiredStyles('email')}
+            onChange={() => {}}
+            value={props.email}
+            disabled={true}
           />
-          {!props.email && (
-            <TextField
-              id="confirm_email"
-              name="confirm_email"
-              label="Confirm Email Address"
-              onChange={e =>
-                handleChange({
-                  confirm_email: e.target.value,
-                })
-              }
-              value={formState.confirm_email}
-              errorMessage={formErrors.confirm_email}
-              className={getRequiredStyles('confirm_email')}
-            />
-          )}
+          <Typography
+            semanticTag="p"
+            visualAppearance="body-three"
+            className={styles.no_margin}
+          >
+            If you need to change your account email,{' '}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={studio('/users/edit')}
+            >
+              click here
+            </a>
+            .
+          </Typography>
           <div className={styles.school_info_container}>
             <SchoolDataInputs
               includeHeaders={false}

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.tsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.tsx
@@ -62,6 +62,7 @@ interface EnrollFormState {
   csf_intro_intent: string;
   csf_intro_other_factors: string[];
   describe_role: string;
+  email: string;
   explain_csf_course_other: string;
   explain_not_teaching: string;
   explain_teaching_other: string;
@@ -93,7 +94,7 @@ type EnrollmentResponse = {
  */
 type EnrollFormProps = {
   collect_demographics?: boolean;
-  email: string;
+  email?: string;
   first_name?: string;
   last_name?: string;
   role?: string;
@@ -176,6 +177,7 @@ export default function EnrollForm(props: EnrollFormProps) {
     csf_intro_intent: props.csf_intro_intent ?? '',
     csf_intro_other_factors: [],
     describe_role: '',
+    email: props.email ?? '',
     explain_csf_course_other: '',
     explain_not_teaching: '',
     explain_teaching_other: '',
@@ -331,7 +333,7 @@ export default function EnrollForm(props: EnrollFormProps) {
       user_id: props.user_id,
       first_name: formState.first_name,
       last_name: formState.last_name,
-      email: props.email,
+      email: formState.email,
       school_info: buildSchoolData({
         schoolId: schoolInfo.schoolId,
         country: schoolInfo.country,
@@ -415,7 +417,11 @@ export default function EnrollForm(props: EnrollFormProps) {
   };
 
   const requiredFields: Array<keyof EnrollFormState> = useMemo(() => {
-    const fields: Array<keyof EnrollFormState> = ['first_name', 'last_name'];
+    const fields: Array<keyof EnrollFormState> = [
+      'first_name',
+      'last_name',
+      'email',
+    ];
 
     if (props.workshop_course === CSF) {
       fields.push('role', 'grades_teaching');
@@ -575,7 +581,7 @@ export default function EnrollForm(props: EnrollFormProps) {
               name="email"
               label="Email Address"
               onChange={() => {}}
-              value={props.email}
+              value={formState.email}
               disabled={true}
             />
             <Typography

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.tsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.tsx
@@ -569,29 +569,31 @@ export default function EnrollForm(props: EnrollFormProps) {
             errorMessage={formErrors.last_name}
             className={getRequiredStyles('last_name')}
           />
-          <TextField
-            id="email"
-            name="email"
-            label="Email Address"
-            onChange={() => {}}
-            value={props.email}
-            disabled={true}
-          />
-          <Typography
-            semanticTag="p"
-            visualAppearance="body-three"
-            className={styles.no_margin}
-          >
-            If you need to change your account email,{' '}
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href={studio('/users/edit')}
+          <div>
+            <TextField
+              id="email"
+              name="email"
+              label="Email Address"
+              onChange={() => {}}
+              value={props.email}
+              disabled={true}
+            />
+            <Typography
+              semanticTag="p"
+              visualAppearance="body-three"
+              className={styles.no_margin}
             >
-              click here
-            </a>
-            .
-          </Typography>
+              If you need to change your account email,{' '}
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href={studio('/users/edit')}
+              >
+                click here
+              </a>
+              .
+            </Typography>
+          </div>
           <div className={styles.school_info_container}>
             <SchoolDataInputs
               includeHeaders={false}

--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
@@ -15,7 +15,6 @@ import WorkshopDetails from './workshop_details';
 export default class WorkshopEnroll extends React.Component {
   static propTypes = {
     user_id: PropTypes.number.isRequired,
-    email: PropTypes.string.isRequired,
     workshop: WorkshopPropType,
     workshop_location_for_calendar: PropTypes.string,
     session_dates: PropTypes.arrayOf(PropTypes.string),
@@ -27,6 +26,7 @@ export default class WorkshopEnroll extends React.Component {
       })
     ),
     enrollment: PropTypes.shape({
+      email: PropTypes.string,
       first_name: PropTypes.string,
       last_name: PropTypes.string,
     }),
@@ -216,7 +216,7 @@ export default class WorkshopEnroll extends React.Component {
                         workshop_course={this.props.workshop.course}
                         first_name={this.props.enrollment.first_name}
                         last_name={this.props.enrollment.last_name}
-                        email={this.props.email}
+                        email={this.props.enrollment.email}
                         onSubmissionComplete={this.onSubmissionComplete}
                         workshop_subject={this.props.workshop.subject}
                         previous_courses={this.props.previous_courses}

--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
@@ -15,6 +15,7 @@ import WorkshopDetails from './workshop_details';
 export default class WorkshopEnroll extends React.Component {
   static propTypes = {
     user_id: PropTypes.number.isRequired,
+    email: PropTypes.string.isRequired,
     workshop: WorkshopPropType,
     workshop_location_for_calendar: PropTypes.string,
     session_dates: PropTypes.arrayOf(PropTypes.string),
@@ -26,7 +27,6 @@ export default class WorkshopEnroll extends React.Component {
       })
     ),
     enrollment: PropTypes.shape({
-      email: PropTypes.string,
       first_name: PropTypes.string,
       last_name: PropTypes.string,
     }),
@@ -216,7 +216,7 @@ export default class WorkshopEnroll extends React.Component {
                         workshop_course={this.props.workshop.course}
                         first_name={this.props.enrollment.first_name}
                         last_name={this.props.enrollment.last_name}
-                        email={this.props.enrollment.email}
+                        email={this.props.email}
                         onSubmissionComplete={this.onSubmissionComplete}
                         workshop_subject={this.props.workshop.subject}
                         previous_courses={this.props.previous_courses}

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -553,9 +553,6 @@ describe('Enroll Form', () => {
       // of the validation errors.
       enrollForm.find(getIdSelector('submit')).simulate('click');
       expect(fetchStub.called).to.be.false;
-      expect(
-        enrollForm.find(getIdSelector('email')).prop('errorMessage')
-      ).to.equal('Field is required');
       expect(enrollForm.find(getIdSelector('first_name')).prop('errorMessage'))
         .to.be.undefined;
     });

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -44,6 +44,9 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       render :missing_application
     elsif current_user.teacher? && current_user.email.blank?
       render '/pd/application/teacher_application/no_teacher_email'
+    elsif @workshop.enrollments.any? {|enrollment| enrollment.user_id == current_user.id}
+      @user_email = current_user.email
+      render :already_enrolled
     else
       @enrollment = ::Pd::Enrollment.new workshop: @workshop
       @enrollment.full_name = current_user.name
@@ -81,6 +84,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       @script_data = {
         props: {
           user_id: current_user.id,
+          email: current_user.email,
           workshop: @workshop.attributes.merge(
             {
               organizer: @workshop.organizer,

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -51,7 +51,6 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       @enrollment = ::Pd::Enrollment.new workshop: @workshop
       @enrollment.full_name = current_user.name
       @enrollment.email = current_user.email
-      @enrollment.email_confirmation = current_user.email
 
       session_dates = @workshop.sessions.map(&:formatted_date_with_start_and_end_times)
       session_info_for_calendar = @workshop.sessions.map(&:session_info_for_calendar)
@@ -84,7 +83,6 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       @script_data = {
         props: {
           user_id: current_user.id,
-          email: current_user.email,
           workshop: @workshop.attributes.merge(
             {
               organizer: @workshop.organizer,

--- a/dashboard/app/views/pd/workshop_enrollment/already_enrolled.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/already_enrolled.haml
@@ -6,6 +6,4 @@
   under the email
   = @user_email + '.'
   To view workshops you're enrolled in, visit the
-  %a{href: CDO.studio_url("/my-professional-learning")}
-    My Professional Learning page
-  .
+  = link_to('My Professional Learning page', CDO.studio_url("/my-professional-learning")) + '.'

--- a/dashboard/app/views/pd/workshop_enrollment/already_enrolled.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/already_enrolled.haml
@@ -1,0 +1,7 @@
+%h1
+  You Are Already Enrolled
+
+%p
+  There is already an enrollment for this workshop associated with your account
+  under the email
+  = @user_email + '.'

--- a/dashboard/app/views/pd/workshop_enrollment/already_enrolled.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/already_enrolled.haml
@@ -5,3 +5,7 @@
   There is already an enrollment for this workshop associated with your account
   under the email
   = @user_email + '.'
+  To view workshops you're enrolled in, visit the
+  %a{href: CDO.studio_url("/my-professional-learning")}
+    My Professional Learning page
+  .

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -127,6 +127,18 @@ class Pd::WorkshopEnrollmentControllerTest < ActionController::TestCase
     assert_template :missing_application
   end
 
+  test 'teacher already enrolled in workshop cannot enroll again' do
+    teacher = create :teacher
+    application = create :pd_teacher_application, user: teacher, status: 'accepted'
+    workshop = create :workshop
+    create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :already_enrolled
+  end
+
   test 'teacher with required application gets new view' do
     teacher = create :teacher
     create :pd_teacher_application, user: teacher, status: 'accepted'


### PR DESCRIPTION
Implements some fixes for a couple workshop enrollment data integrity issues discussed in [this thread](https://codedotorg.slack.com/archives/C04540KNGDQ/p1739375746856579):
1. Restricting an account to enroll in a workshop only once.
2. Shows their current account email in the email field but in a locked state. Then add text below with a link to account settings to update their email if needed.
3. Adding a note on the enrollment form advising users to enroll using the account they plan to use during the workshop.

### Text and field updates to the enroll form
Previous form:
![enroll form](https://github.com/user-attachments/assets/16b83860-fbf3-48a9-bb76-9dcde74c0a86)

New form:
- Updated note telling the user to enroll with the account they want on the enrollment
- Locked email field that tells the user they can edit their email in the account settings (opens in a new tab)
![new enroll form](https://github.com/user-attachments/assets/32589999-1254-4d20-8f2b-9ec952a38c62)

### Attempting to enroll for a workshop the user is already enrolled in
![already enrolled update](https://github.com/user-attachments/assets/e58aae70-83f7-465a-a826-b39ae44ca8e1)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3102)
Slack discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1739375746856579)

## Testing story
Local testing and updating unit tests.
