### PR TITLE
Ceara/hot fix always generate for preset prompt

### DIFF
--- a/dashboard/app/controllers/ai_diff_controller.rb
+++ b/dashboard/app/controllers/ai_diff_controller.rb
@@ -120,7 +120,7 @@ class AiDiffController < ApplicationController
     course_name = @unit_group.present? ? @unit_group.name : @unit&.name
 
     course_display_name = CourseOffering.find_by(id: @unit_group&.course_version&.course_offering_id)&.display_name
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(params[:context], course_display_name, params[:unitDisplayName], lesson_name)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(params[:context], course_display_name, params[:unitDisplayName], lesson_name, params[:isPreset])
 
     bedrock_rag_response = AiDiffBedrockHelper.request_bedrock_rag_chat(params[:inputText], prompt, lesson_num, unit_num, course_name, session_id)
     #TODO: check for profanity/PII in model response

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -11,42 +11,40 @@ module AiDiffBedrockHelper
     Aws::BedrockAgentRuntime::Client.new
   end
 
-  def self.get_prompt_for_context(context, course_name, unit_name, lesson_name)
+  def self.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
     case context
     when SharedConstants::AI_DIFF_CONTEXT[:LESSON]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the %{course_name} course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is %{course_name} %{unit_name}, %{lesson_name}.
 
       Here are the search results in numbered order:
-      $search_results$
-
-      $output_format_instructions$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
+      $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
       )
     when SharedConstants::AI_DIFF_CONTEXT[:UNIT]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the %{course_name} course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is %{course_name} %{unit_name}.
 
       Here are the search results in numbered order:
-      $search_results$
-
-      $output_format_instructions$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
+      $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
       )
     when SharedConstants::AI_DIFF_CONTEXT[:COURSE]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the %{course_name} course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is %{course_name}.
 
       Here are the search results in numbered order:
-      $search_results$
-
-      $output_format_instructions$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
+      $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
       )
     when SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
 
       Here are the search results in numbered order:
-      $search_results$
+      $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
+      )
+    end
+    unless is_preset
+      prompt = format("%{prompt}
 
-      $output_format_instructions$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
+      $output_format_instructions$", prompt: prompt
       )
     end
     prompt

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -43,12 +43,13 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     AiDiffBedrockHelper.stubs(:create_bedrock_client).returns(@bedrock_client)
   end
 
-  test 'Testing prompt formatting for lesson' do
+  test 'Testing prompt formatting for lesson, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:LESSON]
     course_name = "Computer Science Discoveries"
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name)
+    is_preset = false
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the Computer Science Discoveries course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is Computer Science Discoveries CSD Unit 3, Test Lesson Name.
 
@@ -59,12 +60,13 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     assert_equal prompt, expected_prompt
   end
 
-  test 'Testing prompt formatting for unit' do
+  test 'Testing prompt formatting for unit, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:UNIT]
     course_name = "Computer Science Discoveries"
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name)
+    is_preset = false
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the Computer Science Discoveries course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is Computer Science Discoveries CSD Unit 3.
 
@@ -75,12 +77,13 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     assert_equal prompt, expected_prompt
   end
 
-  test 'Testing prompt formatting for course' do
+  test 'Testing prompt formatting for course, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:COURSE]
     course_name = "Computer Science Discoveries"
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name)
+    is_preset = false
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the Computer Science Discoveries course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is Computer Science Discoveries.
 
@@ -91,18 +94,78 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     assert_equal prompt, expected_prompt
   end
 
-  test 'Testing prompt formatting for general' do
+  test 'Testing prompt formatting for general, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
     course_name = nil
     unit_name = nil
     lesson_name = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name)
+    is_preset = false
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
 
       Here are the search results in numbered order:
       $search_results$
 
       $output_format_instructions$"
