### PR TITLE
P20 1394/create multi auth users

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -453,7 +453,7 @@ class User < ApplicationRecord
     Services::Lti.create_lti_user_identity(self)
   end
 
-  after_create_commit :migrate_to_multi_auth
+  after_create :migrate_to_multi_auth
 
   after_update if: -> {cap_status? && property_previously_changed?(:us_state)} do
     Services::ChildAccount.remove_compliance(self)

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -38,6 +38,7 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
     post :link_email, params: {email: @user.email, password: 'password'}
     assert_equal I18n.t('lti.account_linking.successfully_linked'), flash[:notice]
     assert_redirected_to target_url
+    @user.reload
     assert Policies::Lti.lti?(@user)
   end
 
@@ -72,6 +73,7 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
     post :link_email, params: {email: @user.email, password: 'password'}
     assert_equal I18n.t('lti.account_linking.successfully_linked'), flash[:notice]
     assert_redirected_to target_url
+    @user.reload
     assert Policies::Lti.lti?(@user)
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -530,7 +530,6 @@ FactoryBot.define do
       after(:create) do |user|
         user.lms_landing_opted_out = true
         user.authentication_options.destroy_all
-        user.reload
         lti_user_id = create(:lti_user_identity, user: user)
         user.lti_user_identities << lti_user_id
         auth_id = lti_user_id.lti_integration.issuer + "|" + lti_user_id.lti_integration.client_id + "|" + lti_user_id.subject

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -530,6 +530,7 @@ FactoryBot.define do
       after(:create) do |user|
         user.lms_landing_opted_out = true
         user.authentication_options.destroy_all
+        user.reload
         lti_user_id = create(:lti_user_identity, user: user)
         user.lti_user_identities << lti_user_id
         auth_id = lti_user_id.lti_integration.issuer + "|" + lti_user_id.lti_integration.client_id + "|" + lti_user_id.subject

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -627,6 +627,7 @@ FactoryBot.define do
             oauth_token_expiration: '999999'
           }.to_json
         )
+        user.reload
       end
     end
 
@@ -644,6 +645,7 @@ FactoryBot.define do
             oauth_token_expiration: '999999'
           }.to_json
         )
+        user.reload
       end
     end
 
@@ -659,6 +661,7 @@ FactoryBot.define do
             oauth_token: 'some-clever-token'
           }.to_json
         )
+        user.reload
       end
     end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -530,6 +530,8 @@ FactoryBot.define do
       after(:create) do |user|
         user.lms_landing_opted_out = true
         user.authentication_options.destroy_all
+        user.save!
+        user.reload
         lti_user_id = create(:lti_user_identity, user: user)
         user.lti_user_identities << lti_user_id
         auth_id = lti_user_id.lti_integration.issuer + "|" + lti_user_id.lti_integration.client_id + "|" + lti_user_id.subject
@@ -537,6 +539,7 @@ FactoryBot.define do
         user.authentication_options << lti_auth
         user.lti_roster_sync_enabled = true
         user.save!
+        user.reload
       end
     end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -521,6 +521,8 @@ FactoryBot.define do
         ao = user.authentication_options.find_by(credential_type: AuthenticationOption::EMAIL)
         ao&.destroy
         user.save
+        # Reload to ensure that further uses of the pre-loaded user don't see the now-destroyed auth option
+        user.reload
       end
     end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -709,6 +709,11 @@ FactoryBot.define do
     credential_type {AuthenticationOption::EMAIL}
     authentication_id {SecureRandom.uuid}
 
+    after(:create) do |auth_option|
+      # Ensure that the original user model reloads the auth options list
+      auth_option.user&.reload
+    end
+
     factory :google_authentication_option do
       credential_type {AuthenticationOption::GOOGLE}
     end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -530,7 +530,6 @@ FactoryBot.define do
       after(:create) do |user|
         user.lms_landing_opted_out = true
         user.authentication_options.destroy_all
-        user.save!
         user.reload
         lti_user_id = create(:lti_user_identity, user: user)
         user.lti_user_identities << lti_user_id
@@ -539,7 +538,6 @@ FactoryBot.define do
         user.authentication_options << lti_auth
         user.lti_roster_sync_enabled = true
         user.save!
-        user.reload
       end
     end
 

--- a/dashboard/test/integration/cap/cpa/lockout_test.rb
+++ b/dashboard/test/integration/cap/cpa/lockout_test.rb
@@ -184,15 +184,8 @@ module CAP
           end
 
           context 'when student provider is Google' do
