### PR TITLE
DIFF - include experiment tag in header of TA

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1284,6 +1284,7 @@
   "exampleSolution": "Example Solution {number}",
   "expand": "Expand",
   "expandAll": "Expand all student rows",
+  "experiment": "Experiment",
   "explainCourseAssignmentsLearnMore": " Learn what happens when you assign a course.",
   "explainTtsAutoplay": "For Chrome, Internet Explorer, and Edge browsers only: When this setting is on, level instructions will be automatically read aloud to students using text-to-speech each time they open a level. This makes it easier for students who are not yet fluent readers to complete lessons.",
   "explainTtsAutoplayToolTip": "For Chrome, Internet Explorer, and Edge browsers only: When this setting is on, level instructions will be automatically read aloud to students using text-to-speech each time they open a level. This makes it easier for students who are not yet fluent readers to complete lessons. Not available in all courses.",

--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -1,8 +1,10 @@
 import Button from '@code-dot-org/component-library/button';
+import Tags from '@code-dot-org/component-library/tags';
 import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 import Draggable, {DraggableEventHandler} from 'react-draggable';
 
+import i18n from '@cdo/locale';
 import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 
 import {useAppSelector} from '../util/reduxHooks';
@@ -89,6 +91,13 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
             </div>
             <span className={style.aiDiffHeaderText}>
               {AI_DIFF_HEADER_TEXT}
+            </span>
+            <span>
+              <Tags
+                tagsList={[{label: i18n.experiment()}]}
+                size="s"
+                className={style.headerTag}
+              />
             </span>
           </div>
           <div className={style.aiDiffHeaderRightSide}>

--- a/apps/src/aiDifferentiation/ai-differentiation.module.scss
+++ b/apps/src/aiDifferentiation/ai-differentiation.module.scss
@@ -117,6 +117,18 @@
     width: 1.5rem;
     height: 1.5rem;
   }
+
+  .headerTag {
+    margin-left: 4px;
+
+    div {
+      background-color: $neutral_dark80;
+
+      span {
+        color: $neutral_white;
+      }
+    }
+  }
 }
 
 .aiDiffHeaderText {

--- a/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
@@ -62,6 +62,7 @@ describe('AiDiffContainer', () => {
   it('visible when open', () => {
     renderDefault();
     expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
+    screen.getByText('Experiment');
   });
 
   it('moves rubric container when user clicks and drags component', () => {


### PR DESCRIPTION


This PR adds the below "experiment" tag to the header of the TA dialog.

<img width="448" alt="image" src="https://github.com/user-attachments/assets/63fcfc0c-0510-47ab-867f-11f91efaa322" />

What the figma looks like:
<img width="336" alt="image" src="https://github.com/user-attachments/assets/e394752e-30e7-4fdc-bf74-12976441535e" />


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?selectedIssue=AITT-909)
[Figma](https://www.figma.com/design/x8fuePmEOuWsR79UycULPd/AI-TA%3A-Chat-Experience?node-id=2532-2974&m=dev)