### PR TITLE
Codebridge: don't save start code to the server

### DIFF
--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -8,6 +8,7 @@ import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {TestResults} from '@cdo/apps/constants';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {
   getAppOptionsEditBlocks,
   getAppOptionsEditingExemplar,
@@ -148,6 +149,12 @@ export const useSource = (defaultSources: ProjectSources) => {
       initialSources !== previousInitialSources.current
     ) {
       if (initialSources) {
+        // Set the last source in project manager to initial sources.
+        // This prevents us from immediately saving the source on load,
+        // as we only want to save when the user makes a change.
+        Lab2Registry.getInstance()
+          .getProjectManager()
+          ?.setLastSource(initialSources);
         setSourceHelper(initialSources);
       }
       if (levelId) {

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -152,6 +152,8 @@ export const useSource = (defaultSources: ProjectSources) => {
         // Set the last source in project manager to initial sources.
         // This prevents us from immediately saving the source on load,
         // as we only want to save when the user makes a change.
+        // Initial sources always comes from the server, so we never need to save
+        // it again.
         Lab2Registry.getInstance()
           .getProjectManager()
           ?.setLastSource(initialSources);

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -316,6 +316,10 @@ export default class ProjectManager {
     return this.forceReloading;
   }
 
+  setLastSource(lastSource: ProjectSources) {
+    this.lastSource = JSON.stringify(lastSource);
+  }
+
   /**
    * Helper function to save a project, called either after a timeout or directly by save().
    * On a save, we check if there are unsaved changes to the source or channel.

--- a/apps/test/unit/codebridge/hooks/useSourceTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useSourceTest.tsx
@@ -43,7 +43,6 @@ const ownedChannel: Channel = {
 describe('useSource', () => {
   let store: Store;
   let mockedProjectManager: jest.Mocked<ProjectManager>;
-  let projectSaveSpy: jest.Mock;
   beforeEach(() => {
     stubRedux();
     registerReducers({
@@ -53,9 +52,9 @@ describe('useSource', () => {
       progress,
     });
     store = getStore();
-    projectSaveSpy = jest.fn();
     mockedProjectManager = {
-      save: projectSaveSpy,
+      save: jest.fn(),
+      setLastSource: jest.fn(),
     } as unknown as jest.Mocked<ProjectManager>;
     Lab2Registry.getInstance().setProjectManager(mockedProjectManager);
     // Set up the channel so we are not in read only mode (isOwner = true)
@@ -148,6 +147,7 @@ describe('useSource', () => {
     );
     renderDefault();
     expect(mockedProjectManager.save).toHaveBeenCalledTimes(1);
+    expect(mockedProjectManager.setLastSource).toHaveBeenCalledTimes(1);
     act(() => {
       store.dispatch(
         onLevelChange({
@@ -157,6 +157,7 @@ describe('useSource', () => {
       );
     });
     expect(mockedProjectManager.save).toHaveBeenCalledTimes(2);
+    expect(mockedProjectManager.setLastSource).toHaveBeenCalledTimes(2);
     const expectedNewSources = {
       source: nonValidatedLevelProperties.startSources,
       labConfig: undefined,


### PR DESCRIPTION
When we load a level for the first time, we always immediately save the start code to the user's channel. This is because there is no `lastSource` set on the ProjectManager, so it doesn't know if the code is start code or not (we compare future saves against `lastSource` to avoid saving the same code over and over). This causes a couple issues. One is if a levelbuilder is working on a level and loads it, then changes the start code, they have to start over to see their new start code. The other is we are doing extra writes to the server that we don't need to do. 

The solution here is when we load code from the server, we update `lastSource` in ProjectManager to that loaded code. We know it's safe to ignore saving this code because we just loaded it from the server.

I considered doing this at the lab2 level, but both Codebridge and Music Lab do some custom pre-processing on start sources sometimes (Codebridge to save the neighborhood maze and the mini app type, Music Lab to save the library). So Music Lab could adopt a similar change to Codebridge to reproduce this behavior.

## Links

- jira ticket: [CT-757](https://codedotorg.atlassian.net/browse/CT-757). There is a duplicate labs ticket, [LABS-1236](https://codedotorg.atlassian.net/browse/LABS-1236), which I'm leaving open since this change only affects codebridge.


## Testing story
Tested locally and updated unit tests.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
