### PR TITLE
feat(marketing): remove default margin and padding on body of site

### DIFF
--- a/frontend/apps/marketing/src/app/globals.css
+++ b/frontend/apps/marketing/src/app/globals.css
@@ -3,3 +3,8 @@ body {
   max-width: 100vw;
   overflow-x: hidden;
 }
+
+body {
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
Sets the `margin` and `padding` on the `body` element to 0 to remove default spacing. 8px of margin is being applied by default, but I'm also explicitly removing the padding too just in case.

## Links
Jira ticket: [CMS-383](https://codedotorg.atlassian.net/browse/CMS-383)

## Testing story
Tested locally

---- 

## Before
<img width="1740" alt="Before" src="https://github.com/user-attachments/assets/056f1bdb-2a31-4a3b-bb53-43c362223c70" />

## After
<img width="1735" alt="After" src="https://github.com/user-attachments/assets/c4966129-41f8-4d08-b9a1-a38c2eef5be1" />
