### PR TITLE
update all redirects to point to global.code.org/pd

### DIFF
--- a/pegasus/sites.v3/code.org/public/administrators.haml
+++ b/pegasus/sites.v3/code.org/public/administrators.haml
@@ -43,7 +43,7 @@ theme: responsive_full_width
       %a.link-button.secondary.white{href: "/educate/district/partners"}
         =hoc_s(:call_to_action_see_district_partners)
     %p.body-three.white.no-margin-bottom{style: "margin-top: 1rem"}
-      =hoc_s(:admins_page_district_program_disclaimer, markdown: :inline, locals: {intl_url: "https://global.code.org/"})
+      =hoc_s(:admins_page_district_program_disclaimer, markdown: :inline, locals: {intl_url: "https://global.code.org/pd"})
 
 %section.driving-change.bg-neutral-light
   .wrapper

--- a/pegasus/sites.v3/code.org/public/international/apply.moved
+++ b/pegasus/sites.v3/code.org/public/international/apply.moved
@@ -1,1 +1,1 @@
-https://global.code.org/
+https://global.code.org/pd

--- a/pegasus/sites.v3/code.org/public/professional-learning/international-partners.moved
+++ b/pegasus/sites.v3/code.org/public/professional-learning/international-partners.moved
@@ -1,1 +1,1 @@
-https://global.code.org/
+https://global.code.org/pd

--- a/pegasus/sites.v3/code.org/public/professional-learning/international.moved
+++ b/pegasus/sites.v3/code.org/public/professional-learning/international.moved
@@ -1,1 +1,1 @@
-https://global.code.org/
+https://global.code.org/pd

--- a/pegasus/sites.v3/code.org/views/administrators/admins_additional_resources.haml
+++ b/pegasus/sites.v3/code.org/views/administrators/admins_additional_resources.haml
@@ -4,7 +4,7 @@
       title: hoc_s(:heading_intl_opportunities),
       image: "/images/admins-page-resources-intl.png",
       desc: hoc_s(:admins_page_resources_desc_intl),
-      url: "https://global.code.org/",
+      url: "https://global.code.org/pd",
       button_label: hoc_s(:call_to_action_learn_more)
     },
     {

--- a/pegasus/sites.v3/code.org/views/professional_learning/pl_page_resources.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning/pl_page_resources.haml
@@ -4,7 +4,7 @@
       image: "/images/editorial-card-intl.png",
       title: hoc_s("pl_page.resources.intl.title"),
       desc: hoc_s("pl_page.resources.intl.desc"),
-      url: "https://global.code.org/",
+      url: "https://global.code.org/pd",
       button_label: hoc_s("pl_page.resources.intl.button"),
     },
     {


### PR DESCRIPTION
Forest made a page to point all the old international PD pages to so updating the redirects to point to that page