### PR TITLE
Adding aria label to popup buttons

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -29,6 +29,7 @@
   "duplicateFolderError": "Foldername {folderName} is already in use in this folder. Please choose a different name.",
   "duplicateSupportFileError": "Filename {fileName} is already in use in this folder in the level's support code. Please choose a different name.",
   "filesHeader": "Files",
+  "fileOptions": "File Options",
   "filesInBackpackMessage": "Files saved to your backpack will appear here.",
   "filesInBackpackTitle": "Files saved in backpack",
   "forTeachersOnlyHeader": "For Teachers Only",

--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -43,7 +43,12 @@ export const FileBrowserHeaderPopUpButton = () => {
   return (
     <>
       <FileUploaderComponent />
-      <PopUpButton iconName="plus" alignment="left" id="uitest-files-plus">
+      <PopUpButton
+        iconName="plus"
+        alignment="left"
+        id="uitest-files-plus"
+        ariaLabel={codebridgeI18n.fileOptions()}
+      >
         <PopUpButtonOption
           iconName="plus"
           labelText={codebridgeI18n.newFolder()}

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -13,6 +13,7 @@ type PopUpButtonProps = {
   alignment?: 'left' | 'right';
   id?: string;
   disabled?: boolean;
+  ariaLabel?: string;
 };
 
 const TOP_PADDING = 5;
@@ -24,6 +25,7 @@ export const PopUpButton = ({
   alignment = 'left',
   id,
   disabled,
+  ariaLabel,
 }: PopUpButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [buttonRef, setButtonRef] = useState<HTMLElement | null>(null);
@@ -113,6 +115,7 @@ export const PopUpButton = ({
         type={'tertiary'}
         id={id}
         disabled={disabled}
+        ariaLabel={ariaLabel}
       />
       {isOpen &&
         // We use a portal so the dropdown can appear above all other elements.


### PR DESCRIPTION
This PR includes a small refactor for the popupButton element to allow for aria labels. In addition, it adds an aria label for the plus button in Codebridge. KeyboardNav+Screenreader demo below!

Followup work: make that popup menu tab navigable


https://github.com/user-attachments/assets/5a8545da-65fc-4fad-815f-4d90e48c9408



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-1093

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
