### PR TITLE
Fix Ai Diff Welcome test

### DIFF
--- a/apps/src/aiDifferentiation/welcome/AiDiffWelcome.tsx
+++ b/apps/src/aiDifferentiation/welcome/AiDiffWelcome.tsx
@@ -79,7 +79,6 @@ const optionButton = (
       )}
       onClick={onClick}
       type="button"
-      id="uitest-ai-diff-option"
       aria-label={title}
     >
       <FontAwesomeV6Icon
@@ -115,11 +114,7 @@ const getStartedPage = (onClick: () => void) => {
           <Heading1>AI Teaching Assistant</Heading1>
           <BodyOneText>Empowering teachers. Enhancing learning.</BodyOneText>
         </div>
-        <Button
-          onClick={onClick}
-          id="uitest-ai-diff-get-started"
-          text="Get Started"
-        />
+        <Button onClick={onClick} text="Get Started" />
       </div>
     </div>
   );
@@ -182,7 +177,6 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
             onClick={() => setCurrentWelcomeState(nextState)}
             text="Continue"
             disabled={continueDisabled}
-            id="uitest-ai-diff-continue"
           />
           <Link
             className={style.skipLink}
@@ -190,7 +184,6 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
             text="Skip the tutorial"
             size="xs"
             type="secondary"
-            id="uitest-ai-diff-skip"
           />
         </div>
       );
@@ -289,11 +282,7 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
             />
           </a>
         </div>
-        <Button
-          onClick={() => updateShowWelcomeExperience()}
-          text="Finish"
-          id="uitest-ai-diff-finish"
-        />
+        <Button onClick={() => updateShowWelcomeExperience()} text="Finish" />
       </div>
     );
   }, [updateShowWelcomeExperience, confettiActive]);

--- a/apps/src/aiDifferentiation/welcome/AiDiffWelcome.tsx
+++ b/apps/src/aiDifferentiation/welcome/AiDiffWelcome.tsx
@@ -47,6 +47,7 @@ interface AiDiffWelcomeProps {
   scriptId: number;
   scriptName: string;
   unitDisplayName: string;
+  firstState?: WelcomeState;
 }
 
 const SUGGESTED_PROMPTS_FOR_SELECTION: {
@@ -150,9 +151,11 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
   scriptId,
   scriptName,
   unitDisplayName,
+  // This should only be used for testing purposes
+  firstState = 'get_started',
 }) => {
   const [currentWelcomeState, setCurrentWelcomeState] =
-    React.useState<WelcomeState>('get_started');
+    React.useState<WelcomeState>(firstState);
 
   const [chatContinueButtonDisabled, setChatContinueButtonDisabled] =
     React.useState(true);
@@ -289,6 +292,8 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
 
   const practicePage = React.useCallback(() => {
     if (!selectedOption) {
+      // Default to something so we don't just show a blank page
+      setSelectedOption('plan');
       return null;
     }
     const {initialMessage, suggestedPrompts} =

--- a/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
+++ b/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
@@ -18,6 +18,17 @@ jest.mock('@react-pdf/renderer', () => {
   };
 });
 
+jest.mock('@cdo/apps/aiDifferentiation/AiDiffChat', () => {
+  return function MockAiDiffChat(props) {
+    return (
+      // eslint-disable-next-line react/prop-types
+      <button onClick={props.chatResponseCallback} type="button">
+        ai chat mocked
+      </button>
+    );
+  };
+});
+
 jest.mock('react-dom-confetti', () => () => <div>confetti</div>);
 
 const DEFAULT_PROPS = {
@@ -58,29 +69,18 @@ describe('AiDiffWelcome', () => {
 
     fireEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
-    screen.getByText(
-      'Lets iterate together! What would you like to change? Below are some of the tasks I can help you with.'
-    );
+    screen.getByText('ai chat mocked');
   });
 
   test('practice page buttons work correctly', async () => {
     render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'practice'} />);
 
-    await waitFor(
-      () =>
-        expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled(),
-      {timeout: 100}
-    );
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
 
-    const input = screen.getByRole('textbox');
-    fireEvent.change(input, {target: {value: 'Test'}});
-    fireEvent.click(screen.getByRole('button', {name: 'Submit'}));
+    // Click a button that simulates getting a chat response
+    fireEvent.click(screen.getByText('ai chat mocked'));
 
-    await waitFor(
-      () =>
-        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled(),
-      {timeout: 100}
-    );
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
     fireEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
     screen.getByText('You’re on your way to becoming an AI all-star!');

--- a/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
+++ b/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
@@ -107,7 +107,7 @@ describe('AiDiffWelcome', () => {
       () => expect(setShowWelcomeExperienceStub).toHaveBeenCalledWith(false),
       {timeout: 100}
     );
-  });
+  }, 15000);
 
   test('End page buttons work correctly', async () => {
     render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'end_page'} />);

