### PR TITLE
Switch AI differentiation knowledge base

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -221,6 +221,12 @@ Resources:
               - !Sub 'arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:knowledge-base/1WHRENJ0OA'
           - Effect: Allow
             Action:
+              - 'bedrock:Retrieve'
+            Resource:
+              # TODO: Deploy KB with Cloudformation and !Ref it here
+              - !Sub 'arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:knowledge-base/ODWSNBOEZG'
+          - Effect: Allow
+            Action:
               - 'bedrock:InvokeModel'
             Resource:
               - 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'

--- a/dashboard/app/controllers/ai_diff_controller.rb
+++ b/dashboard/app/controllers/ai_diff_controller.rb
@@ -82,7 +82,7 @@ class AiDiffController < ApplicationController
 
     unit_num = @unit&.unit_group_units&.first&.position
 
-    course_name = @unit_group.name
+    course_name = @unit_group.present? ? @unit_group.name : @unit&.name
 
     course_display_name = CourseOffering.find_by(id: @unit_group&.course_version&.course_offering_id)&.display_name
     prompt = AiDiffBedrockHelper.get_prompt_for_context(params[:context], course_display_name, params[:unitDisplayName], lesson_name)

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -3,6 +3,7 @@ module AiDiffBedrockHelper
   TEMP = 0.5
   MODEL_ID = 'anthropic.claude-3-sonnet-20240229-v1:0'
   MODEL_ARN = 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
+  # TODO: extract this to a secret or other centralized parameter once KB is deployed via cloudformation.
   KB_ID = 'ODWSNBOEZG'
   RETRIEVAL_LIMIT = 10
 

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -3,7 +3,7 @@ module AiDiffBedrockHelper
   TEMP = 0.5
   MODEL_ID = 'anthropic.claude-3-sonnet-20240229-v1:0'
   MODEL_ARN = 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
-  KB_ID = '1WHRENJ0OA'
+  KB_ID = 'ODWSNBOEZG'
   RETRIEVAL_LIMIT = 10
 
   def self.create_bedrock_client
@@ -89,7 +89,7 @@ module AiDiffBedrockHelper
     unless unit_num.nil?
       temp_filters.push(
         or_all: [
-          {equals: {key: "unit", value: format("U%d", unit_num)}},
+          {equals: {key: "unit", value: format("U%02d", unit_num)}},
           {equals: {key: "unit", value: "all"}}
         ]
       )

--- a/dashboard/lib/policies/ai.rb
+++ b/dashboard/lib/policies/ai.rb
@@ -52,19 +52,11 @@ class Policies::Ai
   end
 
   def self.ai_differentiation_enabled_for_unit?(unit_or_unit_group)
-    # Checks the allowlists of specifically enabled units for this feature
-    return true if UNIT_DIFFERENTIATION_ALLOWLIST.include?(unit_or_unit_group&.name) && unit_or_unit_group.is_a?(Unit)
-    return true if UNIT_GROUP_DIFFERENTIATION_ALLOWLIST.include?(unit_or_unit_group&.name) && unit_or_unit_group.is_a?(UnitGroup)
-
-    # Otherwise, disabled
-    false
+    unit_or_unit_group.stable?
   end
 
   def self.ai_differentiation_enabled_for_lesson?(lesson)
     # Currently, all lessons of an allowed unit will allow ai differentiation features
-    return true if ai_differentiation_enabled_for_unit?(lesson&.script)
-
-    # Otherwise, disabled
-    false
+    ai_differentiation_enabled_for_unit?(lesson&.script)
   end
 end

--- a/dashboard/lib/policies/ai.rb
+++ b/dashboard/lib/policies/ai.rb
@@ -1,21 +1,4 @@
 class Policies::Ai
-  # Units that enable the Differentiation feature
-  UNIT_DIFFERENTIATION_ALLOWLIST = %w[
-    csd3-2023
-    interactive-games-animations-2023
-    focus-on-creativity3-2023
-    focus-on-coding3-2023
-    interactive-games-animations-2024
-    focus-on-creativity3-2024
-    focus-on-coding3-2024
-  ]
-
-  # UnitGroups that enable the Differentiation feature
-  UNIT_GROUP_DIFFERENTIATION_ALLOWLIST = %w[
-    csd-2023
-    csd-2024
-  ]
-
   # Whether or not AI rubric features (AI TA) are enabled.
   def self.ai_rubrics_enabled?(user)
     return false if user.nil?
@@ -52,11 +35,11 @@ class Policies::Ai
   end
 
   def self.ai_differentiation_enabled_for_unit?(unit_or_unit_group)
-    unit_or_unit_group.stable?
+    # Documents are added to KB for all stable units.
+    !!unit_or_unit_group.stable?
   end
 
   def self.ai_differentiation_enabled_for_lesson?(lesson)
