### PR TITLE
Adding aria label to console options ellipsis

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -10,6 +10,7 @@
   "clearConsole": "Clear console",
   "closeFile": "close file {filename}",
   "consoleHeader": "Console",
+  "consoleOptions": "Console Options",
   "defaultLayout": "Default layout",
   "defaultNewFileContents": "Add your changes to {fileName}",
   "delete": "Delete",

--- a/apps/src/codebridge/components/SwapLayoutDropdown.tsx
+++ b/apps/src/codebridge/components/SwapLayoutDropdown.tsx
@@ -54,6 +54,7 @@ const SwapLayoutDropdown: React.FunctionComponent = () => {
       iconName="ellipsis-v"
       alignment="right"
       disabled={isRunningOrValidating}
+      ariaLabel={codebridgeI18n.consoleOptions()}
     >
       <div onClick={onLayoutChange} className={darkModeStyles.dropdownItem}>
         <FontAwesomeV6Icon iconName={iconName} iconStyle={'solid'} />


### PR DESCRIPTION
Simple PR to add an aria label to the console options ellipsis button for screenreaders. Tested locally

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-1012

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
