### PR TITLE
Add pl topics for survey variables

### DIFF
--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditor.jsx
@@ -262,6 +262,7 @@ class FoormEntityEditor extends React.Component {
                   day: this.state.day,
                   is_friday_institute: this.state.is_friday_institute,
                   workshop_agenda: this.state.workshop_agenda,
+                  pl_topics: this.state.pl_topics,
                 }}
               />
             </Tab>

--- a/dashboard/app/controllers/foorm_preview_controller.rb
+++ b/dashboard/app/controllers/foorm_preview_controller.rb
@@ -54,7 +54,8 @@ class FoormPreviewController < ApplicationController
       is_virtual: params[:isVirtual] == 'true' || false,
       is_friday_institute: params[:isFridayInstitute] == 'true' || false,
       num_facilitators: 3,
-      workshop_agenda: params[:workshopAgenda] || "module1"
+      workshop_agenda: params[:workshopAgenda] || "module1",
+      pl_topics: params[:plTopics] || ['self-paced-1', 'self-paced-2']
     }
 
     @script_data = {

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -337,7 +337,8 @@ module Pd
         num_facilitators: workshop.facilitators.count,
         day: day,
         is_friday_institute: workshop.friday_institute?,
-        workshop_agenda: workshop_agenda
+        workshop_agenda: workshop_agenda,
+        pl_topics: workshop.course_offerings.map {|co| co&.key}
       }
     end
   end


### PR DESCRIPTION
Added pl_topics as daily survey variable so that RED can use it as part of surveys they create for PL. Followed what I did in this past PR: https://github.com/code-dot-org/code-dot-org/pull/46799/files

Checked that I could see the variable in the variables preview on http://localhost-studio.code.org:3000/foorm/forms/editor
<img width="476" alt="Screenshot 2025-03-04 at 1 55 32 PM" src="https://github.com/user-attachments/assets/dd0045be-9b63-48b0-9335-c3e11e378409" />

