### PR TITLE
Include channel ID in events query

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -125,12 +125,14 @@ export async function postLogChatEvent(
 export async function getStudentChatHistory(
   studentUserId: number,
   levelId: number,
-  scriptId: number | null
+  scriptId: number | null,
+  channelId?: string
 ): Promise<ServerChatEvent[]> {
   const params: Record<string, string> = {
     studentUserId: studentUserId.toString(),
     levelId: levelId.toString(),
     scriptId: scriptId?.toString() || '',
+    channelId: channelId || '',
   };
   const response = await HttpClient.fetchJson<ServerChatEvent[]>(
     paths.STUDENT_CHAT_HISTORY_URL + '?' + new URLSearchParams(params)

--- a/apps/src/aichat/redux/thunks/fetchStudentChatHistory.ts
+++ b/apps/src/aichat/redux/thunks/fetchStudentChatHistory.ts
@@ -6,19 +6,24 @@ import {RootState} from '@cdo/apps/types/redux';
 import {getStudentChatHistory} from '../../aichatApi';
 import {setStudentChatHistory} from '../slice';
 
+interface FetchStudentChatHistoryArgs {
+  studentUserId: number;
+  channelId?: string;
+}
 // This thunk's callback function submits a teacher's student's id along with the level/script id
 // (and the scriptLevelId if the level is a sublevel) to the student chat history endpoint,
 // waits for a response, and then returns the student's chat events for that level/script.
 export const fetchStudentChatHistory = createAsyncThunk(
   'aichat/fetchStudentChatHistory',
-  async (studentUserId: number, thunkAPI) => {
+  async ({studentUserId, channelId}: FetchStudentChatHistoryArgs, thunkAPI) => {
     const state = thunkAPI.getState() as RootState;
     // Post teacher's student's user id to backend and retrieve student's chat history.
     try {
       const studentChatHistoryApiResponse = await getStudentChatHistory(
         studentUserId,
         parseInt(state.progress.currentLevelId || ''),
-        state.progress.scriptId
+        state.progress.scriptId,
+        channelId
       );
       thunkAPI.dispatch(setStudentChatHistory(studentChatHistoryApiResponse));
     } catch (error) {

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -59,14 +59,20 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       );
     }
   });
+  const currentChannelId = useAppSelector(state => state.lab.channel?.id);
 
   const dispatch = useAppDispatch();
 
   useEffect(() => {
     if (selectedStudent) {
-      dispatch(fetchStudentChatHistory(selectedStudent.id));
+      dispatch(
+        fetchStudentChatHistory({
+          studentUserId: selectedStudent.id,
+          channelId: currentChannelId,
+        })
+      );
     }
-  }, [selectedStudent, dispatch]);
+  }, [selectedStudent, currentChannelId, dispatch]);
 
   const selectedStudentName =
     selectedStudent && getShortName(selectedStudent.name);

--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -52,11 +52,23 @@ class AichatEventsController < ApplicationController
     script_id = params[:scriptId]
     level_id = params[:levelId]
     student_user_id = params[:studentUserId]
+
+    if params[:channelId].empty?
+      return render json: []
+    else
+      _, project_id = storage_decrypt_channel_id(params[:channelId])
+    end
+
     unless can_view_student_chat_history?(student_user_id)
       return render(status: :forbidden, json: {error: "Access denied for student chat history."})
     end
 
-    aichat_events = AichatEvent.where(user_id: student_user_id, level_id: level_id, script_id: script_id).order(:created_at).map do |event|
+    aichat_events = AichatEvent.where(
+      user_id: student_user_id,
+      level_id: level_id,
+      script_id: script_id,
+      project_id: project_id
+    ).order(:created_at).map do |event|
       chat_event = event[:aichat_event].is_a?(String) ? JSON.parse(event[:aichat_event]) : event[:aichat_event]
       {
         id: event.id,


### PR DESCRIPTION
Require a channel ID in addition to level ID, script ID, and user ID when a user requests chat history.

This is a prefactor for allowing users to access their own history. There is no expected behavior change here.

Channel ID is a proxy for the student that owns the project that the a teacher is interacting with.

I don't love what I have here currently, as this generates two requests to the `student_chat_history` endpoint for each actual update (once when the selected student changes, and then once when the channel ID is updated).

We could also make channel ID optional, as it's not strictly necessary for the student-facing use case (ie, a student won't need to differentiate between between multiple channel IDs.