### PR TITLE
Revert "Update Code.org logo to inverse version in header nav"

### DIFF
--- a/dashboard/app/assets/images/logo-inverse.svg
+++ b/dashboard/app/assets/images/logo-inverse.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06b5d0700d7954228dcd46c56b1412e437359f3b79626838b60cb0fbcdbe9b72
-size 5181

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -76,9 +76,9 @@
       .header_left
         .header_logo
           - if current_user
-            = link_to(image_tag('logo-inverse.svg', alt: I18n.t(:code_org_logo_alt)), home_path, {id: "logo_home_link"})
+            = link_to(image_tag('logo.svg', alt: I18n.t(:code_org_logo_alt)), home_path, {id: "logo_home_link"})
           - else
-            = link_to(image_tag('logo-inverse.svg', alt: I18n.t(:code_org_logo_alt)), CDO.code_org_url(ge_region: request.ge_region), {id: "logo_home_link"})
+            = link_to(image_tag('logo.svg', alt: I18n.t(:code_org_logo_alt)), CDO.code_org_url(ge_region: request.ge_region), {id: "logo_home_link"})
 
       .header_middle{dir: locale_dir}
         - if should_show_progress || level

--- a/pegasus/sites.v3/code.org/public/images/logo-inverse.svg
+++ b/pegasus/sites.v3/code.org/public/images/logo-inverse.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06b5d0700d7954228dcd46c56b1412e437359f3b79626838b60cb0fbcdbe9b72
-size 5181
+oid sha256:222a889fd3ccb3b7caa0b206f453e48173f12fcc78ad7eee7324e1664a3d73f4
+size 4497

--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -28,7 +28,7 @@
   .left
     -# rubocop:disable CustomCops/DashboardDbUsage
     %a{href: current_user ? CDO.studio_url("/home") : CDO.code_org_url}
-      %img.logo{src: '/images/logo-inverse.svg', alt: I18n.t(:code_org_logo_alt)}
+      %img.logo{src: '/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
     -# rubocop:enable CustomCops/DashboardDbUsage
     %ul#headerlinks
       - Hamburger.get_header_contents(header_contents_options).each do |entry|


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#64594

Issue with GitHub is preventing DTTs so reverting for now and will merge another time when we have more headroom to accept new Eyes baselines. 