### PR TITLE
Evaluate Student Learning: initial UserLevelEvaluations table 

### DIFF
--- a/dashboard/db/migrate/20250305163452_create_user_level_evaluations.rb
+++ b/dashboard/db/migrate/20250305163452_create_user_level_evaluations.rb
@@ -1,0 +1,19 @@
+class CreateUserLevelEvaluations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_level_evaluations do |t|
+      t.integer :user_id, null: false
+      t.integer :level_id, null: false
+      t.integer :script_id, null: false
+      t.string :school_year, null: false
+      t.text :evaluation_criteria
+      t.text :ai_evaluation
+      t.text :ai_reasoning
+      t.string :ai_model_version
+
+      t.timestamps
+
+      t.index :user_id
+      t.index :level_id
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_03_03_183756) do
+ActiveRecord::Schema.define(version: 2025_03_05_163452) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2025_03_03_183756) do
     t.index ["user_id", "level_id", "script_id"], name: "index_ace_user_level_script"
   end
 
-  create_table "aichat_message_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aichat_message_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "aichat_message_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "approval"
@@ -93,7 +93,7 @@ ActiveRecord::Schema.define(version: 2025_03_03_183756) do
     t.index ["aichat_message_id"], name: "index_aichat_message_feedbacks_on_aichat_message_id", unique: true
   end
 
-  create_table "aichat_messages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aichat_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "aichat_thread_id", null: false
     t.text "external_id", null: false
     t.integer "role", null: false
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 2025_03_03_183756) do
     t.index ["user_id", "level_id", "script_id"], name: "index_acs_user_level_script"
   end
 
-  create_table "aichat_threads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aichat_threads", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "external_id", null: false
     t.text "llm_version", null: false
@@ -973,7 +973,7 @@ ActiveRecord::Schema.define(version: 2025_03_03_183756) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "lti_deployment_id", null: false
     t.bigint "lti_user_identity_id", null: false
     t.index ["lti_deployment_id"], name: "index_lti_deployments_user_identities_on_lti_deployment_id"
@@ -2285,7 +2285,22 @@ ActiveRecord::Schema.define(version: 2025_03_03_183756) do
     t.index ["user_id"], name: "index_user_geos_on_user_id"
   end
 
-  create_table "user_level_interactions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_level_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "level_id", null: false
+    t.integer "script_id", null: false
+    t.string "school_year", null: false
+    t.text "evaluation_criteria"
+    t.text "ai_evaluation"
+    t.text "ai_reasoning"
+    t.string "ai_model_version"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["level_id"], name: "index_user_level_evaluations_on_level_id"
+    t.index ["user_id"], name: "index_user_level_evaluations_on_user_id"
+  end
+
+  create_table "user_level_interactions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -2487,9 +2502,9 @@ ActiveRecord::Schema.define(version: 2025_03_03_183756) do
     t.integer "primary_contact_info_id"
     t.string "unlock_token"
     t.string "cap_status", limit: 1
-    t.datetime "cap_status_date"
+    t.datetime "cap_state_date"
     t.index ["birthday"], name: "index_users_on_birthday"
-    t.index ["cap_status", "cap_status_date"], name: "index_users_on_cap_status_and_cap_status_date"
+    t.index ["cap_status", "cap_state_date"], name: "index_users_on_cap_state_and_cap_state_date"
     t.index ["current_sign_in_at"], name: "index_users_on_current_sign_in_at"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email", "deleted_at"], name: "index_users_on_email_and_deleted_at"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2025_03_05_163452) do
     t.index ["user_id", "level_id", "script_id"], name: "index_ace_user_level_script"
   end
 
-  create_table "aichat_message_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "aichat_message_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "aichat_message_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "approval"
@@ -93,7 +93,7 @@ ActiveRecord::Schema.define(version: 2025_03_05_163452) do
     t.index ["aichat_message_id"], name: "index_aichat_message_feedbacks_on_aichat_message_id", unique: true
   end
 
-  create_table "aichat_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "aichat_messages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "aichat_thread_id", null: false
     t.text "external_id", null: false
     t.integer "role", null: false
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 2025_03_05_163452) do
     t.index ["user_id", "level_id", "script_id"], name: "index_acs_user_level_script"
   end
 
-  create_table "aichat_threads", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "aichat_threads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "external_id", null: false
     t.text "llm_version", null: false
