### PR TITLE
Fix settings not updating grades or showing correct lessonExtra toggle

### DIFF
--- a/apps/src/sites/studio/pages/sections/edit.js
+++ b/apps/src/sites/studio/pages/sections/edit.js
@@ -13,11 +13,17 @@ function initPage() {
   const section = getScriptData('section');
   const canEnableAITutor = getScriptData('canEnableAITutor');
 
+  const sectionWithUpdatedFields = {
+    ...section,
+    grades: section.grade,
+    lessonExtras: section.stageExtras,
+  };
+
   ReactDOM.render(
     <div className={moduleStyles.containerWithMarginTop}>
       <Heading1>{i18n.editSectionDetails()}</Heading1>
       <SectionsSetUpContainer
-        sectionToBeEdited={section}
+        sectionToBeEdited={sectionWithUpdatedFields}
         canEnableAITutor={canEnableAITutor}
         defaultRedirectUrl="/home"
       />

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -42,17 +42,7 @@ const useSections = section => {
   // added "default properties" for any new section
   const [sections, setSections] = useState(
     section
-      ? [
-          {
-            ...Object.keys(section).reduce((acc, cur) => {
-              if (cur !== 'stageExtras') {
-                acc[cur] = section[cur];
-              }
-              return acc;
-            }, {}),
-            lessonExtras: section.stageExtras,
-          },
-        ]
+      ? [section]
       : [
           {
             pairingAllowed: true,

--- a/apps/src/templates/sectionsRefresh/SingleSectionSetUp.jsx
+++ b/apps/src/templates/sectionsRefresh/SingleSectionSetUp.jsx
@@ -45,8 +45,8 @@ export default function SingleSectionSetUp({
             required={true}
             requiredMessageText={i18n.chooseAtLeastOne()}
             options={gradeOptions}
-            values={section.grade || section.grades || []}
-            setValues={g => updateSection('grade', g)}
+            values={section.grades || []}
+            setValues={g => updateSection('grades', g)}
           />
         </div>
       )}


### PR DESCRIPTION
Fixes:
* lessonExtra toggle not showing the correct value
  * This was caused by the settings page automatically changing `stageExtras` to `lessonExtras`, however the response for the dashboard already has lesson extras correctly parsed
  * I fixed this by moving the modification from the settings component to the `edit.js` page for settings
* grades not updating correctly on the new dashboard page
  * This was because the old version used `grade` and the new version used `grades`. We correctly parsed this out when reading the grades, but did not update the update function
  * I fixed this by only using the new `grades` version and in the old page, manually changing from `grade` to `grades`.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1653

https://codedotorg.slack.com/archives/C0T0PNTM3/p1740696927776619
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
