### PR TITLE
bin/drone/stats: build duration stats for drone

### DIFF
--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -1,16 +1,12 @@
 #!/usr/bin/env bundle exec ruby
 
-# Outputs min/max/mean build duration for successful drone builds in the past week
-# you must have the drone CLI command installed, and be logged in to drone.
-#
-# Example: bin/drone/stats --ago="1 month" --only-successful=false --only-stages="ui,unit" --csv
-
 require "json"
 require "time"
 require "active_support/time"
 require "optparse"
 require "parallel"
 require "csv"
+require 'httparty'
 
 options = {ago: 1.week, json: false, only_successful: true, only_stages: nil, verbose: nil}
 OptionParser.new do |opts|
@@ -31,44 +27,43 @@ OptionParser.new do |opts|
   end
 end.parse!
 
+def drone_api_get(path)
+  drone_url = "https://drone.cdn-code.org"
+  url = "#{drone_url}/api/repos/code-dot-org/code-dot-org/#{path}"
+  drone_token = ENV.fetch('DRONE_TOKEN', nil)
+  raise "Env var DRONE_TOKEN must be set to 'Your Personal Token' from #{drone_url}/account" if drone_token.nil?
+
+  res = HTTParty.get(
+    url,
+    headers: {
+      "Authorization" => "Bearer #{ENV.fetch('DRONE_TOKEN', nil)}",
+      "Content-Type" => "application/json",
+    },
+    format: :plain,
+  )
+  raise "#{res.code} #{res.message} - GET request to #{url} failed" unless res.success?
+  JSON.parse res.body, symbolize_names: true
+end
+
 OPTIONS_NOT_TO_OUTPUT_TO_TABLE = [:json]
 
 OLDEST_BUILD_OF_INTEREST = options[:ago].ago
 oldest_build_seen = Time.now
-
-# This template is used to output JSON from the `drone info` command: https://pkg.go.dev/text/template
-# If you want to add more stats, you may need to modify this template to fetch more values.
-# Valid values can be discovered by looking up the drone info rest apis values: https://docs.drone.io/api/builds/build_info/
-DRONE_INFO_JSON_TEMPLATE = <<-GOLANG_TEMPLATE
-  [
-  {{- range $i, $stage := .Stages }}
-    {{- if $i }},{{ end }}
-    {
-      "name": "{{$stage.Name}}",
-      "started":{{$stage.Started}},
-      "stopped":{{$stage.Stopped}}
-    }
-  {{- end }}
-  ]
-GOLANG_TEMPLATE
-
-MAX_DRONE_CLI_PAGE_NUM = 200
+MAX_DRONE_PAGE_NUM = 200
 drone_page_num = 1
 build_stages = []
 
 while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
-  raise "Exceeded max drone CLI --page limit (#{MAX_DRONE_CLI_PAGE_NUM})" if drone_page_num > MAX_DRONE_CLI_PAGE_NUM
+  raise "Exceeded hardcoded max drone API page limit (#{MAX_DRONE_PAGE_NUM})" if drone_page_num > MAX_DRONE_PAGE_NUM
 
-  drone_ls_cmd = "drone build ls code-dot-org/code-dot-org #{options[:only_successful] ? "--status success" : ""} --limit 10000 --page #{drone_page_num} --format '{{ .Number }}'"
-  build_nums = `#{drone_ls_cmd}`.strip.lines.map(&:strip).reject(&:empty?).map(&:to_i)
+  builds = drone_api_get("builds?page=#{drone_page_num}").
+    select {|build| options[:only_successful] ? build[:status] == "success" : true}
+  build_nums = builds.map {|build| build[:number]}
 
-  new_build_stages = Parallel.flat_map(build_nums, in_threads: 1) do |build_num|
-    drone_info_cmd = "drone build info code-dot-org/code-dot-org #{build_num} --format '#{DRONE_INFO_JSON_TEMPLATE}'"
-    drone_info_cmd_output = `#{drone_info_cmd}`
+  new_build_stages = Parallel.flat_map(build_nums, in_threads: 32) do |build_num|
+    build_info = drone_api_get("builds/#{build_num}")
 
