### PR TITLE
AI Tutor: use updated suggested prompts component

### DIFF
--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback} from 'react';
 
-import DeprecatedSuggestedPrompts from '@cdo/apps/aiComponentLibrary/suggestedPrompt/DeprecatedSuggestedPrompts';
+import SuggestedPrompts from '@cdo/apps/aiComponentLibrary/suggestedPrompt/SuggestedPrompts';
 import {
   AITutorTypes as ActionType,
   AITutorTypesValue,
@@ -149,25 +149,30 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
     [studentCode, isWaitingForChatResponse, level, dispatch]
   );
 
+  // We set selected to false because once the user selects a prompt, we convert
+  // the chip into a message in the chat history.
   const suggestedPrompts = [
     {
       label: QuickActions[ActionType.COMPILATION],
       onClick: () => handleClick(ActionType.COMPILATION),
       show: showCompilationOption,
+      selected: false,
     },
     {
       label: QuickActions[ActionType.VALIDATION],
       onClick: () => handleClick(ActionType.VALIDATION),
       show: showValidationOption,
+      selected: false,
     },
     {
       label: QuickActions[ActionType.GENERIC_HELP],
       onClick: () => handleClick(ActionType.GENERIC_HELP),
       show: showGenericErrorOption,
+      selected: false,
     },
   ];
 
-  return <DeprecatedSuggestedPrompts suggestedPrompts={suggestedPrompts} />;
+  return <SuggestedPrompts suggestedPrompts={suggestedPrompts} />;
 };
 
 export default AITutorSuggestedPrompts;

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -32,9 +32,12 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   );
 
   const hasPythonLabError = useAppSelector(state => state.lab2System.hasError);
-  const hasRunOrTestedPythonLabCode = useAppSelector(
-    state => state.lab2System.hasRun || state.lab2System.hasValidated
+  const hasRunPythonCode = useAppSelector(state => state.lab2System.hasRun);
+  const hasValidatedPythonCode = useAppSelector(
+    state => state.lab2System.hasValidated
   );
+  const hasRunOrTestedPythonLabCode =
+    hasRunPythonCode || hasValidatedPythonCode;
   const isPythonLabRunning = useAppSelector(
     state => state.lab2System.isRunning
   );
@@ -44,7 +47,8 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   const {hasConditions, satisfied} = useAppSelector(
     state => state.lab.validationState
   );
-  const pythonLabValidationPassed = !hasConditions || satisfied;
+  const pythonLabValidationFailed =
+    hasConditions && hasValidatedPythonCode && !satisfied;
 
   // For JavaLab
   const javaLabSources = useAppSelector(state => state.javalabEditor.sources);
@@ -80,7 +84,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
         hasRunOrTestedPythonLabCode &&
         !isWaitingForChatResponse;
       const showGenericErrorOption = showOption && hasPythonLabError;
-      const showValidationOption = showOption && !pythonLabValidationPassed;
+      const showValidationOption = showOption && pythonLabValidationFailed;
       return {studentCode, showGenericErrorOption, showValidationOption};
     } else if (labType === 'Javalab') {
       const studentCode = javaLabSources[fileMetadata[activeTabKey]].text;


### PR DESCRIPTION
Switch from using `DeprecatedSuggestedPrompts` to `SuggestedPrompts`, which uses dsco chips behind the scenes. 
I also updated some logic around showing the validation prompt; if we were on a validation level it would show the "why are my tests failing" prompt if you hadn't yet run your tests.

## Screen Recording
https://github.com/user-attachments/assets/36333c7e-2515-4d51-9018-057a6ccc5a89

## Multiple suggested prompts
<img width="763" alt="Screenshot 2025-02-28 at 11 45 33 AM" src="https://github.com/user-attachments/assets/6bee7098-ec67-4d4d-826f-20b1aa36e309" />

## One suggested prompt
<img width="763" alt="Screenshot 2025-02-28 at 11 45 21 AM" src="https://github.com/user-attachments/assets/681814bf-691c-4c4b-beb3-84ef7a67f7a5" />



## Links

- jira ticket: [CT-1065](https://codedotorg.atlassian.net/browse/CT-1065)
- [slack discussion](https://codedotorg.slack.com/archives/C06JELCAPT9/p1740762742432989) on if we ever want the prompts to be "selected"


## Testing story
Tested locally



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
