### PR TITLE
fix(bundler): do not use style injection

### DIFF
--- a/apps/jest.config.js
+++ b/apps/jest.config.js
@@ -96,7 +96,7 @@ const config = {
   // globals: {},
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-  maxWorkers: '50%',
+  // maxWorkers: '100%',
 
   // An array of directory names to be searched recursively up from the requiring module's location
   // moduleDirectories: [

--- a/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
+++ b/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
@@ -58,7 +58,7 @@ describe('FileTabs', () => {
     const user = userEvent.setup();
     await user.click(tab);
     expect(context.setActiveFile).toHaveBeenCalledWith(file.id);
-  }, 10000);
+  });
 
   it('can close a tab', async () => {
     renderDefault();
@@ -68,5 +68,5 @@ describe('FileTabs', () => {
     const user = userEvent.setup();
     await user.click(closeButton);
     expect(context.closeFile).toHaveBeenCalledWith('1');
-  }, 15000);
+  });
 });

--- a/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryButtonTest.tsx
+++ b/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryButtonTest.tsx
@@ -101,7 +101,7 @@ describe('VersionHistoryButton', () => {
     getByText('Initial version');
     getByRole('button', {name: 'Restore'});
     getByRole('button', {name: 'Cancel'});
-  }, 10000);
+  });
 
   it('renders alert if getVersionList fails', async () => {
     mockedProjectManager = {
@@ -143,7 +143,7 @@ describe('VersionHistoryButton', () => {
     // 3 is the latest version in the sample version list.
     const latestVersion = getByDisplayValue('3') as HTMLInputElement;
     expect(latestVersion.checked).toBe(true);
-  }, 10000);
+  });
 
   it('restores selected version on restore', async () => {
     const {getByDisplayValue, getByRole, queryByRole} = renderDefault();
@@ -172,5 +172,5 @@ describe('VersionHistoryButton', () => {
       {timeout: 2000}
     );
     expect(queryByRole('dialog', {name: 'Version History List'})).toBeNull();
-  }, 10000);
+  });
 });

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -106,5 +106,5 @@ describe('TeacherHomepage', () => {
 
     await screen.findByText('hidden');
     expect(screen.queryByText('Period 1')).toBeNull();
-  }, 10000);
+  });
 });

--- a/frontend/apps/design-system-storybook/.storybook/main.ts
+++ b/frontend/apps/design-system-storybook/.storybook/main.ts
@@ -1,5 +1,6 @@
 import {join, dirname, resolve} from 'node:path';
 import {StorybookConfig} from '@storybook/react-webpack5';
