### PR TITLE
Fix Project Endpoints Intermittently Failing to Decrypt Channel ID

### DIFF
--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -28,13 +28,15 @@ def destroy_storage_id_cookie
 end
 
 def storage_decrypt(encrypted)
-  $storage_id_decrypter ||= OpenSSL::Cipher.new('AES-128-CBC').tap do |decrypter|
+  Thread.current[:storage_id_decrypter] ||= OpenSSL::Cipher.new('AES-128-CBC').tap do |decrypter|
     decrypter.decrypt
     decrypter.pkcs5_keyivgen(CDO.channels_api_secret, '8 octets')
   end
-  (decrypter = $storage_id_decrypter).reset
+  decrypter = Thread.current[:storage_id_decrypter]
+  decrypter.reset
   plain = decrypter.update(encrypted)
   plain << decrypter.final
+  plain
 end
 
 def storage_decrypt_id(encrypted)
@@ -68,13 +70,15 @@ def valid_encrypted_channel_id(encrypted)
 end
 
 def storage_encrypt(plain)
-  $storage_id_encrypter ||= OpenSSL::Cipher.new('AES-128-CBC').tap do |encrypter|
+  Thread.current[:storage_id_encrypter] ||= OpenSSL::Cipher.new('AES-128-CBC').tap do |encrypter|
     encrypter.encrypt
     encrypter.pkcs5_keyivgen(CDO.channels_api_secret, '8 octets')
   end
-  (encrypter = $storage_id_encrypter).reset
+  encrypter = Thread.current[:storage_id_encrypter]
+  encrypter.reset
   encrypted = encrypter.update(plain.to_s)
   encrypted << encrypter.final
+  encrypted
 end
 
 def storage_encrypt_id(id)

--- a/shared/test/middleware/helpers/test_storage_id.rb
+++ b/shared/test/middleware/helpers/test_storage_id.rb
@@ -243,7 +243,7 @@ class StorageIdTest < Minitest::Test
       "Expected #{total_operations} successful operations but got #{actual_successful_operations}: #{failed_operations_message}"
     )
     assert_equal 0, failure_count, "Expected 0 failures but got #{failure_count}"
-    # Ensure execution time was less than 1 second.
-    assert_operator total_time.round(2), :<, 1
+    # Ensure execution time was less than 5 seconds.
+    assert_operator total_time.round(2), :<, 5
   end
 end

--- a/shared/test/middleware/helpers/test_storage_id.rb
+++ b/shared/test/middleware/helpers/test_storage_id.rb
@@ -4,6 +4,28 @@ require_relative '../../../middleware/helpers/storage_id'
 class StorageIdTest < Minitest::Test
   include SetupTest
 
+  # Create a barrier to synchronize thread start
+  class ThreadBarrier
+    def initialize(count)
+      @count = count
+      @mutex = Mutex.new
+      @cond = ConditionVariable.new
+      @waiting = 0
+    end
+
+    def wait
+      @mutex.synchronize do
+        @waiting += 1
+        if @waiting >= @count
+          @waiting = 0
+          @cond.broadcast
+        else
+          @cond.wait(@mutex)
+        end
+      end
+    end
+  end
+
   def test_storage_id_for_current_user
     request = mock
     stubs(:request).returns(request)
@@ -122,5 +144,106 @@ class StorageIdTest < Minitest::Test
       end
     end
     assert_operator result.entries.first.ips, :>, 3000
