### PR TITLE
fix(sdk): pin contentful sdk to 1.30.3

### DIFF
--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@code-dot-org/component-library": "workspace:*",
     "@code-dot-org/fonts": "workspace:*",
-    "@contentful/experiences-sdk-react": "^1.33.2",
+    "@contentful/experiences-sdk-react": "1.30.3",
     "contentful": "^11.2.5",
     "next": "^15.1.2",
     "react": "^18.3.1",

--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -329,7 +329,7 @@
     "@code-dot-org/changelogs": "workspace:*",
     "@code-dot-org/component-library-styles": "workspace:*",
     "@code-dot-org/lint-config": "workspace:*",
-    "@contentful/experiences-sdk-react": "^1.24.0",
+    "@contentful/experiences-sdk-react": "1.30.3",
     "@eslint/js": "^9.15.0",
     "@release-it/conventional-changelog": "^10.0.0",
     "@swc/core": "^1.9.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -789,7 +789,7 @@ __metadata:
     "@code-dot-org/changelogs": "workspace:*"
     "@code-dot-org/component-library-styles": "workspace:*"
     "@code-dot-org/lint-config": "workspace:*"
-    "@contentful/experiences-sdk-react": "npm:^1.24.0"
+    "@contentful/experiences-sdk-react": "npm:1.30.3"
     "@eslint/js": "npm:^9.15.0"
     "@release-it/conventional-changelog": "npm:^10.0.0"
     "@swc/core": "npm:^1.9.3"
@@ -956,7 +956,7 @@ __metadata:
   dependencies:
     "@code-dot-org/component-library": "workspace:*"
     "@code-dot-org/fonts": "workspace:*"
-    "@contentful/experiences-sdk-react": "npm:^1.33.2"
+    "@contentful/experiences-sdk-react": "npm:1.30.3"
     "@next/eslint-plugin-next": "npm:^15.0.3"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
@@ -990,92 +990,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@contentful/experiences-components-react@npm:1.24.0":
-  version: 1.24.0
-  resolution: "@contentful/experiences-components-react@npm:1.24.0"
+"@contentful/experiences-components-react@npm:1.30.3":
+  version: 1.30.3
+  resolution: "@contentful/experiences-components-react@npm:1.30.3"
   dependencies:
-    "@contentful/experiences-core": "npm:1.24.0"
-    "@contentful/rich-text-react-renderer": "npm:^15.17.2"
-    postcss-import: "npm:^16.0.1"
-    style-inject: "npm:^0.3.0"
-  peerDependencies:
-    react: ">=17.0.0"
-    react-dom: ">=17.0.0"
-  checksum: 10c0/712f97de7fd486eabca259920a2d9571cc32a123bc4ff547425e99fd599d84294b177966b8d295663b5a921d06a68cfb59279330b6f9f5723af380a92aa58fad
-  languageName: node
-  linkType: hard
-
-"@contentful/experiences-components-react@npm:1.33.2":
-  version: 1.33.2
-  resolution: "@contentful/experiences-components-react@npm:1.33.2"
-  dependencies:
-    "@contentful/experiences-core": "npm:1.33.2"
+    "@contentful/experiences-core": "npm:1.30.3"
     "@contentful/rich-text-react-renderer": "npm:^16.0.1"
     postcss-import: "npm:^16.0.1"
     style-inject: "npm:^0.3.0"
   peerDependencies:
     react: ">=17.0.0"
     react-dom: ">=17.0.0"
-  checksum: 10c0/16d22dd669a3e52082459270c3e79e135f3243386ac9888d23d8b2d0d7cd8f2363a03921e96793f7d10336c7d511bdbdd20002c39692154f02666ae2f24feb90
+  checksum: 10c0/d4527f6d8782d0b09dbab4b2529f23eaf99c4a550635e394387ae0a7e148cc150e8a176369945566a3f26a7093ce4517e390d7c3e2c880b876d5658c151dc61f
   languageName: node
   linkType: hard
 
