### PR TITLE
Add unit tests for useInitialSources

### DIFF
--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -1,0 +1,57 @@
+import {renderHook} from '@testing-library/react-hooks';
+import React from 'react';
+import {Provider} from 'react-redux';
+import {Store} from 'redux';
+
+import {useInitialSources} from '@cdo/apps/codebridge/hooks';
+import lab from '@cdo/apps/lab2/lab2Redux';
+import {
+  getStore,
+  registerReducers,
+  restoreRedux,
+  stubRedux,
+} from '@cdo/apps/redux';
+
+import {smallProjectSources} from '../test-files';
+
+describe('useInitialSources', () => {
+  let store: Store;
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({
+      lab,
+    });
+    store = getStore();
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
+  function getWrapper() {
+    return ({children}: {children?: React.ReactNode}) => (
+      <Provider store={store}>{children}</Provider>
+    );
+  }
+
+  it('returns default sources if none are found', () => {
+    const wrapper = getWrapper();
+    const {result} = renderHook(() => useInitialSources(smallProjectSources), {
+      wrapper,
+    });
+    const expectedSources = {
+      ...smallProjectSources,
+      labConfig: undefined,
+    };
+    const {
+      initialSources,
+      levelStartSources,
+      templateStartSources,
+      parsedDefaultSources,
+    } = result.current;
+    expect(initialSources).toEqual(expectedSources);
+    expect(levelStartSources).toBeUndefined();
+    expect(templateStartSources).toBeUndefined();
+    expect(parsedDefaultSources).toEqual(expectedSources);
+  });
+});

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -3,8 +3,13 @@ import React from 'react';
 import {Provider} from 'react-redux';
 import {Store} from 'redux';
 
+import {
+  DEFAULT_FOLDER_ID,
+  MAZE_FILE_NAME,
+} from '@cdo/apps/codebridge/constants';
 import {useInitialSources} from '@cdo/apps/codebridge/hooks';
