### PR TITLE
Refactor Selenium Connection Logic

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -397,11 +397,7 @@ end
 
 When /^I rotate to (landscape|portrait)$/ do |orientation|
   if ENV['BS_ROTATABLE'] == "true"
-    $http_client.call(
-      :post,
-      "/wd/hub/session/#{@browser.session_id}/orientation",
-      {orientation: orientation.upcase}
-    )
+    change_orientation(orientation)
   end
 end
 

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -10,7 +10,7 @@ UI_TEST_DIR = File.expand_path('../..', __dir__)
 $browser_config = JSON.parse(File.read(File.join(UI_TEST_DIR, 'browsers.json'))).detect {|b| b['name'] == ENV['BROWSER_CONFIG']} || {}
 
 MAX_CONNECT_RETRIES = 3
-SAUCELABS_SELENIUM_URL = 'https://ondemand.us-west-1.saucelabs.com/wd/hub'.freeze
+SAUCELABS_SELENIUM_URL = ENV.fetch('SAUCELABS_SELENIUM_URL', 'https://ondemand.us-west-1.saucelabs.com/wd/hub').freeze
 
 # Run all feature scenarios in a single session.
 def single_session?

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -7,18 +7,19 @@ require_relative '../../utils/selenium_browser'
 require 'retryable'
 
 UI_TEST_DIR = File.expand_path('../..', __dir__)
-$browser_config = JSON.parse(File.read(File.join(UI_TEST_DIR, "browsers.json"))).detect {|b| b['name'] == ENV['BROWSER_CONFIG']} || {}
+$browser_config = JSON.parse(File.read(File.join(UI_TEST_DIR, 'browsers.json'))).detect {|b| b['name'] == ENV['BROWSER_CONFIG']} || {}
 
 MAX_CONNECT_RETRIES = 3
+SAUCELABS_SELENIUM_URL = 'https://ondemand.us-west-1.saucelabs.com/wd/hub'.freeze
 
 # Run all feature scenarios in a single session.
 def single_session?
   $browser_config['mobile'] || $single_session
 end
 
-def saucelabs_browser(test_run_name)
-  raise "Please define CDO.saucelabs_username" if CDO.saucelabs_username.blank?
-  raise "Please define CDO.saucelabs_authkey"  if CDO.saucelabs_authkey.blank?
+def saucelabs_browser(test_run_name, http_client: nil)
+  raise 'Please define CDO.saucelabs_username' if CDO.saucelabs_username.blank?
+  raise 'Please define CDO.saucelabs_authkey'  if CDO.saucelabs_authkey.blank?
 
   capabilities = Selenium::WebDriver::Remote::Capabilities.new($browser_config.except('name'))
 
@@ -34,19 +35,15 @@ def saucelabs_browser(test_run_name)
   }
 
   sauce_options[:priority] = ENV['PRIORITY'].to_i if ENV['PRIORITY']
-  capabilities["sauce:options"] ||= {}
-  capabilities["sauce:options"].merge!(sauce_options)
+  capabilities['sauce:options'] ||= {}
+  capabilities['sauce:options'].merge!(sauce_options)
 
-  very_verbose "DEBUG: Capabilities: #{CGI.escapeHTML capabilities.inspect}"
-
-  $http_client = SeleniumBrowser::Client.new(read_timeout: 2.minutes)
-  with_read_timeout(5.minutes) do
-    Selenium::WebDriver.for(:remote,
-      url: "https://ondemand.us-west-1.saucelabs.com/wd/hub",
-      capabilities: capabilities,
-      http_client: $http_client
-    )
-  end
+  browser = SeleniumBrowser.remote(
+    SAUCELABS_SELENIUM_URL,
+    capabilities: capabilities,
+    http_client: http_client
+  )
+  return browser
 end
 
 # Set HTTP read timeout to the specified value during the block.
@@ -58,12 +55,13 @@ end
 
 def get_browser(test_run_name)
   browser = nil
+  $http_client ||= SeleniumBrowser::Client.new(read_timeout: 2.minutes)
   if ENV['TEST_LOCAL'] == 'true'
     headless = ENV['TEST_LOCAL_HEADLESS'] == 'true'
     browser = SeleniumBrowser.local(browser: ENV.fetch('BROWSER_CONFIG', nil), headless: headless)
   else
     browser = Retryable.retryable(tries: MAX_CONNECT_RETRIES) do
-      saucelabs_browser(test_run_name)
+      saucelabs_browser(test_run_name, http_client: $http_client)
     end
     $session_id = browser.session_id
     visual_log_url = "https://saucelabs.com/tests/#{$session_id}"

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -49,15 +49,15 @@ end
 # Set HTTP read timeout to the specified value during the block.
 # Invocable from Cucumber steps.
 def with_read_timeout(timeout, &block)
-  $http_client ?
-    $http_client.with_read_timeout(timeout, &block) :
+  $selenium_http_client ?
+    $selenium_http_client.with_read_timeout(timeout, &block) :
     yield
 end
 
 # Set the virtual browser to either portrait or landscape orientation.
 # Invocable from Cucumber steps.
 def change_orientation(orientation)
