### PR TITLE
RUBRIC - fix styles of student-facing rubrics

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -443,7 +443,7 @@ button.rubricHeaderTab {
     height: 40px;
     padding: 0 1rem 0 2rem;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     align-self: stretch;
     line-height: 154%;
     position: relative;
@@ -486,6 +486,7 @@ button.rubricHeaderTab {
   gap: 16px;
   font-size: 14px;
   padding-left: 10px;
+  padding-top: 0.5rem;
 }
 
 .learningGoalHeaderRightSide {
@@ -559,7 +560,6 @@ h2.studentName {
   display: flex;
   flex-direction: row;
   width: 100%;
-  height: 100px;
   gap: 8px;
   min-height: 92px;
 }


### PR DESCRIPTION
Modified the student-facing rubrics styles so that the text did not clobber each other.

<img width="865" alt="image" src="https://github.com/user-attachments/assets/ec44d4d4-84a2-440d-9f3c-e84e85b9d0a3" />


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1668)