### PR TITLE
Add go to lesson dropdown to section card

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1458,6 +1458,7 @@
   "goToCodeStudio": "Go to Code Studio",
   "goToCourse": "Go to Course page",
   "goToDashboard": "Go to dashboard",
+  "goTo": "Go to...",
   "goToMyDashboard": "Go to my Dashboard",
   "goToUnit": "Go to Unit",
   "grade": "Grade",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1458,7 +1458,7 @@
   "goToCodeStudio": "Go to Code Studio",
   "goToCourse": "Go to Course page",
   "goToDashboard": "Go to dashboard",
-  "goTo": "Go to...",
+  "goToLesson": "Go to a lesson",
   "goToMyDashboard": "Go to my Dashboard",
   "goToUnit": "Go to Unit",
   "grade": "Grade",

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -17,7 +17,8 @@ interface CourseContentDropdownProps {
   section: Section;
 }
 
-interface UnitLessons {
+// Interface for the unit lessons dropdown
+interface UnitLessonOptions {
   value: string;
   text: string;
 }
@@ -31,17 +32,16 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
   section,
 }) => {
   const navigate = useNavigate();
-  const [lessonList, setLessonList] = useState<UnitLessons[]>([]);
+  const [lessonList, setLessonList] = useState<UnitLessonOptions[]>([]);
 
   // Retrieve units and lessons for the section
   useEffect(() => {
     if (section.unitId) {
-      HttpClient.fetchJson<UnitLessons[]>(
-        `/sections/retrieve_lessons_for_dropdown/${section.id}`
+      HttpClient.fetchJson<UnitLessonOptions[]>(
+        `/sections/${section.id}/retrieve_lessons_for_dropdown`
       )
         .then(response => {
-          console.log(response.value);
-          const lessons: UnitLessons[] = response.value.map(lesson => {
+          const lessons: UnitLessonOptions[] = response.value.map(lesson => {
             if (lesson.text.includes('Unit')) {
               lesson.text = lesson.text.replace(' - ', ': ');
             } else if (!lesson.text.includes('Lesson')) {

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -40,10 +40,11 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
         `/sections/retrieve_lessons_for_dropdown/${section.id}`
       )
         .then(response => {
+          console.log(response.value);
           const lessons: UnitLessons[] = response.value.map(lesson => {
             if (lesson.text.includes('Unit')) {
               lesson.text = lesson.text.replace(' - ', ': ');
-            } else {
+            } else if (!lesson.text.includes('Lesson')) {
               lesson.text = `${i18n.lesson()} ${lesson.text}`;
             }
             return lesson;
@@ -68,7 +69,6 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
           `../${TEACHER_NAVIGATION_SECTIONS_URL}/${section.id}/unit/${unit}`
         );
       }
-      console.log(args.target.value);
       window.location.href = `..${args.target.value}`;
     }
   };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -1,8 +1,9 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import {BodyThreeText} from '@code-dot-org/component-library/typography';
-import React from 'react';
+import React, {useEffect, useState, useMemo} from 'react';
 
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import i18n from '@cdo/locale';
 
 import styles from './teacherHomepage.module.scss';
@@ -11,30 +12,39 @@ interface CourseContentDropdownProps {
   section: Section;
 }
 
+interface UnitLessons {
+  value: string;
+  text: string;
+}
+
+/**
+ * CourseContentDropdown component.
+ * Used to render a dropdown for selecting a lesson to navigate to.
+ * @param section - Section object containing the course display name.
+ */
 export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
   section,
 }) => {
-  const dropdownItems = [
-    {
-      value: 'Go to a lesson',
-      text: 'Go to a lesson',
-    },
-    {
-      value: 'test1',
-      text: 'test1',
-    },
-    {
-      value: 'test2',
-      text: 'test2',
-    },
-    {
-      value: 'test3',
-      text: 'test3',
-    },
-  ];
+  const [unitLessons, setUnitLessons] = useState<UnitLessons[]>([]);
+
+  // Retrieve units and lessons for the section
+  useEffect(() => {
+    HttpClient.fetchJson<UnitLessons[]>(
+      `/sections/retrieve_units_and_lessons/${section.id}`
+    )
+      .then(response => setUnitLessons(response.value))
+      .catch(error => console.error(error));
+  }, [section.id]);
+
+  const dropdownOptions = useMemo(() => {
+    const options = [{value: 'Go to a lesson', text: 'Go to a lesson'}];
+    options.push(...unitLessons);
+    return options;
+  }, [unitLessons]);
 
   const onDropdownChange = (args: React.ChangeEvent<HTMLSelectElement>) => {
     console.log(args.target.value);
+    window.location.href = `..${args.target.value}`;
   };
 
   return (
@@ -48,7 +58,7 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
         name="go-to-lesson-dropdown"
         labelText="Go to a lesson"
         isLabelVisible={false}
-        items={dropdownItems}
+        items={dropdownOptions}
         selectedValue="Go to a lesson"
         size="m"
         color="gray"

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -1,3 +1,4 @@
+import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import {BodyThreeText} from '@code-dot-org/component-library/typography';
 import React from 'react';
 
@@ -13,12 +14,47 @@ interface CourseContentDropdownProps {
 export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
   section,
 }) => {
+  const dropdownItems = [
+    {
+      value: 'Go to a lesson',
+      text: 'Go to a lesson',
+    },
+    {
+      value: 'test1',
+      text: 'test1',
+    },
+    {
+      value: 'test2',
+      text: 'test2',
+    },
+    {
+      value: 'test3',
+      text: 'test3',
+    },
+  ];
+
+  const onDropdownChange = (args: React.ChangeEvent<HTMLSelectElement>) => {
+    console.log(args.target.value);
+  };
+
   return (
     <div className={styles.courseContentDropdownContainer}>
       <BodyThreeText>
         <b>{`${i18n.course()}: `}</b>
         {section.courseDisplayName}
       </BodyThreeText>
+      <SimpleDropdown
+        className={styles.courseContentDropdown}
+        name="go-to-lesson-dropdown"
+        labelText="Go to a lesson"
+        isLabelVisible={false}
+        items={dropdownItems}
+        selectedValue="Go to a lesson"
+        size="m"
+        color="gray"
+        dropdownTextThickness="thin"
+        onChange={args => onDropdownChange(args)}
+      />
     </div>
   );
 };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -9,6 +9,8 @@ import i18n from '@cdo/locale';
 
 import {TEACHER_NAVIGATION_SECTIONS_URL} from '../../teacherNavigation/TeacherNavigationPaths';
 
+import {TaskButton} from './TaskButton';
+
 import styles from './teacherHomepage.module.scss';
 
 interface CourseContentDropdownProps {
@@ -29,32 +31,34 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
   section,
 }) => {
   const navigate = useNavigate();
-  const [unitLessons, setUnitLessons] = useState<UnitLessons[]>([]);
+  const [lessonList, setLessonList] = useState<UnitLessons[]>([]);
 
   // Retrieve units and lessons for the section
   useEffect(() => {
-    HttpClient.fetchJson<UnitLessons[]>(
-      `/sections/retrieve_lessons_for_dropdown/${section.id}`
-    )
-      .then(response => {
-        const lessons: UnitLessons[] = response.value.map(lesson => {
-          if (lesson.text.includes('Unit')) {
-            lesson.text = lesson.text.replace(' - ', ': ');
-          } else {
-            lesson.text = `${i18n.lesson()} ${lesson.text}`;
-          }
-          return lesson;
-        });
-        setUnitLessons(lessons);
-      })
-      .catch(error => console.error(error));
+    if (section.unitId) {
+      HttpClient.fetchJson<UnitLessons[]>(
+        `/sections/retrieve_lessons_for_dropdown/${section.id}`
+      )
+        .then(response => {
+          const lessons: UnitLessons[] = response.value.map(lesson => {
+            if (lesson.text.includes('Unit')) {
+              lesson.text = lesson.text.replace(' - ', ': ');
+            } else {
+              lesson.text = `${i18n.lesson()} ${lesson.text}`;
+            }
+            return lesson;
+          });
+          setLessonList(lessons);
+        })
+        .catch(error => console.error(error));
+    }
   }, [section.id, section.unitId]);
 
   const dropdownOptions = useMemo(() => {
-    const options = [{value: 'Go to', text: i18n.goTo()}];
-    options.push(...unitLessons);
+    const options = [{value: i18n.goToLesson(), text: i18n.goToLesson()}];
+    options.push(...lessonList);
     return options;
-  }, [unitLessons]);
+  }, [lessonList]);
 
   const onDropdownChange = (args: React.ChangeEvent<HTMLSelectElement>) => {
     if (args.target.value !== 'Go to') {
@@ -75,17 +79,26 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
         <b>{`${i18n.course()}: `}</b>
         {section.courseDisplayName}
       </BodyThreeText>
-      <SimpleDropdown
-        className={styles.courseContentDropdown}
-        name="go-to-lesson-dropdown"
-        labelText="Go to a lesson"
-        isLabelVisible={false}
-        items={dropdownOptions}
-        selectedValue="Go to a lesson"
-        size="m"
-        dropdownTextThickness="thin"
-        onChange={args => onDropdownChange(args)}
-      />
+      {section.unitId ? (
+        <SimpleDropdown
+          className={styles.courseContentDropdown}
+          name="go-to-lesson-dropdown"
+          labelText={i18n.goToLesson()}
+          isLabelVisible={false}
+          items={dropdownOptions}
+          selectedValue={i18n.goToLesson()}
+          size="m"
+          dropdownTextThickness="thin"
+          onChange={args => onDropdownChange(args)}
+        />
+      ) : (
+        <TaskButton
+          buttonText={i18n.goToCourse()}
+          icon="desktop"
+          sectionId={section.id}
+          path={`courses/${section.courseVersionName}`}
+        />
+      )}
     </div>
   );
 };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -1,10 +1,13 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import {BodyThreeText} from '@code-dot-org/component-library/typography';
 import React, {useEffect, useState, useMemo} from 'react';
+import {useNavigate} from 'react-router-dom';
 
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import i18n from '@cdo/locale';
+
+import {TEACHER_NAVIGATION_SECTIONS_URL} from '../../teacherNavigation/TeacherNavigationPaths';
 
 import styles from './teacherHomepage.module.scss';
 
@@ -25,26 +28,45 @@ interface UnitLessons {
 export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
   section,
 }) => {
+  const navigate = useNavigate();
   const [unitLessons, setUnitLessons] = useState<UnitLessons[]>([]);
 
   // Retrieve units and lessons for the section
   useEffect(() => {
     HttpClient.fetchJson<UnitLessons[]>(
-      `/sections/retrieve_units_and_lessons/${section.id}`
+      `/sections/retrieve_lessons_for_dropdown/${section.id}`
     )
-      .then(response => setUnitLessons(response.value))
+      .then(response => {
+        const lessons: UnitLessons[] = response.value.map(lesson => {
+          if (lesson.text.includes('Unit')) {
+            lesson.text = lesson.text.replace(' - ', ': ');
+          } else {
+            lesson.text = `${i18n.lesson()} ${lesson.text}`;
+          }
+          return lesson;
+        });
+        setUnitLessons(lessons);
+      })
       .catch(error => console.error(error));
-  }, [section.id]);
+  }, [section.id, section.unitId]);
 
   const dropdownOptions = useMemo(() => {
-    const options = [{value: 'Go to a lesson', text: 'Go to a lesson'}];
+    const options = [{value: 'Go to', text: i18n.goTo()}];
     options.push(...unitLessons);
     return options;
   }, [unitLessons]);
 
   const onDropdownChange = (args: React.ChangeEvent<HTMLSelectElement>) => {
-    console.log(args.target.value);
-    window.location.href = `..${args.target.value}`;
+    if (args.target.value !== 'Go to') {
+      if (!section.unitId) {
+        const unit = args.target.value.replace('/s/', '');
+        navigate(
+          `../${TEACHER_NAVIGATION_SECTIONS_URL}/${section.id}/unit/${unit}`
+        );
+      }
+      console.log(args.target.value);
+      window.location.href = `..${args.target.value}`;
+    }
   };
 
   return (
@@ -61,7 +83,6 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
         items={dropdownOptions}
         selectedValue="Go to a lesson"
         size="m"
-        color="gray"
         dropdownTextThickness="thin"
         onChange={args => onDropdownChange(args)}
       />

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TaskButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TaskButton.tsx
@@ -14,6 +14,14 @@ interface TaskButtonProps {
   path: string;
 }
 
+/**
+ * TaskButton component.
+ * Used to render a button that navigates to a specific page in the teacher dashboard.
+ * @param buttonText - Text to display on the button.
+ * @param icon - FontAwesome Icon to display on the left of the button.
+ * @param sectionId - Section ID to navigate to in teacher dashboard
+ * @param path - Path to navigate to in teacher dashboard
+ */
 export const TaskButton: React.FC<TaskButtonProps> = ({
   buttonText,
   icon,

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -173,9 +173,6 @@
 }
 
 .courseContentDropdown {
-  height: 40px;
-  width: 100%;
-
   div {
     height: 40px;
     width: 100%;

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -162,3 +162,11 @@
   gap: 8px;
   width: 375px;
 }
+
+.courseContentDropdown {
+  width: 100%;
+
+  div {
+    width: 100%;
+  }
+}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -120,6 +120,7 @@
   gap: 16px;
 }
 
+// Task Button
 .taskButtons {
   border: 1px solid var(--neutral-gray-40);
   display: flex;
@@ -131,6 +132,7 @@
   align-items: center;
   justify-content: space-between;
   margin: 0;
+  width: 100%;
 }
 
 .taskButtonLeft {

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -116,6 +116,7 @@
 .sectionCardBodyRight {
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   width: 375px;
   gap: 16px;
 }
@@ -157,18 +158,30 @@
 
 // CourseContentDropdown
 .courseContentDropdownContainer {
+  display: flex;
+  flex-direction: column;
   background-color: var(--neutral-base-white);
   border: 1px solid var(--neutral-gray-20);
   border-radius: 4px;
   padding: 12px;
-  gap: 8px;
   width: 375px;
+  gap: 8px;
+
+  p {
+    margin: 0;
+  }
 }
 
 .courseContentDropdown {
+  height: 40px;
   width: 100%;
 
   div {
+    height: 40px;
     width: 100%;
+
+    select {
+      border-color: var(--neutral-gray-40);
+    }
   }
 }

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/CourseContentDropdownTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/CourseContentDropdownTest.tsx
@@ -1,0 +1,167 @@
+import {render, screen, act} from '@testing-library/react';
+import React from 'react';
+import {Provider} from 'react-redux';
+import {
+  createMemoryRouter,
+  createRoutesFromElements,
+  Route,
+  RouterProvider,
+} from 'react-router-dom';
+import {Store} from 'redux';
+
+import {getStore} from '@cdo/apps/redux';
+import {CourseContentDropdown} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown';
+import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
+import {TEACHER_NAVIGATION_PATHS} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
+import HttpClient from '@cdo/apps/util/HttpClient';
+
+describe('CourseContentDropdown', () => {
+  const nonUnitSection: Section = {
+    id: 11,
+    name: 'Period 1',
+    hidden: false,
+    courseVersionName: 'csd-2024',
+    unitName: null,
+    aiTutorEnabled: false,
+    atRiskAgeGatedDate: new Date(),
+    atRiskAgeGatedUsState: 'xyz',
+    anyStudentHasProgress: false,
+    code: 'ABCDEF',
+    codeReviewExpiresAt: null,
+    course: null,
+    courseDisplayName: "Computer Science Discoveries ('24-'25)",
+    courseId: 52,
+    courseOfferingId: 192,
+    courseVersionId: 553,
+    createdAt: '2024-10-04T18:19:41.000Z',
+    grades: [],
+    isAssignedCSA: false,
+    isAssignedStandaloneCourse: false,
+    lessonExtras: false,
+    loginType: 'picture',
+    loginTypeName: 'Picture Password',
+    pairingAllowed: false,
+    participantType: undefined,
+    postMilestoneDisabled: false,
+    providerManaged: false,
+    restrictSection: false,
+    sectionInstructors: [],
+    sharingDisabled: false,
+    studentCount: 1,
+    syncEnabled: false,
+    ttsAutoplayEnabled: false,
+    unitId: null,
+  };
+
+  const unitSection: Section = {
+    id: 11,
+    name: 'Period 1',
+    hidden: false,
+    courseVersionName: 'csd-2024',
+    unitName: null,
+    aiTutorEnabled: false,
+    atRiskAgeGatedDate: new Date(),
+    atRiskAgeGatedUsState: 'xyz',
+    anyStudentHasProgress: false,
+    code: 'ABCDEF',
+    codeReviewExpiresAt: null,
+    course: null,
+    courseDisplayName: "Computer Science Discoveries ('24-'25)",
+    courseId: 52,
+    courseOfferingId: 192,
+    courseVersionId: 553,
+    createdAt: '2024-10-04T18:19:41.000Z',
+    grades: [],
+    isAssignedCSA: false,
+    isAssignedStandaloneCourse: false,
+    lessonExtras: false,
+    loginType: 'picture',
+    loginTypeName: 'Picture Password',
+    pairingAllowed: false,
+    participantType: undefined,
+    postMilestoneDisabled: false,
+    providerManaged: false,
+    restrictSection: false,
+    sectionInstructors: [],
+    sharingDisabled: false,
+    studentCount: 1,
+    syncEnabled: false,
+    ttsAutoplayEnabled: false,
+    unitId: 1,
+  };
+
+  const lessons = [
+    {
+      text: "Unit 3 - Interactive Animations and Games ('24-'25)",
+      value: '/unit/csd3-2024',
+    },
+    {
+      text: '1: Programming for a Purpose',
+      value: '/s/csd3-2024/lessons/1/levels/1',
+    },
+    {
+      text: '2: Plotting Shapes',
+      value: '/s/csd3-2024/lessons/2/levels/1',
+    },
+    {
+      text: '3: Drawing in Game Lab',
+      value: '/s/csd3-2024/lessons/3/levels/1',
+    },
+    {
+      text: '4: Shapes and Parameters',
+      value: '/s/csd3-2024/lessons/4/levels/1',
+    },
+  ];
+
+  const store: Store = getStore();
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(HttpClient, 'fetchJson').mockResolvedValue({
+      value: lessons,
+      response: new Response(),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function renderComponent(
+    section = nonUnitSection,
+    initialRoute = '/teacher_dashboard/home'
+  ) {
+    return render(
+      <Provider store={store}>
+        <RouterProvider
+          router={createMemoryRouter(
+            createRoutesFromElements([
+              <Route
+                path={TEACHER_NAVIGATION_PATHS.home}
+                element={<CourseContentDropdown section={section} />}
+              />,
+            ]),
+            {initialEntries: [initialRoute], basename: '/teacher_dashboard'}
+          )}
+        />
+      </Provider>
+    );
+  }
+
+  it('renders course display name', () => {
+    renderComponent();
+    screen.getByText("Computer Science Discoveries ('24-'25)");
+  });
+
+  it('renders section Go to Course page button when no unit is assigned', () => {
+    renderComponent();
+    screen.getByText('Go to Course page');
+  });
+
+  it('renders Go to a lesson dropdown when a unit is assigned', async () => {
+    renderComponent(unitSection);
+    await act(async () => await new Promise(process.nextTick));
+    expect(fetchSpy).toHaveBeenCalled();
+    screen.getByLabelText('Go to a lesson');
+  });
+});

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -360,7 +360,6 @@ class LevelsController < ApplicationController
 
     # Handle thumbnail_url
     if @level.respond_to?(:thumbnail_url) || !@level.properties.key?("thumbnail_url")
-      puts changes["thumbnail_url"]
       @level.properties["thumbnail_url"] = changes["thumbnail_url"]
     end
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -360,6 +360,7 @@ class LevelsController < ApplicationController
 
     # Handle thumbnail_url
     if @level.respond_to?(:thumbnail_url) || !@level.properties.key?("thumbnail_url")
+      puts changes["thumbnail_url"]
       @level.properties["thumbnail_url"] = changes["thumbnail_url"]
     end
 

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -85,18 +85,6 @@ class SectionsController < ApplicationController
     render json: {num_hidden: num_hidden}
   end
 
-  def retrieve_units_for_dropdown
-    section = Section.find(params[:section_id])
-    units = []
-    if section.course_id
-      course = UnitGroup.find(section.course_id)
-      course.default_units.each do |unit|
-        units << {text: unit.title_for_display, value: unit.link}
-      end
-    end
-    render json: units
-  end
-
   def retrieve_lessons_for_dropdown
     section = Section.find(params[:section_id])
     lessons = []
@@ -106,9 +94,6 @@ class SectionsController < ApplicationController
       unit.lesson_groups.each do |lesson_group|
         lessons.concat(lesson_group.lessons.select(&:has_lesson_plan).map {|lesson| {text: lesson.relative_position.to_s + ': ' + lesson.localized_name, value: script_lesson_path(unit, lesson) << '/levels/1'}})
       end
-    else
-      retrieve_units_for_dropdown
-      return
     end
     render json: lessons
   end

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -85,21 +85,32 @@ class SectionsController < ApplicationController
     render json: {num_hidden: num_hidden}
   end
 
-  def retrieve_units_and_lessons
+  def retrieve_units_for_dropdown
     section = Section.find(params[:section_id])
-    unit_lessons = []
+    units = []
     if section.course_id
       course = UnitGroup.find(section.course_id)
       course.default_units.each do |unit|
-        lessons = []
-        unit.lesson_groups.each do |lesson_group|
-          lessons.concat(lesson_group.lessons.select(&:has_lesson_plan).map {|lesson| {text: lesson.localized_name, value: script_lesson_path(unit, lesson) << '/levels/1'}})
-        end
-        unit_lessons << {text: unit.title_for_display, value: unit.link}
-        unit_lessons.concat(lessons)
+        units << {text: unit.title_for_display, value: unit.link}
       end
     end
-    render json: unit_lessons
+    render json: units
+  end
+
+  def retrieve_lessons_for_dropdown
+    section = Section.find(params[:section_id])
+    lessons = []
+    if section.script_id
+      unit = Unit.find(section.script_id)
+      lessons << {text: unit.title_for_display, value: unit.link}
+      unit.lesson_groups.each do |lesson_group|
+        lessons.concat(lesson_group.lessons.select(&:has_lesson_plan).map {|lesson| {text: lesson.relative_position.to_s + ': ' + lesson.localized_name, value: script_lesson_path(unit, lesson) << '/levels/1'}})
+      end
+    else
+      retrieve_units_for_dropdown
+      return
+    end
+    render json: lessons
   end
 
   private def redirect_to_section_script_or_course

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -85,6 +85,23 @@ class SectionsController < ApplicationController
     render json: {num_hidden: num_hidden}
   end
 
+  def retrieve_units_and_lessons
+    section = Section.find(params[:section_id])
+    unit_lessons = []
+    if section.course_id
+      course = UnitGroup.find(section.course_id)
+      course.default_units.each do |unit|
+        lessons = []
+        unit.lesson_groups.each do |lesson_group|
+          lessons.concat(lesson_group.lessons.select(&:has_lesson_plan).map {|lesson| {text: lesson.localized_name, value: script_lesson_path(unit, lesson) << '/levels/1'}})
+        end
+        unit_lessons << {text: unit.title_for_display, value: unit.link}
+        unit_lessons.concat(lessons)
+      end
+    end
+    render json: unit_lessons
+  end
+
   private def redirect_to_section_script_or_course
     if @section.script
       redirect_to script_path(@section.script)

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -86,7 +86,7 @@ class SectionsController < ApplicationController
   end
 
   def retrieve_lessons_for_dropdown
-    section = Section.find(params[:section_id])
+    section = Section.find(params[:id])
     lessons = []
     if section.script_id
       unit = Unit.find(section.script_id)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -144,11 +144,11 @@ Dashboard::Application.routes.draw do
     resources :sections, only: [:show, :new, :edit] do
       member do
         post 'log_in'
+        get :retrieve_lessons_for_dropdown
       end
       collection do
         post 'section_instructors_verified'
         post 'archive_all'
-        get 'retrieve_lessons_for_dropdown/:section_id', to: 'sections#retrieve_lessons_for_dropdown'
       end
     end
     # Section API routes (JSON only)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -148,7 +148,8 @@ Dashboard::Application.routes.draw do
       collection do
         post 'section_instructors_verified'
         post 'archive_all'
-        get 'retrieve_units_and_lessons/:section_id', to: 'sections#retrieve_units_and_lessons'
+        get 'retrieve_lessons_for_dropdown/:section_id', to: 'sections#retrieve_lessons_for_dropdown'
+        get 'retrieve_units_for_dropdown/:section_id', to: 'sections#retrieve_units_for_dropdown'
       end
     end
     # Section API routes (JSON only)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -148,6 +148,7 @@ Dashboard::Application.routes.draw do
       collection do
         post 'section_instructors_verified'
         post 'archive_all'
+        get 'retrieve_units_and_lessons/:section_id', to: 'sections#retrieve_units_and_lessons'
       end
     end
     # Section API routes (JSON only)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -149,7 +149,6 @@ Dashboard::Application.routes.draw do
         post 'section_instructors_verified'
         post 'archive_all'
         get 'retrieve_lessons_for_dropdown/:section_id', to: 'sections#retrieve_lessons_for_dropdown'
-        get 'retrieve_units_for_dropdown/:section_id', to: 'sections#retrieve_units_for_dropdown'
       end
     end
     # Section API routes (JSON only)


### PR DESCRIPTION
Adds the following to the section card component on the new teacher homepage: 
- a dropdown to navigate to lessons in a unit when a unit is assigned in the section
- a button to go to the course overview for the section when no unit is assigned

https://github.com/user-attachments/assets/303f58b4-9f01-437a-a919-dea2233848c6



## Links
[TEACH-1575](https://codedotorg.atlassian.net/browse/TEACH-1575)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Added unit tests for new functionality

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
