### PR TITLE
AI Chat: no logging of teacher interactions with student model

### DIFF
--- a/apps/src/aichat/redux/thunks/addChatEvent.ts
+++ b/apps/src/aichat/redux/thunks/addChatEvent.ts
@@ -17,44 +17,42 @@ import {addEventToChatEventsCurrent} from '../slice';
 export const addChatEvent =
   <T extends ChatEvent>(chatEvent: T) =>
   (dispatch: AppDispatch, getState: () => RootState) => {
-    // If teacher is viewing as a student, do not add chat events to the chat history.
-    if (getState().progress.viewAsUserId) {
-      return;
-    }
-
-    // User action events are hidden from participants and only displayed in teacher view of student chat history.
+    // Do not log to frontend for UserActionEvents (eg, clear chat),
+    // which are hidden from participants and only displayed in teacher view of student chat history.
     if (!isUserActionEvent(chatEvent)) {
       dispatch(addEventToChatEventsCurrent(chatEvent));
     }
 
-    // Other than notifications that are not included in chat history (save errors not due to profanity),
-    // log the chat event to backend.
+    // Do not log to backend if a teacher is viewing a student's work,
+    // and for most Notifications (exception being when a student fully reset's their project).
     if (
-      !isNotification(chatEvent) ||
-      (isNotification(chatEvent) && chatEvent.includeInChatHistory)
+      getState().progress.viewAsUserId ||
+      (isNotification(chatEvent) && !chatEvent.includeInChatHistory)
     ) {
-      // If a model update, log only the updated value for temperature and selected model id.
-      // Do not log free text updated values (e.g., system prompt, retrieval contexts, model card info).
-      if (isModelUpdate(chatEvent)) {
-        const {updatedField, updatedValue} = chatEvent;
-        // Only log updated value for temperature and selected model id - free text values are not logged.
-        const updatedValueToLog =
-          updatedField === 'temperature' || updatedField === 'selectedModelId'
-            ? updatedValue
-            : 'N/A';
-        chatEvent = {
-          ...chatEvent,
-          updatedValue: updatedValueToLog,
-        };
-      }
-
-      const state = getState() as RootState;
-      const aichatContext: AichatContext = {
-        currentLevelId: parseInt(state.progress.currentLevelId || ''),
-        scriptId: state.progress.scriptId,
-        channelId: state.lab.channel?.id,
-      };
-
-      ChatEventLogger.getInstance().logChatEvent(chatEvent, aichatContext);
+      return;
     }
+
+    // If a model update, log only the updated value for temperature and selected model id.
+    // Do not log free text updated values (e.g., system prompt, retrieval contexts, model card info).
+    if (isModelUpdate(chatEvent)) {
+      const {updatedField, updatedValue} = chatEvent;
+      // Only log updated value for temperature and selected model id - free text values are not logged.
+      const updatedValueToLog =
+        updatedField === 'temperature' || updatedField === 'selectedModelId'
+          ? updatedValue
+          : 'N/A';
+      chatEvent = {
+        ...chatEvent,
+        updatedValue: updatedValueToLog,
+      };
+    }
+
+    const state = getState() as RootState;
+    const aichatContext: AichatContext = {
+      currentLevelId: parseInt(state.progress.currentLevelId || ''),
+      scriptId: state.progress.scriptId,
+      channelId: state.lab.channel?.id,
+    };
+
+    ChatEventLogger.getInstance().logChatEvent(chatEvent, aichatContext);
   };

--- a/apps/src/aichat/redux/thunks/addChatEvent.ts
+++ b/apps/src/aichat/redux/thunks/addChatEvent.ts
@@ -17,7 +17,7 @@ import {addEventToChatEventsCurrent} from '../slice';
 export const addChatEvent =
   <T extends ChatEvent>(chatEvent: T) =>
   (dispatch: AppDispatch, getState: () => RootState) => {
-    // Do not log to frontend for UserActionEvents (eg, clear chat),
+    // Do not show in chat window for UserActionEvents (eg, clear chat),
     // which are hidden from participants and only displayed in teacher view of student chat history.
     if (!isUserActionEvent(chatEvent)) {
       dispatch(addEventToChatEventsCurrent(chatEvent));

--- a/apps/src/aichat/redux/thunks/addChatEvent.ts
+++ b/apps/src/aichat/redux/thunks/addChatEvent.ts
@@ -13,20 +13,20 @@ import {addEventToChatEventsCurrent} from '../slice';
 
 // This thunk adds a chat event to chatEventsCurrent (displayed in current chat workspace) if visible.
 // Then it logs the event to the backend for all chat events except notifications with includeInHistory != true.
+// It also excludes logging to both frontend and backend if the teacher is viewing as a student.
 export const addChatEvent =
   <T extends ChatEvent>(chatEvent: T) =>
   (dispatch: AppDispatch, getState: () => RootState) => {
+    // If teacher is viewing as a student, do not add chat events to the chat history.
+    if (getState().progress.viewAsUserId) {
+      return;
+    }
+
     // User action events are hidden from participants and only displayed in teacher view of student chat history.
     if (!isUserActionEvent(chatEvent)) {
       dispatch(addEventToChatEventsCurrent(chatEvent));
     }
-    // Log chat event to backend.
-    const state = getState() as RootState;
-    const aichatContext: AichatContext = {
-      currentLevelId: parseInt(state.progress.currentLevelId || ''),
-      scriptId: state.progress.scriptId,
-      channelId: state.lab.channel?.id,
-    };
+
     // Other than notifications that are not included in chat history (save errors not due to profanity),
     // log the chat event to backend.
     if (
@@ -47,6 +47,14 @@ export const addChatEvent =
           updatedValue: updatedValueToLog,
         };
       }
+
+      const state = getState() as RootState;
+      const aichatContext: AichatContext = {
+        currentLevelId: parseInt(state.progress.currentLevelId || ''),
+        scriptId: state.progress.scriptId,
+        channelId: state.lab.channel?.id,
+      };
+
       ChatEventLogger.getInstance().logChatEvent(chatEvent, aichatContext);
     }
   };


### PR DESCRIPTION
We got confirmation from curriculum that extending conversations across page reloads for teachers viewing student work is not a feature we need. As a result, we can just not log any chat events generated when a teacher is viewing student work. This is a pre-step for supporting cross-page load conversations.

## Links

- Slack discussion: https://codedotorg.slack.com/archives/C06FELVTV0Q/p1741628866159219

## Testing story

Tested manually that events generated when I interacted with my model as teacher are still generated, and not generated when interacting with student model. I also was still able to generate student history and view it as teacher.