### PR TITLE
DIFF - Tweak CSS for FAB

### DIFF
--- a/apps/src/aiDifferentiation/ai-differentiation.module.scss
+++ b/apps/src/aiDifferentiation/ai-differentiation.module.scss
@@ -20,7 +20,7 @@
 .aiDiffContainer {
   position: fixed;
   left: 10px;
-  bottom: 120px;
+  bottom: 100px;
   z-index: 2000;
   width: 512px;
 
@@ -237,11 +237,11 @@
 .floatingActionButton {
   position: fixed;
   left: 10px;
-  bottom: 48px;
+  bottom: 33px;
 
-  height: 66px;
-  width: 66px;
-  background-size: 66px;
+  height: 60px;
+  width: 60px;
+  background-size: 60px;
   padding: 0;
   background-color: transparent;
 

--- a/apps/src/aiDifferentiation/ai-differentiation.module.scss
+++ b/apps/src/aiDifferentiation/ai-differentiation.module.scss
@@ -20,7 +20,7 @@
 .aiDiffContainer {
   position: fixed;
   left: 10px;
-  bottom: 100px;
+  bottom: 106px;
   z-index: 2000;
   width: 512px;
 


### PR DESCRIPTION
From ticket: TA currently is too large for a standard chrome.  The following updates are included in this PR:


- drop the icon to 60px x 60px
- halve the distance to the bottom of the container to 33px
- shift modal down to ~ 100px from bottom

Let me know if you have any questions or need to tweak a bit!
<img width="906" alt="image" src="https://github.com/user-attachments/assets/061fc592-d321-486c-bfd1-fcc525ab61fb" />


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?selectedIssue=AITT-944)