### PR TITLE
feat(Section): add Light and Dark theme support

### DIFF
--- a/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
+++ b/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
@@ -23,7 +23,7 @@ const VideoCarousel: React.FC<VideoCarouselProps> = ({slides}) => {
   // Workaround for the experience builder not working with Array
   if (slides == null) {
     return (
-      <div>
+      <div style={{color: 'var(--text-neutral-primary)'}}>
         <em>
           <strong>✍ Video carousel placeholder.</strong> Please add a
           "Carousel" content type entry in the Content sidebar, save, and open

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
@@ -64,7 +64,7 @@ const FAQAccordionContentful: React.FunctionComponent<
   // Workaround for the experience builder not working with Array
   if (!faqItems.length) {
     return (
-      <div>
+      <div style={{color: 'var(--text-neutral-primary)'}}>
         <em>
           <strong>✍ FAQ Accordion placeholder.</strong> Please add a "FAQs"
           content type entry in the FAQ Accordion sidebar, save, and open the

--- a/frontend/apps/marketing/src/components/section/Section.tsx
+++ b/frontend/apps/marketing/src/components/section/Section.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import DSCOSection, {
   SectionProps,
 } from '@code-dot-org/component-library/cms/section';

--- a/frontend/apps/marketing/src/components/section/Section.tsx
+++ b/frontend/apps/marketing/src/components/section/Section.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import DSCOSection, {
   SectionProps,
 } from '@code-dot-org/component-library/cms/section';

--- a/frontend/packages/component-library-styles/typography.module.scss
+++ b/frontend/packages/component-library-styles/typography.module.scss
@@ -193,6 +193,7 @@ html {
 // Caption styles
 @mixin figcaption {
   @include main-font-semi-bold;
+  color: var(--text-neutral-primary);
   font-size: 0.875rem;
   line-height: 1.54;
   margin: 0.5em 0 1em;

--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -51,6 +51,7 @@ export interface SectionProps extends HTMLAttributes<HTMLElement> {
  *
  * Design System: Section Component.
  * Acts as a container for section content in the Contentful CMS.
+ * Supports Light and Dark themes automatically based on background color.
  */
 const Section: React.FC<SectionProps> = ({
   background = 'primary',

--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import {HTMLAttributes, ReactNode} from 'react';
 
 import {SpacingNoneToS, SpacingNoneToL} from '@/common/types';
+import {ThemeProvider} from '@/common/contexts/ThemeContext';
 import moduleStyles from './section.module.scss';
 
 export type SectionBackground =
@@ -32,6 +33,8 @@ export interface SectionProps extends HTMLAttributes<HTMLElement> {
   backgroundImageUrl?: string;
   /** Vertical padding */
   padding?: Exclude<SpacingNoneToL, SpacingNoneToS>;
+  /** Section theme */
+  theme?: 'Light' | 'Dark';
   /** Section content */
   children?: ReactNode;
 }
@@ -53,29 +56,44 @@ const Section: React.FC<SectionProps> = ({
   background = 'primary',
   backgroundImageUrl,
   padding = 'l',
+  theme = 'Light',
   children,
   className,
   ...HTMLAttributes
 }: SectionProps) => {
+  const hasPatternBackground =
+    background === sectionBackground.patternDark ||
+    background === sectionBackground.patternPrimary;
+
+  const useDarkTheme =
+    hasPatternBackground || background === sectionBackground.dark;
+
   return (
-    <section
-      className={classNames(
-        moduleStyles.section,
-        moduleStyles[`section-background-${background}`],
-        moduleStyles[`section-padding-${padding}`],
-        className,
-      )}
-      {...HTMLAttributes}
-      style={{
-        ...(backgroundImageUrl && {
-          backgroundImage: `url(${backgroundImageUrl})`,
-          backgroundRepeat: 'repeat',
-          backgroundSize: '18rem',
-        }),
-      }}
-    >
-      <div className={classNames(moduleStyles.container)}>{children}</div>
-    </section>
+    <ThemeProvider>
+      <section
+        data-theme={hasPatternBackground || useDarkTheme ? 'Dark' : theme}
+        className={classNames(
+          moduleStyles.section,
+          moduleStyles[`section-background-${background}`],
+          moduleStyles[`section-padding-${padding}`],
+          className,
+        )}
+        {...HTMLAttributes}
+        style={{
+          ...(hasPatternBackground
+            ? backgroundImageUrl
+              ? {
+                  backgroundImage: `url(${backgroundImageUrl})`,
+                  backgroundRepeat: 'repeat',
+                  backgroundSize: '18rem',
+                }
+              : {}
+            : {}),
+        }}
+      >
+        <div className={classNames(moduleStyles.container)}>{children}</div>
+      </section>
+    </ThemeProvider>
   );
 };
 

--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import {HTMLAttributes, ReactNode} from 'react';
 
 import {SpacingNoneToS, SpacingNoneToL} from '@/common/types';
-import {ThemeProvider} from '@/common/contexts/ThemeContext';
 import moduleStyles from './section.module.scss';
 
 export type SectionBackground =
@@ -70,31 +69,29 @@ const Section: React.FC<SectionProps> = ({
     hasPatternBackground || background === sectionBackground.dark;
 
   return (
-    <ThemeProvider>
-      <section
-        data-theme={hasPatternBackground || useDarkTheme ? 'Dark' : theme}
-        className={classNames(
-          moduleStyles.section,
-          moduleStyles[`section-background-${background}`],
-          moduleStyles[`section-padding-${padding}`],
-          className,
-        )}
-        {...HTMLAttributes}
-        style={{
-          ...(hasPatternBackground
-            ? backgroundImageUrl
-              ? {
-                  backgroundImage: `url(${backgroundImageUrl})`,
-                  backgroundRepeat: 'repeat',
-                  backgroundSize: '18rem',
-                }
-              : {}
-            : {}),
-        }}
-      >
-        <div className={classNames(moduleStyles.container)}>{children}</div>
-      </section>
-    </ThemeProvider>
+    <section
+      data-theme={hasPatternBackground || useDarkTheme ? 'Dark' : theme}
+      className={classNames(
+        moduleStyles.section,
+        moduleStyles[`section-background-${background}`],
+        moduleStyles[`section-padding-${padding}`],
+        className,
+      )}
+      {...HTMLAttributes}
+      style={{
+        ...(hasPatternBackground
+          ? backgroundImageUrl
+            ? {
+                backgroundImage: `url(${backgroundImageUrl})`,
+                backgroundRepeat: 'repeat',
+                backgroundSize: '18rem',
+              }
+            : {}
+          : {}),
+      }}
+    >
+      <div className={classNames(moduleStyles.container)}>{children}</div>
+    </section>
   );
 };
 

--- a/frontend/packages/component-library/src/cms/section/stories/Section.story.tsx
+++ b/frontend/packages/component-library/src/cms/section/stories/Section.story.tsx
@@ -113,7 +113,7 @@ MultipleSections.args = {
       padding: 'l',
       children: (
         <>
-          <Heading2>This is section one</Heading2>
+          <Heading2>Primary section</Heading2>
           <BodyOneText>I'm just a sentence.</BodyOneText>
         </>
       ),
@@ -123,7 +123,17 @@ MultipleSections.args = {
       padding: 'l',
       children: (
         <>
-          <Heading2>This is section two</Heading2>
+          <Heading2>Secondary section</Heading2>
+          <BodyOneText>I'm just a sentence.</BodyOneText>
+        </>
+      ),
+    },
+    {
+      background: sectionBackground.dark,
+      padding: 'l',
+      children: (
+        <>
+          <Heading2>Dark section</Heading2>
           <BodyOneText>I'm just a sentence.</BodyOneText>
         </>
       ),
@@ -133,7 +143,17 @@ MultipleSections.args = {
       padding: 'l',
       children: (
         <>
-          <Heading2>This is section three</Heading2>
+          <Heading2>Brand Light Primary section</Heading2>
+          <BodyOneText>I'm just a sentence.</BodyOneText>
+        </>
+      ),
+    },
+    {
+      background: sectionBackground.brandLightSecondary,
+      padding: 'l',
+      children: (
+        <>
+          <Heading2>Brand Light Secondary section</Heading2>
           <BodyOneText>I'm just a sentence.</BodyOneText>
         </>
       ),
@@ -144,7 +164,18 @@ MultipleSections.args = {
       padding: 'l',
       children: (
         <>
-          <Heading2>This is section four</Heading2>
+          <Heading2>Pattern Dark section</Heading2>
+          <BodyOneText>I'm just a sentence.</BodyOneText>
+        </>
+      ),
+    },
+    {
+      background: sectionBackground.patternPrimary,
+      backgroundImageUrl: bgPattern,
+      padding: 'l',
+      children: (
+        <>
+          <Heading2>Pattern Primary section</Heading2>
           <BodyOneText>I'm just a sentence.</BodyOneText>
         </>
       ),
@@ -158,13 +189,30 @@ MultipleSections.play = async ({
 }) => {
   const canvas = within(canvasElement);
   const headings = [
-    'This is section one',
-    'This is section two',
-    'This is section three',
-    'This is section four',
+    'Primary section',
+    'Secondary section',
+    'Dark section',
+    'Brand Light Primary section',
+    'Brand Light Secondary section',
+    'Pattern Dark section',
+    'Pattern Primary section',
   ];
-  const sectionWithPattern = canvas
-    .getByText('This is section four')
+  const sectionPrimary = canvas.getByText('Primary section').closest('section');
+  const sectionSecondary = canvas
+    .getByText('Secondary section')
+    .closest('section');
+  const sectionDark = canvas.getByText('Dark section').closest('section');
+  const sectionBrandLightPrimary = canvas
+    .getByText('Brand Light Primary section')
+    .closest('section');
+  const sectionBrandLightSecondary = canvas
+    .getByText('Brand Light Secondary section')
+    .closest('section');
+  const sectionPatternDark = canvas
+    .getByText('Pattern Dark section')
+    .closest('section');
+  const sectionPatternPrimary = canvas
+    .getByText('Pattern Primary section')
     .closest('section');
 
   headings.forEach(async headingText => {
@@ -174,9 +222,39 @@ MultipleSections.play = async ({
     await expect(heading).toBeInTheDocument();
   });
 
-  // check if the fourth section has the background image set
-  if (sectionWithPattern) {
-    const backgroundImage = sectionWithPattern.style.backgroundImage;
-    await expect(backgroundImage).toContain('bg-pattern');
-  }
+  // check if the right sections have the Light data-theme
+  const sectionsWithLightTheme = [
+    sectionPrimary,
+    sectionSecondary,
+    sectionBrandLightPrimary,
+    sectionBrandLightSecondary,
+  ];
+  sectionsWithLightTheme.forEach(async section => {
+    if (section) {
+      const dataTheme = section.getAttribute('data-theme');
+      await expect(dataTheme).toBe('Light');
+    }
+  });
+
+  // check if the right sections have the Dark data-theme
+  const sectionsWithDarkTheme = [
+    sectionDark,
+    sectionPatternDark,
+    sectionPatternPrimary,
+  ];
+  sectionsWithDarkTheme.forEach(async section => {
+    if (section) {
+      const dataTheme = section.getAttribute('data-theme');
+      await expect(dataTheme).toBe('Dark');
+    }
+  });
+
+  // check if the right sections have the background image
+  const sectionsWithBgPattern = [sectionPatternDark, sectionPatternPrimary];
+  sectionsWithBgPattern.forEach(async section => {
+    if (section) {
+      const backgroundImage = section.style.backgroundImage;
+      await expect(backgroundImage).toContain('bg-pattern');
+    }
+  });
 };

--- a/frontend/packages/component-library/src/cms/section/stories/Section.story.tsx
+++ b/frontend/packages/component-library/src/cms/section/stories/Section.story.tsx
@@ -75,10 +75,8 @@ export const SectionWithBackgroundPattern: Story = {
     padding: 'l',
     children: (
       <>
-        <Heading2 style={{color: 'white'}}>
-          This is a section with a background pattern
-        </Heading2>
-        <BodyOneText style={{color: 'white'}}>I'm just a sentence.</BodyOneText>
+        <Heading2>This is a section with a background pattern</Heading2>
+        <BodyOneText>I'm just a sentence.</BodyOneText>
       </>
     ),
   },
@@ -146,10 +144,8 @@ MultipleSections.args = {
       padding: 'l',
       children: (
         <>
-          <Heading2 style={{color: 'white'}}>This is section four</Heading2>
-          <BodyOneText style={{color: 'white'}}>
-            I'm just a sentence.
-          </BodyOneText>
+          <Heading2>This is section four</Heading2>
+          <BodyOneText>I'm just a sentence.</BodyOneText>
         </>
       ),
     },

--- a/frontend/packages/component-library/src/common/contexts/ThemeContext.tsx
+++ b/frontend/packages/component-library/src/common/contexts/ThemeContext.tsx
@@ -63,7 +63,9 @@ export const ThemeProvider = ({children}: {children: ReactNode}) => {
    * */
   return (
     <ThemeContext.Provider value={{theme, toggleTheme, setTheme}}>
-      <div data-theme={theme}>{children}</div>
+      <div data-theme={theme} style={{width: '100%'}}>
+        {children}
+      </div>
     </ThemeContext.Provider>
   );
 };

--- a/frontend/packages/component-library/src/common/contexts/ThemeContext.tsx
+++ b/frontend/packages/component-library/src/common/contexts/ThemeContext.tsx
@@ -63,9 +63,7 @@ export const ThemeProvider = ({children}: {children: ReactNode}) => {
    * */
   return (
     <ThemeContext.Provider value={{theme, toggleTheme, setTheme}}>
-      <div data-theme={theme} style={{width: '100%'}}>
-        {children}
-      </div>
+      <div data-theme={theme}>{children}</div>
     </ThemeContext.Provider>
   );
 };


### PR DESCRIPTION
Adds support for Light and Dark themes to the Section component. I also made a few adjustments to existing components so elements will work with themes.

## Links
Jira ticket: [CMS-409](https://codedotorg.atlassian.net/browse/CMS-409)

## Testing story
Added tests in Storybook to check that the correct data-theme is being applied, and tested locally in Contentful.

----

## Storybook


https://github.com/user-attachments/assets/e4c270e2-c361-450a-98c2-6e03a4b178ad



https://github.com/user-attachments/assets/234347b8-4c53-410f-a788-158237fc1970




## Contentful


https://github.com/user-attachments/assets/771675a5-9bf1-4522-b15d-afae084eb3c6



https://github.com/user-attachments/assets/ab9f56cd-c2e8-4b3a-8921-0bf197fd4ef2

