### PR TITLE
Fix calendar spinning forever if component unloaded

### DIFF
--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -81,11 +81,7 @@ const UnitCalendar: React.FC = () => {
           versionYear: null,
         })
       );
-      setHasInitialLoad(true);
-      return;
-    }
-
-    if (
+    } else if (
       !isLoading &&
       unitToLoad &&
       userType &&
@@ -95,7 +91,6 @@ const UnitCalendar: React.FC = () => {
         (unitToLoad !== calendarUnitName && unitName !== null))
     ) {
       setIsLoading(true);
-      setHasInitialLoad(true);
       HttpClient.fetchJson<UnitSummaryResponse>(
         `/dashboardapi/unit_summary/${unitToLoad}`
       )
@@ -118,6 +113,8 @@ const UnitCalendar: React.FC = () => {
           return null;
         });
     }
+
+    setHasInitialLoad(true);
   }, [
     unitName,
     userId,


### PR DESCRIPTION
Fixes a bug where if the user loads the calendar page, then switches pages (unloading the calendar component) and goes back to the calendar page, it would spin forever.

This was caused because we show the spinner if we have not loaded any data yet in order to prevent showing an empty state until the first load is kicked off. However if the data has already appropriately been loaded into redux, then we would never kick off a load and stop showing the spinner.


https://github.com/user-attachments/assets/7a3677df-60fe-490d-a3c6-84190b049015

This PR fixes the issue by setting the initial load flag even if we do not make a fetch.


## Links
https://codedotorg.atlassian.net/browse/TEACH-1644
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

