### PR TITLE
[Python Lab/AI Tutor] CT-1066: Include PythonLab test file contents with system prompt

### DIFF
--- a/dashboard/app/helpers/aitutor_system_prompt_helper.rb
+++ b/dashboard/app/helpers/aitutor_system_prompt_helper.rb
@@ -84,11 +84,19 @@ module AitutorSystemPromptHelper
 
   def self.get_validated_level_test_file_contents(level)
     test_file_contents = ""
-    if level.respond_to?(:validation) && level.validation && level.validation.values.any?
+
+    # Note: Not all Lab2 levels have the same validation structure
+    if level.type == 'Pythonlab'
+      validation_file = level.properties["validation_file"]
+      if validation_file && validation_file["contents"]
+        test_file_contents += validation_file["contents"]
+      end
+    elsif level.respond_to?(:validation) && level.validation && level.validation.values.any?
       level.validation.each_value do |validation|
         test_file_contents += validation["text"]
       end
     end
+
     test_file_contents.empty? ?
       "\n There are no tests for this level." :
       "\n The contents of the test file are: #{test_file_contents}"

--- a/dashboard/test/helpers/aitutor_system_prompt_helper_test.rb
+++ b/dashboard/test/helpers/aitutor_system_prompt_helper_test.rb
@@ -9,10 +9,14 @@ class AitutorSystemPromptHelperTest < ActionView::TestCase
     @unit = create(:script, :with_levels)
     @level = @unit.levels.first
 
+    # Sample Javalab level
     @level_instructions = "Write a loop."
     @csa_unit = create(:csa_script)
     @javalab_level = create(:javalab, :with_instructions)
     create(:csa_script_level, levels: [@javalab_level])
+
+    # Creating a Pythonlab level with a validation_file
+    @pythonlab_level = create(:pythonlab, :with_instructions)
   end
 
   test "get_programming_language_system_prompt includes Java for CSA level" do
@@ -30,7 +34,7 @@ class AitutorSystemPromptHelperTest < ActionView::TestCase
     assert_includes level_instructions, 'Write a loop.'
   end
 
-  test "get_validated_level_test_file_contents for validated level" do
+  test "get_validated_level_test_file_contents for validated Javalab level" do
     CDO.stubs(:properties_encryption_key).returns(STUB_ENCRYPTION_KEY)
     test_contents = "these are the tests"
     @javalab_level.validation = {"Validation.java" => {"text" => test_contents}}
@@ -38,9 +42,29 @@ class AitutorSystemPromptHelperTest < ActionView::TestCase
     assert_includes test_file_contents, test_contents
   end
 
-  test "get_validated_level_test_file_contents for non-validated level" do
+  test "get_validated_level_test_file_contents for non-validated Javalab level" do
     no_tests_msg = AitutorSystemPromptHelper.get_validated_level_test_file_contents(@level)
     assert_includes no_tests_msg, 'no tests'
+  end
+
+  test "get_validated_level_test_file_contents for validated Pythonlab level" do
+    # Add a sample Pythonlab validation_file
+    sample_test_file_contents = "import unittest\nfrom factorial import factorial\n\nclass TestFactorial(unittest.TestCase):\n\n  def test_factorial_zero(self):\n      self.assertEqual(factorial(0), 1)"
+    @pythonlab_level.properties["validation_file"] = {
+      "id" => "3",
+      "name" => "test_factorial.py",
+      "language" => "py",
+      "contents" => sample_test_file_contents
+    }
+    test_file_contents = AitutorSystemPromptHelper.get_validated_level_test_file_contents(@pythonlab_level)
+    assert_includes test_file_contents, sample_test_file_contents
+  end
+
+  test "get_validated_level_test_file_contents for non-validated Pythonlab level" do
+    # Create a Pythonlab level without a validation_file for this test
+    @pythonlab_level.properties["validation_file"] = nil
+    no_tests_msg = AitutorSystemPromptHelper.get_validated_level_test_file_contents(@pythonlab_level)
+    assert_includes no_tests_msg, 'There are no tests for this level.'
   end
 
   test "get_system_prompt with level_id and script_id" do


### PR DESCRIPTION
I noticed Python Lab test file contents weren't getting included in the request to AI Tutor. This pulls them from the `validation_file` specifically for Pythonlab level types, but keeps the logic the same for existing levels. 

## Links

https://codedotorg.atlassian.net/browse/CT-1066

## Testing story

Tested locally by asking about how to pass validation and also inspecting system prompt server-side. Also added unit tests for a sample Python level.

![Screenshot 2025-02-21 at 4 52 56 PM](https://github.com/user-attachments/assets/d02bc379-bd78-4fff-857d-708cb4c4e4a3)

![Screenshot 2025-02-21 at 4 52 23 PM](https://github.com/user-attachments/assets/f88a2f2e-daa1-4020-bbd3-1272efc9a8fb)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
