### PR TITLE
feat(ga4): add google analytics to `marketing`

### DIFF
--- a/frontend/apps/marketing/lighthouserc.json
+++ b/frontend/apps/marketing/lighthouserc.json
@@ -13,8 +13,9 @@
         "unminified-css": ["error", {"maxLength": 1}],
         "unminified-javascript": ["error", {"maxLength": 20}],
         "unused-css-rules": ["error", {"maxLength": 5}],
-        "unused-javascript": ["error", {"maxLength": 6}],
+        "unused-javascript": ["error", {"maxLength": 10}],
         "uses-text-compression": ["error", {"maxLength": 5}],
+        "third-party-cookies": ["error", {"minScore": 0.9}],
         "valid-source-maps": "off",
         "uses-rel-preconnect": "off"
       }

--- a/frontend/apps/marketing/lighthouserc.json
+++ b/frontend/apps/marketing/lighthouserc.json
@@ -15,7 +15,7 @@
         "unused-css-rules": ["error", {"maxLength": 5}],
         "unused-javascript": ["error", {"maxLength": 10}],
         "uses-text-compression": ["error", {"maxLength": 5}],
-        "third-party-cookies": ["error", {"minScore": 0.9}],
+        "third-party-cookies": "off",
         "valid-source-maps": "off",
         "uses-rel-preconnect": "off"
       }

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -37,6 +37,7 @@
     "@code-dot-org/component-library": "workspace:*",
     "@code-dot-org/fonts": "workspace:*",
     "@contentful/experiences-sdk-react": "^1.34.1",
+    "@next/third-parties": "^15.2.1",
     "contentful": "^11.2.5",
     "next": "^15.1.2",
     "react": "^18.3.1",

--- a/frontend/apps/marketing/src/app/layout.tsx
+++ b/frontend/apps/marketing/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import {GoogleAnalytics} from '@next/third-parties/google';
 import type {Metadata} from 'next';
 
 import '@code-dot-org/component-library-styles/font-awesome.scss';
@@ -5,19 +6,29 @@ import '@code-dot-org/component-library-styles/colors.scss';
 import '@code-dot-org/fonts/index.css';
 
 import './globals.css';
