### PR TITLE
[Python Lab/AI Tutor] CT-1052: Load python and javalab sources and conditionally populate student code

### DIFF
--- a/apps/src/aiTutor/views/AITutorFooter.tsx
+++ b/apps/src/aiTutor/views/AITutorFooter.tsx
@@ -48,8 +48,8 @@ const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
 
   let studentCode: string = '';
   if (level?.type === 'Pythonlab') {
-    // TODO: For PythonLab, we are only considering the active file contents,
-    // but this seems to get us parity with JavaLab. We may need to revisit this.
+    // TODO: For both JavaLab and PythonLab, we are only considering the active file contents,
+    // Ticket to improve: https://codedotorg.atlassian.net/browse/CT-1058
     studentCode = pythonLabSource ? getActiveFileContents(pythonLabSource) : '';
   } else if (level?.type === 'Javalab') {
     studentCode = javaLabSources[fileMetadata[activeTabKey]].text;

--- a/apps/src/aiTutor/views/AITutorFooter.tsx
+++ b/apps/src/aiTutor/views/AITutorFooter.tsx
@@ -1,8 +1,14 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import React, {useCallback} from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {askAITutor} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
 import {AITutorTypes as ActionType} from '@cdo/apps/aiTutor/types';
+import {
+  MultiFileSource,
+  ProjectFile,
+  // ProjectSources,
+} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -17,6 +23,13 @@ interface AITutorFooterProps {
   renderAITutor: boolean;
 }
 
+// Helper function to extract active file contents from a MultiFileSource
+const getActiveFileContents = (multiFileSource: MultiFileSource): string => {
+  const filesArray: ProjectFile[] = Object.values(multiFileSource.files);
+  const activeFile = filesArray.find(file => file.active);
+  return activeFile ? activeFile.contents : '';
+};
+
 const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
@@ -24,14 +37,30 @@ const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
 
   const level = useAppSelector(state => state.aiTutor.level);
 
-  const sources = useAppSelector(state => state.javalabEditor.sources);
+  // For Pythonlab, these selectors will be used and we are guaranteed that source is a MultiFileSource
+  const pythonLabSource = useAppSelector(
+    state => state.lab2Project?.projectSources?.source
+  ) as MultiFileSource | undefined;
+
+  // For JavaLab
+  const javaLabSources = useAppSelector(state => state.javalabEditor.sources);
   const fileMetadata = useAppSelector(
     state => state.javalabEditor.fileMetadata
   );
   const activeTabKey = useAppSelector(
     state => state.javalabEditor.activeTabKey
   );
-  const studentCode = sources[fileMetadata[activeTabKey]].text;
+
+  // Compute studentCode based on the lab type
+  let studentCode: string = '';
+  if (level?.type === 'Pythonlab') {
+    // TODO: For PythonLab, we are only considering the active file contents,
+    // but this seems to get us parity with JavaLab. We may need to revisit this.
+    studentCode = pythonLabSource ? getActiveFileContents(pythonLabSource) : '';
+  } else {
+    // Here, we assume that javaLabSources and fileMetadata are always defined
+    studentCode = javaLabSources[fileMetadata[activeTabKey]].text;
+  }
 
   const dispatch = useAppDispatch();
 

--- a/apps/src/aiTutor/views/AITutorFooter.tsx
+++ b/apps/src/aiTutor/views/AITutorFooter.tsx
@@ -51,7 +51,7 @@ const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
     // TODO: For PythonLab, we are only considering the active file contents,
     // but this seems to get us parity with JavaLab. We may need to revisit this.
     studentCode = pythonLabSource ? getActiveFileContents(pythonLabSource) : '';
-  } else {
+  } else if (level?.type === 'Javalab') {
     studentCode = javaLabSources[fileMetadata[activeTabKey]].text;
   }
 

--- a/apps/src/aiTutor/views/AITutorFooter.tsx
+++ b/apps/src/aiTutor/views/AITutorFooter.tsx
@@ -3,7 +3,7 @@ import React, {useCallback} from 'react';
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {askAITutor} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
 import {AITutorTypes as ActionType} from '@cdo/apps/aiTutor/types';
-import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
+import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -18,13 +18,6 @@ interface AITutorFooterProps {
   renderAITutor: boolean;
 }
 
-// Helper function to extract active file contents from a MultiFileSource
-const getActiveFileContents = (multiFileSource: MultiFileSource): string => {
-  const filesArray: ProjectFile[] = Object.values(multiFileSource.files);
-  const activeFile = filesArray.find(file => file.active);
-  return activeFile ? activeFile.contents : '';
-};
-
 const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
