### PR TITLE
Fix AI Tutor suggested prompt overlapping assistant feedback details and refactor

### DIFF
--- a/apps/src/aiTutor/constants.ts
+++ b/apps/src/aiTutor/constants.ts
@@ -1,4 +1,43 @@
-export const genericCompilation = `"Why doesn't my code compile?"`;
-export const genericValidation = `"Why are my tests failing?"`;
-export const genericHelp = `"Why doesn't my code work?"`;
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+import {PromptOptionKeys} from './types';
+
 export const initialAssistantGreeting = "Hi! I'm your AI Tutor.";
+
+export enum SuggestedPromptActionLabels {
+  COMPILATION = "Why doesn't my code compile?",
+  VALIDATION = 'Why are my tests failing?',
+  GENERIC_HELP = "Why doesn't my code work?",
+}
+
+export enum SuggestedPromptActions {
+  COMPILATION = 'compilation',
+  VALIDATION = 'validation',
+  GENERIC_HELP = 'generic_help',
+}
+
+export const QuickActions: Record<
+  SuggestedPromptActions,
+  SuggestedPromptActionLabels
+> = {
+  [SuggestedPromptActions.COMPILATION]: SuggestedPromptActionLabels.COMPILATION,
+  [SuggestedPromptActions.VALIDATION]: SuggestedPromptActionLabels.VALIDATION,
+  [SuggestedPromptActions.GENERIC_HELP]:
+    SuggestedPromptActionLabels.GENERIC_HELP,
+};
+
+export const AITutorEventMap: Record<
+  keyof typeof SuggestedPromptActions,
+  keyof typeof EVENTS
+> = {
+  COMPILATION: 'AI_TUTOR_SUGGESTED_PROMPT_COMPILATION',
+  VALIDATION: 'AI_TUTOR_SUGGESTED_PROMPT_VALIDATION',
+  GENERIC_HELP: 'AI_TUTOR_SUGGESTED_PROMPT_GENERIC_HELP',
+};
+
+export const PromptOptionMap: Record<SuggestedPromptActions, PromptOptionKeys> =
+  {
+    [SuggestedPromptActions.COMPILATION]: 'showCompilationOption',
+    [SuggestedPromptActions.VALIDATION]: 'showValidationOption',
+    [SuggestedPromptActions.GENERIC_HELP]: 'showGenericErrorOption',
+  };

--- a/apps/src/aiTutor/constants.ts
+++ b/apps/src/aiTutor/constants.ts
@@ -4,26 +4,16 @@ import {PromptOptionKeys} from './types';
 
 export const initialAssistantGreeting = "Hi! I'm your AI Tutor.";
 
-export enum SuggestedPromptActionLabels {
-  COMPILATION = "Why doesn't my code compile?",
-  VALIDATION = 'Why are my tests failing?',
-  GENERIC_HELP = "Why doesn't my code work?",
-}
-
 export enum SuggestedPromptActions {
   COMPILATION = 'compilation',
   VALIDATION = 'validation',
   GENERIC_HELP = 'generic_help',
 }
 
