### PR TITLE
Adding focus trap to version history dropdown

### DIFF
--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -6,6 +6,7 @@ import {RadioButton} from '@code-dot-org/component-library/radioButton';
 import Tags from '@code-dot-org/component-library/tags';
 import {Heading6} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
+import FocusTrap from 'focus-trap-react';
 import React, {
   useCallback,
   useEffect,
@@ -309,129 +310,136 @@ const VersionHistoryDropdown: React.FunctionComponent<
   }, [closeDropdown, dispatch, isLatestVersion, selectedVersion]);
 
   return createPortal(
-    <div
-      className={moduleStyles.versionHistoryDropdown}
-      ref={menuRef}
-      role="dialog"
-      style={dropdownStyles}
-      aria-modal="true"
-      aria-label={lab2I18n.versionHistoryList()}
+    <FocusTrap
+      focusTrapOptions={{
+        onDeactivate: closeDropdown,
+        clickOutsideDeactivates: true,
+      }}
     >
-      <div className={moduleStyles.versionHistoryHeader}>
-        <Heading6 className={moduleStyles.versionHistoryTitle}>
-          {commonI18n.versionHistory_header()}
-        </Heading6>
-        <CloseButton
-          onClick={closeDropdown}
-          aria-label={lab2I18n.closeVersionHistory()}
-          id={'close-version-history'}
-        />
-      </div>
-      {listLoading && (
-        <div
-          className={classNames(
-            moduleStyles.versionHistoryMessage,
-            moduleStyles.loadingVersionSpinner
-          )}
-        >
-          <FontAwesomeV6Icon iconName="spinner" animationType="spin" />
-        </div>
-      )}
-      {listLoadError && (
-        <div className={moduleStyles.versionHistoryMessage}>
-          <Alert
-            type="danger"
-            text={lab2I18n.versionHistoryLoadFailure()}
-            size="s"
+      <div
+        className={moduleStyles.versionHistoryDropdown}
+        ref={menuRef}
+        role="dialog"
+        style={dropdownStyles}
+        aria-modal="true"
+        aria-label={lab2I18n.versionHistoryList()}
+      >
+        <div className={moduleStyles.versionHistoryHeader}>
+          <Heading6 className={moduleStyles.versionHistoryTitle}>
+            {commonI18n.versionHistory_header()}
+          </Heading6>
+          <CloseButton
+            onClick={closeDropdown}
+            aria-label={lab2I18n.closeVersionHistory()}
+            id={'close-version-history'}
           />
         </div>
-      )}
-      {listLoaded && (
-        <div>
-          <div className={moduleStyles.versionHistoryList}>
-            {versionList.map(version => (
-              <div id={version.versionId} key={version.versionId}>
-                <RadioButton
-                  name={version.versionId}
-                  value={version.versionId}
-                  label={parseDate(version.lastModified)}
-                  onChange={onVersionChange}
-                  checked={selectedVersion === version.versionId}
-                  className={moduleStyles.versionHistoryRow}
-                >
-                  {version.isLatest && (
-                    <Tags
-                      tagsList={[
-                        {
-                          label: commonI18n.current(),
-                          icon: {
-                            iconName: 'check',
-                            iconStyle: 'regular',
-                            title: 'check',
-                            placement: 'left',
-                          },
-                          tooltipContent: commonI18n.current(),
-                          tooltipId: 'current-version-tag',
-                          ariaLabel: commonI18n.current(),
-                        },
-                      ]}
-                      className={moduleStyles.latestTag}
-                      size="s"
-                    />
-                  )}
-                </RadioButton>
-              </div>
-            ))}
-            <div id={INITIAL_VERSION_ID}>
-              <RadioButton
-                name={INITIAL_VERSION_ID}
-                value={INITIAL_VERSION_ID}
-                label={lab2I18n.initialVersion()}
-                onChange={onVersionChange}
-                checked={selectedVersion === INITIAL_VERSION_ID}
-                className={moduleStyles.versionHistoryRow}
-              />
-            </div>
+        {listLoading && (
+          <div
+            className={classNames(
+              moduleStyles.versionHistoryMessage,
+              moduleStyles.loadingVersionSpinner
+            )}
+          >
+            <FontAwesomeV6Icon iconName="spinner" animationType="spin" />
           </div>
-          {versionLoadError && (
-            <div className={classNames(moduleStyles.versionLoadError)}>
-              <Alert
-                type="danger"
-                text={lab2I18n.versionLoadFailure()}
-                size="s"
-              />
-            </div>
-          )}
-          <div className={moduleStyles.versionDropdownFooter}>
-            {versionLoading && (
-              <div className={classNames(moduleStyles.loadingVersionSpinner)}>
-                <FontAwesomeV6Icon iconName="spinner" animationType="spin" />
-              </div>
-            )}
-            {!viewAsUserId && (
-              <Button
-                text={commonI18n.restore()}
-                color={'white'}
-                size={'s'}
-                onClick={restoreSelectedVersion}
-                disabled={versionLoading}
-                className={moduleStyles.actionButton}
-                type={'primary'}
-              />
-            )}
-            <Button
-              text={commonI18n.cancel()}
-              color={'white'}
-              size={'s'}
-              onClick={handleCancel}
-              disabled={versionLoading}
-              className={moduleStyles.actionButton}
-              type={'secondary'}
+        )}
+        {listLoadError && (
+          <div className={moduleStyles.versionHistoryMessage}>
+            <Alert
+              type="danger"
+              text={lab2I18n.versionHistoryLoadFailure()}
+              size="s"
             />
           </div>
-        </div>
-      )}
-    </div>,
+        )}
+        {listLoaded && (
+          <div>
+            <div className={moduleStyles.versionHistoryList}>
+              {versionList.map(version => (
+                <div id={version.versionId} key={version.versionId}>
+                  <RadioButton
+                    name={version.versionId}
+                    value={version.versionId}
+                    label={parseDate(version.lastModified)}
+                    onChange={onVersionChange}
+                    checked={selectedVersion === version.versionId}
+                    className={moduleStyles.versionHistoryRow}
+                  >
+                    {version.isLatest && (
+                      <Tags
+                        tagsList={[
+                          {
+                            label: commonI18n.current(),
+                            icon: {
+                              iconName: 'check',
+                              iconStyle: 'regular',
+                              title: 'check',
+                              placement: 'left',
+                            },
+                            tooltipContent: commonI18n.current(),
+                            tooltipId: 'current-version-tag',
+                            ariaLabel: commonI18n.current(),
+                          },
+                        ]}
+                        className={moduleStyles.latestTag}
+                        size="s"
+                      />
+                    )}
+                  </RadioButton>
+                </div>
+              ))}
+              <div id={INITIAL_VERSION_ID}>
+                <RadioButton
+                  name={INITIAL_VERSION_ID}
+                  value={INITIAL_VERSION_ID}
+                  label={lab2I18n.initialVersion()}
+                  onChange={onVersionChange}
+                  checked={selectedVersion === INITIAL_VERSION_ID}
+                  className={moduleStyles.versionHistoryRow}
+                />
+              </div>
+            </div>
+            {versionLoadError && (
+              <div className={classNames(moduleStyles.versionLoadError)}>
+                <Alert
+                  type="danger"
+                  text={lab2I18n.versionLoadFailure()}
+                  size="s"
+                />
+              </div>
+            )}
+            <div className={moduleStyles.versionDropdownFooter}>
+              {versionLoading && (
+                <div className={classNames(moduleStyles.loadingVersionSpinner)}>
+                  <FontAwesomeV6Icon iconName="spinner" animationType="spin" />
+                </div>
+              )}
+              {!viewAsUserId && (
+                <Button
+                  text={commonI18n.restore()}
+                  color={'white'}
+                  size={'s'}
+                  onClick={restoreSelectedVersion}
+                  disabled={versionLoading}
+                  className={moduleStyles.actionButton}
+                  type={'primary'}
+                />
+              )}
+              <Button
+                text={commonI18n.cancel()}
+                color={'white'}
+                size={'s'}
+                onClick={handleCancel}
+                disabled={versionLoading}
+                className={moduleStyles.actionButton}
+                type={'secondary'}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </FocusTrap>,
     document.body
   );
 };


### PR DESCRIPTION
Focus traps keep keyboard nav users from unknowingly tabbing out of the dialogs they've opened. Because we have an exit (x button) they can still leave easily and get to the rest of the site (a wcag requirement).

This looks like a lot of changes but it's only because the rest of the content gets nested and therefore indented! Edits are the import and the new <FocusTrap>

Before:

https://github.com/user-attachments/assets/21c20284-1263-439d-a73d-b86160eaf057



After:

https://github.com/user-attachments/assets/20c7afc6-11ab-4f22-818a-f0d86ed085d5



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1142

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
