### PR TITLE
update aiTutor level from lab2

### DIFF
--- a/apps/src/aiTutor/redux/aiTutorRedux.ts
+++ b/apps/src/aiTutor/redux/aiTutorRedux.ts
@@ -132,6 +132,9 @@ const aiTutorSlice = createSlice({
       state.aiResponse = action.payload;
     },
     setLevel: (state, action: PayloadAction<Level | undefined>) => {
+      if (state.level?.id !== action.payload?.id) {
+        state.chatMessages = initialChatMessages; // Reset chat if the level changes (e.g. when switching levels without a page reload)
+      }
       state.level = action.payload;
     },
     setScriptId: (state, action: PayloadAction<number | undefined>) => {

--- a/apps/src/aiTutor/redux/aiTutorRedux.ts
+++ b/apps/src/aiTutor/redux/aiTutorRedux.ts
@@ -133,7 +133,9 @@ const aiTutorSlice = createSlice({
     },
     setLevel: (state, action: PayloadAction<Level | undefined>) => {
       if (state.level?.id !== action.payload?.id) {
-        state.chatMessages = initialChatMessages; // Reset chat if the level changes (e.g. when switching levels without a page reload)
+        // Reset chat if the level changes (e.g. when switching levels without a page reload)
+        state.chatMessages = initialChatMessages;
+        state.isChatOpen = false;
       }
       state.level = action.payload;
     },

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -24,6 +24,7 @@ import {
 } from '@cdo/apps/templates/currentUserRedux';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
+import {setLevel} from '../aiTutor/redux/aiTutorRedux';
 import {getCurrentLevel} from '../code-studio/progressReduxSelectors';
 import {
   setProjectUpdatedAt,
@@ -55,6 +56,17 @@ import {
   Validation,
 } from './types';
 import {LifecycleEvent} from './utils/LifecycleNotifier';
+
+const mapLevelPropertiesToAITutorLevel = (levelProperties: LevelProperties) => {
+  return {
+    id: levelProperties.id,
+    type: '', // TODO: Map the type directly from levelProperties
+    aiTutorAvailable: !!levelProperties.aiTutorAvailable,
+    hasValidation: false, // TODO: If there are validations, set to true
+    isAssessment: false, // TODO: Add to levelProperties
+    progressionType: 'other', // TODO
+  };
+};
 
 interface PageError {
   errorMessage: string;
@@ -144,8 +156,14 @@ export const setUpWithLevel = createAsyncThunk<
     const levelProperties = await loadLevelProperties(
       payload.levelPropertiesPath
     );
-
+    console.log('****levelProperties', levelProperties);
     thunkAPI.dispatch(setScriptId(payload.scriptId));
+
+    // TODO: Workaround for AI Tutor for now
+    // Massage levelProperties to match aiTutor's format
+    const aiTutorLevel = mapLevelPropertiesToAITutorLevel(levelProperties);
+    console.log('setting level', aiTutorLevel);
+    thunkAPI.dispatch(setLevel(aiTutorLevel));
 
     Lab2Registry.getInstance()
       .getMetricsReporter()

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -57,16 +57,16 @@ import {
 } from './types';
 import {LifecycleEvent} from './utils/LifecycleNotifier';
 
-const mapLevelPropertiesToAITutorLevel = (levelProperties: LevelProperties) => {
-  return {
-    id: levelProperties.id,
-    type: '', // TODO: Map the type directly from levelProperties
-    aiTutorAvailable: !!levelProperties.aiTutorAvailable,
-    hasValidation: false, // TODO: If there are validations, set to true
-    isAssessment: false, // TODO: Add to levelProperties
-    progressionType: 'other', // TODO
-  };
-};
+const mapLevelPropertiesToAITutorLevel = (
+  levelProperties: LevelProperties
+) => ({
+  id: levelProperties.id,
+  type: levelProperties.type || '',
+  aiTutorAvailable: !!levelProperties.aiTutorAvailable,
+  hasValidation: !!levelProperties.hasValidation,
+  isAssessment: !!levelProperties.isAssessment,
+  progressionType: levelProperties.progressionType || '',
+});
 
 interface PageError {
   errorMessage: string;

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -63,7 +63,8 @@ const mapLevelPropertiesToAITutorLevel = (
   id: levelProperties.id,
   type: levelProperties.type || '',
   aiTutorAvailable: !!levelProperties.aiTutorAvailable,
-  hasValidation: !!levelProperties.hasValidation,
+  hasValidation:
+    !!levelProperties.validations && levelProperties.validations.length > 0,
   isAssessment: !!levelProperties.isAssessment,
   progressionType: levelProperties.progressionType || '',
 });

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -158,7 +158,6 @@ export const setUpWithLevel = createAsyncThunk<
     );
     thunkAPI.dispatch(setScriptId(payload.scriptId));
 
-    // TODO: Workaround for AI Tutor for now
     // Massage levelProperties to match aiTutor's format
     const aiTutorLevel = mapLevelPropertiesToAITutorLevel(levelProperties);
     thunkAPI.dispatch(setLevel(aiTutorLevel));

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -156,13 +156,11 @@ export const setUpWithLevel = createAsyncThunk<
     const levelProperties = await loadLevelProperties(
       payload.levelPropertiesPath
     );
-    console.log('****levelProperties', levelProperties);
     thunkAPI.dispatch(setScriptId(payload.scriptId));
 
     // TODO: Workaround for AI Tutor for now
     // Massage levelProperties to match aiTutor's format
     const aiTutorLevel = mapLevelPropertiesToAITutorLevel(levelProperties);
-    console.log('setting level', aiTutorLevel);
     thunkAPI.dispatch(setLevel(aiTutorLevel));
 
     Lab2Registry.getInstance()

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -209,6 +209,7 @@ export interface LevelProperties {
   miniApp?: string;
   serializedMaze?: MazeCell[][];
   startDirection?: number;
+  aiTutorAvailable?: boolean | undefined;
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -209,7 +209,12 @@ export interface LevelProperties {
   miniApp?: string;
   serializedMaze?: MazeCell[][];
   startDirection?: number;
-  aiTutorAvailable?: boolean | undefined;
+  // Properties added for parity with non-lab2 AI Tutor levels
+  aiTutorAvailable?: boolean;
+  hasValidation?: boolean;
+  isAssessment?: boolean;
+  progressionType?: string;
+  type?: string;
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -211,7 +211,6 @@ export interface LevelProperties {
   startDirection?: number;
   // Properties added for parity with non-lab2 AI Tutor levels
   aiTutorAvailable?: boolean;
-  hasValidation?: boolean;
   isAssessment?: boolean;
   progressionType?: string;
   type?: string;

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -855,6 +855,9 @@ class Level < ApplicationRecord
     properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
     properties_camelized[:finishUrl] = script_level.next_level_or_redirect_path_for_user(current_user) if script_level
     properties_camelized[:baseAssetUrl] = Blockly.base_url
+    properties_camelized[:hasValidation] = validated?
+    properties_camelized[:isAssessment] = script_level&.assessment
+    properties_camelized[:progressionType] = script_level&.primm_progression_type
 
     if try(:project_template_level).try(:start_sources)
       properties_camelized['templateSources'] = try(:project_template_level).try(:start_sources)

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -855,7 +855,6 @@ class Level < ApplicationRecord
     properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
     properties_camelized[:finishUrl] = script_level.next_level_or_redirect_path_for_user(current_user) if script_level
     properties_camelized[:baseAssetUrl] = Blockly.base_url
-    properties_camelized[:hasValidation] = validated?
     properties_camelized[:isAssessment] = script_level&.assessment
     properties_camelized[:progressionType] = script_level&.primm_progression_type
 

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -85,7 +85,24 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"id" => level.id, "levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false, "exemplarSources" => nil, "helpVideos" => [], "baseAssetUrl" => "/blockly/"}, body)
+    expected_body = {
+      "id" => 4335,
+      "levelData" => {"hello" => "there"},
+      "other" => "other",
+      "preloadAssetList" => nil,
+      "type" => "Maze",
+      "appName" => "maze",
+      "useRestrictedSongs" => false,
+      "sharedBlocks" => [],
+      "usesProjects" => false,
+      "exemplarSources" => nil,
+      "helpVideos" => [],
+      "baseAssetUrl" => "/blockly/",
+      "hasValidation" => true,
+      "isAssessment" => nil,
+      "progressionType" => nil
+    }
+    assert_equal(expected_body, body)
   end
 
   test "should get filtered levels with just page param" do

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -78,7 +78,7 @@ class LevelsControllerTest < ActionController::TestCase
     )
   end
 
-  test "should return level_properties " do
+  test "should return level_properties" do
     level = create :maze, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
 
     get :level_properties, params: {id: level}
@@ -86,7 +86,7 @@ class LevelsControllerTest < ActionController::TestCase
 
     body = JSON.parse(response.body)
     expected_body = {
-      "id" => 4335,
+      "id" => level.id,
       "levelData" => {"hello" => "there"},
       "other" => "other",
       "preloadAssetList" => nil,
@@ -98,7 +98,6 @@ class LevelsControllerTest < ActionController::TestCase
       "exemplarSources" => nil,
       "helpVideos" => [],
       "baseAssetUrl" => "/blockly/",
-      "hasValidation" => true,
       "isAssessment" => nil,
       "progressionType" => nil
     }


### PR DESCRIPTION
Emma reported a bug that the AI Tutor floating action button was "following her" in Python Lab because the lab2 properties updating were not causing a rerender of the AI Tutor components: https://codedotorg.slack.com/archives/C06KYAJDB24/p1740075009536489

This PR dispatches an update to the `aiTutor.level` field from inside of lab2 `lab/setUpWithLevel` so that when the Lab2 level reloads, AI Tutor state is updated accordingly. Not all of the fields on AI Tutor's `Level` property existed on the lab2 properties, so I added them here: https://github.com/code-dot-org/code-dot-org/blob/ec02774382f8c0550fde1e0b95feacef60b5d531/dashboard/app/models/levels/level.rb#L846

## Links

Slack thread: https://codedotorg.slack.com/archives/C06KYAJDB24/p1740075009536489
Jira ticket: https://codedotorg.atlassian.net/browse/CT-1068

## Testing story

Here's a video showing that AI Tutor is now appropriately disabled on certain levels based on the level settings and switching for Lab2:

https://github.com/user-attachments/assets/20fc51c7-edb9-461c-8d0f-4be6a701574c

I also noticed that the chat history was not getting reset between levels, so I added code in the `setLevel` function in AI Tutor to reset the chat history when the level ID changes:

https://github.com/user-attachments/assets/813facd2-cfe5-44fa-a078-c6a061f482a0

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
