### PR TITLE
Lab2: start passing level properties and sources as props

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -9,6 +9,7 @@ import React, {useCallback, useEffect} from 'react';
 
 import {isProjectTemplateLevel} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {LabProps} from '@cdo/apps/lab2/types';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
@@ -55,7 +56,7 @@ const getResetModelNotification = (): Notification => ({
   includeInChatHistory: true,
 });
 
-const AichatView: React.FunctionComponent = () => {
+const AichatView: React.FunctionComponent<LabProps> = () => {
   const dispatch = useAppDispatch();
 
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -4,6 +4,7 @@ import {TypedUseSelectorHook, useSelector} from 'react-redux';
 import SongSelector from '@cdo/apps/dance/SongSelector';
 import {LabState} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {LabProps} from '@cdo/apps/lab2/types';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {registerReducers} from '@cdo/apps/redux';
@@ -38,7 +39,7 @@ registerReducers(reducers);
  * Renders the Lab2 version of Dance Lab. This separate container
  * allows us to support both Lab2 and legacy Dance.
  */
-const DanceView: React.FunctionComponent = () => {
+const DanceView: React.FunctionComponent<LabProps> = () => {
   const dispatch = useAppDispatch();
 
   const useRestrictedSongs = useTypedSelector(

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -248,7 +248,7 @@ export interface Lab2EntryPoint {
    * component using a dynamic import. See `pythonlab/entrypoint.tsx` for an
    * example.
    */
-  view: LazyExoticComponent<ComponentType>;
+  view: LazyExoticComponent<ComponentType<LabProps>>;
   /**
    * Display theme for this lab. This will likely be configured by user
    * preferences eventually, but for now this is fixed for each lab. Defaults
@@ -361,4 +361,9 @@ export interface ParentLevelPathLink {
   path: string;
   kind: string;
   position: string;
+}
+
+export interface LabProps {
+  initialSources?: ProjectSources;
+  levelProperties: LevelProperties;
 }

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -24,13 +24,13 @@ import moduleStyles from './lab-views-renderer.module.scss';
 const hideExtraLinks = queryParams('hide-extra-links') === 'true';
 
 const LabViewsRenderer: React.FunctionComponent = () => {
-  const currentAppName = useAppSelector(
-    state => state.lab.levelProperties?.appName
-  );
-  const levelId = useAppSelector(state => state.lab.levelProperties?.id);
-  const exemplarSources = useAppSelector(
-    state => state.lab.levelProperties?.exemplarSources
-  );
+  const levelProperties = useAppSelector(state => state.lab.levelProperties);
+  const initialSources = useAppSelector(state => state.lab.initialSources);
+
+  const currentAppName = levelProperties?.appName;
+  const exemplarSources = levelProperties?.exemplarSources;
+  const levelId = levelProperties?.id;
+
   const isBlocked = useAppSelector(state => state.lab.isBlocked);
   const isProjectValidator = useAppSelector(state =>
     state.lab.permissions?.includes(PERMISSIONS.PROJECT_VALIDATOR)
@@ -69,7 +69,10 @@ const LabViewsRenderer: React.FunctionComponent = () => {
     <ProgressContainer key={currentAppName} appType={currentAppName}>
       <div id={`lab2-${currentAppName}`} className={moduleStyles.labContainer}>
         <Suspense fallback={<Loading isLoading={true} />}>
-          <LabView />
+          <LabView
+            levelProperties={levelProperties}
+            initialSources={initialSources}
+          />
         </Suspense>
         {!hideExtraLinks && levelId && <ExtraLinks levelId={levelId} />}
       </div>

--- a/apps/src/music/entrypoint.ts
+++ b/apps/src/music/entrypoint.ts
@@ -6,8 +6,8 @@ export const MusicEntryPoint: Lab2EntryPoint = {
   theme: Theme.DARK,
   view: lazy(() =>
     import(/* webpackChunkName: "music" */ './index.js').then(
-      ({MusicView}) => ({
-        default: MusicView,
+      ({MusicViewWrapper}) => ({
+        default: MusicViewWrapper,
       })
     )
   ),

--- a/apps/src/music/index.js
+++ b/apps/src/music/index.js
@@ -1,3 +1,3 @@
 // This file allows us to lazily load the MusicView component.
 // Due to our configuration this needs to be in js so we can use dynamic imports.
-export {default as MusicView} from './views/MusicView';
+export {default as MusicViewWrapper} from './views/MusicViewWrapper';

--- a/apps/src/music/views/MusicViewWrapper.tsx
+++ b/apps/src/music/views/MusicViewWrapper.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import {LabProps} from '@cdo/apps/lab2/types';
+
+import MusicView from './MusicView';
+
+/** Temporary functional/TS wrapper around MusicView that satisfies type constraints */
+const MusicViewWrapper: React.FC<LabProps> = () => <MusicView />;
+
+export default MusicViewWrapper;

--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -22,6 +22,7 @@ import {
 } from '../code-studio/progressReduxSelectors';
 import {queryParams} from '../code-studio/utils';
 import useLifecycleNotifier from '../lab2/hooks/useLifecycleNotifier';
+import {LabProps} from '../lab2/types';
 import {LifecycleEvent} from '../lab2/utils';
 import MusicAnalyticsReporter from '../music/analytics/AnalyticsReporter';
 import useWindowSize from '../util/hooks/useWindowSize';
@@ -68,7 +69,7 @@ const updateAnalyticsProperty = (key: string, value: string) => {
   identify(identifyEvent);
 };
 
-const PanelsLabView: React.FunctionComponent = () => {
+const PanelsLabView: React.FunctionComponent<LabProps> = () => {
   const dispatch = useAppDispatch();
 
   const panels = useAppSelector(

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -18,7 +18,7 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {ProgressManagerContext} from '@cdo/apps/lab2/progress/ProgressContainer';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {isPredictAnswerLocked} from '@cdo/apps/lab2/redux/predictLevelRedux';
-import {MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
+import {LabProps, MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import {AppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
@@ -96,7 +96,7 @@ const defaultConfig: ConfigType = {
   },
 };
 
-const PythonlabView: React.FunctionComponent = () => {
+const PythonlabView: React.FunctionComponent<LabProps> = () => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
   const {
     source,

--- a/apps/src/standaloneVideo/StandaloneVideo.tsx
+++ b/apps/src/standaloneVideo/StandaloneVideo.tsx
@@ -13,7 +13,7 @@ import {
   navigateToNextLevel,
 } from '@cdo/apps/code-studio/progressRedux';
 import {LabState} from '@cdo/apps/lab2/lab2Redux';
-import {VideoLevelData} from '@cdo/apps/lab2/types';
+import {LabProps, VideoLevelData} from '@cdo/apps/lab2/types';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import standaloneVideoLocale from './locale';
@@ -21,7 +21,7 @@ import Video from './Video';
 
 import styles from './video.module.scss';
 
-const StandaloneVideo: React.FunctionComponent = () => {
+const StandaloneVideo: React.FunctionComponent<LabProps> = () => {
   const dispatch = useAppDispatch();
   const levelData = useSelector(
     (state: {lab: LabState}) => state.lab.levelProperties?.levelData

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -9,7 +9,7 @@ import {html} from '@codemirror/lang-html';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useState} from 'react';
 
-import {MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
+import {LabProps, MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
 
 import {useSource} from '../codebridge/hooks/useSource';
 
@@ -150,7 +150,7 @@ const defaultSource: MultiFileSource = {
 
 const defaultProject: ProjectSources = {source: defaultSource};
 
-const Weblab2View = () => {
+const Weblab2View: React.FC<LabProps> = () => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
   const {source, setProject, startSources, projectVersion} =
     useSource(defaultProject);


### PR DESCRIPTION
First bit of work for some proposed Lab2 architecture updates, discussed [here](https://docs.google.com/document/d/1fpyd88e-mXkyUQrE1ILRh-na6zz9glz9rpcQu80o34o/edit?tab=t.0). This simply creates the `LabProps` type and passes in level properties and initial sources as props to all lab views. No lab views use these yet; they'll continue to grab them out of redux. But now we can convert labs one by one to switch over to using these props instead of the redux values, without disrupting the whole lab2 system.


### Testing story
Tested locally on lab2 levels. No user-facing or functional changes.