+import {headers} from 'next/headers';
+import {getGoogleAnalyticsMeasurementId} from '@/config/ga4';
+import {getBrandFromHostname} from '@/config/brand';
 
 export const metadata: Metadata = {
   title: 'Code.org',
   description: 'Anyone can learn!',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const hostname = (await headers()).get('Host');
+  const brand = getBrandFromHostname(hostname);
+  const googleAnalyticsMeasurementId = getGoogleAnalyticsMeasurementId(brand);
+
   return (
     <html lang="en">
+      {googleAnalyticsMeasurementId && (
+        <GoogleAnalytics gaId={googleAnalyticsMeasurementId} />
+      )}
       <body>{children}</body>
     </html>
   );

--- a/frontend/apps/marketing/src/config/__tests__/brand.test.ts
+++ b/frontend/apps/marketing/src/config/__tests__/brand.test.ts
@@ -1,0 +1,25 @@
+import {Brand, getBrandFromHostname} from '../brand';
+
+describe('Brand Unit Tests', () => {
+  describe('getBrandFromHostname', () => {
+    it('should return HoC', () => {
+      expect(getBrandFromHostname('localhost.hourofcode.com:3001')).toBe(
+        Brand.HOUR_OF_CODE,
+      );
+      expect(getBrandFromHostname('hourofcode.com:3001')).toBe(
+        Brand.HOUR_OF_CODE,
+      );
+    });
+
+    it('should return Code.org', () => {
+      expect(getBrandFromHostname('localhost:3001')).toBe(Brand.CODE_DOT_ORG);
+      expect(getBrandFromHostname('code.org')).toBe(Brand.CODE_DOT_ORG);
+      expect(getBrandFromHostname('staging.code.org')).toBe(Brand.CODE_DOT_ORG);
+      expect(getBrandFromHostname('test.code.org')).toBe(Brand.CODE_DOT_ORG);
+      expect(getBrandFromHostname('anything.dev-code.org')).toBe(
+        Brand.CODE_DOT_ORG,
+      );
+      expect(getBrandFromHostname(null)).toBe(Brand.CODE_DOT_ORG);
+    });
+  });
+});

--- a/frontend/apps/marketing/src/config/brand.ts
+++ b/frontend/apps/marketing/src/config/brand.ts
@@ -1,0 +1,14 @@
+export enum Brand {
+  CODE_DOT_ORG = 'Code.org',
+  HOUR_OF_CODE = 'Hour of Code',
+}
+
+export function getBrandFromHostname(hostname: string | null) {
+  switch (hostname) {
+    case 'localhost.hourofcode.com:3001':
+    case 'hourofcode.com:3001':
+      return Brand.HOUR_OF_CODE;
+    default:
+      return Brand.CODE_DOT_ORG;
+  }
+}

--- a/frontend/apps/marketing/src/config/ga4/__tests__/index.spec.ts
+++ b/frontend/apps/marketing/src/config/ga4/__tests__/index.spec.ts
@@ -1,0 +1,24 @@
+import {
+  getGoogleAnalyticsMeasurementId,
+  GOOGLE_ANALYTICS_CONFIG,
+} from '../index';
+import {Brand} from '@/config/brand';
+
+describe('Google Analytics Config', () => {
+  it('should return the correct measurement ID for CODE_DOT_ORG', () => {
+    const measurementId = getGoogleAnalyticsMeasurementId(Brand.CODE_DOT_ORG);
+    expect(measurementId).toBe(GOOGLE_ANALYTICS_CONFIG[Brand.CODE_DOT_ORG]);
+  });
+
+  it('should return the correct measurement ID for HOUR_OF_CODE', () => {
+    const measurementId = getGoogleAnalyticsMeasurementId(Brand.HOUR_OF_CODE);
+    expect(measurementId).toBe(GOOGLE_ANALYTICS_CONFIG[Brand.HOUR_OF_CODE]);
+  });
+
+  it('should return undefined for an unknown brand', () => {
+    const measurementId = getGoogleAnalyticsMeasurementId(
+      'UNKNOWN_BRAND' as Brand,
+    );
+    expect(measurementId).toBeUndefined();
+  });
+});

--- a/frontend/apps/marketing/src/config/ga4/index.ts
+++ b/frontend/apps/marketing/src/config/ga4/index.ts
@@ -1,0 +1,10 @@
+import {Brand} from '@/config/brand';
+
+export const GOOGLE_ANALYTICS_CONFIG = {
+  [Brand.CODE_DOT_ORG]: 'G-L9HT5MZ3HD',
+  [Brand.HOUR_OF_CODE]: 'G-Z6QQP1041C',
+};
+
+export function getGoogleAnalyticsMeasurementId(brand: Brand) {
+  return GOOGLE_ANALYTICS_CONFIG[brand];
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1263,6 +1263,7 @@ __metadata:
     "@code-dot-org/fonts": "workspace:*"
     "@contentful/experiences-sdk-react": "npm:^1.34.1"
     "@next/eslint-plugin-next": "npm:^15.0.3"
+    "@next/third-parties": "npm:^15.2.1"
     "@playwright/test": "npm:~1.49.1"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
@@ -3263,6 +3264,18 @@ __metadata:
   version: 15.1.4
   resolution: "@next/swc-win32-x64-msvc@npm:15.1.4"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/third-parties@npm:^15.2.1":
+  version: 15.2.1
+  resolution: "@next/third-parties@npm:15.2.1"
+  dependencies:
+    third-party-capital: "npm:1.0.20"
+  peerDependencies:
+    next: ^13.0.0 || ^14.0.0 || ^15.0.0
+    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+  checksum: 10c0/32b09d88727688f8111a7e6f85fe81887139c6b3bebc73da77622f17e6ff6f1a1eb4034a1b0fe699e54a8c4d97a3303aca072d7e6cb6acba6529a678208e8440
   languageName: node
   linkType: hard
 
@@ -17334,6 +17347,13 @@ __metadata:
   dependencies:
     any-promise: "npm:^1.0.0"
   checksum: 10c0/f375aeb2b05c100a456a30bc3ed07ef03a39cbdefe02e0403fb714b8c7e57eeaad1a2f5c4ecfb9ce554ce3db9c2b024eba144843cd9e344566d9fcee73b04767
+  languageName: node
+  linkType: hard
+
+"third-party-capital@npm:1.0.20":
+  version: 1.0.20
+  resolution: "third-party-capital@npm:1.0.20"
+  checksum: 10c0/7f45ff156ec9d7e2957a5b39061be22b780ffbd2d93c127252d908e2bff6cdd09f827a95909d457c8096e036f155006a38e355a06ee11cb6d63c7f4b150bbfb0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds google analytics support and initial scaffolding for breaking out configuration by hostname (code.org vs hourofcode).

---

# Testing

![image](https://github.com/user-attachments/assets/54920339-3bdc-4aec-b828-d513c14aa534)


Confirmed the paths are loading on GA4.