### PR TITLE
[NOT FOR MERGE] Shared Header PoC

### DIFF
--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -114,16 +114,18 @@ header.build = function (
   // Hold off on rendering HeaderMiddle.  This will allow the "app load"
   // to potentially begin before we first render HeaderMiddle, giving HeaderMiddle
   // the opportunity to wait until the app is loaded before rendering.
-  $(document).ready(function () {
+
+
+  function renderHeaderMiddle() {
     ReactDOM.render(
-      <Provider store={getStore()}>
-        <HeaderMiddle
-          scriptNameData={scriptNameData}
-          lessonData={lessonData}
-          scriptData={scriptData}
-        />
-      </Provider>,
-      document.querySelector('.header_level')
+        <Provider store={getStore()}>
+          <HeaderMiddle
+              scriptNameData={scriptNameData}
+              lessonData={lessonData}
+              scriptData={scriptData}
+          />
+        </Provider>,
+        document.querySelector('.header_level')
     );
     // Only render sign in callout if the course is CSF and the user is
     // not signed in
@@ -144,14 +146,35 @@ header.build = function (
       });
 
       ReactDOM.render(
-        <SignInCalloutWrapper />,
-        document.querySelector('.signin_callout_wrapper')
+          <SignInCalloutWrapper />,
+          document.querySelector('.signin_callout_wrapper')
       );
     }
+  }
+
+  function mountMiddle() {
+    const container = document.querySelector('.header_level');
+    console.log(`============ mount middle ${container}`)
+
+    if (container) {
+      renderHeaderMiddle();
+    } else {
+      setTimeout(mountMiddle, 100);
+    }
+  }
+
+  $(document).ready(() => {
+    console.log(`============ middle`)
+    mountMiddle();
   });
 };
 
 header.buildProjectInfoOnly = function (currentLevelId) {
+  const container = document.querySelector('.header_level');
+  if (!container) {
+    setTimeout(header.buildProjectInfoOnly, 100);
+    return;
+  }
   const store = getStore();
 
   // Store the current level ID in the progressRedux store.
@@ -168,6 +191,11 @@ header.buildProjectInfoOnly = function (currentLevelId) {
 // When viewing the level page in code review mode, we want to show only the
 // lesson information (which is displayed by the ScriptName component).
 header.buildScriptNameOnly = function (scriptNameData) {
+  const container = document.querySelector('.header_level');
+  if (!container) {
+    setTimeout(header.buildProjectInfoOnly, 100);
+    return;
+  }
   ReactDOM.render(
     <Provider store={getStore()}>
       <HeaderMiddle scriptNameData={scriptNameData} scriptNameOnly={true} />

--- a/apps/src/layout/Header.tsx
+++ b/apps/src/layout/Header.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import DscoHeader from '@code-dot-org/component-library/header';
+
+const LOGGED_OUT_LINKS = [
+    { text: 'Learn', href: '/students' },
+    { text: 'Teach', href: '/teach' },
+    { text: 'Districts', href: '/administrators' },
+]
+
+const LOGGED_IN_LINKS = [
+    { text: 'My Dashboard', href: '/home' },
+    { text: 'Course Catalog', href: '/catalog' },
+    { text: 'Projects', href: '/projects' },
+    { text: 'Professional Learning', href: '/my-professional-learning' },
+    { text: 'Incubator', href: '/incubator' },
+]
+
+const Header = () => {
+    return <DscoHeader links={LOGGED_IN_LINKS} />;
+}
+
+export default Header;

--- a/apps/src/sites/studio/pages/layouts/_header.js
+++ b/apps/src/sites/studio/pages/layouts/_header.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Header from '@cdo/apps/layout/Header';
+
+// Note: We're not waiting for document.ready; we expect this script to be inlined into
+// the DOM immediately after the necessary #page-small-footer markup.
+ReactDOM.render(
+  <Header />,
+  document.getElementById('cdo-header')
+);

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -67,6 +67,7 @@ const CODE_STUDIO_ENTRIES = {
   'followers/students_cannot_join': './src/sites/studio/pages/followers/students_cannot_join.js',
   'essential': './src/sites/studio/pages/essential.js',
   'home/_homepage': './src/sites/studio/pages/home/_homepage.js',
+  'layouts/_header': './src/sites/studio/pages/layouts/_header.js',
   'layouts/_parent_email_banner': './src/sites/studio/pages/layouts/_parent_email_banner.js',
   'layouts/_race_interstitial': './src/sites/studio/pages/layouts/_race_interstitial.js',
   'layouts/_section_creation_celebration_dialog': './src/sites/studio/pages/layouts/_section_creation_celebration_dialog.js',

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -70,31 +70,24 @@
 
 %link{:href=>'/shared/css/hamburger.css', :rel=>'stylesheet'}
 
-%div{class: header_class}
-  .navbar-static-top.header
-    .container{style: "width: 100%; display: flex; justify-content: space-between; height: 50px;"}
-      .header_left
-        .header_logo
-          - if current_user
-            = link_to(image_tag('logo.svg', alt: I18n.t(:code_org_logo_alt)), home_path, {id: "logo_home_link"})
-          - else
-            = link_to(image_tag('logo.svg', alt: I18n.t(:code_org_logo_alt)), CDO.code_org_url(ge_region: request.ge_region), {id: "logo_home_link"})
+%div{class: header_class, id: 'cdo-header'}
+  -# .navbar-static-top.header
+  -#   .container{style: "width: 100%; display: flex; justify-content: space-between; height: 50px;"}
+  -#     .header_left
+  -#       .header_logo
+  -#         - if current_user
+  -#           = link_to(image_tag('logo.svg', alt: I18n.t(:code_org_logo_alt)), home_path, {id: "logo_home_link"})
+  -#         - else
+  -#           = link_to(image_tag('logo.svg', alt: I18n.t(:code_org_logo_alt)), CDO.code_org_url(ge_region: request.ge_region), {id: "logo_home_link"})
+  -#
+  -#     .header_right
+  -#       - if !@hide_sign_in_option && signin_button_enabled
+  -#         #sign_in_or_user
+  -#           = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'user_header.haml')), type: :haml, locals: user_header_options
+  -#       = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'help_button.haml')), type: :haml, locals: hamburger_options
+  -#       = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'hamburger.haml')), type: :haml, locals: hamburger_options
 
-      .header_middle{dir: locale_dir}
-        - if should_show_progress || level
-          -# React will attach to this.
-          .header_level
-        - else
-          .headerlinks.hide_on_tablet
-            - Hamburger.get_header_contents(header_contents_options).each do |entry|
-              %a.headerlink{id: entry[:id], href: entry[:url], class: entry[:class]}= entry[:title]
-
-      .header_right
-        - if !@hide_sign_in_option && signin_button_enabled
-          #sign_in_or_user
-            = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'user_header.haml')), type: :haml, locals: user_header_options
-        = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'help_button.haml')), type: :haml, locals: hamburger_options
-        = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'hamburger.haml')), type: :haml, locals: hamburger_options
+  %script{src: webpack_asset_path('js/layouts/_header.js'), 'data-ot-ignore' => ''}
 
 :ruby
   if should_show_progress

