### PR TITLE
Python Lab Share View: Part 2

### DIFF
--- a/apps/i18n/pythonlab/en_us.json
+++ b/apps/i18n/pythonlab/en_us.json
@@ -1,5 +1,7 @@
 {
+  "changeConsoleVisibility": "Change Console Visibility",
   "codeEditor": "Code Editor",
+  "console": "Console",
   "inputFailed": "We're sorry, input is unavailable at this time. Input may not work in a private or incognito window. If you are in a standard browser window, please try refreshing the page. If the issue persists, contact support@code.org.",
   "noCode": "You have no code to run.",
   "noFileToRun": "You have no {fileName} to run.",

--- a/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
@@ -19,6 +19,7 @@ interface MiniAppPreviewProps {
   isMaximized: boolean;
   style?: React.CSSProperties;
   showMaximizeButton?: boolean;
+  handleScaling?: boolean;
 }
 
 const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
@@ -27,13 +28,16 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
   isMaximized,
   style,
   showMaximizeButton = true,
+  handleScaling,
 }) => {
   const {labConfig} = useCodebridgeContext();
 
   const miniApp = labConfig?.miniApp?.name;
 
   const miniAppComponent =
-    miniApp === MiniApps.Neighborhood ? <NeighborhoodPreview /> : null;
+    miniApp === MiniApps.Neighborhood ? (
+      <NeighborhoodPreview handleScaling={handleScaling} />
+    ) : null;
 
   return (
     <PanelContainer
@@ -64,7 +68,9 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
         )
       }
     >
-      <div style={style}>{miniAppComponent}</div>
+      <div style={style} className={moduleStyles.miniAppContainer}>
+        {miniAppComponent}
+      </div>
     </PanelContainer>
   );
 };

--- a/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
@@ -18,6 +18,7 @@ interface MiniAppPreviewProps {
   minimizeMiniApp: () => void;
   isMaximized: boolean;
   style?: React.CSSProperties;
+  showMaximizeButton?: boolean;
 }
 
 const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
@@ -25,6 +26,7 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
   minimizeMiniApp,
   isMaximized,
   style,
