### PR TITLE
Add caching for UnitGroupUnit lookups

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -249,7 +249,7 @@ class LessonsController < ApplicationController
       course = UnitGroup.get_from_cache(course_name)
       unit_position = params[:unit_position]
       raise ActiveRecord::RecordNotFound unless course && unit_position
-      unit_group_unit = UnitGroupUnit.find_by(course_id: course.id, position: unit_position)
+      unit_group_unit = UnitGroupUnit.get_with_position_from_cache(course.id, unit_position)
       return Unit.get_from_cache(unit_group_unit.script_id) if unit_group_unit
     end
     raise ActiveRecord::RecordNotFound

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -386,8 +386,7 @@ class ScriptLevelsController < ApplicationController
       course = UnitGroup.get_from_cache(course_name)
       unit_position = params[:unit_position]
       raise ActiveRecord::RecordNotFound unless course && unit_position
-      # TODO TEACH-1633 call UnitGroupUnit.get_from_cache.
-      unit_group_unit = UnitGroupUnit.find_by(course_id: course.id, position: unit_position)
+      unit_group_unit = UnitGroupUnit.get_with_position_from_cache(course.id, unit_position)
       return Unit.get_from_cache(unit_group_unit.script_id, raise_exceptions: false) if unit_group_unit
     end
     raise ActiveRecord::RecordNotFound

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -323,7 +323,7 @@ class ScriptsController < ApplicationController
       @course = UnitGroup.get_from_cache(course_name)
       raise ActiveRecord::RecordNotFound unless @course
       @unit_position = params[:position]
-      unit_group_unit = UnitGroupUnit.find_by(course_id: @course.id, position: @unit_position)
+      unit_group_unit = UnitGroupUnit.get_with_position_from_cache(@course.id, @unit_position)
       @script = Unit.get_from_cache(unit_group_unit.script_id) if unit_group_unit
     else
       @script = get_unit_by_name

--- a/dashboard/app/models/unit_group_unit.rb
+++ b/dashboard/app/models/unit_group_unit.rb
@@ -44,17 +44,9 @@ class UnitGroupUnit < ApplicationRecord
   # @return [UnitGroupUnit] the data corresponding to the given course ID and unit position, either
   #         retrieved directly or from the cache.
   def self.get_with_position_from_cache(course_id, unit_position)
-    if should_cache?
-      cache_key = "#{self.class.name}/course_id/#{course_id}/position/#{unit_position}"
-      Rails.cache.fetch(cache_key) do
-        get_with_position_without_cache(course_id, unit_position)
-      end
-    else
-      get_with_position_without_cache(course_id, unit_position)
+    course = UnitGroup.get_from_cache(course_id)
+    course.default_unit_group_units.find do |ugu|
+      ugu.position == unit_position
     end
-  end
-
-  def self.get_with_position_without_cache(course_id, unit_position)
-    UnitGroupUnit.find_by(course_id: course_id, position: unit_position)
   end
 end

--- a/dashboard/app/models/unit_group_unit.rb
+++ b/dashboard/app/models/unit_group_unit.rb
@@ -24,4 +24,58 @@ class UnitGroupUnit < ApplicationRecord
   def update_course_json
     UnitGroup.find_by(id: course_id)&.write_serialization
   end
+
+  # Caching is disabled when editing in LevelBuilder mode or automated tests
+  # are running.
+  # Caching can also be disabled by configuring `cache_classes` to `false`
+  def self.should_cache?
+    return false if Rails.application.config.levelbuilder_mode
+    return false unless Rails.application.config.cache_classes
+    return false if ENV['UNIT_TEST'] || ENV['CI']
+    true
+  end
+
+  # Finds a UnitGroupUnit for the given parameters and caches the result. Future
+  # calls will use the cache if caching is enabled.
+  # If caching is disabled, then the database is queried every time.
+  #
+  # @param course_id [Integer] the ID of the course to fetch the data for
+  # @param unit_position [Integer] the position of the unit in the course to fetch the data for
+  # @return [UnitGroupUnit] the data corresponding to the given course ID and unit position, either
+  #         retrieved directly or from the cache.
+  def self.get_with_position_from_cache(course_id, unit_position)
+    if should_cache?
+      cache_key = "#{self.class.name}/course_id/#{course_id}/position/#{unit_position}"
+      Rails.cache.fetch(cache_key) do
+        get_with_position_without_cache(course_id, unit_position)
+      end
+    else
+      get_with_position_without_cache(course_id, unit_position)
+    end
+  end
+
+  def self.get_with_position_without_cache(course_id, unit_position)
+    UnitGroupUnit.find_by(course_id: course_id, position: unit_position)
+  end
+
+  # Finds a UnitGroupUnit for the given parameters and caches the result. Future
+  # calls will use the cache if caching is enabled.
+  # If caching is disabled, then the database is queried every time.
+  #
+  # @param [Integer, String] unit_id the Unit the UnitGroupUnits are associated with.
+  # @return [Array<UnitGroupUnit>] the UnitGroupUnits the given Unit is in.
+  def self.get_with_unit_from_cache(unit_id)
+    if should_cache?
+      cache_key = "#{self.class.name}/unit_id/#{unit_id}"
+      Rails.cache.fetch(cache_key) do
+        get_with_unit_without_cache(unit_id)
+      end
+    else
+      get_with_unit_without_cache(unit_id)
+    end
+  end
+
+  def self.get_with_unit_without_cache(unit_id)
+    UnitGroupUnit.where(script_id: unit_id)
+  end
 end

