### PR TITLE
fix(eyes): use a fixed batch name for eyes

### DIFF
--- a/frontend/apps/design-system-storybook/applitools.config.cjs
+++ b/frontend/apps/design-system-storybook/applitools.config.cjs
@@ -3,23 +3,14 @@
  * See: https://applitools.com/tutorials/sdks/storybook/config#config
  */
 
-const {execSync} = require('child_process');
-
 // Used in DevContainers, see `.devcontainer/frontend/Dockerfile`
 const isDocker = !!process.env.IS_DOCKER || !!process.env.CI;
-
-/**
- * @returns Current git commit
- */
-const getBatchName = () => {
-  return execSync('git rev-parse --short HEAD').toString().trim();
-};
 
 module.exports = {
   concurrency: 5,
   showLogs: !!process.env.APPLITOOLS_SHOW_LOGS,
   appName: 'Code.org Design System',
-  batchName: getBatchName(),
+  batchName: 'Component Library',
   browser: [
     {width: 1200, height: 800, name: 'chrome'},
     {width: 1200, height: 800, name: 'firefox'},


### PR DESCRIPTION
This PR updates the batch name to no longer use the git rev id but
rather the 'Component Library' name to make it distinguishable from
other batches.