### PR TITLE
Revert "RUBRIC - fix styles of student-facing rubrics"

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -443,7 +443,7 @@ button.rubricHeaderTab {
     height: 40px;
     padding: 0 1rem 0 2rem;
     justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
     align-self: stretch;
     line-height: 154%;
     position: relative;
@@ -486,7 +486,6 @@ button.rubricHeaderTab {
   gap: 16px;
   font-size: 14px;
   padding-left: 10px;
-  padding-top: 0.5rem;
 }
 
 .learningGoalHeaderRightSide {
@@ -560,6 +559,7 @@ h2.studentName {
   display: flex;
   flex-direction: row;
   width: 100%;
+  height: 100px;
   gap: 8px;
   min-height: 92px;
 }


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#64467

Removing the height caused a change for the teacher's rubric.  Consider separating out the css. 