### PR TITLE
Update k8s docker files to track marketing build changes

### DIFF
--- a/k8s/docker/code-dot-org.dockerfile
+++ b/k8s/docker/code-dot-org.dockerfile
@@ -70,9 +70,15 @@ COPY --chown=${UID} \
   ./apps/eslint \
   ./apps/eslint/
 
+# Required to handle the `portal:../frontend/packages/component-library` link in apps/package.json
 COPY --chown=${UID} \
   ./frontend/packages/component-library/package.json \
   ./frontend/packages/component-library/
+
+# Required to handle the `portal:../frontend/packages/component-library-styles` link in apps/package.json
+COPY --chown=${UID} \
+  ./frontend/packages/component-library-styles/package.json \
+  ./frontend/packages/component-library-styles/
 
 RUN \
   #

--- a/k8s/docker/code-dot-org.dockerfile
+++ b/k8s/docker/code-dot-org.dockerfile
@@ -22,6 +22,8 @@ COPY --chown=${UID} \
   Gemfile.lock \
   ./
 
+# /Gemfile includes '**/engines/*/*.gemspec', these will need to be added to this dockerfile
+# one by one as they are defined, or the build will be broken.
 COPY --chown=${UID} \
   ./dashboard/engines/marketing/marketing.gemspec \
   ./dashboard/engines/marketing/

--- a/k8s/docker/code-dot-org.dockerfile
+++ b/k8s/docker/code-dot-org.dockerfile
@@ -22,6 +22,10 @@ COPY --chown=${UID} \
   Gemfile.lock \
   ./
 
+COPY --chown=${UID} \
+  ./dashboard/engines/marketing/marketing.gemspec \
+  ./dashboard/engines/marketing/
+
 RUN --mount=type=cache,sharing=locked,uid=${UID},gid=${GID},target=${HOME}/.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/cache <<EOF
   bundle install --jobs 8 --quiet
 EOF


### PR DESCRIPTION
Update k8s docker files to track marketing build changes.

1. Splitting out `@code-dot-org/component-library-styles` from `@code-dot-org/component-library`
2. Gemfile searches for .gemspec files in `**/engines/*/*.gemspec`: [github](https://github.com/code-dot-org/code-dot-org/pull/64066/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f)