### PR TITLE
chore(signup): clean up educator role experiment

### DIFF
--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -16,7 +16,6 @@ import React, {useState, useEffect, useMemo} from 'react';
 
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import statsigReporter from '@cdo/apps/metrics/StatsigReporter';
 import {schoolInfoInvalid} from '@cdo/apps/schoolInfo/utils/schoolInfoInvalid';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import SchoolDataInputs from '@cdo/apps/templates/SchoolDataInputs';
@@ -74,18 +73,6 @@ const FinishTeacherAccount: React.FunctionComponent<{
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorCreatingAccountMessage, setErrorCreatingAccountMessage] =
     useState('');
-
-  const showEducatorRole = statsigReporter.getIsInExperiment(
-    'educator_role',
-    'showEducatorRole',
-    false
-  );
-
-  const requireEducatorRole = statsigReporter.getIsInExperiment(
-    'educator_role',
-    'requireEducatorRole',
-    false
-  );
 
   // Remove oauth user_type cookie if it exists
   cookies.remove(NEW_SIGN_UP_USER_TYPE);
@@ -149,8 +136,8 @@ const FinishTeacherAccount: React.FunctionComponent<{
       name?.length > MAX_DISPLAY_NAME_LENGTH ||
       !gdprValid ||
       schoolInfoInvalid(schoolInfo) ||
-      (requireEducatorRole && !educatorRole),
-    [gdprValid, name, schoolInfo, requireEducatorRole, educatorRole]
+      !educatorRole,
+    [gdprValid, name, schoolInfo, educatorRole]
   );
 
   const onNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -299,21 +286,17 @@ const FinishTeacherAccount: React.FunctionComponent<{
               </BodyThreeText>
             )}
           </div>
-          {showEducatorRole && (
-            <SimpleDropdown
-              className={classNames(style.dropdownContainer, {
-                [style.requiredLabel]: requireEducatorRole,
-              })}
-              labelText={locale.what_is_your_role()}
-              name="educator_role"
-              selectedValue={educatorRole}
-              onChange={e => {
-                setEducatorRole(e.target.value);
-              }}
-              itemGroups={roleItemGroups}
-              dropdownTextThickness="thin"
-            />
-          )}
+          <SimpleDropdown
+            className={classNames(style.dropdownContainer, style.requiredLabel)}
+            labelText={locale.what_is_your_role()}
+            name="educator_role"
+            selectedValue={educatorRole}
+            onChange={e => {
+              setEducatorRole(e.target.value);
+            }}
+            itemGroups={roleItemGroups}
+            dropdownTextThickness="thin"
+          />
           <SchoolDataInputs {...schoolInfo} includeHeaders={false} />
           {showGDPR && (
             <div>

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -243,6 +243,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
         'has school': hasSchool,
         'has marketing value selected': true,
         'has display name': !nameErrorMessage,
+        'educator role': educatorRole,
         country: countryCode,
       },
       PLATFORMS.BOTH

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -287,6 +287,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
             )}
           </div>
           <SimpleDropdown
+            id="uitest-educator-role"
             className={classNames(style.dropdownContainer, style.requiredLabel)}
             labelText={locale.what_is_your_role()}
             name="educator_role"

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -3,7 +3,6 @@ import '@testing-library/jest-dom';
 import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
