### PR TITLE
fix(fonts): remove multiple declarations of barlow

### DIFF
--- a/frontend/packages/component-library-styles/typography.module.scss
+++ b/frontend/packages/component-library-styles/typography.module.scss
@@ -5,29 +5,6 @@
    Updating styles in this file will require a manual sync of the that file.
 */
 
-// TODO: [DSCO-64] (https://codedotorg.atlassian.net/browse/DSCO-64)
-//  Once we move Typography to DSCO_ - make sure we delete apps/fonts/ folder,
-//  since that folder is only needed for scss modules
-@font-face {
-  font-family: 'Barlow Semi Condensed Semibold';
-  font-style: normal;
-  font-weight: 600;
-  src:
-    url('/fonts/barlowSemiCondensed/BarlowSemiCondensed-SemiBold.ttf')
-      format('truetype'),
-    local('?');
-}
-
-@font-face {
-  font-family: 'Barlow Semi Condensed Medium';
-  font-style: normal;
-  font-weight: 500;
-  src:
-    url('/fonts/barlowSemiCondensed/BarlowSemiCondensed-Medium.ttf')
-      format('truetype'),
-    local('?');
-}
-
 html {
   font-size: 100%;
 }

--- a/frontend/packages/component-library/tsup.config.ts
+++ b/frontend/packages/component-library/tsup.config.ts
@@ -21,10 +21,6 @@ function createConfig(format: 'cjs' | 'esm'): Options {
     target: 'es2019',
     format: [format],
     sourcemap: true,
-    external: [
-      '/fonts/barlowSemiCondensed/BarlowSemiCondensed-Medium.ttf',
-      '/fonts/barlowSemiCondensed/BarlowSemiCondensed-SemiBold.ttf',
-    ],
     esbuildPlugins: [
       sassPlugin({
         // In ESM mode, CSS Modules are generated which can be cached via the CSS loader.


### PR DESCRIPTION
Barlow is defined in the SCSS Module for Typography, which means the font face is redefined each time typography is used. This results in a font-face declaration in _each_ usage of Typography. To remove the duplicate declarations, remove the font-face declaration from Typography.

Additionally, Barlow is already defined as a global font in [application.scss](https://github.com/code-dot-org/code-dot-org/blob/d207451b6260de67d03eb87d531ae5d0fa43e8ef/dashboard/app/assets/stylesheets/application.scss#L24-L27)