### PR TITLE
feat(marketing): update placeholder text on FAQ Accordion and Carousel components

### DIFF
--- a/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
+++ b/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
@@ -20,15 +20,14 @@ export type VideoCarouselProps = {
 };
 
 const VideoCarousel: React.FC<VideoCarouselProps> = ({slides}) => {
-  // Workaround for the experience builder not working with Array
+  // Show placeholder text until a content entry is added
   if (slides == null) {
     return (
       <div style={{color: 'var(--text-neutral-primary)'}}>
         <em>
           <strong>✍ Video carousel placeholder.</strong> Please add a
           "Carousel" content type entry in the Content sidebar, save, and open
-          the preview tab to see the carousel. An empty carousel will show in
-          this editor, but it's here.
+          the preview tab to see the carousel in action.
         </em>
       </div>
     );

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
@@ -62,7 +62,7 @@ const FAQAccordionContentful: React.FunctionComponent<
     [faqs],
   );
 
-  // Show placeholder text until content entry is added
+  // Show placeholder text until a content entry is added
   if (!faqItems.length) {
     return (
       <div style={{color: 'var(--text-neutral-primary)'}}>

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
@@ -62,15 +62,14 @@ const FAQAccordionContentful: React.FunctionComponent<
     [faqs],
   );
 
-  // Workaround for the experience builder not working with Array
+  // Show placeholder text until content entry is added
   if (!faqItems.length) {
     return (
       <div style={{color: 'var(--text-neutral-primary)'}}>
         <em>
           <strong>✍ FAQ Accordion placeholder.</strong> Please add a "FAQs"
           content type entry in the FAQ Accordion sidebar, save, and open the
-          preview tab to see the carousel. An empty FAQ Accordion will show in
-          this editor, but it's here.
+          preview tab to see the accordions in action.
         </em>
       </div>
     );


### PR DESCRIPTION
Updates the placeholder text when a Carousel or FAQ Accordion component is first dragged into the Experiences editor in Contentful.

## Links
Jira ticket: [CMS-428](https://codedotorg.atlassian.net/browse/CMS-428)

## Testing story
Tested locally in Contentful

----

<img width="1691" alt="Screenshot 2025-03-17 at 9 17 32 AM" src="https://github.com/user-attachments/assets/01c51010-6ab7-466e-af53-8856ecfd6b30" />
