### PR TITLE
Codebridge: add fileUtils tests

### DIFF
--- a/apps/test/unit/codebridge/utils/fileUtilsTest.ts
+++ b/apps/test/unit/codebridge/utils/fileUtilsTest.ts
@@ -1,0 +1,179 @@
+import {
+  combineStartSourcesAndValidation,
+  getFileIconNameAndStyle,
+  prepareSourceForLevelbuilderSave,
+  ProjectFile,
+  shouldShowFile,
+} from '@cdo/apps/codebridge';
+import {ProjectFileType} from '@cdo/apps/lab2/types';
+
+import {mockAppOptions} from '../test_utils';
+
+const defaultFile: ProjectFile = {
+  id: '1',
+  name: '',
+  language: '',
+  contents: '',
+  folderId: '',
+};
+
+describe('fileUtils', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('shoudShowFile is correct in standard mode', () => {
+    expect(shouldShowFile(undefined)).toBe(false);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.SYSTEM_SUPPORT})
+    ).toBe(false);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.SUPPORT})
+    ).toBe(false);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.VALIDATION})
+    ).toBe(false);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.STARTER})
+    ).toBe(true);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.LOCKED_STARTER})
+    ).toBe(true);
+    expect(shouldShowFile({...defaultFile, type: undefined})).toBe(true);
+  });
+
+  it('shoudShowFile is correct in start mode', () => {
+    mockAppOptions({editBlocks: 'start_sources'});
+    expect(shouldShowFile(undefined)).toBe(false);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.SYSTEM_SUPPORT})
+    ).toBe(false);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.SUPPORT})
+    ).toBe(true);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.VALIDATION})
+    ).toBe(true);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.STARTER})
+    ).toBe(true);
+    expect(
+      shouldShowFile({...defaultFile, type: ProjectFileType.LOCKED_STARTER})
+    ).toBe(true);
+    expect(shouldShowFile({...defaultFile, type: undefined})).toBe(true);
+  });
+
+  it('shows basic icons in standard mode', () => {
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.py',
+        type: ProjectFileType.LOCKED_STARTER,
+      })
+    ).toEqual({iconName: 'python', iconStyle: 'regular', isBrand: true});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.txt',
+        type: ProjectFileType.STARTER,
+      })
+    ).toEqual({iconName: 'file', iconStyle: 'regular'});
+  });
+
+  it('shows levelbuilder icons in start mode', () => {
+    mockAppOptions({editBlocks: 'start_sources'});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.py',
+        type: ProjectFileType.VALIDATION,
+      })
+    ).toEqual({iconName: 'flask', iconStyle: 'solid'});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.txt',
+        type: ProjectFileType.SUPPORT,
+      })
+    ).toEqual({iconName: 'eye-slash', iconStyle: 'regular'});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        type: ProjectFileType.LOCKED_STARTER,
+      })
+    ).toEqual({iconName: 'lock', iconStyle: 'solid'});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        type: ProjectFileType.STARTER,
+      })
+    ).toEqual({iconName: 'eye', iconStyle: 'regular'});
+  });
+
+  it('correctly filters source for levelbuilder save', () => {
+    const source = {
+      files: {
+        '1': {...defaultFile, type: ProjectFileType.SYSTEM_SUPPORT},
+        '2': {...defaultFile, id: '2', type: ProjectFileType.STARTER},
+        '3': {
+          ...defaultFile,
+          id: '3',
+          type: ProjectFileType.VALIDATION,
+          open: true,
+          active: true,
+        },
+      },
+      folders: {},
+      openFiles: ['2', '3'],
+    };
+    const expectedParsedSource = {
+      files: {'2': {...defaultFile, id: '2', type: ProjectFileType.STARTER}},
+      folders: {},
+      openFiles: ['2'],
+    };
+    expect(prepareSourceForLevelbuilderSave(source)).toEqual({
+      parsedSource: expectedParsedSource,
+      validationFile: {
+        ...defaultFile,
+        id: '3',
+        open: false,
+        active: false,
+        type: ProjectFileType.VALIDATION,
+      },
+    });
+  });
+
+  it('correctly combines start sources and validation', () => {
+    const startSources = {
+      files: {
+        '1': {...defaultFile, type: ProjectFileType.STARTER},
+      },
+      openFiles: ['1'],
+      folders: {},
+    };
+
+    const validationFile = {
+      ...defaultFile,
+      type: ProjectFileType.VALIDATION,
+      id: '2',
+    };
+
+    const expectedCombinedSources = {
+      files: {
+        '1': {...defaultFile, type: ProjectFileType.STARTER},
+        '2': {
+          ...defaultFile,
+          id: '2',
+          type: ProjectFileType.VALIDATION,
+          open: true,
+        },
+      },
+      openFiles: ['1', '2'],
+      folders: {},
+    };
+
+    expect(
+      combineStartSourcesAndValidation(startSources, validationFile)
+    ).toEqual(expectedCombinedSources);
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for fileUtils. I added tests for all methods except `getValidationFromSource`, as that is just a basic filter method, and is used by a function that is covered by tests here.

## Links

- jira ticket: [CT-956](https://codedotorg.atlassian.net/browse/CT-956)


## Testing story
Only a unit test change, verified that the tests pass.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
