### PR TITLE
Lab2: add level name to level properties

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -317,7 +317,7 @@ export const setUpWithoutLevel = createAsyncThunk(
         {
           initialSources: sources,
           channel,
-          levelProperties: {id: 0, appName: payload.appName},
+          levelProperties: {id: 0, name: '', appName: payload.appName},
         },
         thunkAPI.signal.aborted,
         thunkAPI.dispatch,

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -168,6 +168,7 @@ export interface ProjectFolder {
 export interface LevelProperties {
   // Not a complete list; add properties as needed.
   id: number;
+  name: string;
   isProjectLevel?: boolean;
   hideShareAndRemix?: boolean;
   usesProjects?: boolean;

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -879,6 +879,7 @@ class Level < ApplicationRecord
   def summarize_for_lab2_properties(script, script_level = nil, current_user = nil)
     video = specified_autoplay_video&.summarize(false)&.camelize_keys
     properties_camelized = properties.camelize_keys
+    properties_camelized[:name] = name
     properties_camelized[:id] = id
     properties_camelized[:levelData] = video if video
     properties_camelized[:helpVideos] = related_videos.map(&:summarize)

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -87,6 +87,7 @@ class LevelsControllerTest < ActionController::TestCase
     body = JSON.parse(response.body)
     expected_body = {
       "id" => level.id,
+      "name" => level.name,
       "levelData" => {"hello" => "there"},
       "other" => "other",
       "preloadAssetList" => nil,

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -118,6 +118,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     body = JSON.parse(response.body)
 
     assert_equal body["id"], level.id
+    assert_equal body["name"], level.name
     assert_equal body["levelData"], {"hello" => "there"}
     assert_equal body["other"], "other"
     assert_equal body["preloadAssetList"], nil


### PR DESCRIPTION
Quick change to add the level's name to the level properties bundle we fetch for Lab2 labs. This will be used to fetch level starter assets in AI Chat but could be useful elsewhere down the road too.

## Links

Part of https://codedotorg.atlassian.net/browse/LABS-1387

## Testing story

Tested locally