-            before do
-              # Remove the email option that a student defaults to
-              student.authentication_options.first.destroy!
-              student.reload
-              create(:google_authentication_option, user: student)
-            end
-
             context 'if account is created right before the phase has started' do
-              let(:student) {create(:cpa_non_compliant_student, created_at: all_user_lockout_date.ago(1.second))}
+              let(:student) {create(:cpa_non_compliant_student, :without_email_auth_option, :with_google_authentication_option, created_at: all_user_lockout_date.ago(1.second))}
 
               it 'student should be transited to grace period state' do
                 assert_student_in_grace_period
@@ -204,7 +197,7 @@ module CAP
             end
 
             context 'if account is created right after the phase has started' do
-              let(:student) {create(:cpa_non_compliant_student, created_at: all_user_lockout_date)}
+              let(:student) {create(:cpa_non_compliant_student, :without_email_auth_option, :with_google_authentication_option, created_at: all_user_lockout_date)}
 
               it 'student should be locked out immediately until permission is granted' do
                 assert_student_is_locked_out_until_permission_granted

--- a/dashboard/test/integration/cap/cpa/lockout_test.rb
+++ b/dashboard/test/integration/cap/cpa/lockout_test.rb
@@ -66,12 +66,7 @@ module CAP
           end
 
           context 'when student provider is Google' do
-            before do
-              # Remove the email option that a student defaults to
-              student.authentication_options.first.destroy!
-              student.reload
-              create(:google_authentication_option, user: student)
-            end
+            let(:student) {create(:cpa_non_compliant_student, :predates_policy, :without_email_auth_option, :with_google_authentication_option)}
 
             it 'student should not be locked out yet' do
               assert_student_is_not_locked_out

--- a/dashboard/test/integration/cap/cpa/lockout_test.rb
+++ b/dashboard/test/integration/cap/cpa/lockout_test.rb
@@ -67,6 +67,9 @@ module CAP
 
           context 'when student provider is Google' do
             before do
+              # Remove the email option that a student defaults to
+              student.authentication_options.first.destroy!
+              student.reload
               create(:google_authentication_option, user: student)
             end
 
@@ -187,6 +190,9 @@ module CAP
 
           context 'when student provider is Google' do
             before do
+              # Remove the email option that a student defaults to
+              student.authentication_options.first.destroy!
+              student.reload
               create(:google_authentication_option, user: student)
             end
 

--- a/dashboard/test/lib/services/lti/account_unlinker_test.rb
+++ b/dashboard/test/lib/services/lti/account_unlinker_test.rb
@@ -12,6 +12,7 @@ class Services::Lti::AccountUnlinkerTest < ActiveSupport::TestCase
       before(:context) do
         student_user.authentication_options.find_by(credential_type: 'email')&.destroy
         student_user.authentication_options << auth_option
+        student_user.reload
       end
 
       it 'does not remove the auth option' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -508,8 +508,9 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "email does not have to be unique when existing user has LTI authentication" do
-    user = create :teacher, :with_lti_auth
-    dupe_user = create(:teacher, email: user.email)
+    email = "duplicated_email@foo.com"
+    create :teacher, :with_lti_auth, email: email
+    dupe_user = create(:teacher, email: email)
     assert dupe_user.valid?
   end
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -991,7 +991,7 @@ class UserTest < ActiveSupport::TestCase
     migrated_student = create(:student, email: email)
 
     legacy_student = build(:user, :demigrated, email: email)
-    # ignore "Email has already been taken" error
+    # skip validation since we're creating a second user with the same email
     legacy_student.save(validate: false)
     assert_equal legacy_student.hashed_email, migrated_student.hashed_email
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -990,12 +990,9 @@ class UserTest < ActiveSupport::TestCase
     email = 'test@foo.bar'
     migrated_student = create(:student, email: email)
 
-    legacy_student = build(:student, email: email)
+    legacy_student = build(:user, :demigrated, email: email)
     # ignore "Email has already been taken" error
-    assert_raises(ActiveRecord::RecordInvalid) do
-      legacy_student.save(validate: false)
-    end
-    legacy_student.demigrate_from_multi_auth
+    legacy_student.save(validate: false)
     assert_equal legacy_student.hashed_email, migrated_student.hashed_email
 
     looked_up_user = User.find_for_authentication(hashed_email: User.hash_email(email))


