### PR TITLE
increase DMS LOB max size from 32 to 64

### DIFF
--- a/aws/dms/replication-task-settings.yml.erb
+++ b/aws/dms/replication-task-settings.yml.erb
@@ -253,7 +253,7 @@ TargetMetadata:
   # Enter the maximum size, in kilobytes, for an individual LOB.
   # When a task is configured to run in limited LOB mode, the Max LOB size (K) option sets the maximum size LOB that AWS DMS accepts.
   # Any LOBs that are larger than this value will be truncated to this value.
-  LobMaxSize: 32
+  LobMaxSize: 64
 
   # In full LOB mode AWS DMS migrates all LOBs from source to target regardless of size.
   # In this configuration, AWS DMS has no information about the maximum size of LOBs to expect.


### PR DESCRIPTION
See [slack](https://codedotorg.slack.com/archives/C0SUN2W3D/p1741127841146459?thread_ts=1741125551.589719&cid=C0SUN2W3D) for context. this change should increase the max field size in redshift from 32KB to 64KB.

## Testing story

looking to reviewers for guidance on testing