### PR TITLE
I18n sync In & Up 02/17

### DIFF
--- a/i18n/locales/source/blockly-mooc/pythonlab.json
+++ b/i18n/locales/source/blockly-mooc/pythonlab.json
@@ -1,0 +1,11 @@
+{
+  "inputFailed": "We're sorry, input is unavailable at this time. Input may not work in a private or incognito window. If you are in a standard browser window, please try refreshing the page. If the issue persists, contact support@code.org.",
+  "noCode": "You have no code to run.",
+  "noFileToRun": "You have no {fileName} to run.",
+  "moduleNotSupported": "ModuleNotFoundError: The module {module} is not supported in Python Lab.",
+  "programCompleted": "Program completed.",
+  "programStopped": "Program stopped.",
+  "runningLevelTests": "Running level tests...",
+  "runningProgram": "Running program...",
+  "runningProjectTests": "Running your project's tests..."
+}

--- a/i18n/locales/source/course_content/2018/courseb-2018.json
+++ b/i18n/locales/source/course_content/2018/courseb-2018.json
@@ -225,7 +225,7 @@
     "long_instructions": "[][0] _\"Keep going!\"_"
   },
   "https://studio.code.org/s/courseb-2018/lessons/8/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.courseB_unplugged_loopyMRF_2018.title"
+    "title": "translation missing: en.data.unplugged.courseB_unplugged_loopyMRF_2018.title"
   },
   "https://studio.code.org/s/courseb-2018/lessons/9/levels/1": {
     "short_instructions": "Help Scrat across the ice to get to the acorn!",

--- a/i18n/locales/source/course_content/2018/coursec-2018.json
+++ b/i18n/locales/source/course_content/2018/coursec-2018.json
@@ -1,6 +1,6 @@
 {
   "https://studio.code.org/s/coursec-2018/lessons/1/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.BuildingAFoundation_2018.title"
+    "title": "translation missing: en.data.unplugged.BuildingAFoundation_2018.title"
   },
   "https://studio.code.org/s/coursec-2018/lessons/2/levels/2": {
     "short_instructions": "For this puzzle, drag all of the blocks together and click \"Run\" to watch it go!",

--- a/i18n/locales/source/course_content/2018/coursee-2018.json
+++ b/i18n/locales/source/course_content/2018/coursee-2018.json
@@ -108,7 +108,7 @@
     }
   },
   "https://studio.code.org/s/coursee-2018/lessons/3/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.BuildingAFoundation_2018.title"
+    "title": "translation missing: en.data.unplugged.BuildingAFoundation_2018.title"
   },
   "https://studio.code.org/s/coursee-2018/lessons/4/levels/1": {
     "dsls": {
@@ -347,7 +347,7 @@
     }
   },
   "https://studio.code.org/s/coursee-2018/lessons/6/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.courseB_unplugged_loopyMRF_2018.title"
+    "title": "translation missing: en.data.unplugged.courseB_unplugged_loopyMRF_2018.title"
   },
   "https://studio.code.org/s/coursee-2018/lessons/7/levels/1": {
     "dsls": {
@@ -742,10 +742,10 @@
     }
   },
   "https://studio.code.org/s/coursee-2018/lessons/12/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.courseE_unplugged_privateInformation_2018.title"
+    "title": "translation missing: en.data.unplugged.courseE_unplugged_privateInformation_2018.title"
   },
   "https://studio.code.org/s/coursee-2018/lessons/14/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.SongwritingParameters_2018.title"
+    "title": "translation missing: en.data.unplugged.SongwritingParameters_2018.title"
   },
   "https://studio.code.org/s/coursee-2018/lessons/15/levels/1": {
     "display_name": "Homestead",
@@ -2030,9 +2030,9 @@
     }
   },
   "https://studio.code.org/s/coursee-2018/lessons/27/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.Internet_2018.title"
+    "title": "translation missing: en.data.unplugged.Internet_2018.title"
   },
   "https://studio.code.org/s/coursee-2018/lessons/28/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.Crowdsourcing_2018.title"
+    "title": "translation missing: en.data.unplugged.Crowdsourcing_2018.title"
   }
 }

