### PR TITLE
AI Chat: delete_all instead of destroy_all in historical data cleanup cron script

### DIFF
--- a/bin/cron/delete_old_ai_chat_data
+++ b/bin/cron/delete_old_ai_chat_data
@@ -16,10 +16,10 @@ def main
   # Pilot data collected before September 30th, 2024 is being retained for analysis.
   pilot_end_date = DateTime.new(2024, 10, 1, 0, 0, 0)
 
-  destroyed_events = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).destroy_all
+  destroyed_events = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
   ChatClient.message('cron-daily', "Deleted #{destroyed_events.length} AichatEvent records")
 
-  destroyed_requests = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).destroy_all
+  destroyed_requests = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
   ChatClient.message('cron-daily', "Deleted #{destroyed_requests.length} AichatRequest records")
 end
 

--- a/bin/cron/delete_old_ai_chat_data
+++ b/bin/cron/delete_old_ai_chat_data
@@ -16,11 +16,11 @@ def main
   # Pilot data collected before September 30th, 2024 is being retained for analysis.
   pilot_end_date = DateTime.new(2024, 10, 1, 0, 0, 0)
 
-  destroyed_events = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
-  ChatClient.message('cron-daily', "Deleted #{destroyed_events.length} AichatEvent records")
+  destroyed_event_count = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
+  ChatClient.message('cron-daily', "Deleted #{destroyed_event_count} AichatEvent records")
 
-  destroyed_requests = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
-  ChatClient.message('cron-daily', "Deleted #{destroyed_requests.length} AichatRequest records")
+  destroyed_request_count = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
+  ChatClient.message('cron-daily', "Deleted #{destroyed_request_count} AichatRequest records")
 end
 
 main


### PR DESCRIPTION
A speculative fix for the timeouts we've been seeing in the AI Chat 90-day data deletion script. `destroy_all` instantiates each record in memory and runs a separate delete query per record, whereas `delete_all` executes a single SQL query to delete all matching records. We'd want `destroy_all` if we had any callbacks to execute on deletion (eg, `after_destroy`), but we don't have any of those.

## Links

- jira ticket: [LABS-1348](https://codedotorg.atlassian.net/browse/LABS-1348)

## Testing story

I tested manually locally at least that running `delete_all` instead of `destroy_all` didn't accidentally wipe all history (ie, it was still limited to the date range established by the where clause) 😅 