-    # We've hacked DRONE_INFO_JSON_TEMPLATE to output a JSON array, if you want
-    # to add more kinds of stats, you might need to hack its output
-    JSON.parse(drone_info_cmd_output, symbolize_names: true).map do |stage|
+    build_info[:stages].map do |stage|
       next if stage[:stopped].zero? || stage[:started].zero?
       next if options[:only_stages] && !options[:only_stages].include?(stage[:name])
       {

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -82,10 +82,11 @@ while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
 
   raise "No new build stages found, is --only-stages set correctly?" if new_build_stages.empty?
 
+  oldest_build_seen = new_build_stages.map {|s| s[:finished]}.min
+  new_build_stages.select! {|s| s[:finished] >= OLDEST_BUILD_OF_INTEREST}
   new_build_stages.each {|s| puts s.inspect} if options[:verbose]
   build_stages += new_build_stages
 
-  oldest_build_seen = new_build_stages.map {|s| s[:finished]}.min
   drone_page_num += 1
 end
 

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bundle exec ruby
+
+# Outputs min/max/mean build duration for successful drone builds in the past week
+# you must have the drone CLI command installed, and be logged in to drone.
+#
+# Example: bin/drone/stats --ago="1 month" --only-successful=false --only-stages="ui,unit"
+
+require "json"
+require "time"
+require "active_support/time"
+require "optparse"
+require "parallel"
+
+options = {ago: 1.week, json: false, only_successful: true, only_stages: nil, verbose: nil}
+OptionParser.new do |opts|
+  opts.on("--verbose", 'Output more information') do
+    options[:verbose] = true
+  end
+  opts.on("--json", 'Output successful builds in JSON format') do
+    options[:json] = true
+    options[:verbose] = false
+  end
+  opts.on("--ago=DURATION", 'Oldest build of interest, e.g. `--ago="6 days"`') do |ago_str|
+    num, unit = ago_str.split
+    options[:ago] = num.to_i.public_send(unit.downcase)
+  end
+  opts.on("--only-successful=true", 'Filter to only successful drone builds (default: true)') do |only_successful|
+    options[:only_successful] = [nil, "1", "true"].include? only_successful
+  end
+  opts.on("--only-stages=STAGES", 'Only process some drone stages, e.g. `--only-stages="unit,ui"`') do |stages|
+    options[:only_stages] = stages.split(",").map(&:strip)
+  end
+end.parse!
+
+OLDEST_BUILD_OF_INTEREST = options[:ago].ago # default: 1.week.ago
+oldest_build_seen = Time.now
+
+MAX_DRONE_CLI_PAGE_NUM = 200
+drone_page_num = 1
+build_stages = []
+
+while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
+  raise "Exceeded max drone CLI --page limit (#{MAX_DRONE_CLI_PAGE_NUM})" if drone_page_num > MAX_DRONE_CLI_PAGE_NUM
+
+  cmd = "drone build ls code-dot-org/code-dot-org #{options[:only_successful] ? "--status success" : ""} --limit 10000 --page #{drone_page_num} --format '{{ .Number }}'"
+  build_nums = `#{cmd}`.strip.lines.map(&:strip).reject(&:empty?).map(&:to_i)
+
+  new_build_stages = Parallel.flat_map(build_nums, in_threads: 32) do |build_num|
+    info_cmd = "drone build info code-dot-org/code-dot-org #{build_num} --format '{{ range .Stages }}{{ .Name }} {{ .Started }} {{ .Stopped }}\n{{ end }}'"
+    stages_output = `#{info_cmd}`.strip
+
+    stages_output.lines.map(&:strip).reject(&:empty?).map do |line|
+      stage_name, started, finished = line.split
+      started = started.to_i
+      finished = finished.to_i
+      next if finished.zero? || started.zero?
+      next if options[:only_stages] && !options[:only_stages].include?(stage_name)
+
+      {
+        build_num: build_num,
+        finished: Time.at(finished),
+        duration_mins: ((finished - started) / 60.0).round(2),
+        stage_name: stage_name,
+      }
+    end
+  end.compact
+
+  raise "No new build stages found, is --only-stages set correctly?" if new_build_stages.empty?
+
+  new_build_stages.each {|s| puts s.inspect} if options[:verbose]
+  build_stages += new_build_stages
+
+  oldest_build_seen = new_build_stages.map {|s| s[:finished]}.min
+  drone_page_num += 1
+end
+
+def descriptive_statistics(data)
+  data = data.sort
+  quartile = ->(quartile_num) {data[(data.length * quartile_num / 4.0).round]}
+  {
+    count: data.size,
+    p_0: data.min,
+    p_25: quartile.call(1),
+    p_50: quartile.call(2),
+    p_75: quartile.call(3),
+    p_100: data.max,
+    sum: data.sum,
+    mean: data.sum / data.size.to_f,
+  }
+end
+
+def print_stats_for(build_stages, stage_name, options)
+  stats = descriptive_statistics(build_stages.map {|build| build[:duration_mins]})
+  options_desc = options.reject {|key, value| key == :json || value.nil?}
+  puts
+  puts "#{stage_name} build stage duration stats, #{options_desc}:"
+  unitless_keys = [:count]
+  stats.each do |key, value|
+    puts "  #{key.to_s.ljust(6)}: #{value.round} #{"mins" unless unitless_keys.include? key}"
+  end
+end
+
+def print_duration_stats(build_stages, options)
+  puts
+  puts "## Per-stage drone build duration stats ##"
+  build_stages.group_by {|s| s[:stage_name]}.each do |stage_name, stages|
+    print_stats_for(stages, stage_name, options)
+  end
+  puts
+
+  puts
+  puts "## Overall drone build duration stats ##"
+  print_stats_for(build_stages, options[:only_stages] ? options[:only_stages].join(", ").to_s : "ALL", options)
+  puts
+end
+
+if options[:json]
+  puts JSON.pretty_generate(build_stages)
+else
+  print_duration_stats(build_stages, options)
+end

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -3,7 +3,7 @@
 # Outputs min/max/mean build duration for successful drone builds in the past week
 # you must have the drone CLI command installed, and be logged in to drone.
 #
-# Example: bin/drone/stats --ago="1 month" --only-successful=false --only-stages="ui,unit"
+# Example: bin/drone/stats --ago="1 month" --only-successful=false --only-stages="ui,unit" --csv
 
 require "json"
 require "time"
@@ -31,11 +31,26 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-# To help keep options that affect output near data, we output options as a column in the table.
 OPTIONS_NOT_TO_OUTPUT_TO_TABLE = [:json]
 
 OLDEST_BUILD_OF_INTEREST = options[:ago].ago
 oldest_build_seen = Time.now
+
+# This template is used to output JSON from the `drone info` command: https://pkg.go.dev/text/template
+# If you want to add more stats, you may need to modify this template to fetch more values.
+# Valid values can be discovered by looking up the drone info rest apis values: https://docs.drone.io/api/builds/build_info/
+DRONE_INFO_JSON_TEMPLATE = <<-GOLANG_TEMPLATE
+  [
+  {{- range $i, $stage := .Stages }}
+    {{- if $i }},{{ end }}
+    {
+      "name": "{{$stage.Name}}",
+      "started":{{$stage.Started}},
+      "stopped":{{$stage.Stopped}}
+    }
+  {{- end }}
+  ]
+GOLANG_TEMPLATE
 
 MAX_DRONE_CLI_PAGE_NUM = 200
 drone_page_num = 1
@@ -44,25 +59,23 @@ build_stages = []
 while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
   raise "Exceeded max drone CLI --page limit (#{MAX_DRONE_CLI_PAGE_NUM})" if drone_page_num > MAX_DRONE_CLI_PAGE_NUM
 
-  cmd = "drone build ls code-dot-org/code-dot-org #{options[:only_successful] ? "--status success" : ""} --limit 10000 --page #{drone_page_num} --format '{{ .Number }}'"
-  build_nums = `#{cmd}`.strip.lines.map(&:strip).reject(&:empty?).map(&:to_i)
+  drone_ls_cmd = "drone build ls code-dot-org/code-dot-org #{options[:only_successful] ? "--status success" : ""} --limit 10000 --page #{drone_page_num} --format '{{ .Number }}'"
+  build_nums = `#{drone_ls_cmd}`.strip.lines.map(&:strip).reject(&:empty?).map(&:to_i)
 
-  new_build_stages = Parallel.flat_map(build_nums, in_threads: 32) do |build_num|
-    info_cmd = "drone build info code-dot-org/code-dot-org #{build_num} --format '{{ range .Stages }}{{ .Name }} {{ .Started }} {{ .Stopped }}\n{{ end }}'"
-    stages_output = `#{info_cmd}`.strip
+  new_build_stages = Parallel.flat_map(build_nums, in_threads: 1) do |build_num|
+    drone_info_cmd = "drone build info code-dot-org/code-dot-org #{build_num} --format '#{DRONE_INFO_JSON_TEMPLATE}'"
+    drone_info_cmd_output = `#{drone_info_cmd}`
 
-    stages_output.lines.map(&:strip).reject(&:empty?).map do |line|
-      stage_name, started, finished = line.split
-      started = started.to_i
-      finished = finished.to_i
-      next if finished.zero? || started.zero?
-      next if options[:only_stages] && !options[:only_stages].include?(stage_name)
-
+    # We've hacked DRONE_INFO_JSON_TEMPLATE to output a JSON array, if you want
+    # to add more kinds of stats, you might need to hack its output
+    JSON.parse(drone_info_cmd_output, symbolize_names: true).map do |stage|
+      next if stage[:stopped].zero? || stage[:started].zero?
+      next if options[:only_stages] && !options[:only_stages].include?(stage[:name])
       {
         build_num: build_num,
-        finished: Time.at(finished),
-        duration_mins: ((finished - started) / 60.0).round(2),
-        stage_name: stage_name,
+        finished: Time.at(stage[:stopped]),
+        duration_mins: ((stage[:stopped] - stage[:started]) / 60.0).round(2),
+        stage_name: stage[:name],
       }
     end
   end.compact
@@ -95,18 +108,12 @@ def descriptive_statistics(data, units: nil, round: nil)
 end
 
 def to_justified_tsv_str(hash)
-  # Determine max width for each column
   col_names = hash.first.keys
-  col_widths = col_names.map do |col|
-    [col.to_s.length, *hash.map {|row| row[col].to_s.length}].max
-  end
+  col_widths = col_names.map {|col| [col.to_s.length, *hash.map {|row| row[col].to_s.length}].max}
 
-  # Write CSV to console with justified columns
   CSV.generate(col_sep: "\t", force_quotes: false) do |csv|
     csv << col_names.map.with_index {|col, i| col.to_s.ljust(col_widths[i])}
-    hash.each do |row|
-      csv << row.values.map.with_index {|val, i| val.to_s.ljust(col_widths[i])}
-    end
+    hash.each {|row| csv << row.values.map.with_index {|val, i| val.to_s.ljust(col_widths[i])}}
   end
 end
 
@@ -119,39 +126,26 @@ def write_stats_table(filename, data)
 end
 
 def compute_stats_for(all_build_stages, options, units: nil, round: nil, &data_selector)
-  # We filter the options hash to be appropriate for outputting as a table column
-  # that means keeping it relatively short, but containing data-relevant flags
-  options_filtered = options.
-    reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.
-    inspect.tr('"', "'")
+  options_filtered = options.reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.inspect.tr('"', "'")
 
   stats_for = lambda do |stage_name, build_stages|
     {
       stage_name: stage_name,
-      **descriptive_statistics(
-        build_stages.map(&data_selector),
-        units: units,
-        round: round,
-      ),
+      **descriptive_statistics(build_stages.map(&data_selector), units: units, round: round),
       options: options_filtered,
     }
   end
 
-  # First do stats for each stage_name, each will be a row in the table
   duration_stats = all_build_stages.group_by {|s| s[:stage_name]}.map do |stage_name, subset_of_stages|
     stats_for.call(stage_name, subset_of_stages)
   end
 
-  # Now run stats for all stage_names together, this will be the final row
   all_stage_name_label = options[:only_stages] ? options[:only_stages].join("+") : "ALL"
-  duration_stats <<  stats_for.call(all_stage_name_label, all_build_stages)
+  duration_stats << stats_for.call(all_stage_name_label, all_build_stages)
 end
 
 def write_duration_stats_table(build_stages, options)
-  duration_mins_stats = compute_stats_for(build_stages, options, units: "minutes", round: 2) do |build_stage|
-    # Select which field of a build_stage to use as the data field for stats
-    build_stage[:duration_mins]
-  end
+  duration_mins_stats = compute_stats_for(build_stages, options, units: "minutes", round: 2) {|build_stage| build_stage[:duration_mins]}
   write_stats_table("drone-duration-stats.tsv", duration_mins_stats)
 end
 

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -10,12 +10,11 @@ require "time"
 require "active_support/time"
 require "optparse"
 require "parallel"
+require "csv"
 
 options = {ago: 1.week, json: false, only_successful: true, only_stages: nil, verbose: nil}
 OptionParser.new do |opts|
-  opts.on("--verbose", 'Output more information') do
-    options[:verbose] = true
-  end
+  opts.on("--verbose", 'Output more information') {options[:verbose] = true}
   opts.on("--json", 'Output successful builds in JSON format') do
     options[:json] = true
     options[:verbose] = false
@@ -32,7 +31,10 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-OLDEST_BUILD_OF_INTEREST = options[:ago].ago # default: 1.week.ago
+# To help keep options that affect output near data, we output options as a column in the table.
+OPTIONS_NOT_TO_OUTPUT_TO_TABLE = [:json]
+
+OLDEST_BUILD_OF_INTEREST = options[:ago].ago
 oldest_build_seen = Time.now
 
 MAX_DRONE_CLI_PAGE_NUM = 200
@@ -74,48 +76,87 @@ while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
   drone_page_num += 1
 end
 
-def descriptive_statistics(data)
+def descriptive_statistics(data, units: nil, round: nil)
+  raise "All values must be numeric" unless data.all?(Numeric)
   data = data.sort
-  quartile = ->(quartile_num) {data[(data.length * quartile_num / 4.0).round]}
+  quartile = ->(quartile_num) {data[(data.length * quartile_num / 4.0).floor]}
+  format = round ? ->(v) {v.round(round)} : ->(v) {v}
   {
     count: data.size,
-    p_0: data.min,
-    p_25: quartile.call(1),
-    p_50: quartile.call(2),
-    p_75: quartile.call(3),
-    p_100: data.max,
-    sum: data.sum,
-    mean: data.sum / data.size.to_f,
+    **(units.nil? ? {} : {units: units}),
+    mean: format.call(data.sum / data.size.to_f),
+    sum: format.call(data.sum),
+    p_0: format.call(data.min),
+    p_25: format.call(quartile.call(1)),
+    p_50: format.call(quartile.call(2)),
+    p_75: format.call(quartile.call(3)),
+    p_100: format.call(data.max),
   }
 end
 
-def print_stats_for(build_stages, stage_name, options)
-  stats = descriptive_statistics(build_stages.map {|build| build[:duration_mins]})
-  options_desc = options.reject {|key, value| key == :json || value.nil?}
-  puts
-  puts "#{stage_name} build stage duration stats, #{options_desc}:"
-  unitless_keys = [:count]
-  stats.each do |key, value|
-    puts "  #{key.to_s.ljust(6)}: #{value.round} #{"mins" unless unitless_keys.include? key}"
+def to_justified_tsv_str(hash)
+  # Determine max width for each column
+  col_names = hash.first.keys
+  col_widths = col_names.map do |col|
+    [col.to_s.length, *hash.map {|row| row[col].to_s.length}].max
+  end
+
+  # Write CSV to console with justified columns
+  CSV.generate(col_sep: "\t", force_quotes: false) do |csv|
+    csv << col_names.map.with_index {|col, i| col.to_s.ljust(col_widths[i])}
+    hash.each do |row|
+      csv << row.values.map.with_index {|val, i| val.to_s.ljust(col_widths[i])}
+    end
   end
 end
 
-def print_duration_stats(build_stages, options)
+def write_stats_table(filename, data)
+  tsv = to_justified_tsv_str(data)
+  puts "## #{filename} ##"
+  puts tsv
   puts
-  puts "## Per-stage drone build duration stats ##"
-  build_stages.group_by {|s| s[:stage_name]}.each do |stage_name, stages|
-    print_stats_for(stages, stage_name, options)
-  end
-  puts
+  File.write(filename, tsv)
+end
 
-  puts
-  puts "## Overall drone build duration stats ##"
-  print_stats_for(build_stages, options[:only_stages] ? options[:only_stages].join(", ").to_s : "ALL", options)
-  puts
+def compute_stats_for(all_build_stages, options, units: nil, round: nil, &data_selector)
+  # We filter the options hash to be appropriate for outputting as a table column
+  # that means keeping it relatively short, but containing data-relevant flags
+  options_filtered = options.
+    reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.
+    inspect.tr('"', "'")
+
+  stats_for = lambda do |stage_name, build_stages|
+    {
+      stage_name: stage_name,
+      **descriptive_statistics(
+        build_stages.map(&data_selector),
+        units: units,
+        round: round,
+      ),
+      options: options_filtered,
+    }
+  end
+
+  # First do stats for each stage_name, each will be a row in the table
+  duration_stats = all_build_stages.group_by {|s| s[:stage_name]}.map do |stage_name, subset_of_stages|
+    stats_for.call(stage_name, subset_of_stages)
+  end
+
+  # Now run stats for all stage_names together, this will be the final row
+  all_stage_name_label = options[:only_stages] ? options[:only_stages].join("+") : "ALL"
+  duration_stats <<  stats_for.call(all_stage_name_label, all_build_stages)
+end
+
+def write_duration_stats_table(build_stages, options)
+  duration_mins_stats = compute_stats_for(build_stages, options, units: "minutes", round: 2) do |build_stage|
+    # Select which field of a build_stage to use as the data field for stats
+    build_stage[:duration_mins]
+  end
+  write_stats_table("drone-duration-stats.tsv", duration_mins_stats)
 end
 
 if options[:json]
   puts JSON.pretty_generate(build_stages)
 else
-  print_duration_stats(build_stages, options)
+  write_duration_stats_table(build_stages, options)
 end

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -45,6 +45,9 @@ def drone_api_get(path)
   JSON.parse res.body, symbolize_names: true
 end
 
+# Terminal control code to clear the current line
+TERMINAL_CLEAR_LINE="\r\e[K"
+
 OPTIONS_NOT_TO_OUTPUT_TO_TABLE = [:json]
 
 OLDEST_BUILD_OF_INTEREST = options[:ago].ago
@@ -64,26 +67,26 @@ while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
     build_info = drone_api_get("builds/#{build_num}")
 
     build_info[:stages].map do |stage|
-      next if stage[:stopped].zero? || stage[:started].zero?
       next if options[:only_stages] && !options[:only_stages].include?(stage[:name])
       {
-        build_num: build_num,
-        finished: Time.at(stage[:stopped]),
-        duration_mins: ((stage[:stopped] - stage[:started]) / 60.0).round(2),
-        stage_name: stage[:name],
+        **stage, # see: https://docs.drone.io/api/builds/build_info/
+        build_num: build_info[:number],
+        build: build_info,
+        date: Time.at(stage[:stopped]),
       }
     end
   end.compact
 
   raise "No new build stages found, is --only-stages set correctly?" if new_build_stages.empty?
 
-  oldest_build_seen = new_build_stages.map {|s| s[:finished]}.min
-  new_build_stages.select! {|s| s[:finished] >= OLDEST_BUILD_OF_INTEREST}
-  new_build_stages.each {|s| puts s.inspect} if options[:verbose]
-  build_stages += new_build_stages
+  oldest_build_seen = new_build_stages.map {|s| s[:date]}.min
+  new_build_stages.select! {|s| s[:date] >= OLDEST_BUILD_OF_INTEREST}
+  print("#{TERMINAL_CLEAR_LINE}Processed builds back to #{oldest_build_seen}") if $stdout.tty?
 
+  build_stages += new_build_stages
   drone_page_num += 1
 end
+puts(TERMINAL_CLEAR_LINE) if $stdout.tty?
 
 def descriptive_statistics(data, units: nil, round: nil)
   raise "All values must be numeric" unless data.all?(Numeric)
@@ -125,14 +128,15 @@ def compute_stats_for(all_build_stages, options, units: nil, round: nil, &data_s
   options_filtered = options.reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.inspect.tr('"', "'")
 
   stats_for = lambda do |stage_name, build_stages|
+    data = build_stages.map(&data_selector).compact
     {
       stage_name: stage_name,
-      **descriptive_statistics(build_stages.map(&data_selector), units: units, round: round),
+      **descriptive_statistics(data, units: units, round: round),
       options: options_filtered,
     }
   end
 
-  duration_stats = all_build_stages.group_by {|s| s[:stage_name]}.map do |stage_name, subset_of_stages|
+  duration_stats = all_build_stages.group_by {|stage| stage[:name]}.map do |stage_name, subset_of_stages|
     stats_for.call(stage_name, subset_of_stages)
   end
 
@@ -141,7 +145,14 @@ def compute_stats_for(all_build_stages, options, units: nil, round: nil, &data_s
 end
 
 def write_duration_stats_table(build_stages, options)
-  duration_mins_stats = compute_stats_for(build_stages, options, units: "minutes", round: 2) {|build_stage| build_stage[:duration_mins]}
+  duration_mins_stats = compute_stats_for(build_stages, options, units: "minutes", round: 2) do |stage|
+    # We don't want to generate durations for stages that are still ongoing
+    next if stage[:stopped].zero? || stage[:started].zero?
+
+    # Compute duration in minutes from unix timestamps
+    # for valid fields of stage, see: https://docs.drone.io/api/builds/build_info/
+    ((stage[:stopped] - stage[:started]) / 60.0).round(2)
+  end
   write_stats_table("drone-duration-stats.tsv", duration_mins_stats)
 end
 


### PR DESCRIPTION
Useful tool for digging into how long drone takes.

## --help

```
> bin/drone/stats --help
Usage: stats [options]
        --verbose                    Output more information
        --json                       Output successful builds in JSON format
        --ago=DURATION               Oldest build of interest, e.g. `--ago="6 days"`
        --only-successful=true       Filter to only successful drone builds (default: true)
        --only-stages=STAGES         Only process some drone stages, e.g. `--only-stages="unit,ui"
```

## Examples

### Default

```
> ./bin/drone/stats
## drone-duration-stats.tsv ##
stage_name              count   units   mean    sum             p_0     p_25    p_50    p_75    p_100   options                               
cache-staging-clone     95      minutes 14.89   1414.9          13.3    14.05   14.37   14.78   28.8    {:ago=>1 week, :only_successful=>true}
unit                    191     minutes 48.11   9189.04         27.28   40.05   41.73   59.23   85.1    {:ago=>1 week, :only_successful=>true}
ui                      191     minutes 91.63   17501.06        77.0    80.48   82.72   108.08  122.98  {:ago=>1 week, :only_successful=>true}
ALL                     477     minutes 58.92   28105.0         13.3    39.23   59.23   81.58   122.98  {:ago=>1 week, :only_successful=>true}
```

With some flags:
```
> bin/drone/stats --ago="1 week" --only-successful=true --only-stages="ui,unit"
## drone-duration-stats.tsv ##
stage_name      count   units   mean    sum             p_0     p_25    p_50    p_75    p_100   options                                                             
unit            190     minutes 48.16   9149.94         27.28   40.08   41.73   59.23   85.1    {:ago=>1 week, :only_successful=>true, :only_stages=>['ui', 'unit']}
ui              190     minutes 91.69   17420.98        77.0    80.52   82.9    108.08  122.98  {:ago=>1 week, :only_successful=>true, :only_stages=>['ui', 'unit']}
ui+unit         380     minutes 69.92   26570.92        27.28   41.73   78.18   82.9    122.98  {:ago=>1 week, :only_successful=>true, :only_stages=>['ui', 'unit']}
```