### PR TITLE
Remove Coinbase content from blockchain page

### DIFF
--- a/pegasus/sites.v3/code.org/public/curriculum/blockchain.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/blockchain.haml
@@ -30,7 +30,6 @@ theme: responsive_full_width
       %img{src: "/images/blockchain-works-logo.png", alt: "", style: "width: 100%"}
     .clear
     .video-series
-      = view :"blockchain/blockchain_vid_01_intro"
       = view :"blockchain/blockchain_vid_02_why"
       = view :"blockchain/blockchain_vid_03_hood"
       = view :"blockchain/blockchain_vid_04_beyond"
@@ -93,35 +92,3 @@ theme: responsive_full_width
           %p Students follow along with each video by matching vocabulary from the video, then answering a reflection question about each video.
         .content-footer
           %a{href: CDO.studio_url("/s/blockchain-2023/lessons/6"), class: "link-button", aria:{label: "See lesson details for the Blockchain in a Day lesson"}} See lesson details
-
-= view :section_divider_line
-
-%section
-  .wrapper
-    %h2=hoc_s(:heading_additional_resources)
-    %p=hoc_s(:blockchain_resources_desc)
-    .action-block__wrapper.action-block__wrapper--three-col
-      .action-block.action-block--one-col.flex-space-between
-        .content-wrapper
-          %h3=hoc_s(:blockchain_resources_01_heading)
-          %img{src: "/images/blockchain-coinbase-learn.png", alt: ""}
-          %p=hoc_s(:blockchain_resources_01_desc)
-        .content-footer
-          %a{href: "https://www.coinbase.com/learn", class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:blockchain_resources_01_button_label)}}
-            =hoc_s(:call_to_action_learn_more)
-      .action-block.action-block--one-col.flex-space-between
-        .content-wrapper
-          %h3=hoc_s(:blockchain_resources_02_heading)
-          %img{src: "/images/blockchain-resource-image-generic.png", alt: ""}
-          %p=hoc_s(:blockchain_resources_02_desc)
-        .content-footer
-          %a{href: "https://www.youtube.com/@WhiteboardCrypto/featured", class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:blockchain_resources_02_button_label)}}
-            =hoc_s(:call_to_action_watch_now)
-      .action-block.action-block--one-col.flex-space-between
-        .content-wrapper
-          %h3=hoc_s(:blockchain_resources_03_heading)
-          %img{src: "/images/blockchain-coinbase-hoc-activity.png", alt: ""}
-          %p=hoc_s(:blockchain_resources_03_desc)
-        .content-footer
-          %a{href: "https://coinbase.github.io/memorygame/story.html", class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:blockchain_resources_03_button_label)}}
-            =hoc_s(:call_to_action_try_activity)

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1078,7 +1078,7 @@
   blockchain_hero_heading: 'How Blockchain Works'
   blockchain_hero_desc: 'Dive into the world of blockchain with "How Blockchain Works," our new video series and accompanying lessons!'
   blockchain_intro_heading: 'See how blockchain works'
-  blockchain_intro_desc: 'The video series, made in partnership with Coinbase, features industry experts and aims to demystify this technology.'
+  blockchain_intro_desc: 'The video series features industry experts and aims to demystify this technology.'
   blockchain_intro_list_heading: 'This series will:'
   blockchain_intro_list_item_01: 'Explain what blockchain is'
   blockchain_intro_list_item_02: "Explore why it's important"


### PR DESCRIPTION
Leadership has asked for Coinbase to be removed from code.org/curriculum/blockchain.

3 updates
- Remove the "in partnership" language from the first section
- Remove the intro video with the Coinbase CEO
- Remove the additional resources section which was mostly Coinbase resources

![Screenshot 2025-03-07 at 12 19 15 PM](https://github.com/user-attachments/assets/d840e55a-47dc-4b14-8b25-a9f39f2bc73b)

![Screenshot 2025-03-07 at 12 19 20 PM](https://github.com/user-attachments/assets/025d6b56-39e4-4071-9cae-48ad0da6b60e)