### PR TITLE
Show correct instructions preview when editing codebridge levels

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -20,7 +20,7 @@ import {JSHINT} from 'jshint';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import MainInstructionsBubblePreview from '../codebridge/InfoPanel/MainInstructionsBubblePreview';
+import MainInstructionsPreview from '../codebridge/InfoPanel/MainInstructionsPreview';
 import SafeMarkdown from '../templates/SafeMarkdown';
 
 window.JSHINT = JSHINT;
@@ -80,7 +80,7 @@ function initializeCodeMirror(target, mode, options = {}) {
       updatePreview = editor => {
         if (game === 'Pythonlab' || game === 'Weblab2') {
           ReactDOM.render(
-            React.createElement(MainInstructionsBubblePreview, {
+            React.createElement(MainInstructionsPreview, {
               instructionsText: editor.getValue(),
               theme: 'dark',
               hasPassed: false,

--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -20,6 +20,7 @@ import {JSHINT} from 'jshint';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import MainInstructionsBubblePreview from '../codebridge/InfoPanel/MainInstructionsBubblePreview';
 import SafeMarkdown from '../templates/SafeMarkdown';
 
 window.JSHINT = JSHINT;
@@ -42,10 +43,17 @@ CodeMirrorSpellChecker({
  * @param {(string|Element)} [options.preview] - element or id of element to
  *        populate with a preview. If none specified, will look for an element
  *        by appending "_preview" to the id of the target element.
+ * @param {string} [options.game] optional game name, used to determine which preview to use.
  */
 function initializeCodeMirror(target, mode, options = {}) {
-  let {callback, attachments, onUpdateLinting, additionalAnnotations, preview} =
-    options;
+  let {
+    callback,
+    attachments,
+    onUpdateLinting,
+    additionalAnnotations,
+    preview,
+    game,
+  } = options;
   let updatePreview;
 
   // Code mirror parses html using xml mode
@@ -70,12 +78,23 @@ function initializeCodeMirror(target, mode, options = {}) {
     if (previewElement) {
       const originalCallback = callback;
       updatePreview = editor => {
-        ReactDOM.render(
-          React.createElement(SafeMarkdown, {
-            markdown: editor.getValue(),
-          }),
-          previewElement
-        );
+        if (game === 'Pythonlab' || game === 'Weblab2') {
+          ReactDOM.render(
+            React.createElement(MainInstructionsBubblePreview, {
+              instructionsText: editor.getValue(),
+              theme: 'dark',
+              hasPassed: false,
+            }),
+            previewElement
+          );
+        } else {
+          ReactDOM.render(
+            React.createElement(SafeMarkdown, {
+              markdown: editor.getValue(),
+            }),
+            previewElement
+          );
+        }
       };
 
       callback = (editor, ...rest) => {

--- a/apps/src/codebridge/InfoPanel/MainInstructionsBubblePreview.tsx
+++ b/apps/src/codebridge/InfoPanel/MainInstructionsBubblePreview.tsx
@@ -2,9 +2,8 @@ import classNames from 'classnames';
 import React from 'react';
 
 import {Theme} from '@cdo/apps/lab2/types';
-import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 
-import ValidationStatusIcon from './ValidationStatusIcon';
+import MainInstructionsContent from './MainInstructionsContent';
 
 import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.module.scss';
 
@@ -30,17 +29,12 @@ const MainInstructionsBubblePreview: React.FunctionComponent<
         moduleStyles.bubbleNoSlide
       )}
     >
-      <div className={moduleStyles.mainInstructions}>
-        <ValidationStatusIcon
-          status={hasPassed ? 'passed' : 'pending'}
-          className={moduleStyles.validationIcon}
-        />
-        <EnhancedSafeMarkdown
-          markdown={instructionsText}
-          className={moduleStyles.markdownText}
-          handleInstructionsTextClick={handleInstructionsTextClick}
-        />
-      </div>
+      <MainInstructionsContent
+        instructionsText={instructionsText}
+        handleInstructionsTextClick={handleInstructionsTextClick}
+        theme={theme}
+        hasPassed={hasPassed}
+      />
     </div>
   );
 };

--- a/apps/src/codebridge/InfoPanel/MainInstructionsBubblePreview.tsx
+++ b/apps/src/codebridge/InfoPanel/MainInstructionsBubblePreview.tsx
@@ -25,7 +25,10 @@ const MainInstructionsBubblePreview: React.FunctionComponent<
     <div
       key={instructionsText}
       id="instructions-text"
-      className={classNames(moduleStyles['bubble-' + theme])}
+      className={classNames(
+        moduleStyles['bubble-' + theme],
+        moduleStyles.bubbleNoSlide
+      )}
     >
       <div className={moduleStyles.mainInstructions}>
         <ValidationStatusIcon

--- a/apps/src/codebridge/InfoPanel/MainInstructionsBubblePreview.tsx
+++ b/apps/src/codebridge/InfoPanel/MainInstructionsBubblePreview.tsx
@@ -1,0 +1,45 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import {Theme} from '@cdo/apps/lab2/types';
+import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
+
+import ValidationStatusIcon from './ValidationStatusIcon';
+
+import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.module.scss';
+
+interface MainInstructionsBubblePreviewProps {
+  instructionsText: string;
+  handleInstructionsTextClick?: (id: string) => void;
+  theme: Theme;
+  hasPassed: boolean;
+}
+
+/**
+ * Component for levelbuilder to preview the main instructions bubble (without predict answers or validation).
+ */
+const MainInstructionsBubblePreview: React.FunctionComponent<
+  MainInstructionsBubblePreviewProps
+> = ({instructionsText, handleInstructionsTextClick, theme, hasPassed}) => {
+  return (
+    <div
+      key={instructionsText}
+      id="instructions-text"
+      className={classNames(moduleStyles['bubble-' + theme])}
+    >
+      <div className={moduleStyles.mainInstructions}>
+        <ValidationStatusIcon
+          status={hasPassed ? 'passed' : 'pending'}
+          className={moduleStyles.validationIcon}
+        />
+        <EnhancedSafeMarkdown
+          markdown={instructionsText}
+          className={moduleStyles.markdownText}
+          handleInstructionsTextClick={handleInstructionsTextClick}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MainInstructionsBubblePreview;

--- a/apps/src/codebridge/InfoPanel/MainInstructionsContent.tsx
+++ b/apps/src/codebridge/InfoPanel/MainInstructionsContent.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import {Theme} from '@cdo/apps/lab2/types';
+import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
+
+import ValidationStatusIcon from './ValidationStatusIcon';
+
+import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.module.scss';
+
+interface MainInstructionsContentProps {
+  instructionsText: string;
+  handleInstructionsTextClick?: (id: string) => void;
+  theme: Theme;
+  hasPassed: boolean;
+}
+
+/**
+ * Component to display the main instructions content for a level.
+ * This is extracted out to a component so it can be used both in ValidatedInstructions
+ * and in MainInstructionsBubblePreview.
+ */
+const MainInstructionsContent: React.FunctionComponent<
+  MainInstructionsContentProps
+> = ({instructionsText, handleInstructionsTextClick, theme, hasPassed}) => {
+  return (
+    <div className={moduleStyles.mainInstructions}>
+      <ValidationStatusIcon
+        status={hasPassed ? 'passed' : 'pending'}
+        className={moduleStyles.validationIcon}
+      />
+      <EnhancedSafeMarkdown
+        markdown={instructionsText}
+        className={moduleStyles.markdownText}
+        handleInstructionsTextClick={handleInstructionsTextClick}
+      />
+    </div>
+  );
+};
+
+export default MainInstructionsContent;

--- a/apps/src/codebridge/InfoPanel/MainInstructionsContent.tsx
+++ b/apps/src/codebridge/InfoPanel/MainInstructionsContent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import {Theme} from '@cdo/apps/lab2/types';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 
 import ValidationStatusIcon from './ValidationStatusIcon';
@@ -10,7 +9,6 @@ import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.mo
 interface MainInstructionsContentProps {
   instructionsText: string;
   handleInstructionsTextClick?: (id: string) => void;
-  theme: Theme;
   hasPassed: boolean;
 }
 
@@ -21,7 +19,7 @@ interface MainInstructionsContentProps {
  */
 const MainInstructionsContent: React.FunctionComponent<
   MainInstructionsContentProps
-> = ({instructionsText, handleInstructionsTextClick, theme, hasPassed}) => {
+> = ({instructionsText, handleInstructionsTextClick, hasPassed}) => {
   return (
     <div className={moduleStyles.mainInstructions}>
       <ValidationStatusIcon

--- a/apps/src/codebridge/InfoPanel/MainInstructionsPreview.tsx
+++ b/apps/src/codebridge/InfoPanel/MainInstructionsPreview.tsx
@@ -7,7 +7,7 @@ import MainInstructionsContent from './MainInstructionsContent';
 
 import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.module.scss';
 
-interface MainInstructionsBubblePreviewProps {
+interface MainInstructionsPreviewProps {
   instructionsText: string;
   handleInstructionsTextClick?: (id: string) => void;
   theme: Theme;
@@ -17,8 +17,8 @@ interface MainInstructionsBubblePreviewProps {
 /**
  * Component for levelbuilder to preview the main instructions bubble (without predict answers or validation).
  */
-const MainInstructionsBubblePreview: React.FunctionComponent<
-  MainInstructionsBubblePreviewProps
+const MainInstructionsPreview: React.FunctionComponent<
+  MainInstructionsPreviewProps
 > = ({instructionsText, handleInstructionsTextClick, theme, hasPassed}) => {
   return (
     <div
@@ -32,11 +32,10 @@ const MainInstructionsBubblePreview: React.FunctionComponent<
       <MainInstructionsContent
         instructionsText={instructionsText}
         handleInstructionsTextClick={handleInstructionsTextClick}
-        theme={theme}
         hasPassed={hasPassed}
       />
     </div>
   );
 };
 
-export default MainInstructionsBubblePreview;
+export default MainInstructionsPreview;

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -26,7 +26,6 @@ import PredictSummary from '@cdo/apps/lab2/views/components/PredictSummary';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
 import {ThemeContext} from '@cdo/apps/lab2/views/ThemeWrapper';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {
@@ -35,8 +34,8 @@ import {
 } from '@cdo/generated-scripts/sharedConstants';
 import commonI18n from '@cdo/locale';
 
+import MainInstructionsContent from './MainInstructionsContent';
 import ValidationResults from './ValidationResults';
-import ValidationStatusIcon from './ValidationStatusIcon';
 
 import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
 import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.module.scss';
@@ -339,17 +338,12 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
               id="instructions-text"
               className={classNames(moduleStyles['bubble-' + theme])}
             >
-              <div className={moduleStyles.mainInstructions}>
-                <ValidationStatusIcon
-                  status={hasPassed ? 'passed' : 'pending'}
-                  className={moduleStyles.validationIcon}
-                />
-                <EnhancedSafeMarkdown
-                  markdown={instructionsText}
-                  className={moduleStyles.markdownText}
-                  handleInstructionsTextClick={handleInstructionsTextClick}
-                />
-              </div>
+              <MainInstructionsContent
+                instructionsText={instructionsText}
+                handleInstructionsTextClick={handleInstructionsTextClick}
+                theme={theme}
+                hasPassed={hasPassed}
+              />
               <PredictQuestion
                 predictSettings={predictSettings}
                 predictResponse={predictResponse}

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -341,7 +341,6 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
               <MainInstructionsContent
                 instructionsText={instructionsText}
                 handleInstructionsTextClick={handleInstructionsTextClick}
-                theme={theme}
                 hasPassed={hasPassed}
               />
               <PredictQuestion

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -95,6 +95,10 @@
   color: $neutral_dark;
 }
 
+.bubbleNoSlide {
+  animation: none;
+}
+
 .buttonInstruction {
   width: 100%;
   height: 32px;

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -26,7 +26,7 @@
       localStorage.setItem('markdown_' + '#{@level.id || html_escape(params[:type])}', editor.getValue());
     },
     attachments: true,
-    game: '#{@level.game.name}',
+    game: '#{@level.game&.name}',
   });
 
   var locallyStoredMarkdown = localStorage.getItem('markdown_' + '#{@level.id || html_escape(params[:type])}');

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -25,7 +25,8 @@
 
       localStorage.setItem('markdown_' + '#{@level.id || html_escape(params[:type])}', editor.getValue());
     },
-    attachments: true
+    attachments: true,
+    game: '#{@level.game.name}',
   });
 
   var locallyStoredMarkdown = localStorage.getItem('markdown_' + '#{@level.id || html_escape(params[:type])}');


### PR DESCRIPTION
This updates the long instructions editor to show the codebridge instructions bubble for python lab and web lab 2 levels. To make this work I made a small preview component which relies on no redux or context values, and refactored out the common code between `ValidatedInstructions` and the preview.

## Before
<img width="773" alt="Screenshot 2025-02-26 at 3 50 29 PM" src="https://github.com/user-attachments/assets/714cfd5f-3b2a-46ef-b506-71cdb9686373" />


## After
<img width="773" alt="Screenshot 2025-02-26 at 3 49 42 PM" src="https://github.com/user-attachments/assets/4876a5ab-45d8-4e6b-98f6-67110ad03642" />
(note: the weird spacing here is fixed by #64174)

## Links

- jira ticket: [CT-969](https://codedotorg.atlassian.net/browse/CT-969)

## Testing story
Tested locally. I verified non-codebridge levels are still using the old preview.


## Follow-up work
Music lab also has its own instructions panel (similar to this one, but a different component). I would guess a similar change is desired for Music Lab to show the correct instructions in the editor.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
