### PR TITLE
chore: add alias for `test:unit` to `test`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "release:dryrun": "turbo release:dryrun",
     "start": "yarn dev",
     "test": "turbo test",
+    "test:unit": "yarn test",
     "typecheck": "turbo typecheck"
   },
   "prettier": "@code-dot-org/lint-config/prettier/index.mjs",


### PR DESCRIPTION
Quick helper to point `test:unit` to `test`.