### PR TITLE
Use Latest Stable Chromedriver in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -82,7 +82,7 @@ steps:
   - name: unit-tests
     # see: docker/ci/Dockerfile
     # TODO: switch to codedotorg/cdo-ci
-    image: codedotorg/code-dot-org:1.14
+    image: codedotorg/code-dot-org:chrome-for-testing
     pull: always
     volumes:
       - name: rbenv
@@ -215,7 +215,7 @@ steps:
   - name: ui-tests
     # see: docker/ci/Dockerfile
     # TODO: switch to codedotorg/cdo-ci
-    image: codedotorg/code-dot-org:1.14
+    image: codedotorg/code-dot-org:chrome-for-testing
     pull: always
     volumes:
       - name: rbenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -82,7 +82,7 @@ steps:
   - name: unit-tests
     # see: docker/ci/Dockerfile
     # TODO: switch to codedotorg/cdo-ci
-    image: codedotorg/code-dot-org:chrome-for-testing
+    image: codedotorg/code-dot-org:1.15
     pull: always
     volumes:
       - name: rbenv
@@ -215,7 +215,7 @@ steps:
   - name: ui-tests
     # see: docker/ci/Dockerfile
     # TODO: switch to codedotorg/cdo-ci
-    image: codedotorg/code-dot-org:chrome-for-testing
+    image: codedotorg/code-dot-org:1.15
     pull: always
     volumes:
       - name: rbenv
@@ -316,6 +316,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: 438911a0c59ad180adae90c55e5bf3f15713df10458caf0f44347f7fff00eb4c
+hmac: bee4dcf20e1a1dcbb6b1dddb9777ff0d9c7b73fda6ae26811edce8227fea5413
 
 ...

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -157,10 +157,24 @@ RUN curl --output /tmp/firefox.deb https://s3.amazonaws.com/circle-downloads/fir
     rm /tmp/firefox.deb && \
     true
 
