### PR TITLE
Fix appearance of AI FAB for users who have not specified a preference

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1675,14 +1675,6 @@ class User < ApplicationRecord
     !!sort_by_family_name
   end
 
-  def ai_differentiation_enabled?
-    if ai_differentiation_enabled.nil?
-      return true
-    else
-      return !!ai_differentiation_enabled
-    end
-  end
-
   def generate_username
     # skip an expensive db query if the name is not valid anyway. we can't depend on validations being run
     return if name.blank? || email&.utf8mb4?

--- a/dashboard/lib/policies/ai.rb
+++ b/dashboard/lib/policies/ai.rb
@@ -30,8 +30,8 @@ class Policies::Ai
     # Must be a teacher
     return false unless user.teacher?
 
-    # An individual opt-out can be supplied here if implemented
-    user.ai_differentiation_enabled
+    # Check user preference: default to showing the AI differentiation.
+    user.ai_differentiation_enabled.nil? || user.ai_differentiation_enabled?
   end
 
   def self.ai_differentiation_enabled_for_unit?(unit_or_unit_group)

--- a/dashboard/test/lib/policies/ai_test.rb
+++ b/dashboard/test/lib/policies/ai_test.rb
@@ -125,7 +125,15 @@ class Policies::AiTest < ActiveSupport::TestCase
       _(ai_differentiation_enabled?).must_equal false
     end
 
-    context 'when the user is a teache and has enabled access to ai diff' do
+    context 'when the user is a teacher and has not specified a preference for enabling ai diff' do
+      let(:user) {build_stubbed(:user, user_type: 'teacher')}
+
+      it 'returns true' do
+        _(ai_differentiation_enabled?).must_equal true
+      end
+    end
+
+    context 'when the user is a teacher and has enabled access to ai diff' do
       let(:user) {build_stubbed(:user, user_type: 'teacher', ai_differentiation_enabled: true)}
 
       it 'returns true' do


### PR DESCRIPTION
I was working on a differentiation feature with a local test user who had not explicitly specified a preference for hiding or showing the differentiation AI, and the FAB wasn't showing up.

I discovered a couple of things:
1) The `User.ai_differentiation_enabled?` method added in #63681 has no effect, as a method with this name is already added by default for attributes [here](https://github.com/code-dot-org/code-dot-org/blob/bf6d03f8c31756376f4a0b54f03f2301325a8ff0/dashboard/app/models/concerns/serialized_properties.rb#L80).
2) That method wasn't being called in `policies/ai.rb`. It was instead looking at the `User.ai_differentiation_enabled` attribute directly, which resulted in the FAB not being shown for a `nil` attribute.

This PR updates the policy to show the FAB for users with `ai_differentiation_enabled == nil`, adds a test to ensure the same, and removes the ineffective `User.ai_differentiation_enabled?` method.

Other callers of `User.ai_differentiation_enabled?` that were assuming the custom behavior where `nil` defaults to `true` should be fixed in a separate PR.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
