### PR TITLE
feat(workshops): add new fields to workshop

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -26,6 +26,9 @@
 #  module                 :string(255)
 #  name                   :string(255)
 #  participant_group_type :string(255)
+#  description            :text(65535)
+#  registration_link      :text(65535)
+#  hidden                 :boolean
 #
 # Indexes
 #
@@ -55,6 +58,8 @@ class Pd::Workshop < ApplicationRecord
 
   serialized_attrs [
     'fee',
+    'grades',
+    'prereq',
 
     # Indicates that this workshop will be conducted virtually, which triggers
     # a different, virtual-specific post-workshop survey.

--- a/dashboard/db/migrate/20250214202758_add_fields_to_workshop_description_registration_link_hidden.rb
+++ b/dashboard/db/migrate/20250214202758_add_fields_to_workshop_description_registration_link_hidden.rb
@@ -1,0 +1,7 @@
+class AddFieldsToWorkshopDescriptionRegistrationLinkHidden < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pd_workshops, :description, :text
+    add_column :pd_workshops, :registration_link, :text
+    add_column :pd_workshops, :hidden, :boolean
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_13_210703) do
+ActiveRecord::Schema.define(version: 2025_02_14_202758) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1543,6 +1543,9 @@ ActiveRecord::Schema.define(version: 2025_02_13_210703) do
     t.string "module"
     t.string "name"
     t.string "participant_group_type"
+    t.text "description"
+    t.text "registration_link"
+    t.boolean "hidden"
     t.index ["organizer_id"], name: "index_pd_workshops_on_organizer_id"
     t.index ["regional_partner_id"], name: "index_pd_workshops_on_regional_partner_id"
   end


### PR DESCRIPTION
added new text columns for workshop description and a custom registration link, and a boolean column for hidden. prereq string existing or not wil dictate whether prereqs are required. using existing fee serialized_attr for tracking workshop cost. adding grades and prereq as serialized_attrs since any filtering on these values will be done client side on a small subset of workshops (upcoming and by regional partner)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3075)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
