### PR TITLE
Hide project reset button when viewing student work

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -263,16 +263,17 @@ const AichatView: React.FunctionComponent<LabProps> = () => {
                   headerContent={aichatI18n.modelCustomizationHeader()}
                   className={moduleStyles.panelContainer}
                   headerClassName={moduleStyles.panelHeader}
-                  rightHeaderContent={renderModelCustomizationHeaderRight(
-                    () => {
+                  rightHeaderContent={
+                    !viewAsUserId &&
+                    renderModelCustomizationHeaderRight(() => {
                       onClickStartOver();
                       dispatch(
                         sendAnalytics(EVENTS.AICHAT_START_OVER, {
                           levelPath: window.location.pathname,
                         })
                       );
-                    }
-                  )}
+                    })
+                  }
                 >
                   <ModelCustomizationWorkspace />
                 </PanelContainer>


### PR DESCRIPTION
I'm in pursuit of "stop logging events that make it hard to differentiate between a teacher using their own project vs. one of their student's projects". This is one of them -- an `AichatEvent` is generated on project reset, and I don't think it makes sense for a teacher to be able to reset their project when looking at a student's project.

## Testing story

Tested manually.