### PR TITLE
Adds aria label to Codebridge code editor

### DIFF
--- a/apps/i18n/pythonlab/en_us.json
+++ b/apps/i18n/pythonlab/en_us.json
@@ -1,4 +1,5 @@
 {
+  "codeEditor": "Code Editor",
   "inputFailed": "We're sorry, input is unavailable at this time. Input may not work in a private or incognito window. If you are in a standard browser window, please try refreshing the page. If the issue persists, contact support@code.org.",
   "noCode": "You have no code to run.",
   "noFileToRun": "You have no {fileName} to run.",

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -130,29 +130,10 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
 
   // Sets aria-label on the input div once code mirror loads
   useEffect(() => {
-    const setAriaLabel = () => {
-      const cmContentDiv = editorRef.current?.querySelector('.cm-content');
-      if (cmContentDiv) {
-        cmContentDiv.setAttribute('aria-label', i18n.codeEditor());
-      }
-    };
-
-    // Set the aria-label initially
-    setAriaLabel();
-
-    // Ensure we set aria-label if/when code mirror updates
-    const observer = new MutationObserver(setAriaLabel);
-    if (editorRef.current) {
-      observer.observe(editorRef.current, {
-        childList: true,
-        subtree: true,
-      });
+    const cmContentDiv = editorRef.current?.querySelector('.cm-content');
+    if (cmContentDiv) {
+      cmContentDiv.setAttribute('aria-label', i18n.codeEditor());
     }
-
-    // Cleanup observer on unmount
-    return () => {
-      observer.disconnect();
-    };
   }, []);
 
   return (

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -6,6 +6,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {useDispatch} from 'react-redux';
 
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
+import i18n from '@cdo/apps/pythonlab/locale';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {editorConfig} from './editorConfig';
@@ -126,6 +127,33 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     editorReadOnlyCompartment,
     editorEditableCompartment,
   ]);
+
+  // Sets aria-label on the input div once code mirror loads
+  useEffect(() => {
+    const setAriaLabel = () => {
+      const cmContentDiv = editorRef.current?.querySelector('.cm-content');
+      if (cmContentDiv) {
+        cmContentDiv.setAttribute('aria-label', i18n.codeEditor());
+      }
+    };
+
+    // Set the aria-label initially
+    setAriaLabel();
+
+    // Ensure we set aria-label if/when code mirror updates
+    const observer = new MutationObserver(setAriaLabel);
+    if (editorRef.current) {
+      observer.observe(editorRef.current, {
+        childList: true,
+        subtree: true,
+      });
+    }
+
+    // Cleanup observer on unmount
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
Adds an aria-label to the code editor. I added it to the translation file as well

Before:
https://github.com/user-attachments/assets/0659eda5-cdf1-47eb-b02a-4506209c606d


After:
https://github.com/user-attachments/assets/b64dd936-b02c-46f8-8bf6-65c78fc6a868



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1113


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