+  end
+
+  def test_storage_encrypt_decrypt_thread_safety
+    # Define test parameters
+    thread_count = 50
+    operations_per_thread = 10_000
+    failures = Queue.new
+    successful_operations = 0
+    successful_operations_mutex = Mutex.new
+
+    barrier = ThreadBarrier.new(thread_count)
+
+    # Track execution time.
+    start_time = Time.now
+
+    # Create and start threads.
+    threads = Array.new(thread_count) do |thread_id|
+      Thread.new do
+        thread_successes = 0
+
+        # Wait for all threads to be ready before starting.
+        barrier.wait
+
+        operations_per_thread.times do |i|
+          # Create a unique value for each thread and operation
+          original_value = "thread-#{thread_id}-value-#{i}"
+
+          begin
+            # Encrypt the value using storage_encrypt.
+            encrypted = storage_encrypt(original_value)
+
+            # Introduce random delay to increase chance of collision.
+            sleep(rand * 0.0001) if i % 100 == 0
+
+            # Decrypt the value using storage_decrypt.
+            decrypted = storage_decrypt(encrypted)
+
+            # Verify the decryption matches the original.
+            if decrypted == original_value
+              thread_successes += 1
+            else
+              failures << "Thread #{thread_id}, operation #{i}: Expected '#{original_value}' but got '#{decrypted}'"
+            end
+          rescue => exception
+            failures << "Thread #{thread_id}, operation #{i}: Exception: #{exception.class} - #{exception.message}"
+          end
+        end
+
+        # Add this thread's successful operations to the total.
+        successful_operations_mutex.synchronize do
+          successful_operations += thread_successes
+        end
+      end
+    end
+
+    # Wait for all threads to complete.
+    threads.each(&:join)
+
+    # Calculate execution statistics.
+    total_time = Time.now - start_time
+    total_operations = thread_count * operations_per_thread
+    actual_successful_operations = successful_operations
+    throughput = total_operations / total_time
+
+    # Prepare assertion message with failure details.
+    failure_count = failures.size
+    failed_operations_message = if failure_count > 0
+                                  error_details = []
+                                  error_details << "#{failure_count} failures detected in storage_encrypt/decrypt:"
+
+                                  # Include up to 10 failure details.
+                                  sample_size = [10, failure_count].min
+                                  sample_size.times do
+                                    error_details << failures.pop
+                                  end
+
+                                  # Add ellipsis if more failures exist.
+                                  error_details << "..." unless failures.empty?
+
+                                  # Add performance info to the message.
+                                  error_details << "Threads: #{thread_count}"
+                                  error_details << "Operations per thread: #{operations_per_thread}"
+                                  error_details << "Total expected operations: #{total_operations}"
+                                  error_details << "Successful operations: #{successful_operations}"
+                                  error_details << "Execution time: #{total_time.round(2)} seconds"
+                                  error_details << "Throughput: #{throughput.round(2)} operations/second"
+
+                                  error_details.join("\n")
+                                else
+                                  "Expected #{total_operations} successful operations but got #{successful_operations}"
+                                end
+
+    # Assert all operations were successful.
+    assert_equal(
+      total_operations,
+      actual_successful_operations,
+      "Expected #{total_operations} successful operations but got #{actual_successful_operations}: #{failed_operations_message}"
+    )
+    assert_equal 0, failure_count, "Expected 0 failures but got #{failure_count}"
+    # Ensure execution time was less than 1 second.
+    assert_operator total_time.round(2), :<, 1
   end
 end


### PR DESCRIPTION
Several projects endpoints have started raising a NoMethodError ``undefined method `>'`` for nil:NilClass while decrypting the channel id. About 70-80 HTTP requests to projects endpoints are failing each day due to this issue.
https://codedotorg.atlassian.net/browse/LABS-1402

![image](https://github.com/user-attachments/assets/bbc88363-f556-42ca-8ad0-980505dc8cd6)

Spot checking some instances of these errors, the channel id in the HTTP request URL can be successfully decrypted in the `production-console` `dashboard-console` by invoking the `storage_decrypt_channel_id` method. Possibly our usage of a global variable for the `OpenSSL::Cipher` object is causing these intermittent failures because we try to reset and reuse it across multiple puma threads. Initializing a cipher is computationally expensive by design. Store the initialized cipher object in thread-local, because [we configure puma to provision 5 threads per child puma process](https://github.com/code-dot-org/code-dot-org/blob/0a36a1ff709c0ffa129389b1f26243f7a28459bb/dashboard/config/puma.rb#L11).

This error started occurring more frequently around the time we[ upgraded production EC2 Instance Class](https://github.com/code-dot-org/code-dot-org/pull/61983) from `m5.12xlarge` to the faster `m7i.12xlarge`. Possibly the faster CPU results in more than 1 thread within a single puma child Ruby process accessing the global Cipher object simultaneously.

## Testing story

We likely don't use a multi-threaded web application server in continuous integration builds, so we may need to do some testing in an adhoc. This adhoc provisioned successfully:

`$ bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-thread-safe-cipher`

## Deployment strategy

This is a modification to a foundational component; we should be cautious about deploying this change.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