-export const QuickActions: Record<
-  SuggestedPromptActions,
-  SuggestedPromptActionLabels
-> = {
-  [SuggestedPromptActions.COMPILATION]: SuggestedPromptActionLabels.COMPILATION,
-  [SuggestedPromptActions.VALIDATION]: SuggestedPromptActionLabels.VALIDATION,
-  [SuggestedPromptActions.GENERIC_HELP]:
-    SuggestedPromptActionLabels.GENERIC_HELP,
+export const QuickActions: Record<SuggestedPromptActions, string> = {
+  [SuggestedPromptActions.COMPILATION]: "Why doesn't my code compile?",
+  [SuggestedPromptActions.VALIDATION]: 'Why are my tests failing?',
+  [SuggestedPromptActions.GENERIC_HELP]: "Why doesn't my code work?",
 };
 
 export const AITutorEventMap: Record<

--- a/apps/src/aiTutor/redux/aiTutorRedux.ts
+++ b/apps/src/aiTutor/redux/aiTutorRedux.ts
@@ -22,6 +22,7 @@ export interface AITutorState {
   chatMessages: ChatCompletionMessage[];
   isWaitingForChatResponse: boolean;
   isChatOpen: boolean;
+  showSuggestedPrompts: boolean;
 }
 
 const initialChatMessages: ChatCompletionMessage[] = [
@@ -39,6 +40,7 @@ const initialState: AITutorState = {
   chatMessages: initialChatMessages,
   isWaitingForChatResponse: false,
   isChatOpen: false,
+  showSuggestedPrompts: false,
 };
 
 export const formatQuestionForAITutor = (chatContext: ChatContext) => {
@@ -168,6 +170,9 @@ const aiTutorSlice = createSlice({
     setIsChatOpen: (state, action: PayloadAction<boolean>) => {
       state.isChatOpen = action.payload;
     },
+    setShowSuggestedPrompts: (state, action: PayloadAction<boolean>) => {
+      state.showSuggestedPrompts = action.payload;
+    },
   },
   extraReducers: builder => {
     builder.addCase(askAITutor.fulfilled, state => {
@@ -193,4 +198,5 @@ export const {
   setIsWaitingForChatResponse,
   updateLastChatMessage,
   setIsChatOpen,
+  setShowSuggestedPrompts,
 } = aiTutorSlice.actions;

--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -74,3 +74,15 @@ export interface ChatContext {
   actionType?: AITutorAction | undefined;
   systemPrompt?: string;
 }
+
+export type SuggestedPromptOptions = {
+  studentCode: string;
+  showCompilationOption?: boolean;
+  showValidationOption?: boolean;
+  showGenericErrorOption?: boolean;
+};
+
+export type PromptOptionKeys =
+  | 'showCompilationOption'
+  | 'showValidationOption'
+  | 'showGenericErrorOption';

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -32,8 +32,9 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
 
   return (
     <div id="ai-tutor-chat-workspace">
-      {storedMessages.map(message => (
+      {storedMessages.map((message, index) => (
         <ChatMessage
+          key={message.id ?? `message-${index}`}
           text={message.chatMessageText}
           role={message.role}
           customStyles={style}

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -187,7 +187,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       return {
         label: message,
         onClick: () => handleClick(typedAction),
-        show: optionKey ? promptOptions[optionKey] ?? false : false, // Resolve TS demands.
+        show: optionKey ? !!promptOptions[optionKey] : false,
         selected: false,
       };
     })

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -29,13 +29,13 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
     state => state.lab2Project?.projectSources?.source
   );
   const hasPythonlabError = useAppSelector(state => state.lab2System.hasError);
-  const hasRunPythonCode = useAppSelector(state => state.lab2System.hasRun);
   const runCountPythonlab = useAppSelector(state => state.lab2System.runCount);
-  const hasValidatedPythonCode = useAppSelector(
-    state => state.lab2System.hasValidated
+  const validateCountPythonlab = useAppSelector(
+    state => state.lab2System.validateCount
   );
+
   const hasRunOrTestedPythonlabCode =
-    hasRunPythonCode || hasValidatedPythonCode;
+    runCountPythonlab || validateCountPythonlab;
   const isPythonlabRunning = useAppSelector(
     state => state.lab2System.isRunning
   );
@@ -46,7 +46,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
     state => state.lab.validationState
   );
   const pythonlabValidationFailed =
-    hasConditions && hasValidatedPythonCode && !satisfied;
+    hasConditions && validateCountPythonlab && !satisfied;
 
   // For javalab
   const javalabSources = useAppSelector(state => state.javalabEditor.sources);
@@ -70,9 +70,8 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   );
 
   useEffect(() => {
-    console.log('useEffect run count change');
     setClickPromptCountChange(false);
-  }, [runCountJavalab, runCountPythonlab]);
+  }, [runCountJavalab, runCountPythonlab, validateCountPythonlab]);
 
   function getOptionsByLabType(labType: string) {
     if (labType === 'Pythonlab') {
@@ -153,7 +152,6 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
         progressionType: level?.progressionType,
         suggestedPrompt: suggestedPromptType,
       });
-      console.log('inside handleClick');
       setClickPromptCountChange(() => true);
     },
     [isWaitingForChatResponse, studentCode, dispatch, level]
@@ -183,7 +181,6 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   ];
   const showPrompts = !clickPromptCountChange;
 
-  console.log('showPrompts', showPrompts);
   return showPrompts ? (
     <SuggestedPrompts suggestedPrompts={suggestedPrompts} />
   ) : null;

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -138,8 +138,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       runCountPythonlab,
       validateCountJavalab,
       validateCountPythonlab,
-      validationState.hasConditions,
-      validationState.satisfied,
+      validationState,
     ]
   );
 

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -76,17 +76,17 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
 
   const getSuggestedPromptOptionsByLabType = useCallback(
     (labType: string): SuggestedPromptOptions => {
+      // Show a suggested prompt if:
+      // * we aren't currently running or validating code,
+      // * and we aren't waiting for a chat response
+      // * code has been run or validated.
+      // However, if the user clicks on run/validate again after clicking on a
+      // suggested prompt, hide the suggested prompt(s).
       if (labType === 'Pythonlab') {
         const studentCode =
           typeof pythonlabSource !== 'string' && pythonlabSource
             ? getActiveFileForSource(pythonlabSource)?.contents || ''
             : '';
-        // Show a suggested prompt if:
-        // * we aren't currently running or validating code,
-        // * and we aren't waiting for a chat response
-        // * code has been run or validated.
-        // However, if the user clicks on run/validate again after clicking on a
-        // suggested prompt, hide the suggested prompt(s).
         const showOption =
           !isPythonlabRunning &&
           !isPythonlabValidating &&

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useState, useEffect} from 'react';
 
 import SuggestedPrompts from '@cdo/apps/aiComponentLibrary/suggestedPrompt/SuggestedPrompts';
 import {AITutorAction, AITutorActions} from '@cdo/apps/aiTutor/types';
@@ -17,6 +17,10 @@ const QuickActions = {
 };
 
 const AITutorSuggestedPrompts: React.FunctionComponent = () => {
+  const [clickPromptCount, setClickPromptCount] = useState(0);
+  const [clickPromptCountChange, setClickPromptCountChange] = useState(false);
+  const [runCount, setRunCount] = useState(0);
+  const [runCountChange, setRunCountChange] = useState(false);
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
   );
@@ -29,8 +33,8 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   );
   const hasPythonlabError = useAppSelector(state => state.lab2System.hasError);
   const hasRunPythonCode = useAppSelector(state => state.lab2System.hasRun);
-  const runCount = useAppSelector(state => state.lab2System.runCount);
-  console.log('runCount', runCount);
+  const runCountPythonlab = useAppSelector(state => state.lab2System.runCount);
+  console.log('runCountPythonlab', runCountPythonlab);
   const hasValidatedPythonCode = useAppSelector(
     state => state.lab2System.hasValidated
   );
@@ -69,6 +73,14 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   const javalabValidationPassed = useAppSelector(
     state => state.javalab.validationPassed
   );
+
+  useEffect(() => {
+    console.log('useEffect for run count and run count change');
+    const count = Math.max(runCountJavalab, runCountPythonlab);
+    setRunCount(count);
+    setRunCountChange(true);
+    setClickPromptCountChange(false);
+  }, [runCountChange, runCountJavalab, runCountPythonlab]);
 
   function getOptionsByLabType(labType: string) {
     if (labType === 'Pythonlab') {
@@ -149,8 +161,20 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
         progressionType: level?.progressionType,
         suggestedPrompt: suggestedPromptType,
       });
+      console.log('inside handleClick');
+      // Use functional updates to ensure state updates correctly
+      setClickPromptCount(prev => prev + 1);
+      setClickPromptCountChange(() => true);
+      setRunCountChange(() => false);
+      console.log('clickPromptCountChange', clickPromptCountChange);
     },
-    [studentCode, isWaitingForChatResponse, level, dispatch]
+    [
+      isWaitingForChatResponse,
+      studentCode,
+      dispatch,
+      level,
+      clickPromptCountChange,
+    ]
   );
 
   // We set selected to false because once the user selects a prompt, we convert
@@ -175,8 +199,16 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       selected: false,
     },
   ];
+  console.log('clickPromptCount', clickPromptCount);
+  console.log('runCount', runCount);
+  console.log('clickPromptCountChange', clickPromptCountChange);
+  console.log('runCountChange', runCountChange);
+  const showPrompts = !clickPromptCountChange && runCountChange;
 
-  return <SuggestedPrompts suggestedPrompts={suggestedPrompts} />;
+  console.log('showPrompts', showPrompts);
+  return showPrompts ? (
+    <SuggestedPrompts suggestedPrompts={suggestedPrompts} />
+  ) : null;
 };
 
 export default AITutorSuggestedPrompts;

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -1,72 +1,69 @@
 import React, {useCallback, useState, useEffect} from 'react';
 
 import SuggestedPrompts from '@cdo/apps/aiComponentLibrary/suggestedPrompt/SuggestedPrompts';
-import {AITutorAction, AITutorActions} from '@cdo/apps/aiTutor/types';
+import {AITutorAction} from '@cdo/apps/aiTutor/types';
 import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {genericCompilation, genericValidation, genericHelp} from '../constants';
+import {
+  SuggestedPromptActions,
+  QuickActions,
+  AITutorEventMap,
+  PromptOptionMap,
+} from '../constants';
 import {askAITutor} from '../redux/aiTutorRedux';
+import {SuggestedPromptOptions} from '../types';
 