--- a/dashboard/app/models/unit_group_unit.rb
+++ b/dashboard/app/models/unit_group_unit.rb
@@ -25,16 +25,6 @@ class UnitGroupUnit < ApplicationRecord
     UnitGroup.find_by(id: course_id)&.write_serialization
   end
 
-  # Caching is disabled when editing in LevelBuilder mode or automated tests
-  # are running.
-  # Caching can also be disabled by configuring `cache_classes` to `false`
-  def self.should_cache?
-    return false if Rails.application.config.levelbuilder_mode
-    return false unless Rails.application.config.cache_classes
-    return false if ENV['UNIT_TEST'] || ENV['CI']
-    true
-  end
-
   # Finds a UnitGroupUnit for the given parameters and caches the result. Future
   # calls will use the cache if caching is enabled.
   # If caching is disabled, then the database is queried every time.

--- a/dashboard/app/models/unit_group_unit.rb
+++ b/dashboard/app/models/unit_group_unit.rb
@@ -57,25 +57,4 @@ class UnitGroupUnit < ApplicationRecord
   def self.get_with_position_without_cache(course_id, unit_position)
     UnitGroupUnit.find_by(course_id: course_id, position: unit_position)
   end
-
-  # Finds a UnitGroupUnit for the given parameters and caches the result. Future
-  # calls will use the cache if caching is enabled.
-  # If caching is disabled, then the database is queried every time.
-  #
-  # @param [Integer, String] unit_id the Unit the UnitGroupUnits are associated with.
-  # @return [Array<UnitGroupUnit>] the UnitGroupUnits the given Unit is in.
-  def self.get_with_unit_from_cache(unit_id)
-    if should_cache?
-      cache_key = "#{self.class.name}/unit_id/#{unit_id}"
-      Rails.cache.fetch(cache_key) do
-        get_with_unit_without_cache(unit_id)
-      end
-    else
-      get_with_unit_without_cache(unit_id)
-    end
-  end
-
-  def self.get_with_unit_without_cache(unit_id)
-    UnitGroupUnit.where(script_id: unit_id)
-  end
 end

--- a/dashboard/app/models/unit_group_unit.rb
+++ b/dashboard/app/models/unit_group_unit.rb
@@ -30,10 +30,11 @@ class UnitGroupUnit < ApplicationRecord
   # If caching is disabled, then the database is queried every time.
   #
   # @param course_id [Integer] the ID of the course to fetch the data for
-  # @param unit_position [Integer] the position of the unit in the course to fetch the data for
+  # @param unit_position [Integer, String] the position of the unit in the course to fetch the data for
   # @return [UnitGroupUnit] the data corresponding to the given course ID and unit position, either
   #         retrieved directly or from the cache.
   def self.get_with_position_from_cache(course_id, unit_position)
+    unit_position = unit_position.to_i if unit_position
     course = UnitGroup.get_from_cache(course_id)
     course.default_unit_group_units.find do |ugu|
       ugu.position == unit_position

--- a/dashboard/lib/queries/courses.rb
+++ b/dashboard/lib/queries/courses.rb
@@ -13,9 +13,9 @@ class Queries::Courses
   #     - `:course` - The retrieved Unit/Course
   #     - `:unit_group_unit` - The associated UnitGroupUnit information
   def self.get_course_context(unit_name)
-    unit = Unit.get_from_cache(unit_name)
+    unit = Unit.get_from_cache(unit_name, raise_exceptions: false)
     return nil unless unit
-    unit_group_unit = UnitGroupUnit.get_with_unit_from_cache(unit.id).first
+    unit_group_unit = unit.unit_group_units&.first
     return nil unless unit_group_unit
     course = UnitGroup.get_from_cache(unit_group_unit.course_id)
     {course: course, unit_group_unit: unit_group_unit}

--- a/dashboard/lib/queries/courses.rb
+++ b/dashboard/lib/queries/courses.rb
@@ -15,7 +15,7 @@ class Queries::Courses
   def self.get_course_context(unit_name)
     unit = Unit.get_from_cache(unit_name)
     return nil unless unit
