### PR TITLE
feat(marketing): reorder custom components in Contentful Experiences sidebar

### DIFF
--- a/frontend/apps/marketing/src/components/button/ButtonContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/button/ButtonContentfulDefinition.ts
@@ -3,7 +3,7 @@ import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 export const ButtonContentfulComponentDefinition: ComponentDefinition = {
   id: 'button',
   name: 'Button',
-  category: 'Custom Components',
+  category: '03: Basic',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/6fRMP55wwDZF2C4ubzygTO/bad1643a5db519e1e3f6886f0f7bc7cd/component_button_thumbnail.png',
   tooltip: {

--- a/frontend/apps/marketing/src/components/carousels/videoCarousel/videoCarouselContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/carousels/videoCarousel/videoCarouselContentfulDefinition.ts
@@ -4,7 +4,7 @@ import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 export const VideoCarouselContentfulComponentDefinition: ComponentDefinition = {
   id: 'carousel-video',
   name: 'Video Carousel',
-  category: 'Carousels',
+  category: '05: Carousels',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/6YMaK6meOohBICfHq6CAZf/fa536c664bb65bc2435cb12c1ca48b89/component_carousel_video_thumbnail.png',
   tooltip: {

--- a/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
@@ -4,7 +4,7 @@ import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 export const DividerContentfulComponentDefinition: ComponentDefinition = {
   id: 'divider',
   name: 'Divider',
-  category: 'Custom Components',
+  category: '01: Page Structure',
   // Adding an empty array here so no default style options show in the Design tab.
   builtInStyles: [],
   thumbnailUrl:

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordionContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordionContentfulDefinition.ts
@@ -4,7 +4,7 @@ import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 export const FAQAccordionContentfulComponentDefinition: ComponentDefinition = {
   id: 'faqAccordion',
   name: 'FAQ Accordion',
-  category: 'Custom Components',
+  category: '04: Advanced',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/2T9oZuMVAKZ0HHTJB80ftF/e81cf4131a6580d1edd86c98e0539bfe/component_faq_thumbnail.png',
   tooltip: {

--- a/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
@@ -5,7 +5,7 @@ import {removeMarginBottomDefinition} from '@/components/common/definitions';
 export const HeadingContentfulComponentDefinition: ComponentDefinition = {
   id: 'heading',
   name: 'Heading',
-  category: 'Typography',
+  category: '02: Typography',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/LHRmOBd4IWYZuWScbJG3i/0442e38966e91c0e2aca88fdb2b217ad/component_divider_thumbnail.png',
   tooltip: {

--- a/frontend/apps/marketing/src/components/iframe/iframeContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/iframe/iframeContentfulDefinition.ts
@@ -4,7 +4,7 @@ import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 export const IframeContentfulComponentDefinition: ComponentDefinition = {
   id: 'iframe',
   name: 'iFrame Block',
-  category: 'Advanced',
+  category: '04: Advanced',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/1qy9FC9Bqb4ADrpyszIa5M/eb4c9dde9c1c90ab40036e8fa4412697/component_iframe_thumbnail.png',
   tooltip: {

--- a/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
@@ -5,7 +5,7 @@ import {removeMarginBottomDefinition} from '@/components/common/definitions';
 export const LinkContentfulComponentDefinition: ComponentDefinition = {
   id: 'link',
   name: 'Text Link',
-  category: 'Typography',
+  category: '02: Typography',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/2CPKrKCB3KxD1n6wG9JTn9/aab22373a39e9cc5305b21c08bba588d/component_link_thumbnail.png',
   tooltip: {

--- a/frontend/apps/marketing/src/components/overline/OverlineContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/overline/OverlineContentfulDefinition.ts
@@ -5,7 +5,7 @@ import {removeMarginBottomDefinition} from '@/components/common/definitions';
 export const OverlineContentfulComponentDefinition: ComponentDefinition = {
   id: 'overline',
   name: 'Overline',
-  category: 'Typography',
+  category: '02: Typography',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/30ubXKEp07H0liw3w6jad/222daf47eb2d7f14dfef4e9711522217/component_overline_thumbnail.png',
   tooltip: {

--- a/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
@@ -5,7 +5,7 @@ import {removeMarginBottomDefinition} from '@/components/common/definitions';
 export const ParagraphContentfulComponentDefinition: ComponentDefinition = {
   id: 'paragraph',
   name: 'Paragraph',
-  category: 'Typography',
+  category: '02: Typography',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/5hP7jqXdP90BtLxMi6FSWm/09a555420c3313133d16e87a84e22826/component_paragraph_thumbnail.png',
   tooltip: {

--- a/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
@@ -4,7 +4,7 @@ import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 export const SectionContentfulComponentDefinition: ComponentDefinition = {
   id: 'section',
   name: 'Section (Use me!)',
-  category: 'Page Structure',
+  category: '01: Page Structure',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/1DVXtxBlLLunOb1PrjRTqz/6bfd2cae987a5cf2dd0c211e677b5023/component_section_thumbnail.png',
   tooltip: {

--- a/frontend/apps/marketing/src/components/video/videoContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/video/videoContentfulDefinition.ts
@@ -4,7 +4,7 @@ import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 export const VideoContentfulComponentDefinition: ComponentDefinition = {
   id: 'video',
   name: 'Video',
-  category: 'Custom Components',
+  category: '03: Basic',
   thumbnailUrl:
     'https://images.ctfassets.net/90t6bu6vlf76/34JWsHE14EP6EoqJyoa3vI/516d08ada4c866195d86bc668fcaf458/component_video_thumbnail.png',
   tooltip: {


### PR DESCRIPTION
Reorders the list of custom components in the Contentful sidebar into organized groups. 

## Links
Jira ticket: [CMS-324](https://codedotorg.atlassian.net/browse/CMS-324)
Figma mock: [here](https://www.figma.com/design/l7PsQAs2pitCNP8zUHWEuy/DSCO-CMS?node-id=3521-1149&m=dev)

----

<img width="261" alt="Screenshot 2025-03-13 at 10 15 13 AM" src="https://github.com/user-attachments/assets/88704a6b-37b3-4a75-8638-acf15905565c" />
