### PR TITLE
DIFF - modify logic for enabling Ai Chat

### DIFF
--- a/apps/src/accounts/TurnOffAiDiff.tsx
+++ b/apps/src/accounts/TurnOffAiDiff.tsx
@@ -25,7 +25,7 @@ const TurnOffAiDiff: React.FC = () => {
   const handleToggle = () => {
     analyticsReporter.sendEvent(EVENTS.AI_DIFF_CHAT_TOGGLED, {
       'user id': currentUserId,
-      state: aiDifferentiationEnabled ? 'on' : 'off',
+      state: aiDifferentiationEnabled ? 'off' : 'on',
     });
     new UserPreferences().setAiDifferentiationEnabled(
       !aiDifferentiationEnabled

--- a/apps/src/accounts/TurnOffAiDiff.tsx
+++ b/apps/src/accounts/TurnOffAiDiff.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {setAiDifferentiationToggledOff} from '@cdo/apps/templates/currentUserRedux';
+import {setAiDifferentiationEnabled} from '@cdo/apps/templates/currentUserRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
@@ -16,8 +16,8 @@ import i18n from '@cdo/locale';
 import moduleStyles from './accountSettings.module.scss';
 
 const TurnOffAiDiff: React.FC = () => {
-  const toggledOff = useAppSelector(
-    state => state.currentUser.aiDifferentiationToggledOff
+  const aiDifferentiationEnabled = useAppSelector(
+    state => state.currentUser.aiDifferentiationEnabled
   );
 
   const currentUserId = useAppSelector(state => state.currentUser.userId);
@@ -25,15 +25,19 @@ const TurnOffAiDiff: React.FC = () => {
   const handleToggle = () => {
     analyticsReporter.sendEvent(EVENTS.AI_DIFF_CHAT_TOGGLED, {
       'user id': currentUserId,
-      state: !toggledOff ? 'on' : 'off',
+      state: aiDifferentiationEnabled ? 'on' : 'off',
     });
-    new UserPreferences().setAiDifferentiationToggledOff(!toggledOff);
-    dispatch(setAiDifferentiationToggledOff(!toggledOff));
+    new UserPreferences().setAiDifferentiationEnabled(
+      !aiDifferentiationEnabled
+    );
+    dispatch(setAiDifferentiationEnabled(!aiDifferentiationEnabled));
   };
 
   const dispatch = useAppDispatch();
 
-  const setEnabled = toggledOff ? i18n.disabled() : i18n.enabled();
+  const setEnabled = aiDifferentiationEnabled
+    ? i18n.enabled()
+    : i18n.disabled();
 
   return (
     <div>
@@ -48,7 +52,7 @@ const TurnOffAiDiff: React.FC = () => {
         />
       </BodyTwoText>
       <Toggle
-        checked={!toggledOff}
+        checked={aiDifferentiationEnabled}
         onChange={handleToggle}
         name="aiTeacherDiffToggle"
         position={'left'}

--- a/apps/src/accounts/TurnOffAiDiff.tsx
+++ b/apps/src/accounts/TurnOffAiDiff.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {setAiDifferentiationEnabled} from '@cdo/apps/templates/currentUserRedux';
+import {setAiDifferentiationToggledOff} from '@cdo/apps/templates/currentUserRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
@@ -16,36 +16,24 @@ import i18n from '@cdo/locale';
 import moduleStyles from './accountSettings.module.scss';
 
 const TurnOffAiDiff: React.FC = () => {
-  const reduxState = useAppSelector(
-    state => state.currentUser.aiDifferentiationEnabled
+  const toggledOff = useAppSelector(
+    state => state.currentUser.aiDifferentiationToggledOff
   );
 
   const currentUserId = useAppSelector(state => state.currentUser.userId);
 
-  const startingState = () => {
-    if (reduxState === null) {
-      new UserPreferences().setAiDifferentiationEnabled(true);
-      return true;
-    } else {
-      return reduxState;
-    }
-  };
-
-  const [hasAIDiffAccess, setHasAIDiffAccess] = React.useState(startingState);
-
   const handleToggle = () => {
     analyticsReporter.sendEvent(EVENTS.AI_DIFF_CHAT_TOGGLED, {
       'user id': currentUserId,
-      state: !hasAIDiffAccess ? 'on' : 'off',
+      state: !toggledOff ? 'on' : 'off',
     });
-    dispatch(setAiDifferentiationEnabled(!hasAIDiffAccess));
-    new UserPreferences().setAiDifferentiationEnabled(!hasAIDiffAccess);
-    setHasAIDiffAccess(!hasAIDiffAccess);
+    new UserPreferences().setAiDifferentiationToggledOff(!toggledOff);
+    dispatch(setAiDifferentiationToggledOff(!toggledOff));
   };
 
   const dispatch = useAppDispatch();
 
-  const setEnabled = hasAIDiffAccess ? i18n.enabled() : i18n.disabled();
+  const setEnabled = toggledOff ? i18n.enabled() : i18n.disabled();
 
   return (
     <div>
@@ -60,7 +48,7 @@ const TurnOffAiDiff: React.FC = () => {
         />
       </BodyTwoText>
       <Toggle
-        checked={hasAIDiffAccess}
+        checked={!toggledOff}
         onChange={handleToggle}
         name="aiTeacherDiffToggle"
         position={'left'}

--- a/apps/src/accounts/TurnOffAiDiff.tsx
+++ b/apps/src/accounts/TurnOffAiDiff.tsx
@@ -33,7 +33,7 @@ const TurnOffAiDiff: React.FC = () => {
 
   const dispatch = useAppDispatch();
 
-  const setEnabled = toggledOff ? i18n.enabled() : i18n.disabled();
+  const setEnabled = toggledOff ? i18n.disabled() : i18n.enabled();
 
   return (
     <div>

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -68,10 +68,14 @@ export default class UserPreferences extends Record({userId: 'me'}) {
       ai_rubrics_disabled: aiRubricsDisabled,
     });
   }
-
-  setAiDifferentiationEnabled(aiDifferentiationEnabled) {
-    return $.post(`/api/v1/users/ai_differentiation_enabled`, {
-      ai_differentiation_enabled: aiDifferentiationEnabled,
+  /**
+   * Save the preference to opt-out of AI Differentiation Chat.
+   * @param {boolean} aiDifferentiationToggledOff: True if disabling AI Chat features, false otherwise.
+   */
+  setAiDifferentiationToggledOff(aiDifferentiationToggledOff) {
+    console.log('inside set user preferences');
+    return $.post(`/api/v1/users/ai_differentiation_toggled_off`, {
+      ai_differentiation_toggled_off: aiDifferentiationToggledOff,
     });
   }
 

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -72,10 +72,9 @@ export default class UserPreferences extends Record({userId: 'me'}) {
    * Save the preference to opt-out of AI Differentiation Chat.
    * @param {boolean} aiDifferentiationToggledOff: True if disabling AI Chat features, false otherwise.
    */
-  setAiDifferentiationToggledOff(aiDifferentiationToggledOff) {
-    console.log('inside set user preferences');
-    return $.post(`/api/v1/users/ai_differentiation_toggled_off`, {
-      ai_differentiation_toggled_off: aiDifferentiationToggledOff,
+  setAiDifferentiationEnabled(aiDifferentiationEnabled) {
+    return $.post(`/api/v1/users/ai_differentiation_enabled`, {
+      ai_differentiation_enabled: aiDifferentiationEnabled,
     });
   }
 

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -68,10 +68,7 @@ export default class UserPreferences extends Record({userId: 'me'}) {
       ai_rubrics_disabled: aiRubricsDisabled,
     });
   }
-  /**
-   * Save the preference to opt-out of AI Differentiation Chat.
-   * @param {boolean} aiDifferentiationToggledOff: True if disabling AI Chat features, false otherwise.
-   */
+
   setAiDifferentiationEnabled(aiDifferentiationEnabled) {
     return $.post(`/api/v1/users/ai_differentiation_enabled`, {
       ai_differentiation_enabled: aiDifferentiationEnabled,

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -33,6 +33,6 @@ export interface CurrentUserState {
   usStateCode: string | null;
   uuid: string;
   isLti: boolean;
-  aiDifferentiationToggledOff: boolean;
+  aiDifferentiationEnabled: boolean;
   hasCompletedAiDifferentiationWelcome: boolean;
 }

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -33,6 +33,6 @@ export interface CurrentUserState {
   usStateCode: string | null;
   uuid: string;
   isLti: boolean;
-  aiDifferentiationEnabled: boolean;
+  aiDifferentiationToggledOff: boolean;
   hasCompletedAiDifferentiationWelcome: boolean;
 }

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -18,8 +18,8 @@ const SET_MUTE_MUSIC = 'currentUser/SET_MUTE_MUSIC';
 const SET_SORT_BY_FAMILY_NAME = 'currentUser/SET_SORT_BY_FAMILY_NAME';
 const SET_SHOW_PROGRESS_TABLE_V2 = 'currentUser/SET_SHOW_PROGRESS_TABLE_V2';
 const SET_AI_RUBRICS_DISABLED = 'currentUser/SET_AI_RUBRICS_DISABLED';
-const SET_AI_DIFFERENTIATION_TOGGLED_OFF =
-  'currentUser/SET_AI_DIFFERENTIATION_TOGGLED_OFF';
+const SET_AI_DIFFERENTIATION_ENABLED =
+  'currentUser/SET_AI_DIFFERENTIATION_ENABLED';
 const SET_PROGRESS_TABLE_V2_CLOSED_BETA =
   'currentUser/SET_PROGRESS_TABLE_V2_CLOSED_BETA';
 const SET_DATE_PROGRESS_TABLE_INVITATION_LAST_DELAYED =
@@ -100,9 +100,9 @@ export const setAiRubricsDisabled = aiRubricsDisabled => ({
   type: SET_AI_RUBRICS_DISABLED,
   aiRubricsDisabled,
 });
-export const setAiDifferentiationToggledOff = aiDifferentiationToggledOff => ({
-  type: SET_AI_DIFFERENTIATION_TOGGLED_OFF,
-  aiDifferentiationToggledOff,
+export const setAiDifferentiationEnabled = aiDifferentiationEnabled => ({
+  type: SET_AI_DIFFERENTIATION_ENABLED,
+  aiDifferentiationEnabled,
 });
 export const setUserCreatedAt = userCreatedAt => ({
   type: SET_USER_CREATED_AT,
@@ -117,7 +117,7 @@ const initialState = {
   userRoleInCourse: CourseRoles.Unknown,
   signInState: SignInState.Unknown,
   hasSeenStandardsReportInfo: false,
-  aiDifferentiationToggledOff: null,
+  aiDifferentiationEnabled: null,
   isBackgroundMusicMuted: false,
   isSortedByFamilyName: false,
   isLti: undefined,
@@ -228,10 +228,10 @@ export default function currentUser(state = initialState, action) {
       aiRubricsDisabled: action.aiRubricsDisabled,
     };
   }
-  if (action.type === SET_AI_DIFFERENTIATION_TOGGLED_OFF) {
+  if (action.type === SET_AI_DIFFERENTIATION_ENABLED) {
     return {
       ...state,
-      aiDifferentiationToggledOff: action.aiDifferentiationToggledOff,
+      aiDifferentiationEnabled: action.aiDifferentiationEnabled,
     };
   }
   if (action.type === SET_USER_CREATED_AT) {
@@ -254,7 +254,7 @@ export default function currentUser(state = initialState, action) {
       sort_by_family_name,
       show_progress_table_v2,
       ai_rubrics_disabled,
-      ai_differentiation_toggled_off,
+      ai_differentiation_enabled,
       progress_table_v2_closed_beta,
       is_lti,
       date_progress_table_invitation_last_delayed,
@@ -294,7 +294,7 @@ export default function currentUser(state = initialState, action) {
       isSortedByFamilyName: sort_by_family_name,
       showProgressTableV2: show_progress_table_v2,
       aiRubricsDisabled: ai_rubrics_disabled,
-      aiDifferentiationToggledOff: ai_differentiation_toggled_off,
+      aiDifferentiationEnabled: ai_differentiation_enabled,
       progressTableV2ClosedBeta: progress_table_v2_closed_beta,
       isLti: is_lti,
       isTeacher: user_type === UserTypes.TEACHER,

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -18,8 +18,8 @@ const SET_MUTE_MUSIC = 'currentUser/SET_MUTE_MUSIC';
 const SET_SORT_BY_FAMILY_NAME = 'currentUser/SET_SORT_BY_FAMILY_NAME';
 const SET_SHOW_PROGRESS_TABLE_V2 = 'currentUser/SET_SHOW_PROGRESS_TABLE_V2';
 const SET_AI_RUBRICS_DISABLED = 'currentUser/SET_AI_RUBRICS_DISABLED';
-const SET_AI_DIFFERENTIATION_ENABLED =
-  'currentUser/SET_AI_DIFFERENTIATION_ENABLED';
+const SET_AI_DIFFERENTIATION_TOGGLED_OFF =
+  'currentUser/SET_AI_DIFFERENTIATION_TOGGLED_OFF';
 const SET_PROGRESS_TABLE_V2_CLOSED_BETA =
   'currentUser/SET_PROGRESS_TABLE_V2_CLOSED_BETA';
 const SET_DATE_PROGRESS_TABLE_INVITATION_LAST_DELAYED =
@@ -100,9 +100,9 @@ export const setAiRubricsDisabled = aiRubricsDisabled => ({
   type: SET_AI_RUBRICS_DISABLED,
   aiRubricsDisabled,
 });
-export const setAiDifferentiationEnabled = aiDifferentiationEnabled => ({
-  type: SET_AI_DIFFERENTIATION_ENABLED,
-  aiDifferentiationEnabled,
+export const setAiDifferentiationToggledOff = aiDifferentiationToggledOff => ({
+  type: SET_AI_DIFFERENTIATION_TOGGLED_OFF,
+  aiDifferentiationToggledOff,
 });
 export const setUserCreatedAt = userCreatedAt => ({
   type: SET_USER_CREATED_AT,
@@ -117,7 +117,7 @@ const initialState = {
   userRoleInCourse: CourseRoles.Unknown,
   signInState: SignInState.Unknown,
   hasSeenStandardsReportInfo: false,
-  aiDifferentiationEnabled: null,
+  aiDifferentiationToggledOff: null,
   isBackgroundMusicMuted: false,
   isSortedByFamilyName: false,
   isLti: undefined,
@@ -228,10 +228,10 @@ export default function currentUser(state = initialState, action) {
       aiRubricsDisabled: action.aiRubricsDisabled,
     };
   }
-  if (action.type === SET_AI_DIFFERENTIATION_ENABLED) {
+  if (action.type === SET_AI_DIFFERENTIATION_TOGGLED_OFF) {
     return {
       ...state,
-      aiDifferentiationEnabled: action.aiDifferentiationEnabled,
+      aiDifferentiationToggledOff: action.aiDifferentiationToggledOff,
     };
   }
   if (action.type === SET_USER_CREATED_AT) {
@@ -254,7 +254,7 @@ export default function currentUser(state = initialState, action) {
       sort_by_family_name,
       show_progress_table_v2,
       ai_rubrics_disabled,
-      ai_differentiation_enabled,
+      ai_differentiation_toggled_off,
       progress_table_v2_closed_beta,
       is_lti,
       date_progress_table_invitation_last_delayed,
@@ -294,7 +294,7 @@ export default function currentUser(state = initialState, action) {
       isSortedByFamilyName: sort_by_family_name,
       showProgressTableV2: show_progress_table_v2,
       aiRubricsDisabled: ai_rubrics_disabled,
-      aiDifferentiationEnabled: ai_differentiation_enabled,
+      aiDifferentiationToggledOff: ai_differentiation_toggled_off,
       progressTableV2ClosedBeta: progress_table_v2_closed_beta,
       isLti: is_lti,
       isTeacher: user_type === UserTypes.TEACHER,

--- a/apps/test/unit/aiDifferentiation/TurnOffAiDiffTest.js
+++ b/apps/test/unit/aiDifferentiation/TurnOffAiDiffTest.js
@@ -11,7 +11,7 @@ import {
   restoreRedux,
 } from '@cdo/apps/redux';
 import currentUser, {
-  setAiDifferentiationToggledOff,
+  setAiDifferentiationEnabled,
 } from '@cdo/apps/templates/currentUserRedux';
 import i18n from '@cdo/locale';
 
@@ -22,7 +22,7 @@ describe('TurnOffAiDiff', () => {
     stubRedux();
     registerReducers({currentUser});
     store = getStore();
-    store.dispatch(setAiDifferentiationToggledOff(false));
+    store.dispatch(setAiDifferentiationEnabled(true));
   });
 
   afterEach(() => {
@@ -31,7 +31,7 @@ describe('TurnOffAiDiff', () => {
   });
 
   it('renders correctly with initial state', () => {
-    store.dispatch(setAiDifferentiationToggledOff(false));
+    store.dispatch(setAiDifferentiationEnabled(true));
     render(
       <Provider store={store}>
         <TurnOffAiDiff />
@@ -49,7 +49,7 @@ describe('TurnOffAiDiff', () => {
   });
 
   it('toggles the setting when clicked', () => {
-    store.dispatch(setAiDifferentiationToggledOff(false));
+    store.dispatch(setAiDifferentiationEnabled(true));
 
     render(
       <Provider store={store}>
@@ -59,7 +59,7 @@ describe('TurnOffAiDiff', () => {
 
     const setStub = jest.spyOn(
       UserPreferences.prototype,
-      'setAiDifferentiationToggledOff'
+      'setAiDifferentiationEnabled'
     );
 
     const toggle = screen.getByRole('checkbox', {
@@ -73,6 +73,6 @@ describe('TurnOffAiDiff', () => {
     screen.getByRole('checkbox', {
       name: i18n.aiTeachingAssistantSettingsStatus({status: 'disabled'}),
     });
-    expect(setStub).toHaveBeenCalledWith(true);
+    expect(setStub).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/test/unit/aiDifferentiation/TurnOffAiDiffTest.js
+++ b/apps/test/unit/aiDifferentiation/TurnOffAiDiffTest.js
@@ -11,7 +11,7 @@ import {
   restoreRedux,
 } from '@cdo/apps/redux';
 import currentUser, {
-  setAiDifferentiationEnabled,
+  setAiDifferentiationToggledOff,
 } from '@cdo/apps/templates/currentUserRedux';
 import i18n from '@cdo/locale';
 
@@ -22,7 +22,7 @@ describe('TurnOffAiDiff', () => {
     stubRedux();
     registerReducers({currentUser});
     store = getStore();
-    store.dispatch(setAiDifferentiationEnabled(true));
+    store.dispatch(setAiDifferentiationToggledOff(false));
   });
 
   afterEach(() => {
@@ -31,7 +31,7 @@ describe('TurnOffAiDiff', () => {
   });
 
   it('renders correctly with initial state', () => {
-    store.dispatch(setAiDifferentiationEnabled(true));
+    store.dispatch(setAiDifferentiationToggledOff(false));
     render(
       <Provider store={store}>
         <TurnOffAiDiff />
@@ -49,7 +49,7 @@ describe('TurnOffAiDiff', () => {
   });
 
   it('toggles the setting when clicked', () => {
-    store.dispatch(setAiDifferentiationEnabled(true));
+    store.dispatch(setAiDifferentiationToggledOff(false));
 
     render(
       <Provider store={store}>
@@ -59,7 +59,7 @@ describe('TurnOffAiDiff', () => {
 
     const setStub = jest.spyOn(
       UserPreferences.prototype,
-      'setAiDifferentiationEnabled'
+      'setAiDifferentiationToggledOff'
     );
 
     const toggle = screen.getByRole('checkbox', {
@@ -73,6 +73,6 @@ describe('TurnOffAiDiff', () => {
     screen.getByRole('checkbox', {
       name: i18n.aiTeachingAssistantSettingsStatus({status: 'disabled'}),
     });
-    expect(setStub).toHaveBeenCalledWith(false);
+    expect(setStub).toHaveBeenCalledWith(true);
   });
 });

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@ require 'cdo/firehose'
 class Api::V1::UsersController < Api::V1::JSONApiController
   before_action :load_user
   skip_before_action :verify_authenticity_token
-  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :cached_page_auth_redirect, :post_show_progress_table_v2, :post_ai_rubrics_disabled, :post_ai_differentiation_enabled, :post_has_seen_ai_assessments_announcement, :post_date_progress_table_invitation_last_delayed, :post_has_seen_progress_table_v2_invitation, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access, :set_seen_ta_scores, :post_has_completed_ai_differentiation_welcome]
+  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :cached_page_auth_redirect, :post_show_progress_table_v2, :post_ai_rubrics_disabled, :post_ai_differentiation_toggled_off, :post_has_seen_ai_assessments_announcement, :post_date_progress_table_invitation_last_delayed, :post_has_seen_progress_table_v2_invitation, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access, :set_seen_ta_scores, :post_has_completed_ai_differentiation_welcome]
   skip_before_action :clear_sign_up_session_vars, only: [:current]
 
   def load_user
@@ -45,7 +45,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         in_section: current_user.student? ? current_user.sections_as_student.present? : nil,
         created_at: current_user.created_at,
         has_seen_ai_assessments_announcement: current_user.has_seen_ai_assessments_announcement?,
-        ai_differentiation_enabled: current_user.ai_differentiation_enabled?,
+        ai_differentiation_toggled_off: current_user.ai_differentiation_toggled_off?,
         has_completed_ai_differentiation_welcome: current_user.has_completed_ai_differentiation_welcome?,
       }
     else
@@ -248,10 +248,10 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     head :no_content
   end
 
-  def post_ai_differentiation_enabled
+  def post_ai_differentiation_toggled_off
     return head :unauthorized unless current_user
 
-    current_user.ai_differentiation_enabled = !!params[:ai_differentiation_enabled].try(:to_bool)
+    current_user.ai_differentiation_toggled_off = !!params[:ai_differentiation_toggled_off].try(:to_bool)
     current_user.save
 
     head :no_content

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@ require 'cdo/firehose'
 class Api::V1::UsersController < Api::V1::JSONApiController
   before_action :load_user
   skip_before_action :verify_authenticity_token
-  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :cached_page_auth_redirect, :post_show_progress_table_v2, :post_ai_rubrics_disabled, :post_ai_differentiation_toggled_off, :post_has_seen_ai_assessments_announcement, :post_date_progress_table_invitation_last_delayed, :post_has_seen_progress_table_v2_invitation, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access, :set_seen_ta_scores, :post_has_completed_ai_differentiation_welcome]
+  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :cached_page_auth_redirect, :post_show_progress_table_v2, :post_ai_rubrics_disabled, :post_ai_differentiation_enabled, :post_has_seen_ai_assessments_announcement, :post_date_progress_table_invitation_last_delayed, :post_has_seen_progress_table_v2_invitation, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access, :set_seen_ta_scores, :post_has_completed_ai_differentiation_welcome]
   skip_before_action :clear_sign_up_session_vars, only: [:current]
 
   def load_user
@@ -45,7 +45,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         in_section: current_user.student? ? current_user.sections_as_student.present? : nil,
         created_at: current_user.created_at,
         has_seen_ai_assessments_announcement: current_user.has_seen_ai_assessments_announcement?,
-        ai_differentiation_toggled_off: current_user.ai_differentiation_toggled_off?,
+        ai_differentiation_enabled: !current_user.ai_differentiation_toggled_off?,
         has_completed_ai_differentiation_welcome: current_user.has_completed_ai_differentiation_welcome?,
       }
     else
@@ -248,10 +248,10 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     head :no_content
   end
 
-  def post_ai_differentiation_toggled_off
+  def post_ai_differentiation_enabled
     return head :unauthorized unless current_user
 
-    current_user.ai_differentiation_toggled_off = !!params[:ai_differentiation_toggled_off].try(:to_bool)
+    current_user.ai_differentiation_toggled_off = !params[:ai_differentiation_enabled].try(:to_bool)
     current_user.save
 
     head :no_content

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -207,7 +207,7 @@ class User < ApplicationRecord
     seen_ta_scores_map
     roster_synced
     educator_role
-    ai_differentiation_enabled
+    ai_differentiation_toggled_off
     has_completed_ai_differentiation_welcome
   )
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -981,7 +981,7 @@ Dashboard::Application.routes.draw do
         post 'users/date_progress_table_invitation_last_delayed', to: 'users#post_date_progress_table_invitation_last_delayed'
         post 'users/has_seen_progress_table_v2_invitation', to: 'users#post_has_seen_progress_table_v2_invitation'
         post 'users/ai_rubrics_disabled', to: 'users#post_ai_rubrics_disabled'
-        post 'users/ai_differentiation_enabled', to: 'users#post_ai_differentiation_enabled'
+        post 'users/ai_differentiation_toggled_off', to: 'users#post_ai_differentiation_toggled_off'
         post 'users/has_seen_ai_assessments_announcement', to: 'users#post_has_seen_ai_assessments_announcement'
         post 'users/disable_lti_roster_sync', to: 'users#post_disable_lti_roster_sync'
         post 'users/:user_id/ai_tutor_access', to: 'users#update_ai_tutor_access'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -981,7 +981,7 @@ Dashboard::Application.routes.draw do
         post 'users/date_progress_table_invitation_last_delayed', to: 'users#post_date_progress_table_invitation_last_delayed'
         post 'users/has_seen_progress_table_v2_invitation', to: 'users#post_has_seen_progress_table_v2_invitation'
         post 'users/ai_rubrics_disabled', to: 'users#post_ai_rubrics_disabled'
-        post 'users/ai_differentiation_toggled_off', to: 'users#post_ai_differentiation_toggled_off'
+        post 'users/ai_differentiation_enabled', to: 'users#post_ai_differentiation_enabled'
         post 'users/has_seen_ai_assessments_announcement', to: 'users#post_has_seen_ai_assessments_announcement'
         post 'users/disable_lti_roster_sync', to: 'users#post_disable_lti_roster_sync'
         post 'users/:user_id/ai_tutor_access', to: 'users#update_ai_tutor_access'

--- a/dashboard/lib/policies/ai.rb
+++ b/dashboard/lib/policies/ai.rb
@@ -31,7 +31,7 @@ class Policies::Ai
     return false unless user.teacher?
 
     # Check user preference: default to showing the AI differentiation.
-    user.ai_differentiation_enabled.nil? || user.ai_differentiation_enabled?
+    !user.ai_differentiation_toggled_off?
   end
 
   def self.ai_differentiation_enabled_for_unit?(unit_or_unit_group)

--- a/dashboard/test/lib/policies/ai_test.rb
+++ b/dashboard/test/lib/policies/ai_test.rb
@@ -134,7 +134,7 @@ class Policies::AiTest < ActiveSupport::TestCase
     end
 
     context 'when the user is a teacher and has enabled access to ai diff' do
-      let(:user) {build_stubbed(:user, user_type: 'teacher', ai_differentiation_enabled: true)}
+      let(:user) {build_stubbed(:user, user_type: 'teacher', ai_differentiation_toggled_off: false)}
 
       it 'returns true' do
         _(ai_differentiation_enabled?).must_equal true
@@ -142,7 +142,7 @@ class Policies::AiTest < ActiveSupport::TestCase
     end
 
     context 'when the user is a teacher and has disabled access to ai diff' do
-      let(:user) {build_stubbed(:user, user_type: 'teacher', ai_differentiation_enabled: false)}
+      let(:user) {build_stubbed(:user, user_type: 'teacher', ai_differentiation_toggled_off: true)}
 
       it 'returns true' do
         _(ai_differentiation_enabled?).must_equal false


### PR DESCRIPTION
I noticed two issues with the way the AI Toggle was working:

- When set to `false` the logic for showing the toggle would act as if it were `null` - we had expected this to be `null` only in the case of new teachers.  This [thread](https://codedotorg.slack.com/archives/C06ERUABG01/p1712782385066039) talks a bit more about being able to have a "third state" in serialized attributes .
- The toggle would not always be set correctly - the redux would be correct but the value of the toggle would not be.  

This follows more closely [how AI Rubrics are set](https://github.com/code-dot-org/code-dot-org/pull/53215)

## Links

- Somewhat of a re-work of these two PRS[ 1 ](https://github.com/code-dot-org/code-dot-org/pull/63681/files#diff-b211b03f163672ec8bf7c2064eb4e07f6c9f282f42d843eec87f1c59ea08c7b2)and [2](https://github.com/code-dot-org/code-dot-org/pull/64155#event-16483464430)

## Testing story

Tested locally

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
