### PR TITLE
Scale gpt-4o-mini temperature input to 0-2

### DIFF
--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -15,9 +15,10 @@ module AichatOpenaiHelper
       level_id
     )
 
+    # We expose a temperature scale of 0.1-1 to users of AI Chat Lab, but OpenAI's API allows a scale of 0-2.
     request_chat_completion(
       messages,
-      aichat_model_customizations['temperature'].to_f
+      aichat_model_customizations['temperature'].to_f * 2
     )
   end
 


### PR DESCRIPTION
We accept user temperature input on a scale from 0-1, but OpenAI allows 0-2 [per their docs](https://platform.openai.com/docs/api-reference/chat/create). We scale the user input to match.

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1347

## Testing story

Tested the high and low end of the scale manually (0.1 and 1, respectively) and saw normal model responses.