### PR TITLE
fix(turbo): build dependencies prior to running dev

### DIFF
--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -49,7 +49,8 @@
     },
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
Currently, contributors need to run `yarn build` at some point prior to `yarn dev`. Instead, running `yarn dev` should imply the need to run `yarn build` on the target package's dependency tree.