### PR TITLE
[Python Lab & AI Tutor] CT-707: Add Programming Fundamentals to allowed display names for AI Tutor

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1206,7 +1206,7 @@
   "emptyTopLevelBlock": "There are no blocks to run. You must attach a block to the {topLevelBlockName} block.",
   "enable": "Enable",
   "enableAITutor": "Enable AI Tutor",
-  "enableAITutorTooltip": "Turning this on will give students in your section access to AI Tutor on certain AP CSA levels.",
+  "enableAITutorTooltip": "Turning this on will give students in your section access to AI Tutor on certain levels.",
   "enableCodeReview": "Enable Code Review",
   "enableTtsAutoplay": "Automatically read instructions aloud to students? (Only certain courses and web browsers)",
   "enableTtsAutoplayToggle": "Automatically read instructions aloud to students",

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -354,12 +354,13 @@ export default function SectionsSetUpContainer({
     );
   };
 
-  // TODO: this will probably eventually be a setting on the course similar to textToSpeechEnabled
-  // currently we're working towards piloting in Javalab in CSA only.
+  // TODO: This will probably eventually be a setting on the course similar to textToSpeechEnabled
+  // The ticket to track that work is https://codedotorg.atlassian.net/browse/CT-1063
   const aiTutorAllowedForCourse = section =>
-    ['Data Science *', 'Computer Science A'].includes(
-      section?.course?.displayName
-    );
+    [
+      '[PILOT] Programming Fundamentals (AI Tutor)',
+      'Computer Science A',
+    ].includes(section?.course?.displayName);
 
   const renderAdvancedSettings = () => {
     const aiTutorAvailable =

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -354,12 +354,16 @@ export default function SectionsSetUpContainer({
     );
   };
 
+  // TODO: this will probably eventually be a setting on the course similar to textToSpeechEnabled
+  // currently we're working towards piloting in Javalab in CSA only.
+  const aiTutorAllowedForCourse = section =>
+    ['Data Science *', 'Computer Science A'].includes(
+      section?.course?.displayName
+    );
+
   const renderAdvancedSettings = () => {
-    // TODO: this will probably eventually be a setting on the course similar to textToSpeechEnabled
-    // currently we're working towards piloting in Javalab in CSA only.
     const aiTutorAvailable =
-      canEnableAITutor &&
-      sections[0].course.displayName === 'Computer Science A';
+      canEnableAITutor && aiTutorAllowedForCourse(sections[0]);
 
     return renderExpandableSection(
       'uitest-expandable-settings',


### PR DESCRIPTION
This PR adds the Programming Fundamentals Pilot to the list of display names that allow the teacher to enable AI Tutor for a section. 

Display names is not the best way to do this long-term, but I'd like to pair more closely with a Teacher Tools engineer on the best way to add these as a property on the course because I'm not super familiar with that schema. I've started conversations with @Nokondi via Slack on how to do so, and am keeping track of the brittle checks that would be good to consolidate here: https://docs.google.com/document/d/1rl_aQALcXm_yNv_ZTnhum3qf8oogZ8EK_XI5FcvuVHE/edit?tab=t.0

These links are also tracked in the "Follow-Up Work" section. 

In the meantime, given the time-sensitive nature of the CSAIF pilot, I'd like to go ahead and merge this change for now. 

## Links

https://codedotorg.atlassian.net/browse/CT-707

## Testing story

**Before**
<img width="343" alt="Screenshot 2025-02-14 at 8 15 06 PM" src="https://github.com/user-attachments/assets/0538f6ae-5723-45ca-b695-50680b53ebd1" />

**After**
<img width="326" alt="Screenshot 2025-02-14 at 8 16 16 PM" src="https://github.com/user-attachments/assets/78a2aabe-80e8-4899-b7f4-78bccb4c751f" />

## Deployment strategy

## Follow-up work

Solve this holistically.
- Here's the ticket: https://codedotorg.atlassian.net/browse/CT-1063
- Here's a doc where I'm keeping track of places I see opportunities for improvement: https://docs.google.com/document/d/1rl_aQALcXm_yNv_ZTnhum3qf8oogZ8EK_XI5FcvuVHE/edit?tab=t.0

## Privacy

N/A

## Security

N/A

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