+  showMaximizeButton = true,
 }) => {
   const {labConfig} = useCodebridgeContext();
 
@@ -41,23 +43,25 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
       className={moduleStyles.previewContainer}
       headerClassName={moduleStyles.previewHeader}
       rightHeaderContent={
-        <Button
-          onClick={isMaximized ? minimizeMiniApp : maximizeMiniApp}
-          icon={{
-            iconStyle: 'solid',
-            iconName: isMaximized ? 'compress' : 'expand',
-          }}
-          size={'xs'}
-          type={'tertiary'}
-          className={classNames(darkModeStyles.tertiaryButton)}
-          isIconOnly={true}
-          color={'white'}
-          ariaLabel={
-            isMaximized
-              ? codebridgeI18n.minimizePreview()
-              : codebridgeI18n.maximizePreview()
-          }
-        />
+        showMaximizeButton && (
+          <Button
+            onClick={isMaximized ? minimizeMiniApp : maximizeMiniApp}
+            icon={{
+              iconStyle: 'solid',
+              iconName: isMaximized ? 'compress' : 'expand',
+            }}
+            size={'xs'}
+            type={'tertiary'}
+            className={classNames(darkModeStyles.tertiaryButton)}
+            isIconOnly={true}
+            color={'white'}
+            ariaLabel={
+              isMaximized
+                ? codebridgeI18n.minimizePreview()
+                : codebridgeI18n.maximizePreview()
+            }
+          />
+        )
       }
     >
       <div style={style}>{miniAppComponent}</div>

--- a/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
@@ -6,7 +6,7 @@ import {
   MiniApps,
 } from '@codebridge/constants';
 import {findFile} from '@codebridge/utils';
-import React, {useEffect, useMemo} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 
 import {setIsRunning} from '@cdo/apps/lab2/redux/systemRedux';
 import {MazeCell} from '@cdo/apps/lab2/types';
@@ -15,8 +15,19 @@ import Neighborhood from '@cdo/apps/miniApps/neighborhood/Neighborhood';
 import NeighborhoodVisualization from '@cdo/apps/miniApps/neighborhood/NeighborhoodVisualization';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {DEFAULT_MINI_APP_SIZE} from '../Workspace/constants';
+import {scaleMiniApp} from '../Workspace/outputHelpers';
+
+import moduleStyles from './neighborhood-preview.module.scss';
+
+interface NeighborhoodPreviewProps {
+  handleScaling?: boolean;
+}
+
 // Preview panel for the neighborhood mini app.
-const NeighborhoodPreview: React.FunctionComponent = () => {
+const NeighborhoodPreview: React.FunctionComponent<
+  NeighborhoodPreviewProps
+> = ({handleScaling}) => {
   const levelProperties = useAppSelector(state => state.lab.levelProperties);
   const {source, config} = useCodebridgeContext();
   const serializedMaze = findFile(
@@ -26,6 +37,23 @@ const NeighborhoodPreview: React.FunctionComponent = () => {
   )?.contents;
   const dispatch = useAppDispatch();
   const isVertical = config.activeLayout === 'vertical';
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const scaleNeighborhood = useCallback(() => {
+    if (handleScaling) {
+      const width = containerRef.current?.clientWidth || DEFAULT_MINI_APP_SIZE;
+      const height =
+        containerRef.current?.clientHeight || DEFAULT_MINI_APP_SIZE;
+      scaleMiniApp(height, width);
+    }
+  }, [handleScaling]);
+
+  // Scale neighborhood on load, and on resize.
+  useEffect(() => {
+    scaleNeighborhood();
+    window.addEventListener('resize', scaleNeighborhood);
+    return () => window.removeEventListener('resize', scaleNeighborhood);
+  }, [scaleNeighborhood]);
 
   const neighborhood = useMemo(() => {
     const neighborhoodRef = new Neighborhood(
@@ -91,7 +119,9 @@ const NeighborhoodPreview: React.FunctionComponent = () => {
   ]);
 
   return (
-    <NeighborhoodVisualization isDarkMode={true} useProtectedDiv={false} />
+    <div ref={containerRef} className={moduleStyles.neighborhoodContainer}>
+      <NeighborhoodVisualization isDarkMode={true} useProtectedDiv={false} />
+    </div>
   );
 };
 

--- a/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
@@ -51,7 +51,7 @@ const NeighborhoodPreview: React.FunctionComponent<
     [scaleNeighborhood]
   );
 
-  // Scale neighborhood on load, and on resize.
+  // If handleScaling is true, scale neighborhood on load, and on resize.
   useEffect(() => {
     if (handleScaling) {
       throttledScaleNeighborhood();

--- a/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
@@ -19,7 +19,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {DEFAULT_MINI_APP_SIZE} from '../Workspace/constants';
 import {scaleMiniApp} from '../Workspace/outputHelpers';
 
-import moduleStyles from './neighborhood-preview.module.scss';
+import moduleStyles from './mini-app-preview.module.scss';
 
 interface NeighborhoodPreviewProps {
   handleScaling?: boolean;
@@ -125,7 +125,7 @@ const NeighborhoodPreview: React.FunctionComponent<
   ]);
 
   return (
-    <div ref={containerRef} className={moduleStyles.neighborhoodContainer}>
+    <div ref={containerRef} className={moduleStyles.miniAppContainer}>
       <NeighborhoodVisualization isDarkMode={true} useProtectedDiv={false} />
     </div>
   );

--- a/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
@@ -6,6 +6,7 @@ import {
   MiniApps,
 } from '@codebridge/constants';
 import {findFile} from '@codebridge/utils';
+import {throttle} from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 
 import {setIsRunning} from '@cdo/apps/lab2/redux/systemRedux';
@@ -40,20 +41,25 @@ const NeighborhoodPreview: React.FunctionComponent<
   const containerRef = useRef<HTMLDivElement>(null);
 
   const scaleNeighborhood = useCallback(() => {
-    if (handleScaling) {
-      const width = containerRef.current?.clientWidth || DEFAULT_MINI_APP_SIZE;
-      const height =
-        containerRef.current?.clientHeight || DEFAULT_MINI_APP_SIZE;
-      scaleMiniApp(height, width);
-    }
-  }, [handleScaling]);
+    const width = containerRef.current?.clientWidth || DEFAULT_MINI_APP_SIZE;
+    const height = containerRef.current?.clientHeight || DEFAULT_MINI_APP_SIZE;
+    scaleMiniApp(height, width);
+  }, []);
+
+  const throttledScaleNeighborhood = useMemo(
+    () => throttle(scaleNeighborhood, 30),
+    [scaleNeighborhood]
+  );
 
   // Scale neighborhood on load, and on resize.
   useEffect(() => {
-    scaleNeighborhood();
-    window.addEventListener('resize', scaleNeighborhood);
-    return () => window.removeEventListener('resize', scaleNeighborhood);
-  }, [scaleNeighborhood]);
+    if (handleScaling) {
+      throttledScaleNeighborhood();
+      window.addEventListener('resize', throttledScaleNeighborhood);
+      return () =>
+        window.removeEventListener('resize', throttledScaleNeighborhood);
+    }
+  }, [throttledScaleNeighborhood, handleScaling]);
 
   const neighborhood = useMemo(() => {
     const neighborhoodRef = new Neighborhood(

--- a/apps/src/codebridge/MiniAppPreview/mini-app-preview.module.scss
+++ b/apps/src/codebridge/MiniAppPreview/mini-app-preview.module.scss
@@ -7,3 +7,9 @@
   height: 40px;
   min-height: 40px;
 }
+
+.miniAppContainer {
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+}

--- a/apps/src/codebridge/MiniAppPreview/neighborhood-preview.module.scss
+++ b/apps/src/codebridge/MiniAppPreview/neighborhood-preview.module.scss
@@ -1,0 +1,5 @@
+.neighborhoodContainer {
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+}

--- a/apps/src/codebridge/MiniAppPreview/neighborhood-preview.module.scss
+++ b/apps/src/codebridge/MiniAppPreview/neighborhood-preview.module.scss
@@ -1,5 +1,0 @@
-.neighborhoodContainer {
-  height: 100%;
-  width: 100%;
-  box-sizing: border-box;
-}

--- a/apps/src/pythonlab/layout/ConsoleAndPreviewShare.tsx
+++ b/apps/src/pythonlab/layout/ConsoleAndPreviewShare.tsx
@@ -1,9 +1,31 @@
 import React from 'react';
 
+import MiniAppPreview from '@cdo/apps/codebridge/MiniAppPreview/MiniAppPreview';
 import HorizontalOutput from '@cdo/apps/codebridge/Workspace/HorizontalOutput';
 
-const ConsoleAndPreviewShare: React.FunctionComponent = () => {
-  return <HorizontalOutput height={800} setOutputHeight={() => {}} />;
+import moduleStyles from './share-view.module.scss';
+
+interface ConsoleAndPreviewShareProps {
+  consoleVisible: boolean;
+}
+
+const ConsoleAndPreviewShare: React.FunctionComponent<
+  ConsoleAndPreviewShareProps
+> = ({consoleVisible}) => {
+  if (consoleVisible) {
+    return <HorizontalOutput height={800} setOutputHeight={() => {}} />;
+  }
+
+  return (
+    <div className={moduleStyles.fullScreenPreview}>
+      <MiniAppPreview
+        showMaximizeButton={false}
+        maximizeMiniApp={() => {}}
+        minimizeMiniApp={() => {}}
+        isMaximized={false}
+      />
+    </div>
+  );
 };
 
 export default ConsoleAndPreviewShare;

--- a/apps/src/pythonlab/layout/ConsoleAndPreviewShare.tsx
+++ b/apps/src/pythonlab/layout/ConsoleAndPreviewShare.tsx
@@ -1,55 +1,35 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 
 import MiniAppPreview from '@cdo/apps/codebridge/MiniAppPreview/MiniAppPreview';
 import HorizontalOutput from '@cdo/apps/codebridge/Workspace/HorizontalOutput';
 
-import moduleStyles from './share-view.module.scss';
-
 interface ConsoleAndPreviewShareProps {
   consoleVisible: boolean;
+  height: number;
+  width: number;
 }
 
 const ConsoleAndPreviewShare: React.FunctionComponent<
   ConsoleAndPreviewShareProps
-> = ({consoleVisible}) => {
-  const getAvailableOutputWidth = () => {
-    return Math.max(window.innerWidth - 150, 400);
-  };
-
-  const [outputWidth, setOutputWidth] = useState(getAvailableOutputWidth());
-  const [outputHeight, setOutputHeight] = useState(window.innerHeight);
-
-  useEffect(() => {
-    window.addEventListener('resize', () => {
-      setOutputWidth(getAvailableOutputWidth());
-      setOutputHeight(window.innerHeight);
-    });
-    return () =>
-      window.removeEventListener('resize', () => {
-        setOutputWidth(getAvailableOutputWidth());
-        setOutputHeight(window.innerHeight);
-      });
-  }, []);
-
+> = ({consoleVisible, height, width}) => {
   if (consoleVisible) {
     return (
       <HorizontalOutput
-        height={outputHeight}
-        width={outputWidth}
+        height={height}
+        width={width}
         setOutputHeight={() => {}}
       />
     );
   }
 
   return (
-    <div className={moduleStyles.fullScreenPreview}>
-      <MiniAppPreview
-        showMaximizeButton={false}
-        maximizeMiniApp={() => {}}
-        minimizeMiniApp={() => {}}
-        isMaximized={false}
-      />
-    </div>
+    <MiniAppPreview
+      showMaximizeButton={false}
+      maximizeMiniApp={() => {}}
+      minimizeMiniApp={() => {}}
+      isMaximized={false}
+      handleScaling={true}
+    />
   );
 };
 

--- a/apps/src/pythonlab/layout/ConsoleAndPreviewShare.tsx
+++ b/apps/src/pythonlab/layout/ConsoleAndPreviewShare.tsx
@@ -7,13 +7,20 @@ import moduleStyles from './share-view.module.scss';
 
 interface ConsoleAndPreviewShareProps {
   consoleVisible: boolean;
+  availableWidth: number;
 }
 
 const ConsoleAndPreviewShare: React.FunctionComponent<
   ConsoleAndPreviewShareProps
-> = ({consoleVisible}) => {
+> = ({consoleVisible, availableWidth}) => {
   if (consoleVisible) {
-    return <HorizontalOutput height={800} setOutputHeight={() => {}} />;
+    return (
+      <HorizontalOutput
+        height={800}
+        width={availableWidth}
+        setOutputHeight={() => {}}
+      />
+    );
   }
 
   return (

--- a/apps/src/pythonlab/layout/ConsoleAndPreviewShare.tsx
+++ b/apps/src/pythonlab/layout/ConsoleAndPreviewShare.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import MiniAppPreview from '@cdo/apps/codebridge/MiniAppPreview/MiniAppPreview';
 import HorizontalOutput from '@cdo/apps/codebridge/Workspace/HorizontalOutput';
@@ -7,17 +7,35 @@ import moduleStyles from './share-view.module.scss';
 
 interface ConsoleAndPreviewShareProps {
   consoleVisible: boolean;
-  availableWidth: number;
 }
 
 const ConsoleAndPreviewShare: React.FunctionComponent<
   ConsoleAndPreviewShareProps
-> = ({consoleVisible, availableWidth}) => {
+> = ({consoleVisible}) => {
+  const getAvailableOutputWidth = () => {
+    return Math.max(window.innerWidth - 150, 400);
+  };
+
+  const [outputWidth, setOutputWidth] = useState(getAvailableOutputWidth());
+  const [outputHeight, setOutputHeight] = useState(window.innerHeight);
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
+      setOutputWidth(getAvailableOutputWidth());
+      setOutputHeight(window.innerHeight);
+    });
+    return () =>
+      window.removeEventListener('resize', () => {
+        setOutputWidth(getAvailableOutputWidth());
+        setOutputHeight(window.innerHeight);
+      });
+  }, []);
+
   if (consoleVisible) {
     return (
       <HorizontalOutput
-        height={800}
-        width={availableWidth}
+        height={outputHeight}
+        width={outputWidth}
         setOutputHeight={() => {}}
       />
     );

--- a/apps/src/pythonlab/layout/ConsoleShare.tsx
+++ b/apps/src/pythonlab/layout/ConsoleShare.tsx
@@ -2,14 +2,8 @@ import React from 'react';
 
 import Console from '@cdo/apps/codebridge/Console/Console';
 
-import moduleStyles from './share-view.module.scss';
-
 const ConsoleShare: React.FunctionComponent = () => {
-  return (
-    <div className={moduleStyles.consoleContainer}>
-      <Console />
-    </div>
-  );
+  return <Console />;
 };
 
 export default ConsoleShare;

--- a/apps/src/pythonlab/layout/ShareView.tsx
+++ b/apps/src/pythonlab/layout/ShareView.tsx
@@ -1,6 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import Toggle from '@code-dot-org/component-library/toggle';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {hasPreview} from '@cdo/apps/codebridge';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -28,6 +28,25 @@ const ShareView: React.FunctionComponent = () => {
   const [consoleVisible, setConsoleVisible] = useState(false);
 
   const showPreview = hasPreview(miniApp);
+
+  const getAvailablePreviewWidth = () => {
+    return Math.max(window.innerWidth - 150, 400);
+  };
+
+  const [previewWidth, setPreviewWidth] = useState(getAvailablePreviewWidth());
+  const [previewHeight, setPreviewHeight] = useState(window.innerHeight);
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
+      setPreviewWidth(getAvailablePreviewWidth());
+      setPreviewHeight(window.innerHeight);
+    });
+    return () =>
+      window.removeEventListener('resize', () => {
+        setPreviewWidth(getAvailablePreviewWidth());
+        setPreviewHeight(window.innerHeight);
+      });
+  }, []);
 
   return (
     <div className={moduleStyles.shareContainer}>
@@ -61,11 +80,20 @@ const ShareView: React.FunctionComponent = () => {
           onClick={onRemix}
         />
       </div>
-      {showPreview ? (
-        <ConsoleAndPreviewShare consoleVisible={consoleVisible} />
-      ) : (
-        <ConsoleShare />
-      )}
+      <div
+        className={moduleStyles.previewContainer}
+        style={{width: previewWidth, height: previewHeight}}
+      >
+        {showPreview ? (
+          <ConsoleAndPreviewShare
+            consoleVisible={consoleVisible}
+            height={previewHeight}
+            width={previewWidth}
+          />
+        ) : (
+          <ConsoleShare />
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/src/pythonlab/layout/ShareView.tsx
+++ b/apps/src/pythonlab/layout/ShareView.tsx
@@ -13,6 +13,9 @@ import ConsoleShare from './ConsoleShare';
 
 import moduleStyles from './share-view.module.scss';
 
+const SIDEBAR_WIDTH = 150;
+const MIN_PREVIEW_WIDTH = 200;
+
 const ShareView: React.FunctionComponent = () => {
   const miniApp = useAppSelector(
     state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
@@ -30,7 +33,7 @@ const ShareView: React.FunctionComponent = () => {
   const showPreview = hasPreview(miniApp);
 
   const getAvailablePreviewWidth = () => {
-    return Math.max(window.innerWidth - 150, 400);
+    return Math.max(window.innerWidth - SIDEBAR_WIDTH, MIN_PREVIEW_WIDTH);
   };
 
   const [previewWidth, setPreviewWidth] = useState(getAvailablePreviewWidth());

--- a/apps/src/pythonlab/layout/ShareView.tsx
+++ b/apps/src/pythonlab/layout/ShareView.tsx
@@ -1,6 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import Toggle from '@code-dot-org/component-library/toggle';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {hasPreview} from '@cdo/apps/codebridge';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -17,6 +17,11 @@ const ShareView: React.FunctionComponent = () => {
   const miniApp = useAppSelector(
     state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
   );
+  const getAvailableOutputWidth = () => {
+    return Math.max(window.innerWidth - 172, 400);
+  };
+
+  const [outputWidth, setOutputWidth] = useState(getAvailableOutputWidth());
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   const onViewCode = () => {
     projectManager?.redirectToView();
@@ -29,45 +34,56 @@ const ShareView: React.FunctionComponent = () => {
 
   const showPreview = hasPreview(miniApp);
 
+  useEffect(() => {
+    window.addEventListener('resize', () =>
+      setOutputWidth(getAvailableOutputWidth())
+    );
+    return () =>
+      window.removeEventListener('resize', () =>
+        setOutputWidth(getAvailableOutputWidth())
+      );
+  }, []);
+
   return (
-    <div>
-      <div className={moduleStyles.shareContainer}>
-        <div className={moduleStyles.sidebar} data-theme="Dark">
-          {showPreview && (
-            <div className={moduleStyles.consoleToggle}>
-              <Toggle
-                checked={consoleVisible}
-                onChange={e => setConsoleVisible(e.target.checked)}
-                name={pythonlabI18n.changeConsoleVisibility()}
-                label={pythonlabI18n.console()}
-                position={'right'}
-                size={'xs'}
-              />
-            </div>
-          )}
-          <Button
-            text={commonI18n.viewCode()}
-            type="tertiary"
-            color="black"
-            size="xs"
-            iconLeft={{iconStyle: 'solid', iconName: 'code'}}
-            onClick={onViewCode}
-          />
-          <Button
-            text={commonI18n.makeMyOwn()}
-            type="tertiary"
-            color="black"
-            size="xs"
-            iconLeft={{iconStyle: 'regular', iconName: 'pen-to-square'}}
-            onClick={onRemix}
-          />
-        </div>
-        {showPreview ? (
-          <ConsoleAndPreviewShare consoleVisible={consoleVisible} />
-        ) : (
-          <ConsoleShare />
+    <div className={moduleStyles.shareContainer}>
+      <div className={moduleStyles.sidebar} data-theme="Dark">
+        {showPreview && (
+          <div className={moduleStyles.consoleToggle}>
+            <Toggle
+              checked={consoleVisible}
+              onChange={e => setConsoleVisible(e.target.checked)}
+              name={pythonlabI18n.changeConsoleVisibility()}
+              label={pythonlabI18n.console()}
+              position={'right'}
+              size={'xs'}
+            />
+          </div>
         )}
+        <Button
+          text={commonI18n.viewCode()}
+          type="tertiary"
+          color="black"
+          size="xs"
+          iconLeft={{iconStyle: 'solid', iconName: 'code'}}
+          onClick={onViewCode}
+        />
+        <Button
+          text={commonI18n.makeMyOwn()}
+          type="tertiary"
+          color="black"
+          size="xs"
+          iconLeft={{iconStyle: 'regular', iconName: 'pen-to-square'}}
+          onClick={onRemix}
+        />
       </div>
+      {showPreview ? (
+        <ConsoleAndPreviewShare
+          consoleVisible={consoleVisible}
+          availableWidth={outputWidth}
+        />
+      ) : (
+        <ConsoleShare />
+      )}
     </div>
   );
 };

--- a/apps/src/pythonlab/layout/ShareView.tsx
+++ b/apps/src/pythonlab/layout/ShareView.tsx
@@ -18,7 +18,7 @@ const ShareView: React.FunctionComponent = () => {
     state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
   );
   const getAvailableOutputWidth = () => {
-    return Math.max(window.innerWidth - 172, 400);
+    return Math.max(window.innerWidth - 150, 400);
   };
 
   const [outputWidth, setOutputWidth] = useState(getAvailableOutputWidth());

--- a/apps/src/pythonlab/layout/ShareView.tsx
+++ b/apps/src/pythonlab/layout/ShareView.tsx
@@ -62,7 +62,11 @@ const ShareView: React.FunctionComponent = () => {
             onClick={onRemix}
           />
         </div>
-        {showPreview ? <ConsoleAndPreviewShare /> : <ConsoleShare />}
+        {showPreview ? (
+          <ConsoleAndPreviewShare consoleVisible={consoleVisible} />
+        ) : (
+          <ConsoleShare />
+        )}
       </div>
     </div>
   );

--- a/apps/src/pythonlab/layout/ShareView.tsx
+++ b/apps/src/pythonlab/layout/ShareView.tsx
@@ -1,7 +1,12 @@
-import React from 'react';
+import Button from '@code-dot-org/component-library/button';
+import Toggle from '@code-dot-org/component-library/toggle';
+import React, {useState} from 'react';
 
 import {hasPreview} from '@cdo/apps/codebridge';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import pythonlabI18n from '@cdo/apps/pythonlab/locale';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import commonI18n from '@cdo/locale';
 
 import ConsoleAndPreviewShare from './ConsoleAndPreviewShare';
 import ConsoleShare from './ConsoleShare';
@@ -12,11 +17,53 @@ const ShareView: React.FunctionComponent = () => {
   const miniApp = useAppSelector(
     state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
   );
+  const projectManager = Lab2Registry.getInstance().getProjectManager();
+  const onViewCode = () => {
+    projectManager?.redirectToView();
+  };
+
+  const onRemix = () => {
+    projectManager?.redirectToRemix();
+  };
+  const [consoleVisible, setConsoleVisible] = useState(false);
+
+  const showPreview = hasPreview(miniApp);
 
   return (
-    <div className={moduleStyles.shareContainer}>
-      <div className={moduleStyles.sidebar}>Sidebar</div>
-      {hasPreview(miniApp) ? <ConsoleAndPreviewShare /> : <ConsoleShare />}
+    <div>
+      <div className={moduleStyles.shareContainer}>
+        <div className={moduleStyles.sidebar} data-theme="Dark">
+          {showPreview && (
+            <div className={moduleStyles.consoleToggle}>
+              <Toggle
+                checked={consoleVisible}
+                onChange={e => setConsoleVisible(e.target.checked)}
+                name={pythonlabI18n.changeConsoleVisibility()}
+                label={pythonlabI18n.console()}
+                position={'right'}
+                size={'xs'}
+              />
+            </div>
+          )}
+          <Button
+            text={commonI18n.viewCode()}
+            type="tertiary"
+            color="black"
+            size="xs"
+            iconLeft={{iconStyle: 'solid', iconName: 'code'}}
+            onClick={onViewCode}
+          />
+          <Button
+            text={commonI18n.makeMyOwn()}
+            type="tertiary"
+            color="black"
+            size="xs"
+            iconLeft={{iconStyle: 'regular', iconName: 'pen-to-square'}}
+            onClick={onRemix}
+          />
+        </div>
+        {showPreview ? <ConsoleAndPreviewShare /> : <ConsoleShare />}
+      </div>
     </div>
   );
 };

--- a/apps/src/pythonlab/layout/ShareView.tsx
+++ b/apps/src/pythonlab/layout/ShareView.tsx
@@ -1,6 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import Toggle from '@code-dot-org/component-library/toggle';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 
 import {hasPreview} from '@cdo/apps/codebridge';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -17,11 +17,6 @@ const ShareView: React.FunctionComponent = () => {
   const miniApp = useAppSelector(
     state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
   );
-  const getAvailableOutputWidth = () => {
-    return Math.max(window.innerWidth - 150, 400);
-  };
-
-  const [outputWidth, setOutputWidth] = useState(getAvailableOutputWidth());
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   const onViewCode = () => {
     projectManager?.redirectToView();
@@ -33,16 +28,6 @@ const ShareView: React.FunctionComponent = () => {
   const [consoleVisible, setConsoleVisible] = useState(false);
 
   const showPreview = hasPreview(miniApp);
-
-  useEffect(() => {
-    window.addEventListener('resize', () =>
-      setOutputWidth(getAvailableOutputWidth())
-    );
-    return () =>
-      window.removeEventListener('resize', () =>
-        setOutputWidth(getAvailableOutputWidth())
-      );
-  }, []);
 
   return (
     <div className={moduleStyles.shareContainer}>
@@ -77,10 +62,7 @@ const ShareView: React.FunctionComponent = () => {
         />
       </div>
       {showPreview ? (
-        <ConsoleAndPreviewShare
-          consoleVisible={consoleVisible}
-          availableWidth={outputWidth}
-        />
+        <ConsoleAndPreviewShare consoleVisible={consoleVisible} />
       ) : (
         <ConsoleShare />
       )}

--- a/apps/src/pythonlab/layout/share-view.module.scss
+++ b/apps/src/pythonlab/layout/share-view.module.scss
@@ -24,3 +24,8 @@
   margin-left: 8px;
   margin-bottom: 8px;
 }
+
+.fullScreenPreview {
+  height: 100%;
+  width: 100%;
+}

--- a/apps/src/pythonlab/layout/share-view.module.scss
+++ b/apps/src/pythonlab/layout/share-view.module.scss
@@ -6,13 +6,13 @@
 }
 
 .sidebar {
-  width: 150px;
-  min-width: 150px;
+  width: 130px;
+  min-width: 130px;
   margin-top: 120px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin-left: 20px;
+  padding-left: 20px;
   gap: 8px;
 }
 

--- a/apps/src/pythonlab/layout/share-view.module.scss
+++ b/apps/src/pythonlab/layout/share-view.module.scss
@@ -1,16 +1,26 @@
 @import '@code-dot-org/component-library-styles/colors';
 .shareContainer {
   display: flex;
-  color: var(--text-neutral-white-fixed);
+  color: var(--text-neutral-primary);
   height: 100%;
 }
 
 .sidebar {
-  width: 300px;
+  width: 150px;
   margin-top: 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-left: 20px;
+  gap: 8px;
 }
 
 .consoleContainer {
   height: 100%;
   width: 100%;
+}
+
+.consoleToggle {
+  margin-left: 8px;
+  margin-bottom: 8px;
 }

--- a/apps/src/pythonlab/layout/share-view.module.scss
+++ b/apps/src/pythonlab/layout/share-view.module.scss
@@ -7,6 +7,7 @@
 
 .sidebar {
   width: 150px;
+  min-width: 150px;
   margin-top: 120px;
   display: flex;
   flex-direction: column;

--- a/apps/src/pythonlab/layout/share-view.module.scss
+++ b/apps/src/pythonlab/layout/share-view.module.scss
@@ -1,13 +1,16 @@
 @import '@code-dot-org/component-library-styles/colors';
 .shareContainer {
-  display: flex;
+  display: inline-grid;
+  grid-template-columns: 150px 1fr;
+  grid-template-rows: 1fr;
+  grid-template-areas: "sidebar preview";
   color: var(--text-neutral-primary);
   height: 100%;
+  width: 100%;
 }
 
 .sidebar {
-  width: 130px;
-  min-width: 130px;
+  grid-area: sidebar;
   margin-top: 120px;
   display: flex;
   flex-direction: column;
@@ -16,17 +19,12 @@
   gap: 8px;
 }
 
-.consoleContainer {
-  height: 100%;
-  width: 100%;
+.previewContainer {
+  grid-area: preview;
+  width: auto;
 }
 
 .consoleToggle {
   margin-left: 8px;
   margin-bottom: 8px;
-}
-
-.fullScreenPreview {
-  height: 100%;
-  width: 100%;
 }


### PR DESCRIPTION
This PR covers most of the remaining work for share view in Python Lab (follow up to #64433). There are a couple small polish tasks remaining (see follow-up work). This adds the sidebar with links to view code and remix, and for levels with a preview, the option to see either the preview by itself or the preview and console side-by-side. It also makes it so the preview and/or console are properly sized and resize when the browser resizes.

## Screenshots/Screen recordings
### Console Only
<img width="1709" alt="Screenshot 2025-03-11 at 2 24 13 PM" src="https://github.com/user-attachments/assets/06fa1a75-d6ce-4a41-ba42-336347fb62c3" />

https://github.com/user-attachments/assets/db5d8ba9-004f-4147-849b-3c2a48d318db


### Console and Preview
<img width="1709" alt="Screenshot 2025-03-11 at 2 25 50 PM" src="https://github.com/user-attachments/assets/c18d1688-38e7-4f07-bea5-7369f24c51dc" />
<img width="1709" alt="Screenshot 2025-03-11 at 2 26 04 PM" src="https://github.com/user-attachments/assets/ff3d0123-5afc-4c10-b062-ea968aeb6fd5" />

https://github.com/user-attachments/assets/9e7613ea-a3be-4e6c-8b44-ae2fda49f854


## Links

- jira tickets (there were 3 covered by this pr): [CT-1132](https://codedotorg.atlassian.net/browse/CT-1132), [CT-1134](https://codedotorg.atlassian.net/browse/CT-1134), [CT-1138](https://codedotorg.atlassian.net/browse/CT-1138)

## Testing story
Tested locally

## Deployment strategy

## Follow-up work
I am tracking the polish items in [CT-1139](https://codedotorg.atlassian.net/browse/CT-1139). This includes hiding the white bar on load, removing the experiment flag, and a console warning I noticed is happening for both music and python share views.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
