### PR TITLE
fix(packaging): also hash `frontend` when packaging apps

### DIFF
--- a/lib/cdo/aws/s3_packaging.rb
+++ b/lib/cdo/aws/s3_packaging.rb
@@ -15,12 +15,14 @@ class S3Packaging
   attr_reader :commit_hash
 
   # @param package_name [String] Friendly name of the package, used as part of our S3 key
-  # @param source_location [String] Path to the location on the filesystem where the build input lives
-  # @param target_location [String] Path to the location on the file system where the unzipped packaged contents should lvie
-  def initialize(package_name, source_location, target_location)
-    throw "Missing argument" if package_name.nil? || source_location.nil? || target_location.nil?
+  # @param application_location [String] Path to the location on the filesystem where the application build input lives
+  # @param source_locations [Array<String>] Path to the locations on the filesystem that should be used to calculate the source commit
+  # @param target_location [String] Path to the location on the file system where the unzipped packaged contents should live
+  def initialize(package_name, application_location, source_locations, target_location)
+    throw "Missing argument" if package_name.nil? || application_location.nil? || source_locations.nil? || target_location.nil?
     @package_name = package_name
-    @source_location = source_location
+    @application_location = application_location
+    @source_locations = source_locations
     @target_location = target_location
     @logger = Logger.new($stdout)
     regenerate_commit_hash
@@ -32,7 +34,7 @@ class S3Packaging
 
   # Recreates our commit hash (for cases where we may have updated our git tree)
   def regenerate_commit_hash
-    @commit_hash = RakeUtils.git_folder_hash @source_location
+    @commit_hash = RakeUtils.git_folder_hash @source_locations
   end
 
   # Tries to get an up to date package without building
@@ -71,7 +73,7 @@ class S3Packaging
   end
 
   # Creates a zipped package of the provided assets folder
-  # @param sub_path [String] Path to built assets, relative to source_location
+  # @param sub_path [String] Path to built assets, relative to application_location
   # @param expected_commit_hash [String] optional, when specified an error will be raised
   #        whenever the current commit hash doesn't match the expected one.
   #        Use this to detect file system changes during the build and fail package creation.
@@ -87,7 +89,7 @@ class S3Packaging
 
     package = Tempfile.new(@commit_hash)
     @logger.info "Creating #{package.path}"
-    Dir.chdir(@source_location + '/' + sub_path) do
+    Dir.chdir(@application_location + '/' + sub_path) do
       # add a commit_hash file whose contents represent the key for this package
       File.write('commit_hash', @commit_hash)
       RakeUtils.system "tar -cz --exclude='*.cache.json' --file #{package.path} *"
@@ -97,7 +99,7 @@ class S3Packaging
   end
 
   def log_bundle_size
