### PR TITLE
feat(eslint): add import order rule

### DIFF
--- a/.github/workflows/component-library-ci.yml
+++ b/.github/workflows/component-library-ci.yml
@@ -31,12 +31,12 @@ jobs:
               run: npx playwright install --with-deps
               working-directory: ./frontend/apps/design-system-storybook
 
-            - name: Lint
-              run: yarn lint --filter @code-dot-org/component-library --filter @code-dot-org/design-system-storybook
-              working-directory: ./frontend
-
             - name: Build
               run: yarn build --filter @code-dot-org/component-library --filter @code-dot-org/design-system-storybook
+              working-directory: ./frontend
+
+            - name: Lint
+              run: yarn lint --filter @code-dot-org/component-library --filter @code-dot-org/design-system-storybook
               working-directory: ./frontend
 
             - name: Unit Tests

--- a/frontend/apps/design-system-storybook/.storybook/main.ts
+++ b/frontend/apps/design-system-storybook/.storybook/main.ts
@@ -1,5 +1,5 @@
-import {join, dirname, resolve} from 'node:path';
 import {StorybookConfig} from '@storybook/react-webpack5';
+import {join, dirname, resolve} from 'node:path';
 import {IgnorePlugin} from 'webpack';
 
 /**

--- a/frontend/apps/design-system-storybook/.storybook/preview.js
+++ b/frontend/apps/design-system-storybook/.storybook/preview.js
@@ -1,4 +1,5 @@
 import {default as RtlPreview} from 'storybook-addon-rtl/preview';
+
 import {loadFonts} from '@code-dot-org/fonts';
 
 import '@code-dot-org/fonts/index.css';

--- a/frontend/apps/design-system-storybook/.storybook/test-runner.ts
+++ b/frontend/apps/design-system-storybook/.storybook/test-runner.ts
@@ -1,6 +1,5 @@
 import type {TestRunnerConfig} from '@storybook/test-runner';
 import {getStoryContext} from '@storybook/test-runner';
-
 import {injectAxe, checkA11y} from 'axe-playwright';
 
 /*

--- a/frontend/apps/marketing/eslint.config.mjs
+++ b/frontend/apps/marketing/eslint.config.mjs
@@ -1,6 +1,7 @@
-import cdoReactConfig from '@code-dot-org/lint-config/eslint/react.mjs';
-import cdoJestConfig from '@code-dot-org/lint-config/eslint/jest.mjs';
 import nextPlugin from '@next/eslint-plugin-next';
+
+import cdoJestConfig from '@code-dot-org/lint-config/eslint/jest.mjs';
+import cdoReactConfig from '@code-dot-org/lint-config/eslint/react.mjs';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [

--- a/frontend/apps/marketing/playwright.config.ts
+++ b/frontend/apps/marketing/playwright.config.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
-import {defineConfig, devices} from '@playwright/test';
 import {EyesFixture} from '@applitools/eyes-playwright/fixture';
+import {defineConfig, devices} from '@playwright/test';
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/frontend/apps/marketing/src/app/[locale]/[slug]/page.tsx
+++ b/frontend/apps/marketing/src/app/[locale]/[slug]/page.tsx
@@ -1,10 +1,12 @@
-import {detachExperienceStyles} from '@contentful/experiences-sdk-react';
-import {getExperience} from '@/contentful/get-experience';
-import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
-
 // Register custom components server-side
 import '@/contentful/register-custom-components';
+
+import {detachExperienceStyles} from '@contentful/experiences-sdk-react';
+
 import FontLoader from '@code-dot-org/fonts/FontLoader';
+
+import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
+import {getExperience} from '@/contentful/get-experience';
 
 type ExperiencePageProps = {
   params: Promise<{locale?: string; slug?: string; preview?: string}>;

--- a/frontend/apps/marketing/src/app/[locale]/layout.tsx
+++ b/frontend/apps/marketing/src/app/[locale]/layout.tsx
@@ -1,10 +1,11 @@
 import {GoogleAnalytics} from '@next/third-parties/google';
 import {headers} from 'next/headers';
-import {getGoogleAnalyticsMeasurementId} from '@/config/ga4';
+
 import {getBrandFromHostname} from '@/config/brand';
+import {getGoogleAnalyticsMeasurementId} from '@/config/ga4';
+import {getStage} from '@/config/stage';
 import {generateBootstrapValues} from '@/providers/statsig/statsig-backend';
 import StatsigProvider from '@/providers/statsig/StatsigProvider';
-import {getStage} from '@/config/stage';
 
 /**
  * Nested asynchronous layout to temporarily workaround Font Awesome imports going out of order due to CSS Chunking

--- a/frontend/apps/marketing/src/app/robots.ts
+++ b/frontend/apps/marketing/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type {MetadataRoute} from 'next';
+
 import {getStage} from '@/config/stage';
 
 const DISALLOW_ALL = {

--- a/frontend/apps/marketing/src/components/button/Button.tsx
+++ b/frontend/apps/marketing/src/components/button/Button.tsx
@@ -1,9 +1,10 @@
+import React, {useMemo} from 'react';
+
 import {
   ButtonColor,
   ButtonType,
   LinkButton,
 } from '@code-dot-org/component-library/button';
-import React, {useMemo} from 'react';
 
 import {fontAwesomeV6BrandIconsMap} from '@/components/common/constants';
 

--- a/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
+++ b/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import '@code-dot-org/component-library/carousel/index.css';
-import DSCOCarousel from '@code-dot-org/component-library/carousel';
 import React, {ReactNode, useMemo} from 'react';
 
+import DSCOCarousel from '@code-dot-org/component-library/carousel';
 import Video from '@code-dot-org/component-library/video';
 
 export type VideoCarouselProps = {

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
@@ -1,8 +1,9 @@
 import {EntryFields, BaseEntry} from 'contentful';
+import {useMemo} from 'react';
+
 import FAQAccordion, {
   FAQAccordionItem,
 } from '@code-dot-org/component-library/accordrion/faqAccordion';
-import {useMemo} from 'react';
 
 type FAQAccordionContentfulProps = {
   faqs?: (BaseEntry & {

--- a/frontend/apps/marketing/src/components/heading/Heading.tsx
+++ b/frontend/apps/marketing/src/components/heading/Heading.tsx
@@ -1,10 +1,11 @@
+import classNames from 'classnames';
+import React, {ReactNode} from 'react';
+
 import {
   default as Typography,
   VisualAppearance,
   SemanticTag,
 } from '@code-dot-org/component-library/typography';
-import React, {ReactNode} from 'react';
-import classNames from 'classnames';
 
 import {RemoveMarginBottomProps} from '@/components/common/types';
 

--- a/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
@@ -1,5 +1,6 @@
 // Creates a definition for the Typography component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
 import {removeMarginBottomDefinition} from '@/components/common/definitions';
 
 export const HeadingContentfulComponentDefinition: ComponentDefinition = {

--- a/frontend/apps/marketing/src/components/heading/__tests__/Heading.test.tsx
+++ b/frontend/apps/marketing/src/components/heading/__tests__/Heading.test.tsx
@@ -1,5 +1,6 @@
-import Heading from '@/components/heading';
 import {render, screen} from '@testing-library/react';
+
+import Heading from '@/components/heading';
 
 describe('Heading Component', () => {
   it('should render out all headings', async () => {

--- a/frontend/apps/marketing/src/components/link/Link.tsx
+++ b/frontend/apps/marketing/src/components/link/Link.tsx
@@ -1,8 +1,9 @@
-import {default as DSCOLink} from '@code-dot-org/component-library/link';
+import classNames from 'classnames';
+import React, {ReactNode} from 'react';
+
 import {ComponentSizeXSToL} from '@code-dot-org/component-library/common/types';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import React, {ReactNode} from 'react';
-import classNames from 'classnames';
+import {default as DSCOLink} from '@code-dot-org/component-library/link';
 
 import {RemoveMarginBottomProps} from '@/components/common/types';
 

--- a/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
@@ -1,5 +1,6 @@
 // Creates a definition for the Link component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
 import {removeMarginBottomDefinition} from '@/components/common/definitions';
 
 export const LinkContentfulComponentDefinition: ComponentDefinition = {

--- a/frontend/apps/marketing/src/components/link/__tests__/Link.test.tsx
+++ b/frontend/apps/marketing/src/components/link/__tests__/Link.test.tsx
@@ -1,5 +1,6 @@
-import Link, {LinkProps} from '@/components/link';
 import {render, screen} from '@testing-library/react';
+
+import Link, {LinkProps} from '@/components/link';
 
 describe('Link Component', () => {
   const defaultProps = {

--- a/frontend/apps/marketing/src/components/overline/Overline.tsx
+++ b/frontend/apps/marketing/src/components/overline/Overline.tsx
@@ -1,10 +1,11 @@
+import classNames from 'classnames';
+import React, {ReactNode} from 'react';
+
+import {ComponentSizeXSToL} from '@code-dot-org/component-library/common/types';
 import {
   default as Typography,
   VisualAppearance,
 } from '@code-dot-org/component-library/typography';
-import {ComponentSizeXSToL} from '@code-dot-org/component-library/common/types';
-import classNames from 'classnames';
-import React, {ReactNode} from 'react';
 
 import {RemoveMarginBottomProps} from '@/components/common/types';
 

--- a/frontend/apps/marketing/src/components/overline/OverlineContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/overline/OverlineContentfulDefinition.ts
@@ -1,5 +1,6 @@
 // Creates a definition for the Overline component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
 import {removeMarginBottomDefinition} from '@/components/common/definitions';
 
 export const OverlineContentfulComponentDefinition: ComponentDefinition = {

--- a/frontend/apps/marketing/src/components/overline/__tests__/Overline.test.tsx
+++ b/frontend/apps/marketing/src/components/overline/__tests__/Overline.test.tsx
@@ -1,5 +1,6 @@
-import Overline from '@/components/overline';
 import {render, screen} from '@testing-library/react';
+
+import Overline from '@/components/overline';
 
 type OverlineColorClassMap = [
   'primary' | 'secondary',

--- a/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
+++ b/frontend/apps/marketing/src/components/paragraph/Paragraph.tsx
@@ -1,10 +1,11 @@
+import classNames from 'classnames';
+import React, {ReactNode} from 'react';
+
 import {
   default as Typography,
   StrongText,
   VisualAppearance,
 } from '@code-dot-org/component-library/typography';
-import React, {ReactNode} from 'react';
-import classNames from 'classnames';
 
 import {RemoveMarginBottomProps} from '@/components/common/types';
 

--- a/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
@@ -1,5 +1,6 @@
 // Creates a definition for the Paragraph component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
 import {removeMarginBottomDefinition} from '@/components/common/definitions';
 
 export const ParagraphContentfulComponentDefinition: ComponentDefinition = {

--- a/frontend/apps/marketing/src/components/paragraph/__tests__/Paragraph.test.tsx
+++ b/frontend/apps/marketing/src/components/paragraph/__tests__/Paragraph.test.tsx
@@ -1,5 +1,6 @@
-import Paragraph from '@/components/paragraph';
 import {render, screen} from '@testing-library/react';
+
+import Paragraph from '@/components/paragraph';
 
 describe('Paragraph Component', () => {
   it('should render out the text', async () => {

--- a/frontend/apps/marketing/src/config/ga4/__tests__/index.spec.ts
+++ b/frontend/apps/marketing/src/config/ga4/__tests__/index.spec.ts
@@ -1,8 +1,9 @@
+import {Brand} from '@/config/brand';
+
 import {
   getGoogleAnalyticsMeasurementId,
   GOOGLE_ANALYTICS_CONFIG,
 } from '../index';
-import {Brand} from '@/config/brand';
 
 describe('Google Analytics Config', () => {
   it('should return the correct measurement ID for CODE_DOT_ORG', () => {

--- a/frontend/apps/marketing/src/contentful/__tests__/client.test.ts
+++ b/frontend/apps/marketing/src/contentful/__tests__/client.test.ts
@@ -1,5 +1,6 @@
-import {_private} from '@/contentful/client';
 import {createClient} from 'contentful';
+
+import {_private} from '@/contentful/client';
 
 const DEFAULT_PROPS = {
   space: 'space',

--- a/frontend/apps/marketing/src/contentful/get-experience.ts
+++ b/frontend/apps/marketing/src/contentful/get-experience.ts
@@ -1,4 +1,5 @@
 import {fetchBySlug} from '@contentful/experiences-sdk-react';
+
 import client from './client';
 
 /**

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -3,6 +3,8 @@
  *
  * Note: This file must be imported both server-side and client-side to ensure Contentful is able to map on both rendering modes.
  */
