### PR TITLE
chore(eyes): improve eyes debug reporting

### DIFF
--- a/.github/workflows/component-library-ci.yml
+++ b/.github/workflows/component-library-ci.yml
@@ -71,6 +71,10 @@ jobs:
       - name: Setup Frontend
         uses: ./.github/actions/frontend/setup
 
+      - name: Build
+        run: yarn build --filter @code-dot-org/design-system-storybook
+        working-directory: ./frontend
+
       - name: Eyes Tests
         id: eyes
         run: |

--- a/frontend/apps/design-system-storybook/applitools.config.cjs
+++ b/frontend/apps/design-system-storybook/applitools.config.cjs
@@ -24,6 +24,7 @@ module.exports = {
     {width: 1200, height: 800, name: 'chrome'},
     {width: 1200, height: 800, name: 'firefox'},
   ],
+  showStorybookOutput: true,
   storybookStaticDir: 'dist/component-library-storybook',
   runInDocker: isDocker,
   puppeteerOptions: {

--- a/frontend/apps/design-system-storybook/scripts/eyes-storybook.ts
+++ b/frontend/apps/design-system-storybook/scripts/eyes-storybook.ts
@@ -14,12 +14,12 @@ exec('yarn dotenv-run -- eyes-storybook', (error, stdout) => {
   const testsSuccessful =
     error == null && stdout.includes('No differences were found!');
 
-  if (process.env.CI !== 'true') {
+  if (!eyesFailureLink || process.env.CI !== 'true') {
     console.log(stdout);
     console.log(error);
   }
 
-  const a = dedent(`
+  const report = dedent(`
         # 🖼️ Visual Comparison Report
             
         ${
@@ -44,5 +44,5 @@ exec('yarn dotenv-run -- eyes-storybook', (error, stdout) => {
         }
     `);
 
-  console.log(dedent(a));
+  console.log(dedent(report));
 });


### PR DESCRIPTION
When eyes fails to start storybook, it leaves a visual comparison report with "eyes differences detected" and no link to the report. Detect this scenario and add additional error logging to help debug.