### PR TITLE
Codebridge: Add an alert banner when the project is too large

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -69,6 +69,7 @@
   "noOpenFiles": "Open a file to get started!",
   "predictRunDisabledTooltip": "You must answer the question in the instructions before running the code.",
   "preview": "Preview",
+  "projectTooLarge": "Sorry, your project is too large to save. Please delete some code and try again.",
   "renameFile": "Rename",
   "renameFolder": "Rename",
   "replace": "Replace",

--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -69,7 +69,7 @@
   "noOpenFiles": "Open a file to get started!",
   "predictRunDisabledTooltip": "You must answer the question in the instructions before running the code.",
   "preview": "Preview",
-  "projectTooLarge": "Sorry, your project is too large to save. Please delete some code and try again.",
+  "projectTooLarge": "Sorry, your project is too large to save. Please delete some code.",
   "renameFile": "Rename",
   "renameFolder": "Rename",
   "replace": "Replace",

--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -69,7 +69,7 @@
   "noOpenFiles": "Open a file to get started!",
   "predictRunDisabledTooltip": "You must answer the question in the instructions before running the code.",
   "preview": "Preview",
-  "projectTooLarge": "Sorry, your project is too large to save. Please delete some code.",
+  "projectTooLarge": "Sorry, your project is too large to save. Decrease your project size by deleting files or lines of code/text.",
   "renameFile": "Rename",
   "renameFolder": "Rename",
   "replace": "Replace",

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -42,6 +42,9 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
   const showLockedFilesBanner = useAppSelector(
     state => state.codebridgeWorkspace.showLockedFilesBanner
   );
+  const projectTooLarge = useAppSelector(
+    state => state.lab2Project.projectTooLarge
+  );
   const dispatch = useAppDispatch();
 
   const headerContent = (
@@ -113,6 +116,9 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
                 }
                 type={'warning'}
               />
+            )}
+            {projectTooLarge && (
+              <Alert text={codebridgeI18n.projectTooLarge()} type={'danger'} />
             )}
             {viewingOldVersion && (
               <Alert

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -45,6 +45,7 @@ import {
 import ProjectManager from './projects/ProjectManager';
 import ProjectManagerFactory from './projects/ProjectManagerFactory';
 import {getPredictResponse} from './projects/userLevelsApi';
+import {setProjectTooLarge} from './redux/lab2ProjectRedux';
 import {LevelPropertiesValidator} from './responseValidators';
 import {
   AppName,
@@ -547,7 +548,13 @@ async function setUpAndLoadProject(
       dispatch(setProjectUpdatedSaved());
     }
   });
-  projectManager.addSaveFailListener(() => dispatch(setProjectUpdatedError()));
+  projectManager.addSaveFailListener(error => {
+    dispatch(setProjectUpdatedError());
+    if (error.message?.includes('413')) {
+      // The user's project is too large to save. Mark it as too large.
+      dispatch(setProjectTooLarge(true));
+    }
+  });
   // Figure out if we should reset to start sources. This happens if the url parameter
   // ?reset=true is present.
   // This parameter is only used by levelbuilders.

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -539,6 +539,8 @@ async function setUpAndLoadProject(
   projectManager.addSaveSuccessListener(channel => {
     dispatch(setProjectUpdatedAt(channel.updatedAt));
     dispatch(setChannel(channel));
+    // If we had a successful save, we know the project is not too large.
+    dispatch(setProjectTooLarge(false));
   });
   projectManager.addSaveNoopListener(channel => {
     if (channel) {

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -436,10 +436,9 @@ export default class ProjectManager {
       this.metricsReporter.logWarning(`${error.message}. Reloading page.`);
       reload();
     } else if (error.message.includes('413')) {
-      // If we had a payload too large error, don't try to save again until the project
-      // has changed, as it will fail again. The save fail listener should handle
-      // the 413 error and inform the user accordingly.
-      this.lastSource = JSON.stringify(this.sourcesToSave);
+      // Log 413s as warnings. The save fail listener should handle these errors and labs should
+      // show a reasonable error message to the user.
+      this.metricsReporter.logWarning('Project too large to save');
     } else {
       // Otherwise, we log the error, including the message as details.
       this.metricsReporter.logError(errorMessage, error, {

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -435,6 +435,11 @@ export default class ProjectManager {
       this.forceReloading = true;
       this.metricsReporter.logWarning(`${error.message}. Reloading page.`);
       reload();
+    } else if (error.message.includes('413')) {
+      // If we had a payload too large error, don't try to save again until the project
+      // has changed, as it will fail again. The save fail listener should handle
+      // the 413 error and inform the user accordingly.
+      this.lastSource = JSON.stringify(this.sourcesToSave);
     } else {
       // Otherwise, we log the error, including the message as details.
       this.metricsReporter.logError(errorMessage, error, {

--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -16,6 +16,7 @@ export interface Lab2ProjectState {
   viewingOldVersion: boolean;
   restoredOldVersion: boolean;
   hasEdited: boolean;
+  projectTooLarge: boolean;
 }
 
 const initialState: Lab2ProjectState = {
@@ -23,6 +24,7 @@ const initialState: Lab2ProjectState = {
   viewingOldVersion: false,
   restoredOldVersion: false,
   hasEdited: false,
+  projectTooLarge: false,
 };
 
 // THUNKS
@@ -134,6 +136,9 @@ const projectSlice = createSlice({
     setHasEdited(state, action: PayloadAction<boolean>) {
       state.hasEdited = action.payload;
     },
+    setProjectTooLarge(state, action: PayloadAction<boolean>) {
+      state.projectTooLarge = action.payload;
+    },
     resetProjectMetadata(state) {
       // Reset the state that needs to be reset manually on level change.
       // Project source is handled elsewhere.
@@ -152,6 +157,7 @@ export const {
   resetProjectMetadata,
   setHasEdited,
   setSource,
+  setProjectTooLarge,
 } = projectSlice.actions;
 
 export default projectSlice.reducer;


### PR DESCRIPTION
I noticed a small number of python lab users (13 in the last 2 weeks, almost all on the new project level) are hitting project too large errors. This currently causes a small red "error saving project" message in the top left corner of the screen, but gives them no other information. This PR adds an alert banner to the workspace when the save fails due to a 413 error.

The banner will disappear on the next successful save. I also changed the logging of 413s from error to warning in our system. For codebridge we don't really need to log these at all, but I could see it being useful information for other labs.

<img width="1707" alt="Screenshot 2025-03-06 at 12 16 32 PM" src="https://github.com/user-attachments/assets/924bd389-a090-44d1-a1b7-0fb35e4444a4" />


## Links

- jira ticket: [CT-1124](https://codedotorg.atlassian.net/browse/CT-1124)


## Testing story
Tested locally. I confirmed the banner text with product and curriculum.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