+import {IgnorePlugin} from 'webpack';
 
 /**
  * This function is used to resolve the absolute path of a package.
@@ -89,6 +90,17 @@ const config: StorybookConfig = {
         ...config.resolve.alias,
         '@': resolve(__dirname, '../../../packages/component-library/src'),
       };
+    }
+
+    if (config.plugins) {
+      // Ignore the auto generated index.css which is bundled by tsup
+      // webpack generates its own css in the styling plugin above
+      config.plugins.push(
+        new IgnorePlugin({
+          resourceRegExp: /^\.\/index.css$/,
+          contextRegExp: /component-library\/src/,
+        }),
+      );
     }
 
     return config;

--- a/frontend/apps/marketing/src/components/button/Button.tsx
+++ b/frontend/apps/marketing/src/components/button/Button.tsx
@@ -1,4 +1,3 @@
-import '@code-dot-org/component-library/button/index.css';
 import {
   ButtonColor,
   ButtonType,

--- a/frontend/apps/marketing/src/components/divider/index.ts
+++ b/frontend/apps/marketing/src/components/divider/index.ts
@@ -1,5 +1,3 @@
-import '@code-dot-org/component-library/divider/index.css';
-
 // Export the Component Definition for use in Contentful Studio
 export {DividerContentfulComponentDefinition} from './dividerContentfulDefinition';
 export {default} from '@code-dot-org/component-library/divider';

--- a/frontend/apps/marketing/src/components/heading/Heading.tsx
+++ b/frontend/apps/marketing/src/components/heading/Heading.tsx
@@ -1,4 +1,3 @@
-import '@code-dot-org/component-library/typography/index.css';
 import {
   default as Typography,
   VisualAppearance,

--- a/frontend/apps/marketing/src/components/link/Link.tsx
+++ b/frontend/apps/marketing/src/components/link/Link.tsx
@@ -1,4 +1,3 @@
-import '@code-dot-org/component-library/link/index.css';
 import {default as DSCOLink} from '@code-dot-org/component-library/link';
 import {ComponentSizeXSToL} from '@code-dot-org/component-library/common/types';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';

--- a/frontend/apps/marketing/src/components/overline/Overline.tsx
+++ b/frontend/apps/marketing/src/components/overline/Overline.tsx
@@ -1,4 +1,3 @@
-import '@code-dot-org/component-library/typography/index.css';
 import {
   default as Typography,
   VisualAppearance,

--- a/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
+++ b/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
@@ -1,4 +1,3 @@
-import '@code-dot-org/component-library/typography/index.css';
 import {
   default as Typography,
   StrongText,

--- a/frontend/apps/marketing/src/components/paragraph/index.ts
+++ b/frontend/apps/marketing/src/components/paragraph/index.ts
@@ -1,5 +1,3 @@
-import '@code-dot-org/component-library/typography/index.css';
-
 // Export the Component Definition for use in Contentful Studio
 export {ParagraphContentfulComponentDefinition} from './ParagraphContentfulDefinition';
 export {default} from './Paragraph';

--- a/frontend/apps/marketing/src/components/section/index.ts
+++ b/frontend/apps/marketing/src/components/section/index.ts
@@ -1,5 +1,3 @@
-import '@code-dot-org/component-library/cms/section/index.css';
-
 // Export the Component Definition for use in Contentful Studio
 export {SectionContentfulComponentDefinition} from './sectionContentfulDefinition';
 export {default} from './Section';

--- a/frontend/apps/marketing/src/components/video/index.ts
+++ b/frontend/apps/marketing/src/components/video/index.ts
@@ -1,5 +1,3 @@
-import '@code-dot-org/component-library/video/index.css';
-
 // Export the Component Definition for use in Contentful Studio
 export {VideoContentfulComponentDefinition} from './videoContentfulDefinition';
 export {default} from '@code-dot-org/component-library/video';

--- a/frontend/packages/component-library/src/accordion/faqAccordion/index.ts
+++ b/frontend/packages/component-library/src/accordion/faqAccordion/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {default as FAQAccordion, FAQAccordionProps} from './FAQAccordion';
 export {default as default} from './FAQAccordion';

--- a/frontend/packages/component-library/src/accordion/index.ts
+++ b/frontend/packages/component-library/src/accordion/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {default as Accordion, AccordionProps} from './Accordion';
 export {default as FAQAccordion, FAQAccordionProps} from './faqAccordion';
 export {default as default} from './Accordion';

--- a/frontend/packages/component-library/src/alert/index.ts
+++ b/frontend/packages/component-library/src/alert/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {AlertProps} from './Alert';
 export {alertTypes, default as default} from './Alert';

--- a/frontend/packages/component-library/src/breadcrumbs/index.ts
+++ b/frontend/packages/component-library/src/breadcrumbs/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {default as Breadcrumbs, BreadcrumbsProps} from './Breadcrumbs';
 export {default as default} from './Breadcrumbs';

--- a/frontend/packages/component-library/src/button/index.ts
+++ b/frontend/packages/component-library/src/button/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 // Types
 export {ButtonType, ButtonColor} from './types';
 

--- a/frontend/packages/component-library/src/carousel/index.ts
+++ b/frontend/packages/component-library/src/carousel/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {default as Carousel, CarouselProps} from './Carousel';
 export {default as default} from './Carousel';

--- a/frontend/packages/component-library/src/checkbox/index.ts
+++ b/frontend/packages/component-library/src/checkbox/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {CheckboxProps} from './Checkbox';
 export {default as default} from './Checkbox';

--- a/frontend/packages/component-library/src/chips/index.ts
+++ b/frontend/packages/component-library/src/chips/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {default as Chips, ChipsProps} from './Chips';
 export {default as default} from './Chips';

--- a/frontend/packages/component-library/src/closeButton/index.ts
+++ b/frontend/packages/component-library/src/closeButton/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {CloseButtonProps} from './CloseButton';
 export {default as default} from './CloseButton';

--- a/frontend/packages/component-library/src/cms/section/index.ts
+++ b/frontend/packages/component-library/src/cms/section/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {default as Section, SectionProps} from './Section';
 export {default as default} from './Section';
 

--- a/frontend/packages/component-library/src/common/constants/index.ts
+++ b/frontend/packages/component-library/src/common/constants/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 /**
  * This file contains constants that are used across the component library
  */

