### PR TITLE
Import 2023-24 public school NCES data

### DIFF
--- a/bin/oneoff/nces_data/import_school_stats_by_years_2023_2024_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2023_2024_ccd
@@ -1,0 +1,144 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../dashboard/config/environment'
+
+CDO.log = Logger.new($stdout)
+
+SURVEY_YEAR = '2023-2024'.freeze
+SURVEY_YEAR_HEADER = '2023-24'.freeze
+LAST_SURVEY_YEAR = '2022-2023'.freeze
+
+# Override for the dry run variable using an commandline argument
+DRY_RUN = !(ARGV.find {|arg| arg.casecmp('-dryrun')}).nil?
+
+VIRTUAL_SCHOOL_MAP = {
+  'FULLVIRTUAL' => 'Yes',
+  'NOTVIRTUAL' => 'No',
+  'SUPPVIRTUAL' => 'No',
+  'FACEVIRTUAL' => 'Yes',
+  '–' => nil,
+  '†' => nil
+}.freeze
+
+COMMUNITY_TYPE_MAP = {
+  '11' => 'city_large',
+  '12' => 'city_midsize',
+  '13' => 'city_small',
+  '21' => 'suburban_large',
+  '22' => 'suburban_midsize',
+  '23' => 'suburban_small',
+  '31' => 'town_fringe',
+  '32' => 'town_distant',
+  '33' => 'town_remote',
+  '41' => 'rural_fringe',
+  '42' => 'rural_distant',
+  '43' => 'rural_remote'
+}.freeze
+
+GRADES_MAP = {
+  'Prekindergarten' => 'PK',
+  'Kindergarten' => 'KG',
+  '1st Grade' => '01',
+  '2nd Grade' => '02',
+  '3rd Grade' => '03',
+  '4th Grade' => '04',
+  '5th Grade' => '05',
+  '6th Grade' => '06',
+  '7th Grade' => '07',
+  '8th Grade' => '08',
+  '9th Grade' => '09',
+  '10th Grade' => '10',
+  '11th Grade' => '11',
+  '12th Grade' => '12',
+  '13th Grade' => '13',
+  'Adult Education' => 'AE',
+  'Ungraded' => 'UG',
+  '–' => 'M',
+  '†' => 'N'
+}
+
+TITLE_I_STATUS_MAP = {
+  'Title I targeted assistance eligible school--No program' => '1',
+  'Title I targeted assistance school' => '2',
+  'Title I schoolwide eligible--Title I targeted assistance program' => '3',
+  'Title I schoolwide eligible school--No program' => '4',
+  'Title I schoolwide school' => '5',
+  'Not a Title I school' => '6',
+  'Missing' => nil
+}
+
+# @param unsanitized [String, nil] the unsanitized string
+# @returns [String, nil] the sanitized version of the string, with equal signs and double
+#   quotations removed. Returns nil on nil input.
+def sanitize_string_for_db(unsanitized)
+  unsanitized&.tr('="', '')
+end
+
+# –, † .to_i will return 0
+
+AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/schools_public.csv") do |filename|
+  SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, dry_run: DRY_RUN) do |row|
+    # remove quote and eq sign from ="12345" (the ="" is required to preserve leading 0's in zip codes)
+    row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
+    school_id = row['School ID (12-digit) - NCES Assigned [Public School] Latest available year'].to_i.to_s
+    # NCES did not provide Title 1 Status in the table this year so we are using last year's as a placeholder
+    previous_year_entry = SchoolStatsByYear.where(school_id: school_id, school_year: LAST_SURVEY_YEAR)
+    previous_title_1_status = previous_year_entry.empty? ? nil : previous_year_entry.first['title_i_status']
+
+    {
+      school_id:          school_id,
+      school_year:        SURVEY_YEAR,
+      grades_offered_lo:  GRADES_MAP[row['Lowest Grade Offered [Public School] ' + SURVEY_YEAR_HEADER]],
+      grades_offered_hi:  GRADES_MAP[row['Highest Grade Offered [Public School] ' + SURVEY_YEAR_HEADER]],
+      grade_pk_offered:   row['Prekindergarten offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_kg_offered:   row['Kindergarten offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_01_offered:   row['Grade 1 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_02_offered:   row['Grade 2 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_03_offered:   row['Grade 3 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_04_offered:   row['Grade 4 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_05_offered:   row['Grade 5 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_06_offered:   row['Grade 6 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_07_offered:   row['Grade 7 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_08_offered:   row['Grade 8 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_09_offered:   row['Grade 9 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_10_offered:   row['Grade 10 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_11_offered:   row['Grade 11 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_12_offered:   row['Grade 12 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_13_offered:   row['Grade 13 Offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+
+      virtual_status:     VIRTUAL_SCHOOL_MAP[row['Virtual School Status (SY 2016-17 onward) [Public School] ' + SURVEY_YEAR_HEADER]],
+      students_total:     row['Total Students All Grades (Excludes AE) [Public School] ' + SURVEY_YEAR_HEADER].presence.try {|v| v.to_i == 0 ? nil : v.to_i},
+      student_am_count:   row['American Indian/Alaska Native Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_as_count:   row['Asian or Asian/Pacific Islander Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_hi_count:   row['Hispanic Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_bl_count:   row['Black or African American Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_wh_count:   row['White Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_hp_count:   row['Nat. Hawaiian or Other Pacific Isl. Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_tr_count:   row['Two or More Races Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      title_i_status:     previous_title_1_status,
+      frl_eligible_total: row['Free and Reduced Lunch Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_female: row['Female Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_male: row['Male Students [Public School] ' + SURVEY_YEAR_HEADER].to_i
+    }
+  end
+end
+
+AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/locale_public.csv") do |filename|
+  SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, dry_run: DRY_RUN) do |row|
+    {
+      school_id:      row['NCESSCH'].to_i.to_s,
+      school_year:    SURVEY_YEAR,
+      community_type: COMMUNITY_TYPE_MAP[row['LOCALE']]
+    }
+  end
+end
+
+AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/title_i_statuses.csv") do |filename|
+  SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, dry_run: DRY_RUN) do |row|
+    {
+      school_id:      row['NCES SCH ID'].to_i.to_s,
+      school_year:    SURVEY_YEAR,
+      title_i_status: TITLE_I_STATUS_MAP[row['Program Type']]
+    }
+  end
+end

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -468,6 +468,40 @@ class School < ApplicationRecord
           }
         end
       end
+
+      # Some of this data has #- appended to the front, so we strip that off with .to_s.slice(2) (it's always a single digit)
+      CDO.log.info "Seeding 2023-2024 public school data."
+      AWS::S3.seed_from_file('cdo-nces', "2023-2024/ccd/schools_public.csv") do |filename|
+        merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: true, ignore_attributes: ['last_known_school_year_open']) do |row|
+          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
+          {
+            id:                           row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
+            name:                         row['School Name'].upcase,
+            address_line1:                row['Location Address 1 [Public School] 2023-24'].to_s.upcase.truncate(50).presence,
+            address_line2:                row['Location Address 2 [Public School] 2023-24'].to_s.upcase.truncate(30).presence,
+            address_line3:                row['Location Address 3 [Public School] 2023-24'].to_s.upcase.presence,
+            city:                         row['Location City [Public School] 2023-24'].to_s.upcase.presence,
+            state:                        row['Location State Abbr [Public School] 2023-24'].to_s.strip.upcase.presence,
+            zip:                          row['Location ZIP [Public School] 2023-24'],
+            latitude:                     row['Latitude [Public School] 2023-24'].to_f,
+            longitude:                    row['Longitude [Public School] 2023-24'].to_f,
+            school_type:                  CHARTER_SCHOOL_MAP[row['Charter School [Public School] 2023-24'].to_s] || 'public',
+            school_district_id:           row['Agency ID - NCES Assigned [Public School] Latest available year'].to_i,
+            school_category:              SCHOOL_CATEGORY_MAP[row['School Type [Public School] 2023-24']].presence,
+            last_known_school_year_open:  OPEN_SCHOOL_STATUSES.include?(row['Updated Status [Public School] 2023-24']) ? '2023-2024' : nil
+          }
+        end
+      end
+      AWS::S3.seed_from_file('cdo-nces', "2023-2024/ccd/locale_public.csv") do |filename|
+        merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false) do |row|
+          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
+          {
+            school_id:    row['NCESSCH'].to_i.to_s,
+            county_id:    row['CNTY'].to_i.to_s,
+            county_name:  row['NMCNTY']
+          }
+        end
+      end
     end
   end
 

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -472,7 +472,7 @@ class School < ApplicationRecord
       # Some of this data has #- appended to the front, so we strip that off with .to_s.slice(2) (it's always a single digit)
       CDO.log.info "Seeding 2023-2024 public school data."
       AWS::S3.seed_from_file('cdo-nces', "2023-2024/ccd/schools_public.csv") do |filename|
-        merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: true, ignore_attributes: ['last_known_school_year_open']) do |row|
+        merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
           row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
           {
             id:                           row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -492,6 +492,20 @@ class School < ApplicationRecord
           }
         end
       end
+      ActiveRecord::Base.transaction do
+        CSV.read(filename, **{headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}).each do |row|
+          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
+          begin
+            school = School.find(row['NCESSCH'].to_i.to_s)
+            school&.update!(
+              county_id:    row['CNTY'].to_i.to_s,
+              county_name:  row['NMCNTY']
+            )
+          rescue ActiveRecord::RecordNotFound
+            CDO.log.info "Could not find school with id: #{row['NCESSCH'].to_i}"
+          end
+        end
+      end
     end
   end
 

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -475,7 +475,7 @@ class School < ApplicationRecord
         merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
           row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
           {
-            id:                           row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
+            id:                           row['School ID (12-digit) - NCES Assigned [Public School] Latest available year'].to_i.to_s,
             name:                         row['School Name'].upcase,
             address_line1:                row['Location Address 1 [Public School] 2023-24'].to_s.upcase.truncate(50).presence,
             address_line2:                row['Location Address 2 [Public School] 2023-24'].to_s.upcase.truncate(30).presence,

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -492,16 +492,6 @@ class School < ApplicationRecord
           }
         end
       end
-      AWS::S3.seed_from_file('cdo-nces', "2023-2024/ccd/locale_public.csv") do |filename|
-        merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false) do |row|
-          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
-          {
-            school_id:    row['NCESSCH'].to_i.to_s,
-            county_id:    row['CNTY'].to_i.to_s,
-            county_name:  row['NMCNTY']
-          }
-        end
-      end
     end
   end
 

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -471,8 +471,12 @@ class School < ApplicationRecord
 
       # Some of this data has #- appended to the front, so we strip that off with .to_s.slice(2) (it's always a single digit)
       CDO.log.info "Seeding 2023-2024 public school data."
+      puts 'Start seeding new data'
+      count = 0
       AWS::S3.seed_from_file('cdo-nces', "2023-2024/ccd/schools_public.csv") do |filename|
+        puts filename
         merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
+          count += 1
           row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
           {
             id:                           row['School ID (12-digit) - NCES Assigned [Public School] Latest available year'].to_i.to_s,
@@ -491,21 +495,23 @@ class School < ApplicationRecord
             last_known_school_year_open:  OPEN_SCHOOL_STATUSES.include?(row['Updated Status [Public School] 2023-24']) ? '2023-2024' : nil
           }
         end
+        puts "Total rows processed in new file: #{count}"
       end
-      ActiveRecord::Base.transaction do
-        CSV.read(filename, **{headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}).each do |row|
-          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
-          begin
-            school = School.find(row['NCESSCH'].to_i.to_s)
-            school&.update!(
-              county_id:    row['CNTY'].to_i.to_s,
-              county_name:  row['NMCNTY']
-            )
-          rescue ActiveRecord::RecordNotFound
-            CDO.log.info "Could not find school with id: #{row['NCESSCH'].to_i}"
-          end
-        end
-      end
+      puts 'End'
+      # ActiveRecord::Base.transaction do
+      #   CSV.read(filename, **{headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}).each do |row|
+      #     row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
+      #     begin
+      #       school = School.find(row['NCESSCH'].to_i.to_s)
+      #       school&.update!(
+      #         county_id:    row['CNTY'].to_i.to_s,
+      #         county_name:  row['NMCNTY']
+      #       )
+      #     rescue ActiveRecord::RecordNotFound
+      #       CDO.log.info "Could not find school with id: #{row['NCESSCH'].to_i}"
+      #     end
+      #   end
+      # end
     end
   end
 

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -471,12 +471,8 @@ class School < ApplicationRecord
 
       # Some of this data has #- appended to the front, so we strip that off with .to_s.slice(2) (it's always a single digit)
       CDO.log.info "Seeding 2023-2024 public school data."
-      puts 'Start seeding new data'
-      count = 0
       AWS::S3.seed_from_file('cdo-nces', "2023-2024/ccd/schools_public.csv") do |filename|
-        puts filename
         merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
-          count += 1
           row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
           {
             id:                           row['School ID (12-digit) - NCES Assigned [Public School] Latest available year'].to_i.to_s,
@@ -495,23 +491,23 @@ class School < ApplicationRecord
             last_known_school_year_open:  OPEN_SCHOOL_STATUSES.include?(row['Updated Status [Public School] 2023-24']) ? '2023-2024' : nil
           }
         end
-        puts "Total rows processed in new file: #{count}"
       end
-      puts 'End'
-      # ActiveRecord::Base.transaction do
-      #   CSV.read(filename, **{headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}).each do |row|
-      #     row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
-      #     begin
-      #       school = School.find(row['NCESSCH'].to_i.to_s)
-      #       school&.update!(
-      #         county_id:    row['CNTY'].to_i.to_s,
-      #         county_name:  row['NMCNTY']
-      #       )
-      #     rescue ActiveRecord::RecordNotFound
-      #       CDO.log.info "Could not find school with id: #{row['NCESSCH'].to_i}"
-      #     end
-      #   end
-      # end
+    end
+    School.transaction do
+      AWS::S3.seed_from_file('cdo-nces', "2023-2024/ccd/locale_public.csv") do |filename|
+        CSV.read(filename, **{headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}).each do |row|
+          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
+          begin
+            school = School.find(row['NCESSCH'].to_i.to_s)
+            school&.update!(
+              county_id:    row['CNTY'].to_i.to_s,
+              county_name:  row['NMCNTY']
+            )
+          rescue ActiveRecord::RecordNotFound
+            CDO.log.info "Could not find school with id: #{row['NCESSCH'].to_i}"
+          end
+        end
+      end
     end
   end
 

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -176,6 +176,21 @@ class SchoolDistrict < ApplicationRecord
           }
         end
       end
+
+      CDO.log.info "Seeding 2023-2024 school district data"
+      import_options_2324 = {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}
+      AWS::S3.seed_from_file('cdo-nces', "2023-2024/ccd/district.csv") do |filename|
+        SchoolDistrict.merge_from_csv(filename, import_options_2324, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
+          {
+            id:                           row['Agency ID - NCES Assigned [District] Latest available year'].tr('"=', '').to_i,
+            name:                         row['Agency Name'].upcase,
+            city:                         row['Location City [District] 2023-24'].to_s.upcase.presence,
+            state:                        row['Location State Abbr [District] 2023-24'].strip.to_s.upcase.presence,
+            zip:                          row['Location ZIP [District] 2023-24'].tr('"=', ''),
+            last_known_school_year_open:  OPEN_SCHOOL_STATUSES.include?(row['Updated Status [District] 2023-24']) ? '2023-2024' : nil
+          }
+        end
+      end
     end
   end
 

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -261,15 +261,17 @@ module AWS
     # @param dry_run [Boolean] If true, do not update seeded object tracking.
     def self.seed_from_file(bucket, key, dry_run: false)
       etag = create_client.head_object({bucket: bucket, key: key}).etag
-      AWS::S3.process_file(bucket, key) do |filename|
-        ActiveRecord::Base.transaction do
-          yield filename
-          unless dry_run
-            SeededS3Object.create!(
-              bucket: bucket,
-              key: key,
-              etag: etag,
-            )
+      unless SeededS3Object.exists?(bucket: bucket, key: key, etag: etag)
+        AWS::S3.process_file(bucket, key) do |filename|
+          ActiveRecord::Base.transaction do
+            yield filename
+            unless dry_run
+              SeededS3Object.create!(
+                bucket: bucket,
+                key: key,
+                etag: etag,
+              )
+            end
           end
         end
       end

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -261,17 +261,15 @@ module AWS
     # @param dry_run [Boolean] If true, do not update seeded object tracking.
     def self.seed_from_file(bucket, key, dry_run: false)
       etag = create_client.head_object({bucket: bucket, key: key}).etag
-      unless SeededS3Object.exists?(bucket: bucket, key: key, etag: etag)
-        AWS::S3.process_file(bucket, key) do |filename|
-          ActiveRecord::Base.transaction do
-            yield filename
-            unless dry_run
-              SeededS3Object.create!(
-                bucket: bucket,
-                key: key,
-                etag: etag,
-              )
-            end
+      AWS::S3.process_file(bucket, key) do |filename|
+        ActiveRecord::Base.transaction do
+          yield filename
+          unless dry_run
+            SeededS3Object.create!(
+              bucket: bucket,
+              key: key,
+              etag: etag,
+            )
           end
         end
       end


### PR DESCRIPTION
Imports the 2023-2024 public school NCES data:
- Updates the seeding scripts for `schools` and `school_districts` to seed the new data ([just like last year](https://github.com/code-dot-org/code-dot-org/pull/57659))
- Adds a oneoff import script to get the new `school_stats_by_year` info ([just like last year](https://github.com/code-dot-org/code-dot-org/pull/57664))

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2908)
Files we're importing from: [here](https://us-east-1.console.aws.amazon.com/s3/buckets/cdo-nces?region=us-east-1&bucketType=general&prefix=2023-2024%2Fccd%2F&tab=objects)

## Testing story
### Successfully seeded `schools`
Seeding worked:
![seed whole file](https://github.com/user-attachments/assets/55244da9-b483-40b7-8141-f026a1c83706)

Confirmed that the new county info (`county_id` and `county_name`) showed up in our database after being pulled from a different file:
![county info shows up](https://github.com/user-attachments/assets/fb387c05-d8e5-4765-be08-671f2ae002a0)

### Successfully seeded `school_districts`
![seed school districts](https://github.com/user-attachments/assets/b2b2381c-2f03-4d62-8831-fc78aee5df1d)

### Successfully ran the oneoff script
Dryrun success:
![dryrun success](https://github.com/user-attachments/assets/a3f99401-0c6f-4350-b6ac-2212457efabb)

Then successfully ran the script and checked that the `title_i_status` field was calculated properly since this year the NCES data formatted the status not as a number but as a text field (so we had to map the text to its associated status):
![title i status counts](https://github.com/user-attachments/assets/1f2b7dbd-7727-445c-9562-237f882d4aca)

## Deployment strategy
Once merged, I'll run the oneoff script on production. Just like last year, this script has an override to specify a dry run, so I'll start with a dry run and then execute if that looks good.
