### PR TITLE
Add event to section setup

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -27,6 +27,7 @@ const EVENTS = {
   LMS_INFORMATION_BUTTON_CLICKED: 'LMS Information Button Clicked',
   PARENT_OR_GUARDIAN_SIGN_UP_CLICKED: 'Parent or Guardian Sign Up Clicked',
   FINISH_ACCOUNT_PAGE_LOADED: 'Finish Account Page Loaded',
+  SECTION_SETUP_STARTED: 'Section Setup Started',
 
   // School Association
   // Update School Info Dialog

--- a/apps/src/templates/sectionSetup/InitialSectionCreationInterstitial.jsx
+++ b/apps/src/templates/sectionSetup/InitialSectionCreationInterstitial.jsx
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 
 import fontConstants from '@cdo/apps/fontConstants';
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import PadAndCenter from '@cdo/apps/templates/teacherDashboard/PadAndCenter';
@@ -29,6 +29,11 @@ class InitialSectionCreationInterstitial extends Component {
   beginEditingSection = () => {
     this.setState({isOpen: false});
     analyticsReporter.sendEvent(EVENTS.SECTION_SETUP_SIGN_IN_EVENT);
+    analyticsReporter.sendEvent(
+      EVENTS.SECTION_SETUP_STARTED,
+      {},
+      PLATFORMS.BOTH
+    );
     this.props.beginEditingSection();
   };
 

--- a/apps/src/templates/studioHomepages/SetUpSections.jsx
+++ b/apps/src/templates/studioHomepages/SetUpSections.jsx
@@ -2,16 +2,13 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 
-import {PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import i18n from '@cdo/locale';
 
 import {beginEditingSection} from '../teacherDashboard/teacherSectionsRedux';
 
 import BorderedCallToAction from './BorderedCallToAction';
-
-// Amplitude analytics events.
-const STARTED_EVENT = 'Section Setup Started';
 
 class SetUpSections extends Component {
   static propTypes = {
@@ -29,7 +26,11 @@ class SetUpSections extends Component {
   };
 
   recordSectionSetupStartedEvent = () => {
-    analyticsReporter.sendEvent(STARTED_EVENT, {}, PLATFORMS.BOTH);
+    analyticsReporter.sendEvent(
+      EVENTS.SECTION_SETUP_STARTED,
+      {},
+      PLATFORMS.BOTH
+    );
   };
 
   render() {

--- a/apps/test/unit/templates/sectionSetup/InitialSectionCreationInterstitialTest.js
+++ b/apps/test/unit/templates/sectionSetup/InitialSectionCreationInterstitialTest.js
@@ -2,7 +2,7 @@ import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {Provider} from 'react-redux';
 
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {getStore} from '@cdo/apps/redux';
 import InitialSectionCreationInterstitial from '@cdo/apps/templates/sectionSetup/InitialSectionCreationInterstitial';
@@ -34,9 +34,14 @@ describe('InitialSectionCreationInterstitial', () => {
     );
     wrapper.find('button#uitest-accept-section-creation').simulate('click');
 
-    expect(analyticsSpy).toHaveBeenCalledTimes(1);
+    expect(analyticsSpy).toHaveBeenCalledTimes(2);
     expect(analyticsSpy.mock.calls[0]).toEqual([
       EVENTS.SECTION_SETUP_SIGN_IN_EVENT,
+    ]);
+    expect(analyticsSpy.mock.calls[1]).toEqual([
+      EVENTS.SECTION_SETUP_STARTED,
+      {},
+      PLATFORMS.BOTH,
     ]);
 
     analyticsSpy.mockRestore();


### PR DESCRIPTION
The ticket explains the issue pretty well:

> I’ve noticed that “Section Setup Completed” is often higher than “Section Setup Started”. It turns out that the “Section Setup Started” event is only fired if the “Create a Section” button on the Teacher Homepage is clicked, but brand new users see a call to action to create a section from the InitialSectionCreationInterstitial. The “Create Class Sections” button on that dialog does not fire the “Section Setup Started” event, which explains why “Section Setup Started” events are lower than “Section Setup Completed” for brand new users.
> 
> 
> 
> For accuracy sake, it would probably be worth updating the dialog to also fire this event.

This PR addresses this issue - shout out to Bethany who researched this so thoroughly. 

## Links
[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1597)

## Testing story
Modified tests.