### PR TITLE
Revert "Revert "feat(DSCO): add optional onClose prop to Tag""

### DIFF
--- a/frontend/packages/component-library/src/closeButton/CloseButton.tsx
+++ b/frontend/packages/component-library/src/closeButton/CloseButton.tsx
@@ -8,7 +8,11 @@ import moduleStyles from './closeButton.module.scss';
 
 export interface CloseButtonProps extends HTMLAttributes<HTMLButtonElement> {
   /** Close Button onClick */
-  onClick: () => void;
+  onClick: (
+    e?:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLButtonElement>,
+  ) => void;
   /** Close Button size */
   size?: ComponentSizeXSToL;
   /** Close Button Color*/

--- a/frontend/packages/component-library/src/tags/Tags.tsx
+++ b/frontend/packages/component-library/src/tags/Tags.tsx
@@ -9,7 +9,7 @@ import moduleStyles from './tags.module.scss';
 export interface TagsProps {
   /** Array of tags to be rendered */
   tagsList: TagProps[];
-  /** Size of button */
+  /** Size of tag */
   size?: Exclude<ComponentSizeXSToL, 'xs'>;
   /** Optional className for custom styles, etc*/
   className?: string;
@@ -41,16 +41,19 @@ const Tags: React.FunctionComponent<TagsProps> = ({
     )}
     data-testid="tags"
   >
-    {tagsList.map(({tooltipId, label, tooltipContent, ariaLabel, icon}) => (
-      <Tag
-        key={tooltipId}
-        tooltipId={tooltipId}
-        label={label}
-        ariaLabel={ariaLabel}
-        icon={icon}
-        tooltipContent={tooltipContent}
-      />
-    ))}
+    {tagsList.map(
+      ({key, tooltipId, label, tooltipContent, ariaLabel, icon, ...props}) => (
+        <Tag
+          key={key ?? tooltipId ?? label}
+          tooltipId={tooltipId}
+          label={label}
+          ariaLabel={ariaLabel}
+          icon={icon}
+          tooltipContent={tooltipContent}
+          {...props}
+        />
+      ),
+    )}
   </div>
 );
 

--- a/frontend/packages/component-library/src/tags/_Tag.tsx
+++ b/frontend/packages/component-library/src/tags/_Tag.tsx
@@ -1,7 +1,8 @@
-import React, {memo} from 'react';
+import React, {HTMLAttributes, memo, useCallback} from 'react';
 
 import FontAwesomeV6Icon from '@/fontAwesomeV6Icon';
 import {WithTooltip} from '@/tooltip';
+import CloseButton from '@/closeButton/CloseButton';
 
 import moduleStyles from './tags.module.scss';
 
@@ -16,7 +17,7 @@ const TagIcon: React.FC<TagIconProps> = memo(({iconName, iconStyle, title}) => (
   <FontAwesomeV6Icon iconName={iconName} iconStyle={iconStyle} title={title} />
 ));
 
-export interface TagProps {
+export interface BaseTagProps {
   /** Tag label */
   label: string;
   /** Tag tooltip content. Can be a simple string or ReactNode (some jsx/html markup/view).
@@ -32,39 +33,80 @@ export interface TagProps {
    *  Icon object consists of icon(icon name/style, title for screenReader,
    *  and the placement of the icon (left or right))*/
   icon?: TagIconProps;
+  /** Unique key */
+  key?: React.Key;
 }
 
-const Tag: React.FunctionComponent<TagProps> = ({
-  label,
-  tooltipContent,
-  tooltipId,
-  icon,
-}) => {
-  return tooltipContent && tooltipId ? (
-    <WithTooltip
-      tooltipProps={{
-        direction: 'onTop',
-        text: tooltipContent,
-        tooltipId,
-      }}
-    >
-      <div
-        tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-        aria-describedby={tooltipId}
-        className={moduleStyles.tag}
-      >
+export interface DefaultTagProps extends BaseTagProps {
+  type?: 'default';
+}
+
+export interface ClosableTagProps extends BaseTagProps {
+  type: 'closable';
+  /** onClose callback gives the tag an accessible close button on the
+   * right side of the label */
+  onClose: () => void;
+}
+
+export type TagProps = DefaultTagProps | ClosableTagProps;
+
+const Tag: React.FunctionComponent<TagProps> = props => {
+  const {
+    label,
+    ariaLabel,
+    tooltipContent,
+    tooltipId,
+    icon,
+    type = 'default',
+  } = props;
+  const tooltipWrapper = useCallback(
+    (children: React.ReactNode) =>
+      tooltipContent && tooltipId ? (
+        <WithTooltip
+          tooltipProps={{
+            direction: 'onTop',
+            text: tooltipContent,
+            tooltipId: tooltipId,
+          }}
+        >
+          {children}
+        </WithTooltip>
+      ) : (
+        children
+      ),
+    [tooltipContent, tooltipId],
+  );
+
+  const containerAttrs: HTMLAttributes<HTMLDivElement> = {
+    className: moduleStyles.tag,
+    tabIndex: 0,
+    'aria-label': ariaLabel,
+    'aria-describedby': tooltipContent && tooltipId ? tooltipId : undefined,
+  };
+
+  if (type === 'closable') {
+    delete containerAttrs.tabIndex;
+    const {onClose} = props as ClosableTagProps;
+    return tooltipWrapper(
+      <div {...containerAttrs}>
+        <span>{label}</span>
+        <CloseButton
+          onClick={onClose}
+          aria-label={`Close ${ariaLabel ?? label}`}
+        />
+      </div>,
+    );
+  }
+
+  if (type === 'default') {
+    return tooltipWrapper(
+      <div {...containerAttrs}>
         {icon && icon.placement === 'left' && <TagIcon {...icon} />}
         <span>{label}</span>
         {icon && icon.placement === 'right' && <TagIcon {...icon} />}
-      </div>
-    </WithTooltip>
-  ) : (
-    <div className={moduleStyles.tag}>
-      {icon && icon.placement === 'left' && <TagIcon {...icon} />}
-      <span>{label}</span>
-      {icon && icon.placement === 'right' && <TagIcon {...icon} />}
-    </div>
-  );
+      </div>,
+    );
+  }
 };
 
 export default memo(Tag);

--- a/frontend/packages/component-library/src/tags/_Tag.tsx
+++ b/frontend/packages/component-library/src/tags/_Tag.tsx
@@ -45,7 +45,11 @@ export interface ClosableTagProps extends BaseTagProps {
   type: 'closable';
   /** onClose callback gives the tag an accessible close button on the
    * right side of the label */
-  onClose: () => void;
+  onClose: (
+    e?:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLButtonElement>,
+  ) => void;
 }
 
 export type TagProps = DefaultTagProps | ClosableTagProps;

--- a/frontend/packages/component-library/src/tags/__tests__/Tags.test.tsx
+++ b/frontend/packages/component-library/src/tags/__tests__/Tags.test.tsx
@@ -1,5 +1,5 @@
 import {render, screen, waitFor} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import userEvent, {UserEvent} from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import Tags, {TagProps} from './../index';
@@ -142,5 +142,87 @@ describe('Design System - Tags Component', () => {
 
     expect(tagLabel).toBeInTheDocument();
     expect(icon).toBeInTheDocument();
+  });
+
+  describe('onClose', () => {
+    let user: UserEvent;
+    let onClick1: jest.Mock;
+    let onClick2: jest.Mock;
+    let tagsList: TagProps[];
+    let button1: HTMLElement;
+    let button2: HTMLElement;
+
+    beforeEach(() => {
+      user = userEvent.setup();
+      onClick1 = jest.fn();
+      onClick2 = jest.fn();
+      tagsList = [
+        {
+          type: 'closable',
+          tooltipId: 'tag-icon-1',
+          label: 'tag with icon',
+          tooltipContent: 'Tooltip with icon',
+          onClose: onClick1,
+          icon: {
+            iconName: 'close',
+            iconStyle: 'solid',
+            title: 'Close 1',
+            placement: 'right',
+          },
+        },
+        {
+          type: 'closable',
+          tooltipId: 'tag-icon-2',
+          label: 'tag with icon',
+          tooltipContent: 'Tooltip with icon',
+          onClose: onClick2,
+          icon: {
+            iconName: 'close',
+            iconStyle: 'solid',
+            title: 'Close 2',
+            placement: 'right',
+          },
+        },
+      ];
+
+      render(<Tags tagsList={tagsList} />);
+
+      [button1, button2] = screen.getAllByRole('button', {
+        name: /close/i,
+      });
+    });
+
+    it('has keyboard navigable close button if onClose is present', async () => {
+      await user.tab();
+
+      expect(button1).toHaveFocus();
+
+      await user.tab();
+
+      expect(button2).toHaveFocus();
+    });
+
+    it('calls onClose when the close button is clicked', async () => {
+      await user.click(button1);
+
+      expect(onClick1).toHaveBeenCalledTimes(1);
+      expect(onClick2).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when Enter or Space is pressed while close button has focus', async () => {
+      await user.tab();
+      expect(button1).toHaveFocus();
+      await user.keyboard('{Enter}');
+
+      expect(onClick1).toHaveBeenCalledTimes(1);
+      expect(onClick2).not.toHaveBeenCalled();
+
+      await user.tab();
+      expect(button2).toHaveFocus();
+      await user.keyboard(' ');
+
+      expect(onClick1).toHaveBeenCalledTimes(1);
+      expect(onClick2).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/frontend/packages/component-library/src/tags/stories/Tags.story.tsx
+++ b/frontend/packages/component-library/src/tags/stories/Tags.story.tsx
@@ -1,6 +1,7 @@
 import {Meta, StoryFn} from '@storybook/react';
 
-import Tags, {TagsProps} from '../index';
+import Tags, {TagProps, TagsProps} from '../index';
+import {useState} from 'react';
 
 export default {
   title: 'DesignSystem/Tags',
@@ -22,6 +23,42 @@ const SingleTemplate: StoryFn<TagsProps> = args => (
     </div>
   </>
 );
+
+const SingleTemplateWithTagState: StoryFn<TagsProps> = args => {
+  const initialState = ['AAA', 'BBB', 'CCC'];
+  const [tags, setTags] = useState(initialState);
+
+  const removeTag = (index: number) => {
+    setTags(prev => {
+      const newTags = [...prev];
+      newTags.splice(index, 1);
+      return newTags;
+    });
+  };
+
+  const tagsList: TagProps[] = tags.map((label, i) => ({
+    label,
+    tooltipId: label,
+    tooltipContent: label,
+    onClose: () => removeTag(i),
+    type: 'closable',
+  }));
+
+  return (
+    <>
+      <p>
+        * Margins on this screen does not represent Component's margins, and are
+        only added to improve storybook view *{' '}
+      </p>
+      <div style={{marginTop: 50}}>
+        <Tags {...args} tagsList={tagsList} />
+      </div>
+      <div style={{marginTop: 50}}>
+        <button onClick={() => setTags(initialState)}>Reset</button>
+      </div>
+    </>
+  );
+};
 
 const MultipleTemplate: StoryFn<{
   components: TagsProps[];
@@ -45,7 +82,7 @@ DefaultTags.args = {
   tagsList: [
     {tooltipId: 'math', label: 'Math', tooltipContent: 'Math'},
     {
-      label: '+1',
+      label: 'Icon left',
       icon: {
         iconName: 'check',
         iconStyle: 'solid',
@@ -56,7 +93,7 @@ DefaultTags.args = {
       tooltipContent: 'Science, English',
     },
     {
-      label: '+1',
+      label: 'Icon right',
       icon: {
         iconName: 'check',
         iconStyle: 'solid',
@@ -76,7 +113,7 @@ NoTooltipTags.args = {
   tagsList: [
     {label: 'Math'},
     {
-      label: '+1',
+      label: 'Icon left',
       icon: {
         iconName: 'check',
         iconStyle: 'solid',
@@ -85,7 +122,7 @@ NoTooltipTags.args = {
       },
     },
     {
-      label: '+1',
+      label: 'Icon right',
       icon: {
         iconName: 'check',
         iconStyle: 'solid',
@@ -103,7 +140,7 @@ TagsWithHTMLTooltipContent.args = {
   tagsList: [
     {tooltipId: 'math', label: 'Math', tooltipContent: <>Math</>},
     {
-      label: '+1',
+      label: 'Icon left',
       icon: {
         iconName: 'check',
         iconStyle: 'solid',
@@ -118,7 +155,7 @@ TagsWithHTMLTooltipContent.args = {
       ),
     },
     {
-      label: '+1',
+      label: 'Icon right',
       icon: {
         iconName: 'check',
         iconStyle: 'solid',
@@ -133,6 +170,12 @@ TagsWithHTMLTooltipContent.args = {
   className: 'test',
 };
 
+export const TagsWithOnCloseProp = SingleTemplateWithTagState.bind({});
+TagsWithOnCloseProp.args = {
+  size: 'm',
+  className: 'test',
+};
+
 export const GroupOfSizesOfTags = MultipleTemplate.bind({});
 GroupOfSizesOfTags.args = {
   components: [
@@ -140,7 +183,7 @@ GroupOfSizesOfTags.args = {
       tagsList: [
         {tooltipId: 'mathS', label: 'Math S', tooltipContent: 'Math S'},
         {
-          label: '+1',
+          label: 'Science English S',
           tooltipId: 'science-englishS',
           icon: {
             iconName: 'check',
@@ -152,7 +195,7 @@ GroupOfSizesOfTags.args = {
         },
         {
           tooltipId: 'englishS',
-          label: 'Tags',
+          label: 'English S',
           tooltipContent: 'English S',
           icon: {
             iconName: 'circle-user',
@@ -161,6 +204,13 @@ GroupOfSizesOfTags.args = {
             placement: 'right',
           },
         },
+        {
+          tooltipId: 'closeS',
+          label: 'Close',
+          tooltipContent: 'Close S',
+          onClose: () => {},
+          type: 'closable',
+        },
       ],
       size: 's',
     },
@@ -168,7 +218,7 @@ GroupOfSizesOfTags.args = {
       tagsList: [
         {tooltipId: 'mathM', label: 'Math M', tooltipContent: 'Math M'},
         {
-          label: '+1',
+          label: 'Science english M',
           tooltipId: 'science-englishM',
           icon: {
             iconName: 'check',
@@ -180,7 +230,7 @@ GroupOfSizesOfTags.args = {
         },
         {
           tooltipId: 'englishM',
-          label: 'Tags',
+          label: 'English M',
           tooltipContent: 'English M',
           icon: {
             iconName: 'circle-user',
@@ -189,6 +239,13 @@ GroupOfSizesOfTags.args = {
             placement: 'right',
           },
         },
+        {
+          tooltipId: 'closeM',
+          label: 'Close',
+          tooltipContent: 'Close M',
+          onClose: () => {},
+          type: 'closable',
+        },
       ],
       size: 'm',
     },
@@ -196,7 +253,7 @@ GroupOfSizesOfTags.args = {
       tagsList: [
         {tooltipId: 'mathL', label: 'Math L', tooltipContent: 'Math L'},
         {
-          label: '+1',
+          label: 'Science English L',
           tooltipId: 'science-englishL',
           icon: {
             iconName: 'check',
@@ -208,7 +265,7 @@ GroupOfSizesOfTags.args = {
         },
         {
           tooltipId: 'englishL',
-          label: 'Tags',
+          label: 'English L',
           tooltipContent: 'English L',
           icon: {
             iconName: 'circle-user',
@@ -216,6 +273,13 @@ GroupOfSizesOfTags.args = {
             title: 'check',
             placement: 'right',
           },
+        },
+        {
+          tooltipId: 'closeL',
+          label: 'Close',
+          tooltipContent: 'Close L',
+          onClose: () => {},
+          type: 'closable',
         },
       ],
       size: 'l',

--- a/frontend/packages/component-library/src/tags/tags.module.scss
+++ b/frontend/packages/component-library/src/tags/tags.module.scss
@@ -6,8 +6,6 @@
 .tags {
   display: flex;
   column-gap: 0.5em;
-  row-gap: 0.5em;
-  flex-wrap: wrap;
 
   .tag {
     display: flex;

--- a/frontend/packages/component-library/src/tags/tags.module.scss
+++ b/frontend/packages/component-library/src/tags/tags.module.scss
@@ -6,6 +6,8 @@
 .tags {
   display: flex;
   column-gap: 0.5em;
+  row-gap: 0.5em;
+  flex-wrap: wrap;
 
   .tag {
     display: flex;
@@ -32,7 +34,8 @@
       padding-inline-start: 8px;
     }
 
-    &:has(i:not(:first-child)) {
+    &:has(i:last-child),
+    &:has(button:last-child) {
       padding-inline-end: 8px;
     }
   }


### PR DESCRIPTION
this reverts the revert pr to bring back the closable tags from [here](https://github.com/code-dot-org/code-dot-org/pull/64392). I've removed the [flex-wrap](https://github.com/code-dot-org/code-dot-org/pull/64392/files#diff-a965cf2c89a48f7e93523c11bff8dc4372df1de06922d401e8d8944d41f43728R9-R10) styling that caused an eyes diff, and added the event argument to the onClick handlers in CloseButton and Tags

Reverts code-dot-org/code-dot-org#64513

[slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1741820053790409)