### PR TITLE
unskip flaky RubricContainerTest cases

### DIFF
--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -320,7 +320,7 @@ describe('RubricContainer', () => {
     expect(dropdownOption.textContent).toContain(i18n.inProgress());
   });
 
-  it.skip('handles running ai assessment', async () => {
+  it('handles running ai assessment', async () => {
     /* This is a fairly complex test that has multiple steps
       1. Initial fetch returns a json object that puts AI Status into READY state
       2. User clicks button to run analysis
@@ -1132,7 +1132,7 @@ describe('RubricContainer', () => {
     );
   });
 
-  it.skip('sends event when user exits the tour', async function () {
+  it('sends event when user exits the tour', async function () {
     stubFetch({
       evalStatusForUser: readyJson,
       evalStatusForAll: readyJsonAll,
@@ -1169,7 +1169,7 @@ describe('RubricContainer', () => {
     );
   });
 
-  it.skip('sends event when user completes the tour', async function () {
+  it('sends event when user completes the tour', async function () {
     stubFetch({
       evalStatusForUser: readyJson,
       evalStatusForAll: readyJsonAll,


### PR DESCRIPTION
Speculative fix for https://codedotorg.atlassian.net/browse/TEACH-1619.

Stephen's jest stability PR ([slack](https://codedotorg.slack.com/archives/C08AMQ869QX/p1741726646510339)) has had a big improvement on apps unit test stability. optimistically re-enabling these tests to see if there are still any problems with flakiness.

## Testing story

- passing drone run
- 3 passing local runs of `yarn test:unit ./test/unit/templates/rubrics/`. I was previously able to repro the flaky failures this way, though the repro was unreliable so this is somewhat inconclusive.