### PR TITLE
Remove some eyes tests that were duplicated

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/local_nav_v2_standalone_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/local_nav_v2_standalone_eyes.feature
@@ -15,35 +15,13 @@ Feature: V2 teacher dashboard local navigation - standalone unit - Eyes
     And I get levelbuilder access
 
     When I click selector "a:contains(New Section)" once I see it to load a new page
-
     Given I wait until element "#ui-test-teacher-sidebar" is visible
-
     Given I click selector "#ui-test-teacher-sidebar a:contains('Course')" once I see it
-
     And I wait until element "h1:contains('Interactive Animations and Games')" is visible
-
     Then I see no difference for "unit overview"
 
     Then I click selector "#uitest-view-as-student" once I see it
-
     And I wait until element ".uitest-assigned" is visible
-
     Then I see no difference for "student view"
-
-    Then I click selector "#uitest-view-as-teacher" once I see it
-
-    Then I see no difference for "back to teacher"
-
-    Then I select the "Sally" option in dropdown "uitest-view-as-student-selector"
-
-    Then I see no difference for "selected student view"
-
-    Then I select the "Me" option in dropdown "uitest-view-as-student-selector"
-
-    Then I see no difference for "back to teacher 2"
-
-    Then I click selector "button:contains('Assign to sections')" once I see it
-
-    Then I see no difference for "assign to sections modal"
 
     And I close my eyes


### PR DESCRIPTION
Removing 3 eyes tests from standalone unit eyes 
- back to teacher - should be identical to a previous eyes case
- specific student view - should be very similar to the generic student view and is a more uncommon workflow than we want to test
- back to teacher 2 - should be identical to a previous eyes case

More PRs to speed up these tests later

## Links
https://codedotorg.atlassian.net/browse/TEACH-1651
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
