### PR TITLE
Make sure to include slash in disallowed routes

### DIFF
--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -855,8 +855,8 @@ module SharedConstants
     "/milestone/",
     "/projects/",
     "/sections/",
-    "/r",
-    "/c",
+    "/r/",
+    "/c/",
     "/oauth_sign_out/",
     "/certificates/"
   ].freeze


### PR DESCRIPTION
Noticed we had noindex on studio.code.org because the / at the end was forgotten on the /c and /r routes in the disallow list