### PR TITLE
Fix metadata file names from PDF generation

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -137,10 +137,8 @@ module Services
           pdf_pathname = generate_lesson_pdf(lesson, dir)
 
           # Generate metadata
-          course_name = script.unit_group ? script.unit_group.name : script.name
           metadata = generate_metadata_for_ai(script, lesson)
-          file_path = "/tmp/#{course_name}-#{script.name}-#{format("L%02d", lesson.absolute_position)}.metadata.json"
-          add_metadata_to_ai_s3(file_path, metadata)
+          add_metadata_to_ai_s3(metadata)
           add_pdf_to_ai_s3(pdf_pathname, metadata)
         end
       end
@@ -158,10 +156,8 @@ module Services
             any_pdf_generated = true
 
             # Generate metadata
-            course_name = script.unit_group ? script.unit_group.name : script.name
             metadata = generate_metadata_for_ai(script, lesson)
-            file_path = "/tmp/#{course_name}-#{script.name}-#{format("L%02d", lesson.absolute_position)}.metadata.json"
-            add_metadata_to_ai_s3(file_path, metadata)
+            add_metadata_to_ai_s3(metadata)
             add_pdf_to_ai_s3(pdf_pathname, metadata)
           end
 
@@ -202,16 +198,18 @@ module Services
       full_metadata_json = {
         metadataAttributes: metadata
       }.to_json
-      flat_filename = "live/pdfgen_#{File.basename(file_path)}"
+      flat_filename = s3_file_name(metadata) + ".metadata.json"
       AWS::S3.upload_to_bucket(S3_BUCKET_AI, flat_filename, full_metadata_json, no_random: true)
     end
 
     def self.add_pdf_to_ai_s3(filepath, metadata)
       data = File.read(filepath)
-
-      flat_filename = "live/pdfgen_#{metadata[:course]}-#{metadata[:unit_fullname]}-#{metadata[:lesson]}.pdf"
-
+      flat_filename = s3_file_name(metadata)
       AWS::S3.upload_to_bucket(S3_BUCKET_AI, flat_filename, data, no_random: true)
+    end
+
+    def self.s3_file_name(metadata)
+      "live/pdfgen_#{metadata[:course]}-#{metadata[:unit_fullname]}-#{metadata[:lesson]}.pdf"
     end
 
     def self.generate_missing_pdfs


### PR DESCRIPTION
We discovered a bug where the `pdfgen_` metadata files for AI differentiation embeddings had file names in the form of `pdfgen_course_lesson_unit.metadata.json` instead of the expected `pdfgen_course_lesson_unit.pdf.metadata.json`. This should fix it.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