-const QuickActions = {
-  [AITutorActions.COMPILATION]: genericCompilation,
-  [AITutorActions.VALIDATION]: genericValidation,
-  [AITutorActions.GENERIC_HELP]: genericHelp,
+const useLabSelectors = () => {
+  return useAppSelector(state => ({
+    isWaitingForChatResponse: state.aiTutor.isWaitingForChatResponse,
+    level: state.aiTutor.level,
+
+    // pythonlab selectors
+    pythonlabSource: state.lab2Project?.projectSources?.source,
+    hasPythonlabError: state.lab2System.hasError,
+    runCountPythonlab: state.lab2System.runCount,
+    validateCountPythonlab: state.lab2System.validateCount,
+    isPythonlabRunning: state.lab2System.isRunning,
+    isPythonlabValidating: state.lab2System.isValidating,
+    validationState: state.lab.validationState,
+
+    // javalab selectors
+    javalabSources: state.javalabEditor.sources,
+    fileMetadata: state.javalabEditor.fileMetadata,
+    activeTabKey: state.javalabEditor.activeTabKey,
+    hasJavalabCompilationError: state.javalabEditor.hasCompilationError,
+    runCountJavalab: state.javalab.runCount,
+    validateCountJavalab: state.javalab.validateCount,
+    isJavalabRunning: state.javalab.isRunning,
+    javalabValidationPassed: state.javalab.validationPassed,
+  }));
 };
 
 const AITutorSuggestedPrompts: React.FunctionComponent = () => {
+  const {
+    isWaitingForChatResponse,
+    level,
+    pythonlabSource,
+    hasPythonlabError,
+    runCountPythonlab,
+    validateCountPythonlab,
+    isPythonlabRunning,
+    isPythonlabValidating,
+    validationState,
+    javalabSources,
+    fileMetadata,
+    activeTabKey,
+    hasJavalabCompilationError,
+    runCountJavalab,
+    validateCountJavalab,
+    isJavalabRunning,
+    javalabValidationPassed,
+  } = useLabSelectors();
+
   const [clickPromptCountChange, setClickPromptCountChange] = useState(false);
-  const isWaitingForChatResponse = useAppSelector(
-    state => state.aiTutor.isWaitingForChatResponse
-  );
-
-  const level = useAppSelector(state => state.aiTutor.level);
-
-  // For pythonlab
-  const pythonlabSource = useAppSelector(
-    state => state.lab2Project?.projectSources?.source
-  );
-  const hasPythonlabError = useAppSelector(state => state.lab2System.hasError);
-  const runCountPythonlab = useAppSelector(state => state.lab2System.runCount);
-  const validateCountPythonlab = useAppSelector(
-    state => state.lab2System.validateCount
-  );
-
-  const hasRunOrTestedPythonlabCode =
-    runCountPythonlab || validateCountPythonlab;
-  const isPythonlabRunning = useAppSelector(
-    state => state.lab2System.isRunning
-  );
-  const isPythonlabValidating = useAppSelector(
-    state => state.lab2System.isValidating
-  );
-  const {hasConditions, satisfied} = useAppSelector(
-    state => state.lab.validationState
-  );
-  const pythonlabValidationFailed =
-    hasConditions && validateCountPythonlab && !satisfied;
-
-  // For javalab
-  const javalabSources = useAppSelector(state => state.javalabEditor.sources);
-  const fileMetadata = useAppSelector(
-    state => state.javalabEditor.fileMetadata
-  );
-  const activeTabKey = useAppSelector(
-    state => state.javalabEditor.activeTabKey
-  );
-  const hasJavalabCompilationError = useAppSelector(
-    state => state.javalabEditor.hasCompilationError
-  );
-  const runCountJavalab = useAppSelector(state => state.javalab.runCount);
-  const validateCountJavalab = useAppSelector(
-    state => state.javalab.validateCount
-  );
-  const isJavalabRunning = useAppSelector(state => state.javalab.isRunning);
-  const javalabValidationPassed = useAppSelector(
-    state => state.javalab.validationPassed
-  );
 
   useEffect(() => {
     setClickPromptCountChange(false);
@@ -77,44 +74,78 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
     validateCountJavalab,
   ]);
 
-  function getOptionsByLabType(labType: string) {
-    if (labType === 'Pythonlab') {
-      const studentCode =
-        typeof pythonlabSource !== 'string' && pythonlabSource
-          ? getActiveFileForSource(pythonlabSource)?.contents || ''
-          : '';
-      // Only show a suggested prompt if we aren't currently running or validating code,
-      // code has been run or validated, and we aren't waiting for a chat response.
-      const showOption =
-        !isPythonlabRunning &&
-        !isPythonlabValidating &&
-        hasRunOrTestedPythonlabCode &&
-        !isWaitingForChatResponse;
-      const showGenericErrorOption = showOption && hasPythonlabError;
-      const showValidationOption = showOption && pythonlabValidationFailed;
-      return {studentCode, showGenericErrorOption, showValidationOption};
-    } else if (labType === 'Javalab') {
-      const studentCode = javalabSources[fileMetadata[activeTabKey]].text;
-      const showCompilationOption =
-        !isJavalabRunning &&
-        runCountJavalab &&
-        hasJavalabCompilationError &&
-        !isWaitingForChatResponse;
-      const showValidationOption =
-        validateCountJavalab &&
-        !hasJavalabCompilationError &&
-        !javalabValidationPassed &&
-        !isWaitingForChatResponse;
-      return {studentCode, showCompilationOption, showValidationOption};
-    }
-    return {};
-  }
+  const getSuggestedPromptOptionsByLabType = useCallback(
+    (labType: string): SuggestedPromptOptions => {
+      if (labType === 'Pythonlab') {
+        const studentCode =
+          typeof pythonlabSource !== 'string' && pythonlabSource
+            ? getActiveFileForSource(pythonlabSource)?.contents || ''
+            : '';
+        // Show a suggested prompt if:
+        // * we aren't currently running or validating code,
+        // * and we aren't waiting for a chat response
+        // * code has been run or validated.
+        // However, if the user clicks on run/validate again after clicking on a
+        // suggested prompt, hide the suggested prompt(s).
+        const showOption =
+          !isPythonlabRunning &&
+          !isPythonlabValidating &&
+          (!!runCountPythonlab || !!validateCountPythonlab) &&
+          !isWaitingForChatResponse;
+        return {
+          studentCode,
+          showGenericErrorOption: showOption && hasPythonlabError,
+          showValidationOption:
+            showOption &&
+            validationState.hasConditions &&
+            !!validateCountPythonlab &&
+            !validationState.satisfied,
+        };
+      }
+      if (labType === 'Javalab') {
+        const studentCode = javalabSources[fileMetadata[activeTabKey]].text;
+        return {
+          studentCode,
+          showCompilationOption:
+            !isJavalabRunning &&
+            !!runCountJavalab &&
+            hasJavalabCompilationError &&
+            !isWaitingForChatResponse,
+          showValidationOption:
+            !!validateCountJavalab &&
+            !hasJavalabCompilationError &&
+            !javalabValidationPassed &&
+            !isWaitingForChatResponse,
+        };
+      }
+      return {studentCode: ''};
+    },
+    [
+      activeTabKey,
+      fileMetadata,
+      hasJavalabCompilationError,
+      hasPythonlabError,
+      isJavalabRunning,
+      isPythonlabRunning,
+      isPythonlabValidating,
+      isWaitingForChatResponse,
+      javalabSources,
+      javalabValidationPassed,
+      pythonlabSource,
+      runCountJavalab,
+      runCountPythonlab,
+      validateCountJavalab,
+      validateCountPythonlab,
+      validationState.hasConditions,
+      validationState.satisfied,
+    ]
+  );
 
-  const labOptions = level?.type ? getOptionsByLabType(level.type) : {};
-  const studentCode: string = labOptions.studentCode || '';
-  const showCompilationOption = labOptions.showCompilationOption || false;
-  const showValidationOption = labOptions.showValidationOption || false;
-  const showGenericErrorOption = labOptions.showGenericErrorOption || false;
+  // promptOptions is an object with 3 optional keys (boolean values):
+  // showCompilationOption, showValidatonOption, and showGenericErrorOption
+  const {studentCode, ...promptOptions} = level?.type
+    ? getSuggestedPromptOptionsByLabType(level.type)
+    : {studentCode: ''};
 
   const dispatch = useAppDispatch();
 
@@ -123,66 +154,44 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       if (isWaitingForChatResponse) {
         return;
       }
+      dispatch(
+        askAITutor({
+          studentInput: QuickActions[aiTutorAction as SuggestedPromptActions],
+          studentCode,
+          actionType: aiTutorAction,
+        })
+      );
 
-      let studentInput = '';
-      let suggestedPromptType = '';
-
-      switch (aiTutorAction) {
-        case AITutorActions.COMPILATION:
-          studentInput = QuickActions[AITutorActions.COMPILATION];
-          suggestedPromptType = EVENTS.AI_TUTOR_SUGGESTED_PROMPT_COMPILATION;
-          break;
-        case AITutorActions.VALIDATION:
-          studentInput = QuickActions[AITutorActions.VALIDATION];
-          suggestedPromptType = EVENTS.AI_TUTOR_SUGGESTED_PROMPT_VALIDATION;
-          break;
-        case AITutorActions.GENERIC_HELP:
-          studentInput = QuickActions[AITutorActions.GENERIC_HELP];
-          suggestedPromptType = EVENTS.AI_TUTOR_SUGGESTED_PROMPT_GENERIC_HELP;
-          break;
-      }
-
-      const chatContext = {
-        studentInput,
-        studentCode,
-        actionType: aiTutorAction,
-      };
-
-      dispatch(askAITutor(chatContext));
+      const suggestedPromptEventKey =
+        AITutorEventMap[
+          aiTutorAction.toUpperCase() as keyof typeof AITutorEventMap
+        ];
 
       analyticsReporter.sendEvent(EVENTS.AI_TUTOR_CHAT_EVENT, {
         levelId: level?.id,
         levelType: level?.type,
         progressionType: level?.progressionType,
-        suggestedPrompt: suggestedPromptType,
+        suggestedPrompt: EVENTS[suggestedPromptEventKey],
       });
       setClickPromptCountChange(() => true);
     },
     [isWaitingForChatResponse, studentCode, dispatch, level]
   );
 
