### PR TITLE
P20-1303: Localize numbers in i18n string variables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -220,6 +220,10 @@ gem 'jwt', '~> 2.7.0'
 # https://github.com/twilio/twilio-ruby/blob/6.0.0/UPGRADE.md#2023-05-03-5xx-to-6xx
 gem 'twilio-ruby', '< 6.0'
 
+# TwitterCldr uses Unicode's Common Locale Data Repository (CLDR)
+# to format certain types of text into their localized equivalents.
+gem 'twitter_cldr', '~> 6.12.1'
+
 gem 'sequel', '~> 5.29'
 gem 'user_agent_parser'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,7 @@ GEM
       sass (~> 3.2)
     brakeman (4.5.0)
     builder (3.2.4)
+    camertron-eprun (1.1.1)
     cancancan (3.5.0)
     case_transform (0.2)
       activesupport
@@ -287,6 +288,7 @@ GEM
     chunky_png (1.3.6)
     cld (0.13.0)
       ffi
+    cldr-plurals-runtime-rb (1.1.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.8)
@@ -907,6 +909,10 @@ GEM
       faraday (>= 0.9, < 3.0)
       jwt (>= 1.5, < 3.0)
       nokogiri (>= 1.6, < 2.0)
+    twitter_cldr (6.12.1)
+      camertron-eprun
+      cldr-plurals-runtime-rb (~> 1.1)
+      tzinfo
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
@@ -1131,6 +1137,7 @@ DEPENDENCIES
   thwait
   timecop
   twilio-ruby (< 6.0)
+  twitter_cldr (~> 6.12.1)
   uglifier (>= 1.3.0)
   unf_ext (= 0.0.7.4)
   user_agent_parser

