### PR TITLE
Codebridge: block upload of invalid file names

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -22,11 +22,14 @@ export const FileBrowserHeaderPopUpButton = () => {
   const uploadErrorCallback = useFileUploadErrorCallback();
   const handleFileUpload = useHandleFileUpload(source.files);
 
-  const {startFileUpload, FileUploaderComponent} = useFileUploader({
-    callback: handleFileUpload,
-    errorCallback: uploadErrorCallback,
-    validMimeTypes,
-  });
+  const {startFileUpload, FileUploaderComponent} = useFileUploader(
+    {
+      callback: handleFileUpload,
+      errorCallback: uploadErrorCallback,
+      validMimeTypes,
+    },
+    DEFAULT_FOLDER_ID
+  );
   return (
     <>
       <FileUploaderComponent />

--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -5,7 +5,6 @@ import {PopUpButtonOption} from '@codebridge/PopUpButton/PopUpButtonOption';
 import React from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {
   useFileUploader,
@@ -22,16 +21,11 @@ export const FileBrowserHeaderPopUpButton = () => {
   } = useCodebridgeContext();
   const uploadErrorCallback = useFileUploadErrorCallback();
   const handleFileUpload = useHandleFileUpload(source.files);
-  const validationFile = useAppSelector(
-    state => state.lab.levelProperties?.validationFile
-  );
 
   const {startFileUpload, FileUploaderComponent} = useFileUploader({
     callback: handleFileUpload,
     errorCallback: uploadErrorCallback,
     validMimeTypes,
-    source,
-    validationFile,
   });
   return (
     <>

--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -5,6 +5,7 @@ import {PopUpButtonOption} from '@codebridge/PopUpButton/PopUpButtonOption';
 import React from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {
   useFileUploader,
@@ -21,11 +22,16 @@ export const FileBrowserHeaderPopUpButton = () => {
   } = useCodebridgeContext();
   const uploadErrorCallback = useFileUploadErrorCallback();
   const handleFileUpload = useHandleFileUpload(source.files);
+  const validationFile = useAppSelector(
+    state => state.lab.levelProperties?.validationFile
+  );
 
   const {startFileUpload, FileUploaderComponent} = useFileUploader({
     callback: handleFileUpload,
     errorCallback: uploadErrorCallback,
     validMimeTypes,
+    source,
+    validationFile,
   });
   return (
     <>

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
@@ -35,11 +35,14 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
 
   const handleFileUpload = useHandleFileUpload(files);
   const fileUploadErrorCallback = useFileUploadErrorCallback();
-  const {startFileUpload, FileUploaderComponent} = useFileUploader({
-    callback: handleFileUpload,
-    errorCallback: fileUploadErrorCallback,
-    validMimeTypes,
-  });
+  const {startFileUpload, FileUploaderComponent} = useFileUploader(
+    {
+      callback: handleFileUpload,
+      errorCallback: fileUploadErrorCallback,
+      validMimeTypes,
+    },
+    item.id
+  );
   const {toggleOpenFolder} = useCodebridgeContext();
   const dropdownOptions = useFolderRowOptions(item, startFileUpload);
 

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
@@ -7,6 +7,8 @@ import {
 import {ProjectFolder} from '@codebridge/types';
 import React from 'react';
 
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
 import {FolderRowIcon} from './FolderRowIcon';
 import {FolderRowName} from './FolderRowName';
 import {useFolderRowOptions} from './hooks';
@@ -29,9 +31,13 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
   enableMenu,
 }) => {
   const {
-    source: {files},
+    source,
     config: {validMimeTypes},
   } = useCodebridgeContext();
+  const validationFile = useAppSelector(
+    state => state.lab.levelProperties?.validationFile
+  );
+  const files = source.files;
 
   const handleFileUpload = useHandleFileUpload(files);
   const fileUploadErrorCallback = useFileUploadErrorCallback();
@@ -39,6 +45,8 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
     callback: handleFileUpload,
     errorCallback: fileUploadErrorCallback,
     validMimeTypes,
+    source,
+    validationFile,
   });
   const {toggleOpenFolder} = useCodebridgeContext();
   const dropdownOptions = useFolderRowOptions(item, startFileUpload);

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
@@ -7,8 +7,6 @@ import {
 import {ProjectFolder} from '@codebridge/types';
 import React from 'react';
 
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-
 import {FolderRowIcon} from './FolderRowIcon';
 import {FolderRowName} from './FolderRowName';
 import {useFolderRowOptions} from './hooks';
@@ -31,13 +29,9 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
   enableMenu,
 }) => {
   const {
-    source,
+    source: {files},
     config: {validMimeTypes},
   } = useCodebridgeContext();
-  const validationFile = useAppSelector(
-    state => state.lab.levelProperties?.validationFile
-  );
-  const files = source.files;
 
   const handleFileUpload = useHandleFileUpload(files);
   const fileUploadErrorCallback = useFileUploadErrorCallback();
@@ -45,8 +39,6 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
     callback: handleFileUpload,
     errorCallback: fileUploadErrorCallback,
     validMimeTypes,
-    source,
-    validationFile,
   });
   const {toggleOpenFolder} = useCodebridgeContext();
   const dropdownOptions = useFolderRowOptions(item, startFileUpload);

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -1,3 +1,5 @@
+import {useCodebridgeContext} from '@codebridge/codebridgeContext';
+import {isDuplicateFileName} from '@codebridge/utils';
 import {sendCodebridgeAnalyticsEvent} from '@codebridge/utils/analyticsReporterHelper';
 import {useCallback} from 'react';
 
@@ -11,9 +13,6 @@ import {
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-
-import {useCodebridgeContext} from '../../codebridgeContext';
-import {isDuplicateFileName} from '../../utils';
 
 type UseFileUploaderArgs = Exclude<FileUploaderProps, 'sendAnalyticsEvent'>;
 

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -6,19 +6,21 @@ import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {
   useFileUploader as useLab2FileUploader,
   analyticsEvents,
+  FileUploaderProps,
 } from '@cdo/apps/lab2/hooks';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useCodebridgeContext} from '../../codebridgeContext';
-import {DEFAULT_FOLDER_ID} from '../../constants';
 import {isDuplicateFileName} from '../../utils';
 
-export const useFileUploader: Exclude<
-  typeof useLab2FileUploader,
-  'sendAnalyticsEvent'
-> = args => {
+type UseFileUploaderArgs = Exclude<FileUploaderProps, 'sendAnalyticsEvent'>;
+
+export const useFileUploader = (
+  args: UseFileUploaderArgs,
+  folderId: string
+) => {
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
   const {source} = useCodebridgeContext();
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
@@ -54,7 +56,7 @@ export const useFileUploader: Exclude<
       if (
         isDuplicateFileName({
           fileName,
-          folderId: DEFAULT_FOLDER_ID,
+          folderId,
           projectFiles: source.files,
           isStartMode,
           validationFile,
@@ -64,7 +66,7 @@ export const useFileUploader: Exclude<
       }
       return undefined;
     },
-    [source.files, isStartMode, validationFile]
+    [folderId, source.files, isStartMode, validationFile]
   );
 
   return useLab2FileUploader({

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -1,9 +1,8 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
-import {isDuplicateFileName} from '@codebridge/utils';
+import {validateFileName as validateCodebridgeFileName} from '@codebridge/utils';
 import {sendCodebridgeAnalyticsEvent} from '@codebridge/utils/analyticsReporterHelper';
 import {useCallback} from 'react';
 
-import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {
   useFileUploader as useLab2FileUploader,
@@ -52,18 +51,13 @@ export const useFileUploader = (
 
   const validateFileName = useCallback(
     (fileName: string) => {
-      if (
-        isDuplicateFileName({
-          fileName,
-          folderId,
-          projectFiles: source.files,
-          isStartMode,
-          validationFile,
-        })
-      ) {
-        return codebridgeI18n.duplicateFileError({fileName});
-      }
-      return undefined;
+      return validateCodebridgeFileName({
+        fileName,
+        folderId,
+        projectFiles: source.files,
+        isStartMode,
+        validationFile,
+      });
     },
     [folderId, source.files, isStartMode, validationFile]
   );

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -1,18 +1,30 @@
 import {sendCodebridgeAnalyticsEvent} from '@codebridge/utils/analyticsReporterHelper';
 import {useCallback} from 'react';
 
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {
   useFileUploader as useLab2FileUploader,
   analyticsEvents,
 } from '@cdo/apps/lab2/hooks';
+import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {useCodebridgeContext} from '../../codebridgeContext';
+import {DEFAULT_FOLDER_ID} from '../../constants';
+import {isDuplicateFileName} from '../../utils';
 
 export const useFileUploader: Exclude<
   typeof useLab2FileUploader,
   'sendAnalyticsEvent'
 > = args => {
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const {source} = useCodebridgeContext();
+  const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+  const validationFile = useAppSelector(
+    state => state.lab.levelProperties?.validationFile
+  );
 
   const sendAnalyticsEvent = useCallback(
     (eventName: string, payload: Record<string, string>) => {
@@ -37,5 +49,27 @@ export const useFileUploader: Exclude<
     [appName]
   );
 
-  return useLab2FileUploader({sendAnalyticsEvent, ...args});
+  const validateFileName = useCallback(
+    (fileName: string) => {
+      if (
+        isDuplicateFileName({
+          fileName,
+          folderId: DEFAULT_FOLDER_ID,
+          projectFiles: source.files,
+          isStartMode,
+          validationFile,
+        })
+      ) {
+        return codebridgeI18n.duplicateFileError({fileName});
+      }
+      return undefined;
+    },
+    [source.files, isStartMode, validationFile]
+  );
+
+  return useLab2FileUploader({
+    sendAnalyticsEvent,
+    validateFileName,
+    ...args,
+  });
 };

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -1,11 +1,6 @@
 import React, {useCallback, useMemo, useRef} from 'react';
 
-import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
-import {isDuplicateFileName} from '@cdo/apps/codebridge/utils';
-import {START_SOURCES} from '@cdo/apps/lab2/constants';
-import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
-import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
 
 export const enum analyticsEvents {
   UPLOAD_FAILED = 'UPLOAD_FAILED',
@@ -21,8 +16,7 @@ type FileUploaderProps = {
     callbackArgs?: unknown
   ) => void;
   errorCallback: (error: string, callbackArgs?: unknown) => void;
-  source: MultiFileSource;
-  validationFile: ProjectFile | undefined;
+  validateFileName?: (fileName: string) => string | undefined;
   multiple?: boolean;
   validMimeTypes?: string[];
   sendAnalyticsEvent?: (
@@ -92,14 +86,12 @@ export const useFileUploader = ({
   callback,
   errorCallback,
   validMimeTypes,
-  source,
-  validationFile,
+  validateFileName = () => undefined,
   sendAnalyticsEvent = () => {},
   multiple = true,
 }: FileUploaderProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const callbackArgs = useRef<unknown>();
-  const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 
   const changeHandler = useCallback(() => {
     Array.from(inputRef.current?.files || []).forEach(file => {
@@ -114,19 +106,9 @@ export const useFileUploader = ({
         );
         return;
       }
-      if (
-        isDuplicateFileName({
-          fileName: file.name,
-          folderId: DEFAULT_FOLDER_ID,
-          projectFiles: source.files,
-          isStartMode,
-          validationFile,
-        })
-      ) {
-        errorCallback(
-          codebridgeI18n.duplicateFileError({fileName: file.name}),
-          callbackArgs.current
-        );
+      const fileNameErrorMessage = validateFileName(file.name);
+      if (fileNameErrorMessage) {
+        errorCallback(fileNameErrorMessage, callbackArgs.current);
         return;
       }
 
@@ -163,9 +145,7 @@ export const useFileUploader = ({
     });
   }, [
     validMimeTypes,
-    source.files,
-    isStartMode,
-    validationFile,
+    validateFileName,
     sendAnalyticsEvent,
     errorCallback,
     callback,

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -1,6 +1,11 @@
 import React, {useCallback, useMemo, useRef} from 'react';
 
+import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {isDuplicateFileName} from '@cdo/apps/codebridge/utils';
+import {START_SOURCES} from '@cdo/apps/lab2/constants';
+import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
+import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
 
 export const enum analyticsEvents {
   UPLOAD_FAILED = 'UPLOAD_FAILED',
@@ -16,6 +21,8 @@ type FileUploaderProps = {
     callbackArgs?: unknown
   ) => void;
   errorCallback: (error: string, callbackArgs?: unknown) => void;
+  source: MultiFileSource;
+  validationFile: ProjectFile | undefined;
   multiple?: boolean;
   validMimeTypes?: string[];
   sendAnalyticsEvent?: (
@@ -85,11 +92,14 @@ export const useFileUploader = ({
   callback,
   errorCallback,
   validMimeTypes,
+  source,
+  validationFile,
   sendAnalyticsEvent = () => {},
   multiple = true,
 }: FileUploaderProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const callbackArgs = useRef<unknown>();
+  const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 
   const changeHandler = useCallback(() => {
     Array.from(inputRef.current?.files || []).forEach(file => {
@@ -104,6 +114,22 @@ export const useFileUploader = ({
         );
         return;
       }
+      if (
+        isDuplicateFileName({
+          fileName: file.name,
+          folderId: DEFAULT_FOLDER_ID,
+          projectFiles: source.files,
+          isStartMode,
+          validationFile,
+        })
+      ) {
+        errorCallback(
+          codebridgeI18n.duplicateFileError({fileName: file.name}),
+          callbackArgs.current
+        );
+        return;
+      }
+
       const reader = new FileReader();
       if (file.type.match(/^text/)) {
         reader.readAsText(file);
@@ -135,7 +161,15 @@ export const useFileUploader = ({
         }
       };
     });
-  }, [callback, errorCallback, validMimeTypes, sendAnalyticsEvent]);
+  }, [
+    validMimeTypes,
+    source.files,
+    isStartMode,
+    validationFile,
+    sendAnalyticsEvent,
+    errorCallback,
+    callback,
+  ]);
 
   return useMemo(
     () => ({

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -8,7 +8,7 @@ export const enum analyticsEvents {
   UPLOAD_UNACCEPTED_FILE = 'UPLOAD_UNACCEPTED_FILE',
 }
 
-type FileUploaderProps = {
+export type FileUploaderProps = {
   children?: React.ReactNode;
   callback: (
     filename: string,


### PR DESCRIPTION
Alice noticed the file uploader wasn't blocking duplicate files. We also were not blocking invalid file names. This adds that check to the file upload logic. It works for both the root file upload and the per-folder file upload. We now use the same file name validation for uploads that we do for new files/renames.

Since the main logic of the file uploader lives in lab2, I added a parameter, `validateFileName`, that returns either an error string or undefined, depending if the filename is valid. Codebridge can then use its validate method to validate the filename. If other labs want to use the uploader they may have slightly different validation, so I thought it made sense to keep this specific to codebridge for now.

## Error messages
![Screenshot 2025-02-19 at 1 38 44 PM](https://github.com/user-attachments/assets/805e6890-ca72-4940-bca5-01cab9129166)
![Screenshot 2025-02-19 at 1 54 45 PM](https://github.com/user-attachments/assets/928d9a80-34ab-4460-9958-aa2030c1603b)
![Screenshot 2025-02-19 at 1 54 58 PM](https://github.com/user-attachments/assets/ea0bf947-00e2-44dc-8a58-d3b30a184b1e)


## Links
- jira ticket: [CT-1060](https://codedotorg.atlassian.net/browse/CT-1060)

## Testing story
Tested locally. The main logic here, `validateFileName`, already has unit tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