-# install Chrome for Testing (and corresponding chromedriver) based on instructions at
-# https://developer.chrome.com/blog/chrome-for-testing/#how_can_i_get_chrome_for_testing_binaries
-RUN npx @puppeteer/browsers install chrome@stable && \
-    npx @puppeteer/browsers install chromedriver@stable
+# Install Chrome for Testing and the corresponding chromedriver; see
+# https://googlechromelabs.github.io/chrome-for-testing/ for more details.
+# We could also attempt to automatically detect and install dependencies; see
+# https://github.com/GoogleChromeLabs/chrome-for-testing?tab=readme-ov-file#how-to-install-the-system-level-dependencies-required-for-archived-linux64-binaries
+RUN export CHROME_STABLE_VERSION=$(curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json | jq -r .channels.Stable.version) && \
+    # chrome \
+    curl -sSLOJ "https://storage.googleapis.com/chrome-for-testing-public/$CHROME_STABLE_VERSION/linux64/chrome-linux64.zip" && \
+    unzip chrome-linux64.zip && \
+    mv chrome-linux64 /opt/chrome && \
+    ln -s /opt/chrome/chrome /usr/local/bin/chrome && \
+    rm chrome-linux64.zip && \
+    # chromedriver \
+    curl -sSLOJ "https://storage.googleapis.com/chrome-for-testing-public/$CHROME_STABLE_VERSION/linux64/chromedriver-linux64.zip" && \
+    unzip chromedriver-linux64.zip && \
+    mv chromedriver-linux64/chromedriver /usr/local/bin/chromedriver && \
+    chmod +x /usr/local/bin/chromedriver && \
+    rm -r chromedriver-linux64 && \
+    rm chromedriver-linux64.zip
 
 # install pdftk & tidy
 RUN mv /usr/bin/parallel /usr/bin/gnu_parallel && \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -176,6 +176,8 @@ RUN export CHROME_STABLE_VERSION=$(curl -s https://googlechromelabs.github.io/ch
     rm -r chromedriver-linux64 && \
     rm chromedriver-linux64.zip
 
+ENV CHROME_BIN=/usr/local/bin/chrome
+
 # install pdftk & tidy
 RUN mv /usr/bin/parallel /usr/bin/gnu_parallel && \
     curl -sSLOJ https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/pdftk-java_3.0.9-1_all.deb && \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -157,21 +157,10 @@ RUN curl --output /tmp/firefox.deb https://s3.amazonaws.com/circle-downloads/fir
     rm /tmp/firefox.deb && \
     true
 
-# install chrome
-RUN curl -sSLOJ https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    dpkg -i google-chrome-stable_current_amd64.deb || apt-get -fy install && \
-    rm google-chrome-stable_current_amd64.deb && \
-    sed -i \
-        's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
-        "/opt/google/chrome/google-chrome"
-
-# install chromedriver
-RUN export CHROMEDRIVER_RELEASE=$(curl http://chromedriver.storage.googleapis.com/LATEST_RELEASE) && \
-    curl -sSLOJ "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" && \
-    unzip chromedriver_linux64.zip && \
-    rm chromedriver_linux64.zip && \
-    mv chromedriver /usr/local/bin/chromedriver && \
-    chmod +x /usr/local/bin/chromedriver
+# install Chrome for Testing (and corresponding chromedriver) based on instructions at
+# https://developer.chrome.com/blog/chrome-for-testing/#how_can_i_get_chrome_for_testing_binaries
+RUN npx @puppeteer/browsers install chrome@stable && \
+    npx @puppeteer/browsers install chromedriver@stable
 
 # install pdftk & tidy
 RUN mv /usr/bin/parallel /usr/bin/gnu_parallel && \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -157,26 +157,22 @@ RUN curl --output /tmp/firefox.deb https://s3.amazonaws.com/circle-downloads/fir
     rm /tmp/firefox.deb && \
     true
 
-# Install Chrome for Testing and the corresponding chromedriver; see
-# https://googlechromelabs.github.io/chrome-for-testing/ for more details.
-# We could also attempt to automatically detect and install dependencies; see
-# https://github.com/GoogleChromeLabs/chrome-for-testing?tab=readme-ov-file#how-to-install-the-system-level-dependencies-required-for-archived-linux64-binaries
+# install chrome
+RUN curl -sSLOJ https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+    dpkg -i google-chrome-stable_current_amd64.deb || apt-get -fy install && \
+    rm google-chrome-stable_current_amd64.deb && \
+    sed -i \
+        's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
+        "/opt/google/chrome/google-chrome"
+
+# install chromedriver
 RUN export CHROME_STABLE_VERSION=$(curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json | jq -r .channels.Stable.version) && \
-    # chrome \
-    curl -sSLOJ "https://storage.googleapis.com/chrome-for-testing-public/$CHROME_STABLE_VERSION/linux64/chrome-linux64.zip" && \
-    unzip chrome-linux64.zip && \
-    mv chrome-linux64 /opt/chrome && \
-    ln -s /opt/chrome/chrome /usr/local/bin/chrome && \
-    rm chrome-linux64.zip && \
-    # chromedriver \
     curl -sSLOJ "https://storage.googleapis.com/chrome-for-testing-public/$CHROME_STABLE_VERSION/linux64/chromedriver-linux64.zip" && \
     unzip chromedriver-linux64.zip && \
     mv chromedriver-linux64/chromedriver /usr/local/bin/chromedriver && \
     chmod +x /usr/local/bin/chromedriver && \
     rm -r chromedriver-linux64 && \
     rm chromedriver-linux64.zip
-
-ENV CHROME_BIN=/usr/local/bin/chrome
 
 # install pdftk & tidy
 RUN mv /usr/bin/parallel /usr/bin/gnu_parallel && \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -8,7 +8,7 @@
 
 
 #########################################################
-FROM ubuntu:20.04 as base
+FROM ubuntu:20.04 AS base
 #########################################################
 # multi-stage build for parallel compiling ruby:
 # see: https://docs.docker.com/build/building/multi-stage/
@@ -50,7 +50,7 @@ RUN groupadd --gid 3434 ${USER} && \
     printf "${USER} ALL=NOPASSWD: ALL\n" > /etc/sudoers.d/50-${USER}
 
 #########################################################
-FROM base as rbenv
+FROM base AS rbenv
 #########################################################
 # compile ruby to /home/${USER}/.rbenv
 #########################################################
@@ -67,7 +67,7 @@ RUN mkdir -p "$(rbenv root)"/plugins && \
 
 
 #########################################################
-FROM base as primary-layer
+FROM base AS primary-layer
 #########################################################
 # Main layer of this Dockerfile: add packages etc below
 #########################################################

--- a/docker/unit-tests-compose.yml
+++ b/docker/unit-tests-compose.yml
@@ -20,7 +20,7 @@ version: "3"
 services:
   site:
     # TODO: switch to codedotorg/cdo-ci or other new image
-    image: codedotorg/code-dot-org:1.14
+    image: codedotorg/code-dot-org:chrome-for-testing
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/ci/code-dot-org:delegated

--- a/docker/unit-tests-compose.yml
+++ b/docker/unit-tests-compose.yml
@@ -20,7 +20,7 @@ version: "3"
 services:
   site:
     # TODO: switch to codedotorg/cdo-ci or other new image
-    image: codedotorg/code-dot-org:chrome-for-testing
+    image: codedotorg/code-dot-org:1.15
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/ci/code-dot-org:delegated


### PR DESCRIPTION
[Google has deprecated the `http://chromedriver.storage.googleapis.com` installation endpoint in favor of the new `https://googlechromelabs.github.io/chrome-for-testing/` approach](https://groups.google.com/g/chromedriver-users/c/clpipqvOGjE/m/5NxzS_SRAgAJ). As such, although our CI image is using a relatively recent version of chrome, its version of chromedriver is quite out of date:

```bash
$ docker run --rm -it --entrypoint bash codedotorg/code-dot-org:1.14
ci@0b68e20ed657:~$ google-chrome --version
Google Chrome 131.0.6778.139
ci@0b68e20ed657:~$ chromedriver --version
ChromeDriver 114.0.5735.90 (386bc09e8f4f2e025eddae123f36f6263096ae49-refs/branch-heads/5735@{#1052})
```

In preparation for [some ongoing work to run Selenium within Drone](https://github.com/code-dot-org/code-dot-org/pull/64432), we need Chrome and Chromedriver to be at similar versions. Which they now are:

```bash
$ docker run --rm -it --entrypoint bash codedotorg/code-dot-org:chrome-for-testing
ci@fac6d7f353aa:~$ google-chrome --version
Google Chrome 134.0.6998.35
ci@fac6d7f353aa:~$ chromedriver --version
ChromeDriver 134.0.6998.88 (7e3d5c978c6d3a6eda25692cfac7f893a2b20dd0-refs/branch-heads/6998@{#1898})
```

Note that we are still installing Chrome via `https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb`, which will not always be exactly up to date with the `chrome-for-testing` distribution. It is significantly more complicated to install manually than chromedriver is, unfortunately, so I left it as-is for now. The two dependencies should be kept significantly more in sync than previously, even if they won't be perfect.

## Links

- https://developer.chrome.com/blog/chrome-for-testing/

## Testing story

Relying entirely on Drone CI to validate this Drone-CI-only change

## Deployment strategy

### **BEFORE MERGING**

Tag image with `1.15`

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
