### PR TITLE
Lab2: remove setUpWithoutLevel

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -48,7 +48,6 @@ import {getPredictResponse} from './projects/userLevelsApi';
 import {setProjectTooLarge} from './redux/lab2ProjectRedux';
 import {LevelPropertiesValidator} from './responseValidators';
 import {
-  AppName,
   Channel,
   LevelProperties,
   ProjectManagerStorageType,
@@ -281,54 +280,6 @@ export const setUpWithLevel = createAsyncThunk<
   }
 });
 
-// Given a channel id and app name as the payload, set up the lab for that channel id.
-// This consists of cleaning up the existing project manager (if applicable), then
-// creating a project manager and loading the project data.
-// This method is used for loading a lab that is not associated with a level.
-// (This was previously used for /projectbeats).
-// If we get an aborted signal, we will exit early.
-export const setUpWithoutLevel = createAsyncThunk(
-  'lab/setUpWithoutLevel',
-  async (payload: {channelId: string; appName: AppName}, thunkAPI) => {
-    try {
-      // Update properties for reporting as early as possible in case of errors.
-      Lab2Registry.getInstance().getMetricsReporter().updateProperties({
-        channelId: payload.channelId,
-        appName: payload.appName,
-      });
-
-      await cleanUpProjectManager();
-
-      Lab2Registry.getInstance().setAppName(payload.appName);
-
-      // Create the new project manager.
-      const projectManager = ProjectManagerFactory.getProjectManager(
-        ProjectManagerStorageType.REMOTE,
-        payload.channelId
-      );
-      Lab2Registry.getInstance().setProjectManager(projectManager);
-
-      // Load channel and source.
-      const {sources, channel} = await setUpAndLoadProject(
-        projectManager,
-        thunkAPI.dispatch
-      );
-      setProjectAndLevelData(
-        {
-          initialSources: sources,
-          channel,
-          levelProperties: {id: 0, name: '', appName: payload.appName},
-        },
-        thunkAPI.signal.aborted,
-        thunkAPI.dispatch,
-        thunkAPI.getState as () => RootState
-      );
-    } catch (error) {
-      return thunkAPI.rejectWithValue(error);
-    }
-  }
-);
-
 // Selectors
 
 // If any load is currently in progress.
@@ -463,24 +414,6 @@ const labSlice = createSlice({
       }
     });
     builder.addCase(setUpWithLevel.pending, state => {
-      state.isLoadingProjectOrLevel = true;
-    });
-    builder.addCase(setUpWithoutLevel.fulfilled, state => {
-      state.isLoadingProjectOrLevel = false;
-    });
-    builder.addCase(setUpWithoutLevel.rejected, (state, action) => {
-      // If the set up was aborted, that means another load got started
-      // before we finished. Therefore we only set loading to false
-      // and set the page error if the action was not aborted.
-      if (!action.meta.aborted) {
-        state.isLoadingProjectOrLevel = false;
-        state.pageError = getErrorFromThunkAction(
-          action,
-          'setUpWithoutLevel failed'
-        );
-      }
-    });
-    builder.addCase(setUpWithoutLevel.pending, state => {
       state.isLoadingProjectOrLevel = true;
     });
   },

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -18,7 +18,6 @@ import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {
   isReadOnlyWorkspace,
   setUpWithLevel,
-  setUpWithoutLevel,
   shouldHideShareAndRemix,
 } from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -86,11 +85,6 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
           channelId,
         })
       );
-    } else if (channelId && appName) {
-      // Otherwise, if we have a channel id, set up the lab using the channel id.
-      // This path should only be used for lab pages that don't have a level, such as
-      // /projectbeats previously. App name also must be provided if using this path.
-      promise = dispatch(setUpWithoutLevel({channelId, appName}));
     }
     return () => {
       // If we have an early return, we will abort the promise in progress.


### PR DESCRIPTION
`setUpWithoutLevel` was used for the now-defunct `/projectbeats` page. We think it's unlikely we will need a lab2 lab without a level going forward, so we can get rid of this code path at this point. There was a small maintenance cost to keep the function working.

## Links

- jira ticket: [CT-1145](https://codedotorg.atlassian.net/browse/CT-1145)


## Testing story
Tested that lab2 labs still work after this change.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
