### PR TITLE
Fix bug with deleting level starter assets

### DIFF
--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -64,7 +64,7 @@ class LevelStarterAssetsController < ApplicationController
   # but does not delete the asset from S3 as other levels may still be
   # using it.
   def destroy
-    if @level.remove_starter_asset!(params[:filename])
+    if @level.remove_starter_asset!("#{params[:filename]}.#{params[:format]}")
       return head :no_content
     else
       return head :unprocessable_entity

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -388,7 +388,7 @@ Dashboard::Application.routes.draw do
       member do
         get '/:filename', to: 'level_starter_assets#file', format: true
         post '', to: 'level_starter_assets#upload'
-        delete '/:filename', to: 'level_starter_assets#destroy'
+        delete '/:filename', to: 'level_starter_assets#destroy', format: true
       end
     end
 

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -224,7 +224,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
 
   test 'destroy: forbidden for non-levelbuilders' do
     sign_in create(:student)
-    delete :destroy, params: {level_name: create(:applab).name, filename: 'my-file.png'}
+    delete :destroy, params: {level_name: create(:applab).name, filename: 'my-file', format: 'png'}
 
     assert_response :forbidden
   end
@@ -233,7 +233,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     Rails.application.config.stubs(:levelbuilder_mode).returns(false)
 
     sign_in create(:levelbuilder)
-    delete :destroy, params: {level_name: create(:applab).name, filename: 'my-file.png'}
+    delete :destroy, params: {level_name: create(:applab).name, filename: 'my-file', format: 'png'}
 
     assert_response :forbidden
   end
@@ -242,18 +242,20 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     level = create :applab, starter_assets: {'my-file.png' => '123-abc.png'}
 
     sign_in create(:levelbuilder)
-    delete :destroy, params: {level_name: level.name, filename: 'my-file.png'}
+    delete :destroy, params: {level_name: level.name, filename: 'my-file', format: 'png'}
 
     assert_response :no_content
+    assert_nil level.reload.starter_assets
   end
 
   test 'destroy: returns no_content if starter asset does not exist' do
     level = create :applab, starter_assets: {'my-file.png' => '123-abc.png'}
 
     sign_in create(:levelbuilder)
-    delete :destroy, params: {level_name: level.name, filename: 'my-other-file.png'}
+    delete :destroy, params: {level_name: level.name, filename: 'my-other-file', format: 'png'}
 
     assert_response :no_content
+    assert level.reload.starter_assets.key?('my-file.png')
   end
 
   test 'destroy: raises if starter asset fails to be deleted' do
@@ -261,7 +263,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
 
     sign_in create(:levelbuilder)
     assert_raises ActiveRecord::RecordInvalid do
-      delete :destroy, params: {level_name: create(:applab).name, filename: 'my-file.png'}
+      delete :destroy, params: {level_name: create(:applab).name, filename: 'my-file', format: 'png'}
     end
   end
 end


### PR DESCRIPTION
The issue here was that we weren't using the file's extension when looking up the entry in the level's `starter_assets` hash. Without the extension, we just wouldn't delete anything since we didn't find a matching key. The fix is to pass through the `format` in the router and use that to do the lookup when deleting, similar to how we already use the `format` in the GET `file` function.

## Links

https://codedotorg.slack.com/archives/C03DBDN67B7/p1741999327375119?thread_ts=1741995297.515269&cid=C03DBDN67B7

## Testing story

Tested locally on Java Lab and App Lab levels