### PR TITLE
RUBRICS - add back in feedback tab

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -681,10 +681,9 @@ class TopInstructions extends Component {
       (levelVideos && levelVideos.length > 0) || !!levelResourcesAvailable;
 
     const displayFeedbackTab =
-      !taRubric &&
-      (!!miniRubric ||
-        (teacherViewingStudentWork && teacherCanLeaveFeedback) ||
-        (this.isViewingAsStudent && !!latestFeedback));
+      !!miniRubric ||
+      (teacherViewingStudentWork && teacherCanLeaveFeedback) ||
+      (this.isViewingAsStudent && !!latestFeedback);
 
     const displayTaRubricTab =
       !!taRubric && !teacherViewingStudentWork && this.isViewingAsStudent;

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -245,7 +245,7 @@ describe('TopInstructions', () => {
         ).toBe(true);
       });
 
-      it('passes displayFeedback = false to TopInstructionsHeader on a level with a TA Rubric', () => {
+      it('passes displayFeedback = true to TopInstructionsHeader on a level with a TA Rubric', () => {
         const wrapper = shallow(
           <TopInstructions {...DEFAULT_PROPS} taRubric={{learningGoals: []}} />
         );
@@ -268,7 +268,7 @@ describe('TopInstructions', () => {
 
         expect(
           wrapper.find(TopInstructionsHeader).props().displayFeedback
-        ).toBe(false);
+        ).toBe(true);
       });
 
       it('passes displayFeedback = true to TopInstructionsHeader teacher is viewing student work and cannot leave feedback', () => {
@@ -336,7 +336,7 @@ describe('TopInstructions', () => {
         ).toBe(true);
       });
 
-      it('passes displayFeedback = false to TopInstructionsHeader on a level where there is a TA Rubric', () => {
+      it('passes displayFeedback = true to TopInstructionsHeader on a level where there is a TA Rubric', () => {
         const wrapper = shallow(
           <TopInstructions
             {...DEFAULT_PROPS}
@@ -372,7 +372,7 @@ describe('TopInstructions', () => {
 
         expect(
           wrapper.find(TopInstructionsHeader).props().displayFeedback
-        ).toBe(false);
+        ).toBe(true);
       });
 
       it('passes displayFeedback = false to TopInstructionsHeader on a level where the instructor has not given feedback and there is no miniRubric', () => {


### PR DESCRIPTION
For lessons/levels with a "taRubric", teachers will still be able to provide feedback through the "feedback" tab.

NEW:
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/a85997a0-7fdd-463d-8617-ee462af6d7bd" />


OLD (no "feedback" tab along the top bar):
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/a2e93f9c-d121-4895-9eba-97bb15e405df" />



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1669)

## Testing story

- Modified exisiting tests.
- Checked on all-the-things on production to locally for taRubric levels/lessons and non taRubric lessons/levels
- Expecting needing to approve new eyes baselines after this is merged in.  I will let the DOTD know. 