### PR TITLE
Python Lab: add retry if package load fails

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -35,31 +35,20 @@ async function loadPyodideAndPackages() {
 
   // Pre-load our custom packages (unittest_runner and pythonlab_setup), as well as
   // matplotlib, which pythonlab_setup depends on, and numpy,
-  // which will frequently be used. We have seen issues with loading these via
-  // loadPyodide, so we load them here to ensure they are available.
-  const loadErrors: string[] = [];
-  await pyodide.loadPackage(
-    [
-      'numpy',
-      'matplotlib',
-      // These are custom packages that we have built. They are defined in the
-      // python/pythonlab/ folder in the codebase.
-      `/blockly/js/pyodide/${version}/unittest_runner-0.1.0-py3-none-any.whl`,
-      `/blockly/js/pyodide/${version}/pythonlab_setup-0.2.0-py3-none-any.whl`,
-      `/blockly/js/pyodide/${version}/neighborhood-0.2.0-py3-none-any.whl`,
-    ],
-    {
-      errorCallback: (message: string) => {
-        loadErrors.push(message);
-      },
-    }
-  );
+  // which will frequently be used. We have seen occasional issues with loading
+  // packages, so we retry loading if we see any errors.
+  let loadErrors = await loadPackages();
   if (loadErrors.length > 0) {
-    postMessage({
-      type: 'internal_error',
-      message: `Error(s) loading python packages: ${loadErrors.join('\n')}`,
-      id: 'startup',
-    });
+    // Retry loading packages once. Any packages that were successfully loaded
+    // will be skipped in the retry.
+    loadErrors = await loadPackages();
+    if (loadErrors.length > 0) {
+      postMessage({
+        type: 'internal_error',
+        message: `Error(s) loading python packages: ${loadErrors.join('\n')}`,
+        id: 'startup',
+      });
+    }
   }
   // Warm up the pyodide environment by running setup code.
   await runInternalCode(SETUP_CODE, -1);
@@ -170,4 +159,25 @@ function getStreamHandlerOptions(type: MessageType) {
 
 async function patchInput(id: number) {
   await runInternalCode(patchInputCode(id), id);
+}
+
+async function loadPackages() {
+  const loadErrors: string[] = [];
+  await pyodide.loadPackage(
+    [
+      'numpy',
+      'matplotlib',
+      // These are custom packages that we have built. They are defined in the
+      // python/pythonlab/ folder in the codebase.
+      `/blockly/js/pyodide/${version}/unittest_runner-0.1.0-py3-none-any.whl`,
+      `/blockly/js/pyodide/${version}/pythonlab_setup-0.2.0-py3-none-any.whl`,
+      `/blockly/js/pyodide/${version}/neighborhood-0.2.0-py3-none-any.whl`,
+    ],
+    {
+      errorCallback: (message: string) => {
+        loadErrors.push(message);
+      },
+    }
+  );
+  return loadErrors;
 }


### PR DESCRIPTION
We see occasional issues where a package that should have been loaded by our setup package load is not found. I added logging previously to see if the load was failing; at least in some cases it is. This adds a retry if the initial package load returns any errors.

## Links
- [Cloudwatch dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/PythonLab?start=PT168H&end=null)

## Testing story
Tested locally--if we see a load failure we retry, then log if the retry failed. Otherwise the code behaves as normal.

## Follow-up work
After this has been deployed for a few days I'll check to see if our failures decrease.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
