### PR TITLE
AI Chat: Add UI test for teacher-facing scenarios

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -27,7 +27,12 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
   messageStyle = 'default',
 }) => {
   return (
-    <div className={moduleStyles[`message-container-${role}`]}>
+    <div
+      className={classNames(
+        moduleStyles[`message-container-${role}`],
+        'uitest-chat-message'
+      )}
+    >
       <div className={moduleStyles.messageWithChildren}>
         <div className={moduleStyles[`container-${role}`]}>
           {role === Role.ASSISTANT && (

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -173,7 +173,12 @@ const SetupCustomization: React.FunctionComponent = () => {
         {isVisible(selectedModelId) && renderChooseAndCompareModels()}
         {isVisible(temperature) && (
           <>
-            <div className={styles.horizontalFlexContainer}>
+            <div
+              className={classNames(
+                styles.horizontalFlexContainer,
+                'uitest-temperature-container'
+              )}
+            >
               <FieldLabel
                 id="temperature"
                 label={aichatI18n.technicalInfoHeader_temperature()}

--- a/apps/src/aichat/views/teacherFeedback/CleanFeedbackFooter.tsx
+++ b/apps/src/aichat/views/teacherFeedback/CleanFeedbackFooter.tsx
@@ -70,7 +70,7 @@ const CleanFeedbackFooter: React.FC<Props> = ({
           teacherFlagged && moduleStyles.selected
         )}
         ariaLabel={
-          teacherFlagged ? aichatI18n.aria_flag() : aichatI18n.aria_unflag()
+          teacherFlagged ? aichatI18n.aria_unflag() : aichatI18n.aria_flag()
         }
       />
     </WithTooltip>
@@ -83,7 +83,8 @@ const CleanFeedbackFooter: React.FC<Props> = ({
     <div
       className={classNames(
         moduleStyles.teacherFeedbackContainer,
-        isAssistant && moduleStyles.leftAlign
+        isAssistant && moduleStyles.leftAlign,
+        'uitest-clean-feedback-footer'
       )}
     >
       {footerElements}

--- a/apps/src/aichat/views/teacherFeedback/ProfanityFeedbackFooter.tsx
+++ b/apps/src/aichat/views/teacherFeedback/ProfanityFeedbackFooter.tsx
@@ -85,7 +85,12 @@ const ProfanityFeedbackFooter: React.FC<Props> = ({
   };
 
   return (
-    <div className={moduleStyles.teacherFeedbackContainer}>
+    <div
+      className={classNames(
+        moduleStyles.teacherFeedbackContainer,
+        'uitest-profane-feedback-footer'
+      )}
+    >
       {profaneMessageVisible && (
         <>
           <EmText className={moduleStyles.flaggedText}>{text}</EmText>

--- a/apps/src/lab2/views/Loading.tsx
+++ b/apps/src/lab2/views/Loading.tsx
@@ -40,7 +40,12 @@ const Loading: React.FunctionComponent<LoadingProps> = ({
       )}
     >
       {isLoading && (
-        <div className={moduleStyles.slowLoadContainer}>
+        <div
+          className={classNames(
+            moduleStyles.slowLoadContainer,
+            'uitest-is-loading-overlay'
+          )}
+        >
           <div className={moduleStyles.spinnerContainer}>
             <FontAwesome
               title={undefined}

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -114,6 +114,7 @@ namespace :seed do
     interactive-games-animations-2024
     focus-on-creativity3-2024
     focus-on-coding3-2024
+    customizing-llms-2024
     csp1-2017
     csp2-2017
     csp3-2017

--- a/dashboard/test/ui/features/star_labs/aichat/chat.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/chat.feature
@@ -1,7 +1,6 @@
 @no_mobile
 @no_ci
-
-Feature: AI Chat
+Feature: Model customizations and interactions in AI Chat Lab
 
   "AI Chat" is our lab that introduces students to generative AI
   by allowing them to customize, then interact with large language models.
@@ -13,12 +12,17 @@ Feature: AI Chat
     And I wait until element "#ui-close-dialog" is not visible
     And I dismiss the teacher panel
 
-  Scenario: Making chat request gets response
+  Scenario: Making chat request gets appropriate response
     When I press keys "Hello" for element "#uitest-chat-textarea"
     And I wait until element "#uitest-chat-submit" is enabled
     And I click selector "#uitest-chat-submit"
     And I wait until element "[aria-label='AI bot chat message']" is visible
     Then element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(224, 248, 249)"
+
+    When I press keys "Damn" for element "#uitest-chat-textarea"
+    And I wait until element "#uitest-chat-submit" is enabled
+    And I click selector "#uitest-chat-submit"
+    Then I wait until element ".uitest-chat-message" contains text "This message has been flagged by our content moderation policy."
 
   Scenario: Editing system prompt produces success notification and saves
     When I press keys "You are a safe chatbot" for element "#system-prompt"

--- a/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
@@ -1,55 +1,60 @@
-Feature: Teacher viewing student chat history in AI Chat lab
+@no_mobile
+@no_ci
+Feature: Teacher viewing student chat history in AI Chat Lab
 
-Scenario: Teacher views student chat history
-  # Create teacher, student, and section
+  Teachers can view student chat history and interact with the student's customized models in AI Chat Lab.
+  Teachers can provide feedback on whether messages are flagged as inappropriate by our safety tools.
+
+Background:
   Given I create a teacher named "Simone"
   And I give user "Simone" authorized teacher permission
   And I create a new student section assigned to "customizing-llms-2024" and save the section
+
   Given I create a student named "Hermione"
   And I join the section
 
-  # Have student interact with model
-  And I am on "http://studio.code.org/s/customizing-llms-2024/lessons/2/levels/9"
+  # Student interacts with model to create chat history for teacher to view.
+  Given I am on "http://studio.code.org/s/customizing-llms-2024/lessons/2/levels/9"
   And I click selector "#ui-close-dialog" once I see it
   And I wait until element "#ui-close-dialog" is not visible
   When I press keys "Hello" for element "#uitest-chat-textarea"
   And I wait until element "#uitest-chat-submit" is enabled
   And I click selector "#uitest-chat-submit"
-  And I wait until element "[aria-label='AI bot chat message']" is visible
-  Then element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(224, 248, 249)"
+  Then I wait until element "[aria-label='AI bot chat message']" is visible
+  And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(224, 248, 249)"
   When I press keys "Damn" for element "#uitest-chat-textarea"
   And I wait until element "#uitest-chat-submit" is enabled
   And I click selector "#uitest-chat-submit"
   And I wait until element ".uitest-chat-message" contains text "This message has been flagged by our content moderation policy."
-  And I click selector "[aria-label='Decrease']"
+  When I click selector "[aria-label='Decrease']"
   And I wait until element "#uitest-update-customizations" is enabled
   And I click selector "#uitest-update-customizations"
   Then I wait until element ".uitest-aichat-chat-alert" contains text "Temperature has been updated to 0.7"
 
-  # Have teacher view chat history
-  When I sign in as "Simone"
+Scenario: Teacher views student chat histor
+  # Teacher can view chat history and provide feedback on messages flagged as inappropriate.
+  Given I sign in as "Simone"
   And I am on "http://studio.code.org/s/customizing-llms-2024/lessons/2/levels/9"
-  And I click selector "#ui-close-dialog" once I see it
+  When I click selector "#ui-close-dialog" once I see it
   And I wait until element "#ui-close-dialog" is not visible
-#  And I load student number 1's project from the blue teacher panel
   And I wait to see ".show-handle"
   And I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
   And I click selector "#teacher-panel-container tr:eq(1)"
   And I dismiss the teacher panel
-  And I wait until element ".uitest-chat-message" contains text "This message has been flagged by our content moderation policy."
-  And I click selector "[aria-label='show message']"
-  And I wait until element ".uitest-profane-feedback-footer" contains text "Was this content flagged correctly?"
-  And I click selector "[aria-label='thumbs up']"
-  And I wait until element ".uitest-profane-feedback-footer" contains text "This content was flagged correctly."
-  And I click selector ".uitest-clean-feedback-footer button[aria-label='flag']"
-  And I wait until element ".uitest-clean-feedback-footer button[aria-label='unflag']" is visible
-  # Interact with student model
-  # Confirm value is 0.7
-  And I wait until element ".uitest-temperature-container" contains text "0.7"
-  And I press the last button with text "Test student model"
-  When I press keys "Hello" for element "#uitest-chat-textarea"
+  Then element ".uitest-chat-message" contains text "This message has been flagged by our content moderation policy."
+  When I click selector "[aria-label='show message']"
+  Then I wait until element ".uitest-profane-feedback-footer" contains text "Was this content flagged correctly?"
+  When I click selector "[aria-label='thumbs up']"
+  Then I wait until element ".uitest-profane-feedback-footer" contains text "This content was flagged correctly."
+  When I click selector ".uitest-clean-feedback-footer button[aria-label='flag']"
+  Then I wait until element ".uitest-clean-feedback-footer button[aria-label='unflag']" is visible
+
+  # Teacher can interact with student model.
+  Given element ".uitest-temperature-container" contains text "0.7"
+  When I press the last button with text "Test student model"
+  And I press keys "Hello" for element "#uitest-chat-textarea"
   And I wait until element "#uitest-chat-submit" is enabled
   And I click selector "#uitest-chat-submit"
-  And I wait until element "[aria-label='AI bot chat message']" is visible
-  Then element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(224, 248, 249)"
+  Then I wait until element "[aria-label='AI bot chat message']" is visible
+  And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(224, 248, 249)"

--- a/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
@@ -1,16 +1,15 @@
-# student writes appropriate chat
-# student writes inappropriate chat
-# *** need to be able to stub inappropriate response? ***
-# student sees inappropriate chat message?
 Feature: Teacher viewing student chat history in AI Chat lab
 
 Scenario: Teacher views student chat history
+  # Create teacher, student, and section
   Given I create a teacher named "Simone"
   And I give user "Simone" authorized teacher permission
   And I create a new student section assigned to "customizing-llms-2024" and save the section
   Given I create a student named "Hermione"
   And I join the section
-  And I am on "http://studio.code.org/s/customizing-llms-2024/lessons/2/levels/2"
+
+  # Have student interact with model
+  And I am on "http://studio.code.org/s/customizing-llms-2024/lessons/2/levels/9"
   And I click selector "#ui-close-dialog" once I see it
   And I wait until element "#ui-close-dialog" is not visible
   When I press keys "Hello" for element "#uitest-chat-textarea"
@@ -21,12 +20,36 @@ Scenario: Teacher views student chat history
   When I press keys "Damn" for element "#uitest-chat-textarea"
   And I wait until element "#uitest-chat-submit" is enabled
   And I click selector "#uitest-chat-submit"
+  And I wait until element ".uitest-chat-message" contains text "This message has been flagged by our content moderation policy."
+  And I click selector "[aria-label='Decrease']"
+  And I wait until element "#uitest-update-customizations" is enabled
+  And I click selector "#uitest-update-customizations"
+  Then I wait until element ".uitest-aichat-chat-alert" contains text "Temperature has been updated to 0.7"
+
+  # Have teacher view chat history
+  When I sign in as "Simone"
+  And I am on "http://studio.code.org/s/customizing-llms-2024/lessons/2/levels/9"
+  And I click selector "#ui-close-dialog" once I see it
+  And I wait until element "#ui-close-dialog" is not visible
+#  And I load student number 1's project from the blue teacher panel
+  And I wait to see ".show-handle"
+  And I click selector ".show-handle .fa-chevron-left"
+  And I wait until element ".student-table" is visible
+  And I click selector "#teacher-panel-container tr:eq(1)"
+  And I dismiss the teacher panel
+  And I wait until element ".uitest-chat-message" contains text "This message has been flagged by our content moderation policy."
+  And I click selector "[aria-label='show message']"
+  And I wait until element ".uitest-profane-feedback-footer" contains text "Was this content flagged correctly?"
+  And I click selector "[aria-label='thumbs up']"
+  And I wait until element ".uitest-profane-feedback-footer" contains text "This content was flagged correctly."
+  And I click selector ".uitest-clean-feedback-footer button[aria-label='flag']"
+  And I wait until element ".uitest-clean-feedback-footer button[aria-label='unflag']" is visible
+  # Interact with student model
+  # Confirm value is 0.7
+  And I wait until element ".uitest-temperature-container" contains text "0.7"
+  And I press the last button with text "Test student model"
+  When I press keys "Hello" for element "#uitest-chat-textarea"
+  And I wait until element "#uitest-chat-submit" is enabled
+  And I click selector "#uitest-chat-submit"
   And I wait until element "[aria-label='AI bot chat message']" is visible
-  # Update to check for red background?
   Then element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(224, 248, 249)"
-# teacher logs in
-# teacher sees appropriate chat and message flagged as inappropriate
-# teacher can unhide flagged message
-# teacher can mark flagged message as appropriate
-# teacher can mark unflagged message as inappropriate
-# teacher can interact with student bot (all model stuff should be locked, cannot update)

--- a/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
@@ -1,0 +1,32 @@
+# student writes appropriate chat
+# student writes inappropriate chat
+# *** need to be able to stub inappropriate response? ***
+# student sees inappropriate chat message?
+Feature: Teacher viewing student chat history in AI Chat lab
+
+Scenario: Teacher views student chat history
+  Given I create a teacher named "Simone"
+  And I give user "Simone" authorized teacher permission
+  And I create a new student section assigned to "customizing-llms-2024" and save the section
+  Given I create a student named "Hermione"
+  And I join the section
+  And I am on "http://studio.code.org/s/customizing-llms-2024/lessons/2/levels/2"
+  And I click selector "#ui-close-dialog" once I see it
+  And I wait until element "#ui-close-dialog" is not visible
+  When I press keys "Hello" for element "#uitest-chat-textarea"
+  And I wait until element "#uitest-chat-submit" is enabled
+  And I click selector "#uitest-chat-submit"
+  And I wait until element "[aria-label='AI bot chat message']" is visible
+  Then element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(224, 248, 249)"
+  When I press keys "Damn" for element "#uitest-chat-textarea"
+  And I wait until element "#uitest-chat-submit" is enabled
+  And I click selector "#uitest-chat-submit"
+  And I wait until element "[aria-label='AI bot chat message']" is visible
+  # Update to check for red background?
+  Then element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(224, 248, 249)"
+# teacher logs in
+# teacher sees appropriate chat and message flagged as inappropriate
+# teacher can unhide flagged message
+# teacher can mark flagged message as appropriate
+# teacher can mark unflagged message as inappropriate
+# teacher can interact with student bot (all model stuff should be locked, cannot update)

--- a/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
@@ -42,13 +42,13 @@ Scenario: Teacher views student chat histor
   And I wait until element ".student-table" is visible
   And I click selector "#teacher-panel-container tr:eq(1)"
   And I dismiss the teacher panel
+  When I click selector ".uitest-clean-feedback-footer button[aria-label='flag']"
+  Then I wait until element ".uitest-clean-feedback-footer button[aria-label='unflag']" is visible
   Then element ".uitest-chat-message" contains text "This message has been flagged by our content moderation policy."
   When I click selector "[aria-label='show message']"
   Then I wait until element ".uitest-profane-feedback-footer" contains text "Was this content flagged correctly?"
   When I click selector "[aria-label='thumbs up']"
   Then I wait until element ".uitest-profane-feedback-footer" contains text "This content was flagged correctly."
-  When I click selector ".uitest-clean-feedback-footer button[aria-label='flag']"
-  Then I wait until element ".uitest-clean-feedback-footer button[aria-label='unflag']" is visible
 
   # Teacher can interact with student model.
   Given element ".uitest-temperature-container" contains text "0.7"

--- a/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
@@ -31,7 +31,7 @@ Background:
   And I click selector "#uitest-update-customizations"
   Then I wait until element ".uitest-aichat-chat-alert" contains text "Temperature has been updated to 0.7"
 
-Scenario: Teacher views student chat histor
+Scenario: Teacher views student chat history and interacts with student model
   # Teacher can view chat history and provide feedback on messages flagged as inappropriate.
   Given I sign in as "Simone"
   And I am on "http://studio.code.org/s/customizing-llms-2024/lessons/2/levels/9"
@@ -42,7 +42,9 @@ Scenario: Teacher views student chat histor
   And I wait until element ".student-table" is visible
   And I click selector "#teacher-panel-container tr:eq(1)"
   And I dismiss the teacher panel
-  When I click selector ".uitest-clean-feedback-footer button[aria-label='flag']"
+  And I wait to see ".uitest-is-loading-overlay"
+  And I wait until element ".uitest-is-loading-overlay" is not visible
+  When I click selector ".uitest-clean-feedback-footer button[aria-label='flag']" once I see it
   Then I wait until element ".uitest-clean-feedback-footer button[aria-label='unflag']" is visible
   Then element ".uitest-chat-message" contains text "This message has been flagged by our content moderation policy."
   When I click selector "[aria-label='show message']"


### PR DESCRIPTION
Adds a UI test to test our teacher-facing scenarios in AI Chat:
- Teacher can view student chat history.
- Teacher can give feedback on our safety filtering.
- Teacher can interact with a student's model.

## Links

- jira ticket: [LABS-1346](https://codedotorg.atlassian.net/browse/LABS-1346)

## Testing story

Tested running this test locally via SauceLabs.

## Follow-up work

Our safety layer currently doesn't work on Drone, so this (along with our other AI Chat UI test) is disabled there currently. I have a rough proposal to fix this here:

https://github.com/code-dot-org/code-dot-org/pull/63845