### PR TITLE
Make embedded census map responsive

### DIFF
--- a/pegasus/sites.v3/code.org/public/embeddable_census_map.haml
+++ b/pegasus/sites.v3/code.org/public/embeddable_census_map.haml
@@ -3,6 +3,7 @@ no_header: true
 no_footer: true
 embeddable: true
 english_only: true
+theme: responsive
 ---
 
 :css


### PR DESCRIPTION
Marketing reported that this map is not responsive when embedded into their site. Locally, adding `responsive: true` made the map responsive.

This is tough to test locally but got good signal that this is the right direction. I put an iframe on a random dashboard page. The iframe was tiny and I couldn't quickly get it to be bigger, but it actually worked to demonstrate the fix.

Staging branch:

<img width="362" alt="Screenshot 2025-03-04 at 3 07 50 PM" src="https://github.com/user-attachments/assets/0c55a9a1-ff27-4756-aebb-b9582951a876" />

This branch:

<img width="393" alt="Screenshot 2025-03-04 at 3 05 21 PM" src="https://github.com/user-attachments/assets/3a271a6c-e5f8-4124-929f-22539394682a" />


