### PR TITLE
Don't redirect from courses/units on levelbuilder

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -1,5 +1,6 @@
 class CoursesController < ApplicationController
   include VersionRedirectOverrider
+  include TeacherDashboardUtils
 
   before_action :require_levelbuilder_mode, except: [:index, :show, :vocab, :resources, :code, :standards]
   before_action :authenticate_user!, except: [:index, :show, :vocab, :resources, :code, :standards]
@@ -43,14 +44,14 @@ class CoursesController < ApplicationController
       return
     end
 
-    if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.course_id == @unit_group.id} && (Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
+    if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.course_id == @unit_group.id} && TeacherDashboardUtils.can_redirect_to_teacher_dashboard?
       section_id = params[:section_id] || current_user.sections_instructed.select {|s| s.course_id == @unit_group.id}.last.id
       if section_id
         redirect_to "/teacher_dashboard/sections/#{section_id}/courses/#{@unit_group.name}"
         return
       end
     end
-    if (!params[:section_id] && current_user&.last_section_id) && !(Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
+    if !params[:section_id] && current_user&.last_section_id && !TeacherDashboardUtils.can_redirect_to_teacher_dashboard?
       redirect_to "#{request.path}?section_id=#{current_user.last_section_id}"
       return
     end

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -44,14 +44,14 @@ class CoursesController < ApplicationController
       return
     end
 
-    if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.course_id == @unit_group.id} && TeacherDashboardUtils.can_redirect_to_teacher_dashboard?
+    if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.course_id == @unit_group.id} && TeacherDashboardUtils.can_redirect_to_teacher_dashboard?(current_user)
       section_id = params[:section_id] || current_user.sections_instructed.select {|s| s.course_id == @unit_group.id}.last.id
       if section_id
         redirect_to "/teacher_dashboard/sections/#{section_id}/courses/#{@unit_group.name}"
         return
       end
     end
-    if !params[:section_id] && current_user&.last_section_id && !TeacherDashboardUtils.can_redirect_to_teacher_dashboard?
+    if !params[:section_id] && current_user&.last_section_id && !TeacherDashboardUtils.can_redirect_to_teacher_dashboard?(current_user)
       redirect_to "#{request.path}?section_id=#{current_user.last_section_id}"
       return
     end

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -27,7 +27,7 @@ class ScriptsController < ApplicationController
       return
     end
 
-    if TeacherDashboardUtils.can_redirect_to_teacher_dashboard?
+    if TeacherDashboardUtils.can_redirect_to_teacher_dashboard?(current_user)
       if request.query_parameters.include? "user_id"
         redirect_query_string = request.query_string.sub("user_id=#{request.query_parameters[:user_id]}", "").sub("&&", "&")
         if redirect_query_string.empty?

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -2,6 +2,7 @@ require 'cdo/i18n'
 
 class ScriptsController < ApplicationController
   include VersionRedirectOverrider
+  include TeacherDashboardUtils
 
   before_action :require_levelbuilder_mode, except: [:show, :vocab, :resources, :code, :standards, :edit, :update, :new, :create]
   before_action :require_levelbuilder_mode_or_test_env, only: [:edit, :update, :new, :create]
@@ -26,7 +27,7 @@ class ScriptsController < ApplicationController
       return
     end
 
-    if Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false)
+    if TeacherDashboardUtils.can_redirect_to_teacher_dashboard?
       if request.query_parameters.include? "user_id"
         redirect_query_string = request.query_string.sub("user_id=#{request.query_parameters[:user_id]}", "").sub("&&", "&")
         if redirect_query_string.empty?

--- a/dashboard/lib/teacher_dashboard_utils.rb
+++ b/dashboard/lib/teacher_dashboard_utils.rb
@@ -1,0 +1,6 @@
+module TeacherDashboardUtils
+  def self.can_redirect_to_teacher_dashboard?
+    (!rack_env?(:levelbuilder)) &&
+      (Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
+  end
+end

--- a/dashboard/lib/teacher_dashboard_utils.rb
+++ b/dashboard/lib/teacher_dashboard_utils.rb
@@ -1,6 +1,6 @@
 module TeacherDashboardUtils
   def self.can_redirect_to_teacher_dashboard?
-    (!rack_env?(:levelbuilder)) &&
+    !rack_env?(:levelbuilder) &&
       (Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
   end
 end

--- a/dashboard/lib/teacher_dashboard_utils.rb
+++ b/dashboard/lib/teacher_dashboard_utils.rb
@@ -1,5 +1,7 @@
 module TeacherDashboardUtils
-  def self.can_redirect_to_teacher_dashboard?
+  # Don't redirect on levelbuilder so that builders can view extra links.
+  # Redirect if the DCDO flag or experiment is enabled.
+  def self.can_redirect_to_teacher_dashboard?(current_user)
     !rack_env?(:levelbuilder) &&
       (Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
   end


### PR DESCRIPTION
We don't want to have these redirects to the teacher dashboard on Levelbuilder. This is because levelbuilders need to see the extra_links that are only shown on the non-dashboard version of the unit and course overview page.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1621
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
