### PR TITLE
AI Chat: Remove experimental suffix from gpt-4o-mini model name

### DIFF
--- a/apps/static/aichat/modelDescriptions.json
+++ b/apps/static/aichat/modelDescriptions.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53509496424051069c9671ba427a32a32fc8574474be6734c2e5d586be216cf0
-size 2392
+oid sha256:48df3cd7933600e18559fae4c7a41bd7b7b1b7da55616bb7c6e800ca1c62ed1d
+size 2354


### PR DESCRIPTION
Removes the "experimental" suffix from the user-facing name for gpt-4o-mini.