### PR TITLE
feat(statsig): add educator role to statsig user properties

### DIFF
--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -79,16 +79,22 @@ class StatsigReporter {
   }
 
   // Utilizes Statsig's function for updating a user once we've recognized a sign in
-  async setUserProperties(
+  async setUserProperties({
     userId,
     userType,
     isVerifiedInstructor,
-    enabledExperiments
-  ) {
+    enabledExperiments,
+    educatorRole,
+  }) {
     const formattedUserId = this.formatUserId(userId);
     const user = {
       userID: formattedUserId,
-      custom: {userType, isVerifiedInstructor, enabledExperiments},
+      custom: {
+        userType,
+        isVerifiedInstructor,
+        enabledExperiments,
+        educatorRole,
+      },
     };
     if (!this.shouldPutRecord(ALWAYS_SEND)) {
       this.log(

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -267,6 +267,7 @@ export default function currentUser(state = initialState, action) {
       created_at,
       is_verified_instructor,
       has_completed_ai_differentiation_welcome,
+      educator_role,
     } = action.serverUser;
     analyticsReport.setUserProperties(
       id,
@@ -275,12 +276,13 @@ export default function currentUser(state = initialState, action) {
     );
     // Calling Statsig separately to emphasize different user integrations
     // and because dual reporting is aspirationally temporary (March 2024)
-    statsigReporter.setUserProperties(
-      id,
-      user_type,
-      is_verified_instructor,
-      experiments.getEnabledExperiments()
-    );
+    statsigReporter.setUserProperties({
+      userId: id,
+      userType: user_type,
+      isVerifiedInstructor: is_verified_instructor,
+      enabledExperiments: experiments.getEnabledExperiments(),
+      educatorRole: educator_role,
+    });
     return {
       ...state,
       userId: id,

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -47,6 +47,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         has_seen_ai_assessments_announcement: current_user.has_seen_ai_assessments_announcement?,
         ai_differentiation_enabled: !current_user.ai_differentiation_toggled_off?,
         has_completed_ai_differentiation_welcome: current_user.has_completed_ai_differentiation_welcome?,
+        educator_role: current_user.educator_role,
       }
     else
       render json: {

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -276,6 +276,7 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     assert_equal teacher.username, response["username"]
     assert_equal "teacher", response["user_type"]
     assert_equal teacher.short_name, response["short_name"]
+    assert_equal teacher.educator_role, response["educator_role"]
     assert_equal false, response["is_verified_instructor"]
   end
 


### PR DESCRIPTION
- adds educator_role to /api/v1/users/current response
- passes role from api response to redux store, where statsig user properties are initialized
- update setUserProperties to accept an object argument

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3159)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
