### PR TITLE
Falsify valid_secret_words when secret_words are missing

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1696,6 +1696,7 @@ class User < ApplicationRecord
   end
 
   def valid_secret_words?(words)
+    return false unless secret_words
     words.delete(' ') == secret_words.delete(' ')
   end
 


### PR DESCRIPTION
There are cases where migrated accounts are added to sections and do not have secret words. In this case, they cannot log in, but also, this causes a 500 error in the `valid_secret_words?` method. This prevents the 500.

You can reproduce this by creating a new student with an email and then joining a secret words section. You'll not have secret words until the teacher resets them via:

![image](https://github.com/user-attachments/assets/7d9a5115-b392-4e01-8a90-e9e972a792b2)

(You can see that there are no words there. Hitting reset generates them)

This is not really an issue... teachers will certainly notice a blank secret words... when they need to tell them what they are. Though, we could generate them once we detect that a student without them joins such a section that requires them (although... they could also get to the section via their other auth option)

## Links

- honeybadger: [fault 117652787](https://app.honeybadger.io/projects/3240/faults/117652787)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
