### PR TITLE
Python Lab: Add maximize/minimize button to mini app preview

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -53,6 +53,8 @@
   "makeSupport": "Make support file",
   "makeValidation": "Make validation file",
   "manageFiles": "Manage Files",
+  "maximizePreview": "Maximize preview",
+  "minimizePreview": "Minimize preview",
   "moveFile": "Move",
   "moveFolder": "Move",
   "moveFilePrompt": "Please enter your destination folder",

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -25,7 +25,6 @@ import BackpackClientApi from '@cdo/apps/sharedComponents/backpack/BackpackClien
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import Workspace from './Workspace';
-import Output from './Workspace/Output';
 
 import moduleStyles from './styles/codebridgeContainer.module.scss';
 import './styles/codebridge.scss';
@@ -93,7 +92,6 @@ export const Codebridge = React.memo(
           'file-preview': FilePreview,
           'info-panel': config.Instructions || InfoPanel,
           workspace: Workspace,
-          output: Output,
         };
         let gridLayout: string;
         let gridLayoutRows: string;

--- a/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
@@ -17,12 +17,14 @@ interface MiniAppPreviewProps {
   maximizeMiniApp: () => void;
   minimizeMiniApp: () => void;
   isMaximized: boolean;
+  style?: React.CSSProperties;
 }
 
 const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
   maximizeMiniApp,
   minimizeMiniApp,
   isMaximized,
+  style,
 }) => {
   const {labConfig} = useCodebridgeContext();
 
@@ -58,7 +60,7 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
         />
       }
     >
-      {miniAppComponent}
+      <div style={style}>{miniAppComponent}</div>
     </PanelContainer>
   );
 };

--- a/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
@@ -1,6 +1,8 @@
+import Button from '@code-dot-org/component-library/button';
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import ControlButtons from '@codebridge/Console/ControlButtons';
 import {MiniApps} from '@codebridge/constants';
+import classNames from 'classnames';
 import React from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
@@ -9,14 +11,42 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import NeighborhoodPreview from './NeighborhoodPreview';
 
 import moduleStyles from './mini-app-preview.module.scss';
+import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
 
