### PR TITLE
AI Tutor - scroll to top of latest assistant message in workspace

### DIFF
--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -119,16 +119,18 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
 const WaitingAnimation: React.FunctionComponent<{shouldDisplay: boolean}> = ({
   shouldDisplay,
 }) => {
-  if (!shouldDisplay) return null;
-  return (
-    <div className={style.waitingAnimationWrapper}>
-      <img
-        src="/blockly/media/aichat/typing-animation.gif"
-        alt="Waiting for response"
-        className={style.waitingForResponse}
-      />
-    </div>
-  );
+  if (shouldDisplay) {
+    return (
+      <div className={style.waitingAnimationWrapper}>
+        <img
+          src="/blockly/media/aichat/typing-animation.gif"
+          alt="Waiting for response"
+          className={style.waitingForResponse}
+        />
+      </div>
+    );
+  }
+  return null;
 };
 
 export default AITutorChatWorkspace;

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -5,7 +5,6 @@ import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {initialAssistantGreeting} from '../constants';
-import {ChatCompletionMessage} from '../types';
 
 import AITutorSuggestedPrompts from './AITutorSuggestedPrompts';
 import AssistantMessageFeedback from './AssistantMessageFeedback';
@@ -26,51 +25,36 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
 
   const [feedbackDetailsOpen, setFeedbackDetailsOpen] = useState(false);
 
-  const findAssistantLastIndex = (array: ChatCompletionMessage[]) => {
-    for (let i = array.length - 1; i >= 0; i--) {
-      if (array[i].role === Role.ASSISTANT) {
-        return i;
-      }
-    }
-    return -1;
-  };
-  const lastAssistantMessageIndex = findAssistantLastIndex(storedMessages);
+  const lastAssistantMessageIndex = storedMessages
+    .map(msg => msg.role)
+    .lastIndexOf(Role.ASSISTANT);
+
   const isLastMessageFromAssistant =
-    storedMessages.length - 1 === lastAssistantMessageIndex;
+    lastAssistantMessageIndex === storedMessages.length - 1;
 
   useEffect(() => {
-    console.log('conversation useEffect', conversationContainerRef.current);
-    // Autoscroll to the bottom of the workspace when new user messages, suggested prompts,
-    // or waiting animation is displayed.
+    if (!conversationContainerRef.current) return;
+
     setTimeout(() => {
-      if (conversationContainerRef.current) {
-        conversationContainerRef.current.scrollTo({
+      if (isLastMessageFromAssistant && lastAssistantMessageRef.current) {
+        // Scroll to the top of the latest assistant message
+        lastAssistantMessageRef.current.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      } else {
+        // Scroll to the bottom for user messages or other elements
+        conversationContainerRef.current?.scrollTo({
           top: conversationContainerRef.current.scrollHeight,
           behavior: 'smooth',
         });
       }
-    }, 250); // Small delay to ensure DOM updates before scrolling.
+    }, 250); // Small delay to allow DOM updates
   }, [
     storedMessages.length,
     isWaitingForChatResponse,
     showSuggestedPrompts,
     feedbackDetailsOpen,
-    isLastMessageFromAssistant,
-  ]);
-  useEffect(() => {
-    console.log('lastAssistant useEffect', lastAssistantMessageRef.current);
-    // Autoscroll to the top of the latest assistant message.
-    setTimeout(() => {
-      if (lastAssistantMessageRef.current && isLastMessageFromAssistant) {
-        lastAssistantMessageRef.current.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start', // Ensures it scrolls to the top of the message.
-        });
-      }
-    }, 250); // Small delay to ensure DOM updates before scrolling.
-  }, [
-    storedMessages.length,
-    isWaitingForChatResponse,
     isLastMessageFromAssistant,
   ]);
 

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -24,6 +24,8 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   );
 
   const [feedbackDetailsOpen, setFeedbackDetailsOpen] = useState(false);
+  const currentMessagesCountRef = useRef(storedMessages.length);
+  const currentFeedbackDetailsOpenRef = useRef(feedbackDetailsOpen);
 
   const lastAssistantMessageIndex = storedMessages
     .map(msg => msg.role)
