### PR TITLE
Python Lab: fix validation issue with global variables

### DIFF
--- a/apps/lib/pyodide/unittest_runner-0.1.0-py3-none-any.whl
+++ b/apps/lib/pyodide/unittest_runner-0.1.0-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:240d219936d35f66d9eb88bf0ce63531bbb61b06662622cf76cd2f9314c9657d
-size 3641

--- a/apps/lib/pyodide/unittest_runner-0.2.0-py3-none-any.whl
+++ b/apps/lib/pyodide/unittest_runner-0.2.0-py3-none-any.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:536106442dfa35b015dabdffe61b67d76dc0f8091a8e810954ee347df96a796b
+size 3652

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -170,7 +170,7 @@ async function loadPackages() {
       'matplotlib',
       // These are custom packages that we have built. They are defined in the
       // python/pythonlab/ folder in the codebase.
-      `/blockly/js/pyodide/${version}/unittest_runner-0.1.0-py3-none-any.whl`,
+      `/blockly/js/pyodide/${version}/unittest_runner-0.2.0-py3-none-any.whl`,
       `/blockly/js/pyodide/${version}/pythonlab_setup-0.2.0-py3-none-any.whl`,
       `/blockly/js/pyodide/${version}/neighborhood-0.2.0-py3-none-any.whl`,
     ],

--- a/python/pythonlab/unittest_runner/pyproject.toml
+++ b/python/pythonlab/unittest_runner/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'unittest_runner'
-version = '0.1.0'
+version = '0.2.0'
 requires-python = '>=3.12'
 dependencies = ['neighborhood']
 

--- a/python/pythonlab/unittest_runner/tests/sample_main_with_function.py
+++ b/python/pythonlab/unittest_runner/tests/sample_main_with_function.py
@@ -1,0 +1,17 @@
+# sample main for testing that uses a function and a global variable.
+from neighborhood import Painter
+
+print("Hello world")
+p1 = Painter(0,1)
+
+def move_painter():
+  p1.turn_left()
+  p1.turn_left()
+  p2 = Painter(0,0,'south',2)
+  p2.move()
+  p2.paint('Red')
+  p2.turn_left()
+  p2.move()
+  p2.paint('Blue')
+
+move_painter()

--- a/python/pythonlab/unittest_runner/tests/test_validation_protocol.py
+++ b/python/pythonlab/unittest_runner/tests/test_validation_protocol.py
@@ -35,6 +35,17 @@ def test_get_neighborhood_log_returns_expected_info():
   assert neighborhood_log.one_painter_did_action('TURN_LEFT', 2)
   assert neighborhood_log.action_happened('TURN_LEFT', 3)
 
+def test_main_with_function_returns_expected_info():
+  validation_protocol = ValidationProtocol()
+  neighborhood_world = World()
+  neighborhood_world.set_grid_from_string(SAMPLE_MAZE)
+  neighborhood_world.set_context_type(NeighborhoodContextType.VALIDATE)
+  main_path = os.path.join(os.path.dirname(__file__), 'sample_main_with_function.py')
+  neighborhood_log = validation_protocol.get_neighborhood_log(main_path)
+  painter_logs = neighborhood_log.painter_logs
+  assert len(painter_logs) == 2
+  painter_log_1 = painter_logs[0]
+  assert painter_log_1.did_action_exactly
 
 def test_get_neighborhood_log_with_invalid_main_resets_context():
   validation_protocol = ValidationProtocol()

--- a/python/pythonlab/unittest_runner/unittest_runner/validation_protocol.py
+++ b/python/pythonlab/unittest_runner/unittest_runner/validation_protocol.py
@@ -37,6 +37,6 @@ class ValidationProtocol(object):
     file_path = file_path or 'main.py'
     try:
       with open(file_path) as main_file:
-        exec(main_file.read())
+        exec(main_file.read(), globals())
     except Exception:
       pass

--- a/uv.lock
+++ b/uv.lock
@@ -979,7 +979,7 @@ wheels = [
 
 [[package]]
 name = "unittest-runner"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/pythonlab/unittest_runner" }
 dependencies = [
     { name = "neighborhood" },


### PR DESCRIPTION
I saw in a classroom visit that on [this level](https://studio.code.org/s/pf-pilot-content-2024/lessons/7/levels/6/sublevel/1) even after fixing the code, their "painter moved four times" test was still failing. It turned out this was because a variable declared outside a function was not available inside the function when we were running tests, even though that works in a regular run. The fix to this was to pass `globals()` through to `exec`.

I'm not 100% sure why this fixes the issue. Per [the docs](https://docs.python.org/3/library/functions.html#exec), if you provide both globals and locals then "functions and classes defined in the executed code will not be able to access variables assigned at the top level". We were providing neither. However, this change seems safe to make and fixes the issue.

## Links

- jira ticket: [CT-1141](https://codedotorg.atlassian.net/browse/CT-1141)

## Testing story
Tested locally and added a unit test. Before this change the new unit test fails.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
