### PR TITLE
Python Lab: update continue button logic

### DIFF
--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -107,9 +107,9 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
   );
   const isRunning = useAppSelector(state => state.lab2System.isRunning);
   const shouldValidateBeDisabled = !hasLoadedEnvironment || isRunning;
-  const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
 
   const currentLevel = useAppSelector(state => getCurrentLevel(state));
+  const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
 
   // The icon in the validated instructions panel should match the icon in the
   // header.

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -192,7 +192,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
     }
   };
 
-  // There are 3 ways to "meet validation" for a level:
+  // There are 4 ways to "meet validation" for a level:
   // If the level is a predict level, the user must run the code.
   // If the level has conditions, they must be satisfied.
   // If the level is a submittable level and has no conditions,

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -109,7 +109,6 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
   const shouldValidateBeDisabled = !hasLoadedEnvironment || isRunning;
 
   const currentLevel = useAppSelector(state => getCurrentLevel(state));
-  const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
 
   // The icon in the validated instructions panel should match the icon in the
   // header.
@@ -203,9 +202,9 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
     } else if (hasConditions) {
       return satisfied;
     } else {
-      return hasRun && hasEdited;
+      return hasRun;
     }
-  }, [predictSettings, hasConditions, satisfied, hasRun, hasEdited]);
+  }, [predictSettings, hasConditions, satisfied, hasRun]);
 
   /**
    * Returns the props for the navigation (continue/finish/submit/unsubmit)

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -107,6 +107,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
   );
   const isRunning = useAppSelector(state => state.lab2System.isRunning);
   const shouldValidateBeDisabled = !hasLoadedEnvironment || isRunning;
+  const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
 
   const currentLevel = useAppSelector(state => getCurrentLevel(state));
 
@@ -193,18 +194,28 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
 
   // There are 3 ways to "meet validation" for a level:
   // If the level is a predict level, the user must run the code.
-  // Otherwise, if the level has conditions, they must be satisfied.
-  // If the level has no conditions and is not a predict level,
-  // the user must run their code at least once.
+  // If the level has conditions, they must be satisfied.
+  // If the level is a submittable level and has no conditions,
+  // the user must run and edit their code.
+  // Otherwise, the user must run their code at least once.
   const hasMetValidation = useMemo(() => {
     if (predictSettings?.isPredictLevel) {
       return hasRun;
     } else if (hasConditions) {
       return satisfied;
+    } else if (isSubmittable) {
+      return hasRun && hasEdited;
     } else {
       return hasRun;
     }
-  }, [predictSettings, hasConditions, satisfied, hasRun]);
+  }, [
+    predictSettings?.isPredictLevel,
+    hasConditions,
+    isSubmittable,
+    hasRun,
+    satisfied,
+    hasEdited,
+  ]);
 
   /**
    * Returns the props for the navigation (continue/finish/submit/unsubmit)

--- a/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
+++ b/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
@@ -86,7 +86,7 @@ describe('ValidatedInstructions', () => {
       screen.queryByRole('button', {name: commonI18n.continue()})
     ).toBeNull();
 
-    // Update run flags in redux
+    // Update run flag in redux
     store.dispatch(setHasRun(true));
 
     // Continue button should be present.
@@ -163,8 +163,13 @@ describe('ValidatedInstructions', () => {
       screen.queryByRole('button', {name: commonI18n.unsubmit()})
     ).toBeNull();
 
-    // Mark code as run and edited; submit should show up
+    // Mark code as run; submit not yet should show up.
     store.dispatch(setHasRun(true));
+    expect(
+      screen.queryByRole('button', {name: commonI18n.submit()})
+    ).toBeNull();
+
+    // Mark as edited, now submit should show up.
     store.dispatch(setHasEdited(true));
 
     // Submit button should be present.

--- a/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
+++ b/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
@@ -163,7 +163,7 @@ describe('ValidatedInstructions', () => {
       screen.queryByRole('button', {name: commonI18n.unsubmit()})
     ).toBeNull();
 
-    // Mark code as run; submit should not yet should show up.
+    // Mark code as run; submit should not yet show up.
     store.dispatch(setHasRun(true));
     expect(
       screen.queryByRole('button', {name: commonI18n.submit()})

--- a/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
+++ b/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
@@ -163,7 +163,7 @@ describe('ValidatedInstructions', () => {
       screen.queryByRole('button', {name: commonI18n.unsubmit()})
     ).toBeNull();
 
-    // Mark code as run; submit not yet should show up.
+    // Mark code as run; submit should not yet should show up.
     store.dispatch(setHasRun(true));
     expect(
       screen.queryByRole('button', {name: commonI18n.submit()})

--- a/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
+++ b/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
@@ -86,9 +86,8 @@ describe('ValidatedInstructions', () => {
       screen.queryByRole('button', {name: commonI18n.continue()})
     ).toBeNull();
 
-    // Update edit and run flags in redux
+    // Update run flags in redux
     store.dispatch(setHasRun(true));
-    store.dispatch(setHasEdited(true));
 
     // Continue button should be present.
     screen.getByRole('button', {name: commonI18n.continue()});
@@ -191,9 +190,8 @@ describe('ValidatedInstructions', () => {
       screen.queryByRole('button', {name: commonI18n.finish()})
     ).toBeNull();
 
-    // Mark code as run and edited; finish should show up
+    // Mark code as run; finish should show up
     store.dispatch(setHasRun(true));
-    store.dispatch(setHasEdited(true));
 
     // Finish button should be present.
     screen.getByRole('button', {name: commonI18n.finish()});


### PR DESCRIPTION
Curriculum requested that for regular (non-submittable) levels without validation, we show the continue button after the user runs the code, not after they've both run and edited. Submittable levels still need both run and edit.

## Links

- jira ticket: [CT-1076](https://codedotorg.atlassian.net/browse/CT-1076)


## Testing story
Tested locally and updated unit tests.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
