### PR TITLE
feat(Image): move component to Basics group in Contentful sidebar

### DIFF
--- a/frontend/apps/marketing/src/components/image/imageContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/image/imageContentfulDefinition.ts
@@ -4,7 +4,7 @@ import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 export const ImageContentfulComponentDefinition: ComponentDefinition = {
   id: 'image',
   name: 'Image',
-  category: 'Custom Components',
+  category: '03: Basic',
   // Adding an empty array here so no default style options show in the Design tab.
   builtInStyles: [],
   thumbnailUrl:


### PR DESCRIPTION
Moves the Image component into the Basics group in the Contentful sidebar.

## Links
Jira ticket: [CMS-423](https://codedotorg.atlassian.net/browse/CMS-423)

----

<img width="260" alt="Screenshot 2025-03-13 at 2 09 00 PM" src="https://github.com/user-attachments/assets/33151ed4-beba-41ca-b8f2-f08fb5b4a7ab" />

