### PR TITLE
feat(marketing): update placeholder emojis on FAQ and Video Carousel components

### DIFF
--- a/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
+++ b/frontend/apps/marketing/src/components/carousels/videoCarousel/VideoCarousel.tsx
@@ -25,7 +25,7 @@ const VideoCarousel: React.FC<VideoCarouselProps> = ({slides}) => {
     return (
       <div style={{color: 'var(--text-neutral-primary)'}}>
         <em>
-          <strong>✍ Video carousel placeholder.</strong> Please add a
+          <strong>🎠 Video carousel placeholder.</strong> Please add a
           "Carousel" content type entry in the Content sidebar, save, and open
           the preview tab to see the carousel in action.
         </em>

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
@@ -67,7 +67,7 @@ const FAQAccordionContentful: React.FunctionComponent<
     return (
       <div style={{color: 'var(--text-neutral-primary)'}}>
         <em>
-          <strong>✍ FAQ Accordion placeholder.</strong> Please add a "FAQs"
+          <strong>❓ FAQ Accordion placeholder.</strong> Please add a "FAQs"
           content type entry in the FAQ Accordion sidebar, save, and open the
           preview tab to see the accordions in action.
         </em>


### PR DESCRIPTION
Updates the emojis to match the components' Content Types in the placeholder text before content is added.

## Links
[CMS-433](https://codedotorg.atlassian.net/browse/CMS-433)

## Testing story
Tested locally in Contentful

----

<img width="1380" alt="Screenshot 2025-03-18 at 1 28 48 PM" src="https://github.com/user-attachments/assets/3c5e9b94-6fc4-4954-9ef1-7895ef8c8de5" />
