### PR TITLE
P20/farsi mvp update teacher tabs

### DIFF
--- a/pegasus/sites.v3/code.org/public/images/resources-tabs-assessments-fa.png
+++ b/pegasus/sites.v3/code.org/public/images/resources-tabs-assessments-fa.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:166aa131aef73b55c8d0b1dd0c768eecc4b0cb6d2a4d5e5956e1ed73c72712d3
+size 50622

--- a/pegasus/sites.v3/code.org/public/images/resources-tabs-progress-fa.png
+++ b/pegasus/sites.v3/code.org/public/images/resources-tabs-progress-fa.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d854856fb225f4a75dfdc4963946b0630beaead0f63ad33f6d65b4656842d4d
+size 220619

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs.haml
@@ -29,7 +29,7 @@
     %div#slides.content.tab-content
       = view :"global/fa/resources_tabs_content_slides"
     %div#assessments.content.tab-content
-      = view :"tabs_section/resources/resources_tabs_content_assessments"
+      = view :"global/fa/resources_tabs_content_assessments"
     %div#tools.content.tab-content
       = view :"global/fa/resources_tabs_content_progress"
 
@@ -46,7 +46,7 @@
     = view :"global/fa/resources_tabs_content_slides"
   %details.assessments
     %summary=hoc_s(:resources_tabs_tab_label_assessments)
-    = view :"tabs_section/resources/resources_tabs_content_assessments"
+    = view :"global/fa/resources_tabs_content_assessments"
   %details.tools
     %summary=hoc_s(:"resources_tabs.progress.tab_label")
     = view :"global/fa/resources_tabs_content_progress"

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_assessments.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_assessments.haml
@@ -8,5 +8,5 @@
         =hoc_s(:resources_tabs_assessments_subhead)
     %p.body-three
       =hoc_s(:resources_tabs_assessments_desc)
