### PR TITLE
[CMS-362] CMS - Typography - add 'remove margin bottom' prop to typography components in cms

### DIFF
--- a/frontend/apps/marketing/src/components/common/definitions/index.ts
+++ b/frontend/apps/marketing/src/components/common/definitions/index.ts
@@ -12,3 +12,10 @@ export const marginBottomNoneToMDefinition = {
     ],
   },
 };
+
+export const removeMarginBottomDefinition = {
+  displayName: 'Remove margin bottom?',
+  type: 'Boolean',
+  defaultValue: false,
+  group: 'style',
+};

--- a/frontend/apps/marketing/src/components/common/types/index.ts
+++ b/frontend/apps/marketing/src/components/common/types/index.ts
@@ -1,0 +1,8 @@
+export interface RemoveMarginBottomProps {
+  /** Whether to remove the margin bottom */
+  removeMarginBottom: boolean;
+}
+
+// Generic interface to extend components with the `removeMarginBottom` prop.
+export type WithRemoveMarginBottomProp<T extends object> = T &
+  RemoveMarginBottomProps;

--- a/frontend/apps/marketing/src/components/common/types/index.ts
+++ b/frontend/apps/marketing/src/components/common/types/index.ts
@@ -2,7 +2,3 @@ export interface RemoveMarginBottomProps {
   /** Whether to remove the margin bottom */
   removeMarginBottom: boolean;
 }
-
-// Generic interface to extend components with the `removeMarginBottom` prop.
-export type WithRemoveMarginBottomProp<T extends object> = T &
-  RemoveMarginBottomProps;