-"@contentful/experiences-core@npm:1.24.0":
-  version: 1.24.0
-  resolution: "@contentful/experiences-core@npm:1.24.0"
+"@contentful/experiences-core@npm:1.30.3":
+  version: 1.30.3
+  resolution: "@contentful/experiences-core@npm:1.30.3"
   dependencies:
-    "@contentful/experiences-validators": "npm:1.24.0"
-    "@contentful/rich-text-types": "npm:^16.3.0"
-  peerDependencies:
-    contentful: ">=10.6.0"
-  checksum: 10c0/9cf3b3846b742d3121799ddf90938bfa24598aea4e257bfce2be4478f38316f5d726b55838e5bf8f44aeb4e147686ba801194db1334aa01ec14c959663ac5666
-  languageName: node
-  linkType: hard
-
-"@contentful/experiences-core@npm:1.33.2":
-  version: 1.33.2
-  resolution: "@contentful/experiences-core@npm:1.33.2"
-  dependencies:
-    "@contentful/experiences-validators": "npm:1.33.2"
+    "@contentful/experiences-validators": "npm:1.30.3"
     "@contentful/rich-text-types": "npm:^17.0.0"
   peerDependencies:
     contentful: ">=10.6.0"
-  checksum: 10c0/6a2668a175aa7d4ae72ac5baf481b5c0f0c586dbaf322c7b7067bfdd0db2071281599049dd19c320a84e95c5b2b0c52c3bd05745f6731dd93a49b963731379e6
+  checksum: 10c0/d45b784691d2bcf29540b03960ab2fe5221329d45d4accfd2c4d546390b69eaddcf7f50fceecf0186a1acd5c60cfded64a4654ebee37623508a323335dbda8d7
   languageName: node
   linkType: hard
 
-"@contentful/experiences-sdk-react@npm:^1.24.0":
-  version: 1.24.0
-  resolution: "@contentful/experiences-sdk-react@npm:1.24.0"
+"@contentful/experiences-sdk-react@npm:1.30.3":
+  version: 1.30.3
+  resolution: "@contentful/experiences-sdk-react@npm:1.30.3"
   dependencies:
-    "@contentful/experiences-components-react": "npm:1.24.0"
-    "@contentful/experiences-core": "npm:1.24.0"
-    "@contentful/experiences-validators": "npm:1.24.0"
-    "@contentful/experiences-visual-editor-react": "npm:1.24.0"
-    "@contentful/rich-text-types": "npm:^16.2.1"
-    classnames: "npm:^2.3.2"
-    csstype: "npm:^3.1.2"
-    immer: "npm:^10.0.3"
-    lodash-es: "npm:^4.17.21"
-    md5: "npm:^2.3.0"
-    style-inject: "npm:^0.3.0"
-    vite-plugin-css-injected-by-js: "npm:^3.1.1"
-  peerDependencies:
-    contentful: ">=10.6.0"
-    react: ">=16.0.0"
-    react-dom: ">=16.0.0"
-  checksum: 10c0/1d99da7fa3272f277e0430638cbd37fc536934070f51ae1d5e624625f4f938e1b0438f0db253f08df20d1566e8e32687b16138003beae14ae4d59a1017e5e190
-  languageName: node
-  linkType: hard
-
-"@contentful/experiences-sdk-react@npm:^1.33.2":
-  version: 1.33.2
-  resolution: "@contentful/experiences-sdk-react@npm:1.33.2"
-  dependencies:
-    "@contentful/experiences-components-react": "npm:1.33.2"
-    "@contentful/experiences-core": "npm:1.33.2"
-    "@contentful/experiences-validators": "npm:1.33.2"
-    "@contentful/experiences-visual-editor-react": "npm:1.33.2"
+    "@contentful/experiences-components-react": "npm:1.30.3"
+    "@contentful/experiences-core": "npm:1.30.3"
+    "@contentful/experiences-validators": "npm:1.30.3"
+    "@contentful/experiences-visual-editor-react": "npm:1.30.3"
     "@contentful/rich-text-types": "npm:^17.0.0"
     classnames: "npm:^2.3.2"
     csstype: "npm:^3.1.2"
