### PR TITLE
fix(workshops): replace virtual attribute with method in serializer

### DIFF
--- a/dashboard/app/serializers/api/v1/pd/workshop_download_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_download_serializer.rb
@@ -10,7 +10,7 @@
 class Api::V1::Pd::WorkshopDownloadSerializer < ActiveModel::Serializer
   attributes :id, :status, :created_date, :start_date, :sessions, :organizer_name, :organizer_email, :regional_partner_name,
     :location_address, :location_name, :on_map, :funded, :course, :subject, :enrollment_url,
-    :enrolled_teacher_count, :capacity, :facilitators, :virtual, :third_party_provider, :notes
+    :enrolled_teacher_count, :capacity, :facilitators, :virtual?, :third_party_provider, :notes
 
   def status
     object.state

--- a/dashboard/app/serializers/api/v1/pd/workshop_download_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_download_serializer.rb
@@ -10,7 +10,7 @@
 class Api::V1::Pd::WorkshopDownloadSerializer < ActiveModel::Serializer
   attributes :id, :status, :created_date, :start_date, :sessions, :organizer_name, :organizer_email, :regional_partner_name,
     :location_address, :location_name, :on_map, :funded, :course, :subject, :enrollment_url,
-    :enrolled_teacher_count, :capacity, :facilitators, :virtual?, :third_party_provider, :notes
+    :enrolled_teacher_count, :capacity, :facilitators, :virtual, :third_party_provider, :notes
 
   def status
     object.state
@@ -50,5 +50,9 @@ class Api::V1::Pd::WorkshopDownloadSerializer < ActiveModel::Serializer
 
   def facilitators
     object.facilitators.map {|f| "#{f.name} <#{f.email}>"}.join("\n")
+  end
+
+  def virtual
+    object.virtual?
   end
 end

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -4,7 +4,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
     :enrollment_code, :pre_workshop_survey_url, :attended, :on_map, :funded, :funding_type, :ready_to_close?,
     :workshop_starting_date, :date_and_location_name, :regional_partner_name, :regional_partner_id,
-    :scholarship_workshop?, :can_delete, :created_at, :virtual?, :suppress_email, :third_party_provider, :course_offerings, :module,
+    :scholarship_workshop?, :can_delete, :created_at, :virtual, :suppress_email, :third_party_provider, :course_offerings, :module,
     :participant_group_type, :description, :registration_link, :prereq, :hidden, :grades, :time_zone
 
   def sessions
@@ -56,5 +56,9 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
 
   def can_delete
     @scope.try(:[], :current_user) && object.can_user_delete?(@scope[:current_user])
+  end
+
+  def virtual
+    object.virtual?
   end
 end


### PR DESCRIPTION
workshop_download_serializer expected a virtual attribute on the workshop, but that's been replaced with a method that returns a boolean. I didn't realize if I added `:virtual?` as an attribute that I'd literally get `"virtual?"` with the question mark in the json response. I replaced it with a method in each serializer that calls the workshop's `virtual?` method

recording of csv download:

https://github.com/user-attachments/assets/3314ce67-a131-453d-ba0f-878e6fe68f56




<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