--- a/i18n/locales/source/course_content/2018/coursef-2018.json
+++ b/i18n/locales/source/course_content/2018/coursef-2018.json
@@ -108,7 +108,7 @@
     }
   },
   "https://studio.code.org/s/coursef-2018/lessons/3/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.BuildingAFoundation_2018.title"
+    "title": "translation missing: en.data.unplugged.BuildingAFoundation_2018.title"
   },
   "https://studio.code.org/s/coursef-2018/lessons/4/levels/1": {
     "dsls": {
@@ -347,7 +347,7 @@
     }
   },
   "https://studio.code.org/s/coursef-2018/lessons/6/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.courseB_unplugged_loopyMRF_2018.title"
+    "title": "translation missing: en.data.unplugged.courseB_unplugged_loopyMRF_2018.title"
   },
   "https://studio.code.org/s/coursef-2018/lessons/7/levels/1": {
     "dsls": {
@@ -866,10 +866,10 @@
     }
   },
   "https://studio.code.org/s/coursef-2018/lessons/13/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.courseF_unplugged_powerOfWords_2018.title"
+    "title": "translation missing: en.data.unplugged.courseF_unplugged_powerOfWords_2018.title"
   },
   "https://studio.code.org/s/coursef-2018/lessons/14/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.EnvelopeVariables_2018.title"
+    "title": "translation missing: en.data.unplugged.EnvelopeVariables_2018.title"
   },
   "https://studio.code.org/s/coursef-2018/lessons/15/levels/1": {
     "long_instructions": "Let's draw an equilateral triangle. \n\nIt has to be exactly 50 pixels long on each side.",
@@ -1166,7 +1166,7 @@
     }
   },
   "https://studio.code.org/s/coursef-2018/lessons/18/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.ForLoopFun_2018.title"
+    "title": "translation missing: en.data.unplugged.ForLoopFun_2018.title"
   },
   "https://studio.code.org/s/coursef-2018/lessons/19/levels/1": {
     "short_instructions": "Collect the nectar from each flower using the fewest blocks possible.",

--- a/i18n/locales/source/course_content/2018/express-2018.json
+++ b/i18n/locales/source/course_content/2018/express-2018.json
@@ -1710,7 +1710,7 @@
     }
   },
   "https://studio.code.org/s/express-2018/lessons/19/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.SongwritingParameters_2018.title"
+    "title": "translation missing: en.data.unplugged.SongwritingParameters_2018.title"
   },
   "https://studio.code.org/s/express-2018/lessons/20/levels/1": {
     "display_name": "Homestead",
@@ -2635,10 +2635,10 @@
     "long_instructions": "Create your own Flappy game! \n\nYou can change the visuals and the rules...even the gravity! \nWhen you're done, click \"Finish\" to share with friends on their phones."
   },
   "https://studio.code.org/s/express-2018/lessons/27/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.courseF_unplugged_powerOfWords_2018.title"
+    "title": "translation missing: en.data.unplugged.courseF_unplugged_powerOfWords_2018.title"
   },
   "https://studio.code.org/s/express-2018/lessons/28/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.EnvelopeVariables_2018.title"
+    "title": "translation missing: en.data.unplugged.EnvelopeVariables_2018.title"
   },
   "https://studio.code.org/s/express-2018/lessons/29/levels/1": {
     "long_instructions": "Let's draw an equilateral triangle. \n\nIt has to be exactly 50 pixels long on each side.",
@@ -2935,7 +2935,7 @@
     }
   },
   "https://studio.code.org/s/express-2018/lessons/32/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.ForLoopFun_2018.title"
+    "title": "translation missing: en.data.unplugged.ForLoopFun_2018.title"
   },
   "https://studio.code.org/s/express-2018/lessons/33/levels/1": {
     "short_instructions": "Collect the nectar from each flower using the fewest blocks possible.",
@@ -3851,9 +3851,9 @@
     }
   },
   "https://studio.code.org/s/express-2018/lessons/46/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.Internet_2018.title"
