### PR TITLE
Lab2 Dance: use level properties and sources from props

### DIFF
--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,37 +1,24 @@
 import React, {useCallback, useEffect, useState} from 'react';
-import {TypedUseSelectorHook, useSelector} from 'react-redux';
 
 import SongSelector from '@cdo/apps/dance/SongSelector';
-import {LabState} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {LabProps} from '@cdo/apps/lab2/types';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {registerReducers} from '@cdo/apps/redux';
 import AgeDialog from '@cdo/apps/templates/AgeDialog';
-import {CurrentUserState} from '@cdo/apps/templates/CurrentUserState';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {commonI18n} from '@cdo/apps/types/locale';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {installCommonBlocks, installDanceBlocks} from '../../blockly/setup';
-import {DanceState, initSongs, reducers, setSong} from '../../danceRedux';
+import {initSongs, reducers, setSong} from '../../danceRedux';
 import {getFilterStatus} from '../../songs';
 import {DanceLevelProperties, DanceProjectSources} from '../../types';
 
 import moduleStyles from './dance-view.module.scss';
 
-const commonI18n = require('@cdo/locale');
-
 const DANCE_VISUALIZATION_ID = 'dance-visualization';
 const BLOCKLY_DIV_ID = 'dance-blockly-div';
-
-const useTypedSelector: TypedUseSelectorHook<{
-  currentUser: CurrentUserState;
-  dance: DanceState;
-  lab: LabState & {
-    levelProperties?: DanceLevelProperties;
-    initialSources?: DanceProjectSources;
-  };
-}> = useSelector;
 
 registerReducers(reducers);
 
@@ -39,37 +26,12 @@ registerReducers(reducers);
  * Renders the Lab2 version of Dance Lab. This separate container
  * allows us to support both Lab2 and legacy Dance.
  */
-const DanceView: React.FunctionComponent<LabProps> = () => {
+const DanceView: React.FunctionComponent<
+  LabProps<DanceLevelProperties, DanceProjectSources>
+> = ({initialSources, levelProperties}) => {
   const dispatch = useAppDispatch();
 
-  const useRestrictedSongs = useTypedSelector(
-    state => state.lab.levelProperties?.useRestrictedSongs || false
-  );
-  const defaultSong = useTypedSelector(
-    state => state.lab.levelProperties?.defaultSong
-  );
-  const projectSelectedSong = useTypedSelector(
-    state => state.lab.initialSources?.selectedSong
-  );
-  const isProjectLevel = useTypedSelector(
-    state => state.lab.levelProperties?.isProjectLevel || false
-  );
-  const freePlay = useTypedSelector(
-    state => state.lab.levelProperties?.freePlay || false
-  );
-  const isRunning = useTypedSelector(state => state.dance.isRunning);
-
-  const sharedBlocks = useTypedSelector(
-    state => state.lab.levelProperties?.sharedBlocks || undefined
-  );
-
-  const skin = useTypedSelector(
-    state => state.lab.levelProperties?.skin || undefined
-  );
-
-  const isK1 = useTypedSelector(
-    state => state.lab.levelProperties?.isK1 || false
-  );
+  const isRunning = useAppSelector(state => state.dance.isRunning);
 
   const onAuthError = (songId: string) => {
     Lab2Registry.getInstance().getMetricsReporter().logWarning({
@@ -79,45 +41,38 @@ const DanceView: React.FunctionComponent<LabProps> = () => {
   };
 
   useEffect(() => {
-    installCommonBlocks(skin, isK1);
-  }, [skin, isK1]);
+    installCommonBlocks(levelProperties.skin, levelProperties.isK1);
+  }, [levelProperties.skin, levelProperties.isK1]);
 
   useEffect(() => {
-    installDanceBlocks(sharedBlocks);
-  }, [sharedBlocks]);
+    installDanceBlocks(levelProperties.sharedBlocks);
+  }, [levelProperties.sharedBlocks]);
 
   // Initialize song manifest and load initial song when level loads.
   useEffect(() => {
     dispatch(
       initSongs({
-        useRestrictedSongs,
+        useRestrictedSongs: levelProperties.useRestrictedSongs || false,
         selectSongOptions: {
-          defaultSong,
-          selectedSong: projectSelectedSong,
-          isProjectLevel,
-          freePlay,
+          defaultSong: levelProperties.defaultSong,
+          selectedSong: initialSources?.selectedSong,
+          isProjectLevel: levelProperties.isProjectLevel || false,
+          freePlay: levelProperties.freePlay || false,
         },
         onAuthError,
       })
     );
-  }, [
-    isProjectLevel,
-    freePlay,
-    defaultSong,
-    projectSelectedSong,
-    useRestrictedSongs,
-    dispatch,
-  ]);
+  }, [levelProperties, initialSources, dispatch]);
 