-    stats = JSON.parse(File.read(@source_location + '/build/package/js/stats.json'))
+    stats = JSON.parse(File.read(@application_location + '/build/package/js/stats.json'))
     @logger.info(
       stats['assets'].filter_map do |asset|
         next nil unless asset['name'].end_with? '.js'

--- a/lib/rake/package.rake
+++ b/lib/rake/package.rake
@@ -10,7 +10,7 @@ namespace :package do
 
   namespace :apps do
     def apps_packager
-      S3Packaging.new('apps', apps_dir, dashboard_dir('public/apps-package'))
+      S3Packaging.new('apps', apps_dir, [apps_dir, frontend_dir], dashboard_dir('public/apps-package'))
     end
 
     desc 'Update apps static asset package.'

--- a/shared/test/test_s3_packaging.rb
+++ b/shared/test/test_s3_packaging.rb
@@ -10,21 +10,27 @@ class S3PackagingTest < Minitest::Test
   include SetupTest
 
   def create_packager(commit_hash = ORIGINAL_HASH)
-    source_location = Dir.mktmpdir
+    application1_location = Dir.mktmpdir
+    application2_location = Dir.mktmpdir
     target_location = Dir.mktmpdir
-    Dir.chdir(source_location) do
+    Dir.chdir(application1_location) do
       FileUtils.mkdir('src')
       File.write('src/one.js', "file one")
       File.write('src/two.js', "file two")
       FileUtils.mkdir('build')
       File.write('build/output.js', "output")
     end
+
+    Dir.chdir(application2_location) do
+      FileUtils.mkdir('src')
+      File.write('src/three.js', "file three")
+    end
     RakeUtils.stubs(:git_folder_hash).returns(commit_hash)
-    packager = S3Packaging.new('test-package', source_location, target_location).tap do |s3|
+    packager = S3Packaging.new('test-package', application1_location, [application1_location, application2_location], target_location).tap do |s3|
       s3.instance_variable_get(:@logger).level = Logger::Severity::WARN
     end
     RakeUtils.unstub(:git_folder_hash)
-    [source_location, target_location, packager]
+    [application1_location, application2_location, target_location, packager]
   end
 
   def cleanup_packager(source_location, target_location)
@@ -33,12 +39,14 @@ class S3PackagingTest < Minitest::Test
   end
 
   def setup
-    @source_location, @target_location, @packager = create_packager
+    @application1_location, @application2_location, @target_location, @packager = create_packager
     CDO.log.level = Logger::Severity::WARN
   end
 
   def teardown
-    cleanup_packager(@source_location, @target_location)
+    FileUtils.remove_entry_secure @application1_location
+    FileUtils.remove_entry_secure @application2_location
+    FileUtils.remove_entry_secure @target_location
     CDO.log.level = Logger::Severity::INFO
   end
 
@@ -82,7 +90,7 @@ class S3PackagingTest < Minitest::Test
   end
 
   def test_download_nonexistent
-    alt_source_loc, alt_target_loc, alt_packager = create_packager('fake-nonexistent-hash')
+    alt_application_loc, alt_source_loc, alt_target_loc, alt_packager = create_packager('fake-nonexistent-hash')
 
     begin
       threw = false
@@ -94,12 +102,13 @@ class S3PackagingTest < Minitest::Test
       assert threw
     ensure
       cleanup_packager(alt_source_loc, alt_target_loc)
+      FileUtils.remove_entry_secure alt_application_loc
     end
   end
 
   def test_ensure_updated_package
     alt_hash = 'alternate-hash'
-    alt_source_loc, alt_target_loc, alt_packager = create_packager(alt_hash)
+    alt_application_loc, _, alt_target_loc, alt_packager = create_packager(alt_hash)
     begin
       # upload package for ORIGINAL_HASH
       RakeUtils.expects(:git_folder_hash).returns(ORIGINAL_HASH)
@@ -132,8 +141,8 @@ class S3PackagingTest < Minitest::Test
       assert File.exist?(alt_target_loc + '/output.js')
 
       # if there is no package to download, we throw
-      cleanup_packager(alt_source_loc, alt_target_loc)
-      alt_source_loc, alt_target_loc, alt_packager = create_packager('fake-nonexistent-hash')
+      cleanup_packager(alt_application_loc, alt_target_loc)
+      alt_application_loc, _, alt_target_loc, alt_packager = create_packager('fake-nonexistent-hash')
       threw = false
       begin
         alt_packager.send(:ensure_updated_package)
@@ -142,7 +151,7 @@ class S3PackagingTest < Minitest::Test
       end
       assert threw
     ensure
-      cleanup_packager(alt_source_loc, alt_target_loc)
+      cleanup_packager(alt_application_loc, alt_target_loc)
     end
   end
 


### PR DESCRIPTION
The CI/CD process includes a git hash mechanism to detect if a precompiled version of `apps` is available on S3. If so, it will download that compiled version and extract it locally skipping a local build. This mechanism uses a git file hashes for `apps`. However, now that we have a separate repo called `frontend`, changes to this directory also need to be reflected in the calculated hash otherwise the following race condition can occur:

**Stage 1:**
1. Push a change specific to `apps`, no changes to `frontend`.
2. A hash is generated based on the hashes of the files in `apps`.
2. Create a build for `apps`, triggering its bundler process.
3. The build output is zipped and stored as the hash generated in (2).

**Stage 2:**
1. Push a change specific to `frontend`, no changes to `apps`.
2. A hash is generated based on the hashes of the files in `apps`.
3. No build is performed as the hash will match one on S3 from Stage 1.

There are a couple variations to this race condition but they all result in a build that does not incorporate changes from `frontend` if the changes occurred outside of `apps` only (cross changes will trigger a build).

To fix this, the hashing process should include all files that contribute to `apps`.