### PR TITLE
Applab: fix `getColumn()` data block not displaying throttling warnings

### DIFF
--- a/apps/src/JavaScriptModeErrorHandler.js
+++ b/apps/src/JavaScriptModeErrorHandler.js
@@ -29,6 +29,9 @@ export default class JavaScriptModeErrorHandler {
    * @param {number} [lineNumber]
    */
   outputError(errorString, lineNumber, libraryName) {
+    if (errorString.msg) {
+      errorString = errorString.msg;
+    }
     this.output_(errorString, LogLevel.ERROR, lineNumber, libraryName);
   }
 
@@ -40,6 +43,9 @@ export default class JavaScriptModeErrorHandler {
    * @param {number} [lineNumber]
    */
   outputWarning(errorString, lineNumber) {
+    if (errorString.msg) {
+      errorString = errorString.msg;
+    }
     this.output_(errorString, LogLevel.WARNING, lineNumber);
   }
 
@@ -50,13 +56,7 @@ export default class JavaScriptModeErrorHandler {
    */
   getAsyncOutputWarning() {
     const lineNumber = this.getNearestUserCodeLine_();
-    return error => {
-      if (error.msg) {
-        this.output_(error.msg, LogLevel.WARNING, lineNumber);
-      } else {
-        this.output_(error, LogLevel.WARNING, lineNumber);
-      }
-    };
+    return error => this.outputWarning(error, lineNumber);
   }
 
   /**


### PR DESCRIPTION
In zendesk, we've seen a number of issues where data block storage throttling was occurring, but teachers & students didn't get a msg what was happening, just that something was wrong. In particular, the commonly used `getColumn` data block wasn't displaying throttling messages to the console.

This PR fixes `getColumn` and `getKeyValueSync` so they display throttling warnings to the console when they occur.

## Underlying issue: inconsistency in async vs sync warning handlers

DatablockStorage returns an error object not just a string for throttling notifications. This allows parts of the app that want to be throttling-aware to catch `error.type == 'THROTTLE'`, and parts that just want to print a string to print `error.msg`.

This works great with all of our async blocks (most data blocks: readRecords, getKeyValue, etc), because `getAsyncOutputWarning()` already had support for errors with a .msg field in them.

Two of our data blocks were defined as synchronous: `getKeyValueSync` and `getColumn`, and the synchronous error handling functions weren't aware of the `error.msg` convention.

This PR unifies support for the `error.msg` convention, allowing it in both synchronous and (already support) async error and warning handlers.

## Before, no clear throttling message from getColumn

![image (5)](https://github.com/user-attachments/assets/129f09dd-e16c-44f1-bd5c-b3055f685041)

## After, message in console and warning on line
<img width="911" alt="image" src="https://github.com/user-attachments/assets/a3da5a18-9e9c-4a07-95b6-ce8357fe5d06" />