### PR TITLE
AI Chat: Add CSAIF pilot access

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -637,6 +637,8 @@ class Section < ApplicationRecord
   end
 
   def assigned_ai_chat?
+    # Our generative AI courses have scripts that can be assigned individually,
+    # whereas CS and AI Foundations (CSAIF) does not.
     gen_ai_scripts = %w[
       exploring-gen-ai1-2024
       exploring-gen-ai2-2024

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -636,20 +636,24 @@ class Section < ApplicationRecord
     script&.csa? || [CSA, CSA_PILOT_FACILITATOR].include?(unit_group&.family_name)
   end
 
-  def assigned_gen_ai?
-    [
-      'exploring-gen-ai1-2024',
-      'exploring-gen-ai2-2024',
-      'foundations-gen-ai-2024',
-      'customizing-llms-2024'
-    ].include?(script&.name) ||
-      [
-       'exploring-gen-ai-2024',
-       'computer-systems-and-devices-2024',
-       'programming-fundamentals-2024',
-       'programming-fundamentals-aitutor-2024',
-       'networks-and-the-internet-2024'
-      ].include?(unit_group&.name)
+  def assigned_ai_chat?
+    gen_ai_scripts = %w[
+      exploring-gen-ai1-2024
+      exploring-gen-ai2-2024
+      foundations-gen-ai-2024
+      customizing-llms-2024
+    ]
+    gen_ai_course = 'exploring-gen-ai-2024'
+
+    csaif_courses = %w[
+      computer-systems-and-devices-2024
+      programming-fundamentals-2024
+      programming-fundamentals-aitutor-2024
+      networks-and-the-internet-2024
+    ]
+
+    gen_ai_scripts.include?(script&.name) ||
+      (csaif_courses + [gen_ai_course]).include?(unit_group&.name)
   end
 
   def reset_code_review_groups(new_groups)

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -643,7 +643,13 @@ class Section < ApplicationRecord
       'foundations-gen-ai-2024',
       'customizing-llms-2024'
     ].include?(script&.name) ||
-      unit_group&.name == 'exploring-gen-ai-2024'
+      [
+       'exploring-gen-ai-2024',
+       'computer-systems-and-devices-2024',
+       'programming-fundamentals-2024',
+       'programming-fundamentals-aitutor-2024',
+       'networks-and-the-internet-2024'
+      ].include?(unit_group&.name)
   end
 
   def reset_code_review_groups(new_groups)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1599,7 +1599,7 @@ class User < ApplicationRecord
 
   def student_can_access_ai_chat?
     teachers.any?(&:teacher_can_access_ai_chat?) &&
-      sections_as_student.any?(&:assigned_gen_ai?)
+      sections_as_student.any?(&:assigned_ai_chat?)
   end
 
   def has_aichat_access?


### PR DESCRIPTION
Gives access to AI Chat to students who are assigned one of the CSAIF courses.