+import {defineComponents} from '@contentful/experiences-sdk-react';
+
 import Button, {ButtonContentfulComponentDefinition} from '@/components/button';
 import VideoCarousel, {
   VideoCarouselContentfulComponentDefinition,
@@ -29,8 +31,6 @@ import Section, {
   SectionContentfulComponentDefinition,
 } from '@/components/section';
 import Video, {VideoContentfulComponentDefinition} from '@/components/video';
-
-import {defineComponents} from '@contentful/experiences-sdk-react';
 
 defineComponents(
   [

--- a/frontend/apps/marketing/src/providers/statsig/StatsigProvider.tsx
+++ b/frontend/apps/marketing/src/providers/statsig/StatsigProvider.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import {ReactNode} from 'react';
 import {StatsigProvider as BaseStatsigProvider} from '@statsig/react-bindings';
-import {getClient} from '@/providers/statsig/client';
+import {ReactNode} from 'react';
+
 import {Stage} from '@/config/stage';
+import {getClient} from '@/providers/statsig/client';
 
 interface StatsigProviderProps {
   stage: Stage;

--- a/frontend/apps/marketing/src/providers/statsig/__tests__/StatsigProvider.test.tsx
+++ b/frontend/apps/marketing/src/providers/statsig/__tests__/StatsigProvider.test.tsx
@@ -1,4 +1,5 @@
 import {render} from '@testing-library/react';
+
 import StatsigProvider from '@/providers/statsig/StatsigProvider';
 
 describe('StatsigProvider', () => {

--- a/frontend/apps/marketing/src/providers/statsig/__tests__/initialized-statsig-backend.test.ts
+++ b/frontend/apps/marketing/src/providers/statsig/__tests__/initialized-statsig-backend.test.ts
@@ -1,5 +1,6 @@
-import {generateBootstrapValues} from '../statsig-backend';
 import statsig from '@/providers/statsig/statsig';
+
+import {generateBootstrapValues} from '../statsig-backend';
 
 jest.mock('@/providers/statsig/statsig', () => ({
   __esModule: true,

--- a/frontend/apps/marketing/src/providers/statsig/client.ts
+++ b/frontend/apps/marketing/src/providers/statsig/client.ts
@@ -1,6 +1,7 @@
 import {useClientBootstrapInit} from '@statsig/react-bindings';
-import plugins from '@/providers/statsig/plugins';
+
 import {Stage} from '@/config/stage';
+import plugins from '@/providers/statsig/plugins';
 
 export function getClient(clientKey: string, stage: Stage, values: string) {
   return useClientBootstrapInit(clientKey, {userID: 'marketing-user'}, values, {

--- a/frontend/apps/marketing/src/providers/statsig/statsig-backend.ts
+++ b/frontend/apps/marketing/src/providers/statsig/statsig-backend.ts
@@ -1,4 +1,5 @@
 import {StatsigUser} from '@statsig/statsig-node-core';
+
 import statsig from '@/providers/statsig/statsig';
 
 const statsigInitializer = statsig ? statsig.initialize() : undefined;

--- a/frontend/apps/marketing/src/providers/statsig/statsig.ts
+++ b/frontend/apps/marketing/src/providers/statsig/statsig.ts
@@ -1,4 +1,5 @@
 import {Statsig} from '@statsig/statsig-node-core';
+
 import {getStage} from '@/config/stage';
 
 export default process.env.STATSIG_SERVER_KEY

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -1,8 +1,9 @@
-import {expect, Locator} from '@playwright/test';
-import {test} from './fixtures/base';
-import {EXPECTED_LOCALIZATION_STRINGS} from './config/i18n';
-import {AllTheThingsPage} from './pom/all-the-things';
 import AxeBuilder from '@axe-core/playwright';
+import {expect, Locator} from '@playwright/test';
+
+import {EXPECTED_LOCALIZATION_STRINGS} from './config/i18n';
+import {test} from './fixtures/base';
+import {AllTheThingsPage} from './pom/all-the-things';
 
 test.describe('All the things UI e2e test', () => {
   test.describe('a11y', () => {

--- a/frontend/apps/marketing/tests/e2e/fixtures/base.ts
+++ b/frontend/apps/marketing/tests/e2e/fixtures/base.ts
@@ -1,5 +1,5 @@
-import {mergeTests} from '@playwright/test';
 import {test as eyesTest} from '@applitools/eyes-playwright/fixture';
+import {mergeTests} from '@playwright/test';
 
 export const test = mergeTests(eyesTest);
 

--- a/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
@@ -1,4 +1,5 @@
 import {type Locator, type Page} from '@playwright/test';
+
 import {MarketingPage} from './marketing';
 
 type Section =

--- a/frontend/apps/marketing/tests/e2e/pom/marketing.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/marketing.ts
@@ -1,4 +1,5 @@
 import {type Page} from '@playwright/test';
+
 import {loadFonts, FONT_FAMILY_NAMES} from '@code-dot-org/fonts';
 
 export class MarketingPage {

--- a/frontend/apps/marketing/tests/e2e/robots.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/robots.spec.ts
@@ -1,7 +1,9 @@
-import {MarketingPage} from './pom/marketing';
-import {test} from './fixtures/base';
 import {expect} from '@playwright/test';
+
 import {getStage} from '@/config/stage';
+
+import {test} from './fixtures/base';
+import {MarketingPage} from './pom/marketing';
 
 test.describe('robots.txt', () => {
   test('should disallow everything in preprod', async ({page, browserName}) => {

--- a/frontend/packages/component-library/.release-it.ts
+++ b/frontend/packages/component-library/.release-it.ts
@@ -1,4 +1,5 @@
 import {createConfig} from '@code-dot-org/changelogs';
+
 import packageJson from './package.json';
 
 const config = createConfig(packageJson.name);

--- a/frontend/packages/component-library/eslint.config.mjs
+++ b/frontend/packages/component-library/eslint.config.mjs
@@ -1,6 +1,7 @@
-import cdoReactConfig from '@code-dot-org/lint-config/eslint/react.mjs';
-import cdoJestConfig from '@code-dot-org/lint-config/eslint/jest.mjs';
 import storybook from 'eslint-plugin-storybook';
+
+import cdoJestConfig from '@code-dot-org/lint-config/eslint/jest.mjs';
+import cdoReactConfig from '@code-dot-org/lint-config/eslint/react.mjs';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -11,10 +12,11 @@ export default [
   ...cdoReactConfig,
   ...cdoJestConfig,
   {
-    // Allow `clean-package` to use require as it does not work in ESM today.
-    files: ['clean-package.config.cjs'],
     rules: {
-      '@typescript-eslint/no-require-imports': 'off',
+      'import-x/no-unresolved': [
+        'error',
+        {ignore: ['\\./index.css', '^\\@public/']},
+      ],
     },
   },
 ];

--- a/frontend/packages/component-library/src/accordion/Accordion.tsx
+++ b/frontend/packages/component-library/src/accordion/Accordion.tsx
@@ -1,5 +1,5 @@
-import {HTMLAttributes, ReactNode} from 'react';
 import classNames from 'classnames';
+import {HTMLAttributes, ReactNode} from 'react';
 
 import FontAwesomeV6Icon from '@/fontAwesomeV6Icon';
 import {BodyTwoText, StrongText} from '@/typography';

--- a/frontend/packages/component-library/src/accordion/__tests__/Accordion.test.tsx
+++ b/frontend/packages/component-library/src/accordion/__tests__/Accordion.test.tsx
@@ -1,4 +1,5 @@
 import {render, screen, fireEvent} from '@testing-library/react';
+
 import Accordion, {AccordionProps} from './../Accordion';
 
 const mockAccordionItems: AccordionProps['items'] = [

--- a/frontend/packages/component-library/src/accordion/faqAccordion/__tests__/FAQAccordion.test.tsx
+++ b/frontend/packages/component-library/src/accordion/faqAccordion/__tests__/FAQAccordion.test.tsx
@@ -1,4 +1,5 @@
 import {render, screen} from '@testing-library/react';
+
 import FAQAccordion, {FAQAccordionProps} from '../FAQAccordion';
 
 const mockFAQItems: FAQAccordionProps['items'] = [

--- a/frontend/packages/component-library/src/button/_BaseButton.tsx
+++ b/frontend/packages/component-library/src/button/_BaseButton.tsx
@@ -5,6 +5,7 @@ import {ComponentSizeXSToL} from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
 import {ButtonType, ButtonColor} from './types';
+
 import moduleStyles from './_baseButton.module.scss';
 
 export interface TextButtonSpecificProps {

--- a/frontend/packages/component-library/src/button/stories/LinkButton.story.tsx
+++ b/frontend/packages/component-library/src/button/stories/LinkButton.story.tsx
@@ -1,8 +1,7 @@
 import {Meta, StoryFn} from '@storybook/react';
 
-import LinkButton, {LinkButtonProps} from '../LinkButton';
-
 import {buttonColors} from '../index';
+import LinkButton, {LinkButtonProps} from '../LinkButton';
 
 export default {
   title: 'DesignSystem/Button/LinkButton',

--- a/frontend/packages/component-library/src/button/stories/_BaseButton.story.tsx
+++ b/frontend/packages/component-library/src/button/stories/_BaseButton.story.tsx
@@ -1,7 +1,7 @@
 import {Meta, StoryFn} from '@storybook/react';
 
-import {buttonColors} from '../index';
 import _BaseButton, {_BaseButtonProps} from '../_BaseButton';
+import {buttonColors} from '../index';
 
 export default {
   title: 'DesignSystem/Button/_BaseButton',

--- a/frontend/packages/component-library/src/carousel/Carousel.tsx
+++ b/frontend/packages/component-library/src/carousel/Carousel.tsx
@@ -1,18 +1,18 @@
 import classNames from 'classnames';
 import {HTMLAttributes, ReactNode, useId} from 'react';
-
 // Import Swiper React components
 // See Swiper documentation here: https://swiperjs.com/react
-import {Swiper, SwiperSlide} from 'swiper/react';
 import {Navigation, Pagination, A11y} from 'swiper/modules';
+import {Swiper, SwiperSlide} from 'swiper/react';
 
 // Import Swiper styles
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 
-import moduleStyles from './carousel.module.scss';
 import FontAwesomeV6Icon from '@/fontAwesomeV6Icon/FontAwesomeV6Icon';
+
+import moduleStyles from './carousel.module.scss';
 
 export interface CarouselProps extends HTMLAttributes<HTMLElement> {
   /** Unique identifier for the carousel instance */

--- a/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
+++ b/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
@@ -1,10 +1,10 @@
 import type {Meta, StoryFn} from '@storybook/react';
 import {within, expect, userEvent} from '@storybook/test';
 
-import Carousel, {CarouselProps} from '../index';
-
 import {Heading2} from '@/typography';
+
 import Video from '../../video/Video';
+import Carousel, {CarouselProps} from '../index';
 
 export default {
   title: 'DesignSystem/Carousel',

--- a/frontend/packages/component-library/src/cms/image/__tests__/Image.test.tsx
+++ b/frontend/packages/component-library/src/cms/image/__tests__/Image.test.tsx
@@ -1,4 +1,5 @@
 import {render, screen} from '@testing-library/react';
+
 import {Image} from '../';
 
 describe('Image Component', () => {

--- a/frontend/packages/component-library/src/cms/image/stories/Image.story.tsx
+++ b/frontend/packages/component-library/src/cms/image/stories/Image.story.tsx
@@ -1,8 +1,7 @@
-import {useState} from 'react';
+import imageFile from '@public/images/image-component.png';
 import type {Meta, StoryObj} from '@storybook/react';
 import {within, expect} from '@storybook/test';
-
-import imageFile from '@public/images/image-component.png';
+import {useState} from 'react';
 
 import Image, {ImageProps} from '../index';
 

--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import {HTMLAttributes, ReactNode} from 'react';
 
 import {SpacingNoneToS, SpacingNoneToL} from '@/common/types';
+
 import moduleStyles from './section.module.scss';
 
 export type SectionBackground =

--- a/frontend/packages/component-library/src/cms/section/__tests__/Section.test.tsx
+++ b/frontend/packages/component-library/src/cms/section/__tests__/Section.test.tsx
@@ -1,4 +1,5 @@
 import {render, screen} from '@testing-library/react';
+
 import Section, {SectionProps, sectionBackground} from '../Section';
 
 describe('Section Component', () => {

--- a/frontend/packages/component-library/src/cms/section/stories/Section.story.tsx
+++ b/frontend/packages/component-library/src/cms/section/stories/Section.story.tsx
@@ -1,10 +1,10 @@
+import bgPattern from '@public/images/bg-pattern.png';
 import type {Meta, StoryObj, StoryFn} from '@storybook/react';
 import {within, expect} from '@storybook/test';
 
-import bgPattern from '@public/images/bg-pattern.png';
+import {BodyOneText, Heading2} from '@/typography';
 
 import Section, {SectionProps, sectionBackground} from '../index';
-import {BodyOneText, Heading2} from '@/typography';
 
 export default {
   title: 'CMS/Section',

--- a/frontend/packages/component-library/src/common/constants/index.ts
+++ b/frontend/packages/component-library/src/common/constants/index.ts
@@ -2,9 +2,8 @@
  * This file contains constants that are used across the component library
  */
 
-import {VisualAppearance} from '@/typography';
-
 import {ComponentSizeXSToL, DropdownColor} from '@/common/types';
+import {VisualAppearance} from '@/typography';
 
 /**
  *  This is the map of component size to body text size (visualAppearance)

--- a/frontend/packages/component-library/src/dialog/Dialog.tsx
+++ b/frontend/packages/component-library/src/dialog/Dialog.tsx
@@ -6,6 +6,7 @@ import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 import {BodyTwoText, Heading2} from '@/typography';
 
 import CustomDialog from './CustomDialog';
+
 import moduleStyles from './dialog.module.scss';
 
 export interface DialogProps extends HTMLAttributes<HTMLDivElement> {

--- a/frontend/packages/component-library/src/divider/Divider.tsx
+++ b/frontend/packages/component-library/src/divider/Divider.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import {HTMLAttributes} from 'react';
 
 import {SpacingNoneToL} from './../common/types';
+
 import moduleStyles from './divider.module.scss';
 
 export interface DividerProps extends HTMLAttributes<HTMLElement> {

--- a/frontend/packages/component-library/src/divider/__tests__/Divider.test.tsx
+++ b/frontend/packages/component-library/src/divider/__tests__/Divider.test.tsx
@@ -1,4 +1,5 @@
 import {render, screen} from '@testing-library/react';
+
 import {Divider} from '../';
 
 describe('Divider Component', () => {

--- a/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
@@ -10,6 +10,7 @@ import {ComponentSizeXSToL} from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
 import CustomDropdown, {_CustomDropdownOption} from './../_CustomDropdown';
+
 import moduleStyles from './../customDropdown.module.scss';
 
 export interface ActionDropdownOption extends _CustomDropdownOption {

--- a/frontend/packages/component-library/src/dropdown/checkboxDropdown/CheckboxDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/checkboxDropdown/CheckboxDropdown.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/common/types';
 
 import CustomDropdown, {_CustomDropdownOption} from './../_CustomDropdown';
+
 import moduleStyles from './../customDropdown.module.scss';
 
 export type CheckboxDropdownOption = _CustomDropdownOption;

--- a/frontend/packages/component-library/src/dropdown/checkboxDropdown/stories/CheckboxDropdown.story.tsx
+++ b/frontend/packages/component-library/src/dropdown/checkboxDropdown/stories/CheckboxDropdown.story.tsx
@@ -1,9 +1,9 @@
 import {Meta, StoryFn} from '@storybook/react';
 import React, {useState, useCallback} from 'react';
 
-import {dropdownColors} from './../../index';
-
 import CheckboxDropdown, {CheckboxDropdownProps} from '../index';
+
+import {dropdownColors} from './../../index';
 
 export default {
   title: 'DesignSystem/Dropdown/Checkbox Dropdown',

--- a/frontend/packages/component-library/src/dropdown/iconDropdown/IconDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/iconDropdown/IconDropdown.tsx
@@ -14,6 +14,7 @@ import {
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
 import CustomDropdown, {_CustomDropdownOption} from './../_CustomDropdown';
+
 import moduleStyles from './../customDropdown.module.scss';
 
 export interface IconDropdownOption extends _CustomDropdownOption {

--- a/frontend/packages/component-library/src/dropdown/iconDropdown/stories/IconDropdown.story.tsx
+++ b/frontend/packages/component-library/src/dropdown/iconDropdown/stories/IconDropdown.story.tsx
@@ -1,9 +1,9 @@
 import {Meta, StoryFn} from '@storybook/react';
 import {useState, useCallback} from 'react';
 
-import {dropdownColors} from './../../index';
-
 import IconDropdown, {IconDropdownProps, IconDropdownOption} from '../index';
+
+import {dropdownColors} from './../../index';
 
 export default {
   title: 'DesignSystem/Dropdown/Icon Dropdown',

--- a/frontend/packages/component-library/src/popover/__tests__/WithPopover.test.tsx
+++ b/frontend/packages/component-library/src/popover/__tests__/WithPopover.test.tsx
@@ -2,6 +2,7 @@ import {render, screen, fireEvent} from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import * as helpers from '@/common/helpers';
+
 import {WithPopover, PopoverProps} from './../index';
 
 jest.mock('./../../common/helpers', () => ({

--- a/frontend/packages/component-library/src/tabs/Tabs.tsx
+++ b/frontend/packages/component-library/src/tabs/Tabs.tsx
@@ -5,6 +5,7 @@ import {ComponentSizeXSToL} from '@/common/types';
 
 import _Tab, {TabModel} from './_Tab';
 import _TabPanel from './_TabPanel';
+
 import moduleStyles from './tabs.module.scss';
 
 export interface TabsProps {

--- a/frontend/packages/component-library/src/tabs/stories/Tabs.story.tsx
+++ b/frontend/packages/component-library/src/tabs/stories/Tabs.story.tsx
@@ -2,7 +2,6 @@ import {Meta, StoryFn} from '@storybook/react';
 import {useState} from 'react';
 
 import {TabModel} from '../_Tab';
-
 import Tabs, {TabsProps} from '../index';
 
 export default {

--- a/frontend/packages/component-library/src/tags/_Tag.tsx
+++ b/frontend/packages/component-library/src/tags/_Tag.tsx
@@ -1,8 +1,8 @@
 import React, {HTMLAttributes, memo, useCallback} from 'react';
 
+import CloseButton from '@/closeButton/CloseButton';
 import FontAwesomeV6Icon from '@/fontAwesomeV6Icon';
 import {WithTooltip} from '@/tooltip';
-import CloseButton from '@/closeButton/CloseButton';
 
 import moduleStyles from './tags.module.scss';
 

--- a/frontend/packages/component-library/src/tags/stories/Tags.story.tsx
+++ b/frontend/packages/component-library/src/tags/stories/Tags.story.tsx
@@ -1,7 +1,7 @@
 import {Meta, StoryFn} from '@storybook/react';
+import {useState} from 'react';
 
 import Tags, {TagProps, TagsProps} from '../index';
-import {useState} from 'react';
 
 export default {
   title: 'DesignSystem/Tags',

--- a/frontend/packages/component-library/src/toggle/stories/Toggle.story.tsx
+++ b/frontend/packages/component-library/src/toggle/stories/Toggle.story.tsx
@@ -1,5 +1,4 @@
 import {Meta, StoryFn} from '@storybook/react';
-
 import {useState} from 'react';
 
 import Toggle, {ToggleProps} from '../index';

--- a/frontend/packages/component-library/src/typography/stories/Typography.story.tsx
+++ b/frontend/packages/component-library/src/typography/stories/Typography.story.tsx
@@ -1,4 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
+
 import Typography, {
   StrongText,
   ExtraStrongText,

--- a/frontend/packages/component-library/src/video/Video.tsx
+++ b/frontend/packages/component-library/src/video/Video.tsx
@@ -1,12 +1,12 @@
-import {useState, useEffect, HTMLAttributes} from 'react';
 import classNames from 'classnames';
+import {useState, useEffect, HTMLAttributes} from 'react';
 
-import moduleStyles from './video.module.scss';
 import {LinkButton} from '@/button';
+import {checkIfYouTubeIsBlocked} from '@/common/helpers';
 import FontAwesomeV6Icon from '@/fontAwesomeV6Icon';
 import {BodyTwoText, BodyThreeText, Figcaption, StrongText} from '@/typography';
 
-import {checkIfYouTubeIsBlocked} from '@/common/helpers';
+import moduleStyles from './video.module.scss';
 
 export interface VideoProps extends HTMLAttributes<HTMLElement> {
   /** Video title */

--- a/frontend/packages/component-library/tsup.config.ts
+++ b/frontend/packages/component-library/tsup.config.ts
@@ -1,8 +1,8 @@
-import {defineConfig} from 'tsup';
 import {postcssModules, sassPlugin} from 'esbuild-sass-plugin';
-import type {Options} from 'tsup';
 import {glob} from 'glob';
 import {spawnSync} from 'node:child_process';
+import type {Options} from 'tsup';
+import {defineConfig} from 'tsup';
 
 const entryPoints = glob.sync('./src/**/index.ts', {
   posix: true,

--- a/frontend/packages/fonts/eslint.config.mjs
+++ b/frontend/packages/fonts/eslint.config.mjs
@@ -1,5 +1,5 @@
-import cdoReactConfig from '@code-dot-org/lint-config/eslint/react.mjs';
 import cdoJestConfig from '@code-dot-org/lint-config/eslint/jest.mjs';
+import cdoReactConfig from '@code-dot-org/lint-config/eslint/react.mjs';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [

--- a/frontend/packages/fonts/src/loader/index.ts
+++ b/frontend/packages/fonts/src/loader/index.ts
@@ -1,5 +1,5 @@
-import {getFontByLocale} from '@/resolver';
 import {InternationalFontLocale} from '@/constants';
+import {getFontByLocale} from '@/resolver';
 
 /**
  * Injects an empty div with the CSS module className that references the web font appropriate for the given locale.

--- a/frontend/packages/fonts/src/react/FontLoader/index.tsx
+++ b/frontend/packages/fonts/src/react/FontLoader/index.tsx
@@ -1,6 +1,7 @@
 'use client';
-import type {InternationalFontLocale} from '@/constants';
 import {useEffect, useState} from 'react';
+
+import type {InternationalFontLocale} from '@/constants';
 import {getFontByLocale} from '@/resolver/getFontByLocale';
 
 interface FontLoaderProps {

--- a/frontend/packages/fonts/tsup.config.ts
+++ b/frontend/packages/fonts/tsup.config.ts
@@ -1,8 +1,9 @@
-import {defineConfig} from 'tsup';
 import {sassPlugin} from 'esbuild-sass-plugin';
-import type {Options} from 'tsup';
 import {glob} from 'glob';
 import {resolve} from 'node:path';
+import type {Options} from 'tsup';
+import {defineConfig} from 'tsup';
+
 import {LOCALES_WITH_INTERNATIONAL_FONTS} from '@/constants';
 
 /**

--- a/frontend/packages/lint-config/eslint/base.mjs
+++ b/frontend/packages/lint-config/eslint/base.mjs
@@ -1,6 +1,6 @@
+import js from '@eslint/js';
 import importPlugin from 'eslint-plugin-import-x';
 import {configs as tseslintConfig} from 'typescript-eslint';
-import js from '@eslint/js';
 
 export default [
   js.configs.recommended,
@@ -10,7 +10,43 @@ export default [
   {
     rules: {
       'import-x/no-cycle': 'error',
-      'import-x/no-unresolved': 'off', // https://codedotorg.atlassian.net/browse/ACQ-2875
+      'import-x/no-duplicates': 'error',
+      'import-x/order': [
+        'error',
+        {
+          'newlines-between': 'always',
+          groups: [
+            ['builtin', 'external'],
+            'internal',
+            'parent',
+            'sibling',
+            'index',
+          ],
+          pathGroups: [
+            {
+              pattern: '*.scss',
+              group: 'index',
+              position: 'after',
+              patternOptions: {matchBase: true},
+            },
+            {
+              pattern: '@code-dot-org/**',
+              group: 'internal',
+              position: 'before',
+            },
+            {
+              pattern: '@cdo/**',
+              group: 'internal',
+              position: 'before',
+            },
+          ],
+          alphabetize: {
+            order: 'asc',
+            caseInsensitive: true,
+          },
+          pathGroupsExcludedImportTypes: ['builtin', 'object'],
+        },
+      ],
     },
   },
 ];

--- a/frontend/packages/lint-config/eslint/node.mjs
+++ b/frontend/packages/lint-config/eslint/node.mjs
@@ -1,4 +1,5 @@
 import globals from 'globals';
+
 import cdoBase from './base.mjs';
 
 /** @type {import('eslint').Linter.Config[]} */

--- a/frontend/packages/lint-config/eslint/react.mjs
+++ b/frontend/packages/lint-config/eslint/react.mjs
@@ -1,7 +1,8 @@
-import globals from 'globals';
-import cdoBase from './base.mjs';
-import pluginReact from 'eslint-plugin-react';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
+import pluginReact from 'eslint-plugin-react';
+import globals from 'globals';
+
+import cdoBase from './base.mjs';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [


### PR DESCRIPTION
This PR ports the `apps` import order rule to `frontend`.