### PR TITLE
Remove footer from CensusMap

### DIFF
--- a/apps/src/templates/census/CensusMap.jsx
+++ b/apps/src/templates/census/CensusMap.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 
-import i18n from '@cdo/locale';
-
 class CensusMapInfoWindow extends Component {
   static propTypes = {
     onTakeSurveyClick: PropTypes.func,
@@ -401,20 +399,6 @@ export default class CensusMap extends Component {
           <div className="caption">No CS opportunities</div>
           <div className="color legend-no-data-cs" />
           <div className="caption">No Data</div>
-        </div>
-        <div id="map-footer">
-          <div id="left">
-            <a href="/yourschool/about" target="_blank">
-              Summary of the data sources we use
-            </a>
-          </div>
-          <div id="right">
-            <span id="footer-text">In partnership with</span>
-            <img
-              src="/images/fit-100/avatars/computer_science_teachers_association.png"
-              alt={i18n.CSTALogo()}
-            />
-          </div>
         </div>
         <br />
         <br />

--- a/pegasus/sites.v3/code.org/public/css/census-map.css
+++ b/pegasus/sites.v3/code.org/public/css/census-map.css
@@ -6,24 +6,6 @@
   color: rgb(26,172,186);
 }
 
-#map-footer {
-  font-size: 13px;
-  padding-top: 5px;
-}
-
-#map-footer #left {
-  float: left;
-  margin-right: 40px;
-}
-
-#map-footer #left a {
-  font-family: var(--main-font);
-}
-
-#map-footer #right {
-  float: right;
-}
-
 #mapbox {
   width: 100%;
   padding-bottom: 56.25%;

--- a/pegasus/sites.v3/code.org/public/yourschool.haml
+++ b/pegasus/sites.v3/code.org/public/yourschool.haml
@@ -62,8 +62,3 @@ social:
       = " "
       %a{href: "https://advocacy.code.org/stateofcs/", target: "_blank"}> annual State of Computer Science Education
       , published each fall.
-    %span{style: "font-family: var(--main-font); font-weight: var(--bold-font-weight); font-size: 20px; margin: 0 25px 0 25px;"} In partnership with
-    %img{src: '/images/fit-200/avatars/computer_science_teachers_association.png'}
-
-%br
-%br


### PR DESCRIPTION
Everything in the footer is outdated, from a broken link to the partnership with CSTA. I also removed the CSTA callout at the bottom of /yourschool.

Embeddable map:

![Screenshot 2025-03-11 at 8 35 34 AM](https://github.com/user-attachments/assets/9bdbff7e-bb93-42b8-b178-d8c7bd3916a7)

Map on /yourschool:

![Screenshot 2025-03-11 at 8 36 02 AM](https://github.com/user-attachments/assets/0df13743-5d6b-4e04-bc00-945302a996e2)

Bottom of /yourschool with CSTA callout removed:

![Screenshot 2025-03-11 at 8 40 04 AM](https://github.com/user-attachments/assets/67b15d2f-e898-4595-bd50-6982083de9c8)


Completes both https://codedotorg.atlassian.net/browse/ACQ-3148 and https://codedotorg.atlassian.net/browse/ACQ-3149