### PR TITLE
Accessible Dialog: color

### DIFF
--- a/apps/src/sharedComponents/accessible-dialogue.module.scss
+++ b/apps/src/sharedComponents/accessible-dialogue.module.scss
@@ -20,6 +20,7 @@
   width: 70%;
   max-width: 600px;
   background-color: #fff;
+  color: $default_text;
   border-radius: 4px;
   padding: 1rem;
   overflow: auto;


### PR DESCRIPTION
This gives the Accessible Dialog a default text color, complementing its existing background color.

As a follow-up to https://github.com/code-dot-org/code-dot-org/pull/63884, this ensures that the levelbuilder-specific "Extra links" menu has visible text over dark mode lessons.

### before

<img width="1301" alt="Screenshot 2025-02-15 at 8 41 00 AM" src="https://github.com/user-attachments/assets/43191e31-2e6b-43c7-9fc5-5bf2a8e2d253" />

### after

<img width="1301" alt="Screenshot 2025-02-15 at 8 40 45 AM" src="https://github.com/user-attachments/assets/a5736bf1-8f7a-49c8-9623-09b785c0d185" />
