### PR TITLE
AI Tutor - add auto-scroll

### DIFF
--- a/apps/src/aiTutor/redux/aiTutorRedux.ts
+++ b/apps/src/aiTutor/redux/aiTutorRedux.ts
@@ -69,6 +69,7 @@ const formatResponseForStudent = (response: string) => {
 export const askAITutor = createAsyncThunk(
   'aitutor/askAITutor',
   async (chatContext: ChatContext, thunkAPI) => {
+    thunkAPI.dispatch(setIsWaitingForChatResponse(true));
     const state = thunkAPI.getState();
     const aiTutorState = state as {aiTutor: AITutorState};
     const levelContext = {
@@ -97,6 +98,7 @@ export const askAITutor = createAsyncThunk(
       levelContext.levelId,
       levelContext.scriptId
     );
+    thunkAPI.dispatch(setIsWaitingForChatResponse(false));
     thunkAPI.dispatch(
       updateLastChatMessage({
         status: chatApiResponse.status,
@@ -173,18 +175,6 @@ const aiTutorSlice = createSlice({
     setShowSuggestedPrompts: (state, action: PayloadAction<boolean>) => {
       state.showSuggestedPrompts = action.payload;
     },
-  },
-  extraReducers: builder => {
-    builder.addCase(askAITutor.fulfilled, state => {
-      state.isWaitingForChatResponse = false;
-    });
-    builder.addCase(askAITutor.rejected, (state, action) => {
-      state.isWaitingForChatResponse = false;
-      console.error(action.error);
-    });
-    builder.addCase(askAITutor.pending, state => {
-      state.isWaitingForChatResponse = true;
-    });
   },
 });
 

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef, useEffect} from 'react';
 
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
@@ -13,44 +13,60 @@ import WarningModal from './WarningModal';
 import style from './ai-tutor.module.scss';
 
 const AITutorChatWorkspace: React.FunctionComponent = () => {
+  const conversationContainerRef = useRef<HTMLDivElement>(null);
   const storedMessages = useAppSelector(state => state.aiTutor.chatMessages);
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
   );
 
-  const showWaitingAnimation = () => {
-    if (isWaitingForChatResponse) {
-      return (
-        <img
-          src="/blockly/media/aichat/typing-animation.gif"
-          alt={'Waiting for response'}
-          className={style.waitingForResponse}
-        />
-      );
-    }
-  };
+  useEffect(() => {
+    // Autoscroll to the bottom of the workspace when new messages are added.
+    conversationContainerRef.current?.scrollTo({
+      top: conversationContainerRef.current.scrollHeight,
+      behavior: 'smooth',
+    });
+  }, [storedMessages.length, isWaitingForChatResponse]);
 
   return (
-    <div id="ai-tutor-chat-workspace">
-      {storedMessages.map((message, index) => (
-        <ChatMessage
-          key={message.id ?? `message-${index}`}
-          text={message.chatMessageText}
-          role={message.role}
-          customStyles={style}
-          footer={
-            message.role === Role.ASSISTANT &&
-            message.chatMessageText !== initialAssistantGreeting ? (
-              <AssistantMessageFeedback messageId={message.id} />
-            ) : null
-          }
-        />
-      ))}
-      {showWaitingAnimation()}
+    <div id="ai-tutor-chat-workspace" className={style.aiTutorChatWorkspace}>
+      <div
+        className={style.conversationContainer}
+        ref={conversationContainerRef}
+      >
+        {storedMessages.map((message, index) => (
+          <ChatMessage
+            key={message.id ?? `message-${index}`}
+            text={message.chatMessageText}
+            role={message.role}
+            customStyles={style}
+            footer={
+              message.role === Role.ASSISTANT &&
+              message.chatMessageText !== initialAssistantGreeting ? (
+                <AssistantMessageFeedback messageId={message.id} />
+              ) : null
+            }
+          />
+        ))}
+        <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
+      </div>
       <WarningModal />
       <AITutorSuggestedPrompts />
     </div>
   );
 };
 
+const WaitingAnimation: React.FunctionComponent<{shouldDisplay: boolean}> = ({
+  shouldDisplay,
+}) => {
+  if (shouldDisplay) {
+    return (
+      <img
+        src="/blockly/media/aichat/typing-animation.gif"
+        alt={'Waiting for response'}
+        className={style.waitingForResponse}
+      />
+    );
+  }
+  return null;
+};
 export default AITutorChatWorkspace;

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useEffect} from 'react';
+import React, {useRef, useEffect, useState} from 'react';
 
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
@@ -18,14 +18,33 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
   );
+  const showSuggestedPrompts = useAppSelector(
+    state => state.aiTutor.showSuggestedPrompts
+  );
 
+  const [feedbackDetailsOpen, setFeedbackDetailsOpen] = useState(false);
   useEffect(() => {
-    // Autoscroll to the bottom of the workspace when new messages are added.
-    conversationContainerRef.current?.scrollTo({
-      top: conversationContainerRef.current.scrollHeight,
-      behavior: 'smooth',
-    });
-  }, [storedMessages.length, isWaitingForChatResponse]);
+    // Autoscroll to the bottom of the workspace when new messages, suggested prompts,
+    // or waiting for animation gif is displayed.
+    console.log('showSuggestedPrompts', showSuggestedPrompts);
+    console.log(
+      'conversationContainerRef.current.scrollHeight',
+      conversationContainerRef?.current?.scrollHeight
+    );
+    setTimeout(() => {
+      if (conversationContainerRef.current) {
+        conversationContainerRef.current.scrollTo({
+          top: conversationContainerRef.current.scrollHeight,
+          behavior: 'smooth',
+        });
+      }
+    }, 150); // Small delay to ensure DOM updates before scrolling.
+  }, [
+    storedMessages.length,
+    isWaitingForChatResponse,
+    showSuggestedPrompts,
+    feedbackDetailsOpen,
+  ]);
 
   return (
     <div id="ai-tutor-chat-workspace" className={style.aiTutorChatWorkspace}>
@@ -42,13 +61,16 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
             footer={
               message.role === Role.ASSISTANT &&
               message.chatMessageText !== initialAssistantGreeting ? (
-                <AssistantMessageFeedback messageId={message.id} />
+                <AssistantMessageFeedback
+                  messageId={message.id}
+                  onDetailsOpenChange={setFeedbackDetailsOpen}
+                />
               ) : null
             }
           />
         ))}
         <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