@@ -31,30 +33,50 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
 
   const isLastMessageFromAssistant =
     lastAssistantMessageIndex === storedMessages.length - 1;
+  const isNewMessage =
+    storedMessages.length !== currentMessagesCountRef.current;
+  // Tracks if assistant feedback details section was just opened.
+  const isFeedbackOpened =
+    feedbackDetailsOpen && !currentFeedbackDetailsOpenRef.current;
+
+  const scrollToBottom = () => {
+    conversationContainerRef.current?.scrollTo({
+      top: conversationContainerRef.current.scrollHeight,
+      behavior: 'smooth',
+    });
+  };
+
+  const scrollToAssistantMessage = () => {
+    lastAssistantMessageRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  };
 
   useEffect(() => {
     if (!conversationContainerRef.current) return;
 
     setTimeout(() => {
-      if (isLastMessageFromAssistant && lastAssistantMessageRef.current) {
-        // Scroll to the top of the latest assistant message
-        lastAssistantMessageRef.current.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
-      } else {
-        // Scroll to the bottom for user messages or other elements
-        conversationContainerRef.current?.scrollTo({
-          top: conversationContainerRef.current.scrollHeight,
-          behavior: 'smooth',
-        });
+      if (isNewMessage) {
+        isLastMessageFromAssistant
+          ? scrollToAssistantMessage()
+          : scrollToBottom();
+      } else if (isFeedbackOpened || showSuggestedPrompts) {
+        scrollToBottom();
       }
-    }, 250); // Small delay to allow DOM updates
+
+      // Update refs to track changes in number of stored messages and whether
+      // assistant feedback details is open.
+      currentMessagesCountRef.current = storedMessages.length;
+      currentFeedbackDetailsOpenRef.current = feedbackDetailsOpen;
+    }, 200); // Small delay to allow DOM updates
   }, [
     storedMessages.length,
     isWaitingForChatResponse,
     showSuggestedPrompts,
     feedbackDetailsOpen,
+    isNewMessage,
+    isFeedbackOpened,
     isLastMessageFromAssistant,
   ]);
 
@@ -99,17 +121,16 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
 const WaitingAnimation: React.FunctionComponent<{shouldDisplay: boolean}> = ({
   shouldDisplay,
 }) => {
-  if (shouldDisplay) {
-    return (
-      <div className={style.waitingAnimationWrapper}>
-        <img
-          src="/blockly/media/aichat/typing-animation.gif"
-          alt={'Waiting for response'}
-          className={style.waitingForResponse}
-        />
-      </div>
-    );
-  }
-  return null;
+  if (!shouldDisplay) return null;
+  return (
+    <div className={style.waitingAnimationWrapper}>
+      <img
+        src="/blockly/media/aichat/typing-animation.gif"
+        alt="Waiting for response"
+        className={style.waitingForResponse}
+      />
+    </div>
+  );
 };
+
 export default AITutorChatWorkspace;

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -24,20 +24,14 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   );
 
   const [feedbackDetailsOpen, setFeedbackDetailsOpen] = useState(false);
-  const currentMessagesCountRef = useRef(storedMessages.length);
-  const currentFeedbackDetailsOpenRef = useRef(feedbackDetailsOpen);
+  const prevMessagesCountRef = useRef(storedMessages.length);
+  const prevFeedbackDetailsOpenRef = useRef(feedbackDetailsOpen);
 
   const lastAssistantMessageIndex = storedMessages
     .map(msg => msg.role)
     .lastIndexOf(Role.ASSISTANT);
-
   const isLastMessageFromAssistant =
     lastAssistantMessageIndex === storedMessages.length - 1;
