### PR TITLE
fix(workshops): exclude bootstrap styles from new dashboard components

### DIFF
--- a/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
+++ b/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
@@ -8,7 +8,7 @@ import {
   Location,
 } from 'react-router-dom';
 
-interface WithRouterProps {
+interface WithRouterPropsType {
   component: React.ComponentType<
     {
       params: Readonly<Params<string>>;
@@ -27,7 +27,7 @@ interface RouteConfig {
 }
 
 export const WithRouterProps: React.FC<
-  WithRouterProps & Record<string, unknown>
+  WithRouterPropsType & Record<string, unknown>
 > = ({component: Component, routeConfigs, ...props}) => {
   const params = useParams();
   const location = useLocation();
@@ -48,11 +48,13 @@ export const WithRouterProps: React.FC<
     {breadcrumbs},
   ];
   return (
-    <Component
-      {...props}
-      params={params}
-      location={locationWithQuery}
-      routes={routes}
-    />
+    <div className="legacy-bs">
+      <Component
+        {...props}
+        params={params}
+        location={locationWithQuery}
+        routes={routes}
+      />
+    </div>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
@@ -10,11 +10,13 @@ export default {
 
 const Template = args => (
   // Currently the Bootstrap 3 styles required by React-Bootstrap are
-  // only applied inside div#workshop-container.
+  // only applied inside #workshop-container .legacy-bs
   // This is to prevent conflicts with other parts of Code Studio using Bootstrap 2.
   // See pd.scss. Without this container div it won't render properly.
   <div id="workshop-container" style={{width: 300}}>
-    <DatePicker {...args} />
+    <div className="legacy-bs">
+      <DatePicker {...args} />
+    </div>
   </div>
 );
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -79,6 +79,7 @@ const routeConfigs = [
     breadcrumbs: `Workshops,${workshopLabel(`New ${config.label}`)}`,
     component: WorkshopFormTemplate,
     props: {config},
+    noRouter: true,
   })),
   {
     path: 'workshops/:workshopId',
@@ -172,13 +173,21 @@ const WorkshopDashboard = ({
           <Routes>
             <Route path="/" element={<HeaderWrapper />}>
               <Route index element={<Navigate to="/workshops" replace />} />
-              {routeConfigs.map(({path, component, props = {}}) => (
-                <Route
-                  key={path}
-                  path={path}
-                  element={<WithRouterProps component={component} {...props} />}
-                />
-              ))}
+              {routeConfigs.map(
+                ({path, component: Component, noRouter, props = {}}) => (
+                  <Route
+                    key={path}
+                    path={path}
+                    element={
+                      noRouter ? (
+                        <Component {...props} />
+                      ) : (
+                        <WithRouterProps component={Component} {...props} />
+                      )
+                    }
+                  />
+                )
+              )}
             </Route>
           </Routes>
         </RouterProvider>

--- a/apps/style/code-studio/pd.scss
+++ b/apps/style/code-studio/pd.scss
@@ -28,7 +28,7 @@
 // doesn't conflict with the footer and header that are still using
 // Bootstrap 2.2.3
 // TODO: Remove this once Dashboard is upgraded to Bootstrap 3
-#workshop-container,
+#workshop-container .legacy-bs,
 #application-container,
 #application-header {
   @import "bootstrap-sass/assets/stylesheets/bootstrap"; /* stylelint-disable-line no-invalid-position-at-import-rule */


### PR DESCRIPTION
The workshop dashboard is a child of #workshop-container which is used as a css selector to import a bootstrap stylesheet, but the new workshop dashboard components will use DSCO, so I needed to make the css more specific to the legacy components with a class wrapper for any components that need the WithRouterProps shim.

I also renamed interface WithRouterProps to WithRouterPropsType for clarity

BEFORE:
![Screenshot 2025-03-06 at 1 33 50 PM](https://github.com/user-attachments/assets/bb0752ee-1303-403b-bff7-dd725a7d421e)


AFTER:
![Screenshot 2025-03-06 at 1 33 19 PM](https://github.com/user-attachments/assets/3af22faa-e3bc-4c0b-97a7-86a6931ca91a)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3144)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