--- a/frontend/packages/component-library/src/common/constants/index.ts
+++ b/frontend/packages/component-library/src/common/constants/index.ts
@@ -1,6 +1,3 @@
-// Auto-import SASS generated CSS
-import './index.css';
-
 /**
  * This file contains constants that are used across the component library
  */

--- a/frontend/packages/component-library/src/common/contexts/index.ts
+++ b/frontend/packages/component-library/src/common/contexts/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {useDropdownContext, DropdownProviderWrapper} from './DropdownContext';
 
 export {useTheme, ThemeProvider} from './ThemeContext';

--- a/frontend/packages/component-library/src/common/contexts/index.ts
+++ b/frontend/packages/component-library/src/common/contexts/index.ts
@@ -1,6 +1,3 @@
-// Auto-import SASS generated CSS
-import './index.css';
-
 export {useDropdownContext, DropdownProviderWrapper} from './DropdownContext';
 
 export {useTheme, ThemeProvider} from './ThemeContext';

--- a/frontend/packages/component-library/src/common/helpers/index.ts
+++ b/frontend/packages/component-library/src/common/helpers/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 import React, {AriaAttributes} from 'react';
 
 import {ComponentPlacementDirection} from '@/common/types';

--- a/frontend/packages/component-library/src/common/helpers/index.ts
+++ b/frontend/packages/component-library/src/common/helpers/index.ts
@@ -1,6 +1,3 @@
-// Auto-import SASS generated CSS
-import './index.css';
-
 import React, {AriaAttributes} from 'react';
 
 import {ComponentPlacementDirection} from '@/common/types';

--- a/frontend/packages/component-library/src/common/hooks/index.ts
+++ b/frontend/packages/component-library/src/common/hooks/index.ts
@@ -1,6 +1,3 @@
-// Auto-import SASS generated CSS
-import './index.css';
-
 import useBodyScrollLock from './useBodyScrollLock';
 import useDocumentKeydown from './useDocumentKeydown';
 import useEscapeKeyHandler from './useEscapeKeyHandler';

--- a/frontend/packages/component-library/src/common/hooks/index.ts
+++ b/frontend/packages/component-library/src/common/hooks/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 import useBodyScrollLock from './useBodyScrollLock';
 import useDocumentKeydown from './useDocumentKeydown';
 import useEscapeKeyHandler from './useEscapeKeyHandler';

