### PR TITLE
Update a couple AI Tutor types

### DIFF
--- a/apps/src/aiTutor/chatApi.ts
+++ b/apps/src/aiTutor/chatApi.ts
@@ -137,7 +137,7 @@ type OpenaiChatCompletionMessage = {
   content: string;
   // Only used in case of PII or profanity violation
   flagged_content?: string;
-  safety_status?: AITutorInteractionStatusValue;
+  safety_status?: ShareFilterStatus;
 };
 
 type ChatCompletionResponse = {

--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -1,20 +1,21 @@
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+import {ValueOf} from '@cdo/apps/types/utils';
 import {
   AiTutorInteractionStatus as AITutorInteractionStatus,
-  AiTutorTypes as AITutorTypes,
+  AiTutorTypes as AITutorActions,
 } from '@cdo/generated-scripts/sharedConstants';
 
-// TODO: Update this once https://codedotorg.atlassian.net/browse/CT-471 is resolved
-export type AITutorTypesValue = string;
-export type AITutorInteractionStatusValue = string;
-
-export {AITutorInteractionStatus, AITutorTypes};
+export type AITutorAction = ValueOf<typeof AITutorActions>;
+export type AITutorInteractionStatusValue = ValueOf<
+  typeof AITutorInteractionStatus
+>;
+export {AITutorInteractionStatus, AITutorActions};
 
 export interface ChatCompletionMessage {
   id?: number;
   role: Role;
   chatMessageText: string;
-  status: string;
+  status: AITutorInteractionStatusValue;
   timestamp?: string;
 }
 
@@ -22,7 +23,7 @@ export interface AITutorInteraction {
   userId?: number;
   levelId?: number;
   scriptId?: number;
-  type: AITutorTypesValue | undefined;
+  type: AITutorAction | undefined;
   prompt: string;
   status: AITutorInteractionStatusValue;
   aiResponse?: string;
@@ -39,7 +40,7 @@ export interface StudentChatRow {
   scriptId?: number;
   status: AITutorInteractionStatusValue;
   studentName: string;
-  type: AITutorTypesValue;
+  type: AITutorAction;
   updatedAt?: string;
   userId: number;
 }
@@ -70,6 +71,6 @@ export interface ChatContext {
   // or the student's code for compilation and validation.
   studentInput: string;
   studentCode?: string;
-  actionType?: AITutorTypesValue | undefined;
+  actionType?: AITutorAction | undefined;
   systemPrompt?: string;
 }

--- a/apps/src/aiTutor/views/AITutorFooter.tsx
+++ b/apps/src/aiTutor/views/AITutorFooter.tsx
@@ -2,7 +2,7 @@ import React, {useCallback} from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {askAITutor} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
-import {AITutorTypes as ActionType} from '@cdo/apps/aiTutor/types';
+import {AITutorActions} from '@cdo/apps/aiTutor/types';
 import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -63,7 +63,7 @@ const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
       const chatContext = {
         studentInput: userMessage,
         studentCode,
-        actionType: ActionType.GENERAL_CHAT,
+        actionType: AITutorActions.GENERAL_CHAT,
       };
 
       dispatch(askAITutor(chatContext));

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -1,10 +1,7 @@
 import React, {useCallback} from 'react';
 
 import SuggestedPrompts from '@cdo/apps/aiComponentLibrary/suggestedPrompt/SuggestedPrompts';
-import {
-  AITutorTypes as ActionType,
-  AITutorTypesValue,
-} from '@cdo/apps/aiTutor/types';
+import {AITutorAction, AITutorActions} from '@cdo/apps/aiTutor/types';
 import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -14,9 +11,9 @@ import {genericCompilation, genericValidation, genericHelp} from '../constants';
 import {askAITutor} from '../redux/aiTutorRedux';
 
 const QuickActions = {
-  [ActionType.COMPILATION]: genericCompilation,
-  [ActionType.VALIDATION]: genericValidation,
-  [ActionType.GENERIC_HELP]: genericHelp,
+  [AITutorActions.COMPILATION]: genericCompilation,
+  [AITutorActions.VALIDATION]: genericValidation,
+  [AITutorActions.GENERIC_HELP]: genericHelp,
 };
 
 const AITutorSuggestedPrompts: React.FunctionComponent = () => {
@@ -112,7 +109,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
 
   const handleClick = useCallback(
-    (actionType: AITutorTypesValue) => {
+    (aiTutorAction: AITutorAction) => {
       if (isWaitingForChatResponse) {
         return;
       }
@@ -120,17 +117,17 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       let studentInput = '';
       let suggestedPromptType = '';
 
-      switch (actionType) {
-        case ActionType.COMPILATION:
-          studentInput = QuickActions[ActionType.COMPILATION];
+      switch (aiTutorAction) {
+        case AITutorActions.COMPILATION:
+          studentInput = QuickActions[AITutorActions.COMPILATION];
           suggestedPromptType = EVENTS.AI_TUTOR_SUGGESTED_PROMPT_COMPILATION;
           break;
-        case ActionType.VALIDATION:
-          studentInput = QuickActions[ActionType.VALIDATION];
+        case AITutorActions.VALIDATION:
+          studentInput = QuickActions[AITutorActions.VALIDATION];
           suggestedPromptType = EVENTS.AI_TUTOR_SUGGESTED_PROMPT_VALIDATION;
           break;
-        case ActionType.GENERIC_HELP:
-          studentInput = QuickActions[ActionType.GENERIC_HELP];
+        case AITutorActions.GENERIC_HELP:
+          studentInput = QuickActions[AITutorActions.GENERIC_HELP];
           suggestedPromptType = EVENTS.AI_TUTOR_SUGGESTED_PROMPT_GENERIC_HELP;
           break;
       }
@@ -138,7 +135,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       const chatContext = {
         studentInput,
         studentCode,
-        actionType,
+        actionType: aiTutorAction,
       };
 
       dispatch(askAITutor(chatContext));
@@ -157,20 +154,20 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   // the chip into a message in the chat history.
   const suggestedPrompts = [
     {
-      label: QuickActions[ActionType.COMPILATION],
-      onClick: () => handleClick(ActionType.COMPILATION),
+      label: QuickActions[AITutorActions.COMPILATION],
+      onClick: () => handleClick(AITutorActions.COMPILATION),
       show: showCompilationOption,
       selected: false,
     },
     {
-      label: QuickActions[ActionType.VALIDATION],
-      onClick: () => handleClick(ActionType.VALIDATION),
+      label: QuickActions[AITutorActions.VALIDATION],
+      onClick: () => handleClick(AITutorActions.VALIDATION),
       show: showValidationOption,
       selected: false,
     },
     {
-      label: QuickActions[ActionType.GENERIC_HELP],
-      onClick: () => handleClick(ActionType.GENERIC_HELP),
+      label: QuickActions[AITutorActions.GENERIC_HELP],
+      onClick: () => handleClick(AITutorActions.GENERIC_HELP),
       show: showGenericErrorOption,
       selected: false,
     },

--- a/apps/src/aiTutor/views/teacherDashboard/InteractionsTable.tsx
+++ b/apps/src/aiTutor/views/teacherDashboard/InteractionsTable.tsx
@@ -49,6 +49,7 @@ const STATUS_LABELS: StatusLabels = {
   profanity_violation: 'Profanity Violation',
   ok: 'Successful',
   unknown: 'Unknown Status',
+  user_input_too_large: 'User Input Too Large',
 };
 
 enum TimeFilter {
@@ -183,7 +184,13 @@ const InteractionsTable: React.FC<InteractionsTableProps> = ({sectionId}) => {
         props: {style: {...style.headerCell, ...styleOverrides.headerCell}},
       },
       cell: {
-        formatters: [(status: string) => <span>{STATUS_LABELS[status]}</span>],
+        formatters: [
+          (status: string) => (
+            <span>
+              {STATUS_LABELS[status as AITutorInteractionStatusValue]}
+            </span>
+          ),
+        ],
         props: {style: style.cell},
       },
     },

--- a/apps/src/applab/ValidationButton.tsx
+++ b/apps/src/applab/ValidationButton.tsx
@@ -2,7 +2,7 @@ import Button from '@code-dot-org/component-library/button';
 import React, {useCallback, useEffect, useState} from 'react';
 
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
-import {AITutorTypes as ActionType} from '@cdo/apps/aiTutor/types';
+import {AITutorActions} from '@cdo/apps/aiTutor/types';
 
 import {askAITutor} from '../aiTutor/redux/aiTutorRedux';
 import {useAppDispatch, useAppSelector} from '../util/reduxHooks';
@@ -45,7 +45,7 @@ const ValidationButton: React.FunctionComponent = () => {
       systemPrompt,
       studentInput: `${systemPrompt} ${studentCode}`,
       studentCode,
-      actionType: ActionType.COMPLETION,
+      actionType: AITutorActions.COMPLETION,
     };
 
     dispatch(askAITutor(chatContext));


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
While refreshing the [AI tutor UI](https://github.com/code-dot-org/code-dot-org/pull/64279), I took the opportunity to make a couple updates to AI Tutor types.
There is no change in functionality.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
[jira](https://codedotorg.atlassian.net/browse/CT-471)

## Testing story
I confirmed locally on `pythonlab` and `javalab` levels there were no changes as well as the AI Tutor interactions table in the teacher dashboard.


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
