### PR TITLE
fail safe_browsing check if url is invalid

### DIFF
--- a/lib/cdo/safe_browsing.rb
+++ b/lib/cdo/safe_browsing.rb
@@ -11,6 +11,7 @@ module SafeBrowsing
   # @param [String] url The url to lookup in Google Safe Browsing API.
   # @return [Boolean] False, if Google Safe Browsing has identified threat at given website. True, otherwise.
   def self.determine_safe_to_open(url_to_check)
+    return false unless valid_url?(url_to_check)
     return false unless CDO.google_safe_browsing_key
 
     uri = URI("https://safebrowsing.googleapis.com/v4/threatMatches:find?key=" + CDO.google_safe_browsing_key)
@@ -69,5 +70,12 @@ module SafeBrowsing
     )
 
     site_approved
+  end
+
+  def self.valid_url?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+  rescue URI::InvalidURIError
+    false
   end
 end

--- a/lib/test/cdo/test_safe_browsing.rb
+++ b/lib/test/cdo/test_safe_browsing.rb
@@ -15,6 +15,13 @@ class SafeBrowsingTest < Minitest::Test
     c.filter_sensitive_data('<SAFE_BROWSE_API_KEY>') {CDO.google_safe_browsing_key}
   end
 
+  def test_invalid_url
+    refute SafeBrowsing.determine_safe_to_open("some string")
+    refute SafeBrowsing.determine_safe_to_open("ftp://example.com")
+    refute SafeBrowsing.determine_safe_to_open("mailto:user@example.com")
+    refute SafeBrowsing.determine_safe_to_open("example.com") # missing protocol
+  end
+
   def test_determine_safe_website
     assert SafeBrowsing.determine_safe_to_open("https://code.org/")
   end


### PR DESCRIPTION
When users submit invalid URL's to the `openUrl` function in AppLab, they are sent on to the `/safe_browsing` route, checked with Google's API, and reported to Firehose even if the URL is obviously invalid. This PR performs a quick check before performing any expensive operations or 3rd party API calls.

This should be followed up with frontend work to perform a similar check in [applab/commands.js](https://github.com/code-dot-org/code-dot-org/blob/5d7f495e7faa9062df068b0ada3b3b2d73232887/apps/src/applab/commands.js#L1639), but this small change is sufficient to mitigate the most harmful effects of this issue.

One thing to note about this implementation is that it effectively defines "invalid URLs" as "unsafe URLs", as that's how the frontend will interpret the `false` response from this endpoint. If we want to provide specific notes to users, we should check on the frontend.

## Links

Slack discussion on the underlying issue: https://codedotorg.slack.com/archives/C03DBDN67B7/p1740766312356979

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
