### PR TITLE
AI Chat: support Spanish-specific safety system prompt

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -144,11 +144,15 @@ export async function getStudentChatHistory(
  * Returns a {@link DetectToxicityResponse}.
  */
 export async function detectToxicityInCustomizations(
-  aiCustomizations: AiCustomizations
+  aiCustomizations: AiCustomizations,
+  levelId: number | null
 ): Promise<DetectToxicityResponse> {
   const response = await HttpClient.post(
     paths.FIND_TOXICITY_URL,
-    JSON.stringify(extractFieldsToCheckForToxicity(aiCustomizations)),
+    JSON.stringify({
+      ...extractFieldsToCheckForToxicity(aiCustomizations),
+      levelId,
+    }),
     true,
     {
       'Content-Type': 'application/json; charset=UTF-8',

--- a/apps/src/aichat/redux/thunks/helpers/saveAiCustomization.ts
+++ b/apps/src/aichat/redux/thunks/helpers/saveAiCustomization.ts
@@ -20,7 +20,8 @@ import {handleToxicityRequestError} from './handleToxicityRequestError';
 export const saveAiCustomization = async (
   currentAiCustomizations: AiCustomizations,
   saveType: SaveType,
-  dispatch: AppDispatch
+  dispatch: AppDispatch,
+  levelId: number | null
 ) => {
   // Remove any empty example topics on save
   const trimmedExampleTopics =
@@ -52,7 +53,8 @@ export const saveAiCustomization = async (
   let toxicity: DetectToxicityResponse;
   try {
     toxicity = await detectToxicityInCustomizations(
-      trimmedCurrentAiCustomizations
+      trimmedCurrentAiCustomizations,
+      levelId
     );
   } catch (error) {
     await handleToxicityRequestError(error as Error, dispatch);

--- a/apps/src/aichat/redux/thunks/publishModelCard.ts
+++ b/apps/src/aichat/redux/thunks/publishModelCard.ts
@@ -13,11 +13,14 @@ import {saveAiCustomization} from './helpers/saveAiCustomization';
 export const publishModelCard = createAsyncThunk(
   'aichat/publishModelCard',
   async (_, {dispatch, getState}) => {
+    const state = getState() as RootState;
+
     dispatch(setModelCardProperty({property: 'isPublished', value: true}));
     await saveAiCustomization(
-      (getState() as RootState).aichat.currentAiCustomizations,
+      state.aichat.currentAiCustomizations,
       'publishModelCard',
-      dispatch as AppDispatch
+      dispatch as AppDispatch,
+      parseInt(state.progress.currentLevelId || '')
     );
   }
 );

--- a/apps/src/aichat/redux/thunks/saveModelCard.ts
+++ b/apps/src/aichat/redux/thunks/saveModelCard.ts
@@ -13,7 +13,9 @@ import {saveAiCustomization} from './helpers/saveAiCustomization';
 export const saveModelCard = createAsyncThunk(
   'aichat/saveModelCard',
   async (_, {dispatch, getState}) => {
-    const {currentAiCustomizations} = (getState() as RootState).aichat;
+    const state = getState() as RootState;
+
+    const {currentAiCustomizations} = state.aichat;
     const modelCardInfo = currentAiCustomizations.modelCardInfo;
     if (!hasFilledOutModelCard(modelCardInfo)) {
       dispatch(setModelCardProperty({property: 'isPublished', value: false}));
@@ -22,7 +24,8 @@ export const saveModelCard = createAsyncThunk(
     await saveAiCustomization(
       currentAiCustomizations,
       'saveModelCard',
-      dispatch as AppDispatch
+      dispatch as AppDispatch,
+      parseInt(state.progress.currentLevelId || '')
     );
   }
 );

--- a/apps/src/aichat/redux/thunks/updateAiCustomization.ts
+++ b/apps/src/aichat/redux/thunks/updateAiCustomization.ts
@@ -12,10 +12,13 @@ import {saveAiCustomization} from './helpers/saveAiCustomization';
 export const updateAiCustomization = createAsyncThunk(
   'aichat/updateAiCustomization',
   async (_, {dispatch, getState}) => {
+    const state = getState() as RootState;
+
     await saveAiCustomization(
-      (getState() as RootState).aichat.currentAiCustomizations,
+      state.aichat.currentAiCustomizations,
       'updateChatbot',
-      dispatch as AppDispatch
+      dispatch as AppDispatch,
+      parseInt(state.progress.currentLevelId || '')
     );
   }
 );

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -9,7 +9,6 @@ class AichatController < ApplicationController
   # POST /aichat/find_toxicity
   # Finds toxicity in the given system prompt and retrieval contexts and returns a list of flagged fields.
   def find_toxicity
-    puts params
     locale = params[:locale] || "en"
     level_id = params[:levelId]
     flagged_fields = []

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -9,17 +9,19 @@ class AichatController < ApplicationController
   # POST /aichat/find_toxicity
   # Finds toxicity in the given system prompt and retrieval contexts and returns a list of flagged fields.
   def find_toxicity
+    puts params
     locale = params[:locale] || "en"
+    level_id = params[:levelId]
     flagged_fields = []
 
     if params[:systemPrompt].present?
-      toxicity = AichatSafetyHelper.find_toxicity('user', params[:systemPrompt], locale)
+      toxicity = AichatSafetyHelper.find_toxicity('user', params[:systemPrompt], locale, level_id)
       flagged_fields << {field: 'systemPrompt', toxicity: toxicity} if toxicity.present?
     end
 
     if params[:retrievalContexts].present?
       retrieval_joined = params[:retrievalContexts].join(' ')
-      toxicity = AichatSafetyHelper.find_toxicity('user', retrieval_joined, locale)
+      toxicity = AichatSafetyHelper.find_toxicity('user', retrieval_joined, locale, level_id)
       flagged_fields << {field: 'retrievalContexts', toxicity: toxicity} if toxicity.present?
     end
 

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -103,14 +103,17 @@ module AichatSafetyHelper
     private def get_safety_system_prompt(level_id)
       spanish_script_name = 'gen-ai-spanish-test-a-unit'
 
-      level = Level.find_by(id: level_id)
-      bubble_choice_parents = BubbleChoice.parent_levels(level.name)
+      in_spanish_script = false
+      if level_id
+        level = Level.find_by(id: level_id)
+        bubble_choice_parents = BubbleChoice.parent_levels(level.name)
 
-      any_parent_in_spanish_script = bubble_choice_parents.any? do |pl|
-        pl.script_levels.any? {|sl| sl.script.name == spanish_script_name}
+        any_parent_in_spanish_script = bubble_choice_parents.any? do |pl|
+          pl.script_levels.any? {|sl| sl.script.name == spanish_script_name}
+        end
+        level_in_spanish_script = level.script_levels.any? {|sl| sl.script.name == spanish_script_name}
+        in_spanish_script = any_parent_in_spanish_script || level_in_spanish_script
       end
-      level_in_spanish_script = level.script_levels.any? {|sl| sl.script.name == spanish_script_name}
-      in_spanish_script = any_parent_in_spanish_script || level_in_spanish_script
 
       "You are a content filter trying to keep a school teacher out of trouble. Determine if chat text is inappropriate for an #{in_spanish_script ? 'Spanish' : 'American'} public middle school classroom. Examples of inappropriate content: profanity, swears, illegal behavior, insults, bullying, slurs, sex, violence, racism, sexism, threats, weapons, dirty slang, etc. If text is inappropriate, respond with the single word `INAPPROPRIATE`, otherwise respond with the single word `OK`."
     end

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -13,7 +13,7 @@ module AichatSafetyHelper
 
     # Checks for toxicity in the given text using various services, determined by DCDO settings.
     # Returns {text: input (string), blocked_by: serviced that detected toxicity (string), details: filtering details (hash)}
-    def find_toxicity(role, text, locale)
+    def find_toxicity(role, text, locale, level_id)
       if blocklist_enabled?(role)
         text.split.each do |word|
           return {text: text, blocked_by: 'blocklist', details: {blocked_word: word}} if profane_word_blocklist.include? word
@@ -32,13 +32,13 @@ module AichatSafetyHelper
       end
 
       if openai_enabled?(role)
-        details = openai_safety_check(text)
+        details = openai_safety_check(text, level_id)
         return {text: text, blocked_by: 'openai', details: details} if details
       end
     end
 
     # Used to check safety content given text with the given moderation system prompt.
-    private def openai_safety_check(text)
+    private def openai_safety_check(text, level_id)
       details = nil
       start_time = Time.now
       report_openai_safety_check("Start")
@@ -46,7 +46,7 @@ module AichatSafetyHelper
       # replying with something other valid expected output.
       attempts = 1
       Retryable.retryable(tries: 2) do
-        messages = safety_check_messages(text)
+        messages = safety_check_messages(text, level_id)
         response = client.request_chat_completion(messages, 1)
         raise "OpenAI request failed with status #{response.code}: #{response.body}" unless response.success?
 
@@ -100,8 +100,19 @@ module AichatSafetyHelper
       DCDO.get("aichat_toxicity_threshold_model_output", DEFAULT_TOXICITY_THRESHOLD_MODEL_OUTPUT)
     end
 
-    private def get_safety_system_prompt
-      'You are a content filter trying to keep a school teacher out of trouble. Determine if chat text is inappropriate for an American public middle school classroom. Examples of inappropriate content: profanity, swears, illegal behavior, insults, bullying, slurs, sex, violence, racism, sexism, threats, weapons, dirty slang, etc. If text is inappropriate, respond with the single word `INAPPROPRIATE`, otherwise respond with the single word `OK`.'
+    private def get_safety_system_prompt(level_id)
+      spanish_script_name = 'gen-ai-spanish-test-a-unit'
+
+      level = Level.find_by(id: level_id)
+      bubble_choice_parents = BubbleChoice.parent_levels(level.name)
+
+      any_parent_in_spanish_script = bubble_choice_parents.any? do |pl|
+        pl.script_levels.any? {|sl| sl.script.name == spanish_script_name}
+      end
+      level_in_spanish_script = level.script_levels.any? {|sl| sl.script.name == spanish_script_name}
+      in_spanish_script = any_parent_in_spanish_script || level_in_spanish_script
+
+      "You are a content filter trying to keep a school teacher out of trouble. Determine if chat text is inappropriate for an #{in_spanish_script ? 'Spanish' : 'American'} public middle school classroom. Examples of inappropriate content: profanity, swears, illegal behavior, insults, bullying, slurs, sex, violence, racism, sexism, threats, weapons, dirty slang, etc. If text is inappropriate, respond with the single word `INAPPROPRIATE`, otherwise respond with the single word `OK`."
     end
 
     private def get_safety_system_prompt_version
@@ -109,11 +120,11 @@ module AichatSafetyHelper
     end
 
     # Format messages with text to be checked for safety and moderation system prompt.
-    private def safety_check_messages(text)
+    private def safety_check_messages(text, level_id)
       [
         {
           role: "system",
-          content: get_safety_system_prompt
+          content: get_safety_system_prompt(level_id)
         },
         {
           role: "user",
@@ -162,7 +173,7 @@ module AichatSafetyHelper
     end
   end
 
-  def self.find_toxicity(role, text, locale)
-    ToxicityDetector.new.find_toxicity(role, text, locale)
+  def self.find_toxicity(role, text, locale, level_id)
+    ToxicityDetector.new.find_toxicity(role, text, locale, level_id)
   end
 end

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -56,7 +56,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
 
   private def get_execution_status_and_response(model_customizations, stored_messages, new_message, level_id, locale)
     # Moderate user input for toxicity.
-    user_toxicity = AichatSafetyHelper.find_toxicity('user', new_message['chatMessageText'], locale)
+    user_toxicity = AichatSafetyHelper.find_toxicity('user', new_message['chatMessageText'], locale, level_id)
     return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:USER_PROFANITY], user_toxicity.to_json] if user_toxicity
 
     user_pii = find_pii(new_message['chatMessageText'], locale)
@@ -87,7 +87,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
     end
 
     # Moderate model output for toxicity.
-    model_toxicity = AichatSafetyHelper.find_toxicity('assistant', response, locale)
+    model_toxicity = AichatSafetyHelper.find_toxicity('assistant', response, locale, level_id)
     return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:MODEL_PROFANITY], model_toxicity.to_json] if model_toxicity
 
     model_pii = find_pii(response, locale)

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -64,7 +64,7 @@ class AichatControllerTest < ActionController::TestCase
     system_prompt = 'hello system prompt'
     locale = 'en'
     toxicity_response = {text: system_prompt, blocked_by: 'comprehend', details: {}}
-    AichatSafetyHelper.expects(:find_toxicity).with('user', system_prompt, locale).returns(toxicity_response)
+    AichatSafetyHelper.expects(:find_toxicity).with('user', system_prompt, locale, nil).returns(toxicity_response)
 
     expected_response = {
       flaggedFields: [{field: 'systemPrompt', toxicity: toxicity_response.camelize_keys}]
@@ -80,7 +80,7 @@ class AichatControllerTest < ActionController::TestCase
     retrieval_contexts = ['retrieval1', 'retrieval2']
     locale = 'en'
     toxicity_response = {text: retrieval_contexts.join(' '), blocked_by: 'comprehend', details: {}}
-    AichatSafetyHelper.expects(:find_toxicity).with('user', retrieval_contexts.join(' '), locale).returns(toxicity_response)
+    AichatSafetyHelper.expects(:find_toxicity).with('user', retrieval_contexts.join(' '), locale, nil).returns(toxicity_response)
 
     expected_response = {
       flaggedFields: [{field: 'retrievalContexts', toxicity: toxicity_response.camelize_keys}]
@@ -98,8 +98,8 @@ class AichatControllerTest < ActionController::TestCase
     locale = 'en'
     toxicity_response_system_prompt = {text: system_prompt, blocked_by: 'comprehend', details: {}}
     toxicity_response_retrieval_contexts = {text: retrieval_contexts.join(' '), blocked_by: 'comprehend', details: {}}
-    AichatSafetyHelper.expects(:find_toxicity).with('user', system_prompt, locale).returns(toxicity_response_system_prompt)
-    AichatSafetyHelper.expects(:find_toxicity).with('user', retrieval_contexts.join(' '), locale).returns(toxicity_response_retrieval_contexts)
+    AichatSafetyHelper.expects(:find_toxicity).with('user', system_prompt, locale, nil).returns(toxicity_response_system_prompt)
+    AichatSafetyHelper.expects(:find_toxicity).with('user', retrieval_contexts.join(' '), locale, nil).returns(toxicity_response_retrieval_contexts)
 
     expected_response = {
       flaggedFields: [

--- a/dashboard/test/helpers/aichat_safety_helper_test.rb
+++ b/dashboard/test/helpers/aichat_safety_helper_test.rb
@@ -67,7 +67,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
     SERVICES.each do |service|
       test "returns toxicity for #{role} input if detected using #{service}" do
         stub_safety_services(service, role)
-        response = AichatSafetyHelper.find_toxicity(role, @profane_message, 'en')
+        response = AichatSafetyHelper.find_toxicity(role, @profane_message, 'en', nil)
         verify_safety_response(service, response)
       end
     end
@@ -75,7 +75,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
 
   test "returns nil if no services are enabled for role" do
     stub_safety_services('comprehend', 'assistant')
-    response = AichatSafetyHelper.find_toxicity('user', 'message', 'en')
+    response = AichatSafetyHelper.find_toxicity('user', 'message', 'en', nil)
     assert_nil response
   end
 
@@ -89,7 +89,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
     ROLES.each do |role|
       SERVICES.each do |service|
         stub_safety_services(service, role)
-        response = AichatSafetyHelper.find_toxicity(role, 'clean message', 'en')
+        response = AichatSafetyHelper.find_toxicity(role, 'clean message', 'en', nil)
         assert_nil response
       end
     end
@@ -100,7 +100,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
     mock_response = create_stubbed_response(@openai_response_safe_json)
     OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response).once
 
-    AichatSafetyHelper.find_toxicity('user', 'clean message', 'en')
+    AichatSafetyHelper.find_toxicity('user', 'clean message', 'en', nil)
   end
 
   test "retries if request_safety_check returns a response.body other than INAPPROPRIATE or OK" do
@@ -112,7 +112,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
       returns(mock_response_safe).
       twice
 
-    AichatSafetyHelper.find_toxicity('user', 'clean message', 'en')
+    AichatSafetyHelper.find_toxicity('user', 'clean message', 'en', nil)
   end
 
   test "raises an error if request_safety_check returns a response.body other than INAPPROPRIATE or OK twice" do
@@ -121,7 +121,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
     OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
 
     assert_raises do
-      AichatSafetyHelper.find_toxicity('user', 'clean message', 'en')
+      AichatSafetyHelper.find_toxicity('user', 'clean message', 'en', nil)
     end
   end
 

--- a/dashboard/test/jobs/aichat_request_chat_completion_job_test.rb
+++ b/dashboard/test/jobs/aichat_request_chat_completion_job_test.rb
@@ -22,8 +22,9 @@ class AichatRequestChatCompletionJobTest < ActiveJob::TestCase
 
   test "execution status is set to USER_PROFANITY if toxicity detected in user input" do
     request = create :aichat_request
+
     user_message = request.new_message['chatMessageText']
-    AichatSafetyHelper.expects(:find_toxicity).with('user', user_message, @locale).returns(@toxic_response)
+    AichatSafetyHelper.expects(:find_toxicity).with('user', user_message, @locale, request.level_id).returns(@toxic_response)
 
     perform_enqueued_jobs do
       AichatRequestChatCompletionJob.perform_later(request: request, locale: @locale)
@@ -34,9 +35,9 @@ class AichatRequestChatCompletionJobTest < ActiveJob::TestCase
   end
 
   test "execution status is set to MODEL_PROFANITY if toxicity detected in model output" do
-    AichatSafetyHelper.stubs(:find_toxicity).with('user', anything, anything).returns(nil)
+    AichatSafetyHelper.stubs(:find_toxicity).with('user', anything, anything, anything).returns(nil)
     AichatSagemakerHelper.stubs(:get_sagemaker_assistant_response).returns('response')
-    AichatSafetyHelper.stubs(:find_toxicity).with('assistant', anything, anything).returns(@toxic_response)
+    AichatSafetyHelper.stubs(:find_toxicity).with('assistant', anything, anything, anything).returns(@toxic_response)
 
     request = create :aichat_request
 


### PR DESCRIPTION
Uses the script(s) associated with a level to determine whether to use a Spanish-specific safety system prompt, which Tyrone has tested and seen better safety benchmarking.

For now, this would only work for a single test script that we are using for a bug bash and just replaces the word "American" with the word "Spanish" in our standard safety system prompt, but could be updated to whatever. I confirmed with Tyrone that the prompt he tested was "Spanish school", not "Spanish-speaking school" or anything like that.

We may want to rework this depending on how we configure defining a piece of content as "Spanish" (ie, will it be script (aka unit) level? course level?), but the level ID is already being plumbed through our code to find the levelbuilder system prompt, so I used it.

## Testing story

I tested manually on an allthethings level (usual prompt), the level that is currently in the Spanish test unit (Spanish prompt), and a AI Chat level that is a sublevel (usual prompt). 