### PR TITLE
feat(Section): update component name in Contentful

### DIFF
--- a/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
@@ -3,13 +3,13 @@ import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 
 export const SectionContentfulComponentDefinition: ComponentDefinition = {
   id: 'section',
-  name: 'Section',
+  name: 'Section (Use me!)',
   category: 'Page Structure',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/1DVXtxBlLLunOb1PrjRTqz/6bfd2cae987a5cf2dd0c211e677b5023/component_section_thumbnail.png',
   tooltip: {
     description:
-      'A flexible content block for grouping text, media, and other components into a structured layout.',
+      '** Use this component instead of the Section component in the "Structure" section at the top ** A flexible content block for grouping text, media, and other components into a structured layout.',
     imageUrl:
       'https://images.ctfassets.net/90t6bu6vlf76/2u0fxxgU5ACOFA9Co8yHmG/a110e0c14e2ac0c065ffafeaebb32d58/component_section_tooltip.png',
   },

--- a/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
@@ -9,7 +9,7 @@ export const SectionContentfulComponentDefinition: ComponentDefinition = {
     'https://images.ctfassets.net/90t6bu6vlf76/1DVXtxBlLLunOb1PrjRTqz/6bfd2cae987a5cf2dd0c211e677b5023/component_section_thumbnail.png',
   tooltip: {
     description:
-      '** Use this component instead of the Section component in the "Structure" section at the top ** A flexible content block for grouping text, media, and other components into a structured layout.',
+      '** Use this component instead of the Section component in the "Structure" group at the top ** A flexible content block for grouping text, media, and other components into a structured layout.',
     imageUrl:
       'https://images.ctfassets.net/90t6bu6vlf76/2u0fxxgU5ACOFA9Co8yHmG/a110e0c14e2ac0c065ffafeaebb32d58/component_section_tooltip.png',
   },


### PR DESCRIPTION
Updates the custom Section component name to say "Use me!" so editors know to use this one instead of the default Section component provided by Contentful. I also updated the tooltip description. 

## Links
Jira ticket: [CMS-354](https://codedotorg.atlassian.net/browse/CMS-354)

## Testing story
Tested locally in Contenful

----

| Before | After |
| ---- | ---- |
| <img width="461" alt="Before" src="https://github.com/user-attachments/assets/342a3412-a163-4625-81d5-38129edc1988" /> | <img width="461" alt="After" src="https://github.com/user-attachments/assets/d30f6f65-0334-496f-9f87-65e5b28dad7d" /> |
