### PR TITLE
Python Lab backpack: add analytics and error logging

### DIFF
--- a/apps/src/codebridge/FileBrowser/prompts/openImportFromBackpackPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openImportFromBackpackPrompt.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 
 import BackpackErrorAlertBody from '@cdo/apps/codebridge/FileBrowser/BackpackErrorAlertBody';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
 import {
   DialogType,
@@ -40,15 +41,19 @@ export const openImportFromBackpackPrompt = async ({
   projectFiles,
   validationFile,
 }: OpenImportFromBackpackPromptArgsType) => {
-  const handleError = (title: string, message: string) => () => {
-    // TODO: send analytics / add logging.
-    const bodyComponent = <BackpackErrorAlertBody message={message} />;
-    dialogControl?.showDialog({
-      type: DialogType.GenericAlert,
-      title,
-      bodyComponent,
-    });
-  };
+  const handleError =
+    (title: string, message: string, errorMessage: string) =>
+    (error?: Error) => {
+      const bodyComponent = <BackpackErrorAlertBody message={message} />;
+      dialogControl?.showDialog({
+        type: DialogType.GenericAlert,
+        title,
+        bodyComponent,
+      });
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .logError(errorMessage, error);
+    };
   // Delete a file from the backpack.
   const handleDelete = async (selectedFileName: string) => {
     backpackApi.deleteFiles(
@@ -57,7 +62,8 @@ export const openImportFromBackpackPrompt = async ({
         codebridgeI18n.deleteFromBackpackTitle(),
         codebridgeI18n.deleteFromBackpackError({selectedFileName}) +
           ' ' +
-          codebridgeI18n.closeWindowTryAgain()
+          codebridgeI18n.closeWindowTryAgain(),
+        'Backpack file delete error'
       ),
       () => sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_DELETE_FROM_BACKPACK)
     );
@@ -75,7 +81,8 @@ export const openImportFromBackpackPrompt = async ({
         codebridgeI18n.importFromBackpackTitle(),
         codebridgeI18n.getBackpackFileError({selectedFileName}) +
           ' ' +
-          codebridgeI18n.closeWindowTryAgain()
+          codebridgeI18n.closeWindowTryAgain(),
+        'Backpack file fetch error'
       ),
       (fileContent: string) => {
         if (newFileName) {
@@ -100,7 +107,8 @@ export const openImportFromBackpackPrompt = async ({
   backpackApi.getFileList(
     handleError(
       codebridgeI18n.filesInBackpackTitle(),
-      `${codebridgeI18n.getBackpackFileListError()} ${codebridgeI18n.closeWindowTryAgain()}`
+      `${codebridgeI18n.getBackpackFileListError()} ${codebridgeI18n.closeWindowTryAgain()}`,
+      'Backpack file list fetch error'
     ),
     async (filenames: string[]) => {
       if (filenames.length === 0) {

--- a/apps/src/codebridge/FileBrowser/prompts/openImportFromBackpackPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openImportFromBackpackPrompt.tsx
@@ -171,7 +171,7 @@ export const openImportFromBackpackPrompt = async ({
               handleConfirm: () =>
                 fetchFileContentAndProcess(
                   selectedBackpackFileName,
-                  EVENTS.CODEBRIDGE_IMPORT_FROM_BACKPACK_REPLACE,
+                  EVENTS.CODEBRIDGE_IMPORT_FROM_BACKPACK_RENAME,
                   newFileName
                 ), // Fetch backpack file content and import new file with numeric suffix.
             });

--- a/apps/src/codebridge/FileBrowser/prompts/openImportFromBackpackPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openImportFromBackpackPrompt.tsx
@@ -7,6 +7,7 @@ import {
   getFileNameWithNumberSuffix,
   isDuplicateFileName,
   DuplicateFileError,
+  sendCodebridgeAnalyticsEvent,
 } from '@codebridge/utils';
 import React from 'react';
 
@@ -19,6 +20,7 @@ import {
   extractUserInput,
 } from '@cdo/apps/lab2/views/dialogs';
 import {GenericDropdownProps} from '@cdo/apps/lab2/views/dialogs/GenericDropdown';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {BackpackContextType} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
 
 type OpenImportFromBackpackPromptArgsType = {
@@ -57,13 +59,14 @@ export const openImportFromBackpackPrompt = async ({
           ' ' +
           codebridgeI18n.closeWindowTryAgain()
       ),
-      () => {}
+      () => sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_DELETE_FROM_BACKPACK)
     );
   };
 
   // Fetch file content from backpack and then update or create a project file.
   const fetchFileContentAndProcess = (
     selectedFileName: string,
+    successMetric: string,
     newFileName?: string
   ) => {
     backpackApi.fetchFile(
@@ -85,6 +88,7 @@ export const openImportFromBackpackPrompt = async ({
           );
           if (fileId) saveFile(fileId, fileContent);
         }
+        sendCodebridgeAnalyticsEvent(successMetric);
       }
     );
   };
@@ -159,6 +163,7 @@ export const openImportFromBackpackPrompt = async ({
               handleConfirm: () =>
                 fetchFileContentAndProcess(
                   selectedBackpackFileName,
+                  EVENTS.CODEBRIDGE_IMPORT_FROM_BACKPACK_REPLACE,
                   newFileName
                 ), // Fetch backpack file content and import new file with numeric suffix.
             });
@@ -177,10 +182,14 @@ export const openImportFromBackpackPrompt = async ({
               confirmText: codebridgeI18n.replaceFile(),
               neutralText: codebridgeI18n.importAsNewName({newFileName}),
               handleConfirm: () =>
-                fetchFileContentAndProcess(selectedBackpackFileName), // Update existing project file.
+                fetchFileContentAndProcess(
+                  selectedBackpackFileName,
+                  EVENTS.CODEBRIDGE_IMPORT_FROM_BACKPACK_REPLACE
+                ), // Update existing project file.
               handleNeutral: () =>
                 fetchFileContentAndProcess(
                   selectedBackpackFileName,
+                  EVENTS.CODEBRIDGE_IMPORT_FROM_BACKPACK_RENAME,
                   newFileName
                 ), // Fetch backpack file content and import new file with numeric suffix.
             });
@@ -188,6 +197,7 @@ export const openImportFromBackpackPrompt = async ({
             // Fetch backpack file content and import new file to project - not a duplicate file name.
             fetchFileContentAndProcess(
               selectedBackpackFileName,
+              EVENTS.CODEBRIDGE_IMPORT_FROM_BACKPACK_NEW,
               selectedBackpackFileName
             );
           }

--- a/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
@@ -1,5 +1,8 @@
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
-import {getFileNameWithNumberSuffix} from '@codebridge/utils';
+import {
+  getFileNameWithNumberSuffix,
+  sendCodebridgeAnalyticsEvent,
+} from '@codebridge/utils';
 import React from 'react';
 
 import BackpackErrorAlertBody from '@cdo/apps/codebridge/FileBrowser/BackpackErrorAlertBody';
@@ -10,6 +13,7 @@ import {
   DialogControlInterface,
   TypedDialogProps,
 } from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {BackpackContextType} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
 
 type OpenSaveToBackpackPromptArgsType = {
@@ -71,8 +75,19 @@ export const openSaveToBackpackPrompt = async ({
       if (results.type === 'cancel') {
         return;
       }
+
       const selectedFileName =
         results.type === 'confirm' ? file.name : fileNameCopy;
+
+      let successMetric = EVENTS.CODEBRIDGE_SAVE_TO_BACKPACK_NEW;
+      if (isDuplicateFileName) {
+        successMetric =
+          selectedFileName === file.name
+            ? EVENTS.CODEBRIDGE_SAVE_TO_BACKPACK_REPLACE
+            : EVENTS.CODEBRIDGE_SAVE_TO_BACKPACK_RENAME;
+      }
+      const successCallback = () => sendCodebridgeAnalyticsEvent(successMetric);
+
       const fileContents = {
         name: selectedFileName,
         contents: file.contents,
@@ -90,7 +105,7 @@ export const openSaveToBackpackPrompt = async ({
             ' ' +
             codebridgeI18n.closeWindowTryAgain()
         ),
-        () => {}
+        successCallback
       );
     }
   );

--- a/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 import BackpackErrorAlertBody from '@cdo/apps/codebridge/FileBrowser/BackpackErrorAlertBody';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {ProjectFile} from '@cdo/apps/lab2/types';
 import {
   DialogType,
@@ -27,19 +28,24 @@ export const openSaveToBackpackPrompt = async ({
   backpackApi,
   file,
 }: OpenSaveToBackpackPromptArgsType) => {
-  const handleError = (title: string, message: string) => () => {
-    // TODO: send analytics / add logging.
-    const bodyComponent = <BackpackErrorAlertBody message={message} />;
-    dialogControl?.showDialog({
-      type: DialogType.GenericAlert,
-      title,
-      bodyComponent,
-    });
-  };
+  const handleError =
+    (title: string, message: string, errorMessage: string) =>
+    (error?: Error) => {
+      const bodyComponent = <BackpackErrorAlertBody message={message} />;
+      dialogControl?.showDialog({
+        type: DialogType.GenericAlert,
+        title,
+        bodyComponent,
+      });
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .logError(errorMessage, error);
+    };
   backpackApi.getFileList(
     handleError(
       codebridgeI18n.importFromBackpackTitle(),
-      `${codebridgeI18n.getBackpackFileListError()} ${codebridgeI18n.closeWindowTryAgain()}`
+      `${codebridgeI18n.getBackpackFileListError()} ${codebridgeI18n.closeWindowTryAgain()}`,
+      'Backpack file list fetch error'
     ),
     async (filenames: string[]) => {
       // Check if filename is a duplicate of a saved file in backpack.
@@ -103,7 +109,8 @@ export const openSaveToBackpackPrompt = async ({
           codebridgeI18n.saveToBackpackTitle(),
           codebridgeI18n.saveToBackpackError({selectedFileName}) +
             ' ' +
-            codebridgeI18n.closeWindowTryAgain()
+            codebridgeI18n.closeWindowTryAgain(),
+          'Save to backpack error'
         ),
         successCallback
       );

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -464,6 +464,19 @@ const EVENTS = {
     'Attempted upload of unaccepted file on codebridge',
   CODEBRIDGE_UPLOAD_FAILED: 'Failed to upload file on codebridge',
 
+  // Codebridge - Backpack events
+  CODEBRIDGE_SAVE_TO_BACKPACK_NEW: 'Save new file to backpack on codebridge',
+  CODEBRIDGE_SAVE_TO_BACKPACK_REPLACE: 'Replace file in backpack on codebridge',
+  CODEBRIDGE_SAVE_TO_BACKPACK_RENAME:
+    'Save renamed file to backpack on codebridge',
+  CODEBRIDGE_DELETE_FROM_BACKPACK: 'Delete from backpack on codebridge',
+  CODEBRIDGE_IMPORT_FROM_BACKPACK_NEW:
+    'Import new file from backpack on codebridge',
+  CODEBRIDGE_IMPORT_FROM_BACKPACK_REPLACE:
+    'Import a file from backpack on codebridge, replacing existing file',
+  CODEBRIDGE_IMPORT_FROM_BACKPACK_RENAME:
+    'Import a file from backpack on codebridge, renaming it',
+
   // Codebridge - Other events
   CODEBRIDGE_CLEAR_CONSOLE: 'Console cleared on codebridge',
   CODEBRIDGE_MOVE_CONSOLE: 'Console moved on codebridge',

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.js
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.js
@@ -38,7 +38,7 @@ export default class BackpackClientApi {
       this.channelId + '/' + filename + cacheBustSuffix,
       (error, data) => {
         if (error) {
-          onError();
+          onError(error);
         } else {
           onSuccess(data);
         }

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.js
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.js
@@ -111,7 +111,7 @@ export default class BackpackClientApi {
           fileObject,
           [filename],
           onError,
-          () => {},
+          onSuccess,
           'pythonlab'
         )
     );


### PR DESCRIPTION
Add statsig analytics and cloudwatch error logging to backpack. The analytics cover import, upload and delete actions, and we now have error logs for all the points of failure where a user would see an error message.

## Links
- jira ticket: [CT-1077](https://codedotorg.atlassian.net/browse/CT-1077)


## Testing story
Tested locally that the statsig logs show up for each action, and when simulating failures the error logs show up.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
