### PR TITLE
Removing hidden empty button in Musiclab dialog

### DIFF
--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -254,8 +254,6 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
 
   const currentFolderRef: React.MutableRefObject<HTMLDivElement | null> =
     useRef(null);
-  const currentSoundRef: React.MutableRefObject<HTMLDivElement | null> =
-    useRef(null);
 
   const onModeChange = useCallback((value: Mode) => {
     setMode(value);
@@ -270,7 +268,6 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
     // when wrapping the content with FocusLock.
     setTimeout(() => {
       currentFolderRef.current?.scrollIntoView();
-      currentSoundRef.current?.scrollIntoView();
     }, 0);
   }, []);
 
@@ -279,7 +276,6 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   };
 
   const currentSoundRefCallback = (ref: HTMLDivElement) => {
-    currentSoundRef.current = ref;
     if (!isFocusSet && ref) {
       setTimeout(() => {
         ref.focus();

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -337,7 +337,6 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
         aria-modal
         role="dialog"
       >
-        <div id="hidden-item" tabIndex={0} role="button" />
         {showSoundFilters && (
           <div
             id="sounds-panel-top"

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -250,6 +250,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   );
   const [mode, setMode] = useState<Mode>('packs');
   const [filter, setFilter] = useState<Filter>('all');
+  const [isFocusSet, setIsFocusSet] = useState(false);
 
   const currentFolderRef: React.MutableRefObject<HTMLDivElement | null> =
     useRef(null);
@@ -279,6 +280,12 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
 
   const currentSoundRefCallback = (ref: HTMLDivElement) => {
     currentSoundRef.current = ref;
+    if (!isFocusSet && ref) {
+      setTimeout(() => {
+        ref.focus();
+        setIsFocusSet(true);
+      }, 0);
+    }
   };
 
   let possibleSoundEntries: SoundEntry[] = [];

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -31,12 +31,14 @@
       background-color: $neutral_dark;
       flex: 1;
       overflow-y: scroll;
+      scroll-padding: 1px 0;
     }
 
     .rightColumn {
       background-color: $neutral_dark;
       flex: 1;
       overflow-y: scroll;
+      scroll-padding: 1px 0;
     }
   }
 


### PR DESCRIPTION
Removes empty button div that is a hidden item and receives keyboard focus unnecessarily. See screenreader experience before and after to catch the empty focus step. Now, the focus is set on the currently active beat.

Before:

https://github.com/user-attachments/assets/c9dbd0a5-1bf8-4cfe-9451-1edf9f1f3a08


After:


https://github.com/user-attachments/assets/d19d8577-3f34-47a7-864e-f3334b6b18a5




## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1006
- https://codedotorg.atlassian.net/browse/CT-1010

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
