### PR TITLE
Send reminder emails to BYOW

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -783,7 +783,7 @@ export class WorkshopForm extends React.Component {
     });
     this.loadAvailableFacilitators(course);
     if (course === COURSE_BUILD_YOUR_OWN) {
-      this.setState({funded: false, suppress_email: true});
+      this.setState({funded: false});
     }
   };
 


### PR DESCRIPTION
Send the 3- and 10-day enrollment reminder emails to Build Your Own workshops.

Using `mailcatcher` on localhost, I joined a fake Build Your Own workshop starting in 3 days and triggered the `Pd::Workshop.send_reminder_for_upcoming_in_days(3)` method to ensure it included the Build Your Own workshop enrollment reminder.

Teacher email (including the name of the workshop, "Test 3 Day Emails"):
![send teacher reminder](https://github.com/user-attachments/assets/15f1d046-6fe7-48c4-883c-d4f94e2b2348)

Organizer email (including the name of the workshop, "Test 3 Day Emails"):
![organizedr reminder](https://github.com/user-attachments/assets/e26d6a4b-f450-4ef3-b3e1-65713768d745)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3150)

## Testing story
Local testing.
