### PR TITLE
Add a cache busting suffix to backpack file fetch

### DIFF
--- a/apps/src/sharedComponents/backpack/BackpackClientApi.js
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.js
@@ -32,8 +32,10 @@ export default class BackpackClientApi {
     if (!this.hasBackpack()) {
       onError();
     }
+    // Cache bust suffix ensures we always get the latest version of the file.
+    const cacheBustSuffix = `?t=${Date.now()}`;
     this.backpackApi.fetch(
-      this.channelId + '/' + filename,
+      this.channelId + '/' + filename + cacheBustSuffix,
       (error, data) => {
         if (error) {
           onError();


### PR DESCRIPTION
Emma noticed that sometimes backpack file import was importing an older version of the file. This is due to caching. The fix for this is to add a unique url parameter to the fetch request (using the current time here) to ensure we are always getting the most recent file version.

## Links
- [slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1739906409339789)

## Testing story
Tested locally. Before the change I could repro the issue as described on slack, afterwards I always get the latest file version.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
