### PR TITLE
Evaluate Student Learning: add evaluations of student code to dataset maker

### DIFF
--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -1,4 +1,5 @@
 import Button from '@code-dot-org/component-library/button';
+import Checkbox from '@code-dot-org/component-library/checkbox';
 import TextField from '@code-dot-org/component-library/textField';
 import Papa from 'papaparse';
 import React, {useState} from 'react';
@@ -8,14 +9,20 @@ import {fetchStudentCodeSamples} from './StudentCodeSamplesApi';
 interface StudentCodeSample {
   projectId: string;
   studentCode: string | undefined;
+  codeVersion?: string;
   userId: number | undefined;
+  aiEvaluation?: string;
+  aiReasoning?: string;
+  evaluationCriteria?: string;
 }
 
 const StudentCodeDatasetMaker: React.FC = () => {
   const [datasetName, setDatasetName] = useState<string>('');
   const [levelId, setLevelId] = useState<string>('');
-  const [scriptId, setScriptId] = useState<string>('');
+  const [unitId, setUnitId] = useState<string>('');
   const [numSamples, setNumSamples] = useState<string>('25');
+  const [includeAiEvaluations, setIncludeAiEvaluations] =
+    useState<boolean>(false);
   const [pending, setPending] = useState<boolean>(false);
   const [fetchedSamples, setFetchedSamples] = useState<StudentCodeSample[]>([]);
 
@@ -31,11 +38,13 @@ const StudentCodeDatasetMaker: React.FC = () => {
 
   const getStudentCodeSamples = async () => {
     setPending(true);
-    const codeSamples = await fetchStudentCodeSamples(
-      Number(numSamples),
-      Number(scriptId),
-      Number(levelId)
-    );
+    const studentWorkRequest = {
+      includeAiEvaluations: includeAiEvaluations,
+      numSamples: Number(numSamples),
+      unitId: Number(unitId),
+      levelId: Number(levelId),
+    };
+    const codeSamples = await fetchStudentCodeSamples(studentWorkRequest);
     setFetchedSamples(codeSamples as unknown as StudentCodeSample[]);
     setPending(false);
   };
@@ -52,13 +61,19 @@ const StudentCodeDatasetMaker: React.FC = () => {
           value={levelId}
         />
         <TextField
-          name="Script Id"
-          label="Script Id"
-          onChange={e => setScriptId(e.target.value)}
-          value={scriptId}
+          name="Unit Id"
+          label="Unit Id"
+          onChange={e => setUnitId(e.target.value)}
+          value={unitId}
         />
         <br />
         <br />
+        <Checkbox
+          name="include AI evaluations"
+          label="Include AI evaluations"
+          onChange={() => setIncludeAiEvaluations(!includeAiEvaluations)}
+          checked={includeAiEvaluations}
+        />
         <TextField
           name="Number of Samples"
           label="How many samples of student work do you want?"

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeSamplesApi.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeSamplesApi.tsx
@@ -1,21 +1,24 @@
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
+interface StudentWorkRequest {
+  includeAiEvaluations: boolean;
+  numSamples: number;
+  unitId: number;
+  levelId: number;
+}
+
 export async function fetchStudentCodeSamples(
-  numSamples: number,
-  scriptId: number,
-  levelId: number
+  studentWorkRequest: StudentWorkRequest
 ): Promise<string | null> {
   try {
-    const response = await fetch(
-      `/student_code_sample/${numSamples}/${scriptId}/${levelId}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': await getAuthenticityToken(),
-        },
-      }
-    );
+    const response = await fetch(`/student_code_samples`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': await getAuthenticityToken(),
+      },
+      body: JSON.stringify(studentWorkRequest),
+    });
     if (!response.ok) {
       throw new Error('Network response was not ok');
     }

--- a/dashboard/app/controllers/student_code_sample_controller.rb
+++ b/dashboard/app/controllers/student_code_sample_controller.rb
@@ -8,8 +8,18 @@ class StudentCodeSampleController < ApplicationController
     num_samples = student_code_sample_params[:num_samples].to_i
 
     return render json: [] if num_samples == 0
-    check_valid_level(level_id)
-    check_valid_unit(unit_id)
+
+    begin
+      Level.find(level_id)
+    rescue ActiveRecord::RecordNotFound
+      return render status: :not_found, json: "Level with id #{level_id}"
+    end
+
+    begin
+      Unit.find(unit_id)
+    rescue ActiveRecord::RecordNotFound
+      return render status: :not_found, json: "Unit with id #{unit_id}"
+    end
 
     if student_code_sample_params[:include_ai_evaluations]
       fetch_student_code_samples_with_evaluations(level_id, unit_id, num_samples)
@@ -75,40 +85,26 @@ class StudentCodeSampleController < ApplicationController
     user_level = UserLevel.where(user_id: user_id, level_id: level_id, script_id: unit_id).last
     if user_level && channel_token
       storage_app_id = channel_token.storage_app_id
-      token = storage_encrypt_channel_id(storage_id, storage_app_id)
-      _owner_storage_id, project_id = storage_decrypt_channel_id(token)
-      s3_filename = "#{base_dir}/#{storage_id}/#{project_id}/main.json"
+      channel_id = storage_encrypt_channel_id(storage_id, storage_app_id)
+      s3_filename = "#{base_dir}/#{storage_id}/#{storage_app_id}/main.json"
       s3_args = {bucket: bucket, key: s3_filename}
       s3_args[:version_id] = code_version if code_version
       body = s3.get_object(s3_args)[:body].read
       student_code = JSON.parse(body)['source'] if body
     end
     {
-      project_id: token,
+      project_id: channel_id,
       code_version: code_version,
       student_code: student_code,
     }
   end
 
-  def check_valid_level(level_id)
-    Level.find(level_id)
-  rescue ActiveRecord::RecordNotFound
-    return render status: :not_found, json: "Level with id #{level_id}"
-  end
-
-  def check_valid_unit(unit_id)
-    Unit.find(unit_id)
-  rescue ActiveRecord::RecordNotFound
-    return render status: :not_found, json: "Unit with id #{unit_id}"
-  end
-
   def student_code_sample_params
-    student_code_sample_params = params.transform_keys(&:underscore).permit(
+    params.transform_keys(&:underscore).permit(
       :level_id,
       :unit_id,
       :num_samples,
       :include_ai_evaluations,
     )
-    student_code_sample_params
   end
 end

--- a/dashboard/app/controllers/student_code_sample_controller.rb
+++ b/dashboard/app/controllers/student_code_sample_controller.rb
@@ -3,45 +3,32 @@ class StudentCodeSampleController < ApplicationController
 
   # GET /student_code_sample/fetch_student_code_samples
   def fetch_student_code_samples
-    level_id = params[:level_id]
-    script_id = params[:script_id]
-    num_samples = params[:num_samples].to_i
+    level_id = student_code_sample_params[:level_id]
+    unit_id = student_code_sample_params[:unit_id]
+    num_samples = student_code_sample_params[:num_samples].to_i
 
     return render json: [] if num_samples == 0
+    check_valid_level(level_id)
+    check_valid_unit(unit_id)
 
-    begin
-      Level.find(level_id)
-    rescue ActiveRecord::RecordNotFound
-      return render status: :not_found, json: "Level with id #{level_id}"
+    if student_code_sample_params[:include_ai_evaluations]
+      fetch_student_code_samples_with_evaluations(level_id, unit_id, num_samples)
+    else
+      fetch_student_code_samples_without_evaluations(level_id, unit_id, num_samples)
     end
+  end
 
-    begin
-      Unit.find(script_id)
-    rescue ActiveRecord::RecordNotFound
-      return render status: :not_found, json: "Script with id #{script_id}"
-    end
-
-    s3 = Aws::S3::Client.new
-    bucket = CDO.sources_s3_bucket
-    base_dir = CDO.sources_s3_directory
+  def fetch_student_code_samples_without_evaluations(level_id, unit_id, num_samples)
     # We want to pull samples from students who have been assigned to work on the level.
-    sections = Section.where(script_id: params[:script_id].to_i)
-    student_ids = include_evaluations ? evaluations.pluck(:user_id) : Follower.where(section: sections).pluck(:student_user_id)
+    sections = Section.where(script_id: unit_id)
+    student_ids = Follower.where(section: sections).pluck(:student_user_id)
     code_samples = []
     have_enough_samples = false
     student_ids.each do |student_id|
       unless have_enough_samples
-        storage_id = storage_id_for_user_id(student_id)
-        channel_token = ChannelToken.where(storage_id: storage_id, level_id: level_id, script_id: script_id).last
-        user_level = UserLevel.where(user_id: student_id, level_id: level_id, script_id: script_id).last
-        if user_level && channel_token
-          storage_app_id = channel_token.storage_app_id
-          token = storage_encrypt_channel_id(storage_id, storage_app_id)
-          _owner_storage_id, project_id = storage_decrypt_channel_id(token)
-          s3_filename = "#{base_dir}/#{storage_id}/#{project_id}/main.json"
-          body = s3.get_object(bucket: bucket, key: s3_filename)[:body].read
-          student_code = JSON.parse(body)['source'] if body
-          code_samples << {level_id: level_id, script_id: script_id, user_id: student_id, project_id: token, student_code: student_code}
+        student_code = get_student_code(student_id, level_id, unit_id)
+        if student_code[:student_code]
+          code_samples << {level_id: level_id, unit_id: unit_id, user_id: student_id, project_id: student_code[:project_id], student_code: student_code[:student_code]}
         end
         have_enough_samples = code_samples.length >= num_samples
       end
@@ -49,65 +36,77 @@ class StudentCodeSampleController < ApplicationController
     render json: code_samples
   end
 
-  # GET /student_code_sample/fetch_evaluated_student_code_samples
-  def fetch_evaluted_student_code_samples
-    level_id = params[:level_id]
-    script_id = params[:script_id]
-    num_samples = params[:num_samples].to_i
-
-    return render json: [] if num_samples == 0
-
-    begin
-      Level.find(level_id)
-    rescue ActiveRecord::RecordNotFound
-      return render status: :not_found, json: "Level with id #{level_id}"
-    end
-
-    begin
-      Unit.find(script_id)
-    rescue ActiveRecord::RecordNotFound
-      return render status: :not_found, json: "Script with id #{script_id}"
-    end
-
-    evaluations = UserLevelEvaluation.where(level_id: level_id, script_id: script_id)
+  def fetch_student_code_samples_with_evaluations(level_id, unit_id, num_samples)
+    evaluations = UserLevelEvaluation.where(level_id: level_id, script_id: unit_id)
     if evaluations.empty?
-      return render status: :not_found, json: "There are no evaluations for the level with id #{level_id} in script with id #{script_id}"
+      return render status: :not_found, json: "There are no evaluations for the level with id #{level_id} in unit with id #{unit_id}"
     end
-
-    s3 = Aws::S3::Client.new
-    bucket = CDO.sources_s3_bucket
-    base_dir = CDO.sources_s3_directory
-
     code_samples = []
     have_enough_samples = false
     evaluations.each do |evaluation|
-      student_id = evaluation.user_id
       unless have_enough_samples
-        storage_id = storage_id_for_user_id(student_id)
-        channel_token = ChannelToken.where(storage_id: storage_id, level_id: level_id, script_id: script_id).last
-        user_level = UserLevel.where(user_id: student_id, level_id: level_id, script_id: script_id).last
-        if user_level && channel_token
-          storage_app_id = channel_token.storage_app_id
-          token = storage_encrypt_channel_id(storage_id, storage_app_id)
-          _owner_storage_id, project_id = storage_decrypt_channel_id(token)
-          # TODO: figure out if this is the correct way to get the code from the s3 bucket if we have a version.
-          s3_filename = "#{base_dir}/#{storage_id}/#{project_id}/main.json?version=#{evaluation.code_version}`"
-          body = s3.get_object(bucket: bucket, key: s3_filename)[:body].read
-          student_code = JSON.parse(body)['source'] if body
+        student_code = get_student_code(evaluation.user_id, level_id, unit_id, evaluation.code_version)
+        if student_code[:student_code]
           code_samples << {
             level_id: level_id,
-            script_id: script_id,
-            user_id: student_id,
-            project_id: token,
-            student_code: student_code,
-            evaluation: evaluation.aiEvaluation,
-            reasoning: evaluation.aiReasoning,
-            criteria: evaluation.evaluationCriteria
+            unit_id: unit_id,
+            user_id: evaluation.user_id,
+            project_id: student_code[:project_id],
+            code_version: student_code[:code_version],
+            student_code: student_code[:student_code],
+            evaluation: evaluation.ai_evaluation,
+            reasoning: evaluation.ai_reasoning,
+            criteria: evaluation.evaluation_criteria
           }
         end
         have_enough_samples = code_samples.length >= num_samples
       end
     end
     render json: code_samples
+  end
+
+  def get_student_code(user_id, level_id, unit_id, code_version = nil)
+    s3 = Aws::S3::Client.new
+    bucket = CDO.sources_s3_bucket
+    base_dir = CDO.sources_s3_directory
+
+    storage_id = storage_id_for_user_id(user_id)
+    channel_token = ChannelToken.where(storage_id: storage_id, level_id: level_id, script_id: unit_id).last
+    user_level = UserLevel.where(user_id: user_id, level_id: level_id, script_id: unit_id).last
+    if user_level && channel_token
+      storage_app_id = channel_token.storage_app_id
+      token = storage_encrypt_channel_id(storage_id, storage_app_id)
+      _owner_storage_id, project_id = storage_decrypt_channel_id(token)
+      s3_filename = "#{base_dir}/#{storage_id}/#{project_id}/main.json"
+      body = s3.get_object(bucket: bucket, key: s3_filename, version_id: code_version)[:body].read
+      student_code = JSON.parse(body)['source'] if body
+    end
+    {
+      project_id: token,
+      code_version: code_version,
+      student_code: student_code,
+    }
+  end
+
+  def check_valid_level(level_id)
+    Level.find(level_id)
+  rescue ActiveRecord::RecordNotFound
+    return render status: :not_found, json: "Level with id #{level_id}"
+  end
+
+  def check_valid_unit(unit_id)
+    Unit.find(unit_id)
+  rescue ActiveRecord::RecordNotFound
+    return render status: :not_found, json: "Unit with id #{unit_id}"
+  end
+
+  def student_code_sample_params
+    student_code_sample_params = params.transform_keys(&:underscore).permit(
+      :level_id,
+      :unit_id,
+      :num_samples,
+      :include_ai_evaluations,
+    )
+    student_code_sample_params
   end
 end

--- a/dashboard/app/controllers/student_code_sample_controller.rb
+++ b/dashboard/app/controllers/student_code_sample_controller.rb
@@ -26,7 +26,7 @@ class StudentCodeSampleController < ApplicationController
     base_dir = CDO.sources_s3_directory
     # We want to pull samples from students who have been assigned to work on the level.
     sections = Section.where(script_id: params[:script_id].to_i)
-    student_ids = Follower.where(section: sections).pluck(:student_user_id)
+    student_ids = include_evaluations ? evaluations.pluck(:user_id) : Follower.where(section: sections).pluck(:student_user_id)
     code_samples = []
     have_enough_samples = false
     student_ids.each do |student_id|
@@ -42,6 +42,68 @@ class StudentCodeSampleController < ApplicationController
           body = s3.get_object(bucket: bucket, key: s3_filename)[:body].read
           student_code = JSON.parse(body)['source'] if body
           code_samples << {level_id: level_id, script_id: script_id, user_id: student_id, project_id: token, student_code: student_code}
+        end
+        have_enough_samples = code_samples.length >= num_samples
+      end
+    end
+    render json: code_samples
+  end
+
+  # GET /student_code_sample/fetch_evaluated_student_code_samples
+  def fetch_evaluted_student_code_samples
+    level_id = params[:level_id]
+    script_id = params[:script_id]
+    num_samples = params[:num_samples].to_i
+
+    return render json: [] if num_samples == 0
+
+    begin
+      Level.find(level_id)
+    rescue ActiveRecord::RecordNotFound
+      return render status: :not_found, json: "Level with id #{level_id}"
+    end
+
+    begin
+      Unit.find(script_id)
+    rescue ActiveRecord::RecordNotFound
+      return render status: :not_found, json: "Script with id #{script_id}"
+    end
+
+    evaluations = UserLevelEvaluation.where(level_id: level_id, script_id: script_id)
+    if evaluations.empty?
+      return render status: :not_found, json: "There are no evaluations for the level with id #{level_id} in script with id #{script_id}"
+    end
+
+    s3 = Aws::S3::Client.new
+    bucket = CDO.sources_s3_bucket
+    base_dir = CDO.sources_s3_directory
+
+    code_samples = []
+    have_enough_samples = false
+    evaluations.each do |evaluation|
+      student_id = evaluation.user_id
+      unless have_enough_samples
+        storage_id = storage_id_for_user_id(student_id)
+        channel_token = ChannelToken.where(storage_id: storage_id, level_id: level_id, script_id: script_id).last
+        user_level = UserLevel.where(user_id: student_id, level_id: level_id, script_id: script_id).last
+        if user_level && channel_token
+          storage_app_id = channel_token.storage_app_id
+          token = storage_encrypt_channel_id(storage_id, storage_app_id)
+          _owner_storage_id, project_id = storage_decrypt_channel_id(token)
+          # TODO: figure out if this is the correct way to get the code from the s3 bucket if we have a version.
+          s3_filename = "#{base_dir}/#{storage_id}/#{project_id}/main.json?version=#{evaluation.code_version}`"
+          body = s3.get_object(bucket: bucket, key: s3_filename)[:body].read
+          student_code = JSON.parse(body)['source'] if body
+          code_samples << {
+            level_id: level_id,
+            script_id: script_id,
+            user_id: student_id,
+            project_id: token,
+            student_code: student_code,
+            evaluation: evaluation.aiEvaluation,
+            reasoning: evaluation.aiReasoning,
+            criteria: evaluation.evaluationCriteria
+          }
         end
         have_enough_samples = code_samples.length >= num_samples
       end

--- a/dashboard/app/controllers/student_code_sample_controller.rb
+++ b/dashboard/app/controllers/student_code_sample_controller.rb
@@ -78,7 +78,9 @@ class StudentCodeSampleController < ApplicationController
       token = storage_encrypt_channel_id(storage_id, storage_app_id)
       _owner_storage_id, project_id = storage_decrypt_channel_id(token)
       s3_filename = "#{base_dir}/#{storage_id}/#{project_id}/main.json"
-      body = s3.get_object(bucket: bucket, key: s3_filename, version_id: code_version)[:body].read
+      s3_args = {bucket: bucket, key: s3_filename}
+      s3_args[:version_id] = code_version if code_version
+      body = s3.get_object(s3_args)[:body].read
       student_code = JSON.parse(body)['source'] if body
     end
     {

--- a/dashboard/app/controllers/student_code_sample_controller.rb
+++ b/dashboard/app/controllers/student_code_sample_controller.rb
@@ -54,9 +54,9 @@ class StudentCodeSampleController < ApplicationController
             project_id: student_code[:project_id],
             code_version: student_code[:code_version],
             student_code: student_code[:student_code],
-            evaluation: evaluation.ai_evaluation,
-            reasoning: evaluation.ai_reasoning,
-            criteria: evaluation.evaluation_criteria
+            ai_evaluation: evaluation.ai_evaluation,
+            ai_reasoning: evaluation.ai_reasoning,
+            evaluation_criteria: evaluation.evaluation_criteria
           }
         end
         have_enough_samples = code_samples.length >= num_samples

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -167,6 +167,8 @@ class Ability
       # all signed in users can get their level source
       can :get_level_source, UserLevel
 
+      can :evaluate, :openai_evaluate
+
       if user.teacher?
         can :manage, Section do |s|
           s.instructors.include?(user)
@@ -498,10 +500,6 @@ class Ability
 
       can :chat_completion, :openai_chat do
         user.has_ai_tutor_access?
-      end
-
-      can :evaluate, :openai_evaluate do
-        user.verified_instructor?
       end
 
       can [:start_chat_completion, :chat_request], :aichat_request do

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -96,7 +96,7 @@ Dashboard::Application.routes.draw do
     resources :images, only: [:new]
 
     get "/ai_iteration/tools", to: "ai_iteration#tools"
-    get "/student_code_sample/:num_samples/:script_id/:level_id", to: "student_code_sample#fetch_student_code_samples"
+    post "/student_code_samples", to: "student_code_sample#fetch_student_code_samples"
 
     get 'maker/home', to: 'maker#home'
     get 'maker/setup', to: 'maker#setup'


### PR DESCRIPTION
Continuation of https://github.com/code-dot-org/code-dot-org/pull/64567

### Links
[Summary of Evaluate Student Learning Projects](https://docs.google.com/document/d/1dj7OzyRDGjA8mj8_feWoDpy2o3gI7Yi9jlpq7pxp7sA/edit?tab=t.0)
[CSP AI Validation Quiet Pilot spec](https://docs.google.com/document/d/1YdYJeSXWu52qxQjFah4q5fSz5E58k5xn68sfEYB8UV0/edit?tab=t.0)

For the Evaluate Student Learning project we want to start collecting AI evaluations of student code samples so we can determine accuracy of AI-driven evaluation.

We recently began writing AI evaluations to the UserLevelEvaluations table for 2 CSP unit 4 programming levels so we can collect and review them. To review code samples alongside their AI evaluations, I extended the functionality of the Student Dataset Maker to include the UserLevelEvaluations of the pulled code samples. This will set us up nicely to have csvs ready for human "grading".

The Student Dataset Maker is an internal tool found at `/ai_iteration/tools` takes in a level id, unit id and number of requested samples and pulls student code samples that can then be downloaded as a csv. The work in this PR adds a checkbox to indicate whether the fetched student code samples should include AI evaluations or not. If the box is checked, we fetch UserLevelEvaluations for the requested level and unit, then use those to determine the user id's for the code samples to fetch. 

### Testing 
Here's the tool in action: 

https://github.com/user-attachments/assets/8c949663-dd50-4445-8263-37500c5f8d50

Which produced this [csv](https://docs.google.com/spreadsheets/d/1T3Y7y4c5mMZtLo71XXe_yvMsbuFYdei_oT76JlFTPM4/edit?usp=sharing) 

I also confirmed locally that the path to fetch student code samples without evaluations also returns data as expected. 

### Follow up 
- When this is in production, we can use it to pull student code samples + their evaluations for the tester levels we're currently collecting data from: '/s/csp4-2024/lessons/3/levels/2' and '/s/csp4-2024/lessons/3/levels/6'. If everything looks at expected, we can start having human graders tag the data and potentially expand to collecting data for other programming levels in CSP units 4 and 6. 

- I'd also like the extend the functionality of the Student Dataset Maker to pull free response answers and their AI evaluations if the process outlined here works well for code samples.  