+    "title": "translation missing: en.data.unplugged.Internet_2018.title"
   },
   "https://studio.code.org/s/express-2018/lessons/47/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.Crowdsourcing_2018.title"
+    "title": "translation missing: en.data.unplugged.Crowdsourcing_2018.title"
   }
 }

--- a/i18n/locales/source/course_content/2018/pre-express-2018.json
+++ b/i18n/locales/source/course_content/2018/pre-express-2018.json
@@ -233,7 +233,7 @@
     "long_instructions": "[][0] _\"Keep going!\"_"
   },
   "https://studio.code.org/s/pre-express-2018/lessons/10/levels/1": {
-    "title": "translation missing: en-US.data.unplugged.courseB_unplugged_loopyMRF_2018.title"
+    "title": "translation missing: en.data.unplugged.courseB_unplugged_loopyMRF_2018.title"
   },
   "https://studio.code.org/s/pre-express-2018/lessons/11/levels/1": {
     "short_instructions": "Help Scrat across the ice to get to the acorn!",

--- a/i18n/locales/source/course_content/other/self-paced-pl-k5-2024-1.json
+++ b/i18n/locales/source/course_content/other/self-paced-pl-k5-2024-1.json
@@ -322,8 +322,8 @@
           "correct": false
         },
         {
-          "text": "If you have a membership card, then you get a 10% discount.",
-          "correct": true
+          "text": "It is good to have a membership card when you shop.",
+          "correct": false
         }
       ],
       "questions": [

--- a/i18n/locales/source/dashboard/courses.yml
+++ b/i18n/locales/source/dashboard/courses.yml
@@ -997,6 +997,18 @@ en:
           description_student: ''
           description_teacher: ''
           version_title: ''
+        ui-test-single-unit-course-2025:
+          title: Single Unit Course 2025
+          description_short: This is the short description for Single-Unit Course 2025.
+          description_student: This is the student description for Single-Unit Course 2025.
+          description_teacher: This is the teacher description for Single-Unit Course 2025.
+          version_title: '2025'
+        ui-test-single-unit-course-2026:
+          title: Single-Unit Course 2026
+          description_short: This is the short description for Single-Unit Course 2026.
+          description_student: This is the student description for Single-Unit Course 2026.
+          description_teacher: This is the teacher description for Single-Unit Course 2026.
+          version_title: '2026'
     resources:
       curriculum/csd/2017:
         name: Curriculum

--- a/i18n/locales/source/dashboard/marketing_announcements.json
+++ b/i18n/locales/source/dashboard/marketing_announcements.json
@@ -5,11 +5,6 @@
       "body": "Join our highly supportive Professional Learning Program for middle and high school educators.",
       "buttonText": "Learn More"
     },
-    "hoc-2024": {
-      "title": "Register your Hour of Code",
-      "body": "Join us December 9th-15th for Computer Science Education Week and help us bring what students love to life!",
-      "buttonText": "Host an event"
-    },
     "curriculum-launch-2024": {
       "title": "Discover new and updated curriculum!",
       "body": "Explore our latest units and professional learning resources to inspire future tech innovators.",
@@ -19,11 +14,6 @@
       "title": "Help shape the future of Code.org",
       "body": "Your classroom experience and feedback can help shape improvements to Code.org for all teachers. Join our research community to share your insights, try out new features, and pilot new courses.",
       "buttonText": "Join our research community"
-    },
-    "music-lab-jam-launch-2024": {
-      "title": "Introducing Music Lab: Jam Session",
-      "body": "Make music and learn to code in our new Music Lab activity for Hour of Code! In this self-guided, one-hour activity, students remix tracks from artists like Sabrina Carpenter, Lady Gaga, and Shakira while mastering coding basics such as sequencing, functions, and exploring AI-driven beat creation.",
-      "buttonText": "Explore Music Lab: Jam Session"
     }
   }
 }

--- a/i18n/locales/source/dashboard/scripts.yml
+++ b/i18n/locales/source/dashboard/scripts.yml
@@ -10713,7 +10713,7 @@ en:
               display_name: 'Part II:  Concepts in Courses A - F'
             k5_next_steps_1:
               display_name: 'Part III:  Next Steps'
