### PR TITLE
fix(jest): use absolute path to alias

### DIFF
--- a/frontend/packages/component-library/jest.config.mjs
+++ b/frontend/packages/component-library/jest.config.mjs
@@ -1,3 +1,6 @@
+import {dirname} from 'path';
+import {fileURLToPath} from 'url';
+
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 export default {
   testEnvironment: 'jsdom',
@@ -8,7 +11,7 @@ export default {
         jsc: {
           baseUrl: '.',
           paths: {
-            '@/*': ['./src/*'],
+            '@/*': [`${dirname(fileURLToPath(import.meta.url))}/src/*`],
           },
           transform: {
             react: {
@@ -20,6 +23,7 @@ export default {
     ],
   },
   moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css|scss|sass)$': 'identity-obj-proxy',
   },
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],


### PR DESCRIPTION
Jest extension runner for VS Code runs at the base directory of code-dot-org. This causes the module to be resolved at the base. Instead, use the absolute path to the module which allows jest to run regardless of the current working directory.