### PR TITLE
Revert "Revert "Fix School Info Confirmation dialog when user confirms they work at the same school""

### DIFF
--- a/apps/src/schoolInfo/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/schoolInfo/SchoolInfoConfirmationDialog.jsx
@@ -6,6 +6,7 @@ import Button from '@cdo/apps/legacySharedComponents/Button';
 import Dialog, {Body} from '@cdo/apps/legacySharedComponents/Dialog';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
@@ -49,9 +50,7 @@ class SchoolInfoConfirmationDialog extends Component {
   static propTypes = {
     schoolName: PropTypes.string,
     scriptData: PropTypes.shape({
-      formUrl: PropTypes.string.isRequired,
-      authTokenName: PropTypes.string.isRequired,
-      authTokenValue: PropTypes.string.isRequired,
+      usIp: PropTypes.bool.isRequired,
       existingSchoolInfo: PropTypes.shape({
         id: PropTypes.number,
         user_school_info_id: PropTypes.number,
@@ -86,20 +85,21 @@ class SchoolInfoConfirmationDialog extends Component {
     this.props.onClose();
   };
 
-  handleClickYes = () => {
+  handleClickYes = async () => {
     analyticsReporter.sendEvent(
       EVENTS.CONFIRM_SCHOOL_CLICKED,
       {},
       PLATFORMS.BOTH
     );
-    const {authTokenName, authTokenValue} = this.props.scriptData;
     const formData = new FormData();
-    formData.append(authTokenName, authTokenValue);
     fetch(
       `/api/v1/user_school_infos/${this.props.scriptData.existingSchoolInfo.user_school_info_id}/update_last_confirmation_date`,
       {
         method: 'PATCH',
         body: formData,
+        headers: {
+          'X-CSRF-Token': await getAuthenticityToken(),
+        },
       }
     )
       .then(this.closeModal)

--- a/apps/src/schoolInfo/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/schoolInfo/SchoolInfoConfirmationDialog.jsx
@@ -92,20 +92,21 @@ class SchoolInfoConfirmationDialog extends Component {
       PLATFORMS.BOTH
     );
     const formData = new FormData();
-    fetch(
-      `/api/v1/user_school_infos/${this.props.scriptData.existingSchoolInfo.user_school_info_id}/update_last_confirmation_date`,
-      {
-        method: 'PATCH',
-        body: formData,
-        headers: {
-          'X-CSRF-Token': await getAuthenticityToken(),
-        },
-      }
-    )
-      .then(this.closeModal)
-      .catch(error => {
-        this.setState({error});
-      });
+    try {
+      await fetch(
+        `/api/v1/user_school_infos/${this.props.scriptData.existingSchoolInfo.user_school_info_id}/update_last_confirmation_date`,
+        {
+          method: 'PATCH',
+          body: formData,
+          headers: {
+            'X-CSRF-Token': await getAuthenticityToken(),
+          },
+        }
+      );
+      this.closeModal();
+    } catch (error) {
+      this.setState({error});
+    }
   };
 
   handleClickUpdate = () => {

--- a/apps/src/schoolInfo/SchoolInfoConfirmationDialog.story.jsx
+++ b/apps/src/schoolInfo/SchoolInfoConfirmationDialog.story.jsx
@@ -20,9 +20,7 @@ const Template = args => <SchoolInfoConfirmationDialog {...args} />;
 export const DisplaySchoolInfoConfirmationDialog = Template.bind({});
 DisplaySchoolInfoConfirmationDialog.args = {
   scriptData: {
-    formUrl: '',
-    authTokenName: 'auth_token',
-    authTokenValue: 'fake_auth_token',
+    usIp: false,
     existingSchoolInfo: {},
   },
   onClose: action('onClose callback'),

--- a/apps/src/schoolInfo/SchoolInfoInterstitial.story.jsx
+++ b/apps/src/schoolInfo/SchoolInfoInterstitial.story.jsx
@@ -20,9 +20,6 @@ const Template = args => <SchoolInfoInterstitial {...args} />;
 export const Overview = Template.bind({});
 Overview.args = {
   scriptData: {
-    formUrl: '',
-    authTokenName: 'auth_token',
-    authTokenValue: 'fake_auth_token',
     usIp: false,
     existingSchoolInfo: {
       country: '',

--- a/apps/test/unit/schoolInfo/SchoolInfoConfirmationDialogTest.js
+++ b/apps/test/unit/schoolInfo/SchoolInfoConfirmationDialogTest.js
@@ -8,12 +8,14 @@ import SchoolInfoInterstitial from '@cdo/apps/schoolInfo/SchoolInfoInterstitial'
 
 import {expect} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
+jest.mock('@cdo/apps/util/AuthenticityTokenStore', () => ({
+  getAuthenticityToken: jest.fn().mockResolvedValue('authToken'),
+}));
+
 describe('SchoolInfoConfirmationDialog', () => {
   const MINIMUM_PROPS = {
     scriptData: {
-      formUrl: '',
-      authTokenName: 'auth_token',
-      authTokenValue: 'fake_auth_token',
+      usIp: true,
       existingSchoolInfo: {},
     },
     onClose: function () {},
@@ -89,9 +91,8 @@ describe('SchoolInfoConfirmationDialog', () => {
       const onClose = sinon.spy();
       const wrapper = mount(
         <SchoolInfoConfirmationDialog
-          {...MINIMUM_PROPS}
           scriptData={{
-            ...MINIMUM_PROPS.scriptData,
+            usIp: true,
             existingSchoolInfo: {
               country: 'US',
             },
@@ -121,7 +122,7 @@ describe('SchoolInfoConfirmationDialog', () => {
 
         expect(wrapperInstance.handleClickYes).to.have.been.called;
         await setTimeout(() => {}, 50);
-        expect(onClose).to.have.been.called;
+        expect(await onClose).to.have.been.called;
         await setTimeout(() => {}, 50);
         expect(wrapper.state('showSchoolInterstitial')).to.be.false;
         handleClickYesSpy.restore();

--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -17,7 +17,7 @@ Feature: School Info Confirmation Dialog
 Scenario: School Info Confirmation Dialog
   # Teacher account is created with partial school info
   Given I create a teacher named "Teacher_Chuba" and go home
-   # Wait for homepage to load before reloading the page.
+  # Wait for homepage to load before reloading the page.
   Then I wait until element "h1" contains text "My Dashboard"
   # The date of the teacher's account is updated to 7 days ago to simulate time travel
   # This enables the condition (see school_info_interstitial helper.rb) that checks
@@ -47,7 +47,7 @@ Scenario: School Info Confirmation Dialog
   Then I reload the page
   And element ".modal-body" is visible
   Then I press "#yes-button" using jQuery
-  And element ".modal" is not visible
+  And I wait until element ".modal" is gone
 
   # One week later, the teacher does not see the prompt
   And eight days pass for user "Teacher_Chuba"

--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -42,13 +42,14 @@ Scenario: School Info Confirmation Dialog
   Then I reload the page
   And element ".modal" is not visible
 
-  # One year later, the teacher sees the school info confirmation dialog
+  # One year later, the teacher sees the school info confirmation dialog and confirms at the same school
   And one year passes for user "Teacher_Chuba"
   Then I reload the page
   And element ".modal-body" is visible
-  Then I press "#update-button" using jQuery
-  And element ".modal" is visible
-  Then element "#uitest-country-dropdown" has value "US"
-  Then element "#uitest-school-zip" has value "31513"
-  # value is school_id for "Appling County High School"
-  Then I wait until element "#uitest-school-dropdown" has the value "130006000010"
+  Then I press "#yes-button" using jQuery
+  And element ".modal" is not visible
+
+  # One week later, the teacher does not see the prompt
+  And eight days pass for user "Teacher_Chuba"
+  Then I reload the page
+  And element ".modal" is not visible


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#64598.

This PR reinstates the code from [this PR](https://github.com/code-dot-org/code-dot-org/pull/64534) with a couple changes:
- As some feedback from Wilkie, this PR wraps the `fetch` call in a `try/catch` block rather than using the fetch's `.then/.catch` so that if `getAuthenticityToken` fails it is caught
   - Change: [here](https://github.com/code-dot-org/code-dot-org/pull/64600/files#diff-511a7e1f2ffbf1f915098e9eb44faf38988de43443fb08ef8f9bbc27429afd72R95-R109)
- After it merged, [the original PR](https://github.com/code-dot-org/code-dot-org/pull/64534) caused a [UI test failure](https://codedotorg.slack.com/archives/C03CM903Y/p1742237148300529) from a race condition where the async function from the user clicking "Yes" didn't finish before the UI test checked to see if the modal had disappeared. This PR updates the UI test to wait for the modal to disappear after the user clicks "Yes"
   - Change: [here](https://github.com/code-dot-org/code-dot-org/pull/64600/files#diff-bafcd8d6ce45b1a9c6cb160da56a89e49284543e52f7d50b68a12328308d8d28R50)

