### PR TITLE
Evaluate Student Learning: store AI evaluations on run click for 2 App Lab levels

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -11,12 +11,12 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 
 import applabMsg from '@cdo/applab/locale';
+import {evaluateStudentWork} from '@cdo/apps/aiEvaluation/evaluationApi';
 import autogenerateML from '@cdo/apps/applab/ai';
 import * as aiConfig from '@cdo/apps/applab/ai/dropletConfig';
 import SmallFooter from '@cdo/apps/code-studio/components/SmallFooter';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi';
-import {evaluateStudentWork} from '@cdo/apps/aiEvaluation/evaluationApi';
 import {workspace_running_background, white} from '@cdo/apps/util/color';
 import {UserLevelInteractions} from '@cdo/generated-scripts/sharedConstants';
 import commonMsg from '@cdo/locale';
@@ -1129,9 +1129,10 @@ Applab.runButtonClick = function () {
   ];
   const shouldEvaluateStudentCode = aiEvaluationLevels.includes(levelUrl);
   if (shouldEvaluateStudentCode) {
+    const evaluationCriteria = `"Does the code run without errors? Does the code follow best practices?"`;
     const systemPrompt = `Please review the student's work. Respond in correctly formatted JSON.
-    evaluationCriteria should just be a copy of "Is this good code?".
-    aiEvaluation should be your assessment of the student's work. Respond with "great", "ok", or "needs revision".
+    evaluationCriteria should just be a copy of ${evaluationCriteria}.
+    aiEvaluation should be your assessment of the student's work based on the evaluationCriteria. Respond with "great", "ok", or "needs revision".
     aiReasoning should be one sentence with your reasoning.`;
     evaluateStudentWork(
       {

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -16,6 +16,7 @@ import * as aiConfig from '@cdo/apps/applab/ai/dropletConfig';
 import SmallFooter from '@cdo/apps/code-studio/components/SmallFooter';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi';
+import {evaluateStudentWork} from '@cdo/apps/aiEvaluation/evaluationApi';
 import {workspace_running_background, white} from '@cdo/apps/util/color';
 import {UserLevelInteractions} from '@cdo/generated-scripts/sharedConstants';
 import commonMsg from '@cdo/locale';
@@ -1114,6 +1115,35 @@ Applab.runButtonClick = function () {
     scriptId: analyticsData.scriptId,
     interaction: UserLevelInteractions.click_run,
   });
+
+  const config = studioApp().config;
+  const levelUrl = config.currentScriptLevelUrl;
+  // These are the hand-selected levels that are eligible for AI code analysis
+  // as part of the initial Evaluate Student Learning pilot. We want to tightly
+  // scope which levels we run AI code analysis on in for early testing. If we
+  // gain confidence in the approach and accuracy of AI evaluations, we'll expand,
+  // and ultimately likely store this information as a property of the level itself.
+  const aiEvaluationLevels = [
+    '/s/csp4-2024/lessons/3/levels/2',
+    '/s/csp4-2024/lessons/3/levels/6',
+  ];
+  const shouldEvaluateStudentCode = aiEvaluationLevels.includes(levelUrl);
+  if (shouldEvaluateStudentCode) {
+    const systemPrompt = `Please review the student's work. Respond in correctly formatted JSON.
+    evaluationCriteria should just be a copy of "Is this good code?".
+    aiEvaluation should be your assessment of the student's work. Respond with "great", "ok", or "needs revision".
+    aiReasoning should be one sentence with your reasoning.`;
+    evaluateStudentWork(
+      {
+        studentId: config.userId,
+        studentDisplayName: config.codeOwnersName,
+        studentWork: config.getCode(),
+      },
+      analyticsData.levelId,
+      analyticsData.scriptId,
+      systemPrompt
+    );
+  }
 
   // Enable the Finish button if is present:
   var shareCell = document.getElementById('share-cell');

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -64,6 +64,7 @@ jwk_private_key_data:
 
 openai_evaluate_rubric_api_key:
 openai_student_learning_api_key: !Secret
+openai_measures_of_learning_api_key: !Secret
 
 # Mapbox
 mapbox_upload_tileset:    'censustiles-dev'


### PR DESCRIPTION
Continuation of https://github.com/code-dot-org/code-dot-org/pull/64445

### Links
[Summary of Evaluate Student Learning Projects](https://docs.google.com/document/d/1dj7OzyRDGjA8mj8_feWoDpy2o3gI7Yi9jlpq7pxp7sA/edit?tab=t.0)
[Tech speclet for store AI evaluations](https://docs.google.com/document/d/1SvhsQDDCI1J9Nk-b6zOGuezzmQMJAnk43wet5IQcGdQ/edit?tab=t.0) 
[CSP AI Validation Quiet Pilot spec](https://docs.google.com/document/d/1YdYJeSXWu52qxQjFah4q5fSz5E58k5xn68sfEYB8UV0/edit?tab=t.0)

Implementation of `UserLevelEvaluations` table: https://github.com/code-dot-org/code-dot-org/pull/64313

### Summary 

For the Evaluate Student Learning project we want to start collecting AI evaluations of student code samples so we can determine accuracy of AI-driven evaluation. 

This PR is a baby step toward our "Quiet Pilot" goals of collecting AI-evaluated student code samples for levels in CSP 2024 units 4 & 6. This code includes writing AI evaluations to the `UserLevelEvaluations` table for 2 CSP unit 4 programming levels so we can collect and review them. 

### Testing story
I confirmed locally that AI evaluation occurs on run clicks for levels '/s/csp4-2024/lessons/3/levels/2' and 
'/s/csp4-2024/lessons/3/levels/6', but not for others. And that `UserLevelEvaluations` are logging as expected locally: 
<img width="1037" alt="Screenshot 2025-03-12 at 4 06 32 PM" src="https://github.com/user-attachments/assets/f523a907-be02-4ffa-a5c6-a1289e496c5e" />

### Follow-up work

- Once the backend work to generate system prompts is in https://github.com/code-dot-org/code-dot-org/pull/64459, I'm going to use that instead of passing in generic system prompts from the frontend for both evaluation of student code and evaluation of free text responses. 

- I'm more convinced that we _do_ want to store code_version with `UserLevelEvaluations`. That will require a migration to add the field and updating the code in this PR to pass in `project.getCurrentSourceVersionId()` when `evaluateStudentWork` is called. 

- To review code samples alongside their AI evaluations, I'm planning to extend the functionality of the Student Dataset Maker (i.e. modify dashboard/app/controllers/student_code_sample_controller.rb) to include the UserLevelEvaluations of the pulled code samples. This will set us up nicely to have csvs ready for human "grading". 

- If everything goes smoothly with these initial levels, we can add the other CSP 2024 unit 4 & 6 programming levels to our `aiEvaluationLevels` array or implement a more dynamic, sustainable solution like a property on levels that indicates whether they are eligible to be evaluated by AI. I wanted to start really small though since we know, at the bare minimum, the system prompts need more refinement. 