-    %a.link-button{href: CDO.studio_url("/global/fa/s/courseb-2022/lessons/13?lang=fa-IR"), target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button{href: CDO.studio_url("/s/courseb-2022/lessons/13?lang=fa-IR", ge_region: request.ge_region), target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_resources_assessments)

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_assessments.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_assessments.haml
@@ -1,6 +1,6 @@
 %div.flex-container.justify-space-between.align-items-center
   %figure.col-50
-    %img.rounded-corners{src: "/images/resources-tabs-assessments.png", alt: "", style: "position: relative; width: 100%;"}
+    %img.rounded-corners{src: "/images/resources-tabs-assessments-fa.png", alt: "", style: "position: relative; width: 100%;"}
   .text-wrapper.col-45{style: "float: right"}
     %h3=hoc_s(:resources_tabs_tab_label_assessments)
     %p
@@ -8,5 +8,5 @@
         =hoc_s(:resources_tabs_assessments_subhead)
     %p.body-three
       =hoc_s(:resources_tabs_assessments_desc)
-    %a.link-button{href: CDO.studio_url("/s/courseb-2022/lessons/13?lang=fa-IR"), target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button{href: CDO.studio_url("/global/fa/s/courseb-2022/lessons/13?lang=fa-IR"), target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_resources_assessments)

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_progress.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_progress.haml
@@ -1,6 +1,6 @@
 %div.flex-container.justify-space-between.align-items-center
   %figure.col-50
-    %img.rounded-corners{src: "/images/resources-tabs-progress.png", alt: "", style: "position: relative; width: 100%;"}
+    %img.rounded-corners{src: "/images/resources-tabs-progress-fa.png", alt: "", style: "position: relative; width: 100%;"}
   .text-wrapper.col-45{style: "float: right"}
     %h3=hoc_s(:"resources_tabs.progress.heading")
     %p.body-three

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_slides.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_slides.haml
@@ -1,6 +1,6 @@
 %div.flex-container.justify-space-between.align-items-center
   %figure.col-50
-    %iframe{allowfullscreen: "true", frameborder: "0", height: "299", mozallowfullscreen: "true", src: "https://docs.google.com/presentation/d/e/2PACX-1vQyh-0nJJcExGA2DyZSGJMfwNCr70NolmCvFUeL8TOZW7gjFqRT2pmYpT469-ZOvJz8EbKcvRQzW0aR/embed?start=false&loop=false&delayms=3000", webkitallowfullscreen: "true", width: "468", style: "max-width: 100%;"}
+    %iframe{allowfullscreen: "true", frameborder: "0", height: "299", mozallowfullscreen: "true", src: "https://docs.google.com/presentation/d/1btgoCeZC2T9fmLdyA9Ql71WcIKe2p2p1OXifpJlkwhw/embed", webkitallowfullscreen: "true", width: "468", style: "max-width: 100%;"}
   .text-wrapper.col-45{style: "float: right"}
     %h3=hoc_s(:resources_tabs_slides_heading)
     %p
@@ -8,5 +8,5 @@
         =hoc_s(:resources_tabs_slides_subhead)
     %p.body-three
       =hoc_s(:resources_tabs_slides_desc)
-    %a.link-button.has-external-link{href: "https://docs.google.com/presentation/d/1lR2Il6bOm-OHQltTtHO5XJ_p0q2J-3dye_RiCZW-sGY/template/preview", target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button.has-external-link{href: "https://docs.google.com/presentation/d/1btgoCeZC2T9fmLdyA9Ql71WcIKe2p2p1OXifpJlkwhw/template/preview", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_resources_slides)

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_videos.haml
@@ -1,6 +1,6 @@
 %div.flex-container.justify-space-between.align-items-center
   %figure.col-50
-    = view :video_with_fallback, video_code: "gp7f8HZqPsPk", download_path: "//videos.code.org/farsi/ai-01-intro-to-ai.mp4"
+    = view :video_with_fallback, video_code: "UzrBpYrcacM", download_path: "//videos.code.org/farsi/ai-01-intro-to-ai.mp4"
     %figcaption.no-margin-bottom
       =hoc_s(:ai_vid_intro_caption)
   .text-wrapper.col-45{style: "float: right"}
@@ -10,5 +10,5 @@
         =hoc_s(:resources_tabs_videos_subhead)
     %p.body-three
       =hoc_s(:resources_tabs_videos_desc)
-    %a.link-button{href: "https://www.youtube.com/watch?v=p7f8HZqPsPk", target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button{href: "https://www.youtube.com/watch?v=UzrBpYrcacM", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_resources_videos)


### PR DESCRIPTION
Updates the teacher page for the Farsi MVP marketing pages (pegasus) to provide information and images in Farsi.

This does a few things that will be illustrated below. There are five tabs. The first one was already ready and had a translated image. The other four tabs are addressed here:

1. Update the videos tab (which was broken) to point to a valid Farsi video, specifically the AI video.
2. Update the progress tab to show the progress view image with Arabic instead of English.
3. Update the assessment tab with a screenshot of a teacher rubric rendered in our Farsi translations.
4. Update the slides tab to point to a Farsi-translated slide deck and also embed it instead of the English one.

| Visual Aids |
|------------|
| **Video Tab** |
| ![image](https://github.com/user-attachments/assets/78af42ec-6c8e-4265-b44d-14fe332d4903) |
| **Slides Tab** |
| ![image](https://github.com/user-attachments/assets/958c1456-5307-4492-bc2c-d772fb94e00c) |
| **Assessment Tab** |
| ![image](https://github.com/user-attachments/assets/5972a86d-7ad2-4d29-88ae-8a061f5eeaa6) |
| **Progress Tab** |
| ![image](https://github.com/user-attachments/assets/9e7d70b2-148d-4636-a4d5-c712ff1e342d) |

## Links

- jira ticket: [P20-1169](https://codedotorg.atlassian.net/browse/P20-1169)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