-        <AITutorSuggestedPrompts />
+        {showSuggestedPrompts && <AITutorSuggestedPrompts />}
       </div>
       <WarningModal />
     </div>
@@ -60,11 +82,13 @@ const WaitingAnimation: React.FunctionComponent<{shouldDisplay: boolean}> = ({
 }) => {
   if (shouldDisplay) {
     return (
-      <img
-        src="/blockly/media/aichat/typing-animation.gif"
-        alt={'Waiting for response'}
-        className={style.waitingForResponse}
-      />
+      <div className={style.waitingAnimationWrapper}>
+        <img
+          src="/blockly/media/aichat/typing-animation.gif"
+          alt={'Waiting for response'}
+          className={style.waitingForResponse}
+        />
+      </div>
     );
   }
   return null;

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -26,11 +26,6 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   useEffect(() => {
     // Autoscroll to the bottom of the workspace when new messages, suggested prompts,
     // or waiting for animation gif is displayed.
-    console.log('showSuggestedPrompts', showSuggestedPrompts);
-    console.log(
-      'conversationContainerRef.current.scrollHeight',
-      conversationContainerRef?.current?.scrollHeight
-    );
     setTimeout(() => {
       if (conversationContainerRef.current) {
         conversationContainerRef.current.scrollTo({

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -48,9 +48,9 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
           />
         ))}
         <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
+        <AITutorSuggestedPrompts />
       </div>
       <WarningModal />
-      <AITutorSuggestedPrompts />
     </div>
   );
 };

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -33,7 +33,7 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
           behavior: 'smooth',
         });
       }
-    }, 150); // Small delay to ensure DOM updates before scrolling.
+    }, 250); // Small delay to ensure DOM updates before scrolling.
   }, [
     storedMessages.length,
     isWaitingForChatResponse,
@@ -65,7 +65,7 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
           />
         ))}
         <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