--- a/apps/tasks/messages.js
+++ b/apps/tasks/messages.js
@@ -120,6 +120,75 @@ module.exports = function (grunt) {
   }
 
   /**
+   * Formats and rewrites i18n string variable values according to locale-specific rules.
+   *
+   * - Localizes Western Arabic numerals to the numeral system of the specified locale, if applicable.
+   *
+   * @param value {string|number} The input value to be formatted.
+   * @param locale {string} The locale identifier used for formatting.
+   * @returns {string|number} The formatted variable value, localized according to the specified locale.
+   */
+  /* eslint-disable prettier/prettier */
+  function localizeInterpolation(value, locale) {
+    try {
+      // Converts the locale to the BCP 47 format, e.g., "en_us" -> "en-US".
+      var lang = locale.replace(/_(\w+)$/, function (match, region) { return '-' + region.toUpperCase(); });
+
+      // Localizes Western Arabic numbers, e.g., "1234.5678" -> "۱٬۲۳۴٫۵۶۷۸" for "fa-IR".
+      value = String(value).replace(/^(\d+(\.\d+)?)$/, function (match, number) {
+        return new Intl.NumberFormat(lang, {
+          useGrouping: false, // Prevents grouping (e.g., 1,000).
+          minimumFractionDigits: number.includes('.') ? number.split('.')[1].length : 0,
+          maximumFractionDigits: 100, // Prevents rounding (100 is max allowed by ECMA-402).
+        }).format(number);
+      });
+    } catch (e) {
+      window.console.error(e);
+    }
+
+    return value;
+  }
+  /* eslint-enable prettier/prettier */
+
+  /**
+   * Overrides the original `MessageFormat.compile` function
+   * to apply the default `fmt.l` formatter to all i18n message variables without a specified format.
+   * @param mf {MessageFormat} The instance of MessageFormat.
+   * @returns {void}
+   */
+  function applyDefaultVariableFormatter(mf) {
+    mf.addFormatters({
+      l: localizeInterpolation, // The default `fmt.l` formatter.
+    });
+
+    const preprocessMessage = msg => {
+      if (typeof msg === 'string') {
+        return msg.replace(/\{((?:[^{}]*|\{[^{}]*\})*)\}/g, (interp, varName) =>
+          varName.includes(',')
+            ? interp
+            : varName.includes('{')
+            ? `{${preprocessMessage(varName)}}`
+            : `{${varName}, l}`
+        );
+      }
+
+      if (msg && typeof msg === 'object') {
+        return Object.fromEntries(
+          Object.entries(msg).map(([key, value]) => [
+            key,
+            preprocessMessage(value),
+          ])
+        );
+      }
+
+      return msg;
+    };
+
+    const mfCompile = mf.compile.bind(mf);
+    mf.compile = messages => mfCompile(preprocessMessage(messages));
+  }
+
+  /**
    * Applies MessageFormat to all the strings found in the given JSON.
    * @param locale The language/region locale code for the given JSON.
    * @param namespace Some unique ID for the content, usually the file name e.g. 'fish' or 'maze'
@@ -135,6 +204,8 @@ module.exports = function (grunt) {
       // This turns off that check.
       // See https://messageformat.github.io/messageformat/MessageFormat#disablePluralKeyChecks__anchor
       mf.disablePluralKeyChecks();
+
+      applyDefaultVariableFormatter(mf);
     } catch (e) {
       // Fallback to en if locale is not found
       if (locale !== 'en') {

--- a/lib/cdo/i18n/plugins/interpolation_l10n.rb
+++ b/lib/cdo/i18n/plugins/interpolation_l10n.rb
@@ -1,0 +1,51 @@
+require 'i18n'
+require 'twitter_cldr'
+
+module Cdo
+  module I18n
+    module Plugins
+      module InterpolationL10n
+        NUMBER_PATTERN = /^\d+(\.\d+)?$/ # Matches integers and floating-point numbers, e.g., "1" or "1.0"
+        DIGIT_GROUP_SEPARATOR = ',' # The character used to group digits in numbers, e.g., "1,000"
+
+        # Localizes Western Arabic numbers, e.g., "1234.5678" to "۱٬۲۳۴٫۵۶۷۸" for "fa-IR".
+        # @param locale [String|Symbol] The locale
+        # @param value [String] The value to localize
+        # @return [String] The localized value
+        protected def localize_number(locale, value)
+          value.to_s.sub(NUMBER_PATTERN) do |number|
+            formatted_number = number.include?('.') ? number.to_f : number.to_i
+            TwitterCldr::Localized::LocalizedNumber.new(formatted_number, locale).to_s.delete(DIGIT_GROUP_SEPARATOR)
+          end
+        rescue StandardError
+          value
+        end
+
+        protected def localize_interpolation_values(locale, values)
+          return values unless values.is_a?(Hash) && !values.empty?
+
+          values.transform_values do |value|
+            value = localize_number(locale, value)
+            value
+          end
+        end
+
+        # Overrides the protected method +I18n::Backend::Base#interpolate+ to localize interpolation values.
+        # @see https://github.com/ruby-i18n/i18n/blob/v1.14.1/lib/i18n/backend/base.rb#L181-L200
+        protected def interpolate(locale, subject, values = ::I18n::EMPTY_HASH)
+          super locale, subject, localize_interpolation_values(locale, values)
+        rescue StandardError
+          super
+        end
+
+        # Overrides the protected method +I18n::Backend::Base#deep_interpolate+ to localize interpolation values.
+        # @see https://github.com/ruby-i18n/i18n/blob/v1.14.1/lib/i18n/backend/base.rb#L202-L224
+        protected def deep_interpolate(locale, data, values = ::I18n::EMPTY_HASH)
+          super locale, data, localize_interpolation_values(locale, values)
+        rescue StandardError
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/cdo/i18n/plugins/interpolation_l10n.rb
+++ b/lib/cdo/i18n/plugins/interpolation_l10n.rb
@@ -6,7 +6,6 @@ module Cdo
     module Plugins
       module InterpolationL10n
         NUMBER_PATTERN = /^\d+(\.\d+)?$/ # Matches integers and floating-point numbers, e.g., "1" or "1.0"
-        DIGIT_GROUP_SEPARATOR = ',' # The character used to group digits in numbers, e.g., "1,000"
 
         # Localizes Western Arabic numbers, e.g., "1234.5678" to "۱٬۲۳۴٫۵۶۷۸" for "fa-IR".
         # @param locale [String|Symbol] The locale
@@ -14,8 +13,8 @@ module Cdo
         # @return [String] The localized value
         protected def localize_number(locale, value)
           value.to_s.sub(NUMBER_PATTERN) do |number|
-            formatted_number = number.include?('.') ? number.to_f : number.to_i
-            TwitterCldr::Localized::LocalizedNumber.new(formatted_number, locale).to_s.delete(DIGIT_GROUP_SEPARATOR)
+            number_system = TwitterCldr::DataReaders::NumberDataReader.new(locale).number_system
+            TwitterCldr::Shared::NumberingSystem.for_name(number_system).transliterate(number)
           end
         rescue StandardError
           value

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -2,6 +2,7 @@ require 'i18n'
 require 'active_support/core_ext/numeric/bytes'
 require 'cdo/honeybadger'
 require 'cdo/i18n'
+require 'cdo/i18n/plugins/interpolation_l10n'
 require 'cdo/i18n_string_url_tracker'
 
 module Cdo
@@ -170,6 +171,7 @@ module Cdo
       include MarkdownTranslate
       include SafeInterpolation
       include I18nStringUrlTrackerPlugin
+      include InterpolationL10n
     end
 
     class SimpleBackend < ::I18n::Backend::Simple


### PR DESCRIPTION
Extends the platform i18n functionality to auto-detect and localize numbers in string interpolation values.

| | JavaScript (Apps) |
| ---: | :---: |
| Before | <img src="https://github.com/user-attachments/assets/12e56146-919f-4aab-a445-a183673f3e4f" /> |
| After    | <img src="https://github.com/user-attachments/assets/4396dd33-44b4-42ab-94a5-019e2019d6a5" /> |

| | Ruby/Rails (Dashboard/Pegasus) |
| ---: | :---: |
| Before | ![ruby-before](https://github.com/user-attachments/assets/f26ce493-868b-49fd-a2ef-aedf6dd339af) |
| After    | ![ruby-after](https://github.com/user-attachments/assets/4e29e32b-4745-4721-ac25-f825dac70ac4) |

## Links
- JIRA task: [P20-1303](https://codedotorg.atlassian.net/browse/P20-1303)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/63113