### PR TITLE
feat(eyes): implement eyes batching for `frontend`

### DIFF
--- a/.github/actions/frontend/marketing/ui-tests/action.yml
+++ b/.github/actions/frontend/marketing/ui-tests/action.yml
@@ -47,10 +47,3 @@ runs:
         path: frontend/apps/marketing/playwright-report
         name: playwright-report
 
-    - name: Run Google Lighthouse Audits
-      uses: treosh/lighthouse-ci-action@2f8dda6cf4de7d73b29853c3f29e73a01e297bd8
-      with:
-        urls: ${{ inputs.MARKETING_BASE_URL || 'http://localhost:3001' }}/en-US/all-the-things
-        uploadArtifacts: true
-        temporaryPublicStorage: true
-        configPath: './frontend/apps/marketing/.lighthouserc.js'

--- a/.github/workflows/component-library-ci.yml
+++ b/.github/workflows/component-library-ci.yml
@@ -2,14 +2,6 @@ name: Component-Library-CI
 
 on:
   workflow_call:
-  pull_request:
-    branches:
-      - staging
-      - staging-next
-    paths:
-        - 'frontend/packages/component-library/**'
-        - 'frontend/packages/component-library-styles/**'
-        - 'shared/**'
 
 jobs:
     build:
@@ -82,12 +74,10 @@ jobs:
         run: |
           EYES_REPORT=$(COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn eyes-storybook)
           echo "$EYES_REPORT"
-
           # Send multiline report to environment var
           echo "EYES_REPORT<<EOF" >> $GITHUB_OUTPUT
           echo "$EYES_REPORT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-
           # Check if the report was successful, failing if not.
           if echo "$EYES_REPORT" | grep -q "✅"; then
             echo "✅ Eyes report was successful, exiting with 0"
@@ -96,7 +86,6 @@ jobs:
             echo "❌ Eyes report unsuccessful, exiting with 1"
             exit 1
           fi
-
         working-directory: ./frontend/apps/design-system-storybook
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         env:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,62 @@
+# Common workflow for execution of continuous integration for the `frontend` code base.
+# This workflow handles setup and teardown for parallel workflow execution for the various apps and packages in `frontend`.
+name: Frontend-CI
+
+on:
+  pull_request:
+    branches:
+      - staging
+      - staging-next
+    paths:
+      - 'frontend/**'
+
+env:
+  APPLITOOLS_BATCH_ID: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  # Initializes common variables and environment prior to executing other jobs
+  setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      component-library-changed: ${{ steps.changes.outputs.component-library }}
+    steps:
+      # Determine what changed to later skip workflows
+      # Github Actions does not offer conditional runtime path filtering, thus use this action to calculate the
+      # changes. Root level applications (such as marketing) are not skipped as its dependency tree always changes
+      - name: Get Change Sets
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            component-library:
+              - 'frontend/apps/design-system-storybook/**'
+              - 'frontend/packages/component-library/**'
+              - 'frontend/packages/component-library-styles/**'
+              - 'frontend/packages/fonts/**'
+              - 'frontend/*'
+
+  # Start the marketing app CI workflow
+  marketing:
+    needs: setup
+    uses: ./.github/workflows/marketing-app-ci.yml
+    secrets: inherit
+
+  # Start the component library CI workflow
+  component-library:
+    if: ${{ needs.setup.outputs.component-library-changed == 'true' }}
+    needs: setup
+    uses: ./.github/workflows/component-library-ci.yml
+    secrets: inherit
+
+  # Common teardown actions that must occur after _all_ workflows have completed.
+  # For example, closing the Applitools batch after its completion.
+  teardown:
+    needs: [setup, marketing, component-library]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      # Close the eyes batch after all distributed eyes tests have completed
+      - name: Update Applitools batch status
+        shell: bash
+        run: |
+          curl -X POST "https://eyesapi.applitools.com/api/externals/github/servers/github.com/commit/${{ env.APPLITOOLS_BATCH_ID }}/${{ github.run_id }}/complete?apiKey=${{secrets.APPLITOOLS_API_KEY}}"

--- a/.github/workflows/marketing-app-ci.yml
+++ b/.github/workflows/marketing-app-ci.yml
@@ -2,12 +2,6 @@ name: Marketing-CI
 
 on:
   workflow_call:
-  pull_request:
-    branches:
-      - staging
-      - staging-next
-    paths:
-        - 'frontend/**'
 
 defaults:
   run:
@@ -106,3 +100,10 @@ jobs:
           CONTENTFUL_TOKEN: ${{ secrets.CONTENTFUL_TOKEN}}
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY}}
 
+      - name: Run Google Lighthouse Audits
+        uses: treosh/lighthouse-ci-action@2f8dda6cf4de7d73b29853c3f29e73a01e297bd8
+        with:
+          urls: ${{ inputs.MARKETING_BASE_URL || 'http://localhost:3001' }}/en-US/all-the-things
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+          configPath: './frontend/apps/marketing/.lighthouserc.js'

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -2,7 +2,7 @@
 # Future iterations of this workflow will include a matrix strategy to build and publish Docker images for all apps that have Dockerfiles.
 
 # The name does not use spaces due to https://github.com/integrations/slack/issues/1790
-name: Marketing-App-CICD
+name: Marketing-App-Deploy
 
 # Configures this workflow to run every time a change is pushed to `frontend`
 on:

