### PR TITLE
CDO.send_metrics_to_cloudwatch: for AWS-less usage

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -666,3 +666,7 @@ active_job_backend_rolling_restart_in_n_batches: 2
 
 # aiproxy credentials
 aiproxy_api_key: !Secret
+
+# By default, we log metrics to CloudWatch, and generate an error if they cannot be sent.
+# Disable this if you're trying to run without access to AWS.
+send_metrics_to_cloudwatch: true

--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -37,6 +37,8 @@ module Cdo
       end
 
       def flush(events)
+        return unless CDO.send_metrics_to_cloudwatch
+
         client = Cdo::Metrics.client ||= ::Aws::CloudWatch::Client.new(
           retry_limit: 3,
           http_open_timeout: 5,

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -162,3 +162,7 @@ use_my_apps: true
 # Number of workers to start when running `bin/restart-active-job-workers`:
 # active_job_backend_n_workers_to_start: 2
 # active_job_backend_rolling_restart_in_n_batches: 1
+
+# By default, we log metrics to CloudWatch, and generate an error if they cannot be sent.
+# Uncomment this if you're trying to run without access to AWS.
+# send_metrics_to_cloudwatch: false


### PR DESCRIPTION
This PR adds a locals.yml option `CDO. send_metrics_to_cloudwatch` to support "run without AWS" usage, which I'll be using in #62300. It removes voluminous cloudwatch error spew while doing `rake build` without AWS access.

As part of #62300, I'm doing `rake build` steps within a Dockerfile, which means of course no AWS access. [metrics.rb](https://github.com/code-dot-org/code-dot-org/blob/9d16ca992bc44e0350536d7c119829ce2ceed257/lib/cdo/aws/metrics.rb/#L42-L47), which is triggered by many rake build steps which try to log rake step timing, tries to send logs to CloudWatch, and when it inevitably fails, it generates many long exception backtraces.

These are caught, and don't break the build, but the volume is quite large, and makes it hard to debug other errors as well as looking quite frankly broken.

## Testing

Tested by:
1.  making sure `rake build` still works when the property is **not** used (so we aren't breaking current codepath)
2. `rake build` no longer prints numerous cloudwatch when `CDO.send_metrics_to_cloudwatch = true`