### PR TITLE
Add title and description for key pages on code.org and hourofcode.com

### DIFF
--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -1,4 +1,5 @@
 ---
+title: Computer science and artificial intelligence curriculum for K-12 Schools
 theme: responsive_wide
 banner:
 layout: wide

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -1,5 +1,4 @@
 ---
-title: Computer science and artificial intelligence curriculum for K-12 Schools
 theme: responsive_wide
 banner:
 layout: wide
@@ -12,7 +11,7 @@ jquery: defer
 style_min: true
 ---
 :ruby
-  @header["title"] = hoc_s(:hoc2020_header)
+  @header["title"] = hoc_s(:hoc2019_header)
 
   hoc_mode = DCDO.get('hoc_mode', CDO.default_hoc_mode)
 

--- a/pegasus/sites.v3/code.org/public/students.haml
+++ b/pegasus/sites.v3/code.org/public/students.haml
@@ -1,5 +1,5 @@
 ---
-title: Learn Computer Science
+title: Fun tutorials to learn computer science and artificial intelligence
 theme: responsive_full_width
 ---
 

--- a/pegasus/sites.v3/code.org/public/teach.haml
+++ b/pegasus/sites.v3/code.org/public/teach.haml
@@ -1,5 +1,5 @@
 ---
-title: Teach Computer Science
+title: Teach Computer Science and Artificial Intelligence
 theme: responsive_full_width
 ---
 

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -61,7 +61,10 @@
       desc: "Explore how computer science can bring your favorite things to life."
       v2:
         title: "One Hour: Ignite. Inspire. Code."
-        desc: "Bring what your children love to life! Start the fun with an activity."
+        desc: "The Hour of Code is a worldwide movement that aims to introduce millions of students to computer science through one-hour coding activities"
+    learn_social:
+      title: "Free One Hour Coding Tutorials"
+      desc: "Bringing Hour of Code and computer science to your classroom or school is easy! Pick one of over 100 free coding tutorials to begin learning. No experience needed."
     video_caption:
       visible: "One Hour Can Make The Invisible Visible"
       in_a_world: "Make The Invisible Visible | Official Trailer"
@@ -95,7 +98,7 @@
   hoc2020_ai_header: 'Explore Artificial Intelligence'
   hoc2020_ai_description: 'AI and Machine Learning are impacting our entire world. Join us to explore AI in a new video series, train AI for Oceans in 25+ languages, discuss ethics and AI, and more...'
 
-  hoc2019_header: 'Learn computer science. Change the world.'
+  hoc2019_header: 'Computer science and artificial intelligence curriculum for K-12 Schools'
   hoc2019_header_line1_mobile: 'Learn computer science.'
   hoc2019_header_line2_mobile: 'Change the world.'
   social_hoc2019_every_sudent: 'Every student has the potential to change the world. Help them get started. #CSforGood'
@@ -12363,6 +12366,9 @@
   hoc_beyond_carousel_description: "Want to keep learning after Hour of Code? Check out these activities for learners of all ages and skill levels."
   hoc_beyond_submit_activity_form: "Submit your own activity [here](%{form_url})."
   hoc_beyond_end_section_label: "The Hour of Code is organized by [Code.org](%{home_page})"
+
+  code_org_og_description: "Code.org provides free computer science and AI curriculum, plus professional development to support any teacher—no coding experience needed!"
+  students_og_title: "Fun tutorials to learn computer science and artificial intelligence"
 
   pl_curriculum_launch_skinny_banner_2024:
     title: Introducing new professional learning!

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -62,9 +62,6 @@
       v2:
         title: "One Hour: Ignite. Inspire. Code."
         desc: "The Hour of Code is a worldwide movement that aims to introduce millions of students to computer science through one-hour coding activities"
-    learn_social:
-      title: "Free One Hour Coding Tutorials"
-      desc: "Bringing Hour of Code and computer science to your classroom or school is easy! Pick one of over 100 free coding tutorials to begin learning. No experience needed."
     video_caption:
       visible: "One Hour Can Make The Invisible Visible"
       in_a_world: "Make The Invisible Visible | Official Trailer"
@@ -11094,7 +11091,9 @@
 
   hoc_activities:
     heading: "Explore activities"
+    title: "Free One Hour Coding Tutorials"
     desc: "Teachers: [Host an hour](%{host_url}) or [read the How-To Guide](%{how_to_url})"
+    seo_desc: "Bring an Hour of Code and computer science to your classroom or school. With over 100 free coding tutorials available to begin learning it is easy."
     more:
       heading: "Can't find your favorite activity?"
       button: "Explore more here"

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -1,10 +1,9 @@
 ---
-title: One Hour: Ignite. Inspire. Code.
 layout: wide_index
 ---
 
 :ruby
-  @header["title"] = hoc_s(:front_title, locals: {campaign_date: campaign_date('full-year')})
+  @header["title"] = hoc_s("hoc_2024.social.v2.title")
 
 %link{href: '/css/full-width-section.css', rel:'stylesheet', type:'text/css'}
 %link{href: "/css/generated/front-page.css", rel: "stylesheet", type: "text/css"}

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -1,4 +1,5 @@
 ---
+title: One Hour: Ignite. Inspire. Code.
 layout: wide_index
 ---
 

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -1,4 +1,5 @@
 ---
