### PR TITLE
fix(workshops): optimize workshop virtual filter and fix sort

### DIFF
--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -89,15 +89,8 @@ module Pd::WorkshopFilters
         workshops = workshops.facilitated_by(User.find_by(id: params[:facilitator_id])) if params[:facilitator_id]
 
         if params[:virtual]
-          # Note this is an inefficient workaround required
-          # because we store a workshop's virtual status as
-          # a serialized attribute, which cannot be queried easily
-          # via the typical ActiveRecord where method.
-          virtual_status = params[:virtual] == 'yes'
-          workshops_array = workshops.select {|workshop| workshop.virtual? == virtual_status}
-          workshops = workshops_array.empty? ?
-            workshops.none :
-            workshops.where(id: workshops_array.map(&:id))
+          session_format = params[:virtual] == 'yes' ? 'virtual' : 'in_person'
+          workshops = workshops.joins(:sessions).where(sessions: {session_format: session_format})
         end
       end
 
@@ -137,7 +130,11 @@ module Pd::WorkshopFilters
         when 'subject'
           workshops = workshops.order("subject #{direction}".strip)
         when 'virtual'
-          workshops = workshops.order("virtual #{direction}".strip)
+          workshops = workshops.
+          joins("INNER JOIN pd_sessions ON pd_sessions.pd_workshop_id = pd_workshops.id and pd_sessions.deleted_at is null").
+          group("pd_workshops.id").
+          select("pd_workshops.*, MAX(CASE WHEN pd_sessions.session_format = #{Pd::Session.session_formats[:virtual]} THEN 1 ELSE 0 END) as has_virtual").
+          order(Arel.sql("has_virtual #{direction}"))
         when 'date'
           workshops = workshops.order_by_scheduled_start(desc: direction == 'desc')
         when 'enrollments'

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -208,12 +208,12 @@ class Pd::Workshop < ApplicationRecord
 
   # Filters by scheduled start date (date of first session)
   def self.scheduled_start_on_or_before(date)
-    joins(:sessions).group_by_id.having('(DATE(MIN(start)) <= ?)', date)
+    joins(:sessions).group_by_id.having('(DATE(MIN(pd_sessions.start)) <= ?)', date)
   end
 
   # Filters by scheduled start date (date of first session)
   def self.scheduled_start_on_or_after(date)
-    joins(:sessions).group_by_id.having('(DATE(MIN(start)) >= ?)', date)
+    joins(:sessions).group_by_id.having('(DATE(MIN(pd_sessions.start)) >= ?)', date)
   end
 
   scope(
@@ -229,7 +229,7 @@ class Pd::Workshop < ApplicationRecord
   # Orders by the scheduled start date (date of the first session),
   # @param :desc [Boolean] optional - when true, sort descending
   def self.order_by_scheduled_start(desc: false)
-    joins(:sessions).
+    joins("INNER JOIN pd_sessions ON pd_sessions.pd_workshop_id = pd_workshops.id").
       group_by_id.
       # This SQL string is not at risk for injection vulnerabilites because
       # it's not injesting arbitrary strings, but programmatically constructing

--- a/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
+++ b/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
@@ -134,9 +134,8 @@ class Pd::WorkshopFiltersTest < ActionController::TestCase
   test 'filter_workshops with virtual status' do
     params virtual: 'yes'
 
-    # No virtual workshops found, uses none to return empty set of records.
-    @workshop_query.expects(:select).returns([])
-    expects(:none)
+    @workshop_query.expects(:joins).with(:sessions).returns(@workshop_query)
+    @workshop_query.expects(:where).with(sessions: {session_format: 'virtual'}).returns([])
 
     @controller.filter_workshops @workshop_query
 
@@ -144,11 +143,8 @@ class Pd::WorkshopFiltersTest < ActionController::TestCase
       virtual: true,
       suppress_email: true
 
-    # Need to override expects method used elsewhere in this test file
-    # to set the return value to an array, instead of the mock @workshop_query
-    # object.
-    @workshop_query.expects(:select).returns([virtual_workshop])
-    expects(:where).with(id: [virtual_workshop.id])
+    @workshop_query.expects(:joins).with(:sessions).returns(@workshop_query)
+    @workshop_query.expects(:where).with(sessions: {session_format: 'virtual'}).returns([virtual_workshop])
 
     @controller.filter_workshops @workshop_query
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
When moving the `virtual` attribute from the workshop entity to the workshop's individual sessions I came across this a comment in the workshop filter query, saying filtering by `virtual` needed to be done outside the database query due to it being a serialized json attribute. Now that a workshop's format is determined by at least one of its sessions being virtual, it's easier to apply the filter to the query.

Sorting was a little trickier. I had to join with the sessions table and use `MAX` to determine if at least one session was virtual. I couldn't use ruby symbols in the join or group methods because they'd become ambiguous when combined with a filter that already joins `pd_sessions` with the workshops, like the date range filter, and of course the virtual filter.

Sort by virtual plus date range filter:

https://github.com/user-attachments/assets/e8b3af88-b830-4b9b-b25c-b31f771cdc83

Filter by virtual combined with other filters:


https://github.com/user-attachments/assets/351f7cf2-73fd-4731-bd34-f5e8569eb0fe





## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