-  // We set selected to false because once the user selects a prompt, we convert
-  // the chip into a message in the chat history.
-  const suggestedPrompts = [
-    {
-      label: QuickActions[AITutorActions.COMPILATION],
-      onClick: () => handleClick(AITutorActions.COMPILATION),
-      show: showCompilationOption,
-      selected: false,
-    },
-    {
-      label: QuickActions[AITutorActions.VALIDATION],
-      onClick: () => handleClick(AITutorActions.VALIDATION),
-      show: showValidationOption,
-      selected: false,
-    },
-    {
-      label: QuickActions[AITutorActions.GENERIC_HELP],
-      onClick: () => handleClick(AITutorActions.GENERIC_HELP),
-      show: showGenericErrorOption,
-      selected: false,
-    },
-  ];
+  const suggestedPrompts = Object.entries(QuickActions)
+    .map(([action, message]) => {
+      const typedAction = action as SuggestedPromptActions;
+      const optionKey = PromptOptionMap[typedAction];
+      // selected is assigned false so that when the user selects a chip, it is converted to
+      // a message in the chat history.
+      return {
+        label: message,
+        onClick: () => handleClick(typedAction),
+        show: optionKey ? promptOptions[optionKey] ?? false : false, // Resolve TS demands.
+        selected: false,
+      };
+    })
+    .filter(prompt => prompt.show);
   const showPrompts = !clickPromptCountChange;
 
   return showPrompts ? (

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -56,14 +56,13 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   const activeTabKey = useAppSelector(
     state => state.javalabEditor.activeTabKey
   );
-
   const hasJavalabCompilationError = useAppSelector(
     state => state.javalabEditor.hasCompilationError
   );
-  const hasRunOrTestedJavalabCode = useAppSelector(
-    state => state.javalab.hasRunOrTestedCode
-  );
   const runCountJavalab = useAppSelector(state => state.javalab.runCount);
+  const validateCountJavalab = useAppSelector(
+    state => state.javalab.validateCount
+  );
   const isJavalabRunning = useAppSelector(state => state.javalab.isRunning);
   const javalabValidationPassed = useAppSelector(
     state => state.javalab.validationPassed
@@ -71,7 +70,12 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
 
   useEffect(() => {
     setClickPromptCountChange(false);
-  }, [runCountJavalab, runCountPythonlab, validateCountPythonlab]);
+  }, [
+    runCountJavalab,
+    runCountPythonlab,
+    validateCountPythonlab,
+    validateCountJavalab,
+  ]);
 
   function getOptionsByLabType(labType: string) {
     if (labType === 'Pythonlab') {
@@ -93,11 +97,11 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       const studentCode = javalabSources[fileMetadata[activeTabKey]].text;
       const showCompilationOption =
         !isJavalabRunning &&
-        hasRunOrTestedJavalabCode &&
+        runCountJavalab &&
         hasJavalabCompilationError &&
         !isWaitingForChatResponse;
       const showValidationOption =
-        hasRunOrTestedJavalabCode &&
+        validateCountJavalab &&
         !hasJavalabCompilationError &&
         !javalabValidationPassed &&
         !isWaitingForChatResponse;

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -69,8 +69,8 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       // * we aren't currently running or validating code,
       // * and we aren't waiting for a chat response
       // * code has been run or validated.
-      // However, if the user clicks on run/validate again after clicking on a
-      // suggested prompt, hide the suggested prompt(s).
+      // However, if the user clicks on a suggested prompt, hide the suggested prompt(s)
+      // until after they click on run or test/validate again.
       if (labType === 'Pythonlab') {
         const studentCode =
           typeof pythonlabSource !== 'string' && pythonlabSource

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -17,10 +17,7 @@ const QuickActions = {
 };
 
 const AITutorSuggestedPrompts: React.FunctionComponent = () => {
-  const [clickPromptCount, setClickPromptCount] = useState(0);
   const [clickPromptCountChange, setClickPromptCountChange] = useState(false);
-  const [runCount, setRunCount] = useState(0);
-  const [runCountChange, setRunCountChange] = useState(false);
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
   );
@@ -34,7 +31,6 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   const hasPythonlabError = useAppSelector(state => state.lab2System.hasError);
   const hasRunPythonCode = useAppSelector(state => state.lab2System.hasRun);
   const runCountPythonlab = useAppSelector(state => state.lab2System.runCount);
-  console.log('runCountPythonlab', runCountPythonlab);
   const hasValidatedPythonCode = useAppSelector(
     state => state.lab2System.hasValidated
   );
@@ -68,19 +64,15 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
     state => state.javalab.hasRunOrTestedCode
   );
   const runCountJavalab = useAppSelector(state => state.javalab.runCount);
-  console.log('runCountJavalab', runCountJavalab);
   const isJavalabRunning = useAppSelector(state => state.javalab.isRunning);
   const javalabValidationPassed = useAppSelector(
     state => state.javalab.validationPassed
   );
 
   useEffect(() => {
-    console.log('useEffect for run count and run count change');
-    const count = Math.max(runCountJavalab, runCountPythonlab);
-    setRunCount(count);
-    setRunCountChange(true);
+    console.log('useEffect run count change');
     setClickPromptCountChange(false);
-  }, [runCountChange, runCountJavalab, runCountPythonlab]);
+  }, [runCountJavalab, runCountPythonlab]);
 
   function getOptionsByLabType(labType: string) {
     if (labType === 'Pythonlab') {
@@ -162,19 +154,9 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
         suggestedPrompt: suggestedPromptType,
       });
       console.log('inside handleClick');
-      // Use functional updates to ensure state updates correctly
-      setClickPromptCount(prev => prev + 1);
       setClickPromptCountChange(() => true);
-      setRunCountChange(() => false);
-      console.log('clickPromptCountChange', clickPromptCountChange);
     },
-    [
-      isWaitingForChatResponse,
-      studentCode,
-      dispatch,
-      level,
-      clickPromptCountChange,
-    ]
+    [isWaitingForChatResponse, studentCode, dispatch, level]
   );
 
   // We set selected to false because once the user selects a prompt, we convert
@@ -199,11 +181,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       selected: false,
     },
   ];