--- a/frontend/apps/design-system-storybook/applitools.config.cjs
+++ b/frontend/apps/design-system-storybook/applitools.config.cjs
@@ -9,8 +9,9 @@ const isDocker = !!process.env.IS_DOCKER || !!process.env.CI;
 module.exports = {
   concurrency: 5,
   showLogs: !!process.env.APPLITOOLS_SHOW_LOGS,
-  appName: 'Code.org Design System',
-  batchName: 'Component Library',
+  appName: 'Component Library',
+  batchName: 'Frontend Eyes Tests',
+  dontCloseBatches: true,
   browser: [
     {width: 1200, height: 800, name: 'chrome'},
     {width: 1200, height: 800, name: 'firefox'},

--- a/frontend/apps/design-system-storybook/package.json
+++ b/frontend/apps/design-system-storybook/package.json
@@ -47,7 +47,7 @@
     "@storybook/addon-interactions": "^8.4.4",
     "@storybook/addon-storysource": "^8.4.4",
     "@storybook/addon-styling-webpack": "^1.0.1",
-    "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
+    "@storybook/addon-webpack5-compiler-swc": "^1.0.6",
     "@storybook/blocks": "^8.4.4",
     "@storybook/react": "^8.4.4",
     "@storybook/react-webpack5": "^8.4.4",

--- a/frontend/apps/marketing/README.md
+++ b/frontend/apps/marketing/README.md
@@ -1,6 +1,4 @@
-# Code.org Marketing Application
-
-...
+# Code.org Marketing Application.
 
 ## Getting Started
 

--- a/frontend/apps/marketing/playwright.config.ts
+++ b/frontend/apps/marketing/playwright.config.ts
@@ -25,11 +25,15 @@ export default defineConfig<EyesFixture>({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
     eyesConfig: {
-      appName: 'Code.org Marketing',
+      appName: 'Marketing',
       matchLevel: 'Strict',
       // Runner type: 'ufg' for Ultrafast Grid, 'classic' for Classic runner
       type: 'classic',
-      batch: {name: 'Marketing'},
+      batch: {
+        name: 'Frontend Eyes Tests',
+        id: process.env.APPLITOOLS_BATCH_ID,
+        notifyOnCompletion: false,
+      },
       sendDom: true,
       failTestsOnDiff: 'afterEach',
       branchName: 'staging',

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1155,7 +1155,7 @@ __metadata:
     "@storybook/addon-interactions": "npm:^8.4.4"
     "@storybook/addon-storysource": "npm:^8.4.4"
     "@storybook/addon-styling-webpack": "npm:^1.0.1"
-    "@storybook/addon-webpack5-compiler-swc": "npm:^1.0.5"
+    "@storybook/addon-webpack5-compiler-swc": "npm:^1.0.6"
     "@storybook/blocks": "npm:^8.4.4"
     "@storybook/react": "npm:^8.4.4"
     "@storybook/react-webpack5": "npm:^8.4.4"
@@ -4211,13 +4211,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-webpack5-compiler-swc@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "@storybook/addon-webpack5-compiler-swc@npm:1.0.5"
+"@storybook/addon-webpack5-compiler-swc@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "@storybook/addon-webpack5-compiler-swc@npm:1.0.6"
   dependencies:
     "@swc/core": "npm:^1.7.3"
     swc-loader: "npm:^0.2.3"
-  checksum: 10c0/8e3035b12f8381277f767d8eb41090525a1244b697540591be0b3d1583aa939d703b3705ef11350a7d780ccc1eb5129891107d363654a0f89cab5885a72d2a8f
+  checksum: 10c0/1f5e2f9415f84962bd28cc2e81b3ca18aaa795009c49acf1d1e168354b208fa78c37eab545caa9de9c03d4135115b119b7e35e1ae78425a679bb584fa206b989
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the ability to consolidate distributed eyes tests into the same batch within eyes. This is needed because Applitools reports success/fail status on a single batch to Github using its commit id. Previously, eyes tests were executing in their own batches - `marketing` and `component library` which eyes will then report whichever reported first.

Rather, the workflow has been refactored to utilize a common entrypoint, the `frontend-ci` workflow, which will execute on pull requests. The previous workflows are no longer children of this main workflow and will not be triggered when pull requests are executed. This allows a common `setup` and `teardown` job to execute _before_ the execution of the
workflow.

The `setup` workflow will establish common environmental or other setup tasks necessary to enable multiple workflows to execute. The `teardown` job will then perform clean up actions. In the context of eyes batching, it will close the batch notating its completion. This then triggers eyes to report success/fail status in the "checks" section of Github.

As a side effect, this produces a good visualization of all the steps that are executed.

![image](https://github.com/user-attachments/assets/c191f940-b4ed-43a6-ad63-765003841f3f)

## Conditional Execution

Since the trigger path conditions were removed, a similar path condition for conditionally executing the component library at runtime was needed. Unfortunately, Github does not have a native solution necessitating the use of `dorny/paths-filter` which provides this functionality.

If the change set does not include specific paths used by the component library, the component library workflow will then be skipped completely.

## Testing

This was fully tested in the [fork repo](https://github.com/code-dot-org/stephen-frontend-cicd-test/pull/9) to ensure compatability with the Applitools Eyes batching mechanism using the Github App integration.

![image](https://github.com/user-attachments/assets/f6a5eeb2-409a-419b-b4de-857d5542a3f3)