--- a/frontend/apps/marketing/src/app/layout.tsx
+++ b/frontend/apps/marketing/src/app/layout.tsx
@@ -3,11 +3,26 @@ import type {Metadata} from 'next';
 import './globals.css';
 import '@code-dot-org/component-library-styles/font-awesome.scss';
 import '@code-dot-org/component-library-styles/colors.scss';
+import Header from '@/components/header';
 
 export const metadata: Metadata = {
   title: 'Code.org',
   description: 'Anyone can learn!',
 };
+
+const LOGGED_OUT_LINKS = [
+  { text: 'Learn', href: '/students' },
+  { text: 'Teach', href: '/teach' },
+  { text: 'Districts', href: '/administrators' },
+]
+
+const LOGGED_IN_LINKS = [
+  { text: 'My Dashboard', href: '/home' },
+  { text: 'Course Catalog', href: '/catalog' },
+  { text: 'Projects', href: '/projects' },
+  { text: 'Professional Learning', href: '/my-professional-learning' },
+  { text: 'Incubator', href: '/incubator' },
+]
 
 export default function RootLayout({
   children,
@@ -16,7 +31,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body><Header links={LOGGED_IN_LINKS} />{children}</body>
     </html>
   );
 }

--- a/frontend/apps/marketing/src/components/header/Header.tsx
+++ b/frontend/apps/marketing/src/components/header/Header.tsx
@@ -1,0 +1,4 @@
+import '@code-dot-org/component-library/header/index.css';
+import Header from '@code-dot-org/component-library/header';
+
+export default Header;

