### PR TITLE
feat(Divider): change default spacing to medium

### DIFF
--- a/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
@@ -31,7 +31,7 @@ export const DividerContentfulComponentDefinition: ComponentDefinition = {
     margin: {
       displayName: 'Margin',
       type: 'Text',
-      defaultValue: 'none',
+      defaultValue: 'm',
       group: 'style',
       validations: {
         in: [


### PR DESCRIPTION
Changes the default spacing on the Divider component to medium so it's easier to see when dragging into the editor.

## Links
Jira ticket: [CMS-435](https://codedotorg.atlassian.net/browse/CMS-435)

## Testing story
Tested locally in Contentful

----

## Before


https://github.com/user-attachments/assets/8da91f0e-3122-4474-8217-3d352285a40e


## After

https://github.com/user-attachments/assets/849ece57-7da3-40e1-8199-f0fcea5509cb