-    # Currently, all lessons of an allowed unit will allow ai differentiation features
     ai_differentiation_enabled_for_unit?(lesson&.script)
   end
 end

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -102,7 +102,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
       retrieve_and_generate_configuration: {
         type: 'KNOWLEDGE_BASE',
         knowledge_base_configuration: {
-          knowledge_base_id: '1WHRENJ0OA',
+          knowledge_base_id: AiDiffBedrockHelper::KB_ID,
           model_arn: 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0',
           generation_configuration: {
             prompt_template: {
@@ -141,7 +141,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
       retrieve_and_generate_configuration: {
         type: 'KNOWLEDGE_BASE',
         knowledge_base_configuration: {
-          knowledge_base_id: '1WHRENJ0OA',
+          knowledge_base_id: AiDiffBedrockHelper::KB_ID,
           model_arn: 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0',
           generation_configuration: {
             prompt_template: {
@@ -163,7 +163,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
                     {equals: {key: "lesson", value: "all"}}
                   ]},
                   {or_all: [
-                    {equals: {key: "unit", value: "U2"}},
+                    {equals: {key: "unit", value: "U02"}},
                     {equals: {key: "unit", value: "all"}}
                   ]},
                   {equals: {key: "course", value: "test_course"}},
@@ -193,7 +193,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
       retrieve_and_generate_configuration: {
         type: 'KNOWLEDGE_BASE',
         knowledge_base_configuration: {
-          knowledge_base_id: '1WHRENJ0OA',
+          knowledge_base_id: AiDiffBedrockHelper::KB_ID,
           model_arn: 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0',
           generation_configuration: {
             prompt_template: {
@@ -211,7 +211,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
               filter: {
                 and_all: [
                   {or_all: [
-                    {equals: {key: "unit", value: "U2"}},
+                    {equals: {key: "unit", value: "U02"}},
                     {equals: {key: "unit", value: "all"}}
                   ]},
                   {equals: {key: "course", value: "test_course"}},
@@ -241,7 +241,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
       retrieve_and_generate_configuration: {
         type: 'KNOWLEDGE_BASE',
         knowledge_base_configuration: {
-          knowledge_base_id: '1WHRENJ0OA',
+          knowledge_base_id: AiDiffBedrockHelper::KB_ID,
           model_arn: 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0',
           generation_configuration: {
             prompt_template: {

--- a/dashboard/test/lib/policies/ai_test.rb
+++ b/dashboard/test/lib/policies/ai_test.rb
@@ -144,27 +144,15 @@ class Policies::AiTest < ActiveSupport::TestCase
 
     let(:unit_input) {unit}
 
-    let(:unit_differentiation_allowlist) {[]}
-    let(:unit_group_differentiation_allowlist) {[]}
-
-    around do |test|
-      Policies::Ai.stub_const(:UNIT_DIFFERENTIATION_ALLOWLIST, unit_differentiation_allowlist) do
-        Policies::Ai.stub_const(:UNIT_GROUP_DIFFERENTIATION_ALLOWLIST, unit_group_differentiation_allowlist) do
-          test.call
-        end
-      end
-    end
-
     context 'the unit is an actual unit' do
-      context 'the unit name is in the allow list' do
-        let(:unit_differentiation_allowlist) {[unit_name]}
-
+      context 'the unit name is stable' do
+        let(:unit) {build(:unit, name: unit_name, published_state: 'stable')}
         it 'returns true' do
           _(ai_differentiation_enabled_for_unit?).must_equal true
         end
       end
 
-      context 'the unit name is not in the allow list' do
+      context 'the unit is not stable' do
         it 'returns false' do
           _(ai_differentiation_enabled_for_unit?).must_equal false
         end
@@ -174,15 +162,14 @@ class Policies::AiTest < ActiveSupport::TestCase
     context 'the unit is a unit group' do
       let(:unit_input) {unit_group}
 
-      context 'the unit group name is in the allow list' do
-        let(:unit_group_differentiation_allowlist) {[unit_group_name]}
-
+      context 'the unit group is stable' do
+        let(:unit_group) {build(:unit_group, name: unit_group_name, published_state: 'stable')}
         it 'returns true' do
           _(ai_differentiation_enabled_for_unit?).must_equal true
         end
       end
 
-      context 'the unit group name is not in the allow list' do
+      context 'the unit group is not stable' do
         it 'returns false' do
           _(ai_differentiation_enabled_for_unit?).must_equal false
         end
@@ -197,40 +184,23 @@ class Policies::AiTest < ActiveSupport::TestCase
     let(:unit) {build(:unit, name: unit_name)}
     let(:lesson) {build(:lesson, script: unit)}
 
-    let(:mock_allowlist) {true}
-    let(:unit_differentiation_allowlist) {[]}
-
-    around do |test|
-      if mock_allowlist
-        Policies::Ai.stub_const(:UNIT_DIFFERENTIATION_ALLOWLIST, unit_differentiation_allowlist) do
-          test.call
-        end
-      else
-        test.call
-      end
-    end
-
-    context 'the unit name of the lesson is in the allow list' do
-      let(:unit_differentiation_allowlist) {[unit_name]}
-
+    context 'the unit of the lesson is stable' do
+      let(:unit) {build(:unit, name: unit_name, published_state: 'stable')}
       it 'returns true' do
         _(ai_differentiation_enabled_for_lesson?).must_equal true
       end
     end
 
-    context 'the unit name is not in the allow list' do
+    context 'the unit is not stable' do
       it 'returns false' do
         _(ai_differentiation_enabled_for_lesson?).must_equal false
       end
     end
 
     context 'the lesson belongs to a real unit we are specifically allowing' do
-      # Use the real list
-      let(:mock_allowlist) {false}
-
       ['csd3-2023'].each do |real_unit_name|
         context(real_unit_name) do
-          let(:unit_name) {real_unit_name}
+          let(:unit) {build(:unit, name: real_unit_name, published_state: 'stable')}
 
           it 'returns true' do
             _(ai_differentiation_enabled_for_lesson?).must_equal true


### PR DESCRIPTION
This changes the knowledge base from the former one limited to documents about CSD Unit 3, to the new one with documents about all published curriculum.

It also starts showing the FAB for all such curriculum.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/AITT-931)

## Testing story

Spun up an adhoc from this branch (https://adhoc-production-kb-switch-studio.cdn-code.org/) and verified none of the permission issues occurred that happened with the prior adhoc with no updates to the Cloud Formation config file.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
