### PR TITLE
TEACH-1586/attempt to fix ui test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
@@ -218,8 +218,7 @@ Feature: Using the teacher homepage sections feature
     Given I am assigned to course "ui-test-single-unit-course-2025" and unit "ui-test-single-unit-2025" with teacher "Teacher_Sally"
 
     Given I sign in as "Teacher_Sally" and go home
-    Then I should see the student section table
-    And the student section table should have 2 rows
+    Then the student section table should have 2 rows
     And the section table row at index 0 has primary assignment path "/courses/ui-test-single-unit-course-2025"
     And element ".uitest-owned-sections" does not contain text "Current unit:"
 


### PR DESCRIPTION
This test was added in [TEACH-1586](https://github.com/code-dot-org/code-dot-org/commit/8ff62ef202c8a5ec99be8a8a84d8e84d0532f674). It appears to be rather flaky, so this is an attempt to fix it.

![image](https://github.com/user-attachments/assets/43e7dc70-e487-4121-9405-e18c4cdae7a5)

The failure was `Failed: no such element: Unable to locate element: {"method":"css selector","selector":".uitest\-owned\-sections"}`

I saw that I was checking `I should see the student section table` twice: Once by itself, and once in `The student section table should have 2 rows`. I also realized that most times `I should see the student section table` was called, it was wrapped in `wait_short_until`.

This PR removes the first call to `I should see the student section table`. The second call in `The student section table should have 2 rows` is wrapped in `wait_short_until`, so I'm hoping this may help combat the flakiness.

## Links
[Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1739977667195989) where this was discussed