### PR TITLE
Gen AI Spanish: add customizing-llms-latm-pilot script

### DIFF
--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -101,7 +101,7 @@ module AichatSafetyHelper
     end
 
     private def get_safety_system_prompt(level_id)
-      spanish_script_name = 'gen-ai-spanish-test-a-unit'
+      spanish_script_names = ['gen-ai-spanish-test-a-unit', 'customizing-llms-latm-pilot']
 
       in_spanish_script = false
       if level_id
@@ -109,9 +109,9 @@ module AichatSafetyHelper
         bubble_choice_parents = BubbleChoice.parent_levels(level.name)
 
         any_parent_in_spanish_script = bubble_choice_parents.any? do |pl|
-          pl.script_levels.any? {|sl| sl.script.name == spanish_script_name}
+          pl.script_levels.any? {|sl| spanish_script_names.include?(sl.script.name)}
         end
-        level_in_spanish_script = level.script_levels.any? {|sl| sl.script.name == spanish_script_name}
+        level_in_spanish_script = level.script_levels.any? {|sl| spanish_script_names.include?(sl.script.name)}
         in_spanish_script = any_parent_in_spanish_script || level_in_spanish_script
       end
 

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -101,7 +101,7 @@ module AichatSafetyHelper
     end
 
     private def get_safety_system_prompt(level_id)
-      spanish_script_names = ['gen-ai-spanish-test-a-unit', 'customizing-llms-latm-pilot']
+      spanish_script_names = ['customizing-llms-latm-pilot']
 
       in_spanish_script = false
       if level_id

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -657,6 +657,7 @@ class Section < ApplicationRecord
       exploring-gen-ai2-2024
       foundations-gen-ai-2024
       customizing-llms-2024
+      customizing-llms-latm-pilot
     ]
     gen_ai_course = 'exploring-gen-ai-2024'
 

--- a/dashboard/test/helpers/aichat_safety_helper_test.rb
+++ b/dashboard/test/helpers/aichat_safety_helper_test.rb
@@ -61,6 +61,9 @@ class AichatSafetyHelperTest < ActionView::TestCase
     AichatComprehendHelper.stubs(:get_toxicity).returns(@comprehend_response)
     mock_response = create_stubbed_response(@openai_response_profanity_json)
     OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
+
+    @english_script = create(:script, :with_levels, name: 'customizing-llms-2024')
+    @spanish_script = create(:script, :with_levels, name: 'customizing-llms-latm-pilot')
   end
 
   ROLES.each do |role|
@@ -123,6 +126,28 @@ class AichatSafetyHelperTest < ActionView::TestCase
     assert_raises do
       AichatSafetyHelper.find_toxicity('user', 'clean message', 'en', nil)
     end
+  end
+
+  test "Open AI safety check uses American safety prompt if not in Spanish script" do
+    stub_safety_services('openai', 'user')
+
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).with do |messages, _|
+      assert_includes messages[0][:content], "American"
+      return true
+    end
+
+    AichatSafetyHelper.find_toxicity('user', 'clean message', 'en', @english_script.levels.first)
+  end
+
+  test "Open AI safety check uses Spanish safety prompt if in Spanish script" do
+    stub_safety_services('openai', 'user')
+
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).with do |messages, _|
+      assert_includes messages[0][:content], "Spanish"
+      return true
+    end
+
+    AichatSafetyHelper.find_toxicity('user', 'clean message', 'en', @spanish_script.levels.first)
   end
 
   def stub_safety_services(enabled_service, enabled_role)


### PR DESCRIPTION
Add `customizing-llms-latm-pilot` script to the list of Spanish scripts supported in Gen AI. Spanish language scripts receive a slightly different system safety prompt.

## Links

https://codedotorg.slack.com/archives/C06FELVTV0Q/p1742233038431559

## Testing story

Unit tests