### PR TITLE
[Levelbuilder] Add new Blockly menu options to edit modes

### DIFF
--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -245,6 +245,70 @@ const registerAllBlocksUndeletable = function (weight: number) {
   );
 };
 
+const registerAllBlocksUneditable = function (weight: number) {
+  const workspaceBlocksUneditableOption = {
+    displayText: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      return 'Make ALL Blocks Uneditable';
+    },
+    preconditionFn: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      if (Blockly.isStartMode || Blockly.isToolboxMode) {
+        if (
+          scope.workspace?.getAllBlocks().every(block => !block.isEditable())
+        ) {
+          return MenuOptionStates.DISABLED;
+        }
+        return MenuOptionStates.ENABLED;
+      }
+      return MenuOptionStates.HIDDEN;
+    },
+    callback: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      if (scope.workspace) {
+        scope.workspace
+          .getAllBlocks()
+          .forEach(block => block.setEditable(false));
+      }
+    },
+    scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    id: 'workspaceBlocksUneditable',
+    weight,
+  };
+  GoogleBlockly.ContextMenuRegistry.registry.register(
+    workspaceBlocksUneditableOption
+  );
+};
+
+const registerAllBlocksUnmovable = function (weight: number) {
+  const workspaceBlocksUnmovableOption = {
+    displayText: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      return 'Make ALL Blocks Unmovable';
+    },
+    preconditionFn: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      if (Blockly.isStartMode) {
+        if (
+          scope.workspace?.getAllBlocks().every(block => !block.isMovable())
+        ) {
+          return MenuOptionStates.DISABLED;
+        }
+        return MenuOptionStates.ENABLED;
+      }
+      return MenuOptionStates.HIDDEN;
+    },
+    callback: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      if (scope.workspace) {
+        scope.workspace
+          .getAllBlocks()
+          .forEach(block => block.setMovable(false));
+      }
+    },
+    scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    id: 'workspaceBlocksUnMovable',
+    weight,
+  };
+  GoogleBlockly.ContextMenuRegistry.registry.register(
+    workspaceBlocksUnmovableOption
+  );
+};
+
 const registerKeyboardNavigation = function (weight: number) {
   const keyboardNavigationOption = {
     displayText: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
@@ -596,4 +660,6 @@ function registerCustomWorkspaceOptions() {
   registerAllCursors(nextWeight++, NAVIGATION_CURSOR_TYPES);
   registerThemes(nextWeight++, themes);
   registerAllBlocksUndeletable(nextWeight++);
+  registerAllBlocksUneditable(nextWeight++);
+  registerAllBlocksUnmovable(nextWeight++);
 }

--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -17,6 +17,7 @@ import {
   BLOCKLY_THEME,
   NAVIGATION_CURSOR_TYPES,
   DARK_THEME_SUFFIX,
+  BLOCK_TYPES,
 } from '../constants';
 import {ExtendedBlockSvg} from '../types';
 import {getBaseName, isDarkTheme} from '../utils';
@@ -265,6 +266,13 @@ const registerAllBlocksUneditable = function (weight: number) {
       if (scope.workspace) {
         scope.workspace
           .getAllBlocks()
+          // In toolbox mode, category blocks should remain editable.
+          .filter(
+            b =>
+              !(
+                [BLOCK_TYPES.category, BLOCK_TYPES.categoryDynamic] as string[]
+              ).includes(b.type)
+          )
           .forEach(block => block.setEditable(false));
       }
     },

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -119,6 +119,8 @@ export enum BLOCK_TYPES {
   argumentReporter = 'argument_reporter',
   behaviorDefinition = 'behavior_definition',
   behaviorGet = 'gamelab_behavior_get',
+  category = 'category',
+  categoryDynamic = 'custom_category',
   colourRandom = 'colour_random',
   danceWhenSetup = 'Dancelab_whenSetup',
   parametersGet = 'parameters_get',

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -25,6 +25,9 @@ import {setFailedToGenerateCode} from '@cdo/apps/redux/blockly';
 import styleConstants from '@cdo/apps/styleConstants';
 import * as utils from '@cdo/apps/utils';
 
+import {START_BLOCKS} from '../constants';
+import {START_SOURCES} from '../lab2/constants';
+
 import CdoAngleHelper from './addons/cdoAngleHelper';
 import CdoBlockSerializer from './addons/cdoBlockSerializer';
 import CdoConnectionChecker from './addons/cdoConnectionChecker';
@@ -846,7 +849,9 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       !!optOptionsExtended.disableVariableEditing;
     blocklyWrapper.varsInGlobals = !!optOptionsExtended.varsInGlobals;
     blocklyWrapper.isStartMode =
-      optOptionsExtended.editBlocks === 'start_sources';
+      !!optOptionsExtended.editBlocks &&
+      // Lab2 levels such as Music Lab use 'start_sources', while older labs use 'start_blocks'.
+      [START_BLOCKS, START_SOURCES].includes(optOptionsExtended.editBlocks);
     blocklyWrapper.isToolboxMode =
       optOptionsExtended.editBlocks === 'toolbox_blocks';
     blocklyWrapper.analyticsData = optOptionsExtended.analyticsData;

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -909,6 +909,14 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       workspace.addChangeListener(updateBlockLimits);
     }
 
+    // In toolbox mode, automatically clean up the workspace as blocks are moved.
+    if (blocklyWrapper.isToolboxMode) {
+      workspace.addChangeListener(event => {
+        if (event.type === GoogleBlockly.Events.MOVE) {
+          workspace.cleanUp();
+        }
+      });
+    }
     // When either the main workspace or the toolbox workspace viewport
     // changes, adjust any callouts so they stay pointing to the appropriate
     // location.

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -212,6 +212,7 @@ export default class MusicBlocklyWorkspace {
     addToolboxBlocksToWorkspace(toolbox.contents, workspace);
 
     validateBlockCategories(workspace);
+    workspace.cleanUp();
     workspace.addChangeListener(e => {
       if (e.type === Blockly.Events.BLOCK_MOVE) {
         validateBlockCategories(workspace);

--- a/apps/src/music/blockly/blockUtils.js
+++ b/apps/src/music/blockly/blockUtils.js
@@ -184,7 +184,6 @@ export function findParentStatementInputTypes(id) {
  * still save the blocks into a "DEFAULT" category.
  */
 export function validateBlockCategories(workspace) {
-  workspace.cleanUp();
   const topBlocks = workspace.getTopBlocks(true);
 
   const noCategoryBlocks =


### PR DESCRIPTION
This adds two new workspace context menu options:
- "Make ALL Blocks Uneditable" (Start Mode or Toolbox Mode )
- "Make ALL Blocks Unmovable" (Start Mode only)


<img width="529" alt="image" src="https://github.com/user-attachments/assets/411b3230-4bf5-42b7-9855-405b968e20f8" />
<img width="512" alt="image" src="https://github.com/user-attachments/assets/301c284b-05f3-4b59-877c-43ffbe25d988" />

This quick win comes from a direct request by the curriculum team:
https://codedotorg.slack.com/archives/C07UT279KM1/p1739571064761719?thread_ts=1739569501.987649&cid=C07UT279KM1

For the "uneditable" option, I chose to exclude Toolbox Mode's category blocks from the operation. This is because these are not blocks for the student and are just used to designate the start of a new toolbox category.

In the thread linked above, Katie asked if these options could be available in Sprite Lab too. All labs use the same context menu options, so this should be easily done. However, I noticed a regression that occurred when Music Lab's start mode was created last year, resulting in us no longer correctly detecting start mode in other labs. This has been fixed.

While working in this space, I also copied over part of a change listener that cleans up the workspace whenever blocks are moved. This feature has been well received in Music Lab's toolbox mode, and it was easy enough to make it work in all labs. Note: This doesn't port the rest of `validateBlockCategories` over to all labs. The rest of the logic here relates to adding warning text to mis-positioned blocks. This logic would need to be re-tooled slightly for non-Lab2 levels, which felt out of scope for this otherwise quick PR.

## Links

https://codedotorg.slack.com/archives/C07UT279KM1/p1739571064761719?thread_ts=1739569501.987649&cid=C07UT279KM1

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