-  const isNewMessage =
-    storedMessages.length !== currentMessagesCountRef.current;
-  // Tracks if assistant feedback details section was just opened.
-  const isFeedbackOpened =
-    feedbackDetailsOpen && !currentFeedbackDetailsOpenRef.current;
 
   const scrollToBottom = () => {
     conversationContainerRef.current?.scrollTo({
@@ -54,7 +48,14 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   };
 
   useEffect(() => {
-    if (!conversationContainerRef.current) return;
+    if (!conversationContainerRef.current) {
+      return;
+    }
+
+    const isNewMessage = storedMessages.length !== prevMessagesCountRef.current;
+    // Tracks if assistant feedback details section was just opened.
+    const isFeedbackOpened =
+      feedbackDetailsOpen && !prevFeedbackDetailsOpenRef.current;
 
     setTimeout(() => {
       if (isNewMessage) {
@@ -67,16 +68,13 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
 
       // Update refs to track changes in number of stored messages and whether
       // assistant feedback details is open.
-      currentMessagesCountRef.current = storedMessages.length;
-      currentFeedbackDetailsOpenRef.current = feedbackDetailsOpen;
+      prevMessagesCountRef.current = storedMessages.length;
+      prevFeedbackDetailsOpenRef.current = feedbackDetailsOpen;
     }, 200); // Small delay to allow DOM updates
   }, [
     storedMessages.length,
-    isWaitingForChatResponse,
     showSuggestedPrompts,
     feedbackDetailsOpen,
-    isNewMessage,
-    isFeedbackOpened,
     isLastMessageFromAssistant,
   ]);
 

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -5,6 +5,7 @@ import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {initialAssistantGreeting} from '../constants';
+import {ChatCompletionMessage} from '../types';
 
 import AITutorSuggestedPrompts from './AITutorSuggestedPrompts';
 import AssistantMessageFeedback from './AssistantMessageFeedback';
@@ -14,6 +15,7 @@ import style from './ai-tutor.module.scss';
 
 const AITutorChatWorkspace: React.FunctionComponent = () => {
   const conversationContainerRef = useRef<HTMLDivElement>(null);
+  const lastAssistantMessageRef = useRef<HTMLDivElement | null>(null);
   const storedMessages = useAppSelector(state => state.aiTutor.chatMessages);
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
@@ -23,6 +25,36 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   );
 
   const [feedbackDetailsOpen, setFeedbackDetailsOpen] = useState(false);
+
+  const findAssistantLastIndex = (array: ChatCompletionMessage[]) => {
+    for (let i = array.length - 1; i >= 0; i--) {
+      if (array[i].role === Role.ASSISTANT) {
+        return i;
+      }
+    }
+    return -1;
+  };
+  const lastAssistantMessageIndex = findAssistantLastIndex(storedMessages);
+  const isLastMessageFromAssistant =
+    storedMessages.length - 1 === lastAssistantMessageIndex;
+
+  useEffect(() => {
+    // Autoscroll to the bottom of the workspace when new messages, suggested prompts,
+    // or waiting animation is displayed.
+    setTimeout(() => {
+      if (lastAssistantMessageRef.current && isLastMessageFromAssistant) {
+        lastAssistantMessageRef.current.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start', // Ensures it scrolls to the top of the message.
+        });
+      }
+    }, 250); // Small delay to ensure DOM updates before scrolling.
+  }, [
+    storedMessages.length,
+    isWaitingForChatResponse,
+    isLastMessageFromAssistant,
+  ]);
+
   useEffect(() => {
     // Autoscroll to the bottom of the workspace when new messages, suggested prompts,
     // or waiting animation is displayed.
@@ -47,23 +79,30 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
         className={style.conversationContainer}
         ref={conversationContainerRef}
       >
-        {storedMessages.map((message, index) => (
-          <ChatMessage
-            key={message.id ?? `message-${index}`}
-            text={message.chatMessageText}
-            role={message.role}
-            customStyles={style}
-            footer={
-              message.role === Role.ASSISTANT &&
-              message.chatMessageText !== initialAssistantGreeting ? (
-                <AssistantMessageFeedback
-                  messageId={message.id}
-                  onDetailsOpenChange={setFeedbackDetailsOpen}
-                />
-              ) : null
-            }
-          />
-        ))}
+        {storedMessages.map((message, index) => {
+          const isLastAssistantMessage = index === lastAssistantMessageIndex;
+          return (
+            <div
+              key={message.id ?? `message-${index}`}
+              ref={isLastAssistantMessage ? lastAssistantMessageRef : null}
+            >
+              <ChatMessage
+                text={message.chatMessageText}
+                role={message.role}
+                customStyles={style}
+                footer={
+                  message.role === Role.ASSISTANT &&
+                  message.chatMessageText !== initialAssistantGreeting ? (
+                    <AssistantMessageFeedback
+                      messageId={message.id}
+                      onDetailsOpenChange={setFeedbackDetailsOpen}
+                    />
+                  ) : null
+                }
+              />
+            </div>
+          );
+        })}
         <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
         <AITutorSuggestedPrompts />
       </div>

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
@@ -27,9 +27,10 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   const prevMessagesCountRef = useRef(storedMessages.length);
   const prevFeedbackDetailsOpenRef = useRef(feedbackDetailsOpen);
 
-  const lastAssistantMessageIndex = storedMessages
-    .map(msg => msg.role)
-    .lastIndexOf(Role.ASSISTANT);
+  const lastAssistantMessageIndex = useMemo(
+    () => storedMessages.map(msg => msg.role).lastIndexOf(Role.ASSISTANT),
+    [storedMessages]
+  );
   const isLastMessageFromAssistant =
     lastAssistantMessageIndex === storedMessages.length - 1;
 

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -39,24 +39,8 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
     storedMessages.length - 1 === lastAssistantMessageIndex;
 
   useEffect(() => {
-    // Autoscroll to the bottom of the workspace when new messages, suggested prompts,
-    // or waiting animation is displayed.
-    setTimeout(() => {
-      if (lastAssistantMessageRef.current && isLastMessageFromAssistant) {
-        lastAssistantMessageRef.current.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start', // Ensures it scrolls to the top of the message.
-        });
-      }
-    }, 250); // Small delay to ensure DOM updates before scrolling.
-  }, [
-    storedMessages.length,
-    isWaitingForChatResponse,
-    isLastMessageFromAssistant,
-  ]);
-
-  useEffect(() => {
-    // Autoscroll to the bottom of the workspace when new messages, suggested prompts,
+    console.log('conversation useEffect', conversationContainerRef.current);
+    // Autoscroll to the bottom of the workspace when new user messages, suggested prompts,
     // or waiting animation is displayed.
     setTimeout(() => {
       if (conversationContainerRef.current) {
@@ -71,6 +55,23 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
     isWaitingForChatResponse,
     showSuggestedPrompts,
     feedbackDetailsOpen,
+    isLastMessageFromAssistant,
+  ]);
+  useEffect(() => {
+    console.log('lastAssistant useEffect', lastAssistantMessageRef.current);
+    // Autoscroll to the top of the latest assistant message.
+    setTimeout(() => {
+      if (lastAssistantMessageRef.current && isLastMessageFromAssistant) {
+        lastAssistantMessageRef.current.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start', // Ensures it scrolls to the top of the message.
+        });
+      }
+    }, 250); // Small delay to ensure DOM updates before scrolling.
+  }, [
+    storedMessages.length,
+    isWaitingForChatResponse,
+    isLastMessageFromAssistant,
   ]);
 
   return (


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/64407 which added automatic scrolling when elements are added to the AI Tutor workspace.

This PR updates the scroll logic so that if an assistant message is added to the workspace, we scroll to the top of the message so that the user doesn't have to manually scroll up to the beginning of the message.

Although this is not implemented in `aichat` we decided to implement in AI Tutor because assistant messages by default are longer and the workspace is smaller.

The implementation was a little tricky because I initially tracked if there was a new message or if the assistant feedback details was just opened via `useState`. However, this tracked state dependency would trigger another re-render so that the scrolling to the top of the assistant message would then be negated by another call to scroll to the bottom of the conversation ref.

Keeping track of these changes by using `useRef` resolved this issue!

## After update


https://github.com/user-attachments/assets/e46bb8c3-dd05-4a6b-99b7-6103fa969f15




## Links
[jira](https://codedotorg.atlassian.net/browse/CT-1137)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally on `aichat` and `javalab` levels.


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Will see if we can refine the delay in `useEffect` next. https://codedotorg.atlassian.net/browse/CT-1140


<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