--- a/frontend/apps/marketing/src/components/header/index.ts
+++ b/frontend/apps/marketing/src/components/header/index.ts
@@ -1,0 +1,2 @@
+import Header from './Header';
+export default Header;

--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -172,6 +172,15 @@
       "import": "./dist/esm/fontAwesomeV6Icon/index.mjs",
       "require": "./dist/cjs/fontAwesomeV6Icon/index.js"
     },
+    "./header": {
+      "types": {
+        "import": "./dist/esm/header/index.d.mts",
+        "require": "./dist/cjs/header/index.d.ts"
+      },
+      "import": "./dist/esm/header/index.mjs",
+      "require": "./dist/cjs/header/index.js"
+    },
+    "./header/index.css": "./dist/esm/header/index.css",
     "./link": {
       "types": {
         "import": "./dist/esm/link/index.d.mts",

--- a/frontend/packages/component-library/src/header/Header.tsx
+++ b/frontend/packages/component-library/src/header/Header.tsx
@@ -1,0 +1,27 @@
+import ReactDOM from 'react-dom';
+import Link from '../link'
+import headerStyles from './header.module.scss';
+import { useEffect } from 'react';
+
+interface HeaderLink {
+    text: string;
+    href: string;
+}
+
+interface HeaderProps {
+    links: HeaderLink[];
+}
+
+const Header = ({links}: HeaderProps) => {
+    return <nav className={headerStyles.main}>
+        <img src={'https://code.org/images/logo.svg'} className={headerStyles.logo} />
+        <div className={'header_middle'}>
+            <div className={'header_level'} />
+        </div>
+        <ul className={headerStyles.link_list}>
+            {links.map(headerLink => <li><Link href={headerLink.href} text={headerLink.text} /></li>)}
+        </ul>
+    </nav>
+}
+
+export default Header;

--- a/frontend/packages/component-library/src/header/header.module.scss
+++ b/frontend/packages/component-library/src/header/header.module.scss
@@ -1,0 +1,37 @@
+.main {
+    background-color: #0093a4;
+    margin: 0;
+    padding: 0.25rem 1rem;
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: 3rem;
+}
+
+.logo {
+    width: 42px;
+}
+
+.link_list {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: start;
+    gap: 2rem;
+}
+
+.link_list li {
+    padding: 0;
+    text-indent: 0;
+    list-style: none;
+    color: #ffffff;
+}
+
+.link_list li a {
+    color: #ffffff;
+    text-decoration: none;
+    font-weight: 400;
+    cursor: pointer;
+}

--- a/frontend/packages/component-library/src/header/index.ts
+++ b/frontend/packages/component-library/src/header/index.ts
@@ -1,0 +1,1 @@
+export { default as default } from './Header';

--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -24,17 +24,5 @@
 
 =inline_css 'hamburger.css'
 
-%nav.main
-  .left
-    -# rubocop:disable CustomCops/DashboardDbUsage
-    %a{href: current_user ? CDO.studio_url("/home") : CDO.code_org_url}
-      %img.logo{src: '/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
-    -# rubocop:enable CustomCops/DashboardDbUsage
-    %ul#headerlinks
-      - Hamburger.get_header_contents(header_contents_options).each do |entry|
-        %li{class: entry[:class]}
-          %a.headerlink{id: entry[:id], href: entry[:url]}= entry[:title]
-  .right
-    = view :sign_in_or_user
-    = view :help_button, hamburger_options
-    = view :hamburger, hamburger_options
+%nav.main{id: 'cdo-header'}
+%script{src: webpack_asset_path('js/layouts/_header.js'), 'data-ot-ignore' => ''}


### PR DESCRIPTION
This PR is for PoC purposes and is not for merge. It demonstrates sharing a header react component between Code.org Dashboard and the marketing website (and can be applied to any other react based applications).

# High-level Overview

## Demo

[Screencast From 2025-02-19 07-04-41.webm](https://github.com/user-attachments/assets/5dee57c1-ec3f-4987-a98d-71f07dc7c9f0)


## Dashboard

Code.org dashboard renders its header using [HAML](https://github.com/code-dot-org/code-dot-org/blob/a8ae83bd49cad5dc01272e9f97bfd90cdb8ec439/dashboard/app/views/layouts/_header.html.haml) and supplemented with javascript using jQuery. This method results in a server-side rendered header. The header is structured in three structural elements:

1. **Left**: Containing the Code.org logo
2. **Middle**: Usually blank, but when in code studio, it adds the share, remix, save, and progress bubbles.
3. **Right**: For creating projects, account management, and help buttons.

## Migration to React

The simplest method to migrate the header to a shared react component is to have the header be mounted as a react component using the existing `ReactDOM.render` and script-data mechanisms. A blank mount point is created in `_header.html.haml` and an entrypoint is added to render out the header.

The header can then be stored in a shared package library, such as `@code-dot-org/component-library`. While this is less than ideal as it results in multiple react dom render instances on the same page, it is consistent with the existing rendering mechanisms while allowing for future improvements to consolidate renders to a single mount point.

## Existing Header Hooks

The left and right portions are fixed and do not change. However, the middle portion is reserved as a mount point hook for other scripts to run. Normally, the header is server-side rendered and thus the middle mount point is always available for the script to mount to. However, by changing the header to a react component causes the header to be blank and thus no middle mount point is available until _after_ the header is rendered by react. This causes a potential out-of-order scenario:

1. The code studio code renders first, and attempts to hook to the middle of the header
2. The header react component is rendered

In this scenario, the middle is not yet available and thus the middle will not be rendered as its container is not yet available.

To resolve this, this PR uses a recursive `setTimeout` check to wait until the container is available by React before mounting the Code Studio hook. Similar mechanisms may be needed for other hooks into the header.

## Contentful Sourcing

This PR implements a static list of header entries, however such a list can be sourced from Contentful instead. To do this, an asynchronous API request using a public API key reserved for frontend usage for the header content type can be made. There is a potential risk that such an API call fails resulting in a blank header, though a default can be made. Alternatively, the header can be cached or fetched at build time.

Such a feature, if desired, can be done at a later point in time.

## Global Edition

This PR does not implement global edition customization, though it can be implemented through a set of region/locale to link mappings (as evidenced in this PR through the `links` prop).  Such a mapping can also be sourced from Contentful in the aforementioned fetch mechanism.

## Pegasus

Since Pegasus does not use React at this time, it would not be able to use this shared header. If desired, React support can be added to Pegasus but would require a significant effort and since the marketing site is slated to remove Pegasus, it is not recommended to pursue the shared header at this time.

## Recommendations

1. Create and share the header component in a shared package, such as `@code-dot-org/component-library`
  a. **Ideal**: Create a Header component using Component Library atoms
  b. **Consistent**: Pixel-match the existing header
2. Use the existing ReactDOM and script data rendering engine to minimize complexity
3. Repeat this pattern for the footer

## Challenges

1. Error that occur in the header will result in a missing header, though this will be caught by eyes tests.
2. Some changes are needed to ensure all header hooks work, primarily in code studio.