### PR TITLE
Add migration for creating aichat message feedback table

### DIFF
--- a/dashboard/app/models/aichat_message.rb
+++ b/dashboard/app/models/aichat_message.rb
@@ -17,6 +17,7 @@
 #
 class AichatMessage < ApplicationRecord
   belongs_to :aichat_thread
+  has_one :aichat_message_feedback
 
   enum role: {
     user: 1,

--- a/dashboard/app/models/aichat_message_feedback.rb
+++ b/dashboard/app/models/aichat_message_feedback.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: aichat_message_feedbacks
+#
+#  id                :bigint           not null, primary key
+#  aichat_message_id :bigint           not null
+#  teacher_id        :bigint           not null
+#  approval          :boolean
+#  flagged           :boolean
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_aichat_message_feedbacks_on_aichat_message_id  (aichat_message_id) UNIQUE
+#
+class AichatMessageFeedback < ApplicationRecord
+  belongs_to :aichat_message
+end

--- a/dashboard/db/migrate/20250221170834_create_aichat_message_feedbacks.rb
+++ b/dashboard/db/migrate/20250221170834_create_aichat_message_feedbacks.rb
@@ -1,0 +1,11 @@
+class CreateAichatMessageFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :aichat_message_feedbacks do |t|
+      t.belongs_to :aichat_message, null: false, index: {unique: true}, foreign_key: true
+      t.bigint :teacher_id, null: false
+      t.boolean :approval
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/migrate/20250221170834_create_aichat_message_feedbacks.rb
+++ b/dashboard/db/migrate/20250221170834_create_aichat_message_feedbacks.rb
@@ -4,6 +4,7 @@ class CreateAichatMessageFeedbacks < ActiveRecord::Migration[6.1]
       t.belongs_to :aichat_message, null: false, index: {unique: true}, foreign_key: true
       t.bigint :teacher_id, null: false
       t.boolean :approval
+      t.boolean :flagged
 
       t.timestamps
     end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2025_02_21_170834) do
     t.bigint "aichat_message_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "approval"
+    t.boolean "flagged"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["aichat_message_id"], name: "index_aichat_message_feedbacks_on_aichat_message_id", unique: true

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -83,6 +83,15 @@ ActiveRecord::Schema.define(version: 2025_02_14_202758) do
     t.index ["user_id", "level_id", "script_id"], name: "index_ace_user_level_script"
   end
 
+  create_table "aichat_message_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aichat_message_id", null: false
+    t.bigint "teacher_id", null: false
+    t.boolean "approval"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["aichat_message_id"], name: "index_aichat_message_feedbacks_on_aichat_message_id", unique: true
+  end
+
   create_table "aichat_messages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "aichat_thread_id", null: false
     t.text "external_id", null: false
@@ -2518,6 +2527,7 @@ ActiveRecord::Schema.define(version: 2025_02_14_202758) do
   add_foreign_key "ai_tutor_interaction_feedbacks", "ai_tutor_interactions"
   add_foreign_key "ai_tutor_interaction_feedbacks", "users"
   add_foreign_key "aichat_events", "aichat_requests", column: "request_id"
+  add_foreign_key "aichat_message_feedbacks", "aichat_messages"
   add_foreign_key "cap_user_events", "users"
   add_foreign_key "census_submission_form_maps", "census_submissions"
   add_foreign_key "census_summaries", "schools"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_14_202758) do
+ActiveRecord::Schema.define(version: 2025_02_21_170834) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"

--- a/dashboard/test/models/aichat_message_feedback_test.rb
+++ b/dashboard/test/models/aichat_message_feedback_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class AichatMessageFeedbackTest < ActiveSupport::TestCase
+  setup_all do
+    @user = create :user
+  end
+
+  test 'thread, message, feedback create' do
+    thread = AichatThread.create!(
+      user: @user,
+      external_id: 'openai_1234',
+      llm_version: 'chatgpt3.4.5',
+      title: 'Unit 3 differentiation thread',
+      unit_id: 3
+    )
+
+    assert thread.aichat_messages.empty?
+
+    message1 = AichatMessage.create!(
+      role: :user,
+      content: 'Open the pod bay doors, HAL.',
+      aichat_thread: thread,
+      external_id: 'message1',
+      is_preset: false
+    )
+
+    message2 = AichatMessage.create!(
+      role: :assistant,
+      content: "I'm sorry Dave, I'm afraid I can't do that.",
+      aichat_thread: thread,
+      external_id: 'message2',
+      is_preset: false
+    )
+
+    assert_equal [message1, message2], thread.reload.aichat_messages
+    assert_equal 'openai_1234', message1.aichat_thread.external_id
+    assert message1.aichat_message_feedback.nil?
+
+    feedback = AichatMessageFeedback.create!(
+      teacher_id: @user.id,
+      aichat_message: message1,
+      approval: true,
+      flagged: false
+    )
+
+    assert_equal feedback, message1.aichat_message_feedback
+    assert_equal feedback.aichat_message_id, message1.id
+  end
+end


### PR DESCRIPTION
Creating an aichat message feedback table connected to aichat_messages for giving feedback in the AI differentiation chat

aichat_message should have a has_one aichat_message_feedback

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/AITT-863

## Testing story

Added a model test to verify relationship with aichat_messages 

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