-const MiniAppPreview: React.FunctionComponent = () => {
+interface MiniAppPreviewProps {
+  maximizeMiniApp: () => void;
+  minimizeMiniApp: () => void;
+  isMaximized: boolean;
+}
+
+const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
+  maximizeMiniApp,
+  minimizeMiniApp,
+  isMaximized,
+}) => {
   const {labConfig} = useCodebridgeContext();
 
   const miniApp = labConfig?.miniApp?.name;
 
   const miniAppComponent =
     miniApp === MiniApps.Neighborhood ? <NeighborhoodPreview /> : null;
+
+  const getRightButttons = () => {
+    return (
+      <Button
+        onClick={isMaximized ? minimizeMiniApp : maximizeMiniApp}
+        icon={{
+          iconStyle: 'solid',
+          iconName: isMaximized ? 'compress' : 'expand',
+        }}
+        size={'xs'}
+        type={'tertiary'}
+        className={classNames(darkModeStyles.tertiaryButton)}
+        isIconOnly={true}
+        color={'white'}
+      />
+    );
+  };
 
   return (
     <PanelContainer
@@ -25,6 +55,7 @@ const MiniAppPreview: React.FunctionComponent = () => {
       leftHeaderContent={<ControlButtons />}
       className={moduleStyles.previewContainer}
       headerClassName={moduleStyles.previewHeader}
+      rightHeaderContent={getRightButttons()}
     >
       {miniAppComponent}
     </PanelContainer>

--- a/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
@@ -31,23 +31,6 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
   const miniAppComponent =
     miniApp === MiniApps.Neighborhood ? <NeighborhoodPreview /> : null;
 
-  const getRightButttons = () => {
-    return (
-      <Button
-        onClick={isMaximized ? minimizeMiniApp : maximizeMiniApp}
-        icon={{
-          iconStyle: 'solid',
-          iconName: isMaximized ? 'compress' : 'expand',
-        }}
-        size={'xs'}
-        type={'tertiary'}
-        className={classNames(darkModeStyles.tertiaryButton)}
-        isIconOnly={true}
-        color={'white'}
-      />
-    );
-  };
-
   return (
     <PanelContainer
       id="codebridge-preview"
@@ -55,7 +38,25 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
       leftHeaderContent={<ControlButtons />}
       className={moduleStyles.previewContainer}
       headerClassName={moduleStyles.previewHeader}
-      rightHeaderContent={getRightButttons()}
+      rightHeaderContent={
+        <Button
+          onClick={isMaximized ? minimizeMiniApp : maximizeMiniApp}
+          icon={{
+            iconStyle: 'solid',
+            iconName: isMaximized ? 'compress' : 'expand',
+          }}
+          size={'xs'}
+          type={'tertiary'}
+          className={classNames(darkModeStyles.tertiaryButton)}
+          isIconOnly={true}
+          color={'white'}
+          ariaLabel={
+            isMaximized
+              ? codebridgeI18n.minimizePreview()
+              : codebridgeI18n.maximizePreview()
+          }
+        />
+      }
     >
       {miniAppComponent}
     </PanelContainer>

--- a/apps/src/codebridge/Workspace/Output.tsx
+++ b/apps/src/codebridge/Workspace/Output.tsx
@@ -216,6 +216,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
     setOutputSize(MAX_MINI_APP_SIZE);
     setMiniAppSize(MAX_MINI_APP_SIZE);
     setIsMaximized(true);
+    throttledResize(height, width, miniApp, miniAppSize, isVertical);
   };
 
   const minimizeMiniApp = () => {
@@ -223,6 +224,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
     setMiniAppSize(miniAppMinimizeSize);
     setOutputSize(outputMinimizeSize);
     setIsMaximized(false);
+    throttledResize(height, width, miniApp, miniAppSize, isVertical);
   };
 
   return (

--- a/apps/src/codebridge/Workspace/Output.tsx
+++ b/apps/src/codebridge/Workspace/Output.tsx
@@ -52,6 +52,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
   const [outputMinimizeSize, setOutputMinimizeSize] = useState<number>(
     (isVertical ? width : height) || DEFAULT_MINI_APP_SIZE
   );
+  const [waitingForResize, setWaitingForResize] = useState<boolean>(false);
 
   const {
     position: miniAppSize,
@@ -152,14 +153,14 @@ const Output: React.FunctionComponent<OutputProps> = ({
           'margin-left': (newWidth - newVisualizationWidth) / 2,
         });
 
-        console.log(`setting new visualization size: ${newVisualizationWidth}`);
+        setWaitingForResize(false);
       }
     },
     []
   );
 
   const throttledResize = useMemo(
-    () => throttle(handleResize, 10, {leading: false}),
+    () => throttle(handleResize, 20, {leading: false}),
     [handleResize]
   );
 
@@ -169,7 +170,6 @@ const Output: React.FunctionComponent<OutputProps> = ({
       width !== undefined ||
       miniAppSize !== undefined
     ) {
-      console.log('calling throttled resize');
       throttledResize(height, width, miniApp, miniAppSize, isVertical);
     }
   }, [height, width, miniApp, throttledResize, miniAppSize, isVertical]);
@@ -193,6 +193,11 @@ const Output: React.FunctionComponent<OutputProps> = ({
     );
   }
 
+  // We set the opacity to 0 when we initiate a maximize or minimize action
+  // so the use doesn't see a flash of the incorrectly-sized preview
+  // while maximizing/minimizing.
+  const previewOpacity = waitingForResize ? 0 : 1;
+
   const miniAppStyle = isVertical
     ? {height: adjustedMiniAppSize}
     : {width: adjustedMiniAppSize};
@@ -202,6 +207,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
     : {width: consoleSize};
 
   const maximizeMiniApp = () => {
+    setWaitingForResize(true);
     setMiniAppMinimizeSize(adjustedMiniAppSize);
     setOutputMinimizeSize(
       (isVertical ? width : height) || DEFAULT_MINI_APP_SIZE
@@ -212,6 +218,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
   };
 
   const minimizeMiniApp = () => {
+    setWaitingForResize(true);
     setMiniAppSize(miniAppMinimizeSize);
     setOutputSize && setOutputSize(outputMinimizeSize);
     setIsMaximized(false);
@@ -232,6 +239,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
           maximizeMiniApp={maximizeMiniApp}
           minimizeMiniApp={minimizeMiniApp}
           isMaximized={isMaximized}
+          style={{opacity: previewOpacity}}
         />
       </div>
       <ResizeBar

--- a/apps/src/codebridge/Workspace/Output.tsx
+++ b/apps/src/codebridge/Workspace/Output.tsx
@@ -24,7 +24,8 @@ interface OutputProps {
   className?: string;
   height?: number;
   width?: number;
-  setOutputSize?: (size: number) => void;
+  // Set the size of the output container (width in vertical mode, height in horizontal mode).
+  setOutputSize: (size: number) => void;
 }
 
 const Output: React.FunctionComponent<OutputProps> = ({
@@ -212,7 +213,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
     setOutputMinimizeSize(
       (isVertical ? width : height) || DEFAULT_MINI_APP_SIZE
     );
-    setOutputSize && setOutputSize(MAX_MINI_APP_SIZE);
+    setOutputSize(MAX_MINI_APP_SIZE);
     setMiniAppSize(MAX_MINI_APP_SIZE);
     setIsMaximized(true);
   };
@@ -220,7 +221,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
   const minimizeMiniApp = () => {
     setWaitingForResize(true);
     setMiniAppSize(miniAppMinimizeSize);
-    setOutputSize && setOutputSize(outputMinimizeSize);
+    setOutputSize(outputMinimizeSize);
     setIsMaximized(false);
   };
 

--- a/apps/src/codebridge/Workspace/Output.tsx
+++ b/apps/src/codebridge/Workspace/Output.tsx
@@ -52,7 +52,6 @@ const Output: React.FunctionComponent<OutputProps> = ({
   const [outputMinimizeSize, setOutputMinimizeSize] = useState<number>(
     (isVertical ? width : height) || DEFAULT_MINI_APP_SIZE
   );
-  console.log({consoleSize, outputMinimizeSize});
 
   const {
     position: miniAppSize,
@@ -152,13 +151,15 @@ const Output: React.FunctionComponent<OutputProps> = ({
           width: newVisualizationWidth,
           'margin-left': (newWidth - newVisualizationWidth) / 2,
         });
+
+        console.log(`setting new visualization size: ${newVisualizationWidth}`);
       }
     },
     []
   );
 
   const throttledResize = useMemo(
-    () => throttle(handleResize, 30),
+    () => throttle(handleResize, 10, {leading: false}),
     [handleResize]
   );
 
@@ -168,6 +169,7 @@ const Output: React.FunctionComponent<OutputProps> = ({
       width !== undefined ||
       miniAppSize !== undefined
     ) {
+      console.log('calling throttled resize');
       throttledResize(height, width, miniApp, miniAppSize, isVertical);
     }
   }, [height, width, miniApp, throttledResize, miniAppSize, isVertical]);
@@ -200,19 +202,19 @@ const Output: React.FunctionComponent<OutputProps> = ({
     : {width: consoleSize};
 
   const maximizeMiniApp = () => {
-    setIsMaximized(true);
     setMiniAppMinimizeSize(adjustedMiniAppSize);
     setOutputMinimizeSize(
       (isVertical ? width : height) || DEFAULT_MINI_APP_SIZE
     );
     setOutputSize && setOutputSize(MAX_MINI_APP_SIZE);
     setMiniAppSize(MAX_MINI_APP_SIZE);
+    setIsMaximized(true);
   };
 
   const minimizeMiniApp = () => {
-    setIsMaximized(false);
     setMiniAppSize(miniAppMinimizeSize);
     setOutputSize && setOutputSize(outputMinimizeSize);
+    setIsMaximized(false);
   };
 
   return (

--- a/apps/src/codebridge/Workspace/Output.tsx
+++ b/apps/src/codebridge/Workspace/Output.tsx
@@ -24,12 +24,14 @@ interface OutputProps {
   className?: string;
   height?: number;
   width?: number;
+  setOutputSize?: (size: number) => void;
 }
 
 const Output: React.FunctionComponent<OutputProps> = ({
   className,
   height,
   width,
+  setOutputSize,
 }) => {
   const {config, labConfig} = useCodebridgeContext();
   const isVertical = config.activeLayout === 'vertical';
@@ -43,11 +45,20 @@ const Output: React.FunctionComponent<OutputProps> = ({
   // In horizontal mode, consoleSize is the width of the console.
   const [consoleSize, setConsoleSize] = useState<number | undefined>(undefined);
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const [isMaximized, setIsMaximized] = useState<boolean>(false);
+  const [miniAppMinimizeSize, setMiniAppMinimizeSize] = useState(
+    DEFAULT_MINI_APP_SIZE
+  );
+  const [outputMinimizeSize, setOutputMinimizeSize] = useState<number>(
+    (isVertical ? width : height) || DEFAULT_MINI_APP_SIZE
+  );
+  console.log({consoleSize, outputMinimizeSize});
 
   const {
     position: miniAppSize,
     separatorProps: miniAppSeparatorProps,
     isDragging: miniAppDragging,
+    setPosition: setMiniAppSize,
   } = useResizable({
     axis: isVertical ? 'y' : 'x',
     initial: DEFAULT_MINI_APP_SIZE,
@@ -188,6 +199,22 @@ const Output: React.FunctionComponent<OutputProps> = ({
     ? {height: consoleSize}
     : {width: consoleSize};
 
+  const maximizeMiniApp = () => {
+    setIsMaximized(true);
+    setMiniAppMinimizeSize(adjustedMiniAppSize);
+    setOutputMinimizeSize(
+      (isVertical ? width : height) || DEFAULT_MINI_APP_SIZE
+    );
+    setOutputSize && setOutputSize(MAX_MINI_APP_SIZE);
+    setMiniAppSize(MAX_MINI_APP_SIZE);
+  };
+
+  const minimizeMiniApp = () => {
+    setIsMaximized(false);
+    setMiniAppSize(miniAppMinimizeSize);
+    setOutputSize && setOutputSize(outputMinimizeSize);
+  };
+
   return (
     <div
       className={classNames(
@@ -199,7 +226,11 @@ const Output: React.FunctionComponent<OutputProps> = ({
       ref={resizeContainerRef}
     >
       <div style={miniAppStyle} className={moduleStyles.flexShrink0}>
-        <MiniAppPreview />
+        <MiniAppPreview
+          maximizeMiniApp={maximizeMiniApp}
+          minimizeMiniApp={minimizeMiniApp}
+          isMaximized={isMaximized}
+        />
       </div>
       <ResizeBar
         isVertical={!isVertical}

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -52,6 +52,7 @@ const HorizontalLayout: React.FunctionComponent = () => {
     position: rawOutputHeight,
     separatorProps: outputSeparatorProps,
     isDragging: outputDragging,
+    setPosition: setOutputSize,
   } = useResizable({
     axis: 'y',
     initial: INITIAL_OUTPUT_HEIGHT,
@@ -151,7 +152,11 @@ const HorizontalLayout: React.FunctionComponent = () => {
           separatorProps={outputSeparatorProps}
           isDragging={outputDragging}
         />
-        <Output height={outputHeight} width={rightPanelWidth} />
+        <Output
+          height={outputHeight}
+          width={rightPanelWidth}
+          setOutputSize={setOutputSize}
+        />
       </div>
     </div>
   );

--- a/apps/src/pythonlab/layout/VerticalLayout.tsx
+++ b/apps/src/pythonlab/layout/VerticalLayout.tsx
@@ -40,6 +40,7 @@ const VerticalLayout: React.FunctionComponent = () => {
     position: rawOutputWidth,
     separatorProps: outputSeparatorProps,
     isDragging: outputDragging,
+    setPosition: setOutputSize,
   } = useResizable({
     axis: 'x',
     initial: INITIAL_OUTPUT_WIDTH,
@@ -114,7 +115,11 @@ const VerticalLayout: React.FunctionComponent = () => {
         separatorProps={outputSeparatorProps}
         isDragging={outputDragging}
       />
-      <Output width={outputWidth} className={moduleStyles.shrinkAndGrow} />
+      <Output
+        width={outputWidth}
+        className={moduleStyles.shrinkAndGrow}
+        setOutputSize={setOutputSize}
+      />
     </div>
   );
 };


### PR DESCRIPTION
This adds a maximize/minimize button to the mini app preview component. Maximize makes the preview up to 800x800 pixels (it will only get as big as it can without making other components less than their minimum size). 

## Screen recording
https://github.com/user-attachments/assets/8dab05ca-03ec-40fc-b7d1-ff333743bc98


## Links
- jira ticket: [CT-939](https://codedotorg.atlassian.net/browse/CT-939)

## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
