### PR TITLE
chore: refactor marketing cicd to use docker

### DIFF
--- a/.github/actions/frontend/marketing/ui-tests/action.yml
+++ b/.github/actions/frontend/marketing/ui-tests/action.yml
@@ -30,19 +30,7 @@ runs:
       shell: bash
       working-directory: ./frontend/apps/marketing
       run: |
-        echo "CONTENTFUL_SPACE_ID=${{ inputs.CONTENTFUL_SPACE_ID }}
-        CONTENTFUL_ENV_ID=master
-        CONTENTFUL_API_HOST=cdn.contentful.com
-        CONTENTFUL_TOKEN=${{ inputs.CONTENTFUL_TOKEN }}
-        CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID=experience
-        APPLITOOLS_API_KEY=${{ inputs.APPLITOOLS_API_KEY }}
-        " > .env
-
-    - name: Start Application Server (in background)
-      shell: bash
-      working-directory: ./frontend
-      run: |
-        nohup yarn dev --filter @code-dot-org/marketing | tee nohup.out &
+        echo "APPLITOOLS_API_KEY=${{ inputs.APPLITOOLS_API_KEY }}" >> .env
 
     - name: UI Tests
       shell: bash

--- a/.github/actions/frontend/setup/action.yml
+++ b/.github/actions/frontend/setup/action.yml
@@ -8,6 +8,14 @@ runs:
       shell: bash
       run: corepack enable
 
+    - name: Cache turborepo
+      uses: actions/cache@v4
+      with:
+        path: frontend/.turbo
+        key: "${{ runner.os }}-turbo-${{ github.sha }}"
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
     - uses: actions/setup-node@v4
       with:
         node-version-file: ".nvmrc"

--- a/.github/workflows/marketing-app-ci.yml
+++ b/.github/workflows/marketing-app-ci.yml
@@ -1,6 +1,7 @@
 name: Marketing-CI
 
 on:
+  workflow_call:
   pull_request:
     branches:
       - staging
@@ -14,52 +15,94 @@ defaults:
     working-directory: ./frontend
 
 jobs:
-    build:
-        runs-on: ubuntu-24.04
+  build:
+    runs-on: ubuntu-24.04
 
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                lfs: true
-                sparse-checkout: |
-                  frontend
-                  .github
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          sparse-checkout: |
+            frontend
+            .github
 
-            - name: Setup Frontend
-              uses: ./.github/actions/frontend/setup
+      - name: Setup Frontend
+        uses: ./.github/actions/frontend/setup
 
-            - name: Lint
-              run: yarn lint --filter @code-dot-org/marketing
+      - name: Build
+        run: yarn build --filter @code-dot-org/marketing
 
-            - name: Build
-              run: yarn build --filter @code-dot-org/marketing
+  dryrun-release:
+    runs-on: ubuntu-24.04
+    needs: build
 
-            - name: Unit Tests
-              run: yarn test --filter @code-dot-org/marketing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          sparse-checkout: |
+            frontend
+            .github
 
-    ui-tests:
-      runs-on: ubuntu-24.04
+      - name: Setup Frontend
+        uses: ./.github/actions/frontend/setup
 
-      steps:
-        - uses: actions/checkout@v4
-          with:
-            lfs: true
-            sparse-checkout: |
-              frontend
-              .github
+      - name: Dryrun Release
+        run: yarn release:dryrun --filter @code-dot-org/marketing
 
-        - name: Setup Frontend
-          uses: ./.github/actions/frontend/setup
+  ui-tests:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-24.04
+    needs: build
 
-        - name: Build
-          run: yarn build --filter @code-dot-org/marketing
-          working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          sparse-checkout: |
+            frontend
+            .github
 
-        - name: UI Tests
-          uses: ./.github/actions/frontend/marketing/ui-tests
-          with:
-            STAGE: pr
-            CONTENTFUL_SPACE_ID: ${{ vars.CONTENTFUL_SPACE_ID }}
-            CONTENTFUL_TOKEN: ${{ secrets.CONTENTFUL_TOKEN}}
-            APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY}}
+      - name: Setup Frontend
+        uses: ./.github/actions/frontend/setup
+
+      - name: Build
+        run: yarn build --filter @code-dot-org/marketing
+
+      - name: Build Docker image
+        id: build-docker-image
+        uses: docker/build-push-action@v6.10.0
+        with:
+          context: frontend
+          file: frontend/apps/marketing/Dockerfile
+          tags: marketing:test
+          push: false
+
+      - name: Prepare Test Environment
+        shell: bash
+        run: |
+          echo "CONTENTFUL_SPACE_ID=${{ vars.CONTENTFUL_SPACE_ID }}
+          CONTENTFUL_ENV_ID=master
+          CONTENTFUL_API_HOST=cdn.contentful.com
+          CONTENTFUL_TOKEN=${{ secrets.CONTENTFUL_TOKEN }}
+          CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID=experience
+          HOSTNAME=0.0.0.0
+          " > .env
+
+      - name: Run Docker Container
+        run: |
+          docker run -d --env-file .env --rm --name marketing \
+            -p 3001:3000 \
+            marketing:test
+          
+          # Tail the docker logs
+          docker logs -f marketing &
+
+      - name: UI Tests
+        uses: ./.github/actions/frontend/marketing/ui-tests
+        with:
+          STAGE: pr
+          CONTENTFUL_SPACE_ID: ${{ vars.CONTENTFUL_SPACE_ID }}
+          CONTENTFUL_TOKEN: ${{ secrets.CONTENTFUL_TOKEN}}
+          APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY}}
 

