### PR TITLE
Update dependabot codemirror configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,8 +65,6 @@ updates:
       codemirror:
         patterns:
         - "@codemirror/*"
-        - "codemirror"
-        - "codemirror-*"
       dnd-kit:
         patterns:
         - "@dnd-kit/*"


### PR DESCRIPTION
`@codemirror` packages are Codemirror 6, used in Python Lab, Web Lab 2 and Java Lab. `codemirror` is Codemirror 5, which has some legacy usage on our site (I know it's used for the internal foorm editor).  The 2 versions are incompatible with each other. When both are bundled together, we get dependabot trying to upgrade from 5 to 6 (see #64250 for an example), which causes build breakages. We do want to keep upgrading our use of `@codemirror` packages, but we should leave `codemirror` as is.

## Testing story
I don't know how to test this, but it seems like a safe change!

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