@@ -1087,34 +1036,25 @@ __metadata:
     contentful: ">=10.6.0"
     react: ">=16.0.0"
     react-dom: ">=16.0.0"
-  checksum: 10c0/3198461abb5c9edfc68ef04db3d43268185fa208b0e186a69f391cd5800961c9830ad1ccd4dccfc7fedab2d40eb045d839d12d6032df54cc2ef527e07fb932b8
+  checksum: 10c0/d07114d176f7236a3ee09a68e7954b1c14f0262f7f4274e601cb55adc9da3f49f35d8f5fb5c8fd181ee37b9416c0d1d2fe9219b3e113faeb38f17fa2678ee23e
   languageName: node
   linkType: hard
 
-"@contentful/experiences-validators@npm:1.24.0":
-  version: 1.24.0
-  resolution: "@contentful/experiences-validators@npm:1.24.0"
+"@contentful/experiences-validators@npm:1.30.3":
+  version: 1.30.3
+  resolution: "@contentful/experiences-validators@npm:1.30.3"
   dependencies:
     zod: "npm:^3.22.4"
-  checksum: 10c0/52b996d7236afbfc0559f1ca26572592efb59d773641af19ce9b5f04aeddc691c4d7d36666f95d4b146f3bccc35f01ce5e81d4d7d38d05fc25fb9567da6c9a86
+  checksum: 10c0/4de660e32367d3613228e289fed184bd681b463b53b4a4bdf2a39d0a10c90577a74be71f2f107025aad9d7587f007e5486c1de9bfaada61b9f14c0a3327ee87a
   languageName: node
   linkType: hard
 
-"@contentful/experiences-validators@npm:1.33.2":
-  version: 1.33.2
-  resolution: "@contentful/experiences-validators@npm:1.33.2"
+"@contentful/experiences-visual-editor-react@npm:1.30.3":
+  version: 1.30.3
+  resolution: "@contentful/experiences-visual-editor-react@npm:1.30.3"
   dependencies:
-    zod: "npm:^3.22.4"
-  checksum: 10c0/5b920f865a5c0a32ef5b906b63d7286cf0f606bbe3f52ed7daa6f56fb4639f96476053b92cdb7bf1f7313df2a0ffe17085138fee605405d8eac34261f78ce9c1
-  languageName: node
-  linkType: hard
-
-"@contentful/experiences-visual-editor-react@npm:1.24.0":
-  version: 1.24.0
-  resolution: "@contentful/experiences-visual-editor-react@npm:1.24.0"
-  dependencies:
-    "@contentful/experiences-components-react": "npm:1.24.0"
-    "@contentful/experiences-core": "npm:1.24.0"
+    "@contentful/experiences-components-react": "npm:1.30.3"
+    "@contentful/experiences-core": "npm:1.30.3"
     "@hello-pangea/dnd": "npm:^16.3.0"
     classnames: "npm:^2.3.2"
     contentful: "npm:^10.6.14"
@@ -1128,42 +1068,7 @@ __metadata:
   peerDependencies:
     react: ">=17.0.0"
     react-dom: ">=17.0.0"