@@ -32,10 +25,10 @@ const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
 
   const level = useAppSelector(state => state.aiTutor.level);
 
-  // For Pythonlab, these selectors will be used and we are guaranteed that source is a MultiFileSource
+  // For PythonLab
   const pythonLabSource = useAppSelector(
     state => state.lab2Project?.projectSources?.source
-  ) as MultiFileSource | undefined;
+  );
 
   // For JavaLab
   const javaLabSources = useAppSelector(state => state.javalabEditor.sources);
@@ -47,10 +40,14 @@ const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
   );
 
   let studentCode: string = '';
+
+  // TODO: For both JavaLab and PythonLab, we are only considering the active file contents,
+  // Ticket to improve: https://codedotorg.atlassian.net/browse/CT-1058
   if (level?.type === 'Pythonlab') {
-    // TODO: For both JavaLab and PythonLab, we are only considering the active file contents,
-    // Ticket to improve: https://codedotorg.atlassian.net/browse/CT-1058
-    studentCode = pythonLabSource ? getActiveFileContents(pythonLabSource) : '';
+    // String sources should only be used for non-multifile labs (i.e., not Pythonlab)
+    if (typeof pythonLabSource !== 'string' && pythonLabSource) {
+      studentCode = getActiveFileForSource(pythonLabSource)?.contents || '';
+    }
   } else if (level?.type === 'Javalab') {
     studentCode = javaLabSources[fileMetadata[activeTabKey]].text;
   }

--- a/apps/src/aiTutor/views/AITutorFooter.tsx
+++ b/apps/src/aiTutor/views/AITutorFooter.tsx
@@ -1,14 +1,9 @@
-/* eslint-disable react-hooks/rules-of-hooks */
 import React, {useCallback} from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {askAITutor} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
 import {AITutorTypes as ActionType} from '@cdo/apps/aiTutor/types';
-import {
-  MultiFileSource,
-  ProjectFile,
-  // ProjectSources,
-} from '@cdo/apps/lab2/types';
+import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -51,14 +46,12 @@ const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
     state => state.javalabEditor.activeTabKey
   );
 
-  // Compute studentCode based on the lab type
   let studentCode: string = '';
   if (level?.type === 'Pythonlab') {
     // TODO: For PythonLab, we are only considering the active file contents,
     // but this seems to get us parity with JavaLab. We may need to revisit this.
     studentCode = pythonLabSource ? getActiveFileContents(pythonLabSource) : '';
   } else {
-    // Here, we assume that javaLabSources and fileMetadata are always defined
     studentCode = javaLabSources[fileMetadata[activeTabKey]].text;
   }
 


### PR DESCRIPTION
This PR updates the code for the AI Footer (which sends the request to our API endpoint) to load both the active source file for PythonLab and JavaLab (both because using conditional hooks is a no-go) and populates the student code conditionally based on the level type.

N.B. I worried the system prompt always assumed the code should be written in Java, but it looks like there's already a (brittle) condition to assume that any non-CSA levels are looking for Python: https://github.com/code-dot-org/code-dot-org/blob/dbf4a635dc1fc2ba63e4dcc0dcf24e10def5f9d7/dashboard/app/helpers/aitutor_system_prompt_helper.rb#L75

## Links

https://codedotorg.atlassian.net/browse/CT-1052

## Testing story

**Before (tutor unaware of student code in Python)**
<img width="886" alt="Screenshot 2025-02-14 at 8 00 02 PM" src="https://github.com/user-attachments/assets/53ebf6ae-4ffa-4bfb-b087-a9c0727a839b" />

**After (tutor aware of student code in Python)**
<img width="873" alt="Screenshot 2025-02-14 at 7 57 49 PM" src="https://github.com/user-attachments/assets/231331ed-3598-43c3-8ea0-3c6861b9bc14" />


**After (tutor still aware of student code in Java)**
<img width="986" alt="Screenshot 2025-02-18 at 12 31 27 PM" src="https://github.com/user-attachments/assets/8d884e11-8d1c-45a7-b2e2-56a82a654eb8" />

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Follow-up tickets: 
- Longer follow: https://codedotorg.atlassian.net/browse/CT-1058
- Unsure if this is a priority: https://codedotorg.atlassian.net/browse/CT-1061

## Privacy

No change. 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