-  $http_client.call(
+  $selenium_http_client.call(
     :post,
     "/wd/hub/session/#{$browser.session_id}/orientation",
     {orientation: orientation.upcase}
@@ -66,13 +66,13 @@ end
 
 def get_browser(test_run_name)
   browser = nil
-  $http_client ||= SeleniumBrowser::Client.new(read_timeout: 2.minutes)
+  $selenium_http_client ||= SeleniumBrowser::Client.new(read_timeout: 2.minutes)
   if ENV['TEST_LOCAL'] == 'true'
     headless = ENV['TEST_LOCAL_HEADLESS'] == 'true'
     browser = SeleniumBrowser.local(browser: ENV.fetch('BROWSER_CONFIG', nil), headless: headless)
   else
     browser = Retryable.retryable(tries: MAX_CONNECT_RETRIES) do
-      saucelabs_browser(test_run_name, http_client: $http_client)
+      saucelabs_browser(test_run_name, http_client: $selenium_http_client)
     end
     $session_id = browser.session_id
     visual_log_url = "https://saucelabs.com/tests/#{$session_id}"

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -47,10 +47,21 @@ def saucelabs_browser(test_run_name, http_client: nil)
 end
 
 # Set HTTP read timeout to the specified value during the block.
+# Invocable from Cucumber steps.
 def with_read_timeout(timeout, &block)
   $http_client ?
     $http_client.with_read_timeout(timeout, &block) :
     yield
+end
+
+# Set the virtual browser to either portrait or landscape orientation.
+# Invocable from Cucumber steps.
+def change_orientation(orientation)
+  $http_client.call(
+    :post,
+    "/wd/hub/session/#{$browser.session_id}/orientation",
+    {orientation: orientation.upcase}
+  )
 end
 
 def get_browser(test_run_name)

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -720,6 +720,7 @@ def cucumber_arguments_for_feature(options, test_run_string, max_reruns)
 end
 
 def to_percent(number, n_sig_digits)
+  return nil if number.nil?
   percent = number * 100.0
   return 0 if percent.zero?
   "#{percent.round(-(Math.log10(percent).ceil - n_sig_digits))}%"

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -2,7 +2,8 @@ require 'selenium/webdriver'
 
 module SeleniumBrowser
   def self.webdriver_options_object(browser: :chrome, headless: false)
-    options = Selenium::WebDriver::Options.send(browser, args: ['window-size=1280,1024'])
+    options = Selenium::WebDriver::Options.send(browser)
+    options.add_argument('window-size=1280,1024') if [:chrome, :firefox].include?(browser)
     options.add_argument('headless') if headless
     return options
   end

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -1,20 +1,32 @@
 require 'selenium/webdriver'
 
 module SeleniumBrowser
+  def self.webdriver_options_object(browser: :chrome, headless: true)
+    options = Selenium::WebDriver::Options.send(browser, args: ['window-size=1280,1024'])
+    options.add_argument('headless') if headless
+    return options
+  end
+
   def self.local(browser: :chrome, headless: true)
     browser = browser.to_sym
-    options = {}
-    case browser
-    when :chrome
-      options[:options] = Selenium::WebDriver::Chrome::Options.new
-      options[:options].add_argument('headless') if headless
-      options[:options].add_argument('window-size=1280,1024')
-    when :firefox
-      options[:options] = Selenium::WebDriver::Firefox::Options.new
-      options[:options].headless! if headless
-      options[:options].add_argument('window-size=1280,1024')
+    options = webdriver_options_object(browser: browser, headless: headless)
+    return Selenium::WebDriver.for(browser, options: options)
+  end
+
+  def self.remote(url, capabilities: nil, options: nil, http_client: nil)
+    if capabilities.nil? && options.nil?
+      options = webdriver_options_object(browser: :chrome)
     end
-    Selenium::WebDriver.for browser, options
+
+    http_client ||= SeleniumBrowser::Client.new(read_timeout: 2.minutes)
+    return http_client.with_read_timeout(5.minutes) do
+      Selenium::WebDriver.for(:remote,
+        url: url,
+        capabilities: capabilities,
+        options: options,
+        http_client: http_client
+      )
+    end
   end
 
   require 'net/http/persistent'

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -1,7 +1,7 @@
 require 'selenium/webdriver'
 
 module SeleniumBrowser
-  def self.webdriver_options_object(browser: :chrome, headless: true)
+  def self.webdriver_options_object(browser: :chrome, headless: false)
     options = Selenium::WebDriver::Options.send(browser, args: ['window-size=1280,1024'])
     options.add_argument('headless') if headless
     return options


### PR DESCRIPTION
We currently have a `SeleniumBrowser` helper module which defines a method `local` which will return a Selenium WebDriver object configured for running tests locally. We also have a standalone helper method `saucelabs_browser` defined in `connect.rb` which will return a Selenium WebDriver object configured for running remote tests against SauceLabs.

In preparation for some upcoming work which will add an alternative to SauceLabs for remote testing, I extract some of the functionality from `saucelabs_browser` into a new method `remote` on the `SeleniumBrowser` helper module, and some of the shared logic from both the old `local` and the new `remote` method to a new `webdriver_options_object` helper method. Anything that is specific to SauceLabs rather than generically Selenium I left in `connect.rb`.

Also cleaned up a few miscellaneous implementation details while I was in the area.

## Links / Follow-up work

All in preparation for [eventually adding an alternate remote Selenium browser](https://github.com/code-dot-org/code-dot-org/pull/63606)

## Testing story

Relying entirely on existing tests to verify that this test-logic-only change does not change any existing functionality.