### PR TITLE
Codebridge: clean up file browser drag

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowser.tsx
@@ -9,6 +9,10 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
+import {
+  restrictToFirstScrollableAncestor,
+  restrictToVerticalAxis,
+} from '@dnd-kit/modifiers';
 import classNames from 'classnames';
 import React, {useMemo, useState} from 'react';
 
@@ -67,7 +71,14 @@ export const FileBrowser = React.memo(() => {
       rightHeaderContent={!isReadOnly && <FileBrowserHeaderPopUpButton />}
     >
       <div className={moduleStyles.fileBrowserContents}>
-        <DndContext onDragEnd={handleDragEnd} sensors={sensors}>
+        <DndContext
+          onDragEnd={handleDragEnd}
+          sensors={sensors}
+          modifiers={[
+            restrictToVerticalAxis,
+            restrictToFirstScrollableAncestor,
+          ]}
+        >
           <DndDataContextProvider
             value={{dragData, dropData}}
             dndMonitor={dndMonitor}


### PR DESCRIPTION
The file browser was letting you drag both horizontally and too far vertically. There are built-in modifiers in [dnd-kit](https://docs.dndkit.com/api-documentation/modifiers) that handle restricting movement, so I added those here.

## Before
https://github.com/user-attachments/assets/a7053949-bda3-4f76-8cce-d7f4e69cc70b


## After
https://github.com/user-attachments/assets/2b818f2e-7e04-40b7-a902-ecc2eedf3352



## Links
- jira ticket: [CT-1126](https://codedotorg.atlassian.net/browse/CT-1126)


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
