### PR TITLE
[CMS-104] CMS - Typography (Heading, Paragraph, Link) - add text color change logic

### DIFF
--- a/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
+++ b/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
@@ -21,6 +21,8 @@ type ParagraphProps = {
   visualAppearance: ParagraphVisualAppearance;
   /** Whether the paragraph text is strong */
   isStrong: boolean;
+  /** Paragraph color */
+  color: 'primary' | 'secondary';
   /** ClassName passed by contentful to apply styles that are set through contentful native editor*/
   className?: string;
 };
@@ -28,13 +30,18 @@ type ParagraphProps = {
 const Paragraph: React.FunctionComponent<ParagraphProps> = ({
   visualAppearance,
   isStrong,
+  color,
   children,
   className,
 }) => (
   <Typography
     semanticTag="p"
     visualAppearance={visualAppearance}
-    className={classNames(moduleStyles.paragraph, className)}
+    className={classNames(
+      moduleStyles.paragraph,
+      moduleStyles[`paragraph-color-${color}`],
+      className,
+    )}
   >
     {isStrong ? <StrongText>{children}</StrongText> : children}
   </Typography>

--- a/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
@@ -29,6 +29,18 @@ export const ParagraphContentfulComponentDefinition: ComponentDefinition = {
         ],
       },
     },
+    color: {
+      displayName: 'Color',
+      type: 'Text',
+      defaultValue: 'primary',
+      group: 'style',
+      validations: {
+        in: [
+          {value: 'primary', displayName: 'Primary'},
+          {value: 'secondary', displayName: 'Secondary'},
+        ],
+      },
+    },
     children: {
       displayName: 'Content',
       type: 'Text',

--- a/frontend/apps/marketing/src/components/paragraph/paragraph.module.scss
+++ b/frontend/apps/marketing/src/components/paragraph/paragraph.module.scss
@@ -5,4 +5,15 @@ p {
   &.paragraph {
     margin-top: 0;
   }
+
+  // Paragraph colors
+  &.paragraph-color {
+    &-primary {
+      color: var(--text-neutral-primary);
+    }
+
+    &-secondary {
+      color: var(--text-neutral-secondary);
+    }
+  }
 }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [CMS-104] CMS - Typography (Heading, Paragraph, Link) - add text color change logic

* feat(paragraph): added color options

https://github.com/user-attachments/assets/7eb94b13-e90a-44a2-8a03-612d1f9ec3ca


## Links
- jira ticket: [CMS-104](https://codedotorg.atlassian.net/browse/CMS-104)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