+    assert_equal prompt, expected_prompt
+  end
+
+  test 'Testing prompt formatting for lesson, is preset' do
+    context = SharedConstants::AI_DIFF_CONTEXT[:LESSON]
+    course_name = "Computer Science Discoveries"
+    unit_name = "CSD Unit 3"
+    lesson_name = "Test Lesson Name"
+    is_preset = true
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the Computer Science Discoveries course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+      The current lesson this teacher is working on is Computer Science Discoveries CSD Unit 3, Test Lesson Name.
+
+      Here are the search results in numbered order:
+      $search_results$"
+    assert_equal prompt, expected_prompt
+  end
+
+  test 'Testing prompt formatting for unit, is preset' do
+    context = SharedConstants::AI_DIFF_CONTEXT[:UNIT]
+    course_name = "Computer Science Discoveries"
+    unit_name = "CSD Unit 3"
+    lesson_name = "Test Lesson Name"
+    is_preset = true
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the Computer Science Discoveries course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+      The current unit this teacher is working on is Computer Science Discoveries CSD Unit 3.
+
+      Here are the search results in numbered order:
+      $search_results$"
+    assert_equal prompt, expected_prompt
+  end
+
+  test 'Testing prompt formatting for course, is preset' do
+    context = SharedConstants::AI_DIFF_CONTEXT[:COURSE]
+    course_name = "Computer Science Discoveries"
+    unit_name = "CSD Unit 3"
+    lesson_name = "Test Lesson Name"
+    is_preset = true
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the Computer Science Discoveries course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+      The current course this teacher is working on is Computer Science Discoveries.
+
+      Here are the search results in numbered order:
+      $search_results$"
+    assert_equal prompt, expected_prompt
+  end
+
+  test 'Testing prompt formatting for general, is preset' do
+    context = SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
+    course_name = nil
+    unit_name = nil
+    lesson_name = nil
+    is_preset = true
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+
+      Here are the search results in numbered order:
+      $search_results$"
     assert_equal prompt, expected_prompt
   end
 


### PR DESCRIPTION
This is a quick fix for a problem where in some contexts, for some preset prompts, we get a "Sorry, I am unable to assist you with this request" response when we expect a follow-up question from the AI to get more user information.

This is because the retrieval part of the RAG call doesn't return any results, and the `$output_instructions$` tag in the prompt template requires a set of results to populate the XML structure when `$output_instruction$` is expanded in bedrock. This throws an error and within bedrock the error is caught to replace the model output with "Sorry, I am unable to assist you with this request". 

The quick fix for this is to remove the `$output_instructions$` tag in the prompt template for calling retrieve_and_generate in response to a preset prompt. This allows the generation model to generate text even if there are no relevant documents to retrieve for the input, i.e. to generate follow-up questions

All other user messages include the tag in the prompt template when requesting a response

Before (on homepage, `GENERAL` context for support articles)
![Screenshot 2025-03-13 at 5 19 53 PM](https://github.com/user-attachments/assets/a63c8262-bfa2-459d-a5b0-3ec5e107227e)

After (on homepage, `GENERAL` context for support articles)
<img width="512" alt="Screenshot 2025-03-14 at 1 29 58 PM" src="https://github.com/user-attachments/assets/7a257ca1-b1ec-465f-aef5-93027d6bfa21" />

After (on course page)
<img width="775" alt="Screenshot 2025-03-14 at 1 35 05 PM" src="https://github.com/user-attachments/assets/5f07ce09-50d5-4586-810d-2e0063a83f0d" />

After (on lesson page)
<img width="782" alt="Screenshot 2025-03-14 at 1 37 34 PM" src="https://github.com/user-attachments/assets/0274c70e-bf0f-47e9-86c5-44b105df2684" />

## Links
 Slack convo: https://codedotorg.slack.com/archives/C050HE4QDHR/p1741911665226979

## Testing story

Add unit tests for the new prompts

## Deployment strategy

## Follow-up work

- Add a more relevant set of preset prompts for the general context
- Configure each prompt to label if we expect a direct answer from the embedded documents or expect a follow-up question, use that to determine if we include the `$output_instructions$` tag instead

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [X] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
