### PR TITLE
Blockly: update dark trash color

### DIFF
--- a/apps/lib/blockly/media/trash_dark.png
+++ b/apps/lib/blockly/media/trash_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc5c24ccad198a7c89a76191cf4cc8ed5cb70f39498b099ad4ce8034ba342af3
-size 17959
+oid sha256:7eed546fa54c3291af005d4703da68ef65d25b2937cdaa9424e7aece725e1805
+size 15804


### PR DESCRIPTION
This is small proposed update to https://github.com/code-dot-org/code-dot-org/pull/63380 which updates the color of the Blockly trash in dark mode to be closer to the original color, while still maintaining WCAG AAA compliance for a UI component, using brand color `purple 40`.

### before

<img width="1512" alt="Screenshot 2025-02-20 at 11 21 24 AM" src="https://github.com/user-attachments/assets/2603a477-e11b-4c73-bc5f-26ae4e7980a5" />

### after

<img width="1512" alt="Screenshot 2025-02-20 at 11 17 53 AM" src="https://github.com/user-attachments/assets/4d2ffd69-4316-4092-9657-a383724a951b" />