--- a/frontend/packages/component-library/src/common/types/index.ts
+++ b/frontend/packages/component-library/src/common/types/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 import {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
 /**

--- a/frontend/packages/component-library/src/common/types/index.ts
+++ b/frontend/packages/component-library/src/common/types/index.ts
@@ -1,6 +1,3 @@
-// Auto-import SASS generated CSS
-import './index.css';
-
 import {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
 /**

--- a/frontend/packages/component-library/src/dialog/index.ts
+++ b/frontend/packages/component-library/src/dialog/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {DialogProps} from './Dialog';
 export type {CustomDialogProps} from './CustomDialog';
 export {default as CustomDialog} from './CustomDialog';

--- a/frontend/packages/component-library/src/divider/index.ts
+++ b/frontend/packages/component-library/src/divider/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {default as Divider, DividerProps} from './Divider';
 export {default as default} from './Divider';

--- a/frontend/packages/component-library/src/dropdown/actionDropdown/index.ts
+++ b/frontend/packages/component-library/src/dropdown/actionDropdown/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {ActionDropdownProps, ActionDropdownOption} from './ActionDropdown';
 export {default as default} from './ActionDropdown';

--- a/frontend/packages/component-library/src/dropdown/checkboxDropdown/index.ts
+++ b/frontend/packages/component-library/src/dropdown/checkboxDropdown/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {
   CheckboxDropdownProps,
   CheckboxDropdownOption,

--- a/frontend/packages/component-library/src/dropdown/iconDropdown/index.ts
+++ b/frontend/packages/component-library/src/dropdown/iconDropdown/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {IconDropdownProps, IconDropdownOption} from './IconDropdown';
 export {default as default} from './IconDropdown';

--- a/frontend/packages/component-library/src/dropdown/index.ts
+++ b/frontend/packages/component-library/src/dropdown/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 import ActionDropdown, {
   ActionDropdownProps,
 } from './actionDropdown/ActionDropdown';

--- a/frontend/packages/component-library/src/dropdown/simpleDropdown/index.ts
+++ b/frontend/packages/component-library/src/dropdown/simpleDropdown/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {SimpleDropdownProps} from './SimpleDropdown';
 export {default as default} from './SimpleDropdown';

--- a/frontend/packages/component-library/src/formFieldWrapper/index.ts
+++ b/frontend/packages/component-library/src/formFieldWrapper/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {FormFieldWrapperProps} from './FormFieldWrapper';
 export {default as default} from './FormFieldWrapper';

--- a/frontend/packages/component-library/src/link/index.ts
+++ b/frontend/packages/component-library/src/link/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {
   LinkProps,
   LinkBaseProps,

--- a/frontend/packages/component-library/src/modal/index.ts
+++ b/frontend/packages/component-library/src/modal/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {ModalProps} from './Modal';
 export {default as default} from './Modal';

--- a/frontend/packages/component-library/src/popover/index.ts
+++ b/frontend/packages/component-library/src/popover/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {PopoverProps} from './Popover';
 export type {WithPopoverProps} from './WithPopover';
 export {default as WithPopover} from './WithPopover';

--- a/frontend/packages/component-library/src/radioButton/index.ts
+++ b/frontend/packages/component-library/src/radioButton/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {default as RadioButton} from './RadioButton';
 export type {RadioButtonProps} from './RadioButton';
 export {default as RadioButtonsGroup} from './RadioButtonsGroup';

--- a/frontend/packages/component-library/src/segmentedButtons/index.ts
+++ b/frontend/packages/component-library/src/segmentedButtons/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {SegmentedButtonsProps} from './SegmentedButtons';
 export {default as default} from './SegmentedButtons';

--- a/frontend/packages/component-library/src/slider/index.ts
+++ b/frontend/packages/component-library/src/slider/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {SliderProps} from './Slider';
 export {default as default} from './Slider';

--- a/frontend/packages/component-library/src/tabs/index.ts
+++ b/frontend/packages/component-library/src/tabs/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {TabsProps} from './Tabs';
 export {default as default} from './Tabs';

--- a/frontend/packages/component-library/src/tags/index.ts
+++ b/frontend/packages/component-library/src/tags/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {TagsProps} from './Tags';
 export type {TagProps} from './_Tag';
 export {default as default} from './Tags';

--- a/frontend/packages/component-library/src/textField/index.ts
+++ b/frontend/packages/component-library/src/textField/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {TextFieldProps} from './TextField';
 export {default as default} from './TextField';

--- a/frontend/packages/component-library/src/toggle/index.ts
+++ b/frontend/packages/component-library/src/toggle/index.ts
@@ -1,2 +1,5 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {ToggleProps} from './Toggle';
 export {default as default} from './Toggle';

--- a/frontend/packages/component-library/src/tooltip/index.ts
+++ b/frontend/packages/component-library/src/tooltip/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export type {TooltipProps, TooltipOverlayProps} from './_Tooltip';
 export {
   default as default,

--- a/frontend/packages/component-library/src/typography/index.ts
+++ b/frontend/packages/component-library/src/typography/index.ts
@@ -1,3 +1,6 @@
+// Auto-import SASS generated CSS
+import './index.css';
+
 export * from './TypographyElements';
 export * from './types';
 export {default as default, TypographyProps} from './Typography';

--- a/frontend/packages/component-library/src/video/index.ts
+++ b/frontend/packages/component-library/src/video/index.ts
@@ -1,5 +1,8 @@
 // Add this to prevent a Next.js build error in Contentful
 'use client';
 
+// Auto-import SASS generated CSS
+import './index.css';
+
 export {default as Video, VideoProps} from './Video';
 export {default as default} from './Video';

--- a/frontend/packages/component-library/tsup.config.ts
+++ b/frontend/packages/component-library/tsup.config.ts
@@ -20,7 +20,9 @@ function createConfig(format: 'cjs' | 'esm'): Options {
     outDir: `dist/${format}`,
     target: 'es2019',
     format: [format],
+    external: ['./index.css'],
     dts: false, // See typescript generator below
+    splitting: false,
     async onSuccess() {
       console.log(`Generating typescript types...`);
       // This generates the .d.ts files using the official typescript compiler, `tsc`
@@ -55,10 +57,7 @@ function createConfig(format: 'cjs' | 'esm'): Options {
     sourcemap: true,
     esbuildPlugins: [
       sassPlugin({
-        // In ESM mode, CSS Modules are generated which can be cached via the CSS loader.
-        // In CJS mode, styles are injected into the DOM (resulting in a lengthy DOM and lower performance)
-        // CJS mode is utilized by `code-dot-org/apps`, whereas newer applications (such as `marketing`) use ESM mode by default.
-        type: format === 'esm' ? 'css' : 'style',
+        type: 'css',
         transform: postcssModules({
           generateScopedName: '[name]__[local]___[hash:base64:5]',
         }),


### PR DESCRIPTION
When the component library was still in `apps`, its CSS was bundled by Webpack and injected into the DOM. However, jest does not use webpack - rather it bypasses it altogether and uses babel transpilation. This makes sense in unit tests as it cannot "see" styles and CSS files are mocked out anyway. This meant styles are NOT injected in unit tests and therefore the DOM is free of CSS.

When the component library was split out from `apps`, the component library was built to auto-inject styles from the library's entrypoint directly into the DOM. This had a side effect - since the entrypoint is invoked in both unit tests and in browsers, the styles end up being injected into the DOM and thus causes (technically unnecessary) styles to be in the DOM.

For complex tests that include number of component library components in its tree, the tests will become excruciatingly slow. This is because of an existing problem in the component library - the CSS is highly duplicated. For example, each declaration of `Typography` includes its CSS, so for complex trees, there could be dozens of `Typography` components, each with its own entire set of duplicated CSS. In effect, jest is simply showing what happens to students and teachers today in which Code.org's DOM consumes a rather large amount of memory.

To restore stability to jest, this PR restores the prior behavior of style autoinjection by way of the consuming application's bundler (Webpack in this case). Each entrypoint will reference `index.css` and it is now the bundler's responsibility to include it in an optimal manner. This does not resolve the duplicated CSS issue, but it will cause jest to not have performance issues since the styles will no longer be injected into its DOM (since it does not use webpack). This will have the side effect of massively reducing the memory consumption of each jest worker and thus removing a large source of performance issues due to resource consumption constraints.

A [follow up](https://codedotorg.atlassian.net/browse/CMS-393) is to eliminate the duplicated CSS in the component library which is important to do for performance reasons, but not necessary in this PR as the scope of this one is to restore stability to jest.

---

# Testing

Benchmarking for tests that were consistently flaky before:

| Test                     | Previous Runtime | New Runtime |
|--------------------------|------------------|-------------|
| VersionHistoryButtonTest | 3,000 ms         | 228 ms      |
| TeacherHomepageTest      | 1,877 ms         | 97 ms       |
| FileTabsTest             | 1,782 ms         | 88 ms       |
| LearningGoalsTest        | 3,941 ms         | 562 ms      |
| RubricContainerTest      | 13,657 ms        | 9,072 ms    |