--- a/.github/workflows/marketing-app-cicd.yml
+++ b/.github/workflows/marketing-app-cicd.yml
@@ -29,10 +29,15 @@ concurrency:
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
+  ci:
+    uses: ./.github/workflows/marketing-app-ci.yml
+    secrets: inherit
+
   # Job: build-and-push-image
   # This job builds a docker image for the frontend repository and pushes the docker image to Github Packages.
   # More information: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
   build-and-push-image:
+    needs: ci
     runs-on: ubuntu-24.04
 
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
@@ -50,8 +55,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: 'frontend'
+          sparse-checkout: |
+            frontend
+            .github
           lfs: true
+
+      - name: Setup Frontend
+        uses: ./.github/actions/frontend/setup
 
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry

--- a/frontend/apps/marketing/.lighthouserc.js
+++ b/frontend/apps/marketing/.lighthouserc.js
@@ -1,18 +1,13 @@
 const assertions = {
   'bf-cache': 'off',
   'color-contrast': 'off',
-  'frame-title': 'off',
-  'heading-order': 'off',
   'inspector-issues': 'off',
   'offscreen-images': ['error', {minScore: 0.5, maxLength: 1}],
   'total-byte-weight': ['error', {minScore: 0.5}],
-  'unminified-css': ['error', {maxLength: 1}],
-  'unminified-javascript': ['error', {maxLength: 20}],
   'unused-css-rules': ['error', {maxLength: 5}],
   'unused-javascript': ['error', {maxLength: 10}],
   'uses-text-compression': ['error', {maxLength: 5}],
   'third-party-cookies': 'off',
-  'valid-source-maps': 'off',
   'uses-rel-preconnect': 'off',
 };
 

--- a/frontend/apps/marketing/Dockerfile
+++ b/frontend/apps/marketing/Dockerfile
@@ -59,8 +59,9 @@ WORKDIR /app
 # First install the dependencies (as they change less often)
 COPY --link --from=source-code /app/out/json/ .
 RUN yarn install
- 
+
 # Build the project
+COPY --link --from=source-code /app/.turbo .turbo
 COPY --link --from=source-code /app/out/full/ .
 RUN yarn turbo run build
 
@@ -76,15 +77,15 @@ RUN yarn turbo run build
 
 FROM base AS runner
 WORKDIR /app
- 
+
 # Don't run production as root
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 USER nextjs
- 
+
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --link --from=builder --chown=nextjs:nodejs /app/apps/marketing/.next/standalone ./
 COPY --link --from=builder --chown=nextjs:nodejs /app/apps/marketing/.next/static ./apps/marketing/.next/static
- 
+
 CMD ["node", "apps/marketing/server.js"]

--- a/frontend/apps/marketing/README.md
+++ b/frontend/apps/marketing/README.md
@@ -1,5 +1,7 @@
 # Code.org Marketing Application
 
+...
+
 ## Getting Started
 
 ### Secrets

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -13,7 +13,7 @@
     "//#format": {},
     "//#format:fix": {},
     "release:dryrun": {
-      "dependsOn": ["lint", "test", "build"]
+      "dependsOn": ["build", "lint", "test"]
     },
     "lint": {
       "dependsOn": ["^lint", "prettier", "stylelint", "typecheck", "//#format"]


### PR DESCRIPTION
This PR refactors the marketing cicd implementation to utilize a docker image based production build rather than running the dev server. This refactoring allows the marketing app to be tested in an environment identical to what is used in the test environment, allowing the UI tests and lighthouse reports to be an accurate representation of what will be shown in the test environment.

Additionally, to speed up the action, the `actions/cache` has been added which enables turborepo's ability to cache previously built tasks. This has helped to reduce build times by 2-3 minutes.

To capture this time savings, the workflow  is now split into multiple stages, primarily to capture the build caching early on so it can be reused later.

![image](https://github.com/user-attachments/assets/1e3849be-e4a4-440c-9457-1cc4e5e6a17b)
