### PR TITLE
fix(Video Carousel): make all fields optional on videoFallback prop

### DIFF
--- a/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
+++ b/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
@@ -45,7 +45,7 @@ const VideoCarousel: React.FC<VideoCarouselProps> = ({slides}) => {
               videoTitle={videoTitle}
               youTubeId={youTubeId}
               showCaption={true}
-              videoFallback={videoFallbackFile?.fields.file.url}
+              videoFallback={videoFallbackFile?.fields?.file?.url}
             />
           ),
         })),


### PR DESCRIPTION
Fixes an error where `videoFallbackFile.fields` returns null by making all fields optional. 

## Links
Jira ticket: [CMS-410](https://codedotorg.atlassian.net/browse/CMS-410)
Slack convo: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1741707032811159)