### PR TITLE
Don't spam stdout in dev when CDO::Metrics fails to reach CloudWatch

### DIFF
--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -49,7 +49,6 @@ module Cdo
         )
       rescue => exception
         Honeybadger.notify(exception)
-        puts "Error sending metrics to namespace #{@namespace}: #{exception.full_message}" if rack_env?(:development)
       end
 
       def size(events)


### PR DESCRIPTION
Alternative to https://github.com/code-dot-org/code-dot-org/pull/63972 (which has more description if desired)

Instead of implementing a CDO option to silence noisy output during `rake build` from CDO::Metrics, when AWS is not reachable, we just don't spam stdout when it fails to reach AWS.

Upsides: lower complexity (removes features instead of adding them), makes the default setup require less configuration to work without AWS.
Downsides: if a real error condition occurs and local dev metrics stop uploading to AWS when they shoudl work, we'll be less likely to notice

This one is my personal preference just on removing LOC instead of adding them, and making "no AWS" usage one notch less custom.

### Testing

1. `rake build` no longer spams when it can't reach AWS.
2. doesn't fail when it can reach AWS (no surprise, but you know)