--- a/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
+++ b/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
@@ -18,6 +18,8 @@ jest.mock('@react-pdf/renderer', () => {
   };
 });
 
+jest.mock('react-dom-confetti', () => () => <div>confetti</div>);
+
 const DEFAULT_PROPS = {
   setShowWelcomeExperience: () => {},
   context: 'some-context',
@@ -95,12 +97,13 @@ describe('AiDiffWelcome', () => {
 
     fireEvent.click(screen.getByRole('button', {name: 'Finish'}));
 
+    screen.getByText('confetti');
+
     await waitFor(
       () => expect(setShowWelcomeExperienceStub).toHaveBeenCalledWith(false),
       {timeout: 100}
     );
-    return;
-  }, 15000);
+  });
 
   test('End page buttons work correctly', async () => {
     render(<AiDiffWelcome {...DEFAULT_PROPS} />);
@@ -120,6 +123,8 @@ describe('AiDiffWelcome', () => {
     );
     fireEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
+    screen.getByText('confetti');
+
     expect(
       screen.getByRole('link', {
         name: 'Take Code.org’s self-paced AI 101 professional learning course',
@@ -130,8 +135,7 @@ describe('AiDiffWelcome', () => {
       screen.getByRole('button', {name: 'Practice another skill'})
     );
     screen.getByText('Pick a skill to practice');
-    return;
-  }, 15000);
+  });
 
   test('Back button works correctly', () => {
     render(<AiDiffWelcome {...DEFAULT_PROPS} />);
@@ -160,5 +164,5 @@ describe('AiDiffWelcome', () => {
     await waitFor(() =>
       expect(setShowWelcomeExperienceStub).toHaveBeenCalledWith(false)
     );
-  }, 15000);
+  });
 });

--- a/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
+++ b/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
@@ -157,12 +157,18 @@ describe('AiDiffWelcome', () => {
       />
     );
 
+    screen.debug();
+
     fireEvent.click(screen.getByRole('button', {name: 'Get Started'}));
+    screen.debug();
 
     fireEvent.click(screen.getByRole('link', {name: 'Skip the tutorial'}));
+    screen.debug();
 
-    await waitFor(() =>
-      expect(setShowWelcomeExperienceStub).toHaveBeenCalledWith(false)
+    await waitFor(
+      () => expect(setShowWelcomeExperienceStub).toHaveBeenCalledWith(false),
+      {timeout: 100}
     );
+    screen.debug();
   });
 });

--- a/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
+++ b/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
@@ -1,6 +1,5 @@
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import React from 'react';
-import {act} from 'react-dom/test-utils';
 
 import AiDiffWelcome from '@cdo/apps/aiDifferentiation/welcome/AiDiffWelcome';
 
@@ -53,9 +52,7 @@ describe('AiDiffWelcome', () => {
   });
 
   test('selecting an option and clicking "Continue" transitions to practice page', () => {
-    render(<AiDiffWelcome {...DEFAULT_PROPS} />);
-
-    fireEvent.click(screen.getByRole('button', {name: 'Get Started'}));
+    render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'select_option'} />);
 
     fireEvent.click(screen.getByRole('button', {name: 'Plan'}));
 
@@ -66,20 +63,14 @@ describe('AiDiffWelcome', () => {
     );
   });
 
