### PR TITLE
TEACH-1661/Enable certificates for single-unit courses

### DIFF
--- a/dashboard/app/controllers/congrats_controller.rb
+++ b/dashboard/app/controllers/congrats_controller.rb
@@ -20,23 +20,40 @@ class CongratsController < ApplicationController
     if curriculum.is_a?(UnitGroup)
       @curriculum_url = course_path(curriculum)
       units = curriculum.units_for_user(current_user)
-      completed_units = units.filter {|unit| Policies::ScriptActivity.completed?(current_user, unit)}
-      @certificate_data =
-        if completed_units.length == units.length
-          [{
-            courseName: @course_name,
-            courseTitle: curriculum.localized_title,
-            coursePath: course_path(curriculum),
-          }]
-        else
-          completed_units.map do |unit|
-            {
-              courseName: unit.name,
-              courseTitle: unit.localized_title,
-              coursePath: script_path(unit),
-            }
+      if curriculum.single_unit_course?
+        @certificate_data =
+          if Policies::ScriptActivity.can_view_congrats_page?(current_user, units.first)
+            [
+              {
+                courseName: @course_name,
+                courseTitle: curriculum.localized_title,
+                coursePath: @curriculum_url,
+              }
+            ]
+          else
+            []
           end
-        end
+      else
+        completed_units = units.filter {|unit| Policies::ScriptActivity.completed?(current_user, unit)}
+        @certificate_data =
+          if completed_units.length == units.length
+            [
+              {
+                courseName: @course_name,
+                courseTitle: curriculum.localized_title,
+                coursePath: course_path(curriculum),
+              }
+            ]
+          else
+            completed_units.map do |unit|
+              {
+                courseName: unit.name,
+                courseTitle: unit.localized_title,
+                coursePath: script_path(unit),
+              }
+            end
+          end
+      end
     elsif curriculum.nil?
       # This occurs when the user completes a third party tutorial
       @curriculum_url = script_path('hourofcode')

--- a/dashboard/test/controllers/congrats_controller_test.rb
+++ b/dashboard/test/controllers/congrats_controller_test.rb
@@ -14,6 +14,17 @@ class CongratsControllerTest < ActionController::TestCase
     assert_equal hoc_unit.name, certificate_data[0][:courseName]
   end
 
+  test "shows congrats page for single-unit course if unit allows congrats page" do
+    single_unit_course = create :single_unit_course
+    Policies::ScriptActivity.stubs(:can_view_congrats_page?).returns(true)
+    get :index, params: {s: Base64.urlsafe_encode64(single_unit_course.name)}
+    assert_response :success
+
+    certificate_data = assigns(:certificate_data)
+    assert_equal 1, certificate_data.length
+    assert_equal single_unit_course.name, certificate_data[0][:courseName]
+  end
+
   test "cached query test for hoc course" do
     hoc_unit = create(:hoc_script)
 


### PR DESCRIPTION
During the standalone-unit migration bug bash, it was discovered that certificates of completion were not being granted for certain courses. We needed to add an exception for single-unit courses

## Links
Jira: [TEACH-1661](https://codedotorg.atlassian.net/browse/TEACH-1661)

## Testing story
Unit test added to `congrats_controller_test.rb`
Manually verified that certificates are generated correctly for both student courses and completed PL courses.
<img width="1197" alt="Screenshot 2025-03-12 at 3 01 58 PM" src="https://github.com/user-attachments/assets/90a055cb-f840-4d18-a264-86ad56d86ef9" />

