### PR TITLE
[Google Blockly] Add toggle stack shadow option to context menu

### DIFF
--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -214,6 +214,51 @@ const registerUnshadow = function (weight: number) {
   GoogleBlockly.ContextMenuRegistry.registry.register(unshadowOption);
 };
 
+const registerToggleShadowStack = function (weight: number) {
+  const toggleShadowStackOption = {
+    displayText: (scope: GoogleBlockly.ContextMenuRegistry.Scope) => {
+      if (
+        scope.block &&
+        shadowChildCount(scope.block) === scope.block.getChildren(false).length
+      ) {
+        return 'Make All Blocks in Stack Non-Shadow';
+      } else {
+        return 'Make All Blocks in Stack Shadow';
+      }
+    },
+    preconditionFn: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      if (
+        Blockly.isStartMode &&
+        scope.block &&
+        scope.block.isEnabled() &&
+        scope.block === scope.block.getRootBlock()
+      ) {
+        return MenuOptionStates.ENABLED;
+      }
+      return MenuOptionStates.HIDDEN;
+    },
+    callback: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      const workspace = scope.block?.workspace;
+      if (scope.block && workspace) {
+        const shouldShadow =
+          shadowChildCount(scope.block) !==
+          scope.block.getChildren(false).length;
+        workspace
+          .getAllBlocks()
+          .filter(
+            block =>
+              block !== scope.block && block.getRootBlock() === scope.block
+          )
+          .forEach(block => block.setShadow(shouldShadow));
+      }
+    },
+    scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.BLOCK,
+    id: 'stackToggleShadow',
+    weight,
+  };
+  GoogleBlockly.ContextMenuRegistry.registry.register(toggleShadowStackOption);
+};
+
 const registerAllBlocksUndeletable = function (weight: number) {
   const workspaceBlocksUndeletableOption = {
     displayText: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
@@ -648,6 +693,7 @@ function registerCustomBlockOptions() {
   registerEditable(nextWeight++);
   registerShadow(nextWeight++);
   registerUnshadow(nextWeight++);
+  registerToggleShadowStack(nextWeight++);
 }
 
 function registerCustomWorkspaceOptions() {


### PR DESCRIPTION
**Task:** Add ability to set shadow blocks from workspace right-click menu
**Details:** The current system for setting and unsetting shadow blocks doesn't work entirely as expected in music lab, and is pretty tedious. Given how shadow blocks are used by curriculum writers, a straightforward workaround is to give an option to "toggle all blocks under When Run as shadow"

This adds a new custom context menu to Start Mode. With this option, levelbuilders will be able to automatically convert all blocks in a given stack (except for the top block) to shadow blocks, or back.

https://github.com/user-attachments/assets/d147d752-95ab-49a5-8c8b-24c0a7408c5a


Note that the updated shadow block color shown above is not part of the changes in this branch, but is detailed here: https://github.com/code-dot-org/code-dot-org/pull/64490


## Links

https://docs.google.com/document/d/1BppxCmxheTKDyQp6Y3QdBR97jV4BNFA77zw8OrfrRcw/edit?tab=t.0

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
