### PR TITLE
Music: sound selection focus tweaks

### DIFF
--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -254,8 +254,6 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
 
   const currentFolderRef: React.MutableRefObject<HTMLDivElement | null> =
     useRef(null);
-  const currentSoundRef: React.MutableRefObject<HTMLDivElement | null> =
-    useRef(null);
 
   const onModeChange = useCallback((value: Mode) => {
     setMode(value);
@@ -270,7 +268,6 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
     // when wrapping the content with FocusLock.
     setTimeout(() => {
       currentFolderRef.current?.scrollIntoView();
-      currentSoundRef.current?.scrollIntoView();
     }, 0);
   }, []);
 
@@ -279,7 +276,6 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   };
 
   const currentSoundRefCallback = (ref: HTMLDivElement) => {
-    currentSoundRef.current = ref;
     if (!isFocusSet && ref) {
       setTimeout(() => {
         ref.focus();

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -31,12 +31,14 @@
       background-color: $neutral_dark;
       flex: 1;
       overflow-y: scroll;
+      scroll-padding: 1px 0;
     }
 
     .rightColumn {
       background-color: $neutral_dark;
       flex: 1;
       overflow-y: scroll;
+      scroll-padding: 1px 0;
     }
   }
 

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -37,6 +37,7 @@
       background-color: $neutral_dark;
       flex: 1;
       overflow-y: scroll;
+      scroll-padding-top: 1px;
     }
   }
 

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -37,7 +37,6 @@
       background-color: $neutral_dark;
       flex: 1;
       overflow-y: scroll;
-      scroll-padding-top: 1px;
     }
   }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -190,7 +190,7 @@ img.video_thumbnail {
   user-select: none;
 
   .header {
-    position: fixed;
+    position: absolute;
     top: 0;
     width: 100%;
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -190,7 +190,7 @@ img.video_thumbnail {
   user-select: none;
 
   .header {
-    position: absolute;
+    position: fixed;
     top: 0;
     width: 100%;
 


### PR DESCRIPTION
This PR proposes a couple tweaks to the work in progress in https://github.com/code-dot-org/code-dot-org/pull/64398.  

The newly-added `focus` call scrolls the selected sound into view, so we can remove the call to `scrollIntoView`. 

This has the added benefit that the `:focus-visible` `outline` is no longer chopped off at the top after the scroll, which `scrollIntoView` would do.  (The mitigation would be to add a `scroll-padding-top: 1px` to the scroll container, because the `outline` was not accounted for in that type of scroll.)

The `focus` scroll seems to attempt to scroll the item to the middle, rather than the top, but it feels reasonable to use.

That said, it was possible to have the bottom of the bottom item's `outline` chopped off occasionally when navigating the two columns with the keyboard, so extra `scroll-padding`, just `1px` at `top` and `bottom`, has been added to each column's scroll container to help avoid this.  

### before

<img width="717" alt="Screenshot 2025-03-14 at 4 30 14 PM" src="https://github.com/user-attachments/assets/ed78cca4-987c-480a-ad87-ce86768ab280" />

### after

<img width="717" alt="Screenshot 2025-03-14 at 4 56 58 PM" src="https://github.com/user-attachments/assets/ef5bb096-2ffa-454e-9a48-195964e56417" />

