### PR TITLE
Neighborhood: track has_paint calls for validation

### DIFF
--- a/apps/lib/pyodide/neighborhood-0.3.0-py3-none-any.whl
+++ b/apps/lib/pyodide/neighborhood-0.3.0-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82ddbb871fe793ac9452cfc9e33f59fec598592d0359c9ec4eda4a070c557b22
-size 16171

--- a/apps/lib/pyodide/neighborhood-0.4.0-py3-none-any.whl
+++ b/apps/lib/pyodide/neighborhood-0.4.0-py3-none-any.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d637904fda1888af098b691a5f350996ad26e57aa625ab78eee20f669e2bdc8b
+size 16196

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -172,7 +172,7 @@ async function loadPackages() {
       // python/pythonlab/ folder in the codebase.
       `/blockly/js/pyodide/${version}/unittest_runner-0.2.0-py3-none-any.whl`,
       `/blockly/js/pyodide/${version}/pythonlab_setup-0.2.0-py3-none-any.whl`,
-      `/blockly/js/pyodide/${version}/neighborhood-0.3.0-py3-none-any.whl`,
+      `/blockly/js/pyodide/${version}/neighborhood-0.4.0-py3-none-any.whl`,
     ],
     {
       errorCallback: (message: string) => {

--- a/python/pythonlab/neighborhood/neighborhood/painter.py
+++ b/python/pythonlab/neighborhood/neighborhood/painter.py
@@ -154,9 +154,9 @@ class Painter:
     Returns:
       True if the painter has any paint in their personal bucket
     """
-    if self.has_infinite_paint:
-      return True
-    return self.remaining_paint > 0
+    has_paint = self.has_infinite_paint or self.remaining_paint > 0
+    self._send_boolean_message(NeighborhoodSignalKey.HAS_PAINT, has_paint)
+    return has_paint
   
   def can_move(self, direction=None):
     """

--- a/python/pythonlab/neighborhood/neighborhood/support/neighborhood_signal_key.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/neighborhood_signal_key.py
@@ -14,3 +14,4 @@ class NeighborhoodSignalKey(Enum):
   IS_ON_BUCKET = "IS_ON_BUCKET"
   IS_ON_PAINT = "IS_ON_PAINT"
   CAN_MOVE = "CAN_MOVE"
+  HAS_PAINT = "HAS_PAINT"

--- a/python/pythonlab/neighborhood/pyproject.toml
+++ b/python/pythonlab/neighborhood/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neighborhood"
-version = "0.3.0"
+version = "0.4.0"
 requires-python = '>=3.12'
 dependencies = []
 

--- a/python/pythonlab/neighborhood/tests/support/constants.py
+++ b/python/pythonlab/neighborhood/tests/support/constants.py
@@ -2,3 +2,20 @@
 SAMPLE_MAZE = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
 ALL_PASSABLE_MAZE = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
 BUCKET_MAZE = '[[{"tileType":1,"value":3,"assetId":303},{"tileType":1,"value":1,"assetId":0}],[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
+
+def get_large_maze():
+  passable_tile = '{"tileType":1,"value":0,"assetId":0}'
+  maze_str = '[['
+  for row in range(20):
+    for col in range(20):
+      maze_str += passable_tile
+      if col < 19:
+        maze_str += ','
+    maze_str += ']'
+    if row < 19:
+      maze_str += ',['
+  maze_str += ']'
+  return maze_str
+  
+
+LARGE_MAZE = get_large_maze()

--- a/python/pythonlab/neighborhood/tests/test_painter.py
+++ b/python/pythonlab/neighborhood/tests/test_painter.py
@@ -1,7 +1,7 @@
 from neighborhood.painter import Painter
 from neighborhood.support.world import World
 from neighborhood.support.neighborhood_context_type import NeighborhoodContextType
-from support.constants import SAMPLE_MAZE, ALL_PASSABLE_MAZE, BUCKET_MAZE
+from support.constants import SAMPLE_MAZE, ALL_PASSABLE_MAZE, BUCKET_MAZE, LARGE_MAZE
 
 def setUp():
   world = World()
@@ -126,3 +126,13 @@ def test_can_move():
   assert painter.can_move() is True
   painter.move() # Now painter is on 1,0.
   assert painter.can_move("east") is False
+
+def test_has_paint_large_maze():
+  # In a large maze, the painter has infinite paint, so has_paint should always return true.
+  world = World()
+  world.set_grid_from_string(LARGE_MAZE)
+  painter = Painter()
+  assert painter.has_paint() is True
+  painter.paint("green")
+  painter.paint("blue")
+  assert painter.has_paint() is True

--- a/uv.lock
+++ b/uv.lock
@@ -526,7 +526,7 @@ wheels = [
 
 [[package]]
 name = "neighborhood"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "python/pythonlab/neighborhood" }
 
 [package.dev-dependencies]


### PR DESCRIPTION
It seems there is a desire for calls to `has_paint` to be tracked in neighborhood validation. This adds that tracking.

## Links
- jira ticket: [CT-1146](https://codedotorg.atlassian.net/browse/CT-1146)


## Testing story
Tested locally and added a unit test for the refactored has_paint method.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
