### PR TITLE
Add student_female and student_male columns to school_stats_by_years

### DIFF
--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -35,6 +35,8 @@
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  community_type     :string(16)
+#  student_female     :integer
+#  student_male       :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20250228184551_add_female_male_columns_to_school_stats_by_year.rb
+++ b/dashboard/db/migrate/20250228184551_add_female_male_columns_to_school_stats_by_year.rb
@@ -1,0 +1,6 @@
+class AddFemaleMaleColumnsToSchoolStatsByYear < ActiveRecord::Migration[6.1]
+  def change
+    add_column :school_stats_by_years, :student_female, :integer
+    add_column :school_stats_by_years, :student_male, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_21_170834) do
+ActiveRecord::Schema.define(version: 2025_02_28_184551) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1937,6 +1937,8 @@ ActiveRecord::Schema.define(version: 2025_02_21_170834) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "community_type", limit: 16, comment: "Urban-centric community type"
+    t.integer "student_female"
+    t.integer "student_male"
     t.index ["school_id"], name: "index_school_stats_by_years_on_school_id"
   end
 


### PR DESCRIPTION
As part of importing the 2023-2024 NCES public school data, we now have access to more info than we did previously. So this PR adds `student_female` and `student_male` columns to `school_stats_by_years` table to track the number of female and male students at each school we're getting data from.

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1740602708791939?thread_ts=1733928432.418419&cid=C04540KNGDQ)

## Testing story
Successfully ran `db:migration` locally.