-import StatsigReporter from '@cdo/apps/metrics/StatsigReporter';
 import FinishTeacherAccount from '@cdo/apps/signUpFlow/FinishTeacherAccount';
 import locale from '@cdo/apps/signUpFlow/locale';
 import {
@@ -154,13 +153,13 @@ describe('FinishTeacherAccount', () => {
     const schoolName = 'Seattle Academy';
 
     // Fill out zip code and add school by name
-    fireEvent.change(screen.getAllByRole('textbox')[1], {
+    fireEvent.change(screen.getByLabelText(i18n.enterYourSchoolZip()), {
       target: {value: zipCode},
     });
-    fireEvent.change(screen.getAllByRole('combobox')[1], {
+    fireEvent.change(screen.getByLabelText(i18n.selectYourSchool()), {
       target: {value: NonSchoolOptions.CLICK_TO_ADD},
     });
-    fireEvent.change(screen.getAllByRole('textbox')[2], {
+    fireEvent.change(screen.getByLabelText(i18n.schoolOrganizationQuestion()), {
       target: {value: schoolName},
     });
 
@@ -257,12 +256,17 @@ describe('FinishTeacherAccount', () => {
     await screen.findByText(locale.data_transfer_notice());
 
     // Check that button is disabled until GDPR is checked (and other required fields are filled)
-    const displayNameInput = screen.getAllByRole('textbox')[0];
+    const displayNameInput = screen.getByLabelText(
+      locale.what_do_you_want_to_be_called()
+    );
     fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
-    fireEvent.change(screen.getAllByRole('combobox')[0], {
+    fireEvent.change(screen.getByLabelText(locale.what_is_your_role()), {
+      target: {value: 'classroom_teacher'},
+    });
+    fireEvent.change(screen.getByLabelText(i18n.whatCountry()), {
       target: {value: 'AU'},
     });
-    fireEvent.change(screen.getAllByDisplayValue('')[0], {
+    fireEvent.change(screen.getByLabelText(i18n.schoolOrganizationQuestion()), {
       target: {value: 'Test School'},
     });
     const finishSignUpButton = screen.getByRole('button', {
@@ -299,7 +303,7 @@ describe('FinishTeacherAccount', () => {
           school_name: 'Test School',
         },
         country_code: 'US',
-        educator_role: null,
+        educator_role: 'classroom_teacher',
       },
     };
     sessionStorage.setItem('email', email);
@@ -316,13 +320,17 @@ describe('FinishTeacherAccount', () => {
     finishSignUpButton.onclick = handleClick;
 
     // Fill in fields
-    fireEvent.change(screen.getAllByDisplayValue('')[0], {
-      target: {value: name},
+    fireEvent.change(
+      screen.getByLabelText(locale.what_do_you_want_to_be_called()),
+      {target: {value: 'FirstName'}}
+    );
+    fireEvent.change(screen.getByLabelText(locale.what_is_your_role()), {
+      target: {value: 'classroom_teacher'},
     });
-    fireEvent.change(screen.getAllByRole('combobox')[0], {
+    fireEvent.change(screen.getByLabelText(i18n.whatCountry()), {
       target: {value: 'AU'},
     });
-    fireEvent.change(screen.getAllByDisplayValue('')[0], {
+    fireEvent.change(screen.getByLabelText(i18n.schoolOrganizationQuestion()), {
       target: {value: 'Test School'},
     });
     fireEvent.click(screen.getByRole('checkbox'));
@@ -377,7 +385,7 @@ describe('FinishTeacherAccount', () => {
           school_name: 'Test School',
         },
         country_code: 'US',
-        educator_role: null,
+        educator_role: 'classroom_teacher',
       },
     };
     sessionStorage.setItem('email', email);
@@ -394,13 +402,17 @@ describe('FinishTeacherAccount', () => {
     finishSignUpButton.onclick = handleClick;
 
     // Fill in fields
-    fireEvent.change(screen.getAllByDisplayValue('')[0], {
-      target: {value: name},
+    fireEvent.change(
+      screen.getByLabelText(locale.what_do_you_want_to_be_called()),
+      {target: {value: 'FirstName'}}
+    );
+    fireEvent.change(screen.getByLabelText(locale.what_is_your_role()), {
+      target: {value: 'classroom_teacher'},
     });
-    fireEvent.change(screen.getAllByRole('combobox')[0], {
+    fireEvent.change(screen.getByLabelText(i18n.whatCountry()), {
       target: {value: 'AU'},
     });
-    fireEvent.change(screen.getAllByDisplayValue('')[0], {
+    fireEvent.change(screen.getByLabelText(i18n.schoolOrganizationQuestion()), {
       target: {value: 'Test School'},
     });
     fireEvent.click(screen.getByRole('checkbox'));
@@ -463,7 +475,7 @@ describe('FinishTeacherAccount', () => {
           school_name: 'Test School',
         },
         country_code: 'US',
-        educator_role: null,
+        educator_role: 'classroom_teacher',
       },
     };
     sessionStorage.setItem('email', email);
@@ -478,13 +490,17 @@ describe('FinishTeacherAccount', () => {
     finishSignUpButton.onclick = handleClick;
 
     // Fill in fields
-    fireEvent.change(screen.getAllByDisplayValue('')[0], {
-      target: {value: name},
+    fireEvent.change(
+      screen.getByLabelText(locale.what_do_you_want_to_be_called()),
+      {target: {value: 'FirstName'}}
+    );
+    fireEvent.change(screen.getByLabelText(locale.what_is_your_role()), {
+      target: {value: 'classroom_teacher'},
     });
-    fireEvent.change(screen.getAllByRole('combobox')[0], {
+    fireEvent.change(screen.getByLabelText(i18n.whatCountry()), {
       target: {value: 'AU'},
     });
-    fireEvent.change(screen.getAllByDisplayValue('')[0], {
+    fireEvent.change(screen.getByLabelText(i18n.schoolOrganizationQuestion()), {
       target: {value: 'Test School'},
     });
     fireEvent.click(screen.getByRole('checkbox'));
@@ -545,7 +561,7 @@ describe('FinishTeacherAccount', () => {
           school_name: 'Test School',
         },
         country_code: 'US',
-        educator_role: null,
+        educator_role: 'classroom_teacher',
       },
     };
     sessionStorage.setItem('email', email);
@@ -563,13 +579,17 @@ describe('FinishTeacherAccount', () => {
     finishSignUpButton.onclick = handleClick;
 
     // Fill in fields
-    fireEvent.change(screen.getAllByDisplayValue('')[0], {
-      target: {value: name},
+    fireEvent.change(
+      screen.getByLabelText(locale.what_do_you_want_to_be_called()),
+      {target: {value: 'FirstName'}}
+    );
+    fireEvent.change(screen.getByLabelText(locale.what_is_your_role()), {
+      target: {value: 'classroom_teacher'},
     });
-    fireEvent.change(screen.getAllByRole('combobox')[0], {
+    fireEvent.change(screen.getByLabelText(i18n.whatCountry()), {
       target: {value: 'AU'},
     });
-    fireEvent.change(screen.getAllByDisplayValue('')[0], {
+    fireEvent.change(screen.getByLabelText(i18n.schoolOrganizationQuestion()), {
       target: {value: 'Test School'},
     });
     fireEvent.click(screen.getByRole('checkbox'));
@@ -597,117 +617,34 @@ describe('FinishTeacherAccount', () => {
     });
   });
 
-  // TODO: when experiment ends, move relevant tests above and remove this describe block
-  describe('Educator role experiment', () => {
-    let getIsInExperimentSpy: jest.SpyInstance;
+  it('requires educator role', async () => {
+    await waitFor(renderDefault);
 
-    beforeEach(() => {
-      getIsInExperimentSpy = jest
-        .spyOn(StatsigReporter, 'getIsInExperiment')
-        .mockReturnValue(false);
+    const roleDropdown = screen.getByLabelText(locale.what_is_your_role());
+    expect(roleDropdown).toBeInTheDocument();
+
+    fireEvent.change(
+      screen.getByLabelText(locale.what_do_you_want_to_be_called()),
+      {target: {value: 'FirstName'}}
+    );
+    fireEvent.change(screen.getByLabelText(i18n.whatCountry()), {
+      target: {value: 'AU'},
+    });
+    fireEvent.change(screen.getByLabelText(i18n.schoolOrganizationQuestion()), {
+      target: {value: 'Test School'},
     });
 
-    afterEach(() => {
-      jest.restoreAllMocks();
+    let finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+    expect(finishSignUpButton).toBeDisabled();
+
+    fireEvent.change(roleDropdown, {target: {value: 'classroom_teacher'}});
+
+    finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
     });
 
-    it('hides educator_role dropdown if not in experiment', async () => {
-      await waitFor(renderDefault);
-
-      const roleDropdown = screen.queryByLabelText(locale.what_is_your_role());
-      expect(roleDropdown).not.toBeInTheDocument();
-    });
-
-    it('renders educator_role dropdown if in experiment', async () => {
-      getIsInExperimentSpy.mockImplementation((experiment, param) => {
-        if (experiment !== 'educator_role') {
-          return false;
-        }
-        if (param === 'showEducatorRole') {
-          return true;
-        }
-        return false;
-      });
-      await waitFor(renderDefault);
-
-      const roleDropdown = screen.queryByLabelText(locale.what_is_your_role());
-      expect(roleDropdown).toBeInTheDocument();
-    });
-
-    it('does not require educator_role if not in experiment', async () => {
-      getIsInExperimentSpy.mockImplementation((experiment, param) => {
-        if (experiment !== 'educator_role') {
-          return false;
-        }
-        if (param === 'showEducatorRole') {
-          return true;
-        }
-        if (param === 'requireEducatorRole') {
-          return false;
-        }
-        return false;
-      });
-      await waitFor(renderDefault);
-
-      const roleDropdown = screen.queryByLabelText(locale.what_is_your_role());
-      expect(roleDropdown).toBeInTheDocument();
-
-      const displayNameInput = screen.getAllByRole('textbox')[0];
-      fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
-
-      fireEvent.change(screen.getAllByRole('combobox')[1], {
-        target: {value: 'AU'},
-      });
-      fireEvent.change(screen.getAllByDisplayValue('')[0], {
-        target: {value: 'Test School'},
-      });
-
-      const finishSignUpButton = screen.getByRole('button', {
-        name: locale.go_to_my_account(),
-      });
-      expect(finishSignUpButton).toBeEnabled();
-    });
-
-    it('requires educator_role if in experiment', async () => {
-      getIsInExperimentSpy.mockImplementation((experiment, param) => {
-        if (experiment !== 'educator_role') {
-          return false;
-        }
-        if (param === 'showEducatorRole') {
-          return true;
-        }
-        if (param === 'requireEducatorRole') {
-          return true;
-        }
-        return false;
-      });
-      await waitFor(renderDefault);
-
-      const roleDropdown = screen.getByLabelText(locale.what_is_your_role());
-      expect(roleDropdown).toBeInTheDocument();
-
-      const displayNameInput = screen.getAllByRole('textbox')[0];
-      fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
-
-      fireEvent.change(screen.getAllByRole('combobox')[1], {
-        target: {value: 'AU'},
-      });
-      fireEvent.change(screen.getAllByDisplayValue('')[0], {
-        target: {value: 'Test School'},
-      });
-
-      let finishSignUpButton = screen.getByRole('button', {
-        name: locale.go_to_my_account(),
-      });
-      expect(finishSignUpButton).toBeDisabled();
-
-      fireEvent.change(roleDropdown, {target: {value: 'classroom_teacher'}});
-
-      finishSignUpButton = screen.getByRole('button', {
-        name: locale.go_to_my_account(),
-      });
-
-      expect(finishSignUpButton).toBeEnabled();
-    });
+    expect(finishSignUpButton).toBeEnabled();
   });
 });

--- a/dashboard/test/ui/features/acquisition_products/new_sign_up.feature
+++ b/dashboard/test/ui/features/acquisition_products/new_sign_up.feature
@@ -16,6 +16,7 @@ Scenario: Teacher can create a school associated account in the new sign up flow
   And I select the "United States" option in dropdown "uitest-country-dropdown"
   And I press keys "31513" for element "#uitest-school-zip"
   And I select the "Appling County High School" option in dropdown "uitest-school-dropdown"
+  And I select the "Classroom Teacher" option in dropdown "uitest-educator-role"
   And I see no difference for "Finish Sign Up Teacher"
   And I press the last button with text "Go to my account" to load a new page
   And I wait until I see selector "#uitest-accept-section-creation"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This removes the educator_role experiment, making the educator_role form input always render and requires it for form submission. it also adds the role to the teacher sign up finished event.

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-2980)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
