### PR TITLE
feat(Image): add placeholder text in Contentful editor

### DIFF
--- a/frontend/apps/marketing/src/components/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/image/Image.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import DSCOImage, {ImageProps} from '@code-dot-org/component-library/cms/image';
+
+const Image: React.FC<ImageProps> = ({src}) => {
+  // Show placeholder text until a content entry is added
+  if (src == null) {
+    return (
+      <div style={{color: 'var(--text-neutral-primary)'}}>
+        <em>
+          <strong>🖼️ Image placeholder.</strong> Please add an "Image" content
+          type or image asset entry in the Content sidebar.
+        </em>
+      </div>
+    );
+  }
+
+  return <DSCOImage src={src} />;
+};
+
+export default Image;

--- a/frontend/apps/marketing/src/components/image/index.ts
+++ b/frontend/apps/marketing/src/components/image/index.ts
@@ -1,3 +1,3 @@
 // Export the Component Definition for use in Contentful Studio
 export {ImageContentfulComponentDefinition} from './imageContentfulDefinition';
-export {default} from '@code-dot-org/component-library/cms/image';
+export {default} from './Image';


### PR DESCRIPTION
Adds placeholder text to Image component before content entry is added in the Contentful editor. 

## Links
Jira ticket: [CMS-440](https://codedotorg.atlassian.net/browse/CMS-440)

## Testing story
Tested locally in Contentful

----


https://github.com/user-attachments/assets/04163f68-b590-4992-a1e0-92f098929698