+title: Free One Hour Coding Tutorials
 layout: wide_index
 ---
 

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -1,10 +1,9 @@
 ---
-title: Free One Hour Coding Tutorials
 layout: wide_index
 ---
 
 :ruby
-  @header["title"] = hoc_s("hoc_activities.heading")
+  @header["title"] = hoc_s("hoc_activities.title")
 
 :scss
   section.more {

--- a/pegasus/src/social_metadata.rb
+++ b/pegasus/src/social_metadata.rb
@@ -157,16 +157,16 @@ def get_social_metadata_for_page(request)
     },
     "learn" => {
       "default" => {
-        title: hoc_s("hoc_2024.learn_social.title"),
-        description: hoc_s("hoc_2024.learn_social.desc"),
+        title: hoc_s("hoc_activities.title"),
+        description: hoc_s("hoc_activities.seo_desc"),
         image: images[:hoc_2024_social]
       }
     },
   }
 
-  if request.site == "hourofcode.com"
+  if request.path == "/" && request.site == "hourofcode.com"
     page = request.site
-  elsif request.path == "/learn" && request.site == "hourofcode.com"
+  elsif request.path.include?("/learn") && request.site == "hourofcode.com"
     page = "learn"
   elsif request.path == "/" && request.site == "code.org"
     page = request.site

--- a/pegasus/src/social_metadata.rb
+++ b/pegasus/src/social_metadata.rb
@@ -34,6 +34,8 @@ def get_social_metadata_for_page(request)
     music_lab: {path: "/shared/images/social-media/music-lab.png", width: 1200, height: 630},
     music_lab_jam: {path: "/shared/images/social-media/music-lab-jam.png", width: 1200, height: 630},
     lms: {path: "/shared/images/social-media/lms.png", width: 1200, height: 630},
+    teach: {path: "/shared/images/teach-page-top.png", width: 1200, height: 630},
+    students: {path: "/shared/images/courses-art-k-5.png", width: 1200, height: 630},
   }
 
   # Important:
@@ -44,7 +46,7 @@ def get_social_metadata_for_page(request)
     "code.org" => {
       "default" => {
         title: hoc_s(:hoc2019_header),
-        description: I18n.t(:og_description),
+        description: hoc_s(:code_org_og_description),
         image: images[:kids_with_ipads]
       }
     },
@@ -139,10 +141,33 @@ def get_social_metadata_for_page(request)
         image: images[:lms]
       }
     },
+    "teach" => {
+      "default" => {
+        title: hoc_s("teach_page_top_heading"),
+        description: hoc_s("teach_page_top_desc_01"),
+        image: images[:teach]
+      }
+    },
+    "students" => {
+      "default" => {
+        title: hoc_s("students_og_title"),
+        description: hoc_s("student_courses_explore_desc"),
+        image: images[:students]
+      }
+    },
+    "learn" => {
+      "default" => {
+        title: hoc_s("hoc_2024.learn_social.title"),
+        description: hoc_s("hoc_2024.learn_social.desc"),
+        image: images[:hoc_2024_social]
+      }
+    },
   }
 
   if request.site == "hourofcode.com"
     page = request.site
+  elsif request.path == "/learn" && request.site == "hourofcode.com"
+    page = "learn"
   elsif request.path == "/" && request.site == "code.org"
     page = request.site
   elsif request.path == "/minecraft" && request.site == "code.org"
@@ -169,6 +194,10 @@ def get_social_metadata_for_page(request)
     page = "music_lab"
   elsif request.path == "/lms" && request.site == "code.org"
     page = "lms"
+  elsif request.path == "/teach" && request.site == "code.org"
+    page = "teach"
+  elsif request.path == "/students" && request.site == "code.org"
+    page = "students"
   else
     return {}
   end


### PR DESCRIPTION
As part of the SEO Strategy we are doing a couple updates to title and descriptions on key pages of the marketing site.

These pages are:
code.org
code.org/teach
code.org/students
hourofcode.com
hourofcode.com/learn

This PR updates/adds social(og) titles, images and descriptions. The descriptions from social are also used as normal descriptions. Then I also added titles to the haml files. 

### hourofcode.com

<img width="1632" alt="Screenshot 2025-02-27 at 9 24 13 AM" src="https://github.com/user-attachments/assets/b35bd4be-92b2-420a-ba8d-4e74418da5d6" />

### hourofcode.com/learn

<img width="1628" alt="Screenshot 2025-02-27 at 9 38 24 AM" src="https://github.com/user-attachments/assets/90b9e786-5840-4a44-b351-52dc47e21c10" />

### code.org

<img width="1630" alt="Screenshot 2025-02-27 at 9 40 22 AM" src="https://github.com/user-attachments/assets/70008223-2030-4c89-ae1b-6f6fc14858da" />

### code.org/teach

<img width="1665" alt="Screenshot 2025-02-27 at 9 41 30 AM" src="https://github.com/user-attachments/assets/ffaef3d1-c7d1-40d8-b32b-c6dbd0a83df7" />


### code.org/students
<img width="1678" alt="Screenshot 2025-02-27 at 9 41 05 AM" src="https://github.com/user-attachments/assets/f8d9a894-17b8-4f48-b3df-aaa1891595cb" />
