### PR TITLE
Codebridge: fix file tab close button css specificity

### DIFF
--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -45,7 +45,7 @@
   color: $light_gray_100;
 }
 
-.closeButton {
+button.closeButton {
   margin: 4px 0;
   padding-right: 10px;
 }


### PR DESCRIPTION
We got hit with another issue of our button styles getting overwritten by the default styles due to a change in the css load order. This makes the rule more specific so it gets applied.

## Before
<img width="117" alt="Screenshot 2025-03-13 at 1 55 33 PM" src="https://github.com/user-attachments/assets/cd37feab-f5fa-4c77-9887-801c748e013e" />

## After
<img width="114" alt="Screenshot 2025-03-13 at 1 55 17 PM" src="https://github.com/user-attachments/assets/bd5b394c-410b-41a4-9c8b-4289398ceb22" />

## Links
- [slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1741820704954969)


## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
