### PR TITLE
Adding DCDO setting for 'modularity' pilot

### DIFF
--- a/dashboard/lib/policies/courses.rb
+++ b/dashboard/lib/policies/courses.rb
@@ -1,0 +1,10 @@
+class Policies::Courses
+  MODULARITY_PILOT = 'modularity'
+
+  def self.modularity_enabled?(user)
+    # Pilot settings for individual users takes precedence
+    user_enabled = Experiment.enabled?(user: user, experiment_name: MODULARITY_PILOT)
+    return user_enabled if user_enabled
+    DCDO.get(MODULARITY_PILOT, false)
+  end
+end

--- a/dashboard/lib/services/courses.rb
+++ b/dashboard/lib/services/courses.rb
@@ -1,6 +1,4 @@
 class Services::Courses
-  MODULARITY_PILOT = 'modularity'
-
   # This method returns the canonical version of a given path related to a UnitGroup/Course
   # for example given a /s/.../ URL it will return the appropriate /courses/.../units/...
   # URL because /s/.../ is being deprecated.
@@ -10,7 +8,7 @@ class Services::Courses
   # @param current_user [User] the currently authenticated user object, used for experiment checks
   # @return [String] the transformed canonical path if applicable, or the original path if no transformation is made
   def self.canonical_path(path, params, current_user)
-    return path unless Experiment.enabled?(user: current_user, experiment_name: MODULARITY_PILOT)
+    return path unless Policies::Courses.modularity_enabled?(current_user)
 
     # :script_id is defined only for /s/ URLs
     script_name = params[:script_id] || params[:id]

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -1463,8 +1463,7 @@ class LessonsControllerTest < ActionController::TestCase
     let(:modularity_enabled) {false}
 
     before do
-      allow(Experiment).to receive(:enabled?).and_call_original
-      allow(Experiment).to receive(:enabled?).with(user: user, experiment_name: 'modularity').and_return(modularity_enabled)
+      allow(Policies::Courses).to receive(:modularity_enabled?).with(user).and_return(modularity_enabled)
     end
 
     context 'modularity is off' do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -2400,8 +2400,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     let(:modularity_enabled) {false}
 
     before do
-      allow(Experiment).to receive(:enabled?).and_call_original
-      allow(Experiment).to receive(:enabled?).with(user: user, experiment_name: 'modularity').and_return(modularity_enabled)
+      allow(Policies::Courses).to receive(:modularity_enabled?).with(user).and_return(modularity_enabled)
     end
 
     context 'modularity is off' do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1903,8 +1903,7 @@ class ScriptsControllerTest < ActionController::TestCase
     let(:modularity_enabled) {false}
 
     before do
-      allow(Experiment).to receive(:enabled?).and_call_original
-      allow(Experiment).to receive(:enabled?).with(user: user, experiment_name: 'modularity').and_return(modularity_enabled)
+      allow(Policies::Courses).to receive(:modularity_enabled?).with(user).and_return(modularity_enabled)
     end
 
     context 'modularity is off' do

--- a/dashboard/test/lib/policies/courses_test.rb
+++ b/dashboard/test/lib/policies/courses_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+class Policies::CoursesTest < ActiveSupport::TestCase
+  include Minitest::RSpecMocks
+
+  describe '.modularity_enabled?' do
+    let(:user) {instance_double(User)}
+    let(:modularity_enabled) {Policies::Courses.modularity_enabled?(user)}
+
+    context 'nothing configured' do
+      it 'defaults to false' do
+        _(modularity_enabled).must_equal false
+      end
+    end
+
+    context 'DCDO is configured' do
+      let(:dcdo_value) {false}
+
+      before do
+        allow(DCDO).to receive(:get).with('modularity', false).and_return(dcdo_value)
+      end
+
+      context 'DCDO is true' do
+        let(:dcdo_value) {true}
+
+        it 'returns true' do
+          _(modularity_enabled).must_equal true
+        end
+      end
+
+      context 'DCDO is false' do
+        it 'returns false' do
+          _(modularity_enabled).must_equal false
+        end
+
+        context 'Pilot Experiment is true' do
+          let(:pilot_enabled) {true}
+
+          before do
+            allow(Experiment).to receive(:enabled?).with(user: user, experiment_name: 'modularity').and_return(pilot_enabled)
+          end
+
+          it 'returns true' do
+            _(modularity_enabled).must_equal true
+          end
+        end
+      end
+    end
+  end
+end

--- a/dashboard/test/lib/services/courses_test.rb
+++ b/dashboard/test/lib/services/courses_test.rb
@@ -7,9 +7,10 @@ class Services::CoursesTest < ActiveSupport::TestCase
     let(:current_user) {instance_double(User)}
     let(:path) {'/s/script-1/some-path'}
     let(:params) {{}}
+    let(:modularity_enabled) {false}
 
     before do
-      allow(Experiment).to receive(:enabled?).with(user: current_user, experiment_name: 'modularity').and_return(false)
+      allow(Policies::Courses).to receive(:modularity_enabled?).with(current_user).and_return(modularity_enabled)
       allow(Queries::Courses).to receive(:get_course_context).and_return(nil)
     end
 
@@ -20,9 +21,7 @@ class Services::CoursesTest < ActiveSupport::TestCase
     end
 
     context 'the modularity experiment is enabled' do
-      before do
-        allow(Experiment).to receive(:enabled?).with(user: current_user, experiment_name: 'modularity').and_return(true)
-      end
+      let(:modularity_enabled) {true}
 
       context 'script_name is not present in params' do
         it 'returns the original path' do


### PR DESCRIPTION
Adds support for a feature flag 'modularity' for the Modularity project. Before, it was just using Pilots, which allows us to let select users to get the Modularity experience, but this PR adds a DCDO fallback configuration so we can eventually turn on Modularity for all users.

The main motivation for having this is so we can quickly turn the feature off if we discover there is an issue. The modularity project involves changing the navigation of the site, so if something goes wrong, it could potentially make the website unusable.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/TEACH-1603)

## Testing story
* Unit tests

## Deployment strategy
None needed

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
