### PR TITLE
Add more routes to the disallow list

### DIFF
--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -853,6 +853,10 @@ module SharedConstants
     "/join/",
     "/milestone/",
     "/projects/",
-    "/sections/"
+    "/sections/",
+    "/r",
+    "/c",
+    "/oauth_sign_out/",
+    "/certificates/"
   ].freeze
 end


### PR DESCRIPTION
In looking at pages that are getting indexed by google I found some more routes we should not index. This PR disallows indexing for:

- /c/
- /r/
- /oauth_sign_out/
- /certificates/

I confirmed with each team in slack that we don't want to index these routes. 
