### PR TITLE
Add/Update events relating to logging in and signing up

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -28,6 +28,7 @@ const EVENTS = {
   PARENT_OR_GUARDIAN_SIGN_UP_CLICKED: 'Parent or Guardian Sign Up Clicked',
   FINISH_ACCOUNT_PAGE_LOADED: 'Finish Account Page Loaded',
   SECTION_SETUP_STARTED: 'Section Setup Started',
+  LINK_ACCOUNT_PAGE_VISITED_EVENT: 'Link Account Page Visited',
 
   // School Association
   // Update School Info Dialog

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -30,6 +30,7 @@ import {
   EMAIL_SESSION_KEY,
   OAUTH_LOGIN_TYPE_SESSION_KEY,
   NEW_SIGN_UP_USER_TYPE,
+  USER_RETURN_TO_SESSION_KEY,
   setUserReturnToUrl,
 } from './signUpFlowConstants';
 
@@ -69,12 +70,17 @@ const LoginTypeSelection: React.FunctionComponent = () => {
         // If the user type is set as a URL parameter (e.g. being redirected from section signup and skipping
         // the first signup page), then set the user type (and URL to return the user to after signup if
         // provided) in sessionStorage.
+        setUserReturnToUrl();
+        const sourceParam = sessionStorage
+          .getItem(USER_RETURN_TO_SESSION_KEY)
+          ?.includes('/join')
+          ? {source: 'section code sign up form'}
+          : {};
         analyticsReporter.sendEvent(
           EVENTS.SIGN_UP_STARTED_EVENT,
-          {},
+          sourceParam,
           PLATFORMS.BOTH
         );
-        setUserReturnToUrl();
         sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, userType as string);
       } else {
         // If the user hasn't selected a user type and it's not a URL parameter, redirect them back to the

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/index.tsx
@@ -1,6 +1,8 @@
 import Link from '@code-dot-org/component-library/link';
-import React, {useContext} from 'react';
+import React, {useContext, useEffect} from 'react';
 
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {LtiProviderContext} from '@cdo/apps/simpleSignUp/lti/link/LtiLinkAccountPage/context';
 import {navigateToHref} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
@@ -19,6 +21,14 @@ const LtiLinkAccountPage = () => {
       ? navigateToHref(`/users/cancel`)
       : navigateToHref(`/users/sign_out`);
   };
+
+  useEffect(() => {
+    analyticsReporter.sendEvent(
+      EVENTS.LINK_ACCOUNT_PAGE_VISITED_EVENT,
+      {source: 'lti'},
+      PLATFORMS.BOTH
+    );
+  }, []);
 
   return (
     <main>

--- a/apps/src/simpleSignUp/workshop/WorkshopLinkAccountPage.tsx
+++ b/apps/src/simpleSignUp/workshop/WorkshopLinkAccountPage.tsx
@@ -1,6 +1,8 @@
 import Link from '@code-dot-org/component-library/link';
-import React from 'react';
+import React, {useEffect} from 'react';
 
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import AccountBanner from '@cdo/apps/templates/account/AccountBanner';
 import AccountCard from '@cdo/apps/templates/account/AccountCard';
 import i18n from '@cdo/locale';
@@ -10,39 +12,49 @@ import styles from '../link-account.module.scss';
 const WorkshopLinkAccountPage: React.FunctionComponent<{
   newAccountUrl: string;
   existingAccountUrl: string;
-}> = ({newAccountUrl, existingAccountUrl}) => (
-  <main>
-    <div className={styles.contentContainer}>
-      <AccountBanner
-        heading={i18n.accountWelcomeBannerHeaderLabel()}
-        desc={i18n.accountWelcomeBannerContentWorkshopEnroll()}
-        showLogo={true}
-      />
-      <div className={styles.cardContainer}>
-        <AccountCard
-          id={'new-account-card'}
-          icon={'user-plus'}
-          title={i18n.ltiLinkAccountNewAccountCardHeaderLabel()}
-          content={i18n.accountNewAccountCardContentWorkshopEnroll()}
-          buttonText={i18n.createAccount()}
-          buttonType="secondary"
-          href={newAccountUrl}
+}> = ({newAccountUrl, existingAccountUrl}) => {
+  useEffect(() => {
+    analyticsReporter.sendEvent(
+      EVENTS.LINK_ACCOUNT_PAGE_VISITED_EVENT,
+      {source: 'workshop enroll'},
+      PLATFORMS.BOTH
+    );
+  }, []);
+
+  return (
+    <main>
+      <div className={styles.contentContainer}>
+        <AccountBanner
+          heading={i18n.accountWelcomeBannerHeaderLabel()}
+          desc={i18n.accountWelcomeBannerContentWorkshopEnroll()}
+          showLogo={true}
         />
-        <AccountCard
-          id={'existing-account-card'}
-          icon={'user-check'}
-          title={i18n.ltiLinkAccountExistingAccountCardHeaderLabel()}
-          content={i18n.accountExistingAccountCardContentWorkshopEnroll()}
-          buttonText={i18n.ltiLinkAccountExistingAccountCardActionLabel()}
-          buttonType="primary"
-          href={existingAccountUrl}
-        />
+        <div className={styles.cardContainer}>
+          <AccountCard
+            id={'new-account-card'}
+            icon={'user-plus'}
+            title={i18n.ltiLinkAccountNewAccountCardHeaderLabel()}
+            content={i18n.accountNewAccountCardContentWorkshopEnroll()}
+            buttonText={i18n.createAccount()}
+            buttonType="secondary"
+            href={newAccountUrl}
+          />
+          <AccountCard
+            id={'existing-account-card'}
+            icon={'user-check'}
+            title={i18n.ltiLinkAccountExistingAccountCardHeaderLabel()}
+            content={i18n.accountExistingAccountCardContentWorkshopEnroll()}
+            buttonText={i18n.ltiLinkAccountExistingAccountCardActionLabel()}
+            buttonType="primary"
+            href={existingAccountUrl}
+          />
+        </div>
+        <div className={styles.cancelButtonContainer}>
+          <Link text={i18n.cancel()} href={'/users/cancel'} />
+        </div>
       </div>
-      <div className={styles.cancelButtonContainer}>
-        <Link text={i18n.cancel()} href={'/users/cancel'} />
-      </div>
-    </div>
-  </main>
-);
+    </main>
+  );
+};
 
 export default WorkshopLinkAccountPage;

--- a/apps/src/templates/sectionsRefresh/JoinSectionLinkAccountPage.tsx
+++ b/apps/src/templates/sectionsRefresh/JoinSectionLinkAccountPage.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import AccountBanner from '@cdo/apps/templates/account/AccountBanner';
 import AccountCard from '@cdo/apps/templates/account/AccountCard';
 import i18n from '@cdo/locale';
@@ -15,6 +17,14 @@ const JoinSectionLinkAccountPage: React.FunctionComponent<{
   const joinSectionCodeUrlParam = sectionCode ? `/${sectionCode}` : '';
   const signUpJoinSectionUrl = `/users/new_sign_up/login_type?user_type=student&user_return_to=/join${joinSectionCodeUrlParam}`;
   const signInJoinSectionUrl = `/users/sign_in?user_return_to=/join${joinSectionCodeUrlParam}`;
+
+  useEffect(() => {
+    analyticsReporter.sendEvent(
+      EVENTS.LINK_ACCOUNT_PAGE_VISITED_EVENT,
+      {source: 'join section'},
+      PLATFORMS.BOTH
+    );
+  }, []);
 
   return (
     <main>


### PR DESCRIPTION
Adds/Updates events relating to logging in and signing up.

### Specifies if the user is starting the signup coming from the section setup
This previously existed in the section signup flow but was missed when moving that flow to the new signup flow.

Coming from trying to join a section:
![sign up started section](https://github.com/user-attachments/assets/4e445480-6439-4784-87c5-56103aaab5fa)

Coming from somewhere else:
![sign up started normal](https://github.com/user-attachments/assets/04803af1-9ab6-406e-b34a-2f8af1d54f23)

### Adds logging to Link Account pages
LTI:
![lti](https://github.com/user-attachments/assets/a4180cc6-953c-46a6-adaa-3510405ff125)

Workshop enroll:
![workshop enroll](https://github.com/user-attachments/assets/2b65a53b-765c-4785-b0c2-ffe6585e3c8e)

Join section:
![join section](https://github.com/user-attachments/assets/87350e96-1f62-46e7-91d3-7aeb9731984d)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3135)

## Testing story
Local testing.
