### PR TITLE
Evaluate Student Learning: log code version when we evaluate student code

### DIFF
--- a/apps/src/aiEvaluation/evaluationApi.ts
+++ b/apps/src/aiEvaluation/evaluationApi.ts
@@ -9,6 +9,7 @@ export interface StudentAnswer {
   studentId: number;
   studentDisplayName: string;
   studentWork: string;
+  codeVersion?: string;
 }
 
 export interface AIResponse {
@@ -40,6 +41,7 @@ export async function evaluateStudentWork(
       evaluationCriteria: parsedResponse.evaluationCriteria,
       aiEvaluation: parsedResponse.aiEvaluation,
       aiReasoning: parsedResponse.aiReasoning,
+      codeVersion: studentWorkSample.codeVersion,
     });
   }
   return parsedResponse;

--- a/apps/src/aiEvaluation/userLevelEvaluations/types.ts
+++ b/apps/src/aiEvaluation/userLevelEvaluations/types.ts
@@ -6,4 +6,5 @@ export interface UserLevelEvaluation {
   evaluationCriteria: string;
   aiEvaluation: string;
   aiReasoning: string;
+  codeVersion?: string;
 }

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1139,6 +1139,7 @@ Applab.runButtonClick = function () {
         studentId: config.userId,
         studentDisplayName: config.codeOwnersName,
         studentWork: config.getCode(),
+        codeVersion: project.getCurrentSourceVersionId(),
       },
       analyticsData.levelId,
       analyticsData.scriptId,

--- a/dashboard/app/controllers/user_level_evaluations_controller.rb
+++ b/dashboard/app/controllers/user_level_evaluations_controller.rb
@@ -25,12 +25,11 @@ class UserLevelEvaluationsController < ApplicationController
       :ai_evaluation,
       :ai_reasoning,
       :ai_model_version,
+      :code_version
     )
     user_level_evaluation_params[:script_id] = params["unitId"]
     user_level_evaluation_params[:school_year] = school_year
-    # We're currently 'borrowing' the AI Tutor openAI model implementation.
-    # TODO: update to an EVALUATE_STUDENT_LEARNING_MODEL_VERSION when we settle on a model.
-    user_level_evaluation_params[:ai_model_version] = SharedConstants::AI_TUTOR_CHAT_MODEL_VERSION
+    user_level_evaluation_params[:ai_model_version] = SharedConstants::EVALUATE_STUDENT_LEARNING_MODEL_VERSION
     user_level_evaluation_params
   end
 end


### PR DESCRIPTION
Continuation of https://github.com/code-dot-org/code-dot-org/pull/64556

### Links
[Summary of Evaluate Student Learning Projects](https://docs.google.com/document/d/1dj7OzyRDGjA8mj8_feWoDpy2o3gI7Yi9jlpq7pxp7sA/edit?tab=t.0)
[Tech speclet for store AI evaluations](https://docs.google.com/document/d/1SvhsQDDCI1J9Nk-b6zOGuezzmQMJAnk43wet5IQcGdQ/edit?tab=t.0) 
[CSP AI Validation Quiet Pilot spec](https://docs.google.com/document/d/1YdYJeSXWu52qxQjFah4q5fSz5E58k5xn68sfEYB8UV0/edit?tab=t.0)

### Summary 

For the Evaluate Student Learning project we want to start collecting AI evaluations of student code samples so we can determine accuracy of AI-driven evaluation. 

We recently began writing AI evaluations to the `UserLevelEvaluations` table for 2 CSP unit 4 programming levels so we can collect and review them. We want to store `code_version` with `UserLevelEvaluation` so we can have a reference back to the student's code at the time of analysis. This PR writes `code_version` when we evaluate student code from App Lab. 

### Testing 
I checked that `code_version` included as expected and written to the database. 

<img width="1031" alt="Screenshot 2025-03-14 at 4 10 23 PM" src="https://github.com/user-attachments/assets/f5980fa8-52ab-49cc-9724-471fa79deb3e" />

### Follow-up work
 
- To review code samples alongside their AI evaluations, I'm planning to extend the functionality of the Student Dataset Maker (i.e. modify dashboard/app/controllers/student_code_sample_controller.rb) to include the UserLevelEvaluations of the pulled code samples. This will set us up nicely to have csvs ready for human "grading". 