### PR TITLE
CMS-350: Replace `primitiveColors.scss` with `colors.scss` in Link

### DIFF
--- a/frontend/packages/component-library/src/link/link.module.scss
+++ b/frontend/packages/component-library/src/link/link.module.scss
@@ -1,4 +1,4 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/colors';
 @import '@code-dot-org/component-library-styles/mixins.scss';
 
 // Link common styles
@@ -10,7 +10,7 @@
   text-decoration: underline;
 
   &:focus-visible {
-    outline: 2px solid var(--brand-teal-50);
+    outline: 2px solid var(--borders-brand-teal-primary);
     border-radius: 0.25rem;
     outline-offset: 0;
   }
@@ -20,36 +20,36 @@
   }
 
   &-primary {
-    color: var(--brand-purple-50);
+    color: var(--text-brand-purple-primary);
 
     &:hover,
     :active,
     :visited {
-      color: var(--brand-purple-70);
+      color: var(--text-brand-purple-secondary);
     }
 
     &:focus-visible {
-      color: var(--brand-purple-50);
+      color: var(--text-brand-purple-primary);
     }
   }
 
   &-secondary {
-    color: var(--neutral-base-black);
+    color: var(--text-neutral-primary);
 
     &:hover,
     :active,
     :visited {
-      color: var(--neutral-gray-80);
+      color: var(--text-neutral-tertiary);
     }
 
     &:focus-visible {
-      color: var(--neutral-base-black);
+      color: var(--text-neutral-primary);
     }
   }
 
   &[aria-disabled='true'] {
     cursor: not-allowed;
-    color: var(--neutral-gray-30);
+    color: var(--text-neutral-disabled);
   }
 }
 


### PR DESCRIPTION
|            | Primary & Secondary | Disables |
| ------ | --------------------- |  -------- |
| Before | <img alt="before" src="https://github.com/user-attachments/assets/eb3ed333-7288-4bdb-a6d7-05c35b4c102d" /> | <img alt="before" src="https://github.com/user-attachments/assets/695b848e-321c-4133-984d-ae9ba1c24418" /> |
| After | <img alt="after" src="https://github.com/user-attachments/assets/6054b2ca-a757-4234-bd2d-8ce9a923216d" /> | <img alt="after" src="https://github.com/user-attachments/assets/78ec0a9d-bef0-4473-9b1f-fc466ca0216c" /> |


## Links
- JIRA task: [CMS-350](https://codedotorg.atlassian.net/browse/CMS-350)
- Figma: [DSCO Link Component](https://www.figma.com/design/ahYTsb3I7rsJNW0n2vnXm6/DSCO-Components?node-id=1969-7104&t=MkYfy7zmNwHtqjLA-0)