### PR TITLE
Improvements to file tabs and add tests

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -8,7 +8,7 @@
   "cannotTest": "We don't know how to run your tests. Please contact support.",
   "changeLayout": "Change layout",
   "clearConsole": "Clear console",
-  "closeFile": "close file",
+  "closeFile": "close file {filename}",
   "consoleHeader": "Console",
   "defaultLayout": "Default layout",
   "defaultNewFileContents": "Add your changes to {fileName}",

--- a/apps/src/codebridge/Editor/index.tsx
+++ b/apps/src/codebridge/Editor/index.tsx
@@ -54,11 +54,7 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
   }
 
   return (
-    <div
-      className={moduleStyles.editorContainer}
-      role="tabpanel"
-      id="codebridge-editor"
-    >
+    <div className={moduleStyles.editorContainer}>
       {file ? (
         <CodeEditor
           key={`${file.id}/${1}`}

--- a/apps/src/codebridge/Editor/index.tsx
+++ b/apps/src/codebridge/Editor/index.tsx
@@ -54,7 +54,11 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
   }
 
   return (
-    <div className={moduleStyles.editorContainer}>
+    <div
+      className={moduleStyles.editorContainer}
+      role="tabpanel"
+      id="codebridge-editor"
+    >
       {file ? (
         <CodeEditor
           key={`${file.id}/${1}`}

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -25,13 +25,14 @@ const FileTab = ({file}: FileTabProps) => {
     [moduleStyles.active]: isActive,
   });
 
-  const handleClose = (id: string) => {
-    console.log('in handleClose');
-    closeFile(id);
-  };
-
   return (
-    <div className={className} key={file.id}>
+    <div
+      className={className}
+      key={file.id}
+      aria-selected={isActive}
+      role="tab"
+      aria-controls="codebridge-editor"
+    >
       <div
         className={moduleStyles.label}
         onClick={() => setActiveFile(file.id)}
@@ -44,7 +45,7 @@ const FileTab = ({file}: FileTabProps) => {
         <span>{file.name}</span>
       </div>
       <CloseButton
-        onClick={() => handleClose(file.id)}
+        onClick={() => closeFile(file.id)}
         color={'light'}
         aria-label={codebridgeI18n.closeFile()}
         className={classNames(moduleStyles.closeButton, {

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -25,14 +25,13 @@ const FileTab = ({file}: FileTabProps) => {
     [moduleStyles.active]: isActive,
   });
 
+  const handleClose = (id: string) => {
+    console.log('in handleClose');
+    closeFile(id);
+  };
+
   return (
-    <div
-      className={className}
-      key={file.id}
-      aria-selected={isActive}
-      role="tab"
-      aria-controls="codebridge-editor"
-    >
+    <div className={className} key={file.id}>
       <div
         className={moduleStyles.label}
         onClick={() => setActiveFile(file.id)}
@@ -45,7 +44,7 @@ const FileTab = ({file}: FileTabProps) => {
         <span>{file.name}</span>
       </div>
       <CloseButton
-        onClick={() => closeFile(file.id)}
+        onClick={() => handleClose(file.id)}
         color={'light'}
         aria-label={codebridgeI18n.closeFile()}
         className={classNames(moduleStyles.closeButton, {

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -26,7 +26,13 @@ const FileTab = ({file}: FileTabProps) => {
   });
 
   return (
-    <div className={className} key={file.id}>
+    <div
+      className={className}
+      key={file.id}
+      aria-selected={isActive}
+      role="tab"
+      aria-controls="codebridge-editor"
+    >
       <div
         className={moduleStyles.label}
         onClick={() => setActiveFile(file.id)}

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -26,16 +26,14 @@ const FileTab = ({file}: FileTabProps) => {
   });
 
   return (
-    <div
-      className={className}
-      key={file.id}
-      aria-selected={isActive}
-      role="tab"
-      aria-controls="codebridge-editor"
-    >
+    <div className={className} key={file.id}>
       <div
         className={moduleStyles.label}
         onClick={() => setActiveFile(file.id)}
+        aria-selected={isActive}
+        role="tab"
+        aria-controls="codebridge-editor"
+        tabIndex={0}
       >
         <FontAwesomeV6Icon
           iconName={iconName}

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -45,7 +45,7 @@ const FileTab = ({file}: FileTabProps) => {
       <CloseButton
         onClick={() => closeFile(file.id)}
         color={'light'}
-        aria-label={codebridgeI18n.closeFile()}
+        aria-label={codebridgeI18n.closeFile({filename: file.name})}
         className={classNames(moduleStyles.closeButton, {
           [moduleStyles.active]: isActive,
           [moduleStyles.inactive]: !isActive,

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -30,10 +30,6 @@ const FileTab = ({file}: FileTabProps) => {
       <div
         className={moduleStyles.label}
         onClick={() => setActiveFile(file.id)}
-        aria-selected={isActive}
-        role="tab"
-        aria-controls="codebridge-editor"
-        tabIndex={0}
       >
         <FontAwesomeV6Icon
           iconName={iconName}

--- a/apps/src/codebridge/FileTabs/Sortable.tsx
+++ b/apps/src/codebridge/FileTabs/Sortable.tsx
@@ -5,16 +5,18 @@ import React from 'react';
 interface SortableProps {
   id: string;
   isDragging: boolean;
+  isActive: boolean;
   children: React.ReactNode;
 }
 
 const Sortable: React.FunctionComponent<SortableProps> = ({
   id,
   isDragging,
+  isActive,
   children,
 }) => {
   const {attributes, listeners, setNodeRef, transform, transition} =
-    useSortable({id});
+    useSortable({id, attributes: {role: 'tab'}});
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -23,7 +25,14 @@ const Sortable: React.FunctionComponent<SortableProps> = ({
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      aria-selected={isActive}
+      aria-controls="codebridge-editor"
+    >
       {children}
     </div>
   );

--- a/apps/src/codebridge/FileTabs/Sortable.tsx
+++ b/apps/src/codebridge/FileTabs/Sortable.tsx
@@ -5,18 +5,16 @@ import React from 'react';
 interface SortableProps {
   id: string;
   isDragging: boolean;
-  isActive: boolean;
   children: React.ReactNode;
 }
 
 const Sortable: React.FunctionComponent<SortableProps> = ({
   id,
   isDragging,
-  isActive,
   children,
 }) => {
   const {attributes, listeners, setNodeRef, transform, transition} =
-    useSortable({id, attributes: {role: 'tab'}});
+    useSortable({id});
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -25,14 +23,7 @@ const Sortable: React.FunctionComponent<SortableProps> = ({
   };
 
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      {...attributes}
-      {...listeners}
-      aria-selected={isActive}
-      aria-controls="codebridge-editor"
-    >
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
       {children}
     </div>
   );

--- a/apps/src/codebridge/FileTabs/index.tsx
+++ b/apps/src/codebridge/FileTabs/index.tsx
@@ -23,6 +23,8 @@ import {
 } from '@dnd-kit/sortable';
 import React, {useState} from 'react';
 
+import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
+
 import FileTab from './FileTab';
 import Sortable from './Sortable';
 
@@ -30,6 +32,7 @@ import moduleStyles from './styles/fileTabs.module.scss';
 
 export const FileTabs = React.memo(() => {
   const {source, rearrangeFiles, setActiveFile} = useCodebridgeContext();
+  const activeFile = getActiveFileForSource(source);
 
   const files = getOpenFiles(source);
 
@@ -57,6 +60,7 @@ export const FileTabs = React.memo(() => {
     }
   }
   function handleDragStart(event: DragStartEvent) {
+    console.log('in handleDragStart');
     // Handle drag start only if the file is in the list of open files.
     // This can get called when the close button is clicked, and we want to ignore
     // it in this case.
@@ -77,7 +81,12 @@ export const FileTabs = React.memo(() => {
       >
         <SortableContext items={files} strategy={horizontalListSortingStrategy}>
           {files.map(f => (
-            <Sortable id={f.id} key={f.id} isDragging={f.id === draggingFileId}>
+            <Sortable
+              id={f.id}
+              key={f.id}
+              isDragging={f.id === draggingFileId}
+              isActive={activeFile?.id === f.id}
+            >
               <FileTab file={f} />
             </Sortable>
           ))}

--- a/apps/src/codebridge/FileTabs/index.tsx
+++ b/apps/src/codebridge/FileTabs/index.tsx
@@ -23,8 +23,6 @@ import {
 } from '@dnd-kit/sortable';
 import React, {useState} from 'react';
 
-import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
-
 import FileTab from './FileTab';
 import Sortable from './Sortable';
 
@@ -32,7 +30,6 @@ import moduleStyles from './styles/fileTabs.module.scss';
 
 export const FileTabs = React.memo(() => {
   const {source, rearrangeFiles, setActiveFile} = useCodebridgeContext();
-  const activeFile = getActiveFileForSource(source);
 
   const files = getOpenFiles(source);
 
@@ -64,7 +61,7 @@ export const FileTabs = React.memo(() => {
     // Handle drag start only if the file is in the list of open files.
     // This can get called when the close button is clicked, and we want to ignore
     // it in this case.
-    if (files.find(f => f.id === event.active.id)) {
+    if (source.files[event.active.id as string].open) {
       setDraggingFileId(event.active.id as string);
       setActiveFile(event.active.id as string);
     }
@@ -81,12 +78,7 @@ export const FileTabs = React.memo(() => {
       >
         <SortableContext items={files} strategy={horizontalListSortingStrategy}>
           {files.map(f => (
-            <Sortable
-              id={f.id}
-              key={f.id}
-              isDragging={f.id === draggingFileId}
-              isActive={activeFile?.id === f.id}
-            >
+            <Sortable id={f.id} key={f.id} isDragging={f.id === draggingFileId}>
               <FileTab file={f} />
             </Sortable>
           ))}

--- a/apps/src/codebridge/FileTabs/index.tsx
+++ b/apps/src/codebridge/FileTabs/index.tsx
@@ -62,7 +62,7 @@ export const FileTabs = React.memo(() => {
   }
 
   return (
-    <div className={moduleStyles.fileTabs}>
+    <div className={moduleStyles.fileTabs} role="tablist">
       <DndContext
         onDragEnd={handleDragEnd}
         onDragStart={handleDragStart}

--- a/apps/src/codebridge/FileTabs/index.tsx
+++ b/apps/src/codebridge/FileTabs/index.tsx
@@ -29,7 +29,7 @@ import Sortable from './Sortable';
 import moduleStyles from './styles/fileTabs.module.scss';
 
 export const FileTabs = React.memo(() => {
-  const {source, rearrangeFiles} = useCodebridgeContext();
+  const {source, rearrangeFiles, setActiveFile} = useCodebridgeContext();
 
   const files = getOpenFiles(source);
 
@@ -57,8 +57,13 @@ export const FileTabs = React.memo(() => {
     }
   }
   function handleDragStart(event: DragStartEvent) {
-    setDraggingFileId(event.active.id as string);
-    // set file to active
+    // Handle drag start only if the file is in the list of open files.
+    // This can get called when the close button is clicked, and we want to ignore
+    // it in this case.
+    if (files.find(f => f.id === event.active.id)) {
+      setDraggingFileId(event.active.id as string);
+      setActiveFile(event.active.id as string);
+    }
   }
 
   return (

--- a/apps/src/codebridge/FileTabs/index.tsx
+++ b/apps/src/codebridge/FileTabs/index.tsx
@@ -67,7 +67,7 @@ export const FileTabs = React.memo(() => {
   }
 
   return (
-    <div className={moduleStyles.fileTabs} role="tablist">
+    <div className={moduleStyles.fileTabs}>
       <DndContext
         onDragEnd={handleDragEnd}
         onDragStart={handleDragStart}

--- a/apps/src/codebridge/FileTabs/index.tsx
+++ b/apps/src/codebridge/FileTabs/index.tsx
@@ -57,7 +57,6 @@ export const FileTabs = React.memo(() => {
     }
   }
   function handleDragStart(event: DragStartEvent) {
-    console.log('in handleDragStart');
     // Handle drag start only if the file is in the list of open files.
     // This can get called when the close button is clicked, and we want to ignore
     // it in this case.

--- a/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
+++ b/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
@@ -1,4 +1,5 @@
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import {
@@ -36,6 +37,7 @@ const context: CodebridgeContextType = {
     folders: {},
   },
   setActiveFile: jest.fn(),
+  closeFile: jest.fn(),
 };
 
 describe('FileTabs', () => {
@@ -56,7 +58,18 @@ describe('FileTabs', () => {
     const file = context.source.files['1'];
     const tab = screen.getByRole('tab', {selected: false});
     expect(tab).toHaveTextContent(file.name);
-    fireEvent.click(tab);
+    const user = userEvent.setup();
+    await user.click(tab);
     expect(context.setActiveFile).toHaveBeenCalledWith(file.id);
+  });
+
+  it('can close a tab', async () => {
+    renderDefault();
+    const closeButton = screen.getByRole('button', {
+      name: 'close file file1.py',
+    });
+    const user = userEvent.setup();
+    await user.click(closeButton);
+    expect(context.closeFile).toHaveBeenCalledWith('1');
   });
 });

--- a/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
+++ b/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
@@ -4,11 +4,12 @@ import React from 'react';
 import {
   CodebridgeContextProvider,
   CodebridgeContextType,
+  useSourceUtilities,
 } from '@cdo/apps/codebridge';
 import {FileTabs} from '@cdo/apps/codebridge/FileTabs';
 
 import {getDefaultCodebridgeContext} from '../test_utils';
-import '@testing-library/jest-native';
+import '@testing-library/jest-dom';
 
 const context: CodebridgeContextType = {
   ...getDefaultCodebridgeContext(),
@@ -35,6 +36,7 @@ const context: CodebridgeContextType = {
     },
     folders: {},
   },
+  setActiveFile: jest.fn(),
 };
 
 describe('FileTabs', () => {
@@ -55,7 +57,6 @@ describe('FileTabs', () => {
     const file = context.source.files['1'];
     const tab = screen.getByText(file.name);
     fireEvent.click(tab);
-    const activeTab = screen.getByRole('tab', {selected: true});
-    expect(activeTab).toHaveTextContent(file.name);
+    expect(context.setActiveFile).toHaveBeenCalledWith(file.id);
   });
 });

--- a/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
+++ b/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
@@ -1,0 +1,61 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {
+  CodebridgeContextProvider,
+  CodebridgeContextType,
+} from '@cdo/apps/codebridge';
+import {FileTabs} from '@cdo/apps/codebridge/FileTabs';
+
+import {getDefaultCodebridgeContext} from '../test_utils';
+import '@testing-library/jest-native';
+
+const context: CodebridgeContextType = {
+  ...getDefaultCodebridgeContext(),
+  source: {
+    files: {
+      '1': {
+        id: '1',
+        name: 'file1.py',
+        active: false,
+        open: true,
+        language: 'py',
+        contents: '',
+        folderId: '0',
+      },
+      '2': {
+        id: '2',
+        name: 'file2.py',
+        active: true,
+        open: true,
+        language: 'py',
+        contents: '',
+        folderId: '0',
+      },
+    },
+    folders: {},
+  },
+};
+
+describe('FileTabs', () => {
+  function renderDefault() {
+    render(
+      <CodebridgeContextProvider value={context}>
+        <FileTabs />
+      </CodebridgeContextProvider>
+    );
+  }
+
+  it('activates an inactive tab on click', async () => {
+    renderDefault();
+    const defaultOpenFile = context.source.files['2'];
+    expect(screen.getByRole('tab', {selected: true})).toHaveTextContent(
+      defaultOpenFile.name
+    );
+    const file = context.source.files['1'];
+    const tab = screen.getByText(file.name);
+    fireEvent.click(tab);
+    const activeTab = screen.getByRole('tab', {selected: true});
+    expect(activeTab).toHaveTextContent(file.name);
+  });
+});

--- a/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
+++ b/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
@@ -54,10 +54,8 @@ describe('FileTabs', () => {
       defaultOpenFile.name
     );
     const file = context.source.files['1'];
-    expect(screen.getByRole('tab', {selected: false})).toHaveTextContent(
-      file.name
-    );
-    const tab = screen.getByText(file.name);
+    const tab = screen.getByRole('tab', {selected: false});
+    expect(tab).toHaveTextContent(file.name);
     fireEvent.click(tab);
     expect(context.setActiveFile).toHaveBeenCalledWith(file.id);
   });

--- a/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
+++ b/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
@@ -53,13 +53,8 @@ describe('FileTabs', () => {
   // userEvent seems to take a while on drone/staging.
   it('activates an inactive tab on click', async () => {
     renderDefault();
-    const defaultOpenFile = context.source.files['2'];
-    expect(screen.getByRole('tab', {selected: true})).toHaveTextContent(
-      defaultOpenFile.name
-    );
     const file = context.source.files['1'];
-    const tab = screen.getByRole('tab', {selected: false});
-    expect(tab).toHaveTextContent(file.name);
+    const tab = screen.getByText(file.name);
     const user = userEvent.setup();
     await user.click(tab);
     expect(context.setActiveFile).toHaveBeenCalledWith(file.id);

--- a/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
+++ b/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
@@ -49,6 +49,8 @@ describe('FileTabs', () => {
     );
   }
 
+  // Timeout increased to 10 seconds for these tests because sometimes
+  // userEvent seems to take a while on drone/staging.
   it('activates an inactive tab on click', async () => {
     renderDefault();
     const defaultOpenFile = context.source.files['2'];
@@ -61,7 +63,7 @@ describe('FileTabs', () => {
     const user = userEvent.setup();
     await user.click(tab);
     expect(context.setActiveFile).toHaveBeenCalledWith(file.id);
-  });
+  }, 10000);
 
   it('can close a tab', async () => {
     renderDefault();
@@ -71,5 +73,5 @@ describe('FileTabs', () => {
     const user = userEvent.setup();
     await user.click(closeButton);
     expect(context.closeFile).toHaveBeenCalledWith('1');
-  });
+  }, 10000);
 });

--- a/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
+++ b/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {
   CodebridgeContextProvider,
   CodebridgeContextType,
-  useSourceUtilities,
 } from '@cdo/apps/codebridge';
 import {FileTabs} from '@cdo/apps/codebridge/FileTabs';
 
@@ -55,6 +54,9 @@ describe('FileTabs', () => {
       defaultOpenFile.name
     );
     const file = context.source.files['1'];
+    expect(screen.getByRole('tab', {selected: false})).toHaveTextContent(
+      file.name
+    );
     const tab = screen.getByText(file.name);
     fireEvent.click(tab);
     expect(context.setActiveFile).toHaveBeenCalledWith(file.id);


### PR DESCRIPTION
This PR contains a few fixes around the file tabs.

Emma [reported](https://codedotorg.slack.com/archives/C06JELCAPT9/p1739917339331959) that she would often need to click multiple times on a tab to get it to activate. I could only rarely repro this issue, and not nearly at the rate she could. I suspect the increase on her end may be due to a browser plugin. 

I believe the cause here is that there are competing click events. The tabs are draggable and droppable, both with the mouse and keyboard. You should need to do a long press to activate drag, but it's possible the drag handler was occasionally overriding the underlying activate click handler. In addition, if you used the keyboard over the tabs and pressed enter on one, it wouldn't activate the tab (although it would initiate drag and drop). The fix for both of these issues was when the drag handler starts, also activate the tab if it is still open.  "If it is still open" is key here, and it still an outstanding issue. The tabs also have a close button. The button works great when you click with your mouse. It is focusable with the keyboard. However, when you have it focused with the keyboard, pressing enter does nothing. This is because the drag handler is activating and preventing the close button handler from running. I filed [CT-1067](https://codedotorg.atlassian.net/browse/CT-1067) to fix this.

After applying the change described above, I could no longer trigger the issue with needing to click multiple times.

I also added a couple unit tests, which sent me down a rabbit hole. React Testing Library prefers using role to find elements. I discovered there is a `tab` role, which corresponds with `tablist` (the container of the tabs) and `tabpanel` (the thing the tabs are controlling). I considered adding those roles here, but it caused an additional keyboard tab to be required when navigating between the tabs (because the we had the overall button for drag and drop, the inner tab, and the close button). So the unit tests use `getByText`.

## Links

- jira ticket: [CT-1062](https://codedotorg.atlassian.net/browse/CT-1062)

## Testing story
Tested locally and added tests.


## Follow-up work
- Confirm this fixes the issue for Emma.
- Fix the issue of the close button not being keyboard accessible.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
