### PR TITLE
Painter tracker: fix bug with default paint count

### DIFF
--- a/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
+++ b/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d006da5476d148043a6f81db23157d65d81940d48232c29fd8d609ff80f5ffcb
-size 16161

--- a/apps/lib/pyodide/neighborhood-0.3.0-py3-none-any.whl
+++ b/apps/lib/pyodide/neighborhood-0.3.0-py3-none-any.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82ddbb871fe793ac9452cfc9e33f59fec598592d0359c9ec4eda4a070c557b22
+size 16171

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -172,7 +172,7 @@ async function loadPackages() {
       // python/pythonlab/ folder in the codebase.
       `/blockly/js/pyodide/${version}/unittest_runner-0.2.0-py3-none-any.whl`,
       `/blockly/js/pyodide/${version}/pythonlab_setup-0.2.0-py3-none-any.whl`,
-      `/blockly/js/pyodide/${version}/neighborhood-0.2.0-py3-none-any.whl`,
+      `/blockly/js/pyodide/${version}/neighborhood-0.3.0-py3-none-any.whl`,
     ],
     {
       errorCallback: (message: string) => {

--- a/python/pythonlab/neighborhood/neighborhood/support/painter_tracker.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/painter_tracker.py
@@ -5,12 +5,12 @@ from ..painter_log import PainterLog
 from .constants import NORTH, SOUTH, EAST, WEST
 
 class PainterTracker:
-    def __init__(self, painter_id: str, position: Position, paint_count: int):
+    def __init__(self, painter_id: str, position: Position, paint_count: int | None):
         self.painter_id = painter_id
         self.starting_position = position
         self.current_position = position
-        self.starting_paint_count = paint_count
-        self.current_paint_count = paint_count
+        self.starting_paint_count = paint_count or 0
+        self.current_paint_count = paint_count or 0
         self.signals: list[NeighborhoodSignalMessage] = []
     
     # Record the given signal, updating position and paint count if necessary.

--- a/python/pythonlab/neighborhood/pyproject.toml
+++ b/python/pythonlab/neighborhood/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neighborhood"
-version = "0.2.0"
+version = "0.3.0"
 requires-python = '>=3.12'
 dependencies = []
 

--- a/python/pythonlab/neighborhood/tests/support/test_painter_tracker.py
+++ b/python/pythonlab/neighborhood/tests/support/test_painter_tracker.py
@@ -24,3 +24,8 @@ def test_initialize_painter_tracker():
     turn_left_message = NeighborhoodSignalMessage(SignalMessageType.NEIGHBORHOOD, NeighborhoodSignalKey.TURN_LEFT,{"direction": "north"})
     painter_tracker.track_signal(turn_left_message)
     assert painter_tracker.current_position.direction == 'north'
+
+def test_sets_correct_default_paint():
+    painter_tracker = PainterTracker("painter-1", Position(0,0,'East'), None)
+    assert painter_tracker.starting_paint_count == 0
+    assert painter_tracker.current_paint_count == 0

--- a/uv.lock
+++ b/uv.lock
@@ -526,7 +526,7 @@ wheels = [
 
 [[package]]
 name = "neighborhood"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "python/pythonlab/neighborhood" }
 
 [package.dev-dependencies]


### PR DESCRIPTION
If a student initializes a painter without setting a paint count, it defaults to 0. However, in the painter tracker we weren't converting `None` to `0`, so when we tried to add or remove paint [here](https://github.com/code-dot-org/code-dot-org/blob/6027b1d0333a54fa216ff43ab616b7328cfdda89/python/pythonlab/neighborhood/neighborhood/support/painter_tracker.py#L33-L36), we would hit an exception running the user's program. If we hit an exception, the validation does not correctly reflect the state of the neighborhood.

I found this while testing the programming fundamentals script, specifically [Lesson 5, Level 7, sublevel 2](https://studio.code.org/s/pf-pilot-content-2024/lessons/5/levels/7/sublevel/2). I found the "paints line" test always failed.

## Links

- jira ticket: [CT-1141](https://codedotorg.atlassian.net/browse/CT-1141)

## Testing story
Tested locally and added a unit test.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
