### PR TITLE
Lab2: fixed header

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -79,6 +79,13 @@ body.music-black, body.background-dark {
   color: $neutral_light;
 }
 
+body.background-dark, body.background-light {
+  .header-wrapper .header {
+    position: fixed;
+    z-index: 1;
+  }
+}
+
 h1 {
   @include main-font-bold;
   font-size: 32px;
@@ -186,7 +193,7 @@ img.video_thumbnail {
   user-select: none;
 
   .header {
-    position: fixed;
+    position: absolute;
     top: 0;
     width: 100%;
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -79,10 +79,6 @@ body.music-black, body.background-dark {
   color: $neutral_light;
 }
 
-body.background-dark, body.background-light {
-  overscroll-behavior: none;
-}
-
 h1 {
   @include main-font-bold;
   font-size: 32px;
@@ -190,7 +186,7 @@ img.video_thumbnail {
   user-select: none;
 
   .header {
-    position: absolute;
+    position: fixed;
     top: 0;
     width: 100%;
 


### PR DESCRIPTION
We've had an issue for a while in Lab2 labs in which the header might be scrolled.

It could happen when scrolling on a component that didn't want to scroll:

https://github.com/user-attachments/assets/de87ac60-2924-4d3e-a654-af980d11fa4a

This was mitigated by setting `overscroll-behavior: none` on the `body`.

However, Blockly does some other kind of programmatic scroll which, at a very specific browser height, causes the same issue anyway:

https://github.com/user-attachments/assets/b67c7922-9351-4d38-bd28-4a2cf7db6bc8

### Fixed

A simple solution appears to be to set the header's position to be `fixed` rather than `absolute`.  

Now, neither of the above cases causes it to scroll:

https://github.com/user-attachments/assets/959ba255-b69e-4846-bfc0-765657cca002
