### PR TITLE
[Music] Flyout callouts by id

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -663,6 +663,7 @@ export default class MusicBlocklyWorkspace {
       blockList.push({
         kind: 'block',
         type: BLOCK_TYPES.procedureDefinition,
+        id: BLOCK_TYPES.procedureDefinition,
         fields: {
           NAME: musicI18n.blockly_functionNamePlaceholder(),
         },

--- a/apps/src/music/blockly/toolbox/toolboxBlocks.ts
+++ b/apps/src/music/blockly/toolbox/toolboxBlocks.ts
@@ -131,6 +131,7 @@ const toolboxBlocks: {[blockType in BlockTypes | string]: BlockInfoWithText} = {
   },
   [BlockTypes.PLAY_REST_AT_CURRENT_LOCATION_SIMPLE2]: {
     levelbuilderText: 'Rest',
+    id: BlockTypes.PLAY_REST_AT_CURRENT_LOCATION_SIMPLE2,
     kind: 'block',
     type: BlockTypes.PLAY_REST_AT_CURRENT_LOCATION_SIMPLE2,
     fields: {
@@ -139,6 +140,7 @@ const toolboxBlocks: {[blockType in BlockTypes | string]: BlockInfoWithText} = {
   },
   [BlockTypes.SET_VOLUME_EFFECT_AT_CURRENT_LOCATION_SIMPLE2]: {
     levelbuilderText: 'Set Volume',
+    id: BlockTypes.SET_EFFECT_AT_CURRENT_LOCATION_SIMPLE2,
     kind: 'block',
     type: BlockTypes.SET_EFFECT_AT_CURRENT_LOCATION_SIMPLE2,
     fields: {
@@ -148,6 +150,7 @@ const toolboxBlocks: {[blockType in BlockTypes | string]: BlockInfoWithText} = {
   },
   [BlockTypes.SET_FILTER_EFFECT_AT_CURRENT_LOCATION_SIMPLE2]: {
     levelbuilderText: 'Set Filter',
+    id: BlockTypes.SET_EFFECT_AT_CURRENT_LOCATION_SIMPLE2,
     kind: 'block',
     type: BlockTypes.SET_EFFECT_AT_CURRENT_LOCATION_SIMPLE2,
     fields: {
@@ -157,6 +160,7 @@ const toolboxBlocks: {[blockType in BlockTypes | string]: BlockInfoWithText} = {
   },
   [BlockTypes.SET_DELAY_EFFECT_AT_CURRENT_LOCATION_SIMPLE2]: {
     levelbuilderText: 'Set Delay',
+    id: BlockTypes.SET_EFFECT_AT_CURRENT_LOCATION_SIMPLE2,
     kind: 'block',
     type: BlockTypes.SET_EFFECT_AT_CURRENT_LOCATION_SIMPLE2,
     fields: {
@@ -178,11 +182,13 @@ const toolboxBlocks: {[blockType in BlockTypes | string]: BlockInfoWithText} = {
   },
   [BlockTypes.PLAY_SOUNDS_SEQUENTIAL]: {
     levelbuilderText: 'Play Sequential',
+    id: BlockTypes.PLAY_SOUNDS_SEQUENTIAL,
     kind: 'block',
     type: BlockTypes.PLAY_SOUNDS_SEQUENTIAL,
   },
   [BlockTypes.PLAY_SOUNDS_RANDOM]: {
     levelbuilderText: 'Play Random',
+    id: BlockTypes.PLAY_SOUNDS_RANDOM,
     kind: 'block',
     type: BlockTypes.PLAY_SOUNDS_RANDOM,
   },
@@ -257,6 +263,7 @@ const toolboxBlocks: {[blockType in BlockTypes | string]: BlockInfoWithText} = {
   },
   [BlockTypes.TRIGGERED_AT_SIMPLE2]: {
     levelbuilderText: 'Trigger',
+    id: BlockTypes.TRIGGERED_AT_SIMPLE2,
     kind: 'block',
     type: BlockTypes.TRIGGERED_AT_SIMPLE2,
     fields: {

--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -125,17 +125,24 @@ const Callouts: React.FunctionComponent = () => {
     const splitId = calloutId.split(':');
     if (splitId.length === 2) {
       const dataId = splitId[1];
-      validCallouts.push({
-        selector: `.blocklyWorkspace g[data-id="${dataId}"] path`,
-        direction:
-          splitId[0] === 'id-left'
-            ? 'left'
-            : splitId[0] === 'id-up-inside'
-            ? 'up-inside'
-            : splitId[0] === 'id-up-left'
-            ? 'up-left'
-            : 'up',
-      });
+      if (splitId[0] === 'flyout-id') {
+        validCallouts.push({
+          selector: `.blocklyFlyout g[data-id="${dataId}"] path`,
+          direction: 'left',
+        });
+      } else {
+        validCallouts.push({
+          selector: `.blocklyWorkspace g[data-id="${dataId}"] path`,
+          direction:
+            splitId[0] === 'id-left'
+              ? 'left'
+              : splitId[0] === 'id-up-inside'
+              ? 'up-inside'
+              : splitId[0] === 'id-up-left'
+              ? 'up-left'
+              : 'up',
+        });
+      }
     } else if (availableCallouts[calloutId]) {
       validCallouts.push({
         selector: availableCallouts[calloutId].selector,


### PR DESCRIPTION
**Task:** Enable callouts for all possible toolbox blocks
**Details:** Currently a certain number of toolbox blocks are hard-coded to allow callouts. In order to allow broad usage of callouts and flexible curriculum, this should be expanded in a way that allows all possible toolbox blocks to be selected or a different method for selecting blocks in the toolbox should be implemented (ie: utilizing some kind of `flyout-id:` method or something in the link)



Yesterday, @dancodedotorg and I noticed that some toolbox blocks had auto-generated block ids. Below is a log of block types and arrays, as found in a standard level's flyout:
![image (267)](https://github.com/user-attachments/assets/7d5485fd-414d-40af-a2a4-7a7f11d7a4df)

This will make it harder to add callouts to these blocks, until fixed. I followed an existing pattern found for about half of Simple2 toolbox blocks.

This branch also expands upon https://github.com/code-dot-org/code-dot-org/pull/61717 which added the ability for a callout to specify the id of a block in the workspace. Now, if a block id is prefixed with `flyout-id:` we can create a callout for it in the flyout:
`flyout-id:play_rest_at_current_location_simple2`
![image (269)](https://github.com/user-attachments/assets/e7edfbc8-4772-4c9e-84d9-e1fb0c7a24ff)![image](https://github.com/user-attachments/assets/c7a5f773-d06d-4d7b-9567-42913df94869)



## Links
https://docs.google.com/document/d/1BppxCmxheTKDyQp6Y3QdBR97jV4BNFA77zw8OrfrRcw/edit?tab=t.0


<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