@@ -973,7 +973,7 @@ ActiveRecord::Schema.define(version: 2025_03_05_163452) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lti_deployment_id", null: false
     t.bigint "lti_user_identity_id", null: false
     t.index ["lti_deployment_id"], name: "index_lti_deployments_user_identities_on_lti_deployment_id"
@@ -2300,7 +2300,7 @@ ActiveRecord::Schema.define(version: 2025_03_05_163452) do
     t.index ["user_id"], name: "index_user_level_evaluations_on_user_id"
   end
 
-  create_table "user_level_interactions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_level_interactions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -2502,9 +2502,9 @@ ActiveRecord::Schema.define(version: 2025_03_05_163452) do
     t.integer "primary_contact_info_id"
     t.string "unlock_token"
     t.string "cap_status", limit: 1
-    t.datetime "cap_state_date"
+    t.datetime "cap_status_date"
     t.index ["birthday"], name: "index_users_on_birthday"
-    t.index ["cap_status", "cap_state_date"], name: "index_users_on_cap_state_and_cap_state_date"
+    t.index ["cap_status", "cap_status_date"], name: "index_users_on_cap_status_and_cap_status_date"
     t.index ["current_sign_in_at"], name: "index_users_on_current_sign_in_at"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email", "deleted_at"], name: "index_users_on_email_and_deleted_at"


### PR DESCRIPTION
### Links
[Summary of Evaluate Student Learning Projects](https://docs.google.com/document/d/1dj7OzyRDGjA8mj8_feWoDpy2o3gI7Yi9jlpq7pxp7sA/edit?tab=t.0)
[Spec for evaluating free response text ](https://docs.google.com/document/d/1722ScVSjSH9CvgFb_IPmmV3Ax1dGAt9Rvc9HZ85_Rpk/edit?tab=t.0#heading=h.e74xs4gysa5l)
[Spec for evaluating student code ](https://docs.google.com/document/d/1YdYJeSXWu52qxQjFah4q5fSz5E58k5xn68sfEYB8UV0/edit?tab=t.0#heading=h.5aducge6rkj9)
[Tech speclet for store AI evaluations](https://docs.google.com/document/d/1SvhsQDDCI1J9Nk-b6zOGuezzmQMJAnk43wet5IQcGdQ/edit?tab=t.0) 

Prototype of AI Analysis of free response answers: https://github.com/code-dot-org/code-dot-org/pull/64185
Prototype of AI Analysis of student code: https://github.com/code-dot-org/code-dot-org/pull/62126

### Summary 

For the Evaluate Student Learning project we want to start collecting AI evaluations of student check-for-understanding free response answers and AI analysis of student code samples so we can determine accuracy of AI-driven evaluation. 

This PR includes the migration to add a table, `UserLevelEvaluations` that can store AI responses so we can collect and review them and eventually persist them for teachers. 

### Follow-up work
Up next, we'll write to this table for both free response and code sample evaluations. Right now, for free responses, we have a prototype behind an experiment flag that allows teachers to view AI Analysis of student responses in a very rudimentary UI. The AI responses are currently stored in state and disappear with page re-load. For programming levels, we currently have a "Check my Code" button in App Lab hidden behind an experiment flag that when clicked gets an AI response evaluating the student's code. Those response are being stored in the `AITutorInteractions` table with `type == "completion"`. Rather than continuing to muddy the `AITutorInteractions` table, we'll switch those writes to `UserLevelEvaluations` and clean up `AITutorInteractions` (there are _very_ small number of completion type rows just from internally exploring). 

Those reading the docs closely will see in the [tech speclet for store AI evaluations](https://docs.google.com/document/d/1SvhsQDDCI1J9Nk-b6zOGuezzmQMJAnk43wet5IQcGdQ/edit?tab=t.0) that there is some potential refinement that may happen with this table. For example, once we have the Learning Trajectory codified we may want to run a migration to add a `skill_id` column. I think the core columns in this PR are sufficient to get the data flowing, which I'm feeling a mild amount of urgency around given both the project timeline and where we are in the school year for the units we're targeting. 

### Privacy
There is a non-zero chance that if a student entered PII and the AI repeated that PII back in its evaluation this table could have PII in it. I started a conversation [here](https://codedotorg.slack.com/archives/C04VD4ZB6BT/p1741195538157579) to get a better sense of how our other AI products are handling PII. This isn't a privacy/security concern per se more just a reminder that we'll just need to keep in mind when/if we add to https://github.com/code-dot-org/code-dot-org/blob/staging/aws/dms/tasks.yml
