### PR TITLE
fix(Carousel): add eyes ignore region on video carousels

### DIFF
--- a/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
+++ b/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
@@ -387,7 +387,10 @@ VideoCarousels.parameters = {
         'Videos carousels can show or hide captions based on the `showCaption` prop on the `Video` component. There are margins applied between carousels so this displays nicely in Storybook, but this is not a part of the component itself.',
     },
   },
-  eyes: {waitBeforeCapture: 4000},
+  eyes: {
+    waitBeforeCapture: 4000,
+    ignoreRegions: [{selector: '.ytp-impression-link'}],
+  },
 };
 VideoCarousels.play = async ({canvasElement}: {canvasElement: HTMLElement}) => {
   const canvas = within(canvasElement);


### PR DESCRIPTION
Ignore the "Watch on YouTube" image that shows up in Eyes tests.

## Links
Jira ticket: [CMS-407](https://codedotorg.atlassian.net/browse/CMS-407)

----

<img width="1573" alt="Screenshot 2025-03-10 at 12 10 55 PM" src="https://github.com/user-attachments/assets/f1d037c6-6b14-4ff4-be7e-62afc9618204" />