-  const userType = useTypedSelector(state => state.currentUser.userType);
-  const under13 = useTypedSelector(state => state.currentUser.under13);
+  const userType = useAppSelector(state => state.currentUser.userType);
+  const under13 = useAppSelector(state => state.currentUser.under13);
   const [filterOn, setFilterOn] = useState<boolean>(
     getFilterStatus(userType, under13)
   );
   const turnOffFilter = useCallback(() => setFilterOn(false), []);
 
-  const selectedSong = useTypedSelector(state => state.dance.selectedSong);
-  const songData = useTypedSelector(state => state.dance.songData);
+  const selectedSong = useAppSelector(state => state.dance.selectedSong);
+  const songData = useAppSelector(state => state.dance.songData);
   const onSetSong = useCallback(
     (songId: string) => {
       dispatch(setSong({songId, onAuthError}));

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -363,7 +363,10 @@ export interface ParentLevelPathLink {
   position: string;
 }
 
-export interface LabProps {
-  initialSources?: ProjectSources;
-  levelProperties: LevelProperties;
+export interface LabProps<
+  T extends LevelProperties = LevelProperties,
+  U extends ProjectSources = ProjectSources
+> {
+  levelProperties: T;
+  initialSources?: U;
 }

--- a/apps/src/types/redux.ts
+++ b/apps/src/types/redux.ts
@@ -23,6 +23,7 @@ import {CurrentUserState} from '@cdo/apps/templates/CurrentUserState';
 import {TeacherRubricState} from '@cdo/apps/templates/rubrics/teacherRubricRedux';
 import {TeacherSectionState} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
+import {DanceState} from '../dance/danceRedux';
 import {BlocklyState} from '../redux/blockly';
 
 // The type for our global redux store. This is incomplete until we type every slice
@@ -38,6 +39,7 @@ export interface RootState {
   calendar: CalendarState;
   codebridgeWorkspace: CodebridgeWorkspaceState;
   currentUser: CurrentUserState;
+  dance: DanceState;
   header: HeaderReduxState;
   javalab: JavalabState;
   javalabConsole: JavalabConsoleState;


### PR DESCRIPTION
Continuing architecture updates described in [this doc](https://docs.google.com/document/d/1fpyd88e-mXkyUQrE1ILRh-na6zz9glz9rpcQu80o34o/edit?tab=t.0). Now that we're passing level properties and initial sources as props to labs, we can switch over lab views one by one to use these props instead of retrieving data from redux. I started with Dance because it's currently unused/unfinished and therefore a good playground to test out these ideas. I confirmed that level properties are still passed in correctly by changing instructions/song choices/other properties on the level edit page.

A few early advantages of these updates:
- no longer need to use optional chaining / check for undefined when accessing level properties, because they are always defined by definition
- Made the `LabProps` type generic so lab views can parameterize it with specific subtypes of LevelProperties and/or ProjectSources; in lab2 Dance, we actually have dance-specific versions of both, and by parameterizing the props type, we get automatically typed props in the view (no casting `as DanceLevelProperties | undefined` required anymore).

No functional/user-facing changes.

## Testing story

Tested on lab2 dance level in the allthethings lab2 showcase progression.

## Follow-up work

As time permits, will probably look into 'static' labs next (Panels, Standalone Video), and then maybe AI Chat. Leaving Python/Weblab2 and Music for last since they're the most complex.