### PR TITLE
feat(Carousel): add aria-labels directly on nav buttons

### DIFF
--- a/frontend/packages/component-library/src/carousel/Carousel.tsx
+++ b/frontend/packages/component-library/src/carousel/Carousel.tsx
@@ -107,6 +107,7 @@ const Carousel: React.FC<CarouselProps> = ({
             <button
               id={`${carouselId}-prev`}
               className={classNames(moduleStyles.swiperNavPrev)}
+              aria-label={'Previous slide'}
             >
               <FontAwesomeV6Icon iconName="arrow-left" />
             </button>
@@ -114,6 +115,7 @@ const Carousel: React.FC<CarouselProps> = ({
             <button
               id={`${carouselId}-next`}
               className={classNames(moduleStyles.swiperNavNext)}
+              aria-label={'Next slide'}
             >
               <FontAwesomeV6Icon iconName="arrow-right" />
             </button>


### PR DESCRIPTION
Adds `aria-label`s directly on the Previous and Next navigation arrow buttons to fix a WCAG error seen in Safari due to Swiper not loading in time for the Swiper-generated aria-labels to load.

## Links
Jira ticket: [CMS-399](https://codedotorg.atlassian.net/browse/CMS-399)
Slack convo: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1741388126922289?thread_ts=1741386402.128099&cid=C07UW4ED66Q)

## Testing story
Tested locally

---- 

<img width="622" alt="Screenshot 2025-03-07 at 3 27 18 PM" src="https://github.com/user-attachments/assets/fd5411d0-5ea6-426a-8e49-8b26fac046b0" />

<img width="1356" alt="Screenshot 2025-03-07 at 3 27 37 PM" src="https://github.com/user-attachments/assets/da084284-a5ad-481e-8a4e-7f7fed77c260" />