-    unit_group_unit = UnitGroupUnit.where(script_id: unit.id).first
+    unit_group_unit = UnitGroupUnit.get_with_unit_from_cache(unit.id).first
     return nil unless unit_group_unit
     course = UnitGroup.get_from_cache(unit_group_unit.course_id)
     {course: course, unit_group_unit: unit_group_unit}

--- a/dashboard/test/lib/queries/courses_test.rb
+++ b/dashboard/test/lib/queries/courses_test.rb
@@ -6,49 +6,49 @@ class Queries::CoursesTest < ActiveSupport::TestCase
   describe '.get_course_context' do
     let(:script_name) {'test-script'}
     let(:unit) {nil}
-
-    before do
-      allow(Unit).to receive(:get_from_cache).and_return(unit)
-    end
+    let(:subject) {Queries::Courses.get_course_context(script_name)}
 
     context 'unit is nil' do
       it 'returns nil' do
-        _(Queries::Courses.get_course_context(script_name)).must_be_nil
+        _(subject).must_be_nil
       end
     end
 
     context 'unit is defined' do
-      let(:unit) {instance_double(Unit)}
+      let!(:unit) {create :unit, name: script_name}
       let(:unit_group_unit) {nil}
-
-      before do
-        allow(unit).to receive(:id).and_return(1)
-        allow(UnitGroupUnit).to receive(:find_by).and_return(unit_group_unit)
-      end
 
       context 'unit_group_unit is nil' do
         it 'returns nil' do
-          _(Queries::Courses.get_course_context(script_name)).must_be_nil
+          _(subject).must_be_nil
         end
       end
 
       context 'unit_group_unit is defined' do
