### PR TITLE
feat(workshops): add new workshop routes

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -12,6 +12,7 @@ import {
   RouterProvider,
   WithRouterProps,
 } from '@cdo/apps/code-studio/legacyDashboardRoutingCompatibility';
+import {WorkshopCourseConfigs} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import mapboxReducer, {setMapboxAccessToken} from '@cdo/apps/redux/mapbox';
 
 import Header from '../components/header';
@@ -39,6 +40,7 @@ import ReportView from './reports/report_view';
 import Workshop from './workshop';
 import WorkshopFilter from './workshop_filter';
 import WorkshopIndex from './workshop_index';
+import {WorkshopFormTemplate} from './WorkshopFormTemplate';
 
 export const ROOT_PATH = '/pd/workshop_dashboard';
 
@@ -71,6 +73,12 @@ const routeConfigs = [
     breadcrumbs: 'Workshops,New Workshop',
     component: NewWorkshop,
   },
+  ...WorkshopCourseConfigs.map(config => ({
+    path: `workshops/new/${config.slug}`,
+    breadcrumbs: `Workshops,New ${config.label} Workshop`,
+    component: WorkshopFormTemplate,
+    props: config,
+  })),
   {
     path: 'workshops/:workshopId',
     breadcrumbs: 'Workshops,View Workshop',


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Uses WorkshopCourseConfigs shared constant to generate routes for each workshop course type, and passes the config to a the shared WorkshopFormTemplate component

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3086)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
