### PR TITLE
feat(Video): add fallback title attributes to iframe and video elements

### DIFF
--- a/frontend/packages/component-library/src/video/Video.tsx
+++ b/frontend/packages/component-library/src/video/Video.tsx
@@ -71,7 +71,7 @@ const Video: React.FC<VideoProps> = ({
             // eslint-disable-next-line jsx-a11y/media-has-caption
             <video
               className={classNames(className)}
-              title={videoTitle}
+              title={videoTitle || 'Video player'}
               poster={posterThumbnail}
               src={videoFallback}
               controls
@@ -95,7 +95,7 @@ const Video: React.FC<VideoProps> = ({
           <iframe
             className={classNames(className)}
             src={`https://www.youtube-nocookie.com/embed/${youTubeId}`}
-            title={videoTitle}
+            title={videoTitle || 'YouTube video player'}
             allowFullScreen
             {...HTMLAttributes}
           />


### PR DESCRIPTION
Adds fallback `title` attributes on the `iframe` and `<video>` elements on the Video component. This fixes a WCAG issue seen [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1741204426264559).

Both of these should hypothetically never show up without a title from a content entry, but adding them just in case.

## Links
Jira ticket: [CMS-398](https://codedotorg.atlassian.net/browse/CMS-398)
Slack convo: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1741204426264559)

## Testing story
Tested locally

----

<img width="1617" alt="Screenshot 2025-03-07 at 2 59 16 PM" src="https://github.com/user-attachments/assets/82d830c6-8feb-4048-979b-43cd21eafb82" />
