### PR TITLE
Lab2: prevent HTML body from scrolling

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -86,6 +86,13 @@ body.background-dark, body.background-light {
   }
 }
 
+// For modern Lab2 labs, prevent the entire body from scrolling.
+// All content is typically displayed on the page at once, and
+// internal components manage their own scroll behavior.
+body:has(#lab2-container) {
+  overflow: hidden;
+}
+
 h1 {
   @include main-font-bold;
   font-size: 32px;


### PR DESCRIPTION
In some Lab2 scenarios (ex: when a tooltip is rendered partially offscreen), the whole document body can scroll leading to slightly weird UI (scrollbar pushing up content, header scrolling offscreen). Generally speaking, labs tend to have all their content rendered on the page at once, with sub-components managing their own scrolling (e.g. code workspace, visualization area, etc). And even in scenarios when we want the whole body of a lab to scroll (ex. on content levels like bubble choice or multiple choice), I would expect that the header still remain fixed, and only the workspace area scroll.

Turns out that legacy labs manually apply an `overflow: hidden` to the document `body` in StudioApp.js ([source](https://github.com/code-dot-org/code-dot-org/blob/532aa3841d6c50d234a0fdb9bd616ecfdb51d169/apps/src/StudioApp.js#L2234)). I think it would make sense for Lab2 labs to be able to make the assumption; though instead of doing it programmatically in JS, this change does it via CSS in `application.scss`, only applying to the `body` if it contains the `#lab2-container` element.

Before:
<img width="1512" alt="Screenshot 2025-03-17 at 3 22 06 PM (2)" src="https://github.com/user-attachments/assets/e5921712-6c17-4aa0-93a6-9b4bc0dd27d5" />

After:
<img width="1512" alt="Screenshot 2025-03-17 at 3 22 51 PM (2)" src="https://github.com/user-attachments/assets/2a524518-8431-4978-9b88-933deec1e66b" />


## Testing story

Tested locally with AI Chat tooltips (not sure if there are any other repro cases). Tested other Lab2 labs at various window sizes and didn't notice any regressions.