### PR TITLE
Python Lab: Make resize bar easier to grab

### DIFF
--- a/apps/src/lab2/views/components/ResizeBar.tsx
+++ b/apps/src/lab2/views/components/ResizeBar.tsx
@@ -35,11 +35,15 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
     document.body.style.cursor = cursor;
   }, [isDragging, isActive, isVertical]);
 
-  const grabbableClass = useMemo(() => {
+  const grabbableClass = isVertical
+    ? moduleStyles.verticalGrabbable
+    : moduleStyles.horizontalGrabbable;
+
+  const resizingBarClass = useMemo(() => {
     const className = [
       isVertical
-        ? moduleStyles.verticalGrabbable
-        : moduleStyles.horizontalGrabbable,
+        ? moduleStyles.verticalResizing
+        : moduleStyles.horizontalResizing,
     ];
     if (isDragging || isActive) {
       // When we are dragging or the resize bar is active, we show the wider
@@ -56,7 +60,7 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
   return (
     <div className={classNames(moduleStyles.resizeBar, layoutClass)}>
       <div
-        className={classNames(moduleStyles.grabbableDiv, grabbableClass)}
+        className={classNames(moduleStyles.absoluteBar, grabbableClass)}
         {...separatorProps}
         // TODO: the separator props are applying role "separator" as well as min/max/now aria values.
         // Is it ok to ignore this warning?
@@ -67,7 +71,11 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
         onBlur={() => setIsActive(false)}
         onMouseEnter={() => setIsActive(true)}
         onMouseLeave={() => setIsActive(false)}
-      />
+      >
+        <div
+          className={classNames(moduleStyles.absoluteBar, resizingBarClass)}
+        />
+      </div>
     </div>
   );
 };

--- a/apps/src/lab2/views/components/ResizeBar.tsx
+++ b/apps/src/lab2/views/components/ResizeBar.tsx
@@ -14,8 +14,9 @@ export const RESIZE_BAR_SIZE_PX = 1;
 
 // A resize bar that can be dragged to resize two adjacent panels.
 // The visible bar starts out 1px wide. There is an absolutely-positioned 7px bar
-// that is used for grabbing, and a 3px "resize" bar that becomes visible the grabbable bar
-// is hovered/focused or being dragged.
+// that is used for grabbing, and a 3px "resize" bar that becomes visible
+// when the grabbable bar is hovered or being dragged.
+// The keyboard events happen on the 3px resize bar so they are visible to the user.
 // The resize bar should be used with useResizable from react-resizable-layout.
 const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
   isVertical,

--- a/apps/src/lab2/views/components/ResizeBar.tsx
+++ b/apps/src/lab2/views/components/ResizeBar.tsx
@@ -62,8 +62,9 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
   const {onPointerDown, ...mainSeparatorProps} = separatorProps;
 
   return (
+    // The always-visible 1px bar
     <div className={classNames(moduleStyles.resizeBar, layoutClass)}>
-      {/* The visible bar */}
+      {/* The visible 3px bar */}
       <div
         className={classNames(moduleStyles.absoluteBar, resizingBarClass)}
         {...mainSeparatorProps}

--- a/apps/src/lab2/views/components/ResizeBar.tsx
+++ b/apps/src/lab2/views/components/ResizeBar.tsx
@@ -13,8 +13,9 @@ interface ResizeBarProps {
 export const RESIZE_BAR_SIZE_PX = 1;
 
 // A resize bar that can be dragged to resize two adjacent panels.
-// The visible bar starts out 1px wide. There is an absolutely-positioned 5px bar
-// that is used for grabbing, and becomes visible when it is hovered/focused or being dragged.
+// The visible bar starts out 1px wide. There is an absolutely-positioned 7px bar
+// that is used for grabbing, and a 3px "resize" bar that becomes visible the grabbable bar
+// is hovered/focused or being dragged.
 // The resize bar should be used with useResizable from react-resizable-layout.
 const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
   isVertical,
@@ -57,23 +58,29 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
     ? moduleStyles.verticalBar
     : moduleStyles.horizontalBar;
 
+  const {onPointerDown, ...mainSeparatorProps} = separatorProps;
+
   return (
     <div className={classNames(moduleStyles.resizeBar, layoutClass)}>
+      {/* The visible bar */}
       <div
-        className={classNames(moduleStyles.absoluteBar, grabbableClass)}
-        {...separatorProps}
+        className={classNames(moduleStyles.absoluteBar, resizingBarClass)}
+        {...mainSeparatorProps}
         // TODO: the separator props are applying role "separator" as well as min/max/now aria values.
         // Is it ok to ignore this warning?
         // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
-        onFocus={() => setIsActive(true)}
-        onBlur={() => setIsActive(false)}
-        onMouseEnter={() => setIsActive(true)}
-        onMouseLeave={() => setIsActive(false)}
       >
+        {/* The grabbable bar. We take onPointerDown from the separater props and put it here to make the bar
+        easier to grab. */}
         <div
-          className={classNames(moduleStyles.absoluteBar, resizingBarClass)}
+          onPointerDown={onPointerDown}
+          className={classNames(moduleStyles.absoluteBar, grabbableClass)}
+          onFocus={() => setIsActive(true)}
+          onBlur={() => setIsActive(false)}
+          onMouseEnter={() => setIsActive(true)}
+          onMouseLeave={() => setIsActive(false)}
         />
       </div>
     </div>

--- a/apps/src/lab2/views/components/ResizeBar.tsx
+++ b/apps/src/lab2/views/components/ResizeBar.tsx
@@ -72,6 +72,8 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
         // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
+        onFocus={() => setIsActive(true)}
+        onBlur={() => setIsActive(false)}
       >
         {/* The grabbable bar. We take onPointerDown from the separater props and put it here to make the bar
         easier to grab. */}

--- a/apps/src/lab2/views/components/resizeBar.module.scss
+++ b/apps/src/lab2/views/components/resizeBar.module.scss
@@ -1,9 +1,13 @@
 @import 'color.scss';
 
 $bar-width: 1px;
-$bar-width-grab-area: 3px;
+$bar-width-grab-area: 5px;
 $grab-area-offset: calc(($bar-width-grab-area - $bar-width) / 2);
 $negative-grab-area-offset: calc(-1 * $grab-area-offset);
+$visible-area: 3px;
+$visible-area-offset: calc(($visible-area - $bar-width) / 2);
+$visible-negative-area-offset: calc(-1 * $visible-area-offset);
+
 
 .resizeBar {
   background-color: $light_gray_800;
@@ -21,7 +25,7 @@ $negative-grab-area-offset: calc(-1 * $grab-area-offset);
   height: $bar-width;
 }
 
-.grabbableDiv {
+.absoluteBar {
   position: absolute;
   background-color: $light_gray_800;
   opacity: 0;
@@ -29,26 +33,43 @@ $negative-grab-area-offset: calc(-1 * $grab-area-offset);
   transition: opacity 0.1s ease-in;
 }
 
-.verticalGrabbable {
-  width: $bar-width-grab-area;
+@mixin verticalAbsoluteBar($width, $left, $right) {
+  width: $width;
   height: 100%;
   top: 0;
   bottom: 0;
-  left: $negative-grab-area-offset;
-  right: $grab-area-offset;
+  left: $left;
+  right: $right;
   cursor: col-resize;
 }
 
-.horizontalGrabbable {
-  height: $bar-width-grab-area;
+@mixin horizontalAbsoluteBar($width, $top, $bottom) {
+  height: $width;
   width: 100%;
   left: 0;
   right: 0;
-  top: $negative-grab-area-offset;
-  bottom: $grab-area-offset;
+  top: $top;
+  bottom: $bottom;
   cursor: row-resize;
+}
+
+
+.horizontalGrabbable {
+  @include horizontalAbsoluteBar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
+}
+
+.verticalGrabbable {
+  @include verticalAbsoluteBar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
 }
 
 .visible {
   opacity: 1;
+}
+
+.verticalResizing {
+  @include verticalAbsoluteBar($visible-area, $visible-negative-area-offset, $visible-area-offset);
+}
+
+.horizontalResizing {
+  @include horizontalAbsoluteBar($visible-area, $visible-negative-area-offset, $visible-area-offset);
 }

--- a/apps/src/lab2/views/components/resizeBar.module.scss
+++ b/apps/src/lab2/views/components/resizeBar.module.scss
@@ -1,12 +1,12 @@
 @import 'color.scss';
 
 $bar-width: 1px;
-$bar-width-grab-area: 5px;
-$grab-area-offset: calc(($bar-width-grab-area - $bar-width) / 2);
-$negative-grab-area-offset: calc(-1 * $grab-area-offset);
 $visible-area: 3px;
 $visible-area-offset: calc(($visible-area - $bar-width) / 2);
 $visible-negative-area-offset: calc(-1 * $visible-area-offset);
+$bar-width-grab-area: 7px;
+$grab-area-offset: calc(($bar-width-grab-area - $visible-area) / 2);
+$negative-grab-area-offset: calc(-1 * $grab-area-offset);
 
 
 .resizeBar {
@@ -27,10 +27,9 @@ $visible-negative-area-offset: calc(-1 * $visible-area-offset);
 
 .absoluteBar {
   position: absolute;
-  background-color: $light_gray_800;
-  opacity: 0;
   z-index: 3;
   transition: opacity 0.1s ease-in;
+  background-color: transparent;
 }
 
 @mixin verticalAbsoluteBar($width, $left, $right) {
@@ -56,14 +55,12 @@ $visible-negative-area-offset: calc(-1 * $visible-area-offset);
 
 .horizontalGrabbable {
   @include horizontalAbsoluteBar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
+  opacity: 0;
 }
 
 .verticalGrabbable {
   @include verticalAbsoluteBar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
-}
-
-.visible {
-  opacity: 1;
+  opacity: 0;
 }
 
 .verticalResizing {
@@ -72,4 +69,9 @@ $visible-negative-area-offset: calc(-1 * $visible-area-offset);
 
 .horizontalResizing {
   @include horizontalAbsoluteBar($visible-area, $visible-negative-area-offset, $visible-area-offset);
+}
+
+.visible {
+  opacity: 1;
+  background-color: $light_gray_800;
 }

--- a/apps/src/lab2/views/components/resizeBar.module.scss
+++ b/apps/src/lab2/views/components/resizeBar.module.scss
@@ -33,7 +33,7 @@ $negative-grab-area-offset: calc(-1 * $grab-area-offset);
   background-color: transparent;
 }
 
-@mixin verticalAbsoluteBar($width, $left, $right) {
+@mixin vertical-absolute-bar($width, $left, $right) {
   width: $width;
   height: 100%;
   top: 0;
@@ -43,7 +43,7 @@ $negative-grab-area-offset: calc(-1 * $grab-area-offset);
   cursor: col-resize;
 }
 
-@mixin horizontalAbsoluteBar($width, $top, $bottom) {
+@mixin horizontal-absolute-bar($width, $top, $bottom) {
   height: $width;
   width: 100%;
   left: 0;
@@ -55,19 +55,19 @@ $negative-grab-area-offset: calc(-1 * $grab-area-offset);
 
 
 .horizontalGrabbable {
-  @include horizontalAbsoluteBar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
+  @include horizontal-absolute-bar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
 }
 
 .verticalGrabbable {
-  @include verticalAbsoluteBar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
+  @include vertical-absolute-bar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
 }
 
 .verticalResizing {
-  @include verticalAbsoluteBar($visible-area, $visible-negative-area-offset, $visible-area-offset);
+  @include vertical-absolute-bar($visible-area, $visible-negative-area-offset, $visible-area-offset);
 }
 
 .horizontalResizing {
-  @include horizontalAbsoluteBar($visible-area, $visible-negative-area-offset, $visible-area-offset);
+  @include horizontal-absolute-bar($visible-area, $visible-negative-area-offset, $visible-area-offset);
 }
 
 .visible {

--- a/apps/src/lab2/views/components/resizeBar.module.scss
+++ b/apps/src/lab2/views/components/resizeBar.module.scss
@@ -28,6 +28,7 @@ $negative-grab-area-offset: calc(-1 * $grab-area-offset);
 .absoluteBar {
   position: absolute;
   z-index: 3;
+  opacity: 0;
   transition: opacity 0.1s ease-in;
   background-color: transparent;
 }
@@ -55,12 +56,10 @@ $negative-grab-area-offset: calc(-1 * $grab-area-offset);
 
 .horizontalGrabbable {
   @include horizontalAbsoluteBar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
-  opacity: 0;
 }
 
 .verticalGrabbable {
   @include verticalAbsoluteBar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
-  opacity: 0;
 }
 
 .verticalResizing {


### PR DESCRIPTION
This PR makes the resize bar easier to grab onto without making it visibly wider. Previously we had 2 divs, the always-visible 1px divider between panels, and the 3px resize bar which was visible when dragging/hovering. Now there are 3 divs. The new div is an invisible 7px div that has the mouse event for dragging attached to it, so the grabbable area is a bit wider. The keyboard events still occur on the 3px bar (as well as the aria labels), so the element gets highlighted correctly when tabbing around.

## Before
https://github.com/user-attachments/assets/6e836a60-8561-4ee5-838b-987fee381d29

## After
https://github.com/user-attachments/assets/6394d14f-db78-4c5f-9210-d588b7fc907d


## Links
- jira ticket: [CT-1119](https://codedotorg.atlassian.net/browse/CT-1119)


## Testing story
Tested locally. It works for both horizontal and vertical bars.

## Follow up work
I will check to see if the ratio of unique users clicking the run button to unique users resizing increases after this change goes in ([statsig query](https://console.statsig.com/6uqJc02CIZP7hHowwYO7AS/metrics/explore?query=3hf6ieLNZbdMfZxTDgcUQH&ref=query_ref)).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