-  console.log('clickPromptCount', clickPromptCount);
-  console.log('runCount', runCount);
-  console.log('clickPromptCountChange', clickPromptCountChange);
-  console.log('runCountChange', runCountChange);
-  const showPrompts = !clickPromptCountChange && runCountChange;
+  const showPrompts = !clickPromptCountChange;
 
   console.log('showPrompts', showPrompts);
   return showPrompts ? (

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState, useEffect} from 'react';
+import React, {useCallback} from 'react';
 
 import SuggestedPrompts from '@cdo/apps/aiComponentLibrary/suggestedPrompt/SuggestedPrompts';
 import {AITutorAction} from '@cdo/apps/aiTutor/types';
@@ -13,20 +13,21 @@ import {
   AITutorEventMap,
   PromptOptionMap,
 } from '../constants';
-import {askAITutor} from '../redux/aiTutorRedux';
+import {askAITutor, setShowSuggestedPrompts} from '../redux/aiTutorRedux';
 import {SuggestedPromptOptions} from '../types';
 
 const useLabSelectors = () => {
   return useAppSelector(state => ({
     isWaitingForChatResponse: state.aiTutor.isWaitingForChatResponse,
     level: state.aiTutor.level,
+    showSuggestedPrompts: state.aiTutor.showSuggestedPrompts,
 
     // pythonlab selectors
     pythonlabSource: state.lab2Project?.projectSources?.source,
     hasPythonlabError: state.lab2System.hasError,
-    runCountPythonlab: state.lab2System.runCount,
-    validateCountPythonlab: state.lab2System.validateCount,
     isPythonlabRunning: state.lab2System.isRunning,
+    hasRunPythonCode: state.lab2System.hasRun,
+    hasValidatedPythonCode: state.lab2System.hasValidated,
     isPythonlabValidating: state.lab2System.isValidating,
     validationState: state.lab.validationState,
 
@@ -35,8 +36,7 @@ const useLabSelectors = () => {
     fileMetadata: state.javalabEditor.fileMetadata,
     activeTabKey: state.javalabEditor.activeTabKey,
     hasJavalabCompilationError: state.javalabEditor.hasCompilationError,
-    runCountJavalab: state.javalab.runCount,
-    validateCountJavalab: state.javalab.validateCount,
+    hasRunOrTestedJavalabCode: state.javalab.hasRunOrTestedCode,
     isJavalabRunning: state.javalab.isRunning,
     javalabValidationPassed: state.javalab.validationPassed,
   }));
@@ -46,35 +46,22 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   const {
     isWaitingForChatResponse,
     level,
+    showSuggestedPrompts,
     pythonlabSource,
     hasPythonlabError,
-    runCountPythonlab,
-    validateCountPythonlab,
+    hasRunPythonCode,
     isPythonlabRunning,
+    hasValidatedPythonCode,
     isPythonlabValidating,
     validationState,
     javalabSources,
     fileMetadata,
     activeTabKey,
     hasJavalabCompilationError,
-    runCountJavalab,
-    validateCountJavalab,
     isJavalabRunning,
+    hasRunOrTestedJavalabCode,
     javalabValidationPassed,
   } = useLabSelectors();
-
-  const [clickPromptCountChange, setClickPromptCountChange] = useState(false);
-
-  useEffect(() => {
-    // If the user clicks on 'Run' or 'Test'/'Validate', we want to show the user
-    // the suggested prompt(s) if there is an code/validation error.
-    setClickPromptCountChange(false);
-  }, [
-    runCountJavalab,
-    runCountPythonlab,
-    validateCountPythonlab,
-    validateCountJavalab,
-  ]);
 
   const getSuggestedPromptOptionsByLabType = useCallback(
     (labType: string): SuggestedPromptOptions => {
@@ -92,7 +79,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
         const showOption =
           !isPythonlabRunning &&
           !isPythonlabValidating &&
-          (!!runCountPythonlab || !!validateCountPythonlab) &&
+          (hasRunPythonCode || hasValidatedPythonCode) &&
           !isWaitingForChatResponse;
         return {
           studentCode,
@@ -100,7 +87,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
           showValidationOption:
             showOption &&
             validationState.hasConditions &&
-            !!validateCountPythonlab &&
+            hasValidatedPythonCode &&
             !validationState.satisfied,
         };
       }
@@ -110,11 +97,11 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
           studentCode,
           showCompilationOption:
             !isJavalabRunning &&
-            !!runCountJavalab &&
+            hasRunOrTestedJavalabCode &&
             hasJavalabCompilationError &&
             !isWaitingForChatResponse,
           showValidationOption:
-            !!validateCountJavalab &&
+            hasRunOrTestedJavalabCode &&
             !hasJavalabCompilationError &&
             !javalabValidationPassed &&
             !isWaitingForChatResponse,
@@ -127,6 +114,9 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       fileMetadata,
       hasJavalabCompilationError,
       hasPythonlabError,
+      hasRunOrTestedJavalabCode,
+      hasRunPythonCode,
+      hasValidatedPythonCode,
       isJavalabRunning,
       isPythonlabRunning,
       isPythonlabValidating,
@@ -134,11 +124,8 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       javalabSources,
       javalabValidationPassed,
       pythonlabSource,
-      runCountJavalab,
-      runCountPythonlab,
-      validateCountJavalab,
-      validateCountPythonlab,
-      validationState,
+      validationState.hasConditions,
+      validationState.satisfied,
     ]
   );
 
@@ -155,6 +142,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       if (isWaitingForChatResponse) {
         return;
       }
+      dispatch(setShowSuggestedPrompts(false));
       dispatch(
         askAITutor({
           studentInput: QuickActions[aiTutorAction as SuggestedPromptActions],
@@ -174,7 +162,6 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
         progressionType: level?.progressionType,
         suggestedPrompt: EVENTS[suggestedPromptEventKey],
       });
-      setClickPromptCountChange(() => true);
     },
     [isWaitingForChatResponse, studentCode, dispatch, level]
   );
@@ -195,9 +182,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
     .filter(prompt => prompt.show);
   // If the user clicked on a suggested prompt, do not show a suggested prompt until the
   // clicks on the 'Run' or 'Validate'/'Test' buttons.
-  const showPrompts = !clickPromptCountChange;
-
-  return showPrompts ? (
+  return showSuggestedPrompts ? (
     <SuggestedPrompts suggestedPrompts={suggestedPrompts} />
   ) : null;
 };

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -23,32 +23,33 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
 
   const level = useAppSelector(state => state.aiTutor.level);
 
