### PR TITLE
chore: reduce jest workers to 50%

### DIFF
--- a/apps/jest.config.js
+++ b/apps/jest.config.js
@@ -96,7 +96,7 @@ const config = {
   // globals: {},
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-  maxWorkers: '75%',
+  maxWorkers: '50%',
 
   // An array of directory names to be searched recursively up from the requiring module's location
   // moduleDirectories: [


### PR DESCRIPTION
Staging continues to have jest build failures likely due to resources running out. We previously attempted to remediate this by decreasing workers to 75% in #63955 and it does seem to reduce the number of failing tests, but not to a stable level. This PR further reduces workers to 50%, which is likely the lowest amount before tests start to take really long. If this still does not work, some deeper analysis would be required to understand why so much resources is being consumed.