-  test('clicking "Finish" on the end page triggers setShowWelcomeExperience', async () => {
-    const setShowWelcomeExperienceStub = jest.fn();
-    render(
-      <AiDiffWelcome
-        {...DEFAULT_PROPS}
-        setShowWelcomeExperience={setShowWelcomeExperienceStub}
-      />
+  test('practice page buttons work correctly', async () => {
+    render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'practice'} />);
+
+    await waitFor(
+      () =>
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled(),
+      {timeout: 100}
     );
-
-    fireEvent.click(screen.getByRole('button', {name: 'Get Started'}));
-    fireEvent.click(screen.getByRole('button', {name: 'Plan'}));
-    fireEvent.click(screen.getByRole('button', {name: 'Continue'}));
-
-    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
 
     const input = screen.getByRole('textbox');
     fireEvent.change(input, {target: {value: 'Test'}});
@@ -92,6 +83,18 @@ describe('AiDiffWelcome', () => {
     );
     fireEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
+    screen.getByText('You’re on your way to becoming an AI all-star!');
+  });
+
+  test('clicking "Finish" on the end page triggers setShowWelcomeExperience', async () => {
+    const setShowWelcomeExperienceStub = jest.fn();
+    render(
+      <AiDiffWelcome
+        {...DEFAULT_PROPS}
+        setShowWelcomeExperience={setShowWelcomeExperienceStub}
+        firstState={'end_page'}
+      />
+    );
     screen.getByText('You’re on your way to becoming an AI all-star!');
 
     screen.getByText('Continue your learning journey');
@@ -107,22 +110,7 @@ describe('AiDiffWelcome', () => {
   });
 
   test('End page buttons work correctly', async () => {
-    render(<AiDiffWelcome {...DEFAULT_PROPS} />);
-
-    fireEvent.click(screen.getByRole('button', {name: 'Get Started'}));
-    fireEvent.click(screen.getByRole('button', {name: 'Plan'}));
-    fireEvent.click(screen.getByRole('button', {name: 'Continue'}));
-
-    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
-
-    const input = screen.getByRole('textbox');
-    fireEvent.change(input, {target: {value: 'Test'}});
-    fireEvent.click(screen.getByRole('button', {name: 'Submit'}));
-
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled()
-    );
-    fireEvent.click(screen.getByRole('button', {name: 'Continue'}));
+    render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'end_page'} />);
 
     screen.getByText('confetti');
 
@@ -139,9 +127,7 @@ describe('AiDiffWelcome', () => {
   });
 
   test('Back button works correctly', () => {
-    render(<AiDiffWelcome {...DEFAULT_PROPS} />);
-
-    fireEvent.click(screen.getByRole('button', {name: 'Get Started'}));
+    render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'select_option'} />);
 
     fireEvent.click(screen.getByRole('button', {name: 'Back'}));
     screen.getByText('AI Teaching Assistant');
@@ -155,15 +141,11 @@ describe('AiDiffWelcome', () => {
       <AiDiffWelcome
         {...DEFAULT_PROPS}
         setShowWelcomeExperience={setShowWelcomeExperienceStub}
+        firstState={'select_option'}
       />
     );
 
-    await act(async () => {
-      fireEvent.click(await screen.findByRole('button', {name: 'Get Started'}));
-      fireEvent.click(
-        await screen.findByRole('link', {name: 'Skip the tutorial'})
-      );
-    });
+    fireEvent.click(screen.getByRole('link', {name: 'Skip the tutorial'}));
 
     await waitFor(
       () => expect(setShowWelcomeExperienceStub).toHaveBeenCalledWith(false),

--- a/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
+++ b/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
@@ -1,5 +1,6 @@
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 
 import AiDiffWelcome from '@cdo/apps/aiDifferentiation/welcome/AiDiffWelcome';
 
@@ -157,18 +158,16 @@ describe('AiDiffWelcome', () => {
       />
     );
 
-    screen.debug();
-
-    fireEvent.click(screen.getByRole('button', {name: 'Get Started'}));
-    screen.debug();
-
-    fireEvent.click(screen.getByRole('link', {name: 'Skip the tutorial'}));
-    screen.debug();
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('button', {name: 'Get Started'}));
+      fireEvent.click(
+        await screen.findByRole('link', {name: 'Skip the tutorial'})
+      );
+    });
 
     await waitFor(
       () => expect(setShowWelcomeExperienceStub).toHaveBeenCalledWith(false),
       {timeout: 100}
     );
-    screen.debug();
   });
 });


### PR DESCRIPTION
These AIwelcome unit tests were so slow that they would timeout on drone. I bumped the timeout from default 5000ms to 15000ms to unblock, but I still wanted to make sure we could remove the extra timeout.

I fixed this issue by:
* Mocking the confetti to avoid the dom getting flooded
* Mocking the AI chat which was causing significant slowdowns
* Adding a way to skip state steps to tests wouldn't need to always go through the get started page to only test the last page

Local run before:
![image](https://github.com/user-attachments/assets/36d93d00-9974-46ae-b70b-aa9bf8394b7d)

Local run after:
![image](https://github.com/user-attachments/assets/4a4091b5-edd5-4c34-967e-8979290cbad8)


## Links
https://codedotorg.atlassian.net/browse/TEACH-1637
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
