### PR TITLE
DIFF - Add location data for events

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -120,6 +120,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         isPreset: preset,
         text: prompt,
         sessionId: session,
+        url: window.location.href,
       };
       analyticsReporter.sendEvent(
         EVENTS.AI_DIFF_CHAT_EVENT,

--- a/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
@@ -42,6 +42,7 @@ describe('AiDiffChat', () => {
 
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = () => {};
+    // window.location = {href: 'http://test-for-code.org'};
     sessionStorage.clear();
     fetchStub = jest
       .spyOn(HttpClient, 'post')
@@ -93,6 +94,7 @@ describe('AiDiffChat', () => {
       isPreset: true,
       text: 'I need an explanation of a concept. You can ask me a follow-up question to find out what concept needs to be explained.',
       sessionId: '123abc',
+      url: window.location.href,
     };
     const responseEventData2 = {
       chatContext: AiDiffContext.LESSON,
@@ -103,6 +105,7 @@ describe('AiDiffChat', () => {
       isPreset: true,
       text: "Beep boop I'm a bot",
       sessionId: '123abc',
+      url: window.location.href,
     };
 
     //sends the api call then logs the suggested prompt and the bot message
@@ -165,6 +168,7 @@ describe('AiDiffChat', () => {
       isPreset: false,
       text: userMessage,
       sessionId: '123abc',
+      url: window.location.href,
     };
     const responseEventData2 = {
       chatContext: AiDiffContext.LESSON,
@@ -175,6 +179,7 @@ describe('AiDiffChat', () => {
       isPreset: false,
       text: "Beep boop I'm a bot",
       sessionId: '123abc',
+      url: window.location.href,
     };
 
     //sends the api call then logs the user message and the bot message
@@ -239,6 +244,7 @@ describe('AiDiffChat', () => {
       isPreset: false,
       text: userMessage,
       sessionId: '123abc',
+      url: window.location.href,
     };
     const responseEventData2 = {
       chatContext: AiDiffContext.LESSON,
@@ -249,6 +255,7 @@ describe('AiDiffChat', () => {
       isPreset: false,
       text: "Beep boop I'm a bot",
       sessionId: '123abc',
+      url: window.location.href,
     };
     await waitFor(() => {
       expect(fetchStub).toHaveBeenCalledWith(

--- a/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
@@ -42,7 +42,6 @@ describe('AiDiffChat', () => {
 
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = () => {};
-    // window.location = {href: 'http://test-for-code.org'};
     sessionStorage.clear();
     fetchStub = jest
       .spyOn(HttpClient, 'post')


### PR DESCRIPTION
Add location where the `Ai Differentiation Message Event` is triggered from.

Examples:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/b4f6458f-d6b3-4b29-a2c1-44c71d1fa60a" />

<img width="824" alt="image" src="https://github.com/user-attachments/assets/85da4da6-c316-48ce-afa7-ac20e5149b37" />



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?selectedIssue=AITT-915)

## Testing story

Note, I modified the existing tests.