### PR TITLE
Fix School Info Confirmation dialog when user confirms they work at the same school

### DIFF
--- a/apps/src/schoolInfo/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/schoolInfo/SchoolInfoConfirmationDialog.jsx
@@ -6,6 +6,7 @@ import Button from '@cdo/apps/legacySharedComponents/Button';
 import Dialog, {Body} from '@cdo/apps/legacySharedComponents/Dialog';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
@@ -86,7 +87,7 @@ class SchoolInfoConfirmationDialog extends Component {
     this.props.onClose();
   };
 
-  handleClickYes = () => {
+  handleClickYes = async () => {
     analyticsReporter.sendEvent(
       EVENTS.CONFIRM_SCHOOL_CLICKED,
       {},
@@ -100,6 +101,9 @@ class SchoolInfoConfirmationDialog extends Component {
       {
         method: 'PATCH',
         body: formData,
+        headers: {
+          'X-CSRF-Token': await getAuthenticityToken(),
+        },
       }
     )
       .then(this.closeModal)

--- a/apps/src/schoolInfo/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/schoolInfo/SchoolInfoConfirmationDialog.jsx
@@ -50,9 +50,7 @@ class SchoolInfoConfirmationDialog extends Component {
   static propTypes = {
     schoolName: PropTypes.string,
     scriptData: PropTypes.shape({
-      formUrl: PropTypes.string.isRequired,
-      authTokenName: PropTypes.string.isRequired,
-      authTokenValue: PropTypes.string.isRequired,
+      usIp: PropTypes.bool.isRequired,
       existingSchoolInfo: PropTypes.shape({
         id: PropTypes.number,
         user_school_info_id: PropTypes.number,
@@ -93,9 +91,7 @@ class SchoolInfoConfirmationDialog extends Component {
       {},
       PLATFORMS.BOTH
     );
-    const {authTokenName, authTokenValue} = this.props.scriptData;
     const formData = new FormData();
-    formData.append(authTokenName, authTokenValue);
     fetch(
       `/api/v1/user_school_infos/${this.props.scriptData.existingSchoolInfo.user_school_info_id}/update_last_confirmation_date`,
       {

--- a/apps/src/schoolInfo/SchoolInfoConfirmationDialog.story.jsx
+++ b/apps/src/schoolInfo/SchoolInfoConfirmationDialog.story.jsx
@@ -20,9 +20,7 @@ const Template = args => <SchoolInfoConfirmationDialog {...args} />;
 export const DisplaySchoolInfoConfirmationDialog = Template.bind({});
 DisplaySchoolInfoConfirmationDialog.args = {
   scriptData: {
-    formUrl: '',
-    authTokenName: 'auth_token',
-    authTokenValue: 'fake_auth_token',
+    usIp: false,
     existingSchoolInfo: {},
   },
   onClose: action('onClose callback'),

--- a/apps/src/schoolInfo/SchoolInfoInterstitial.story.jsx
+++ b/apps/src/schoolInfo/SchoolInfoInterstitial.story.jsx
@@ -20,9 +20,6 @@ const Template = args => <SchoolInfoInterstitial {...args} />;
 export const Overview = Template.bind({});
 Overview.args = {
   scriptData: {
-    formUrl: '',
-    authTokenName: 'auth_token',
-    authTokenValue: 'fake_auth_token',
     usIp: false,
     existingSchoolInfo: {
       country: '',

--- a/apps/test/unit/schoolInfo/SchoolInfoConfirmationDialogTest.js
+++ b/apps/test/unit/schoolInfo/SchoolInfoConfirmationDialogTest.js
@@ -8,12 +8,14 @@ import SchoolInfoInterstitial from '@cdo/apps/schoolInfo/SchoolInfoInterstitial'
 
 import {expect} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
+jest.mock('@cdo/apps/util/AuthenticityTokenStore', () => ({
+  getAuthenticityToken: jest.fn().mockResolvedValue('authToken'),
+}));
+
 describe('SchoolInfoConfirmationDialog', () => {
   const MINIMUM_PROPS = {
     scriptData: {
-      formUrl: '',
-      authTokenName: 'auth_token',
-      authTokenValue: 'fake_auth_token',
+      usIp: true,
       existingSchoolInfo: {},
     },
     onClose: function () {},
@@ -89,9 +91,8 @@ describe('SchoolInfoConfirmationDialog', () => {
       const onClose = sinon.spy();
       const wrapper = mount(
         <SchoolInfoConfirmationDialog
-          {...MINIMUM_PROPS}
           scriptData={{
-            ...MINIMUM_PROPS.scriptData,
+            usIp: true,
             existingSchoolInfo: {
               country: 'US',
             },

--- a/apps/test/unit/schoolInfo/SchoolInfoConfirmationDialogTest.js
+++ b/apps/test/unit/schoolInfo/SchoolInfoConfirmationDialogTest.js
@@ -122,7 +122,7 @@ describe('SchoolInfoConfirmationDialog', () => {
 
         expect(wrapperInstance.handleClickYes).to.have.been.called;
         await setTimeout(() => {}, 50);
-        expect(onClose).to.have.been.called;
+        expect(await onClose).to.have.been.called;
         await setTimeout(() => {}, 50);
         expect(wrapper.state('showSchoolInterstitial')).to.be.false;
         handleClickYesSpy.restore();

--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -42,13 +42,14 @@ Scenario: School Info Confirmation Dialog
   Then I reload the page
   And element ".modal" is not visible
 
-  # One year later, the teacher sees the school info confirmation dialog
+  # One year later, the teacher sees the school info confirmation dialog and confirms at the same school
   And one year passes for user "Teacher_Chuba"
   Then I reload the page
   And element ".modal-body" is visible
-  Then I press "#update-button" using jQuery
-  And element ".modal" is visible
-  Then element "#uitest-country-dropdown" has value "US"
-  Then element "#uitest-school-zip" has value "31513"
-  # value is school_id for "Appling County High School"
-  Then I wait until element "#uitest-school-dropdown" has the value "130006000010"
+  Then I press "#yes-button" using jQuery
+  And element ".modal" is not visible
+
+  # One week later, the teacher does not see the prompt
+  And eight days pass for user "Teacher_Chuba"
+  Then I reload the page
+  And element ".modal" is not visible


### PR DESCRIPTION
In [this Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/531566), a user kept seeing the dialog confirming they still worked at the same school each week (even though they were presumably confirming it). [Ryan tracked it down](https://codedotorg.slack.com/archives/C0453TUMLE7/p1741888205843269) to an issue where the call to confirm the user was at the same school was missing an authentication token. This PR adds in the authentication token, cleans up parameters passed in (removing some that aren't used and adding in a missing one (`usIp`), and adding UI test coverage so that this issue isn't missed in testing.

### Old behavior
User has a `UserSchoolInfo` entry connecting them to their school (but it's `last_confirmation_date` is over a year ago):
![old confirmation no fix](https://github.com/user-attachments/assets/700360d0-4da8-4258-8d93-10bc23ff5fc8)

Then user logs in and sees the dialog asking them to confirm their school:
![dialog](https://github.com/user-attachments/assets/15d973f6-2079-4ade-bedf-6fb7673bb68a)

They click 'Yes' but their `last_confirmation_date` is not updated (meaning they'll see it again in a week):
![after confirmation no fix](https://github.com/user-attachments/assets/a0ef9590-3392-4ecb-98f4-1cb31d6cb90a)

And a network error occurs:
![error when Yes is clicked](https://github.com/user-attachments/assets/672e27e6-8d58-4e11-8f33-779f6a92b617)

### New behavior
User has a `UserSchoolInfo` entry connecting them to their school (but it's `last_confirmation_date` is over a year ago):
![old confirmation no fix](https://github.com/user-attachments/assets/700360d0-4da8-4258-8d93-10bc23ff5fc8)

Then user logs in and sees the dialog asking them to confirm their school:
![dialog](https://github.com/user-attachments/assets/15d973f6-2079-4ade-bedf-6fb7673bb68a)

They click 'Yes' and their `last_confirmation_date` is updated without an error:
![year updated success](https://github.com/user-attachments/assets/68dbe025-0c3d-4b27-b54e-5bd2597db9ee)
![success no error](https://github.com/user-attachments/assets/a492cb91-993c-416c-b3f5-70430b2305cd)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3160)
Zendesk ticket this was noted in: [here](https://codeorg.zendesk.com/agent/tickets/531566)
Slack discussion: [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1741888205843269)

## Testing story
Local testing.
