### PR TITLE
Improve version history tests

### DIFF
--- a/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryButtonTest.tsx
+++ b/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryButtonTest.tsx
@@ -22,8 +22,6 @@ import {
 
 const SAMPLE_VERSION_LIST: ProjectVersion[] = [
   {versionId: '0', lastModified: '2024-11-25T18:11:10.000Z', isLatest: false},
-  {versionId: '1', lastModified: '2024-12-25T18:11:10.000Z', isLatest: false},
-  {versionId: '2', lastModified: '2025-01-25T18:11:10.000Z', isLatest: false},
   {versionId: '3', lastModified: '2025-02-25T18:11:10.000Z', isLatest: true},
 ];
 const ownedChannel: Channel = {
@@ -35,6 +33,16 @@ const ownedChannel: Channel = {
   createdAt: '',
   updatedAt: '',
 };
+
+// Mock this component to speed up tests.
+jest.mock('@code-dot-org/component-library/tooltip', () => {
+  return {
+    WithTooltip: function MockWithTooltip(props: {children: React.ReactNode}) {
+      return <div>{props.children}</div>;
+    },
+    TooltipProps: {},
+  };
+});
 
 describe('VersionHistoryButton', () => {
   let store: Store;
@@ -93,7 +101,7 @@ describe('VersionHistoryButton', () => {
     getByText('Initial version');
     getByRole('button', {name: 'Restore'});
     getByRole('button', {name: 'Cancel'});
-  });
+  }, 10000);
 
   it('renders alert if getVersionList fails', async () => {
     mockedProjectManager = {
@@ -127,14 +135,15 @@ describe('VersionHistoryButton', () => {
     await act(async () => {
       user.click(button);
     });
-    await waitFor(() =>
-      expect(mockedProjectManager.getVersionList).toHaveBeenCalled()
+    await waitFor(
+      () => expect(mockedProjectManager.getVersionList).toHaveBeenCalled(),
+      {timeout: 2000}
     );
 
     // 3 is the latest version in the sample version list.
     const latestVersion = getByDisplayValue('3') as HTMLInputElement;
     expect(latestVersion.checked).toBe(true);
-  });
+  }, 10000);
 
   it('restores selected version on restore', async () => {
     const {getByDisplayValue, getByRole, queryByRole} = renderDefault();
@@ -150,7 +159,7 @@ describe('VersionHistoryButton', () => {
       {timeout: 2000}
     );
 
-    const versionInput = getByDisplayValue('2') as HTMLInputElement;
+    const versionInput = getByDisplayValue('0') as HTMLInputElement;
     await user.click(versionInput);
 
     const restoreButton = getByRole('button', {name: 'Restore'});
@@ -159,9 +168,9 @@ describe('VersionHistoryButton', () => {
     });
     await waitFor(
       () =>
-        expect(mockedProjectManager.restoreSources).toHaveBeenCalledWith('2'),
+        expect(mockedProjectManager.restoreSources).toHaveBeenCalledWith('0'),
       {timeout: 2000}
     );
     expect(queryByRole('dialog', {name: 'Version History List'})).toBeNull();
-  });
+  }, 10000);
 });


### PR DESCRIPTION
We've seen the new version history button tests time out occasionally, so I made a few improvements:
- Decrease the size of the sample data from 4 versions to 2, to decrease the number of components rendered
- Mock the `WithTooltip` component to decrease the number of components rendered
- For tests that render the version history list, bump the timeout from 5 to 10 seconds.


## Testing story
The timeout doesn't happen locally, but with these changes the tests each run in less than 1 second, so hopefully they will not time out anymore.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
