### PR TITLE
Python Lab: fix validation bug

### DIFF
--- a/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
@@ -49,7 +49,6 @@ export const useHandleFileUpload = (
         fileName,
         folderId,
         contents,
-        validationFileId: validationFile?.id,
       });
       sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_UPLOAD_FILE, appName, {
         fileName,

--- a/apps/src/codebridge/FileBrowser/prompts/openNewFilePrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openNewFilePrompt.tsx
@@ -51,7 +51,6 @@ export const openNewFilePrompt = async ({
   newFile({
     fileName,
     folderId,
-    validationFileId: validationFile?.id,
   });
 
   sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_NEW_FILE);

--- a/apps/src/codebridge/codebridgeContext/codebridgeContextSourceReducer.ts
+++ b/apps/src/codebridge/codebridgeContext/codebridgeContextSourceReducer.ts
@@ -31,19 +31,15 @@ export const sourceReducer = (
       return newSource;
     }
     case SOURCE_REDUCER_ACTIONS.NEW_FILE: {
-      const {fileName, folderId, contents = '', validationFileId} = <
+      const {fileName, folderId, contents = ''} = <
         DefaultFilePayload & {
           fileName: string;
           contents?: string;
           folderId: FolderId;
-          validationFileId?: string;
         }
       >action.payload;
 
-      const fileId = getNextFileId(
-        Object.values(source.files),
-        validationFileId
-      );
+      const fileId = getNextFileId(Object.values(source.files));
 
       const newSource = {...source, files: {...source.files}};
 

--- a/apps/src/codebridge/codebridgeContext/types.ts
+++ b/apps/src/codebridge/codebridgeContext/types.ts
@@ -19,7 +19,6 @@ export type NewFileFunction = (arg: {
   fileName: string;
   folderId?: FolderId;
   contents?: string;
-  validationFileId?: string;
 }) => void;
 export type RenameFileFunction = (fileId: FileId, newName: string) => void;
 export type RenameFolderFunction = (folderId: string, newName: string) => void;

--- a/apps/src/codebridge/codebridgeContext/utils.ts
+++ b/apps/src/codebridge/codebridgeContext/utils.ts
@@ -80,6 +80,7 @@ export const useSourceUtilities = (dispatch: React.Dispatch<ReducerAction>) => {
         // this line causes the apparent circular dependency issue
         // contents = codebridgeI18n.defaultNewFileContents({fileName}),
         contents = DEFAULT_NEW_FILE_CONTENTS,
+        validationFileId,
       }) => {
         dispatch({
           type: SOURCE_REDUCER_ACTIONS.NEW_FILE,
@@ -87,6 +88,7 @@ export const useSourceUtilities = (dispatch: React.Dispatch<ReducerAction>) => {
             fileName,
             folderId,
             contents: contents.replace(/\${fileName}/g, fileName),
+            validationFileId,
           },
         });
       }),

--- a/apps/src/codebridge/codebridgeContext/utils.ts
+++ b/apps/src/codebridge/codebridgeContext/utils.ts
@@ -29,12 +29,8 @@ import {
   SetFileTypeFunction,
 } from './types';
 
-// optionally, we can hand in the validationFileId as the second argument. If it's included, then we'll use that as well
-// when we figure out the next file id. If we're not given one, then just set it to '0' so it doesn't interfere with id generation.
-export const getNextFileId = (files: ProjectFile[], validationFileId = '0') => {
-  return String(
-    Math.max(0, Number(validationFileId), ...files.map(f => Number(f.id))) + 1
-  );
+export const getNextFileId = (files: ProjectFile[]) => {
+  return String(Math.max(0, ...files.map(f => Number(f.id))) + 1);
 };
 
 export const getNextFolderId = (folders: ProjectFolder[]) => {
@@ -80,7 +76,6 @@ export const useSourceUtilities = (dispatch: React.Dispatch<ReducerAction>) => {
         // this line causes the apparent circular dependency issue
         // contents = codebridgeI18n.defaultNewFileContents({fileName}),
         contents = DEFAULT_NEW_FILE_CONTENTS,
-        validationFileId,
       }) => {
         dispatch({
           type: SOURCE_REDUCER_ACTIONS.NEW_FILE,
@@ -88,7 +83,6 @@ export const useSourceUtilities = (dispatch: React.Dispatch<ReducerAction>) => {
             fileName,
             folderId,
             contents: contents.replace(/\${fileName}/g, fileName),
-            validationFileId,
           },
         });
       }),

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -87,13 +87,13 @@ onmessage = async event => {
   let results = undefined;
   let sourceToWrite = source;
   // Add the validation file to the source if it exists. Use the id "validation"
-  // so the validation file does not inadvertently overwrite a user file.
+  // so the validation file does not overwrite a user file.
   if (validationFile) {
     sourceToWrite = {
       ...source,
       files: {
         ...source.files,
-        validation: validationFile,
+        validation: {...validationFile, id: 'validation'},
       },
     };
   }

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -92,7 +92,7 @@ onmessage = async event => {
       ...source,
       files: {
         ...source.files,
-        [validationFile.id]: validationFile,
+        validation: validationFile,
       },
     };
   }

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -87,7 +87,7 @@ onmessage = async event => {
   let results = undefined;
   let sourceToWrite = source;
   // Add the validation file to the source if it exists. Use the id "validation"
-  // so the validation file does not overwrite a user file.
+  // so the validation file does not overwrite a user file (user files have stringified numeric ids).
   if (validationFile) {
     sourceToWrite = {
       ...source,

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -86,7 +86,8 @@ onmessage = async event => {
   const {id, python, source, validationFile} = event.data;
   let results = undefined;
   let sourceToWrite = source;
-  // Add the validation file to the source if it exists.
+  // Add the validation file to the source if it exists. Use the id "validation"
+  // so the validation file does not inadvertently overwrite a user file.
   if (validationFile) {
     sourceToWrite = {
       ...source,


### PR DESCRIPTION
I noticed in classrooms that students were seeing odd validation failures, including that they would create a painter but the validation would say no painter was created. I was able to reproduce the error by importing a second file into my program and creating a painter. It turned out the test was finding no painter because the main method was failing to run due to it not finding the imported file.

It turned out that during some refactoring in #61921 the validation logic got broken. We should have been skipping the validation file id when generating a new file id, but we weren't. This meant that when the user created a new file, it was given the same id as the validation file. Then when we ran the validation, we were [overwriting](https://github.com/code-dot-org/code-dot-org/blob/7cbc5a5934b278672ada161a71fb5729f2e079ef/apps/src/pythonlab/pyodideWebWorker.ts#L95) the new file with the validation file.

There were two options to fix this: fix the id generation logic or fix how we generate the source for running validation. Since there are students in classrooms now with "incorrect" ids, it made the most sense to fix the source generation. Now we just set the validation file id to "validation" so we don't overwrite any existing files. I then removed all the logic to track the validation file id since we no longer care if it overlaps.

This change is safe to make because of how we handle validation. See #61463 for a detailed description. In short, when we are in start mode, the validation is just part of the regular sources and this path isn't used. The path is only used to add the validation file to the source to run the code, and then the validation file is ignored when re-generating the source. So the id is not meaningfully used in this object. (It is only used [here](https://github.com/code-dot-org/code-dot-org/blob/7cbc5a5934b278672ada161a71fb5729f2e079ef/apps/src/pythonlab/pythonHelpers/pythonScriptUtils.ts#L33)).

## Links
- jira ticket: [CT-1141](https://codedotorg.atlassian.net/browse/CT-1141)


## Testing story
Tested locally and ran unit tests. I tested both in start mode and normal mode, with and without conflicting ids.


## Follow-up work
There was another issue that I still need to investigate around the painter's final position not being accurately sent. That is tracked in the ticket linked above.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