-  checksum: 10c0/0ff2f60c455609afa32c6f84adad38fcf9a7ac83d7af5ec0e5576ad8205ae64648519d9a3e58ea4a1b951ad2eac0acb51f2aa542fb1de1b6a2559c3e9a83a0e7
-  languageName: node
-  linkType: hard
-
-"@contentful/experiences-visual-editor-react@npm:1.33.2":
-  version: 1.33.2
-  resolution: "@contentful/experiences-visual-editor-react@npm:1.33.2"
-  dependencies:
-    "@contentful/experiences-components-react": "npm:1.33.2"
-    "@contentful/experiences-core": "npm:1.33.2"
-    "@hello-pangea/dnd": "npm:^16.3.0"
-    classnames: "npm:^2.3.2"
-    contentful: "npm:^10.6.14"
-    immer: "npm:^10.0.3"
-    lodash-es: "npm:^4.17.21"
-    md5: "npm:^2.3.0"
-    style-inject: "npm:^0.3.0"
-    use-debounce: "npm:^10.0.0"
-    uuid: "npm:^9.0.1"
-    zustand: "npm:^4.4.7"
-  peerDependencies:
-    react: ">=17.0.0"
-    react-dom: ">=17.0.0"
-  checksum: 10c0/e3c36ae352b759b0720a5c24330feb0a0e827534f72e64f5a9dcef3a74ca8ae85d5585c61337079137db4189ac4e54463593aeaae6c57851af8be16c3ef99882
-  languageName: node
-  linkType: hard
-
-"@contentful/rich-text-react-renderer@npm:^15.17.2":
-  version: 15.22.11
-  resolution: "@contentful/rich-text-react-renderer@npm:15.22.11"
-  dependencies:
-    "@contentful/rich-text-types": "npm:^16.8.5"
-  peerDependencies:
-    react: ^16.8.6 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/4422ce9f0e93865226012e4551726dec6bb996127c8298c3b9b0011289872fe362e5dabef5b6d7146a1de5145021a0d9ec240ef961c523c5a7748b2f2ca3e3ec
+  checksum: 10c0/6a8da4a507c536ffd128edaeae8f851082ece8d70ee168316d10df8695c0ec62ec06549b80afcc167946231c255d10fbed15a1a88e3be34f56254f812951637d
   languageName: node
   linkType: hard
 
@@ -1179,7 +1084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@contentful/rich-text-types@npm:^16.0.2, @contentful/rich-text-types@npm:^16.2.1, @contentful/rich-text-types@npm:^16.3.0, @contentful/rich-text-types@npm:^16.6.1, @contentful/rich-text-types@npm:^16.8.5":
+"@contentful/rich-text-types@npm:^16.0.2, @contentful/rich-text-types@npm:^16.6.1":
   version: 16.8.5
   resolution: "@contentful/rich-text-types@npm:16.8.5"
   checksum: 10c0/0af82d501bb26d854fa3bc68136db1f0738428135066876062370637f219cd51f10abecf8e02a72c2cf9eb012523add21f4a3f72af4981a7ad4c95a9bbcb237f
@@ -17794,15 +17699,6 @@ __metadata:
     spdx-correct: "npm:^3.0.0"
     spdx-expression-parse: "npm:^3.0.0"
   checksum: 10c0/7b91e455a8de9a0beaa9fe961e536b677da7f48c9a493edf4d4d4a87fd80a7a10267d438723364e432c2fcd00b5650b5378275cded362383ef570276e6312f4f
-  languageName: node
-  linkType: hard
-
-"vite-plugin-css-injected-by-js@npm:^3.1.1":
-  version: 3.5.2
-  resolution: "vite-plugin-css-injected-by-js@npm:3.5.2"
-  peerDependencies:
-    vite: ">2.0.0-0"
-  checksum: 10c0/5c6a2434d4f302640a4bfc7695d56cf83eca03a4f89f05820057fedd8a2e788186105942360d19808042872ba0970ed6b1c04cd02337bbe67d8321993a464c04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
An update to the contentful sdk appears to have resulted in a regression where the screen quickly re-renders but causes anchor links in webkit to not be clickable momentarily. Pinning to 1.30.3 appears to be a viable workaround. The issue has been [reported](https://github.com/contentful/experience-builder/issues/1033) to Contentful.