-import lab from '@cdo/apps/lab2/lab2Redux';
+import lab, {onLevelChange} from '@cdo/apps/lab2/lab2Redux';
+import {MazeCell, MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
 import {
   getStore,
   registerReducers,
@@ -12,7 +17,28 @@ import {
   stubRedux,
 } from '@cdo/apps/redux';
 
-import {smallProjectSources} from '../test-files';
+import {
+  neighborhoodLevelProperties,
+  nonValidatedLevelProperties,
+  smallProjectSources,
+  templateBackedLevelProperties,
+} from '../test-files';
+
+const expectedParsedDefaultSources = {
+  ...smallProjectSources,
+  labConfig: undefined,
+};
+
+const generateMazeFile = (mazeContents: MazeCell[][], fileId: string) => {
+  return {
+    id: fileId,
+    name: MAZE_FILE_NAME,
+    contents: JSON.stringify(mazeContents),
+    type: ProjectFileType.SYSTEM_SUPPORT,
+    language: 'txt',
+    folderId: DEFAULT_FOLDER_ID,
+  };
+};
 
 describe('useInitialSources', () => {
   let store: Store;
@@ -28,30 +54,123 @@ describe('useInitialSources', () => {
     restoreRedux();
   });
 
-  function getWrapper() {
-    return ({children}: {children?: React.ReactNode}) => (
+  function renderDefault() {
+    const wrapper = ({children}: {children?: React.ReactNode}) => (
       <Provider store={store}>{children}</Provider>
     );
-  }
-
-  it('returns default sources if none are found', () => {
-    const wrapper = getWrapper();
     const {result} = renderHook(() => useInitialSources(smallProjectSources), {
       wrapper,
     });
-    const expectedSources = {
-      ...smallProjectSources,
-      labConfig: undefined,
-    };
     const {
       initialSources,
       levelStartSources,
       templateStartSources,
       parsedDefaultSources,
     } = result.current;
-    expect(initialSources).toEqual(expectedSources);
+    return {
+      initialSources,
+      levelStartSources,
+      templateStartSources,
+      parsedDefaultSources,
+    };
+  }
+
+  it('returns default sources if none are found', () => {
+    const {
+      initialSources,
+      levelStartSources,
+      templateStartSources,
+      parsedDefaultSources,
+    } = renderDefault();
+    expect(initialSources).toEqual(expectedParsedDefaultSources);
     expect(levelStartSources).toBeUndefined();
     expect(templateStartSources).toBeUndefined();
-    expect(parsedDefaultSources).toEqual(expectedSources);
+    expect(parsedDefaultSources).toEqual(expectedParsedDefaultSources);
+  });
+
+  it('returns start sources for a non-template level', () => {
+    store.dispatch(
+      onLevelChange({levelProperties: nonValidatedLevelProperties})
+    );
+    const {
+      initialSources,
+      levelStartSources,
+      templateStartSources,
+      parsedDefaultSources,
+    } = renderDefault();
+    const expectedSources = {
+      source: nonValidatedLevelProperties.startSources,
+      labConfig: undefined,
+    };
+    expect(initialSources).toEqual(expectedSources);
+    expect(levelStartSources).toEqual(expectedSources);
+    expect(templateStartSources).toBeUndefined();
+    expect(parsedDefaultSources).toEqual(expectedParsedDefaultSources);
+  });
+
+  it('returns template sources for a template-backed level', () => {
+    store.dispatch(
+      onLevelChange({levelProperties: templateBackedLevelProperties})
+    );
+    const {
+      initialSources,
+      levelStartSources,
+      templateStartSources,
+      parsedDefaultSources,
+    } = renderDefault();
+    const expectedLevelSources = {
+      source: templateBackedLevelProperties.startSources,
+      labConfig: undefined,
+    };
+    const expectedSources = {
+      source: templateBackedLevelProperties.templateSources,
+      labConfig: undefined,
+    };
+    expect(initialSources).toEqual(expectedSources);
+    expect(levelStartSources).toEqual(expectedLevelSources);
+    expect(templateStartSources).toEqual(expectedSources);
+    expect(parsedDefaultSources).toEqual(expectedParsedDefaultSources);
+  });
+
+  it('populates labConfig and serializedMaze for a neighborhood level', () => {
+    store.dispatch(
+      onLevelChange({levelProperties: neighborhoodLevelProperties})
+    );
+    const {
+      initialSources,
+      levelStartSources,
+      templateStartSources,
+      parsedDefaultSources,
+    } = renderDefault();
+    const expectedSources = {
+      source: {
+        ...neighborhoodLevelProperties.startSources,
+        files: {
+          ...neighborhoodLevelProperties.startSources?.files,
+          '1': generateMazeFile(
+            neighborhoodLevelProperties.serializedMaze!,
+            '1'
+          ),
+        },
+      },
+      labConfig: {miniApp: {name: 'neighborhood'}},
+    };
+    const expectedNeighborhoodDefaultSources = {
+      source: {
+        ...(expectedParsedDefaultSources.source as MultiFileSource),
+        files: {
+          ...(expectedParsedDefaultSources.source as MultiFileSource).files,
+          '1': generateMazeFile(
+            neighborhoodLevelProperties.serializedMaze!,
+            '1'
+          ),
+        },
+      },
+      labConfig: {miniApp: {name: 'neighborhood'}},
+    };
+    expect(initialSources).toEqual(expectedSources);
+    expect(levelStartSources).toEqual(expectedSources);
+    expect(templateStartSources).toBeUndefined();
+    expect(parsedDefaultSources).toEqual(expectedNeighborhoodDefaultSources);
   });
 });

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -9,7 +9,12 @@ import {
 } from '@cdo/apps/codebridge/constants';
 import {useInitialSources} from '@cdo/apps/codebridge/hooks';
 import lab, {onLevelChange} from '@cdo/apps/lab2/lab2Redux';
-import {MazeCell, MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
+import {
+  MazeCell,
+  MultiFileSource,
+  ProjectFile,
+  ProjectFileType,
+} from '@cdo/apps/lab2/types';
 import {
   getStore,
   registerReducers,
@@ -20,9 +25,11 @@ import {
 import {
   neighborhoodLevelProperties,
   nonValidatedLevelProperties,
+  predictLevelProperties,
   smallProject,
   smallProjectSources,
   templateBackedLevelProperties,
+  withExemplarLevelProperties,
 } from '../test-files';
 
 const expectedParsedDefaultSources = {
@@ -30,7 +37,15 @@ const expectedParsedDefaultSources = {
   labConfig: undefined,
 };
 
-const generateMazeFile = (mazeContents: MazeCell[][], fileId: string) => {
+const sampleInitialSources = {
+  source: smallProject,
+  labConfig: undefined,
+};
+
+const generateMazeFile = (
+  mazeContents: MazeCell[][],
+  fileId: string
+): ProjectFile => {
   return {
     id: fileId,
     name: MAZE_FILE_NAME,
@@ -70,6 +85,7 @@ describe('useInitialSources', () => {
 
   afterEach(() => {
     restoreRedux();
+    jest.resetAllMocks();
   });
 
   function renderDefault() {
@@ -211,14 +227,10 @@ describe('useInitialSources', () => {
   });
 
   it('sets initial sources as lab initial sources if they exist', () => {
-    const expectedInitialSources = {
-      source: smallProject,
-      labConfig: undefined,
-    };
     store.dispatch(
       onLevelChange({
         levelProperties: nonValidatedLevelProperties,
-        initialSources: expectedInitialSources,
+        initialSources: sampleInitialSources,
       })
     );
     const {
@@ -232,30 +244,24 @@ describe('useInitialSources', () => {
       source: nonValidatedLevelProperties.startSources,
       labConfig: undefined,
     };
-    expect(initialSources).toEqual(expectedInitialSources);
+    expect(initialSources).toEqual(sampleInitialSources);
     expect(levelStartSources).toEqual(expectedStartSources);
     expect(templateStartSources).toBeUndefined();
     expect(parsedDefaultSources).toEqual(expectedParsedDefaultSources);
   });
 
   it('sets start sources as initial sources in start mode', () => {
-    const shouldBeIgnoredInitialSources = {
-      source: smallProject,
-      labConfig: undefined,
-    };
-    const querySelectorMock = jest.spyOn(document, 'querySelector');
-    const mockData = {
-      appoptions: JSON.stringify({
-        editBlocks: 'start_sources',
-      }),
-    };
-    querySelectorMock.mockReturnValue({
-      dataset: mockData,
+    jest.spyOn(document, 'querySelector').mockReturnValue({
+      dataset: {
+        appoptions: JSON.stringify({
+          editBlocks: 'start_sources',
+        }),
+      },
     } as unknown as Element);
     store.dispatch(
       onLevelChange({
         levelProperties: nonValidatedLevelProperties,
-        initialSources: shouldBeIgnoredInitialSources,
+        initialSources: sampleInitialSources,
       })
     );
 
@@ -266,5 +272,109 @@ describe('useInitialSources', () => {
       labConfig: undefined,
     };
     expect(initialSources).toEqual(expectedStartSources);
+  });
+
+  it('uses exemplar code in exemplar mode', () => {
+    jest.spyOn(document, 'querySelector').mockReturnValue({
+      dataset: {
+        appoptions: JSON.stringify({
+          isEditingExemplar: true,
+        }),
+      },
+    } as unknown as Element);
+    store.dispatch(
+      onLevelChange({
+        levelProperties: withExemplarLevelProperties,
+        initialSources: sampleInitialSources,
+      })
+    );
+    const {initialSources} = renderDefault();
+
+    const expectedInitialSources = {
+      source: withExemplarLevelProperties.exemplarSources,
+      labConfig: undefined,
+    };
+
+    expect(initialSources).toEqual(expectedInitialSources);
+  });
+
+  it('uses exemplar code in viewing exemplar mode', () => {
+    jest.spyOn(document, 'querySelector').mockReturnValue({
+      dataset: {
+        appoptions: JSON.stringify({
+          isViewingExemplar: true,
+        }),
+      },
+    } as unknown as Element);
+    store.dispatch(
+      onLevelChange({
+        levelProperties: withExemplarLevelProperties,
+        initialSources: sampleInitialSources,
+      })
+    );
+    const {initialSources} = renderDefault();
+
+    const expectedInitialSources = {
+      source: withExemplarLevelProperties.exemplarSources,
+      labConfig: undefined,
+    };
+
+    expect(initialSources).toEqual(expectedInitialSources);
+  });
+
+  it('does not use exemplar in standard mode', () => {
+    store.dispatch(
+      onLevelChange({
+        levelProperties: withExemplarLevelProperties,
+        initialSources: sampleInitialSources,
+      })
+    );
+    const {initialSources} = renderDefault();
+
+    expect(initialSources).toEqual(sampleInitialSources);
+  });
+
+  it('updates exemplar with level grid in neighborhood mode', () => {
+    const levelProperties = {...neighborhoodLevelProperties};
+    levelProperties.exemplarSources = {
+      ...withExemplarLevelProperties.exemplarSources!,
+      files: {
+        ...withExemplarLevelProperties.exemplarSources?.files,
+        '1': generateMazeFile([[]], '1'),
+      },
+    };
+    store.dispatch(onLevelChange({levelProperties}));
+
+    jest.spyOn(document, 'querySelector').mockReturnValue({
+      dataset: {
+        appoptions: JSON.stringify({
+          isViewingExemplar: true,
+        }),
+      },
+    } as unknown as Element);
+    const expectedInitialSources = getExpectedMazeSources(
+      withExemplarLevelProperties.exemplarSources,
+      levelProperties.serializedMaze!,
+      '1'
+    );
+    const {initialSources} = renderDefault();
+
+    expect(initialSources).toEqual(expectedInitialSources);
+  });
+
+  it('predict levels always use start code', () => {
+    store.dispatch(
+      onLevelChange({
+        levelProperties: predictLevelProperties,
+        initialSources: sampleInitialSources,
+      })
+    );
+
+    const {initialSources} = renderDefault();
+    const expectedInitialSources = {
+      source: predictLevelProperties.startSources,
+      labConfig: undefined,
+    };
+    expect(initialSources).toEqual(expectedInitialSources);
   });
 });

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -20,6 +20,7 @@ import {
 import {
   neighborhoodLevelProperties,
   nonValidatedLevelProperties,
+  smallProject,
   smallProjectSources,
   templateBackedLevelProperties,
 } from '../test-files';
@@ -37,6 +38,23 @@ const generateMazeFile = (mazeContents: MazeCell[][], fileId: string) => {
     type: ProjectFileType.SYSTEM_SUPPORT,
     language: 'txt',
     folderId: DEFAULT_FOLDER_ID,
+  };
+};
+
+const getExpectedMazeSources = (
+  startSources: MultiFileSource | undefined,
+  maze: MazeCell[][],
+  fileId: string
+) => {
+  return {
+    source: {
+      ...startSources,
+      files: {
+        ...startSources?.files,
+        [fileId]: generateMazeFile(maze, fileId),
+      },
+    },
+    labConfig: {miniApp: {name: 'neighborhood'}},
   };
 };
 
@@ -142,35 +160,111 @@ describe('useInitialSources', () => {
       templateStartSources,
       parsedDefaultSources,
     } = renderDefault();
-    const expectedSources = {
-      source: {
-        ...neighborhoodLevelProperties.startSources,
-        files: {
-          ...neighborhoodLevelProperties.startSources?.files,
-          '1': generateMazeFile(
-            neighborhoodLevelProperties.serializedMaze!,
-            '1'
-          ),
-        },
-      },
-      labConfig: {miniApp: {name: 'neighborhood'}},
-    };
-    const expectedNeighborhoodDefaultSources = {
-      source: {
-        ...(expectedParsedDefaultSources.source as MultiFileSource),
-        files: {
-          ...(expectedParsedDefaultSources.source as MultiFileSource).files,
-          '1': generateMazeFile(
-            neighborhoodLevelProperties.serializedMaze!,
-            '1'
-          ),
-        },
-      },
-      labConfig: {miniApp: {name: 'neighborhood'}},
-    };
+    const expectedSources = getExpectedMazeSources(
+      neighborhoodLevelProperties.startSources,
+      neighborhoodLevelProperties.serializedMaze!,
+      '1'
+    );
+
+    const expectedNeighborhoodDefaultSources = getExpectedMazeSources(
+      expectedParsedDefaultSources.source as MultiFileSource,
+      neighborhoodLevelProperties.serializedMaze!,
+      '1'
+    );
+
     expect(initialSources).toEqual(expectedSources);
     expect(levelStartSources).toEqual(expectedSources);
     expect(templateStartSources).toBeUndefined();
     expect(parsedDefaultSources).toEqual(expectedNeighborhoodDefaultSources);
+  });
+
+  it('populates template sources with neighborhood grid', () => {
+    const levelProperties = {...neighborhoodLevelProperties};
+    levelProperties.templateSources =
+      templateBackedLevelProperties.templateSources;
+    store.dispatch(onLevelChange({levelProperties}));
+    const {
+      initialSources,
+      levelStartSources,
+      templateStartSources,
+      parsedDefaultSources,
+    } = renderDefault();
+    const expectedLevelSources = getExpectedMazeSources(
+      levelProperties.startSources,
+      levelProperties.serializedMaze!,
+      '1'
+    );
+    const expectedTemplateSources = getExpectedMazeSources(
+      levelProperties.templateSources,
+      levelProperties.serializedMaze!,
+      '1'
+    );
+    const expectedNeighborhoodDefaultSources = getExpectedMazeSources(
+      expectedParsedDefaultSources.source as MultiFileSource,
+      neighborhoodLevelProperties.serializedMaze!,
+      '1'
+    );
+    expect(initialSources).toEqual(expectedTemplateSources);
+    expect(levelStartSources).toEqual(expectedLevelSources);
+    expect(templateStartSources).toEqual(expectedTemplateSources);
+    expect(parsedDefaultSources).toEqual(expectedNeighborhoodDefaultSources);
+  });
+
+  it('sets initial sources as lab initial sources if they exist', () => {
+    const expectedInitialSources = {
+      source: smallProject,
+      labConfig: undefined,
+    };
+    store.dispatch(
+      onLevelChange({
+        levelProperties: nonValidatedLevelProperties,
+        initialSources: expectedInitialSources,
+      })
+    );
+    const {
+      initialSources,
+      levelStartSources,
+      templateStartSources,
+      parsedDefaultSources,
+    } = renderDefault();
+
+    const expectedStartSources = {
+      source: nonValidatedLevelProperties.startSources,
+      labConfig: undefined,
+    };
+    expect(initialSources).toEqual(expectedInitialSources);
+    expect(levelStartSources).toEqual(expectedStartSources);
+    expect(templateStartSources).toBeUndefined();
+    expect(parsedDefaultSources).toEqual(expectedParsedDefaultSources);
+  });
+
+  it('sets start sources as initial sources in start mode', () => {
+    const shouldBeIgnoredInitialSources = {
+      source: smallProject,
+      labConfig: undefined,
+    };
+    const querySelectorMock = jest.spyOn(document, 'querySelector');
+    const mockData = {
+      appoptions: JSON.stringify({
+        editBlocks: 'start_sources',
+      }),
+    };
+    querySelectorMock.mockReturnValue({
+      dataset: mockData,
+    } as unknown as Element);
+    store.dispatch(
+      onLevelChange({
+        levelProperties: nonValidatedLevelProperties,
+        initialSources: shouldBeIgnoredInitialSources,
+      })
+    );
+
+    const {initialSources} = renderDefault();
+
+    const expectedStartSources = {
+      source: nonValidatedLevelProperties.startSources,
+      labConfig: undefined,
+    };
+    expect(initialSources).toEqual(expectedStartSources);
   });
 });

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -56,6 +56,14 @@ const generateMazeFile = (
   };
 };
 
+const mockAppOptions = (innerAppOptions: Record<string, unknown>) => {
+  jest.spyOn(document, 'querySelector').mockReturnValue({
+    dataset: {
+      appoptions: JSON.stringify(innerAppOptions),
+    },
+  } as unknown as Element);
+};
+
 const getExpectedMazeSources = (
   startSources: MultiFileSource | undefined,
   maze: MazeCell[][],
@@ -251,13 +259,7 @@ describe('useInitialSources', () => {
   });
 
   it('sets start sources as initial sources in start mode', () => {
-    jest.spyOn(document, 'querySelector').mockReturnValue({
-      dataset: {
-        appoptions: JSON.stringify({
-          editBlocks: 'start_sources',
-        }),
-      },
-    } as unknown as Element);
+    mockAppOptions({editBlocks: 'start_sources'});
     store.dispatch(
       onLevelChange({
         levelProperties: nonValidatedLevelProperties,
@@ -275,13 +277,7 @@ describe('useInitialSources', () => {
   });
 
   it('uses exemplar code in exemplar mode', () => {
-    jest.spyOn(document, 'querySelector').mockReturnValue({
-      dataset: {
-        appoptions: JSON.stringify({
-          isEditingExemplar: true,
-        }),
-      },
-    } as unknown as Element);
+    mockAppOptions({isEditingExemplar: true});
     store.dispatch(
       onLevelChange({
         levelProperties: withExemplarLevelProperties,
@@ -299,13 +295,7 @@ describe('useInitialSources', () => {
   });
 
   it('uses exemplar code in viewing exemplar mode', () => {
-    jest.spyOn(document, 'querySelector').mockReturnValue({
-      dataset: {
-        appoptions: JSON.stringify({
-          isViewingExemplar: true,
-        }),
-      },
-    } as unknown as Element);
+    mockAppOptions({isViewingExemplar: true});
     store.dispatch(
       onLevelChange({
         levelProperties: withExemplarLevelProperties,
@@ -345,13 +335,8 @@ describe('useInitialSources', () => {
     };
     store.dispatch(onLevelChange({levelProperties}));
 
-    jest.spyOn(document, 'querySelector').mockReturnValue({
-      dataset: {
-        appoptions: JSON.stringify({
-          isViewingExemplar: true,
-        }),
-      },
-    } as unknown as Element);
+    mockAppOptions({isViewingExemplar: true});
+
     const expectedInitialSources = getExpectedMazeSources(
       withExemplarLevelProperties.exemplarSources,
       levelProperties.serializedMaze!,

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -31,6 +31,7 @@ import {
   templateBackedLevelProperties,
   withExemplarLevelProperties,
 } from '../test-files';
+import {mockAppOptions} from '../test_utils';
 
 const expectedParsedDefaultSources = {
   ...smallProjectSources,
@@ -54,14 +55,6 @@ const generateMazeFile = (
     language: 'txt',
     folderId: DEFAULT_FOLDER_ID,
   };
-};
-
-const mockAppOptions = (innerAppOptions: Record<string, unknown>) => {
-  jest.spyOn(document, 'querySelector').mockReturnValue({
-    dataset: {
-      appoptions: JSON.stringify(innerAppOptions),
-    },
-  } as unknown as Element);
 };
 
 const getExpectedMazeSources = (

--- a/apps/test/unit/codebridge/test-files/index.ts
+++ b/apps/test/unit/codebridge/test-files/index.ts
@@ -21,6 +21,7 @@ const supportFile: ProjectFile = require('./supportFile.json');
 const templateBackedLevelProperties: LevelProperties = require('./templateBackedLevelProperties.json');
 const validatedLevelProperties: LevelProperties = require('./validatedLevelProperties.json');
 const validationFile: ProjectFile = require('./validationFile.json');
+const withExemplarLevelProperties: LevelProperties = require('./withExemplarLevelProperties.json');
 
 export {
   initProgressPayload,
@@ -37,4 +38,5 @@ export {
   templateBackedLevelProperties,
   validatedLevelProperties,
   validationFile,
+  withExemplarLevelProperties,
 };

--- a/apps/test/unit/codebridge/test-files/index.ts
+++ b/apps/test/unit/codebridge/test-files/index.ts
@@ -9,6 +9,7 @@ import {InitProgressPayload, LevelResults} from '@cdo/apps/types/progressTypes';
 
 const initProgressPayload: InitProgressPayload = require('./initProgressPayload.json');
 const levelResults: LevelResults = require('./levelResults.json');
+const neighborhoodLevelProperties: LevelProperties = require('./neighborhoodLevelProperties.json');
 const nonValidatedLevelProperties: LevelProperties = require('./nonValidatedLevelProperties.json');
 const predictLevelProperties: LevelProperties = require('./predictLevelProperties.json');
 const testProject: MultiFileSource = require('./project.json');
@@ -17,12 +18,14 @@ const smallProjectSources: ProjectSources = require('./smallProjectSources.json'
 const starterFile: ProjectFile = require('./starterFile.json');
 const submittableLevelProperties: LevelProperties = require('./submittableLevelProperties.json');
 const supportFile: ProjectFile = require('./supportFile.json');
+const templateBackedLevelProperties: LevelProperties = require('./templateBackedLevelProperties.json');
 const validatedLevelProperties: LevelProperties = require('./validatedLevelProperties.json');
 const validationFile: ProjectFile = require('./validationFile.json');
 
 export {
   initProgressPayload,
   levelResults,
+  neighborhoodLevelProperties,
   nonValidatedLevelProperties,
   predictLevelProperties,
   testProject,
@@ -31,6 +34,7 @@ export {
   starterFile,
   submittableLevelProperties,
   supportFile,
+  templateBackedLevelProperties,
   validatedLevelProperties,
   validationFile,
 };

--- a/apps/test/unit/codebridge/test-files/index.ts
+++ b/apps/test/unit/codebridge/test-files/index.ts
@@ -1,6 +1,10 @@
 import {ProjectFile} from '@codebridge/types';
 
-import {LevelProperties, MultiFileSource} from '@cdo/apps/lab2/types';
+import {
+  LevelProperties,
+  MultiFileSource,
+  ProjectSources,
+} from '@cdo/apps/lab2/types';
 import {InitProgressPayload, LevelResults} from '@cdo/apps/types/progressTypes';
 
 const initProgressPayload: InitProgressPayload = require('./initProgressPayload.json');
@@ -9,6 +13,7 @@ const nonValidatedLevelProperties: LevelProperties = require('./nonValidatedLeve
 const predictLevelProperties: LevelProperties = require('./predictLevelProperties.json');
 const testProject: MultiFileSource = require('./project.json');
 const smallProject: MultiFileSource = require('./smallProject.json');
+const smallProjectSources: ProjectSources = require('./smallProjectSources.json');
 const starterFile: ProjectFile = require('./starterFile.json');
 const submittableLevelProperties: LevelProperties = require('./submittableLevelProperties.json');
 const supportFile: ProjectFile = require('./supportFile.json');
@@ -22,6 +27,7 @@ export {
   predictLevelProperties,
   testProject,
   smallProject,
+  smallProjectSources,
   starterFile,
   submittableLevelProperties,
   supportFile,

--- a/apps/test/unit/codebridge/test-files/neighborhoodLevelProperties.json
+++ b/apps/test/unit/codebridge/test-files/neighborhoodLevelProperties.json
@@ -1,0 +1,45 @@
+{
+  "encrypted": false,
+  "startSources": {
+    "files": {
+      "0": {
+        "id": "0",
+        "name": "main.py",
+        "language": "py",
+        "contents": "print('Hello from a neighborhood level!')",
+        "folderId": "0",
+        "active": false,
+        "open": true,
+        "type": "locked_starter"
+      }
+    },
+    "folders": {},
+    "openFiles": [
+      "0"
+    ]
+  },
+  "longInstructions": "## Welcome to Python Lab\r\n\r\nPress the Run button and see what happens.",
+  "hideShareAndRemix": true,
+  "referenceLinks": [
+    "/courses/csa-2023/guides/instantiating-objects"
+  ],
+  "mapReference": "/docs/concepts/html/",
+  "teacherMarkdown": "Teachers should see this extra info.",
+  "aiTutorAvailable": true,
+  "submittable": false,
+  "predictSettings": {
+    "isPredictLevel": false
+  },
+  "containedLevelNames": null,
+  "id": 28048,
+  "helpVideos": [],
+  "type": "Pythonlab",
+  "appName": "pythonlab",
+  "useRestrictedSongs": false,
+  "usesProjects": true,
+  "finishUrl": "/s/allthethings/lessons/50/levels/2",
+  "exampleSolutions": [],
+  "exemplarSources": null,
+  "miniApp": "neighborhood",
+  "serializedMaze": [[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]
+}

--- a/apps/test/unit/codebridge/test-files/smallProjectSources.json
+++ b/apps/test/unit/codebridge/test-files/smallProjectSources.json
@@ -1,0 +1,16 @@
+{
+  "source": {
+    "files": {
+      "0": {
+        "id": "0",
+        "name": "main.py",
+        "language": "py",
+        "contents": "print('Hello world!')",
+        "folderId": "0",
+        "active": true,
+        "open": true
+      }
+    },
+    "folders": {}
+  }
+}

--- a/apps/test/unit/codebridge/test-files/templateBackedLevelProperties.json
+++ b/apps/test/unit/codebridge/test-files/templateBackedLevelProperties.json
@@ -1,0 +1,73 @@
+{
+  "encrypted": false,
+  "startSources": {
+    "files": {
+      "0": {
+        "id": "0",
+        "name": "main.py",
+        "language": "py",
+        "contents": "print('Hello from the start!')",
+        "folderId": "0",
+        "active": false,
+        "open": true,
+        "type": "locked_starter"
+      },
+      "2": {
+        "id": "2",
+        "name": "support.py",
+        "language": "py",
+        "contents": "",
+        "folderId": "0",
+        "active": false,
+        "open": true,
+        "type": "support"
+      }
+    },
+    "folders": {},
+    "openFiles": [
+      "0",
+      "2"
+    ]
+  },
+  "longInstructions": "## Welcome to Python Lab\r\n\r\nPress the Run button and see what happens.",
+  "hideShareAndRemix": true,
+  "referenceLinks": [
+    "/courses/csa-2023/guides/instantiating-objects"
+  ],
+  "mapReference": "/docs/concepts/html/",
+  "teacherMarkdown": "Teachers should see this extra info.",
+  "aiTutorAvailable": true,
+  "submittable": false,
+  "predictSettings": {
+    "isPredictLevel": false
+  },
+  "containedLevelNames": null,
+  "id": 28048,
+  "helpVideos": [],
+  "type": "Pythonlab",
+  "appName": "pythonlab",
+  "useRestrictedSongs": false,
+  "usesProjects": true,
+  "finishUrl": "/s/allthethings/lessons/50/levels/2",
+  "exampleSolutions": [],
+  "exemplarSources": null,
+  "projectTemplateLevelName": "projectTemplateLevel",
+  "templateSources":  {
+    "files": {
+      "0": {
+        "id": "0",
+        "name": "main.py",
+        "language": "py",
+        "contents": "print('Hello from the template file!')",
+        "folderId": "0",
+        "active": false,
+        "open": true,
+        "type": "locked_starter"
+      }
+    },
+    "folders": {},
+    "openFiles": [
+      "0"
+    ]
+  }
+}

--- a/apps/test/unit/codebridge/test-files/withExemplarLevelProperties.json
+++ b/apps/test/unit/codebridge/test-files/withExemplarLevelProperties.json
@@ -1,0 +1,71 @@
+{
+  "encrypted": false,
+  "startSources": {
+    "files": {
+      "0": {
+        "id": "0",
+        "name": "main.py",
+        "language": "py",
+        "contents": "print('Hello from the start!')",
+        "folderId": "0",
+        "active": false,
+        "open": true,
+        "type": "locked_starter"
+      },
+      "2": {
+        "id": "2",
+        "name": "support.py",
+        "language": "py",
+        "contents": "",
+        "folderId": "0",
+        "active": false,
+        "open": true,
+        "type": "support"
+      }
+    },
+    "folders": {},
+    "openFiles": [
+      "0",
+      "2"
+    ]
+  },
+  "longInstructions": "## Welcome to Python Lab\r\n\r\nPress the Run button and see what happens.",
+  "hideShareAndRemix": true,
+  "referenceLinks": [
+    "/courses/csa-2023/guides/instantiating-objects"
+  ],
+  "mapReference": "/docs/concepts/html/",
+  "teacherMarkdown": "Teachers should see this extra info.",
+  "aiTutorAvailable": true,
+  "submittable": false,
+  "predictSettings": {
+    "isPredictLevel": false
+  },
+  "containedLevelNames": null,
+  "id": 28048,
+  "helpVideos": [],
+  "type": "Pythonlab",
+  "appName": "pythonlab",
+  "useRestrictedSongs": false,
+  "usesProjects": true,
+  "finishUrl": "/s/allthethings/lessons/50/levels/2",
+  "exampleSolutions": ["http://localhost-studio.code.org:3000/s/allthethings/lessons/50/levels/2?exemplar=true"],
+  "exemplarSources": {
+    "files": {
+      "0": {
+        "id": "0",
+        "name": "main.py",
+        "language": "py",
+        "contents": "print('Hello from the exemplar!')",
+        "folderId": "0",
+        "active": false,
+        "open": true,
+        "type": "locked_starter"
+      }
+    },
+    "folders": {},
+    "openFiles": [
+      "0"
+    ]
+  }
+}

--- a/apps/test/unit/codebridge/test_utils.ts
+++ b/apps/test/unit/codebridge/test_utils.ts
@@ -94,3 +94,11 @@ export const getDefaultCodebridgeContext = () => {
   };
   return context;
 };
+
+export const mockAppOptions = (innerAppOptions: Record<string, unknown>) => {
+  jest.spyOn(document, 'querySelector').mockReturnValue({
+    dataset: {
+      appoptions: JSON.stringify(innerAppOptions),
+    },
+  } as unknown as Element);
+};


### PR DESCRIPTION
Add unit tests for the variety of cases covered by `useInitialSources`.

A lot of lines of this PR are sample level configurations, so it's not as big as it seems! 😄 No functionality change here, just tests.

## Links

- jira ticket: [CT-617](https://codedotorg.atlassian.net/browse/CT-617)


## Testing story
Tested by running the new unit tests.


## Follow-up work
Next up I'll add tests for `useSource`.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
