### PR TITLE
[Pythonlab] Remove experiment so Backpack is always available

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {useBackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
-import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {
@@ -62,25 +61,22 @@ export const FileBrowserHeaderPopUpButton = () => {
           clickHandler={() => openNewFilePrompt({folderId: DEFAULT_FOLDER_ID})}
           id="uitest-new-file"
         />
-
         <PopUpButtonOption
           iconName="upload"
           labelText={codebridgeI18n.uploadFile()}
           clickHandler={() => startFileUpload()}
         />
-        {experiments.isEnabled(experiments.PYTHONLAB_BACKPACK) && (
-          <PopUpButtonOption
-            iconName="backpack"
-            labelText={codebridgeI18n.importFromBackpackTitle()}
-            clickHandler={() =>
-              openImportFromBackpackPrompt({
-                backpackApi: backpackApi,
-                projectFiles: source.files,
-                validationFile: validationFile,
-              })
-            }
-          />
-        )}
+        <PopUpButtonOption
+          iconName="backpack"
+          labelText={codebridgeI18n.importFromBackpackTitle()}
+          clickHandler={() =>
+            openImportFromBackpackPrompt({
+              backpackApi: backpackApi,
+              projectFiles: source.files,
+              validationFile: validationFile,
+            })
+          }
+        />
       </PopUpButton>
     </>
   );

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/useFileRowOptions.ts
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/useFileRowOptions.ts
@@ -14,7 +14,6 @@ import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {ProjectFileType} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useBackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
-import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useStartModeFileRowOptions} from './useStartModeFileRowOptions';
@@ -64,8 +63,8 @@ export const useFileRowOptions = (
 
   const isLocked = !isStartMode && file.type === ProjectFileType.LOCKED_STARTER;
 
-  const dropdownOptions = useMemo(() => {
-    const options = [
+  const dropdownOptions = useMemo(
+    () => [
       {
         condition:
           !isLocked &&
@@ -100,31 +99,28 @@ export const useFileRowOptions = (
         labelText: codebridgeI18n.deleteFile(),
         clickHandler: () => openConfirmDeleteFile({file}),
       },
-    ];
-
-    if (experiments.isEnabled(experiments.PYTHONLAB_BACKPACK)) {
-      options.push({
+      {
         condition: true,
         iconName: 'backpack',
         labelText: codebridgeI18n.saveToBackpackTitle(),
         clickHandler: () => openSaveToBackpackPrompt({file, backpackApi}),
-      });
-    }
-    return options;
-  }, [
-    appName,
-    backpackApi,
-    editableFileTypes,
-    file,
-    isLocked,
-    isStartMode,
-    openConfirmDeleteFile,
-    openMoveFilePrompt,
-    openRenameFilePrompt,
-    openSaveToBackpackPrompt,
-    projectFiles,
-    projectFolders,
-  ]);
+      },
+    ],
+    [
+      appName,
+      backpackApi,
+      editableFileTypes,
+      file,
+      isLocked,
+      isStartMode,
+      openConfirmDeleteFile,
+      openMoveFilePrompt,
+      openRenameFilePrompt,
+      openSaveToBackpackPrompt,
+      projectFiles,
+      projectFolders,
+    ]
+  );
 
   const startModeFileOptions = useStartModeFileRowOptions(
     file,

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -61,8 +61,6 @@ experiments.TEACHER_LOCAL_NAV_V2 = 'teacher-local-nav-v2';
 experiments.CSP_VALIDATION_VIA_AI = 'csp_validation_via_ai';
 // Allows users to view the new version of the teacher homepage
 experiments.TEACHER_HOMEPAGE_V2 = 'teacher-homepage-v2';
-// Adds backpack to pythonlab
-experiments.PYTHONLAB_BACKPACK = 'pythonlab-backpack';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR removes the 'pythonlab-backpack' experiment flag so that the Backpack is now always available in `pythonlab`.

![Screenshot 2025-02-26 at 9 11 50 AM](https://github.com/user-attachments/assets/6943d1e4-83f7-4054-9f01-380182bb5faf)


## Links
[jira](https://codedotorg.atlassian.net/browse/CT-1084)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally after disabling experiment.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