-        {showSuggestedPrompts && <AITutorSuggestedPrompts />}
+        <AITutorSuggestedPrompts />
       </div>
       <WarningModal />
     </div>

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -25,7 +25,7 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   const [feedbackDetailsOpen, setFeedbackDetailsOpen] = useState(false);
   useEffect(() => {
     // Autoscroll to the bottom of the workspace when new messages, suggested prompts,
-    // or waiting for animation gif is displayed.
+    // or waiting animation is displayed.
     setTimeout(() => {
       if (conversationContainerRef.current) {
         conversationContainerRef.current.scrollTo({

--- a/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
+++ b/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
@@ -1,5 +1,5 @@
 import Button, {buttonColors} from '@code-dot-org/component-library/button';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -14,10 +14,12 @@ import style from './ai-tutor.module.scss';
 
 interface AssistantMessageProps {
   messageId: number | undefined;
+  onDetailsOpenChange: (isOpen: boolean) => void;
 }
 
 const AssistantMessageFeedback: React.FC<AssistantMessageProps> = ({
   messageId,
+  onDetailsOpenChange,
 }) => {
   const [feedbackState, setFeedbackState] = useState<FeedbackData>({
     thumbsUp: false,
@@ -39,6 +41,10 @@ const AssistantMessageFeedback: React.FC<AssistantMessageProps> = ({
     setFeedbackState({thumbsUp: thumbsUp, thumbsDown: thumbsDown});
     setDetailsOpen(thumbsUp || thumbsDown);
   };
+
+  useEffect(() => {
+    onDetailsOpenChange(detailsOpen);
+  }, [detailsOpen, onDetailsOpenChange]);
 
   return (
     <div className={style.feedbackIcons}>

--- a/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
+++ b/apps/src/aiTutor/views/AssistantMessageFeedback.tsx
@@ -14,6 +14,9 @@ import style from './ai-tutor.module.scss';
 
 interface AssistantMessageProps {
   messageId: number | undefined;
+  // Callback function from parent component to track when assistant feedback details
+  // are opened or closed. Allows auto-scroll to take into account assistant message
+  // feedback height.
   onDetailsOpenChange: (isOpen: boolean) => void;
 }
 

--- a/apps/src/aiTutor/views/ai-tutor.module.scss
+++ b/apps/src/aiTutor/views/ai-tutor.module.scss
@@ -17,8 +17,7 @@ $default-spacing: 16px;
 }
 
 .aiTutorChatWorkspace {
-  max-height: 600px;
-  flex-grow: 1;
+  max-height: 100%;
 }
 
 button.buttonStyle {

--- a/apps/src/aiTutor/views/ai-tutor.module.scss
+++ b/apps/src/aiTutor/views/ai-tutor.module.scss
@@ -17,10 +17,8 @@ $default-spacing: 16px;
 }
 
 .aiTutorChatWorkspace {
-  overflow-y: auto;
   max-height: 600px;
   flex-grow: 1;
-  box-sizing: border-box;
 }
 
 button.buttonStyle {

--- a/apps/src/aiTutor/views/ai-tutor.module.scss
+++ b/apps/src/aiTutor/views/ai-tutor.module.scss
@@ -5,6 +5,7 @@
 
 $border-color: $light_gray_800;
 $border-width: 1px;
+$default-spacing: 16px;
 
 .aiTutorContainer {
   position: fixed;
@@ -13,6 +14,13 @@ $border-width: 1px;
   z-index: 2000;
   width: 760px;
   color: $default_text;
+}
+
+.aiTutorChatWorkspace {
+  overflow-y: auto;
+  max-height: 600px;
+  flex-grow: 1;
+  box-sizing: border-box;
 }
 
 button.buttonStyle {
@@ -144,6 +152,7 @@ button.buttonStyle {
 
 .waitingForResponse {
   width: 50px;
+  margin-left: 1em;
 }
 
 .message-user {
@@ -164,3 +173,15 @@ button.buttonStyle {
 .feedbackButton {
   margin-right: 5px;
 }
+
+.conversationContainer {
+  display: flex;
+  flex-direction: column;
+  gap: $default-spacing;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
+  box-sizing: border-box;
+  padding: $default-spacing;
+}
+

--- a/apps/src/aiTutor/views/ai-tutor.module.scss
+++ b/apps/src/aiTutor/views/ai-tutor.module.scss
@@ -152,7 +152,6 @@ button.buttonStyle {
 
 .waitingForResponse {
   width: 50px;
-  margin-left: 1em;
 }
 
 .message-user {

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,5 +1,4 @@
 import Button from '@code-dot-org/component-library/button';
-import classNames from 'classnames';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -94,10 +93,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   return (
     <div
       id="chat-workspace-conversation"
-      className={classNames(
-        moduleStyles.conversationArea,
-        moduleStyles.scrollToBottomContainer
-      )}
+      className={moduleStyles.conversationArea}
     >
       <div className={moduleStyles.messageArea} ref={conversationContainerRef}>
         {events.map(event => (

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,4 +1,5 @@
 import Button from '@code-dot-org/component-library/button';
+import classNames from 'classnames';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -93,7 +94,10 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   return (
     <div
       id="chat-workspace-conversation"
-      className={moduleStyles.conversationArea}
+      className={classNames(
+        moduleStyles.conversationArea,
+        moduleStyles.scrollToBottomContainer
+      )}
     >
       <div className={moduleStyles.messageArea} ref={conversationContainerRef}>
         {events.map(event => (


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a follow-up to an investigation into [why 3 dot animation was not being displayed when first message is a suggested prompt](https://codedotorg.atlassian.net/browse/CT-1117).

Initially, I thought that maybe this issue was related to how we don't automatically scroll to the bottom, but even after implementing auto-scroll, the 3 dots did not show up when the first message was a suggested prompt. Then I realized that this is NOT an issue on `production`.

So, this PR adds auto-scroll for AI Tutor. I included updates so that the workspace updates when the the user displays the assistant message details as well.

## Before update

Screencast shows when suggested prompts are displayed and selected, and then when a user-generated message is sent.


https://github.com/user-attachments/assets/e7b865fd-349a-48fb-af24-f0ae48c3f38c




## After update
I created an adhoc because of the 3-dot animation issue. You can see in the screencasts below that the waiting animation is displayed even when the first message is a suggested prompt. 

Screencast of scrolling with suggested prompts:



https://github.com/user-attachments/assets/c3e6c02d-627b-4a43-b868-6db2c9fcc431




Screencast of scrolling with user-generated message:

https://github.com/user-attachments/assets/ae591072-d223-4d27-8f63-79e0ba58eeee





## Links
[jira](https://codedotorg.atlassian.net/browse/CT-1135)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally and on an adhoc: https://adhoc-alice-scroll-update-studio.cdn-code.org (confirming 3-dot animation is displayed when first message is a suggested prompt).

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