-          title: Teaching Computer Science Fundamentals ('23-'24)
+          title: Teaching Computer Science Fundamentals
           description: 'Welcome to Code.org’s free self-paced online educator course for getting started with Computer Science Fundamentals! '
           student_description: 'Welcome to Code.org’s free online educator course for CS Fundamentals! '
           description_short: 'Welcome to Code.org’s free self-paced online educator course for getting started with Computer Science Fundamentals! '
@@ -18663,6 +18663,22 @@ en:
               name: Decomposing Adventure Game (Lesson 12)
             lesson-22:
               name: Variables with AI Tutor
+            lesson-23:
+              name: Lesson 5 - Variables and Data Flow
+            lesson-24:
+              name: Lesson 6 - Working with Objects
+            lesson-25:
+              name: Lesson 7 - Functions and Parameters
+            lesson-26:
+              name: Lesson 9 - Intro to Loops
+            lesson-27:
+              name: Lesson 10 - Conditionals
+            lesson-28:
+              name: Lesson 12 - Decomposing a Pixel Image
+            lesson-29:
+              name: Lesson 13 - Two-Way & Nested Selection
+            lesson-30:
+              name: Lesson 14 - Pixels of Me Project
           lesson_groups:
             lessonGroup-2:
               display_name: console-only levels
@@ -18844,3 +18860,32 @@ en:
           description_short: ''
           description: "##### Welcome! This module prepares teachers for Code.org's Programming with Music Lab curriculum. Programming with Music Lab is a short, accessible curriculum for grades 3-5 that teaches programming through music creation. Students learn to code melodies, loops, and interactive compositions in a fun, engaging way while meeting accessibility standards."
           student_description: "##### Welcome! This module prepares teachers for Code.org's Programming with Music Lab curriculum. Programming with Music Lab is a short, accessible curriculum for grades 3-5 that teaches programming through music creation. Students learn to code melodies, loops, and interactive compositions in a fun, engaging way while meeting accessibility standards."
+        ui-test-single-unit-2025:
+          lessons: {}
+          lesson_groups: {}
+          name: ui-test-single-unit-2025
+          title: Single Unit 2025
+          description_audience: ''
+          description_short: This is the short overview for Single Unit 2025.
+          description: This is the teacher overview for Single Unit 2025.
+          student_description: This is the student overview for Single Unit 2025.
+        ui-test-single-unit-2026:
+          lessons: {}
+          lesson_groups: {}
+          name: ui-test-single-unit-2026
+          title: Single Unit 2026
+          description_audience: ''
+          description_short: This is the short overview for Single Unit 2026.
+          description: This is the teacher overview for Single Unit 2026.
+          student_description: This is the student overview for Single Unit 2026.
+        sandbox-teaching-getting-started1:
+          lessons:
+            lesson-1:
+              name: Welcome to Code.org
+          lesson_groups: {}
+          name: sandbox-teaching-getting-started1
+          title: Getting Started Sandbox (Updated)
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''


### PR DESCRIPTION
# I18n Sync In & Up

This PR contains all changes to internationalization source strings made since the last sync (usually a week).

## To Review:

1. Look through the changes in each of the commits and verify that all changes are expected

   - We expect content changes to come in on a regular basis; individual strings will get updated, added, and deleted.

   - We _do not_ usually expect to see "comprehensive" changes - or changes that apply to large numbers of strings or whole categories of strings all at once - unless we have made specific code changes.

2. Notify the International Partners team about any changes that might appear to manifest as "lost translations"

   - For example: https://github.com/code-dot-org/code-dot-org/pull/31031/files#diff-aa1910a8cf8f9290ae3baf7e39dbae3eL397-R398

     This is a change that added new strings (with both new keys and new content) and simultaneously removed some very similar old ones; we can reasonably infer that the intent here was to swap the new strings out for the old ones. Unfortunately, because the swap also included a content change to the strings the crowdin duplication system won't automatically apply translations to the new strings and so they will need to be manually re-translated.

## To Deploy:

Once one or two people have reviewed and approved this change and the tests are passing, ship it!

It's not necessary to wait for everyone on the team to review.