-        let(:unit_group_unit) {instance_double(UnitGroupUnit)}
-        let(:course) {instance_double(UnitGroup)}
-
-        before do
-          allow(course).to receive(:id).and_return(1)
-          allow(UnitGroupUnit).to receive(:where).and_return([unit_group_unit])
-          allow(unit_group_unit).to receive(:course_id).and_return(course.id)
-          allow(UnitGroup).to receive(:get_from_cache).and_return(course)
-        end
-
-        it 'returns course context' do
-          expected_course_context = {
+        let(:course) {create :unit_group}
+        let(:unit_position) {123}
+        let!(:unit_group_unit) {create :unit_group_unit, course_id: course.id, position: unit_position, script_id: unit.id}
+        let(:course_context) do
+          {
             course: course,
             unit_group_unit: unit_group_unit,
           }
-          _(Queries::Courses.get_course_context(script_name)).must_equal expected_course_context
+        end
+
+        it 'returns course context' do
+          _(subject).must_equal course_context
+        end
+
+        context 'caching is enabled' do
+          before do
+            allow(Unit).to receive(:should_cache?).and_return(true)
+          end
+          it 'caches the course context' do
+            _(Queries::Courses.get_course_context(script_name)).must_equal course_context
+            assert_queries(0) do
+              _(Queries::Courses.get_course_context(script_name)).must_equal course_context
+            end
+          end
         end
       end
     end

--- a/dashboard/test/models/unit_group_unit_test.rb
+++ b/dashboard/test/models/unit_group_unit_test.rb
@@ -3,31 +3,36 @@ require 'test_helper'
 class UnitGroupUnitTest < ActiveSupport::TestCase
   include Minitest::RSpecMocks
   describe '.get_with_position_from_cache' do
+    let(:script_name) {'test-script'}
+    let!(:unit) {create :unit, name: script_name}
+    let(:course) {create :unit_group}
+    let(:unit_position) {123}
+    let!(:unit_group_unit) {create :unit_group_unit, course_id: course.id, position: unit_position, script_id: unit.id}
     let(:should_cache) {false}
-    let(:db_call_count) {2}
-    let(:course_id) {123}
-    let(:unit_position) {456}
-    let(:unit_group_unit) {instance_double(UnitGroupUnit)}
-    let(:subject) {UnitGroupUnit.get_with_position_from_cache(course_id, unit_position)}
+    let(:query_count) {1}
 
     before do
-      allow(UnitGroupUnit).to receive(:find_by).with(course_id: course_id, position: unit_position).exactly(db_call_count).times.and_return(unit_group_unit)
+      allow(UnitGroup).to receive(:should_cache?).and_return(should_cache)
     end
 
     context('should not cache') do
       it('does not cache the UnitGroupUnit') do
-        _(subject).must_equal(unit_group_unit)
-        _(subject).must_equal(unit_group_unit)
+        _(UnitGroupUnit.get_with_position_from_cache(course.id, unit_position)).must_equal(unit_group_unit)
+        assert_queries(query_count) do
+          _(UnitGroupUnit.get_with_position_from_cache(course.id, unit_position)).must_equal(unit_group_unit)
+        end
       end
     end
 
     context('should cache') do
       let(:should_cache) {true}
-      let(:db_call_count) {1}
+      let(:query_count) {0}
 
       it('caches the UnitGroupUnit') do
-        _(subject).must_equal(unit_group_unit)
-        _(subject).must_equal(unit_group_unit)
+        _(UnitGroupUnit.get_with_position_from_cache(course.id, unit_position)).must_equal(unit_group_unit)
+        assert_queries(query_count) do
+          _(UnitGroupUnit.get_with_position_from_cache(course.id, unit_position)).must_equal(unit_group_unit)
+        end
       end
     end
   end

--- a/dashboard/test/models/unit_group_unit_test.rb
+++ b/dashboard/test/models/unit_group_unit_test.rb
@@ -31,33 +31,4 @@ class UnitGroupUnitTest < ActiveSupport::TestCase
       end
     end
   end
-
-  describe '.get_with_unit_from_cache' do
-    let(:should_cache) {false}
-    let(:db_call_count) {2}
-    let(:unit_id) {123}
-    let(:unit_group_units) {[instance_double(UnitGroupUnit)]}
-    let(:subject) {UnitGroupUnit.get_with_unit_from_cache(unit_id)}
-
-    before do
-      allow(UnitGroupUnit).to receive(:where).with(script_id: unit_id).exactly(db_call_count).times.and_return(unit_group_units)
-    end
-
-    context('should not cache') do
-      it('does not cache the UnitGroupUnits') do
-        _(subject).must_equal(unit_group_units)
-        _(subject).must_equal(unit_group_units)
-      end
-    end
-
-    context('should cache') do
-      let(:should_cache) {true}
-      let(:db_call_count) {1}
-
-      it('caches the UnitGroupUnit') do
-        _(subject).must_equal(unit_group_units)
-        _(subject).must_equal(unit_group_units)
-      end
-    end
-  end
 end

--- a/dashboard/test/models/unit_group_unit_test.rb
+++ b/dashboard/test/models/unit_group_unit_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class UnitGroupUnitTest < ActiveSupport::TestCase
+  include Minitest::RSpecMocks
+  describe '.get_with_position_from_cache' do
+    let(:should_cache) {false}
+    let(:db_call_count) {2}
+    let(:course_id) {123}
+    let(:unit_position) {456}
+    let(:unit_group_unit) {instance_double(UnitGroupUnit)}
+    let(:subject) {UnitGroupUnit.get_with_position_from_cache(course_id, unit_position)}
+
+    before do
+      allow(UnitGroupUnit).to receive(:find_by).with(course_id: course_id, position: unit_position).exactly(db_call_count).times.and_return(unit_group_unit)
+    end
+
+    context('should not cache') do
+      it('does not cache the UnitGroupUnit') do
+        _(subject).must_equal(unit_group_unit)
+        _(subject).must_equal(unit_group_unit)
+      end
+    end
+
+    context('should cache') do
+      let(:should_cache) {true}
+      let(:db_call_count) {1}
+
+      it('caches the UnitGroupUnit') do
+        _(subject).must_equal(unit_group_unit)
+        _(subject).must_equal(unit_group_unit)
+      end
+    end
+  end
+
+  describe '.get_with_unit_from_cache' do
+    let(:should_cache) {false}
+    let(:db_call_count) {2}
+    let(:unit_id) {123}
+    let(:unit_group_units) {[instance_double(UnitGroupUnit)]}
+    let(:subject) {UnitGroupUnit.get_with_unit_from_cache(unit_id)}
+
+    before do
+      allow(UnitGroupUnit).to receive(:where).with(script_id: unit_id).exactly(db_call_count).times.and_return(unit_group_units)
+    end
+
+    context('should not cache') do
+      it('does not cache the UnitGroupUnits') do
+        _(subject).must_equal(unit_group_units)
+        _(subject).must_equal(unit_group_units)
+      end
+    end
+
+    context('should cache') do
+      let(:should_cache) {true}
+      let(:db_call_count) {1}
+
+      it('caches the UnitGroupUnit') do
+        _(subject).must_equal(unit_group_units)
+        _(subject).must_equal(unit_group_units)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are moving towards a curriculum model where Units will be shared between UnitGroups. This means we will be querying for UnitGroupUnits much more often. Since the associations are static in production, we should aggressively cache them in order to avoid an unnecessary burden on our database.

This PR uses the cached methods `unit.unit_group_units` and `course.default_unit_group_units` instead of directly calling `UnitGroupUnit.find(...)`

## Links
* [Jira](https://codedotorg.atlassian.net/browse/TEACH-1633)

## Testing story
* Unit tests

## Caching
* Uses `unit.unit_group_units` which is cached.
* Uses `course.default_unit_group_units` which is cached.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