### PR DESCRIPTION
Currently, we create new users as "single-auth" users, meaning their authentication information is persisted directly on the User table, not as an Authentication Option. Then, as an `after_create_commit` callback, we [migrate the user to multi-auth](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/user_multi_auth_helper.rb#L54-L58).

The `after_create_commit` callback is triggered after the new user has been committed to the database, and after the transaction has completed. We have around 2-3 new user accounts per day that are failing to "migrate", and are left in a un-migrated or single-auth state. The user is created in the first transaction, and then a second transaction wraps the creation of an `authentication_option` and updates the user's `primary_contact_info` to point to this new `authentication_option`. This second transaction is what is failing occasionally, for unknown reasons.

This PR moves the `migrate_to_multi_auth` method to be invoked by an `after_create` callback. This callback is triggered after the user has been created and saved, but before it is committed. The result is that the entire sequence of creating a user, creating an `authentication_option`, and updating the user's `primary_contact_info` is all done in a single transaction, and will be rolled back if any step fails along the way.

<details>
<summary><h3>Additional Details</h3></summary>
<br>

<details>
<summary>SQL query showing around 2-3 new user records per day that are in an un-migrated state</summary>
<br>

```
mysql> select id, created_at, provider from users where not provider = "migrated" order by created_at desc limit 100;                                                                                                               [43/1999]
+-----------+---------------------+---------------+
| id        | created_at          | provider      |
+-----------+---------------------+---------------+
| 126529901 | 2025-03-11 16:29:43 | clever        |
| 126528295 | 2025-03-11 15:57:45 | clever        |
| 126516497 | 2025-03-11 12:27:55 | clever        |
| 126494676 | 2025-03-10 18:44:10 | clever        |
| 126482504 | 2025-03-10 15:18:15 | google_oauth2 |
| 126436599 | 2025-03-07 20:32:43 | clever        |
| 126434063 | 2025-03-07 19:22:03 | clever        |
| 126394559 | 2025-03-06 18:26:40 | clever        |
| 126394558 | 2025-03-06 18:26:40 | clever        |
| 126391189 | 2025-03-06 17:21:12 | clever        |
| 126349731 | 2025-03-05 16:58:50 | clever        |
| 126316983 | 2025-03-04 19:41:10 | clever        |
| 126311270 | 2025-03-04 18:00:35 | clever        |
| 126309224 | 2025-03-04 17:11:42 | clever        |
| 126305033 | 2025-03-04 15:56:58 | google_oauth2 |
| 126300431 | 2025-03-04 14:53:12 | clever        |
| 126284897 | 2025-03-04 02:37:05 | clever        |
| 126268079 | 2025-03-03 17:16:45 | clever        |
| 126254045 | 2025-03-03 13:34:24 | google_oauth2 |
| 126217830 | 2025-03-01 02:26:07 | clever        |
| 126205682 | 2025-02-28 17:08:35 | clever        |
| 126201623 | 2025-02-28 15:38:48 | clever        |
| 126176081 | 2025-02-27 19:35:57 | clever        |
| 126138947 | 2025-02-26 21:06:19 | clever        |
| 126122420 | 2025-02-26 15:28:08 | clever        |
| 126097948 | 2025-02-25 22:03:16 | clever        |
| 126071288 | 2025-02-25 14:07:59 | clever        |
| 126036619 | 2025-02-24 17:19:50 | clever        |
| 126031777 | 2025-02-24 16:06:07 | clever        |
| 126026249 | 2025-02-24 14:27:40 | clever        |
| 125989439 | 2025-02-22 18:01:06 | clever        |
| 125989440 | 2025-02-22 18:01:06 | clever        |
| 125977109 | 2025-02-21 18:55:40 | clever        |
| 125964952 | 2025-02-21 14:14:10 | clever        |
| 125946504 | 2025-02-20 20:10:02 | clever        |
| 125928458 | 2025-02-20 13:59:04 | clever        |
| 125905028 | 2025-02-19 18:53:48 | clever        |
| 125905029 | 2025-02-19 18:53:48 | clever        |
| 125905027 | 2025-02-19 18:53:48 | clever        |
| 125900462 | 2025-02-19 17:25:19 | clever        |
| 125887121 | 2025-02-19 12:43:29 | clever        |
| 125834362 | 2025-02-18 03:59:28 | clever        |
| 125781700 | 2025-02-14 20:08:11 | clever        |
| 125769359 | 2025-02-14 14:22:44 | clever        |
| 125744056 | 2025-02-13 18:09:29 | clever        |
| 125713273 | 2025-02-12 23:44:05 | google_oauth2 |
| 125713277 | 2025-02-12 23:44:05 | google_oauth2 |
| 125713279 | 2025-02-12 23:44:05 | google_oauth2 |
| 125657017 | 2025-02-11 17:34:49 | clever        |
| 125621030 | 2025-02-10 20:16:15 | clever        |
| 125605753 | 2025-02-10 16:16:16 | clever        |
| 125605335 | 2025-02-10 16:11:51 | clever        |
| 125600176 | 2025-02-10 15:05:16 | clever        |
| 125560822 | 2025-02-08 18:26:55 | clever        |
| 125551508 | 2025-02-07 20:15:30 | clever        |
| 125550321 | 2025-02-07 19:43:52 | clever        |
| 125546212 | 2025-02-07 18:23:03 | clever        |
| 125537307 | 2025-02-07 15:50:50 | clever        |
| 125501676 | 2025-02-06 17:30:05 | clever        |
| 125491660 | 2025-02-06 14:38:06 | clever        |
| 125489447 | 2025-02-06 13:56:03 | clever        |
| 125474634 | 2025-02-06 02:47:57 | clever        |
| 125471023 | 2025-02-05 22:24:08 | clever        |
| 125469177 | 2025-02-05 21:14:58 | clever        |
| 125463094 | 2025-02-05 19:02:12 | clever        |
| 125410320 | 2025-02-04 17:52:18 | clever        |
| 125364431 | 2025-02-03 19:41:16 | clever        |
| 125346270 | 2025-02-03 15:30:26 | clever        |
| 125342273 | 2025-02-03 14:46:51 | clever        |
| 125286083 | 2025-01-31 19:01:26 | clever        |
| 125284574 | 2025-01-31 18:40:33 | clever        |
| 125281299 | 2025-01-31 17:44:39 | clever        |
| 125278995 | 2025-01-31 17:07:45 | clever        |
| 125277491 | 2025-01-31 16:39:51 | clever        |
| 125270624 | 2025-01-31 15:05:32 | clever        |
| 125246001 | 2025-01-30 20:10:45 | clever        |
| 125243749 | 2025-01-30 19:33:40 | clever        |
| 125237429 | 2025-01-30 17:58:16 | clever        |
| 125237205 | 2025-01-30 17:55:21 | clever        |
| 125219231 | 2025-01-30 13:45:16 | clever        |
| 125190535 | 2025-01-29 17:50:16 | clever        |
| 125190022 | 2025-01-29 17:41:06 | clever        |
| 125150323 | 2025-01-28 19:30:26 | clever        |
| 125147951 | 2025-01-28 18:56:52 | clever        |
| 125140793 | 2025-01-28 17:23:31 | clever        |
| 125136868 | 2025-01-28 16:33:09 | clever        |
| 125132242 | 2025-01-28 15:37:49 | clever        |
| 125127797 | 2025-01-28 14:53:38 | clever        |
| 125123382 | 2025-01-28 13:55:07 | clever        |
| 125122882 | 2025-01-28 13:50:35 | clever        |
| 125104603 | 2025-01-27 22:05:21 | clever        |
| 125095975 | 2025-01-27 19:13:21 | clever        |
| 125084428 | 2025-01-27 16:35:45 | clever        |
| 125080638 | 2025-01-27 15:58:35 | clever        |
| 125074786 | 2025-01-27 14:55:05 | clever        |
| 125052859 | 2025-01-26 22:39:54 | clever        |
| 125016537 | 2025-01-24 16:00:12 | clever        |
| 125015849 | 2025-01-24 15:52:32 | clever        |
| 124997613 | 2025-01-24 06:45:45 | google_oauth2 |
| 124976227 | 2025-01-23 17:25:30 | clever        |
+-----------+---------------------+---------------+
100 rows in set (43.66 sec)
```
</details>

<details>
<summary>Example of after_create_commit vs. after_create</summary>
<br>

`after_create_commit` results in two transactions, the first wraps the `user` create, the second wraps the `authentication_option` create and the user update with `primary_contact_info`
<img width="1701" alt="Screenshot 2025-03-11 at 3 24 27 PM" src="https://github.com/user-attachments/assets/efe86c55-0ac5-4532-8c80-6ee69984e2cf" />

`after_create` results in a single transaction that wraps the entire sequence: `user` create, `authentication_option` create, and `user` update with `primary_contact_info`
<img width="1708" alt="Screenshot 2025-03-11 at 3 20 50 PM" src="https://github.com/user-attachments/assets/da5e99f0-a726-405a-81ba-66df6dd99d8e" />
</details>
</details>


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
