### PR TITLE
[HOME] Add DCDO flag to homepage redirect

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -77,11 +77,13 @@ class HomeController < ApplicationController
   # Signed out: redirect to sign in
   def home
     authenticate_user!
-    init_homepage
-    if current_user.teacher? && Experiment.enabled?(user: current_user, experiment_name: 'teacher-homepage-v2')
+
+    if current_user.teacher? && (Experiment.enabled?(user: current_user, experiment_name: 'teacher-homepage-v2') || DCDO.get('teacher-homepage-v2', false))
       redirect_to '/teacher_dashboard/home'
       return
     end
+
+    init_homepage
     render 'home/index'
   end
 


### PR DESCRIPTION
Small refactor to add DCDO flag to the BE redirect for the v2 homepage

This also moves the redirect above `init_homepage` to prevent loading so much data before simply redirecting

## Links
https://codedotorg.atlassian.net/browse/TEACH-1582
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
