### PR TITLE
[Google Blockly] Fix Edge Scrolling

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -946,7 +946,11 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     );
 
     const scrollOptionsPlugin = new ScrollOptions(workspace);
-    scrollOptionsPlugin.init();
+    scrollOptionsPlugin.init({
+      // Rather than using the block edge, we always use the mouse cursor (plus a margin)
+      // to activate block-based scrolling.
+      edgeScrollOptions: {oversizeBlockThreshold: 0},
+    });
 
     const trashcan = new CdoTrashcan(workspace);
     trashcan.init();


### PR DESCRIPTION
Problem: When dragging large chunks of code around, blocks sometimes get "lost" off the edge of the workspace.
Example Level: https://levelbuilder-studio.code.org/s/musiclab-6-12-playground/lessons/1/levels/15 
Repro: disconnect the second Play Together

The videos here were captured locally using a random level where I copied the start sources from the above. (Just because I hadn't seeded `s/musiclab-6-12-playground` yet.)

Local repro:

https://github.com/user-attachments/assets/083158ef-62f1-497f-b2f7-78a1355fad49


This issue was less likely to happen with larger screens or smaller chunks of code. This edge scrolling behavior comes from the `@blockly/plugin-scroll-options` plugin, which was enabled here: https://github.com/code-dot-org/code-dot-org/pull/43310
We added this with the default settings, which includes an `oversizeBlockThreshold` of 0.85. This means that blocks will push and scroll the edges (instead of the mouse cursor) unless they take up 85% of the viewport or more. By setting this to 0, the behavior changes so that we _always_ rely upon the mouse cursor (plus a given margin of 15px) to begin scrolling.

Plugin configuration options and their defaults are defined here: https://github.com/mikeharv/blockly-samples/blob/master/plugins/scroll-options/src/ScrollBlockDragger.js

After fix:

https://github.com/user-attachments/assets/ddfdb1e0-eebf-4ff3-9735-08d86d3aa252






## Links
https://codedotorg.atlassian.net/browse/CT-498
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
