### PR TITLE
fix(Image): add onLoad and onError props and update Storybook tests

### DIFF
--- a/.github/workflows/component-library-ci.yml
+++ b/.github/workflows/component-library-ci.yml
@@ -22,7 +22,7 @@ jobs:
                   frontend
                   shared/fonts
                   .github
-                  lfs: true
+                lfs: true
 
             - name: Setup Frontend
               uses: ./.github/actions/frontend/setup
@@ -68,7 +68,7 @@ jobs:
           sparse-checkout: |
             frontend
             .github
-            lfs: true
+          lfs: true
 
       - name: Setup Frontend
         uses: ./.github/actions/frontend/setup

--- a/.github/workflows/component-library-ci.yml
+++ b/.github/workflows/component-library-ci.yml
@@ -22,6 +22,7 @@ jobs:
                   frontend
                   shared/fonts
                   .github
+                  lfs: true
 
             - name: Setup Frontend
               uses: ./.github/actions/frontend/setup
@@ -67,6 +68,7 @@ jobs:
           sparse-checkout: |
             frontend
             .github
+            lfs: true
 
       - name: Setup Frontend
         uses: ./.github/actions/frontend/setup

--- a/frontend/packages/component-library/src/cms/image/Image.tsx
+++ b/frontend/packages/component-library/src/cms/image/Image.tsx
@@ -14,6 +14,10 @@ export interface ImageProps extends ImgHTMLAttributes<HTMLElement> {
   hasBoxShadow?: boolean;
   /** Image custom className */
   className?: string;
+  /** Image onLoad callback */
+  onLoad?: () => void;
+  /** Image onError callback */
+  onError?: () => void;
 }
 
 /**
@@ -35,6 +39,8 @@ const Image: React.FC<ImageProps> = ({
   hasBorder = false,
   hasBoxShadow = false,
   className,
+  onLoad,
+  onError,
   ...HTMLAttributes
 }: ImageProps) => {
   return (
@@ -48,6 +54,8 @@ const Image: React.FC<ImageProps> = ({
       alt={altText}
       src={src}
       {...HTMLAttributes}
+      onLoad={onLoad}
+      onError={onError}
     />
   );
 };

--- a/frontend/packages/component-library/src/cms/image/stories/Image.story.tsx
+++ b/frontend/packages/component-library/src/cms/image/stories/Image.story.tsx
@@ -17,7 +17,10 @@ type Story = StoryObj<typeof Image>;
 export const DefaultImage: Story = {
   args: {
     src: imageFile,
-    altText: 'Teacher in front of classroom',
+    altText: 'Teacher helping student',
+  },
+  parameters: {
+    eyes: {waitBeforeCapture: 4000},
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
@@ -31,7 +34,7 @@ export const DefaultImage: Story = {
 export const ImageWithBorder: Story = {
   args: {
     src: imageFile,
-    altText: 'Teacher helping student at computer',
+    altText: 'Teacher helping student',
     hasBorder: true,
   },
   parameters: {
@@ -40,6 +43,7 @@ export const ImageWithBorder: Story = {
         story: 'Add a border to an image if it blends into the background.',
       },
     },
+    eyes: {waitBeforeCapture: 4000},
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
@@ -67,7 +71,7 @@ export const ImageWithBorder: Story = {
 export const ImageWithBoxShadow: Story = {
   args: {
     src: imageFile,
-    altText: 'Teacher in front of classroom',
+    altText: 'Teacher helping student',
     hasBoxShadow: true,
   },
   parameters: {
@@ -77,6 +81,7 @@ export const ImageWithBoxShadow: Story = {
           "Add a box shadow to an image if it's used at the top of the page.",
       },
     },
+    eyes: {waitBeforeCapture: 4000},
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);

--- a/frontend/packages/component-library/src/cms/image/stories/Image.story.tsx
+++ b/frontend/packages/component-library/src/cms/image/stories/Image.story.tsx
@@ -1,9 +1,10 @@
+import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {within, expect} from '@storybook/test';
 
 import imageFile from '@public/images/image-component.png';
 
-import Image from '../index';
+import Image, {ImageProps} from '../index';
 
 export default {
   title: 'CMS/Image',
@@ -12,26 +13,52 @@ export default {
 type Story = StoryObj<typeof Image>;
 
 //
+// TEMPLATE
+//
+const SingleTemplate: StoryObj<ImageProps> = {
+  render: args => {
+    const [isImageLoaded, setIsImageLoaded] = useState(false);
+    const [hasImageError, setHasImageError] = useState(false);
+    return (
+      <>
+        <Image
+          {...args}
+          onLoad={() => setIsImageLoaded(true)}
+          onError={() => setHasImageError(true)}
+        />
+        {isImageLoaded && <p>Image loaded</p>}
+        {hasImageError && <p>Image has error</p>}
+      </>
+    );
+  },
+};
+
+//
 // STORIES
 //
 export const DefaultImage: Story = {
+  ...SingleTemplate,
   args: {
     src: imageFile,
     altText: 'Teacher helping student',
   },
-  parameters: {
-    eyes: {waitBeforeCapture: 4000},
-  },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    const image = await canvas.findByAltText('Teacher in front of classroom');
+    const image = (await canvas.findByAltText(
+      'Teacher helping student',
+    )) as HTMLImageElement;
 
     // check if image is visible
-    expect(image).toBeVisible();
+    await expect(image).toBeVisible();
+
+    // check if image is loaded
+    await canvas.findByText('Image loaded');
+    await expect(canvas.queryByText('Image has error')).not.toBeInTheDocument();
   },
 };
 
 export const ImageWithBorder: Story = {
+  ...SingleTemplate,
   args: {
     src: imageFile,
     altText: 'Teacher helping student',
@@ -43,13 +70,10 @@ export const ImageWithBorder: Story = {
         story: 'Add a border to an image if it blends into the background.',
       },
     },
-    eyes: {waitBeforeCapture: 4000},
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    const image = await canvas.findByAltText(
-      'Teacher helping student at computer',
-    );
+    const image = await canvas.findByAltText('Teacher helping student');
     const getComputedStyleValue = (property: string) =>
       window.getComputedStyle(document.body).getPropertyValue(property);
     const expectedBorderColor = getComputedStyleValue(
@@ -61,6 +85,10 @@ export const ImageWithBorder: Story = {
     // check if image is visible
     await expect(image).toBeVisible();
 
+    // check if image is loaded
+    await canvas.findByText('Image loaded');
+    await expect(canvas.queryByText('Image has error')).not.toBeInTheDocument();
+
     // check if image has border
     await expect(image).toHaveStyle(`border-width: ${expectedBorderSize};`);
     await expect(image).toHaveStyle(`border-style: ${expectedBorderStyle};`);
@@ -69,6 +97,7 @@ export const ImageWithBorder: Story = {
 };
 
 export const ImageWithBoxShadow: Story = {
+  ...SingleTemplate,
   args: {
     src: imageFile,
     altText: 'Teacher helping student',
@@ -81,17 +110,47 @@ export const ImageWithBoxShadow: Story = {
           "Add a box shadow to an image if it's used at the top of the page.",
       },
     },
-    eyes: {waitBeforeCapture: 4000},
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    const image = await canvas.findByAltText('Teacher in front of classroom');
+    const image = await canvas.findByAltText('Teacher helping student');
     const expectedBoxShadow = 'rgb(191, 228, 232) 8px 8px 0px 0px';
 
     // check if image is visible
     await expect(image).toBeVisible();
 
+    // check if image is loaded
+    await canvas.findByText('Image loaded');
+    await expect(canvas.queryByText('Image has error')).not.toBeInTheDocument();
+
     // check if image has box shadow
     await expect(image).toHaveStyle(`box-shadow: ${expectedBoxShadow};`);
+  },
+};
+
+export const ImageWithError: Story = {
+  ...SingleTemplate,
+  args: {
+    src: 'bad-image.png',
+    altText: 'Bad image',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Tests the error state of the image component when the image can't be loaded.",
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const image = await canvas.findByAltText('Bad image');
+
+    // check if image is visible
+    await expect(image).toBeVisible();
+
+    // check if image is loaded
+    await expect(canvas.queryByText('Image loaded')).not.toBeInTheDocument();
+    await canvas.findByText('Image has error');
   },
 };


### PR DESCRIPTION
Adds `onLoad` and `onError` props to the Image component so we can test for load errors in Storybook play functions and Eyes tests.

Thanks @stephenliang for your help!

## Links
Jira ticket: [CMS-421](https://codedotorg.atlassian.net/browse/CMS-421)
Slack convo: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1741803484883529)

----

## New error Story
<img width="1054" alt="Screenshot 2025-03-12 at 2 39 21 PM" src="https://github.com/user-attachments/assets/552d7dfb-9b01-4879-946c-0f4474434500" />
