### PR TITLE
improve validation of unit group when cloning units

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1211,7 +1211,6 @@ class Unit < ApplicationRecord
     destination_unit_group = destination_unit_group_name ?
       UnitGroup.find_by_name!(destination_unit_group_name) :
       nil
-    puts "#{destination_unit_group.nil?} || #{destination_professional_learning_course.nil?} || #{destination_unit_group.course_version}"
     raise 'Destination unit group must have a course version. please try saving the course edit page again.' unless destination_unit_group.nil? || destination_professional_learning_course.nil? || destination_unit_group.course_version
 
     begin

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1209,7 +1209,7 @@ class Unit < ApplicationRecord
 
     source_course_version = get_course_version
     destination_unit_group = destination_unit_group_name ?
-      UnitGroup.find_by_name(destination_unit_group_name) :
+      UnitGroup.find_by_name!(destination_unit_group_name) :
       nil
     raise 'Destination unit group must have a course version' unless destination_unit_group.nil? || destination_professional_learning_course.nil? || destination_unit_group.course_version
 

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1211,6 +1211,7 @@ class Unit < ApplicationRecord
     destination_unit_group = destination_unit_group_name ?
       UnitGroup.find_by_name!(destination_unit_group_name) :
       nil
+    puts "#{destination_unit_group.nil?} || #{destination_professional_learning_course.nil?} || #{destination_unit_group.course_version}"
     raise 'Destination unit group must have a course version. please try saving the course edit page again.' unless destination_unit_group.nil? || destination_professional_learning_course.nil? || destination_unit_group.course_version
 
     begin
@@ -1234,7 +1235,7 @@ class Unit < ApplicationRecord
           copied_unit.professional_learning_course = destination_professional_learning_course
           copied_unit.peer_reviews_to_complete = peer_reviews_to_complete
         elsif destination_unit_group
-          raise 'Destination unit group must be in a course version' if destination_unit_group.course_version.nil?
+          raise 'Destination unit group must be in a course version. please try saving the course edit page again.' if destination_unit_group.course_version.nil?
           UnitGroupUnit.create!(unit_group: destination_unit_group, script: copied_unit, position: destination_unit_group.default_units.length + 1)
           copied_unit.reload
         else

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1211,7 +1211,7 @@ class Unit < ApplicationRecord
     destination_unit_group = destination_unit_group_name ?
       UnitGroup.find_by_name!(destination_unit_group_name) :
       nil
-    raise 'Destination unit group must have a course version' unless destination_unit_group.nil? || destination_professional_learning_course.nil? || destination_unit_group.course_version
+    raise 'Destination unit group must have a course version. please try saving the course edit page again.' unless destination_unit_group.nil? || destination_professional_learning_course.nil? || destination_unit_group.course_version
 
     begin
       ActiveRecord::Base.transaction do


### PR DESCRIPTION
For background, see [How to deep-copy a unit](https://docs.google.com/document/d/1KCXzT566zaqMuS460Pp3m0E7wJ2URfRp2UauY4LwBC0/edit?tab=t.0). 

This PR makes two small improvements to the error messages when copying units into a unit group:
1. if the unit group name is not found in the database, raise a helpful error instead of showing a message about standalone units
2. if the course version is missing, give a hint as to what steps will fix it

## Testing story

manual verification