--- a/frontend/apps/marketing/src/components/heading/Heading.tsx
+++ b/frontend/apps/marketing/src/components/heading/Heading.tsx
@@ -7,6 +7,8 @@ import {
 import React, {ReactNode} from 'react';
 import classNames from 'classnames';
 
+import {WithRemoveMarginBottomProp} from '@/components/common/types';
+
 import moduleStyles from './heading.module.scss';
 
 type HeadingVisualAppearance = Extract<
@@ -23,14 +25,14 @@ type HeadingSemanticTag = Extract<
   'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 >;
 
-type HeadingProps = {
+type HeadingProps = WithRemoveMarginBottomProp<{
   /** Heading content */
   children: ReactNode;
   /** Heading visual appearance */
   visualAppearance: HeadingVisualAppearance;
   /** ClassName passed by contentful to apply styles that are set through contentful native editor*/
   className?: string;
-};
+}>;
 
 const headingVisualAppearanceToSemanticTagMap: Record<
   HeadingVisualAppearance,
@@ -47,11 +49,16 @@ const headingVisualAppearanceToSemanticTagMap: Record<
 const Heading: React.FunctionComponent<HeadingProps> = ({
   visualAppearance,
   children,
+  removeMarginBottom,
   className,
 }) => (
   <Typography
     semanticTag={headingVisualAppearanceToSemanticTagMap[visualAppearance]}
-    className={classNames(moduleStyles.heading, className)}
+    className={classNames(
+      moduleStyles.heading,
+      removeMarginBottom && moduleStyles['heading-removeMarginBottom'],
+      className,
+    )}
     visualAppearance={visualAppearance}
   >
     {children}

--- a/frontend/apps/marketing/src/components/heading/Heading.tsx
+++ b/frontend/apps/marketing/src/components/heading/Heading.tsx
@@ -7,7 +7,7 @@ import {
 import React, {ReactNode} from 'react';
 import classNames from 'classnames';
 
-import {WithRemoveMarginBottomProp} from '@/components/common/types';
+import {RemoveMarginBottomProps} from '@/components/common/types';
 
 import moduleStyles from './heading.module.scss';
 
@@ -25,14 +25,14 @@ type HeadingSemanticTag = Extract<
   'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 >;
 
-type HeadingProps = WithRemoveMarginBottomProp<{
+type HeadingProps = RemoveMarginBottomProps & {
   /** Heading content */
   children: ReactNode;
   /** Heading visual appearance */
   visualAppearance: HeadingVisualAppearance;
   /** ClassName passed by contentful to apply styles that are set through contentful native editor*/
   className?: string;
-}>;
+};
 
 const headingVisualAppearanceToSemanticTagMap: Record<
   HeadingVisualAppearance,

--- a/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
@@ -1,5 +1,6 @@
 // Creates a definition for the Typography component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+import {removeMarginBottomDefinition} from '@/components/common/definitions';
 
 export const HeadingContentfulComponentDefinition: ComponentDefinition = {
   id: 'heading',
@@ -31,6 +32,7 @@ export const HeadingContentfulComponentDefinition: ComponentDefinition = {
         ],
       },
     },
+    removeMarginBottom: {...removeMarginBottomDefinition},
     children: {
       displayName: 'Content',
       type: 'Text',

--- a/frontend/apps/marketing/src/components/heading/heading.module.scss
+++ b/frontend/apps/marketing/src/components/heading/heading.module.scss
@@ -10,4 +10,8 @@ h6 {
   &.heading {
     margin-top: 0;
   }
+
+  &.heading-removeMarginBottom {
+    @include mixins.common-margin-bottom-none;
+  }
 }

--- a/frontend/apps/marketing/src/components/link/Link.tsx
+++ b/frontend/apps/marketing/src/components/link/Link.tsx
@@ -5,9 +5,11 @@ import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon
 import React, {ReactNode} from 'react';
 import classNames from 'classnames';
 
+import {WithRemoveMarginBottomProp} from '@/components/common/types';
+
 import moduleStyles from './link.module.scss';
 
-export type LinkProps = {
+export type LinkProps = WithRemoveMarginBottomProp<{
   /** Link Label */
   children: ReactNode;
   /** Link URL */
@@ -16,19 +18,24 @@ export type LinkProps = {
   size: ComponentSizeXSToL;
   /** Whether Link is for internal code.org pages, or external web page. (external links are opened in new tab) */
   isLinkExternal: boolean;
-};
+}>;
 
 const Link: React.FunctionComponent<LinkProps> = ({
   children,
   href,
   size,
   isLinkExternal,
+  removeMarginBottom,
 }) => (
   <DSCOLink
     href={href}
     openInNewTab={isLinkExternal}
     size={size}
-    className={classNames(moduleStyles.link, moduleStyles[`link-size-${size}`])}
+    className={classNames(
+      moduleStyles.link,
+      moduleStyles[`link-size-${size}`],
+      removeMarginBottom && moduleStyles['link-removeMarginBottom'],
+    )}
   >
     {children}
     {isLinkExternal && (

--- a/frontend/apps/marketing/src/components/link/Link.tsx
+++ b/frontend/apps/marketing/src/components/link/Link.tsx
@@ -5,11 +5,11 @@ import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon
 import React, {ReactNode} from 'react';
 import classNames from 'classnames';
 
-import {WithRemoveMarginBottomProp} from '@/components/common/types';
+import {RemoveMarginBottomProps} from '@/components/common/types';
 
 import moduleStyles from './link.module.scss';
 
-export type LinkProps = WithRemoveMarginBottomProp<{
+export type LinkProps = RemoveMarginBottomProps & {
   /** Link Label */
   children: ReactNode;
   /** Link URL */
@@ -18,7 +18,7 @@ export type LinkProps = WithRemoveMarginBottomProp<{
   size: ComponentSizeXSToL;
   /** Whether Link is for internal code.org pages, or external web page. (external links are opened in new tab) */
   isLinkExternal: boolean;
-}>;
+};
 
 const Link: React.FunctionComponent<LinkProps> = ({
   children,

--- a/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
@@ -1,5 +1,6 @@
 // Creates a definition for the Link component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+import {removeMarginBottomDefinition} from '@/components/common/definitions';
 
 export const LinkContentfulComponentDefinition: ComponentDefinition = {
   id: 'link',
@@ -43,6 +44,7 @@ export const LinkContentfulComponentDefinition: ComponentDefinition = {
       type: 'Text',
       group: 'content',
     },
+    removeMarginBottom: {...removeMarginBottomDefinition},
     children: {
       displayName: 'Link Label',
       type: 'Text',

--- a/frontend/apps/marketing/src/components/link/link.module.scss
+++ b/frontend/apps/marketing/src/components/link/link.module.scss
@@ -4,6 +4,10 @@
 a.link {
   margin-top: 0;
   margin-bottom: 1em;
+
+  &.link-removeMarginBottom {
+    @include mixins.common-margin-bottom-none;
+  }
 }
 
 // Link sizes

--- a/frontend/apps/marketing/src/components/overline/Overline.tsx
+++ b/frontend/apps/marketing/src/components/overline/Overline.tsx
@@ -7,7 +7,7 @@ import {ComponentSizeXSToL} from '@code-dot-org/component-library/common/types';
 import classNames from 'classnames';
 import React, {ReactNode} from 'react';
 
-import {WithRemoveMarginBottomProp} from '@/components/common/types';
+import {RemoveMarginBottomProps} from '@/components/common/types';
 
 import moduleStyles from './overline.module.scss';
 
@@ -16,7 +16,7 @@ type OverlineVisualAppearance = Extract<
   'overline-one' | 'overline-two' | 'overline-three'
 >;
 
-type OverlineProps = WithRemoveMarginBottomProp<{
+type OverlineProps = RemoveMarginBottomProps & {
   /** Overline content */
   children: ReactNode;
   /** Overline size */
@@ -25,7 +25,7 @@ type OverlineProps = WithRemoveMarginBottomProp<{
   color: 'primary' | 'secondary';
   /** ClassName passed by Contentful to apply styles that are set through Contentful native editor*/
   className?: string;
-}>;
+};
 
 const overlineSizeToVisualAppearance: Record<
   Exclude<ComponentSizeXSToL, 'xs'>,

--- a/frontend/apps/marketing/src/components/overline/Overline.tsx
+++ b/frontend/apps/marketing/src/components/overline/Overline.tsx
@@ -7,6 +7,8 @@ import {ComponentSizeXSToL} from '@code-dot-org/component-library/common/types';
 import classNames from 'classnames';
 import React, {ReactNode} from 'react';
 
+import {WithRemoveMarginBottomProp} from '@/components/common/types';
+
 import moduleStyles from './overline.module.scss';
 
 type OverlineVisualAppearance = Extract<
@@ -14,7 +16,7 @@ type OverlineVisualAppearance = Extract<
   'overline-one' | 'overline-two' | 'overline-three'
 >;
 
-type OverlineProps = {
+type OverlineProps = WithRemoveMarginBottomProp<{
   /** Overline content */
   children: ReactNode;
   /** Overline size */
@@ -23,7 +25,7 @@ type OverlineProps = {
   color: 'primary' | 'secondary';
   /** ClassName passed by Contentful to apply styles that are set through Contentful native editor*/
   className?: string;
-};
+}>;
 
 const overlineSizeToVisualAppearance: Record<
   Exclude<ComponentSizeXSToL, 'xs'>,
@@ -38,6 +40,7 @@ const Overline: React.FunctionComponent<OverlineProps> = ({
   size,
   children,
   color,
+  removeMarginBottom,
   className,
 }) => {
   return (
@@ -45,6 +48,7 @@ const Overline: React.FunctionComponent<OverlineProps> = ({
       className={classNames(
         moduleStyles.overline,
         moduleStyles[`overline-color-${color}`],
+        removeMarginBottom && moduleStyles['overline-removeMarginBottom'],
         className,
       )}
       semanticTag="p"

--- a/frontend/apps/marketing/src/components/overline/OverlineContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/overline/OverlineContentfulDefinition.ts
@@ -1,5 +1,6 @@
 // Creates a definition for the Overline component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+import {removeMarginBottomDefinition} from '@/components/common/definitions';
 
 export const OverlineContentfulComponentDefinition: ComponentDefinition = {
   id: 'overline',
@@ -40,6 +41,7 @@ export const OverlineContentfulComponentDefinition: ComponentDefinition = {
         ],
       },
     },
+    removeMarginBottom: {...removeMarginBottomDefinition},
     children: {
       displayName: 'Content',
       type: 'Text',

--- a/frontend/apps/marketing/src/components/overline/overline.module.scss
+++ b/frontend/apps/marketing/src/components/overline/overline.module.scss
@@ -6,6 +6,10 @@ p {
     margin-top: 0;
   }
 
+  &.overline-removeMarginBottom {
+    @include mixins.common-margin-bottom-none;
+  }
+
   // Overline colors
   &.overline-color {
     &-primary {

--- a/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
+++ b/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
@@ -7,6 +7,8 @@ import {
 import React, {ReactNode} from 'react';
 import classNames from 'classnames';
 
+import {WithRemoveMarginBottomProp} from '@/components/common/types';
+
 import moduleStyles from './paragraph.module.scss';
 
 type ParagraphVisualAppearance = Extract<
@@ -14,7 +16,7 @@ type ParagraphVisualAppearance = Extract<
   'body-one' | 'body-two' | 'body-three' | 'body-four'
 >;
 
-type ParagraphProps = {
+type ParagraphProps = WithRemoveMarginBottomProp<{
   /** Paragraph content */
   children: ReactNode;
   /** Paragraph visual appearance */
@@ -25,13 +27,14 @@ type ParagraphProps = {
   color: 'primary' | 'secondary';
   /** ClassName passed by contentful to apply styles that are set through contentful native editor*/
   className?: string;
-};
+}>;
 
 const Paragraph: React.FunctionComponent<ParagraphProps> = ({
   visualAppearance,
   isStrong,
   color,
   children,
+  removeMarginBottom,
   className,
 }) => (
   <Typography
@@ -40,6 +43,7 @@ const Paragraph: React.FunctionComponent<ParagraphProps> = ({
     className={classNames(
       moduleStyles.paragraph,
       moduleStyles[`paragraph-color-${color}`],
+      removeMarginBottom && moduleStyles['paragraph-removeMarginBottom'],
       className,
     )}
   >

--- a/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
+++ b/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
@@ -7,7 +7,7 @@ import {
 import React, {ReactNode} from 'react';
 import classNames from 'classnames';
 
-import {WithRemoveMarginBottomProp} from '@/components/common/types';
+import {RemoveMarginBottomProps} from '@/components/common/types';
 
 import moduleStyles from './paragraph.module.scss';
 
@@ -16,7 +16,7 @@ type ParagraphVisualAppearance = Extract<
   'body-one' | 'body-two' | 'body-three' | 'body-four'
 >;
 
-type ParagraphProps = WithRemoveMarginBottomProp<{
+type ParagraphProps = RemoveMarginBottomProps & {
   /** Paragraph content */
   children: ReactNode;
   /** Paragraph visual appearance */
@@ -27,7 +27,7 @@ type ParagraphProps = WithRemoveMarginBottomProp<{
   color: 'primary' | 'secondary';
   /** ClassName passed by contentful to apply styles that are set through contentful native editor*/
   className?: string;
-}>;
+};
 
 const Paragraph: React.FunctionComponent<ParagraphProps> = ({
   visualAppearance,

--- a/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
@@ -1,5 +1,6 @@
 // Creates a definition for the Paragraph component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+import {removeMarginBottomDefinition} from '@/components/common/definitions';
 
 export const ParagraphContentfulComponentDefinition: ComponentDefinition = {
   id: 'paragraph',
@@ -41,6 +42,7 @@ export const ParagraphContentfulComponentDefinition: ComponentDefinition = {
         ],
       },
     },
+    removeMarginBottom: {...removeMarginBottomDefinition},
     children: {
       displayName: 'Content',
       type: 'Text',

--- a/frontend/apps/marketing/src/components/paragraph/paragraph.module.scss
+++ b/frontend/apps/marketing/src/components/paragraph/paragraph.module.scss
@@ -6,6 +6,10 @@ p {
     margin-top: 0;
   }
 
+  &.paragraph-removeMarginBottom {
+    @include mixins.common-margin-bottom-none;
+  }
+
   // Paragraph colors
   &.paragraph-color {
     &-primary {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## [CMS-362] CMS - Typography - add 'remove margin bottom' prop to typography components in cms

* chore(common): added definition and types for removeMarginBottom prop support
* feat(heading): added removeMarginBottom prop support
* feat(link): added removeMarginBottom prop support
* feat(overline): added removeMarginBottom prop support
* feat(paragraph): added removeMarginBottom prop support

https://github.com/user-attachments/assets/84a5e966-5af6-485c-8591-5c0c3ab37cd8

## Links
- jira ticket: [CMS-362(https://codedotorg.atlassian.net/browse/CMS-362)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
