### PR TITLE
AI Chat: reload student history on level change

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -49,6 +49,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   const {showModalType, studentChatHistory} = useAppSelector(
     state => state.aichat
   );
+  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
   const visibleItems = useSelector(selectAllVisibleMessages);
   const selectedStudent = useAppSelector(({teacherSections, progress}) => {
@@ -66,7 +67,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     if (selectedStudent) {
       dispatch(fetchStudentChatHistory(selectedStudent.id));
     }
-  }, [selectedStudent, dispatch]);
+  }, [selectedStudent, currentLevelId, dispatch]);
 
   const selectedStudentName =
     selectedStudent && getShortName(selectedStudent.name);


### PR DESCRIPTION
Sanchit noticed that student chat history doesn't reload if you switch levels when viewing a student's history. This change should fix that.

## Links

- Slack message: https://codedotorg.slack.com/archives/C06FELVTV0Q/p1741218230539869?thread_ts=1741215903.010569&cid=C06FELVTV0Q

## Testing story

Tested manually that I saw history updating as I switched between levels after this change.