### PR TITLE
Add a unit selector to the lesson materials page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2684,6 +2684,7 @@
   "selectStudent": "Filter by student",
   "selectStudentOption": "Select a student",
   "selectStudentsToMove": "Select students to move to a new section in the table. Select which section you want to move your students to in the dropdown below. Choose \"Other teacher\" if you want to move students to a different teacher's section. Moving students will not clear their progress.",
+  "selectUnit": "Select a unit",
   "selectYourSchool": "Select your school from the list",
   "selfPacedPl": "Self-paced PL",
   "selfPacedPlDescription": "Volunteers have translated our tutorials in over 45 languages. Help us continue to expand our tutorials for students around the world!",

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -34,6 +34,8 @@ export const finishedLoadingCoursesWithProgress = () => ({
 });
 
 // Selectors
+export const getSelectedUnitId = state => state.unitSelection.scriptId;
+
 const getSelectedUnit = state => {
   const scriptId = state.unitSelection.scriptId;
   if (!scriptId) {

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -87,7 +87,6 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
   HttpClient.fetchJson(`/dashboardapi/section_courses/${selectedSection.id}`)
     .then(response => response?.value)
     .then(coursesWithProgress => {
-      console.log('lfm loaded', {coursesWithProgress});
       // Reorder coursesWithProgress so that the current section is at the top and other sections are in order from newest to oldest
       const reorderedCourses = [
         ...coursesWithProgress.filter(

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -87,6 +87,7 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
   HttpClient.fetchJson(`/dashboardapi/section_courses/${selectedSection.id}`)
     .then(response => response?.value)
     .then(coursesWithProgress => {
+      console.log('lfm loaded', {coursesWithProgress});
       // Reorder coursesWithProgress so that the current section is at the top and other sections are in order from newest to oldest
       const reorderedCourses = [
         ...coursesWithProgress.filter(

--- a/apps/src/templates/UnitSelectorV2.jsx
+++ b/apps/src/templates/UnitSelectorV2.jsx
@@ -48,7 +48,6 @@ function UnitSelectorV2({
   // Reload courses with progress when selected section changes.
   React.useEffect(() => {
     if (sectionId) {
-      console.log('lfm loading', {sectionId});
       asyncLoadCoursesWithProgress();
     }
   }, [sectionId, asyncLoadCoursesWithProgress]);

--- a/apps/src/templates/UnitSelectorV2.jsx
+++ b/apps/src/templates/UnitSelectorV2.jsx
@@ -98,13 +98,6 @@ function UnitSelectorV2({
     />
   );
 
-  console.log('lfm', {
-    itemGroups,
-    unitId,
-    coursesWithProgress,
-    selectedSectionCourse,
-  });
-
   return isLoadingSectionData ||
     isLoadingCourses ||
     !coursesWithProgress ||

--- a/apps/src/templates/UnitSelectorV2.jsx
+++ b/apps/src/templates/UnitSelectorV2.jsx
@@ -36,7 +36,7 @@ const recordEvent = (eventName, sectionId, dataJson = {}) => {
 function UnitSelectorV2({
   filterToSelectedCourse = false,
   sectionId,
-  scriptId,
+  unitId,
   coursesWithProgress,
   className,
   setScriptId,
@@ -52,7 +52,6 @@ function UnitSelectorV2({
     }
   }, [sectionId, asyncLoadCoursesWithProgress]);
 
-  const unitId = React.useMemo(() => scriptId, [scriptId]);
   const onSelectUnit = React.useCallback(
     e => {
       const newUnitId = parseInt(e.target.value);
@@ -97,12 +96,13 @@ function UnitSelectorV2({
     />
   );
 
-  return isLoadingSectionData ||
-    isLoadingCourses ||
-    !coursesWithProgress ||
-    coursesWithProgress.length === 0 ? (
-    loadingDropdown()
-  ) : (
+  if (isLoadingCourses || isLoadingSectionData) {
+    return loadingDropdown();
+  } else if (!coursesWithProgress || coursesWithProgress.length === 0) {
+    return null;
+  }
+
+  return (
     <SimpleDropdown
       itemGroups={itemGroups}
       selectedValue={unitId}
@@ -121,7 +121,7 @@ function UnitSelectorV2({
 
 UnitSelectorV2.propTypes = {
   filterToSelectedCourse: PropTypes.bool,
-  scriptId: PropTypes.number,
+  unitId: PropTypes.number,
   sectionId: PropTypes.number,
   coursesWithProgress: PropTypes.array.isRequired,
   setScriptId: PropTypes.func.isRequired,
@@ -136,7 +136,7 @@ export const UnconnectedUnitSelectorV2 = UnitSelectorV2;
 
 export default connect(
   state => ({
-    scriptId: state.unitSelection.scriptId,
+    unitId: state.unitSelection.scriptId,
     sectionId: state.teacherSections.selectedSectionId,
     coursesWithProgress: state.unitSelection.coursesWithProgress,
     isLoadingCourses: state.unitSelection.isLoadingCoursesWithProgress,

--- a/apps/src/templates/UnitSelectorV2.jsx
+++ b/apps/src/templates/UnitSelectorV2.jsx
@@ -11,6 +11,7 @@ import {
   setScriptId,
 } from '@cdo/apps/redux/unitSelectionRedux';
 import {loadUnitProgress} from '@cdo/apps/templates/sectionProgress/sectionProgressLoader';
+import i18n from '@cdo/locale';
 
 import firehoseClient from '../metrics/firehose';
 
@@ -47,6 +48,7 @@ function UnitSelectorV2({
   // Reload courses with progress when selected section changes.
   React.useEffect(() => {
     if (sectionId) {
+      console.log('lfm loading', {sectionId});
       asyncLoadCoursesWithProgress();
     }
   }, [sectionId, asyncLoadCoursesWithProgress]);
@@ -74,7 +76,10 @@ function UnitSelectorV2({
 
   const itemGroups = coursesWithProgress
     .filter(
-      version => !filterToSelectedCourse || version.id === selectedSectionCourse
+      version =>
+        !filterToSelectedCourse ||
+        version.id === selectedSectionCourse ||
+        !version.id
     )
     .map(version => ({
       label: version.display_name,
@@ -93,6 +98,13 @@ function UnitSelectorV2({
     />
   );
 
+  console.log('lfm', {
+    itemGroups,
+    unitId,
+    coursesWithProgress,
+    selectedSectionCourse,
+  });
+
   return isLoadingSectionData ||
     isLoadingCourses ||
     !coursesWithProgress ||
@@ -110,6 +122,7 @@ function UnitSelectorV2({
       dropdownTextThickness="thin"
       id="unit-selector-v2"
       color="gray"
+      labelText={i18n.selectUnit()}
     />
   );
 }

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -59,9 +59,7 @@ const UnitCalendar: React.FC = () => {
 
   const unitToLoad = React.useMemo(
     () =>
-      selectedSection.unitName !== null
-        ? unitName || selectedSection.unitName
-        : null,
+      !!selectedSection.unitName ? unitName || selectedSection.unitName : null,
     [unitName, selectedSection.unitName]
   );
 

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -1,15 +1,22 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import _ from 'lodash';
 import React, {useState, useMemo, useCallback} from 'react';
+import {useSelector} from 'react-redux';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {getStore} from '@cdo/apps/redux';
+import {
+  asyncLoadCoursesWithProgress,
+  getSelectedUnitId,
+} from '@cdo/apps/redux/unitSelectionRedux';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
+
+import UnitSelectorV2 from '../../UnitSelectorV2';
 
 import {LessonMaterialsEmptyState} from './LessonMaterialsEmptyState';
 import {Lesson} from './LessonMaterialTypes';
@@ -84,34 +91,54 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
     state => state.teacherSections.needsReload
   );
 
+  const selectedUnitId = useSelector(getSelectedUnitId);
+
+  const dispatch = useAppDispatch();
+
   React.useEffect(() => {
-    const fetchLessonMaterials = async () => {
-      const state = getStore().getState().teacherSections;
-      const selectedSectionId = state.selectedSectionId;
-      const sectionData = state.sections[selectedSectionId];
+    dispatch(asyncLoadCoursesWithProgress());
+  }, [dispatch]);
 
-      if (!selectedSectionId || !sectionData.unitId) {
-        setLessonMaterials(null);
-        setIsLoading(false);
-        return;
+  const isLoadingCoursesWithProgress = useSelector(
+    (state: {unitSelection: {isLoadingCoursesWithProgress: boolean}}) =>
+      state.unitSelection.isLoadingCoursesWithProgress
+  );
+
+  const unitToLoad = React.useMemo(
+    () =>
+      selectedSection.unitId !== null
+        ? selectedUnitId || selectedSection.unitId
+        : null,
+    [selectedSection.unitId, selectedUnitId]
+  );
+
+  React.useEffect(() => {
+    const state = getStore().getState().teacherSections;
+    const selectedSectionId = state.selectedSectionId;
+
+    if (!selectedSectionId || !unitToLoad) {
+      setLessonMaterials(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+
+    if (isLoadingCoursesWithProgress) {
+      return;
+    }
+
+    lessonMaterialsCachedLoader(unitToLoad).then(data => {
+      setLessonMaterials(data);
+      setIsLoading(false);
+
+      if (data?.unitName) {
+        analyticsReporter.sendEvent(EVENTS.VIEW_LESSON_MATERIALS, {
+          unitName: data.unitName,
+        });
       }
-
-      setIsLoading(true);
-
-      await lessonMaterialsCachedLoader(sectionData.unitId).then(data => {
-        setLessonMaterials(data);
-        setIsLoading(false);
-
-        if (data?.unitName) {
-          analyticsReporter.sendEvent(EVENTS.VIEW_LESSON_MATERIALS, {
-            unitName: data.unitName,
-          });
-        }
-      });
-    };
-
-    fetchLessonMaterials();
-  }, [selectedSection]);
+    });
+  }, [isLoadingCoursesWithProgress, unitToLoad]);
 
   const {hasNumberedUnits, lessons, unitNumber, versionYear} = useMemo(() => {
     return {
@@ -230,11 +257,12 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
     );
   };
 
-  if (isLoading || needsReload) {
-    return <Spinner size={'large'} />;
-  }
-
-  if (hasEmptyState) {
+  if (
+    hasEmptyState &&
+    !isLoading &&
+    !isLoadingCoursesWithProgress &&
+    !needsReload
+  ) {
     return (
       <LessonMaterialsEmptyState
         isLegacyScript={isLegacyScript}
@@ -244,10 +272,19 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
   }
 
   return (
-    <div>
-      {renderHeader()}
-      {renderTeacherResources()}
-      {renderStudentResources()}
+    <div className={styles.lessonMaterialsContainer}>
+      <UnitSelectorV2 filterToSelectedCourse={true} />
+      {isLoading || needsReload ? (
+        <div>
+          <Spinner size={'large'} />
+        </div>
+      ) : (
+        <div>
+          {renderHeader()}
+          {renderTeacherResources()}
+          {renderStudentResources()}
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -26,7 +26,7 @@ import UnitResourcesDropdown from './UnitResourcesDropdown';
 import styles from './lesson-materials.module.scss';
 import skeletonizeContent from '@cdo/apps/sharedComponents/skeletonize-content.module.scss';
 
-export interface LessonMaterialsData {
+interface LessonMaterialsData {
   unitId: number;
   unitName?: string;
   title: string;

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -6,7 +6,6 @@ import {useSelector} from 'react-redux';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {getStore} from '@cdo/apps/redux';
 import {
   asyncLoadCoursesWithProgress,
   getSelectedUnitId,
@@ -27,7 +26,7 @@ import UnitResourcesDropdown from './UnitResourcesDropdown';
 import styles from './lesson-materials.module.scss';
 import skeletonizeContent from '@cdo/apps/sharedComponents/skeletonize-content.module.scss';
 
-interface LessonMaterialsData {
+export interface LessonMaterialsData {
   unitId: number;
   unitName?: string;
   title: string;
@@ -39,11 +38,10 @@ interface LessonMaterialsData {
   versionYear?: number;
 }
 
-const lessonMaterialsCachedLoader = _.memoize(async (unitId: number) =>
+const lessonMaterialsApiCall = (unitId: number) =>
   HttpClient.fetchJson<LessonMaterialsData>(
     `/dashboardapi/lesson_materials/${unitId}`
-  ).then(response => response?.value)
-);
+  ).then(response => response?.value);
 
 const skeletonDropdown = () => (
   <div
@@ -53,19 +51,6 @@ const skeletonDropdown = () => (
     )}
   />
 );
-
-export const lessonMaterialsLoader =
-  async (): Promise<LessonMaterialsData | null> => {
-    const state = getStore().getState().teacherSections;
-    const selectedSectionId = state.selectedSectionId;
-    const sectionData = state.sections[selectedSectionId];
-
-    if (!selectedSectionId || !sectionData.unitId) {
-      return null;
-    }
-
-    return lessonMaterialsCachedLoader(sectionData.unitId);
-  };
 
 // Some lessons are lockable and don't have lesson plans (typically assessments or surveys).
 // In this case, we want to display the lesson name without a number.  See CSP1-2022 for an example.
@@ -106,6 +91,11 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
 
   const dispatch = useAppDispatch();
 
+  const lessonMaterialsCachedLoader = React.useMemo(
+    () => _.memoize(lessonMaterialsApiCall),
+    []
+  );
+
   React.useEffect(() => {
     dispatch(asyncLoadCoursesWithProgress());
   }, [dispatch]);
@@ -117,16 +107,14 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
 
   const unitToLoad = React.useMemo(
     () =>
-      selectedSection.unitId !== null
+      !!selectedSection.unitId
         ? selectedUnitId || selectedSection.unitId
         : null,
     [selectedSection.unitId, selectedUnitId]
   );
 
   React.useEffect(() => {
-    const state = getStore().getState().teacherSections;
-    const selectedSectionId = state.selectedSectionId;
-
+    const selectedSectionId = selectedSection.id;
     if (!selectedSectionId || !unitToLoad) {
       setLessonMaterials(null);
       setIsLoading(false);
@@ -149,7 +137,12 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
         });
       }
     });
-  }, [isLoadingCoursesWithProgress, unitToLoad]);
+  }, [
+    isLoadingCoursesWithProgress,
+    unitToLoad,
+    selectedSection.id,
+    lessonMaterialsCachedLoader,
+  ]);
 
   const {hasNumberedUnits, lessons, unitNumber, versionYear} = useMemo(() => {
     return {

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -1,4 +1,5 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
+import classNames from 'classnames';
 import _ from 'lodash';
 import React, {useState, useMemo, useCallback} from 'react';
 import {useSelector} from 'react-redux';
@@ -24,6 +25,7 @@ import LessonResources from './LessonResources';
 import UnitResourcesDropdown from './UnitResourcesDropdown';
 
 import styles from './lesson-materials.module.scss';
+import skeletonizeContent from '@cdo/apps/sharedComponents/skeletonize-content.module.scss';
 
 interface LessonMaterialsData {
   unitId: number;
@@ -41,6 +43,15 @@ const lessonMaterialsCachedLoader = _.memoize(async (unitId: number) =>
   HttpClient.fetchJson<LessonMaterialsData>(
     `/dashboardapi/lesson_materials/${unitId}`
   ).then(response => response?.value)
+);
+
+const skeletonDropdown = () => (
+  <div
+    className={classNames(
+      styles.skeletonDropdown,
+      skeletonizeContent.skeletonizeContent
+    )}
+  />
 );
 
 export const lessonMaterialsLoader =
@@ -201,22 +212,33 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
   const renderHeader = () => {
     return (
       <div className={styles.lessonMaterialsPageHeader}>
-        <SimpleDropdown
-          labelText={i18n.chooseLesson()}
-          isLabelVisible={false}
-          onChange={event => onDropdownChange(event.target.value)}
-          items={lessonOptions}
-          selectedValue={selectedLesson ? selectedLesson.id.toString() : ''}
-          name={'lessons-in-assigned-unit-dropdown'}
-          size="s"
-          id="ui-test-lessons-in-assigned-unit-dropdown"
-        />
+        <div className={styles.lessonMaterialsDropdowns}>
+          <UnitSelectorV2
+            filterToSelectedCourse={true}
+            className={styles.unitSelector}
+          />
+          {isLoading || isLoadingCoursesWithProgress || needsReload ? (
+            skeletonDropdown()
+          ) : (
+            <SimpleDropdown
+              labelText={i18n.chooseLesson()}
+              isLabelVisible={false}
+              onChange={event => onDropdownChange(event.target.value)}
+              items={lessonOptions}
+              selectedValue={selectedLesson ? selectedLesson.id.toString() : ''}
+              name={'lessons-in-assigned-unit-dropdown'}
+              size="s"
+              id="ui-test-lessons-in-assigned-unit-dropdown"
+            />
+          )}
+        </div>
         {lessonMaterials && (
           <UnitResourcesDropdown
             hasNumberedUnits={hasNumberedUnits}
             unitNumber={lessonMaterials.unitNumber}
             scriptOverviewPdfUrl={lessonMaterials.scriptOverviewPdfUrl}
             scriptResourcesPdfUrl={lessonMaterials.scriptResourcesPdfUrl}
+            disabled={isLoading || needsReload}
           />
         )}
       </div>
@@ -273,14 +295,13 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
 
   return (
     <div className={styles.lessonMaterialsContainer}>
-      <UnitSelectorV2 filterToSelectedCourse={true} />
+      {renderHeader()}
       {isLoading || needsReload ? (
         <div>
           <Spinner size={'large'} />
         </div>
       ) : (
         <div>
-          {renderHeader()}
           {renderTeacherResources()}
           {renderStudentResources()}
         </div>

--- a/apps/src/templates/teacherNavigation/lessonMaterials/UnitResourcesDropdown.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/UnitResourcesDropdown.tsx
@@ -12,6 +12,7 @@ type UnitResourcesDropdownProps = {
   hasNumberedUnits?: boolean;
   scriptOverviewPdfUrl: string;
   scriptResourcesPdfUrl: string;
+  disabled?: boolean;
 };
 
 const UnitResourcesDropdown: React.FC<UnitResourcesDropdownProps> = ({
@@ -19,6 +20,7 @@ const UnitResourcesDropdown: React.FC<UnitResourcesDropdownProps> = ({
   hasNumberedUnits,
   scriptOverviewPdfUrl,
   scriptResourcesPdfUrl,
+  disabled = false,
 }) => {
   const downloadLessonPlansLabel =
     hasNumberedUnits && unitNumber
@@ -63,6 +65,7 @@ const UnitResourcesDropdown: React.FC<UnitResourcesDropdownProps> = ({
         labelText="View unit options dropdown"
         options={dropdownOptions}
         size="s"
+        disabled={disabled}
         menuPlacement="right"
         triggerButtonProps={{
           color: 'gray',

--- a/apps/src/templates/teacherNavigation/lessonMaterials/lesson-materials.module.scss
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/lesson-materials.module.scss
@@ -7,6 +7,12 @@
   justify-content: space-between;
 }
 
+.lessonMaterialsDropdowns {
+  display: flex;
+  gap: 16px;
+  margin-right: 16px;
+}
+
 .rowContainer {
   display: flex;
   height: 48px;
@@ -30,7 +36,6 @@
 }
 
 .resourcesTable {
-  margin-top: 20px;
   border: 1px solid var(--borders-neutral-primary);
   border-radius: 4px;
 }
@@ -107,4 +112,15 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+.skeletonDropdown {
+  width: 250px;
+  border-radius: 0.25rem;
+  height: 2rem;
+  margin-inline-start: 8px;
+}
+
+.unitSelector{
+  max-width: 400px;
 }

--- a/apps/src/templates/teacherNavigation/lessonMaterials/lesson-materials.module.scss
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/lesson-materials.module.scss
@@ -102,3 +102,9 @@
   justify-content: center;
   align-items: center;
 }
+
+.lessonMaterialsContainer{
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}

--- a/apps/test/unit/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainerTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainerTest.tsx
@@ -10,9 +10,7 @@ import {
   registerReducers,
   restoreRedux,
 } from '@cdo/apps/redux';
-import unitSelection, {
-  setCoursesWithProgress,
-} from '@cdo/apps/redux/unitSelectionRedux';
+import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import teacherSections, {
   selectSection,
   setSections,
@@ -129,6 +127,7 @@ describe('LessonMaterialsContainer', () => {
     unitNumber: 3,
     hasNumberedUnits: true,
     versionYear: 2023,
+    unitId: 1,
     lessons: [
       {
         name: 'First lesson',
@@ -240,7 +239,11 @@ describe('LessonMaterialsContainer', () => {
     ],
   };
 
-  const renderDefault = async (showNoCurriculumAssigned = false) => {
+  const renderDefault = async (
+    showNoCurriculumAssigned = false,
+    lessonData: object = mockLessonData
+  ) => {
+    mockSpy(lessonData);
     await act(async () =>
       render(
         <Provider store={store}>
@@ -264,21 +267,36 @@ describe('LessonMaterialsContainer', () => {
 
     store.dispatch(setSections(SECTIONS));
     store.dispatch(selectSection(1));
-    store.dispatch(setCoursesWithProgress(COURSES_WITH_PROGRESS));
 
     fetchSpy = jest.spyOn(HttpClient, 'fetchJson');
+    mockSpy(mockLessonData);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     jest.resetAllMocks();
     restoreRedux();
+    fetchSpy.mockReset();
   });
 
-  it('renders the component and dropdown with lessons', async () => {
-    fetchSpy.mockResolvedValue({
-      value: mockLessonData,
-      response: new Response(),
+  const mockSpy = (lessonData: object) => {
+    fetchSpy.mockReset();
+    fetchSpy.mockImplementation((path: string) => {
+      if (path.includes('lesson_materials')) {
+        return Promise.resolve({
+          value: lessonData,
+          response: new Response(),
+        });
+      }
+      if (path.includes('section_courses')) {
+        return Promise.resolve({
+          value: COURSES_WITH_PROGRESS,
+          response: new Response(),
+        });
+      }
     });
+  };
+
+  it('renders the component and dropdown with lessons', async () => {
     await renderDefault();
 
     // check for unit resources dropdown
@@ -290,18 +308,16 @@ describe('LessonMaterialsContainer', () => {
       i18n.downloadUnitXHandouts({unitNumber: mockLessonData.unitNumber})
     );
 
+    // Check for unit selector
+    screen.getByRole('combobox', {name: 'Select a unit'});
+
     // Check for lesson dropdowns
-    screen.getByRole('combobox');
+    screen.getByRole('combobox', {name: 'Choose a lesson'});
     screen.getByRole('option', {name: 'Lesson 1 — First lesson'});
     screen.getByRole('option', {name: 'Lesson 2 — Second lesson'});
   });
 
   it('renders the student and teacher resources for the first lesson on render', async () => {
-    fetchSpy.mockResolvedValue({
-      value: mockLessonData,
-      response: new Response(),
-    });
-
     await renderDefault();
 
     // Teacher resources, including lesson plan, unit vocab and unit standards
@@ -331,24 +347,15 @@ describe('LessonMaterialsContainer', () => {
 
     store.dispatch(selectSection(2));
 
-    fetchSpy.mockResolvedValue({
-      value: lessonDataWithoutNumberedUnits,
-      response: new Response(),
-    });
+    await renderDefault(false, lessonDataWithoutNumberedUnits);
 
-    await renderDefault();
-
-    screen.getByText('Unit Standards');
+    await screen.findByText('Unit Standards');
     screen.getByText('Unit Vocabulary');
     screen.getByText(i18n.downloadUnitLessonPlans());
     screen.getByText(i18n.downloadUnitHandouts());
   });
 
   it('shows no student resources if no student resources are provided', async () => {
-    fetchSpy.mockResolvedValue({
-      value: mockLessonData,
-      response: new Response(),
-    });
     await renderDefault();
 
     // check for unit resources dropdown
@@ -361,7 +368,9 @@ describe('LessonMaterialsContainer', () => {
     );
 
     // Check for lesson dropdowns
-    const lessonDropdown = screen.getByRole('combobox');
+    const lessonDropdown = screen.getByRole('combobox', {
+      name: 'Choose a lesson',
+    });
     screen.getByRole('option', {name: 'Lesson 1 — First lesson'});
     screen.getByRole('option', {name: 'Lesson 2 — Second lesson'});
 
@@ -374,14 +383,8 @@ describe('LessonMaterialsContainer', () => {
   });
 
   it('notifies users if no curriculum is assigned.', async () => {
-    fetchSpy.mockResolvedValue({
-      value: mockLessonData,
-      response: new Response(),
-    });
     store.dispatch(selectSection(12));
-    await act(async () => {
-      renderDefault(true);
-    });
+    await renderDefault(true);
 
     screen.getByAltText('blank screen');
     screen.getByText(i18n.emptySectionHeadline());
@@ -415,13 +418,11 @@ describe('LessonMaterialsContainer', () => {
   });
 
   it('renders the resources for the new lesson when lesson is changed', async () => {
-    fetchSpy.mockResolvedValue({
-      value: mockLessonData,
-      response: new Response(),
-    });
     await renderDefault();
 
-    const selectedLessonInput = screen.getAllByRole('combobox')[0];
+    const selectedLessonInput = screen.getByRole('combobox', {
+      name: 'Choose a lesson',
+    });
 
     fireEvent.change(selectedLessonInput, {target: {value: '2'}});
 
@@ -440,13 +441,11 @@ describe('LessonMaterialsContainer', () => {
   });
 
   it('renders will render message when there is no lesson plan', async () => {
-    fetchSpy.mockResolvedValue({
-      value: mockLessonData,
-      response: new Response(),
-    });
     await renderDefault();
 
-    const selectedLessonInput = screen.getAllByRole('combobox')[0];
+    const selectedLessonInput = screen.getByRole('combobox', {
+      name: 'Choose a lesson',
+    });
 
     fireEvent.change(selectedLessonInput, {target: {value: '3'}});
 
@@ -454,12 +453,8 @@ describe('LessonMaterialsContainer', () => {
   });
 
   it('renders empty state when there are no lesson plans in the whole unit', async () => {
-    fetchSpy.mockResolvedValue({
-      value: mockLessonDataNoLessonPlans,
-      response: new Response(),
-    });
     store.dispatch(selectSection(3));
-    await renderDefault();
+    await renderDefault(false, mockLessonDataNoLessonPlans);
 
     screen.getByText('There are no lesson materials for this unit.');
   });


### PR DESCRIPTION
Adds a unit selector to the lesson materials page


https://github.com/user-attachments/assets/b386f2d7-0d93-442c-ac19-858bbef1f128

Note: the lesson selector will be gray border in [this](https://github.com/code-dot-org/code-dot-org/pull/64148) PR

## Links
https://codedotorg.atlassian.net/browse/TEACH-1643