### PR TITLE
[Music] Effect validation conditions

### DIFF
--- a/apps/src/music/progress/MusicConditions.ts
+++ b/apps/src/music/progress/MusicConditions.ts
@@ -131,4 +131,14 @@ export const MusicConditions: ConditionNames = {
     description:
       'Checks if a given trigger button (1, 2, 3, 4) is pressed. Ex. Value: 1',
   },
+  USED_EFFECT: {
+    name: 'used_effect',
+    description:
+      'Checks if something was played with an effect (any value including Off/Full).',
+  },
+  USED_EFFECT_NON_DEFAULT: {
+    name: 'used_effect_non_default',
+    description:
+      'Checks if something was played with a non-default effect value (High/Low/Medium).',
+  },
 };

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -190,6 +190,17 @@ export default class MusicValidator extends Validator {
         }
       }
 
+      if (eventData.effects) {
+        this.conditionsChecker.addSatisfiedCondition({
+          name: MusicConditions.USED_EFFECT.name,
+        });
+        const effectValues = Object.values(eventData.effects);
+        if (effectValues.includes('low') || effectValues.includes('medium')) {
+          this.conditionsChecker.addSatisfiedCondition({
+            name: MusicConditions.USED_EFFECT_NON_DEFAULT.name,
+          });
+        }
+      }
       const validationInfo = eventData.validationInfo;
       if (validationInfo) {
         // Check for a block nested within an if/else block causing something to play.


### PR DESCRIPTION
from @dancodedotorg : 

> [here's a level we plan to use as an assessment](https://levelbuilder-studio.code.org/s/musiclab-6-12-playground/lessons/2/levels/6) and it requires students to use at least 1 effects block. So I would need some kind of validation to check that they at least used an effects block somewhere.

and

> putting a bunch of effect blocks at the end of a song shouldn’t pass

https://codedotorg.slack.com/archives/C07UT279KM1/p1741715536181589

This adds two new conditions for checking for the presence of effects on playback events. 

For a given playback event, if no effects blocks are used, we’ll see `effects: undefined` . If an effect block is used above the play block, we’ll see `effects: {'delay' | 'filter' | 'volume': 'normal' | 'medium' | 'low'}` depending on the dropdown values selected. `'normal'`  is equivalent to “Off” or, for volume, "Full".

The first condition passes if any effect is present including `'normal'` values: 
![image](https://github.com/user-attachments/assets/1fae923c-ecf8-4ba6-b277-a84b0029bc18)

The second passes only if an effect has a non-default value (`'medium' | 'low'`, which the student sees as "High", "Medium", or "Low", depending on the effect type).
![image](https://github.com/user-attachments/assets/b9fdda93-8dee-460a-bb21-e0b251395d08)

An effect block on its own does not pass. We cannot verify that an effect block is present on the workspace _unless_ the effect is actually applied to a playback event (ie. it must be above a `play` block).
![image](https://github.com/user-attachments/assets/2ccddfa8-0dcb-49a3-aa08-544e436304d9)



## Links
https://docs.google.com/document/d/1BppxCmxheTKDyQp6Y3QdBR97jV4BNFA77zw8OrfrRcw/edit?tab=t.0
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
