### PR TITLE
Add starter assets to AI Chat level type

### DIFF
--- a/dashboard/app/models/levels/aichat.rb
+++ b/dashboard/app/models/levels/aichat.rb
@@ -31,6 +31,7 @@ class Aichat < Level
     bot_title
     bot_description
     aichat_settings
+    starter_assets
   )
 
   def self.create_from_level_builder(params, level_params)
@@ -46,5 +47,25 @@ class Aichat < Level
 
   def uses_lab2?
     true
+  end
+
+  # Add a starter asset to the level and save it in properties.
+  # Starter assets are stored as an object, where the key is the
+  # friendly filename and the value is the UUID filename stored in S3:
+  # {
+  #   # friendly_name => uuid_name
+  #   "welcome.png" => "123-abc-456.png"
+  # }
+  def add_starter_asset!(friendly_name, uuid_name)
+    self.starter_assets ||= {}
+    self.starter_assets[friendly_name] = uuid_name
+    save!
+  end
+
+  # Remove a starter asset by its key (friendly_name) from the level's properties.
+  def remove_starter_asset!(friendly_name)
+    return true unless starter_assets
+    starter_assets.delete(friendly_name)
+    save!
   end
 end


### PR DESCRIPTION
Add the `starter_assets` field to the AI Chat level type, along with relevant add/delete functions. This is just copied from existing implementations in `javalab.rb` and `applab.rb`.

## Links

Part of https://codedotorg.atlassian.net/browse/LABS-1387

## Testing story

Tested locally.

## Deployment strategy

## Follow-up work

See https://codedotorg.atlassian.net/browse/LABS-1387 for overall list of tasks.