### PR TITLE
Rewind to Forked Sprockets Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,13 @@ gem 'syslog' # needed for activesupport in Ruby >= 3.4, drop explicit after we u
 gem 'rails', '~> 6.1'
 gem 'rails-controller-testing', '~> 1.0.5'
 
+# Compile Sprockets assets concurrently in `assets:precompile`.
+# TODO: update to Sprockets 4.x mainline, which includes this change but also
+# other breaking changes from 3.x
+# Ref: https://github.com/rails/sprockets/pull/469
+# Ref: https://github.com/rails/sprockets/blob/main/UPGRADING.md#manifestjs
+gem 'sprockets', github: 'code-dot-org/sprockets', ref: 'concurrent_asset_bundle_3.x'
+
 # provide `respond_to` methods
 # (see: http://guides.rubyonrails.org/4_2_release_notes.html#respond-with-class-level-respond-to)
 gem 'responders', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,15 @@ GIT
       tilt
 
 GIT
+  remote: https://github.com/code-dot-org/sprockets.git
+  revision: 35caa45a78b739362b7db087b141f89e27d107c7
+  ref: concurrent_asset_bundle_3.x
+  specs:
+    sprockets (3.7.1)
+      concurrent-ruby (~> 1.1)
+      rack (> 1, < 3)
+
+GIT
   remote: https://github.com/dooly-ai/omniauth-microsoft_v2_auth.git
   revision: db19d64c2ddb017dddb9a0ff2cee1d84d2fad287
   specs:
@@ -859,9 +868,6 @@ GEM
     spring (3.1.1)
     spring-commands-testunit (1.0.1)
       spring (>= 0.9.1)
-    sprockets (3.7.1)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
     sprockets-rails (3.3.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -1116,6 +1122,7 @@ DEPENDENCIES
   sorted_set
   spring (~> 3.1.1)
   spring-commands-testunit
+  sprockets!
   sshkit
   statsig (~> 1.33)
   stringex (~> 2.5.2)


### PR DESCRIPTION
As part of [our preparations for an eventual Ruby version upgrade](https://github.com/code-dot-org/code-dot-org/pull/60782), we switched from using our own fork of the Sprockets gem back to mainline, after confirming that the upstream PR adding the functionality from our fork back into mainline had been merged. Unfortunately, it was merged into Sprockets 4.x whereas we updated our dependency to Sprockets 3.x, thereby inadvertently removing the functionality we were depending on.

At the time, this worked fine and deployed without issue. When we attempted the actual Ruby version upgrade, we ran into some problems with asset precompilation and backed out of the upgrade. More recently, we ran into asset precompilation issues again when attempting to add a new asset to the pipeline.

It turns out that the reason the initial deploy worked fine is that it was still using the asset cache, but that we inadvertently broke our ability to compile assets in a reasonable amount of time in the event the cache gets busted. Specifically, our fork parallelized the asset compilation process, taking advantage of the many threads available on our staging server. Without that optimization, the overhead added by image optimization makes a full compilation unmanageably slow.

## Links

- Slack threads
  - [Feb 13th problems adding new asset](https://codedotorg.slack.com/archives/C0T0PNTM3/p1739474919922749)
  - [Jan 8th Ruby 3.4 upgrade attempt](https://codedotorg.slack.com/archives/C0T0PNTM3/p1736392040629029)
- Last attempt at upgrading to Sprockets 4.x: https://github.com/code-dot-org/code-dot-org/pull/50493

## Testing story

Tested locally to verify that with this change, asset precompilation again takes advantage of parallelization.

## Follow-up work

With this optimization back in place, we should be able to again attempt to add the shared `component-library-styles` assets, and eventually to again attempt the Ruby 3.4 upgrade.