-  // For PythonLab
-  const pythonLabSource = useAppSelector(
+  // For pythonlab
+  const pythonlabSource = useAppSelector(
     state => state.lab2Project?.projectSources?.source
   );
-
-  const hasPythonLabError = useAppSelector(state => state.lab2System.hasError);
+  const hasPythonlabError = useAppSelector(state => state.lab2System.hasError);
   const hasRunPythonCode = useAppSelector(state => state.lab2System.hasRun);
+  const runCount = useAppSelector(state => state.lab2System.runCount);
+  console.log('runCount', runCount);
   const hasValidatedPythonCode = useAppSelector(
     state => state.lab2System.hasValidated
   );
-  const hasRunOrTestedPythonLabCode =
+  const hasRunOrTestedPythonlabCode =
     hasRunPythonCode || hasValidatedPythonCode;
-  const isPythonLabRunning = useAppSelector(
+  const isPythonlabRunning = useAppSelector(
     state => state.lab2System.isRunning
   );
-  const isPythonLabValidating = useAppSelector(
+  const isPythonlabValidating = useAppSelector(
     state => state.lab2System.isValidating
   );
   const {hasConditions, satisfied} = useAppSelector(
     state => state.lab.validationState
   );
-  const pythonLabValidationFailed =
+  const pythonlabValidationFailed =
     hasConditions && hasValidatedPythonCode && !satisfied;
 
-  // For JavaLab
-  const javaLabSources = useAppSelector(state => state.javalabEditor.sources);
+  // For javalab
+  const javalabSources = useAppSelector(state => state.javalabEditor.sources);
   const fileMetadata = useAppSelector(
     state => state.javalabEditor.fileMetadata
   );
@@ -56,44 +57,46 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
     state => state.javalabEditor.activeTabKey
   );
 
-  const hasJavaLabCompilationError = useAppSelector(
+  const hasJavalabCompilationError = useAppSelector(
     state => state.javalabEditor.hasCompilationError
   );
-  const hasRunOrTestedJavaLabCode = useAppSelector(
+  const hasRunOrTestedJavalabCode = useAppSelector(
     state => state.javalab.hasRunOrTestedCode
   );
-  const isJavaLabRunning = useAppSelector(state => state.javalab.isRunning);
-  const javaLabValidationPassed = useAppSelector(
+  const runCountJavalab = useAppSelector(state => state.javalab.runCount);
+  console.log('runCountJavalab', runCountJavalab);
+  const isJavalabRunning = useAppSelector(state => state.javalab.isRunning);
+  const javalabValidationPassed = useAppSelector(
     state => state.javalab.validationPassed
   );
 
   function getOptionsByLabType(labType: string) {
     if (labType === 'Pythonlab') {
       const studentCode =
-        typeof pythonLabSource !== 'string' && pythonLabSource
-          ? getActiveFileForSource(pythonLabSource)?.contents || ''
+        typeof pythonlabSource !== 'string' && pythonlabSource
+          ? getActiveFileForSource(pythonlabSource)?.contents || ''
           : '';
       // Only show a suggested prompt if we aren't currently running or validating code,
       // code has been run or validated, and we aren't waiting for a chat response.
       const showOption =
-        !isPythonLabRunning &&
-        !isPythonLabValidating &&
-        hasRunOrTestedPythonLabCode &&
+        !isPythonlabRunning &&
+        !isPythonlabValidating &&
+        hasRunOrTestedPythonlabCode &&
         !isWaitingForChatResponse;
-      const showGenericErrorOption = showOption && hasPythonLabError;
-      const showValidationOption = showOption && pythonLabValidationFailed;
+      const showGenericErrorOption = showOption && hasPythonlabError;
+      const showValidationOption = showOption && pythonlabValidationFailed;
       return {studentCode, showGenericErrorOption, showValidationOption};
     } else if (labType === 'Javalab') {
-      const studentCode = javaLabSources[fileMetadata[activeTabKey]].text;
+      const studentCode = javalabSources[fileMetadata[activeTabKey]].text;
       const showCompilationOption =
-        !isJavaLabRunning &&
-        hasRunOrTestedJavaLabCode &&
-        hasJavaLabCompilationError &&
+        !isJavalabRunning &&
+        hasRunOrTestedJavalabCode &&
+        hasJavalabCompilationError &&
         !isWaitingForChatResponse;
       const showValidationOption =
-        hasRunOrTestedJavaLabCode &&
-        !hasJavaLabCompilationError &&
-        !javaLabValidationPassed &&
+        hasRunOrTestedJavalabCode &&
+        !hasJavalabCompilationError &&
+        !javalabValidationPassed &&
         !isWaitingForChatResponse;
       return {studentCode, showCompilationOption, showValidationOption};
     }

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -180,8 +180,9 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       };
     })
     .filter(prompt => prompt.show);
-  // If the user clicked on a suggested prompt, do not show a suggested prompt until the
-  // clicks on the 'Run' or 'Validate'/'Test' buttons.
+  // `showSuggestedPrompts` ensures that if the user clicks on a suggested prompt,
+  // we do not show a suggested prompt again until the user clicks on the 'Run' or
+  // 'Validate'/'Test' buttons.
   return showSuggestedPrompts ? (
     <SuggestedPrompts suggestedPrompts={suggestedPrompts} />
   ) : null;

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -66,6 +66,8 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   const [clickPromptCountChange, setClickPromptCountChange] = useState(false);
 
   useEffect(() => {
+    // If the user clicks on 'Run' or 'Test'/'Validate', we want to show the user
+    // the suggested prompt(s) if there is an code/validation error.
     setClickPromptCountChange(false);
   }, [
     runCountJavalab,
@@ -192,6 +194,8 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
       };
     })
     .filter(prompt => prompt.show);
+  // If the user clicked on a suggested prompt, do not show a suggested prompt until the
+  // clicks on the 'Run' or 'Validate'/'Test' buttons.
   const showPrompts = !clickPromptCountChange;
 
   return showPrompts ? (

--- a/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
+++ b/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
@@ -1,5 +1,5 @@
 import Button, {buttonColors} from '@code-dot-org/component-library/button';
-import React, {useState, useEffect} from 'react';
+import React, {useState} from 'react';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -26,18 +26,6 @@ const AssistantMessageFeedback: React.FC<AssistantMessageProps> = ({
   const [detailsOpen, setDetailsOpen] = useState<boolean>(false);
 
   const level = useAppSelector(state => state.aiTutor.level);
-
-  const runCountPythonlab = useAppSelector(state => state.lab2System.runCount);
-  const validateCountPythonlab = useAppSelector(
-    state => state.lab2System.validateCount
-  );
-  const runCountJavalab = useAppSelector(state => state.javalab.runCount);
-
-  // If the user clicks on 'Run' or 'Validate', close the feedback details.
-  // This is to avoid displaying a suggested prompt chip(s) over feedback details.
-  useEffect(() => {
-    setDetailsOpen(false);
-  }, [runCountJavalab, runCountPythonlab, validateCountPythonlab]);
 
   const handleIconClick = (thumbsUp: boolean, thumbsDown: boolean) => {
     analyticsReporter.sendEvent(EVENTS.AI_TUTOR_FEEDBACK_SUBMITTED, {

--- a/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
+++ b/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
@@ -1,5 +1,5 @@
 import Button, {buttonColors} from '@code-dot-org/component-library/button';
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -26,6 +26,16 @@ const AssistantMessageFeedback: React.FC<AssistantMessageProps> = ({
   const [detailsOpen, setDetailsOpen] = useState<boolean>(false);
 
   const level = useAppSelector(state => state.aiTutor.level);
+
+  const runCountPythonlab = useAppSelector(state => state.lab2System.runCount);
+  const validateCountPythonlab = useAppSelector(
+    state => state.lab2System.validateCount
+  );
+  const runCountJavalab = useAppSelector(state => state.javalab.runCount);
+
+  useEffect(() => {
+    setDetailsOpen(false);
+  }, [runCountJavalab, runCountPythonlab, validateCountPythonlab]);
 
   const handleIconClick = (thumbsUp: boolean, thumbsDown: boolean) => {
     analyticsReporter.sendEvent(EVENTS.AI_TUTOR_FEEDBACK_SUBMITTED, {

--- a/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
+++ b/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
@@ -33,6 +33,8 @@ const AssistantMessageFeedback: React.FC<AssistantMessageProps> = ({
   );
   const runCountJavalab = useAppSelector(state => state.javalab.runCount);
 
+  // If the user clicks on 'Run' or 'Validate', close the feedback details.
+  // This is to avoid displaying a suggested prompt chip(s) over feedback details.
   useEffect(() => {
     setDetailsOpen(false);
   }, [runCountJavalab, runCountPythonlab, validateCountPythonlab]);

--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -11,6 +11,7 @@ import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {
+  incrementRunCount,
   setHasRun,
   setIsRunning,
   setIsValidating,
@@ -79,6 +80,7 @@ const ControlButtons: React.FunctionComponent = () => {
         dispatch(setIsRunning(false))
       );
       dispatch(setHasRun(true));
+      dispatch(incrementRunCount());
     } else {
       CodebridgeRegistry.getInstance()
         .getConsoleManager()

--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -6,12 +6,12 @@ import {sendCodebridgeAnalyticsEvent} from '@codebridge/utils/analyticsReporterH
 import classNames from 'classnames';
 import React, {useCallback} from 'react';
 
+import {setShowSuggestedPrompts} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {
-  incrementRunCount,
   setHasRun,
   setIsRunning,
   setIsValidating,
@@ -80,7 +80,7 @@ const ControlButtons: React.FunctionComponent = () => {
         dispatch(setIsRunning(false))
       );
       dispatch(setHasRun(true));
-      dispatch(incrementRunCount());
+      dispatch(setShowSuggestedPrompts(true));
     } else {
       CodebridgeRegistry.getInstance()
         .getConsoleManager()

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -20,6 +20,7 @@ import {
   setPredictResponse,
 } from '@cdo/apps/lab2/redux/predictLevelRedux';
 import {
+  incrementValidateCount,
   setHasValidated,
   setIsValidating,
 } from '@cdo/apps/lab2/redux/systemRedux';
@@ -176,6 +177,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
         dispatch(setIsValidating(false))
       );
       dispatch(setHasValidated(true));
+      dispatch(incrementValidateCount());
     } else {
       CodebridgeRegistry.getInstance()
         .getConsoleManager()

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import React, {useContext, useEffect, useMemo, useRef} from 'react';
 import {useSelector} from 'react-redux';
 
+import {setShowSuggestedPrompts} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
 import InstructorsOnly from '@cdo/apps/code-studio/components/InstructorsOnly';
 import {sendSubmitReport} from '@cdo/apps/code-studio/progressRedux';
 import {
@@ -20,7 +21,6 @@ import {
   setPredictResponse,
 } from '@cdo/apps/lab2/redux/predictLevelRedux';
 import {
-  incrementValidateCount,
   setHasValidated,
   setIsValidating,
 } from '@cdo/apps/lab2/redux/systemRedux';
@@ -177,7 +177,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
         dispatch(setIsValidating(false))
       );
       dispatch(setHasValidated(true));
-      dispatch(incrementValidateCount());
+      dispatch(setShowSuggestedPrompts(true));
     } else {
       CodebridgeRegistry.getInstance()
         .getConsoleManager()

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -59,6 +59,7 @@ import javalab, {
   setHasRunOrTestedCode,
   setIsJavabuilderConnecting,
   setIsCaptchaDialogOpen,
+  incrementRunCount,
 } from './redux/javalabRedux';
 import javalabView, {setDisplayTheme} from './redux/viewRedux';
 import Theater from './theater/Theater';
@@ -405,6 +406,7 @@ Javalab.prototype.executeJavabuilder = function (executionType) {
 
   getStore().dispatch(setHasRunOrTestedCode(true));
   getStore().dispatch(setIsJavabuilderConnecting(true));
+  getStore().dispatch(incrementRunCount());
 
   this.studioApp_.attempts++;
 

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -60,6 +60,7 @@ import javalab, {
   setIsJavabuilderConnecting,
   setIsCaptchaDialogOpen,
   incrementRunCount,
+  incrementValidateCount,
 } from './redux/javalabRedux';
 import javalabView, {setDisplayTheme} from './redux/viewRedux';
 import Theater from './theater/Theater';
@@ -380,6 +381,7 @@ Javalab.prototype.onRun = function () {
     levelId: this.levelIdForAnalytics,
   });
   this.executeJavabuilder(ExecutionType.RUN);
+  getStore().dispatch(incrementRunCount());
 };
 
 Javalab.prototype.onTest = function () {
@@ -395,6 +397,7 @@ Javalab.prototype.onTest = function () {
     validated: validated,
   });
   this.executeJavabuilder(ExecutionType.TEST);
+  getStore().dispatch(incrementValidateCount());
 };
 
 Javalab.prototype.executeJavabuilder = function (executionType) {
@@ -406,7 +409,6 @@ Javalab.prototype.executeJavabuilder = function (executionType) {
 
   getStore().dispatch(setHasRunOrTestedCode(true));
   getStore().dispatch(setIsJavabuilderConnecting(true));
-  getStore().dispatch(incrementRunCount());
 
   this.studioApp_.attempts++;
 

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 
+import {setShowSuggestedPrompts} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
 import {showLevelBuilderSaveButton} from '@cdo/apps/code-studio/header';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {lockContainedLevelAnswers} from '@cdo/apps/code-studio/levels/codeStudioLevels';
@@ -59,8 +60,6 @@ import javalab, {
   setHasRunOrTestedCode,
   setIsJavabuilderConnecting,
   setIsCaptchaDialogOpen,
-  incrementRunCount,
-  incrementValidateCount,
 } from './redux/javalabRedux';
 import javalabView, {setDisplayTheme} from './redux/viewRedux';
 import Theater from './theater/Theater';
@@ -381,7 +380,7 @@ Javalab.prototype.onRun = function () {
     levelId: this.levelIdForAnalytics,
   });
   this.executeJavabuilder(ExecutionType.RUN);
-  getStore().dispatch(incrementRunCount());
+  getStore().dispatch(setShowSuggestedPrompts(true));
 };
 
 Javalab.prototype.onTest = function () {
@@ -397,7 +396,7 @@ Javalab.prototype.onTest = function () {
     validated: validated,
   });
   this.executeJavabuilder(ExecutionType.TEST);
-  getStore().dispatch(incrementValidateCount());
+  getStore().dispatch(setShowSuggestedPrompts(true));
 };
 
 Javalab.prototype.executeJavabuilder = function (executionType) {

--- a/apps/src/javalab/redux/javalabRedux.ts
+++ b/apps/src/javalab/redux/javalabRedux.ts
@@ -17,8 +17,6 @@ export interface JavalabState {
   hasRunOrTestedCode: boolean;
   isJavabuilderConnecting: boolean;
   isCaptchaDialogOpen: boolean;
-  runCount: number;
-  validateCount: number;
 }
 
 const initialState: JavalabState = {
@@ -35,8 +33,6 @@ const initialState: JavalabState = {
   hasRunOrTestedCode: false,
   isJavabuilderConnecting: false,
   isCaptchaDialogOpen: false,
-  runCount: 0,
-  validateCount: 0,
 };
 
 const javalabSlice = createSlice({
@@ -92,12 +88,6 @@ const javalabSlice = createSlice({
     setIsCaptchaDialogOpen(state, action: PayloadAction<boolean>) {
       state.isCaptchaDialogOpen = action.payload;
     },
-    incrementRunCount(state) {
-      state.runCount += 1;
-    },
-    incrementValidateCount(state) {
-      state.validateCount += 1;
-    },
   },
 });
 
@@ -114,8 +104,6 @@ export const {
   setValidationPassed,
   setHasRunOrTestedCode,
   setIsCaptchaDialogOpen,
-  incrementRunCount,
-  incrementValidateCount,
 } = javalabSlice.actions;
 
 export default javalabSlice.reducer;

--- a/apps/src/javalab/redux/javalabRedux.ts
+++ b/apps/src/javalab/redux/javalabRedux.ts
@@ -1,7 +1,6 @@
 /**
  * Redux store for generic Java Lab state.
  */
-
 import {PayloadAction, createSlice} from '@reduxjs/toolkit';
 
 export interface JavalabState {
@@ -18,6 +17,7 @@ export interface JavalabState {
   hasRunOrTestedCode: boolean;
   isJavabuilderConnecting: boolean;
   isCaptchaDialogOpen: boolean;
+  runCount: number;
 }
 
 const initialState: JavalabState = {
@@ -34,6 +34,7 @@ const initialState: JavalabState = {
   hasRunOrTestedCode: false,
   isJavabuilderConnecting: false,
   isCaptchaDialogOpen: false,
+  runCount: 0,
 };
 
 const javalabSlice = createSlice({
@@ -89,6 +90,9 @@ const javalabSlice = createSlice({
     setIsCaptchaDialogOpen(state, action: PayloadAction<boolean>) {
       state.isCaptchaDialogOpen = action.payload;
     },
+    incrementRunCount(state) {
+      state.runCount += 1;
+    },
   },
 });
 
@@ -105,6 +109,7 @@ export const {
   setValidationPassed,
   setHasRunOrTestedCode,
   setIsCaptchaDialogOpen,
+  incrementRunCount,
 } = javalabSlice.actions;
 
 export default javalabSlice.reducer;

--- a/apps/src/javalab/redux/javalabRedux.ts
+++ b/apps/src/javalab/redux/javalabRedux.ts
@@ -18,6 +18,7 @@ export interface JavalabState {
   isJavabuilderConnecting: boolean;
   isCaptchaDialogOpen: boolean;
   runCount: number;
+  validateCount: number;
 }
 
 const initialState: JavalabState = {
@@ -35,6 +36,7 @@ const initialState: JavalabState = {
   isJavabuilderConnecting: false,
   isCaptchaDialogOpen: false,
   runCount: 0,
+  validateCount: 0,
 };
 
 const javalabSlice = createSlice({
@@ -93,6 +95,9 @@ const javalabSlice = createSlice({
     incrementRunCount(state) {
       state.runCount += 1;
     },
+    incrementValidateCount(state) {
+      state.validateCount += 1;
+    },
   },
 });
 
@@ -110,6 +115,7 @@ export const {
   setHasRunOrTestedCode,
   setIsCaptchaDialogOpen,
   incrementRunCount,
+  incrementValidateCount,
 } = javalabSlice.actions;
 
 export default javalabSlice.reducer;

--- a/apps/src/javalab/redux/javalabRedux.ts
+++ b/apps/src/javalab/redux/javalabRedux.ts
@@ -1,6 +1,7 @@
 /**
  * Redux store for generic Java Lab state.
  */
+
 import {PayloadAction, createSlice} from '@reduxjs/toolkit';
 
 export interface JavalabState {

--- a/apps/src/lab2/redux/systemRedux.ts
+++ b/apps/src/lab2/redux/systemRedux.ts
@@ -11,8 +11,6 @@ export interface Lab2SystemState {
   isValidating: boolean;
   hasValidated: boolean;
   hasError: boolean;
-  runCount: number;
-  validateCount: number;
 }
 
 const initialState: Lab2SystemState = {
@@ -22,8 +20,6 @@ const initialState: Lab2SystemState = {
   isValidating: false,
   hasValidated: false,
   hasError: false,
-  runCount: 0,
-  validateCount: 0,
 };
 
 // SLICE
@@ -49,12 +45,6 @@ const systemSlice = createSlice({
     setHasError(state, action: PayloadAction<boolean>) {
       state.hasError = action.payload;
     },
-    incrementRunCount(state) {
-      state.runCount += 1;
-    },
-    incrementValidateCount(state) {
-      state.validateCount += 1;
-    },
   },
 });
 
@@ -65,8 +55,6 @@ export const {
   setIsValidating,
   setHasValidated,
   setHasError,
-  incrementRunCount,
-  incrementValidateCount,
 } = systemSlice.actions;
 
 export default systemSlice.reducer;

--- a/apps/src/lab2/redux/systemRedux.ts
+++ b/apps/src/lab2/redux/systemRedux.ts
@@ -11,6 +11,7 @@ export interface Lab2SystemState {
   isValidating: boolean;
   hasValidated: boolean;
   hasError: boolean;
+  runCount: number;
 }
 
 const initialState: Lab2SystemState = {
@@ -20,6 +21,7 @@ const initialState: Lab2SystemState = {
   isValidating: false,
   hasValidated: false,
   hasError: false,
+  runCount: 0,
 };
 
 // SLICE
@@ -45,6 +47,9 @@ const systemSlice = createSlice({
     setHasError(state, action: PayloadAction<boolean>) {
       state.hasError = action.payload;
     },
+    incrementRunCount(state) {
+      state.runCount += 1;
+    },
   },
 });
 
@@ -55,6 +60,7 @@ export const {
   setIsValidating,
   setHasValidated,
   setHasError,
+  incrementRunCount,
 } = systemSlice.actions;
 
 export default systemSlice.reducer;

--- a/apps/src/lab2/redux/systemRedux.ts
+++ b/apps/src/lab2/redux/systemRedux.ts
@@ -12,6 +12,7 @@ export interface Lab2SystemState {
   hasValidated: boolean;
   hasError: boolean;
   runCount: number;
+  validateCount: number;
 }
 
 const initialState: Lab2SystemState = {
@@ -22,6 +23,7 @@ const initialState: Lab2SystemState = {
   hasValidated: false,
   hasError: false,
   runCount: 0,
+  validateCount: 0,
 };
 
 // SLICE
@@ -50,6 +52,9 @@ const systemSlice = createSlice({
     incrementRunCount(state) {
       state.runCount += 1;
     },
+    incrementValidateCount(state) {
+      state.validateCount += 1;
+    },
   },
 });
 
@@ -61,6 +66,7 @@ export const {
   setHasValidated,
   setHasError,
   incrementRunCount,
+  incrementValidateCount,
 } = systemSlice.actions;
 
 export default systemSlice.reducer;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR resolves the issue of a suggested prompt overlapping the assistant feedback details textbox.
When a user's code results in a compilation (`javalab`), validation (both labs), or generic code error (`pythonlab`), a suggested prompt is displayed as a chip. The user can select a prompt and it will convert to a user chat message in the chat history.

This PR updates logic so that if a user clicks on a suggested prompt, a suggested prompt will not be displayed until the user either clicks on the run or validate/test button.
Thus, the user can read the assistant message, give feedback without an obstructed view, update code, and then once they run/test code, the suggested prompts will be displayed if there is an error in code/validation.
[Slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1741217863481849?thread_ts=1741023588.033419&cid=C06JELCAPT9) - confirmed with product/curriculum that they're good with this approach to fixing overlapping issue.

In order to implement this, I added the `showSuggestedPrompts` state value in `aiTutorRedux` that is updated when a user clicks on the 'Run' or 'Test'/'Validate' button in `pythonlab` and `javalab`.

While here, I took time to refactor the `AITutorSuggestedPrompt` component.

## Before update

Screencast video of AI Tutor in `pythonlab` (this is also happening in `javalab`).

https://github.com/user-attachments/assets/e7371e5f-545f-4c75-8ba8-e825609ab9a2



## After update

Screencast video of AI Tutor in `pythonlab`:

https://github.com/user-attachments/assets/4965ef9e-f5bd-4619-84ba-004f09bb8d49

Screencast video of AI Tutor in `javalab`:

https://github.com/user-attachments/assets/758d3ea4-5ba2-4411-8d86-19efa51bd559


## Links
[jira](https://codedotorg.atlassian.net/browse/CT-1120)
[Slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1741023588033419)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally on `pythonlab` and `javalab` levels including those with validation tests.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
[3 dots don't show up if first message is a suggested prompt](https://codedotorg.atlassian.net/browse/CT-1117)
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
