### PR TITLE
feat(Video): replace with react-player

### DIFF
--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3768,6 +3768,7 @@ __metadata:
   dependencies:
     dompurify: "npm:^3.2.4"
     lodash: "npm:^4.17.21"
+    react-player: "npm:^3.0.0-canary.4"
   peerDependencies:
     classnames: ^2.5.1
     dompurify: ^3.2.4
@@ -12601,6 +12602,13 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"deepmerge@npm:^4.0.0":
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 10/058d9e1b0ff1a154468bf3837aea436abcfea1ba1d165ddaaf48ca93765fdd01a30d33c36173da8fbbed951dd0a267602bc782fe288b0fc4b7e1e7091afc4529
+  languageName: node
+  linkType: hard
+
 "deepmerge@npm:^4.2.2":
   version: 4.2.2
   resolution: "deepmerge@npm:4.2.2"
@@ -19796,6 +19804,13 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"load-script@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "load-script@npm:1.0.0"
+  checksum: 10/8458e3f07b4a86f8d9d66e47a987811491a5d013af23ba7b371c6d3c9dc899885b072ccf65abf7874c10cb197d4975eacd8a7a125bfb38dbbcb267539f5dc1e9
+  languageName: node
+  linkType: hard
+
 "loadable-components@npm:2.2.3":
   version: 2.2.3
   resolution: "loadable-components@npm:2.2.3"
@@ -23807,6 +23822,13 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"react-fast-compare@npm:^3.0.1":
+  version: 3.2.2
+  resolution: "react-fast-compare@npm:3.2.2"
+  checksum: 10/a6826180ba75cefba1c8d3ac539735f9b627ca05d3d307fe155487f5d0228d376dac6c9708d04a283a7b9f9aee599b637446635b79c8c8753d0b4eece56c125c
+  languageName: node
+  linkType: hard
+
 "react-focus-lock@npm:^2.11.3":
   version: 2.13.2
   resolution: "react-focus-lock@npm:2.13.2"
@@ -24041,6 +24063,23 @@ canvg@gabelerner/canvg:
   peerDependencies:
     react: ^16.0.0
   checksum: 10/3ab4b56d0ef116c967fe327d9394c7a185ccb1f15a619d922ac1a8478f5ffad5f2f3defa009bbb85ab2ab8b79ec8514e323c14a9cc6979544ae2ed72f1194e83
+  languageName: node
+  linkType: hard
+
+"react-player@npm:^3.0.0-canary.4":
+  version: 3.0.0-canary.4
+  resolution: "react-player@npm:3.0.0-canary.4"
+  dependencies:
+    deepmerge: "npm:^4.0.0"
+    load-script: "npm:^1.0.0"
+    memoize-one: "npm:^5.1.1"
+    prop-types: "npm:^15.7.2"
+    react-fast-compare: "npm:^3.0.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18
+    react: ^17.0.2 || ^18
+    react-dom: ^17.0.2 || ^18
+  checksum: 10/0bccc64af554c7c41dad3c4521843ae23e177dda388846f84d886ccd8b3c3619e8159124902f4117011a2e9c059366e9ae617bcc20042d69466035f83b38e158
   languageName: node
   linkType: hard
 

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -262,10 +262,23 @@ test.describe('All the things UI e2e test', () => {
             .filter({hasText: caption});
           await expect(video).toBeVisible();
 
-          // YouTube iframe should also exist
-          await expect(
-            video.locator('iframe[src*="youtube-nocookie.com"]'),
-          ).toBeVisible();
+          // Play Button should display
+          const playButton = video.getByLabel('Play Video', {exact: false});
+          await expect(playButton).toBeVisible();
+
+          // Clicking the play button should start the video
+          if (caption === 'Video without Fallback') {
+            await playButton.click();
+
+            // Video Facade and Play Button will go away and be replaced with a video
+            await expect(playButton).not.toBeVisible();
+
+            // Ensure YouTube loaded
+            const youtubeIFrameLocator = video.locator('iframe');
+
+            // Expect the iframe to be there
+            await expect(youtubeIFrameLocator).toBeVisible();
+          }
         });
       });
 

--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -381,7 +381,8 @@
   },
   "dependencies": {
     "dompurify": "^3.2.4",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "react-player": "^3.0.0-canary.4"
   },
   "devDependencies": {
     "@code-dot-org/changelogs": "workspace:*",

--- a/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
+++ b/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
@@ -416,7 +416,7 @@ VideoCarousels.play = async ({canvasElement}: {canvasElement: HTMLElement}) => {
 
   // check that videos are visible in both carousels
   for (const videoTitle of videoTitles) {
-    const videos = await canvas.findAllByTitle(videoTitle);
+    const videos = await canvas.findAllByLabelText(`Play video ${videoTitle}`);
     videos.forEach(video => expect(video).toBeVisible());
   }
 };

--- a/frontend/packages/component-library/src/video/Facade.tsx
+++ b/frontend/packages/component-library/src/video/Facade.tsx
@@ -1,0 +1,21 @@
+import styles from './video.module.scss';
+
+export interface FacadeProps {
+  alt: string;
+  posterThumbnail?: string;
+}
+
+const Facade = ({posterThumbnail, alt}: FacadeProps) => {
+  return (
+    posterThumbnail && (
+      <img
+        className={styles.posterImage}
+        src={posterThumbnail}
+        loading={'lazy'}
+        alt={alt}
+      />
+    )
+  );
+};
+
+export default Facade;

--- a/frontend/packages/component-library/src/video/Facade.tsx
+++ b/frontend/packages/component-library/src/video/Facade.tsx
@@ -1,8 +1,10 @@
 import styles from './video.module.scss';
 
 export interface FacadeProps {
-  alt: string;
+  /** Facade poster thumbnail */
   posterThumbnail?: string;
+  /** Facade alt text */
+  alt: string;
 }
 
 const Facade = ({posterThumbnail, alt}: FacadeProps) => {

--- a/frontend/packages/component-library/src/video/NativeVideo.tsx
+++ b/frontend/packages/component-library/src/video/NativeVideo.tsx
@@ -1,0 +1,32 @@
+import ReactPlayer from 'react-player/file';
+
+import type {VideoProps} from '@/video/types';
+
+interface NativeVideoProps extends VideoProps {
+  posterThumbnail: string;
+  src?: string;
+  onError: (error: Error) => void;
+}
+
+const NativeVideo = ({
+  videoTitle,
+  posterThumbnail,
+  onError,
+  src,
+}: NativeVideoProps) => {
+  return (
+    <ReactPlayer
+      url={src}
+      onError={onError}
+      playing={true}
+      controls={true}
+      height={'100%'}
+      width={'100%'}
+      config={{
+        attributes: {videoTitle, poster: posterThumbnail, title: videoTitle},
+      }}
+    />
+  );
+};
+
+export default NativeVideo;

--- a/frontend/packages/component-library/src/video/PlayButton.tsx
+++ b/frontend/packages/component-library/src/video/PlayButton.tsx
@@ -4,11 +4,7 @@ import moduleStyles from './video.module.scss';
 
 const PlayButton = ({label}: {label: string}) => {
   return (
-    <button
-      aria-label={label}
-      tabIndex={0}
-      className={moduleStyles.playButtonBackground}
-    >
+    <button aria-label={label} className={moduleStyles.playButtonBackground}>
       <FontAwesomeV6Icon className={moduleStyles.playButton} iconName="play" />
     </button>
   );

--- a/frontend/packages/component-library/src/video/PlayButton.tsx
+++ b/frontend/packages/component-library/src/video/PlayButton.tsx
@@ -1,0 +1,17 @@
+import FontAwesomeV6Icon from '@/fontAwesomeV6Icon/FontAwesomeV6Icon';
+
+import moduleStyles from './video.module.scss';
+
+const PlayButton = ({label}: {label: string}) => {
+  return (
+    <button
+      aria-label={label}
+      tabIndex={0}
+      className={moduleStyles.playButtonBackground}
+    >
+      <FontAwesomeV6Icon className={moduleStyles.playButton} iconName="play" />
+    </button>
+  );
+};
+
+export default PlayButton;

--- a/frontend/packages/component-library/src/video/Video.tsx
+++ b/frontend/packages/component-library/src/video/Video.tsx
@@ -1,31 +1,15 @@
 import classNames from 'classnames';
-import {useState, useEffect, HTMLAttributes} from 'react';
+import {useState} from 'react';
+import ReactPlayer from 'react-player/file';
 
 import {LinkButton} from '@/button';
-import {checkIfYouTubeIsBlocked} from '@/common/helpers';
 import FontAwesomeV6Icon from '@/fontAwesomeV6Icon';
 import {BodyTwoText, BodyThreeText, Figcaption, StrongText} from '@/typography';
+import NativeVideo from '@/video/NativeVideo';
+import {RenderState, VideoProps} from '@/video/types';
+import YouTubeVideo from '@/video/YoutubeVideo';
 
 import moduleStyles from './video.module.scss';
-
-export interface VideoProps extends HTMLAttributes<HTMLElement> {
-  /** Video title */
-  videoTitle?: string;
-  /** Video YouTube ID */
-  youTubeId?: string;
-  /** Video fallback */
-  videoFallback?: string;
-  /** Show caption */
-  showCaption?: boolean;
-  /** Label for Download button */
-  downloadLabel?: string;
-  /** Error heading for placeholder  */
-  errorHeading?: string;
-  /** Error body for placeholder */
-  errorBody?: string;
-  /** Video custom className */
-  className?: string;
-}
 
 /**
  * ### Production-ready Checklist:
@@ -51,56 +35,70 @@ const Video: React.FC<VideoProps> = ({
   errorHeading,
   errorBody,
   className,
-  ...HTMLAttributes
 }: VideoProps) => {
-  const [isYouTubeBlocked, setIsYouTubeBlocked] = useState(false);
-  const posterThumbnail = `//i.ytimg.com/vi/${youTubeId}/mqdefault.jpg`;
+  const youtubeVideoUrl = `https://www.youtube-nocookie.com/watch?v=${youTubeId}`;
 
-  // Check to see if YouTube is blocked.
-  // If it is, we'll use the fallback video player.
-  useEffect(() => {
-    checkIfYouTubeIsBlocked().then(setIsYouTubeBlocked);
-  }, []);
+  const [renderState, setRenderState] = useState<RenderState>('youtube');
+  const posterThumbnail = `//i.ytimg.com/vi/${youTubeId}/hqdefault.jpg`;
 
+  const handleError = (error: Error, nextRenderState: RenderState) => {
+    // If blocked due to an interaction autoplay issue, don't move to the next render state but allow the user to
+    // manually click the play button
+    if (error.name === 'NotAllowedError') {
+      console.warn(error);
+    } else {
+      setRenderState(nextRenderState);
+    }
+  };
+
+  const getVideoPlayer = () => {
+    switch (renderState) {
+      case 'youtube':
+        return (
+          <YouTubeVideo
+            posterThumbnail={posterThumbnail}
+            videoTitle={videoTitle}
+            src={youtubeVideoUrl}
+            onError={error => {
+              const nextRenderState =
+                videoFallback && ReactPlayer.canPlay(videoFallback)
+                  ? 'native'
+                  : 'error';
+
+              handleError(error, nextRenderState);
+            }}
+          />
+        );
+      case 'native':
+        return (
+          <NativeVideo
+            posterThumbnail={posterThumbnail}
+            videoTitle={videoTitle}
+            src={videoFallback}
+            className={className}
+            onError={error => handleError(error, 'error')}
+          />
+        );
+      case 'error':
+        return (
+          <div className={classNames(moduleStyles.errorPlaceholder)}>
+            <FontAwesomeV6Icon
+              iconName="exclamation-circle"
+              iconStyle="solid"
+            />
+            <BodyTwoText>
+              <StrongText>{errorHeading || 'Video unavailable'}</StrongText>
+            </BodyTwoText>
+            <BodyThreeText>
+              {errorBody || 'This video is blocked on your network.'}
+            </BodyThreeText>
+          </div>
+        );
+    }
+  };
   return (
     <figure className={moduleStyles.videoComponentContainer}>
-      <div className={moduleStyles.videoWrapper}>
-        {isYouTubeBlocked ? (
-          videoFallback ? (
-            // Disabling this eslint rule since we don't support captions on all of our videos.
-            // eslint-disable-next-line jsx-a11y/media-has-caption
-            <video
-              className={classNames(className)}
-              title={videoTitle || 'Video player'}
-              poster={posterThumbnail}
-              src={videoFallback}
-              controls
-              {...HTMLAttributes}
-            />
-          ) : (
-            <div className={classNames(moduleStyles.errorPlaceholder)}>
-              <FontAwesomeV6Icon
-                iconName="exclamation-circle"
-                iconStyle="solid"
-              />
-              <BodyTwoText>
-                <StrongText>{errorHeading || 'Video unavailable'}</StrongText>
-              </BodyTwoText>
-              <BodyThreeText>
-                {errorBody || 'This video is blocked on your network.'}
-              </BodyThreeText>
-            </div>
-          )
-        ) : (
-          <iframe
-            className={classNames(className)}
-            src={`https://www.youtube-nocookie.com/embed/${youTubeId}`}
-            title={videoTitle || 'YouTube video player'}
-            allowFullScreen
-            {...HTMLAttributes}
-          />
-        )}
-      </div>
+      <div className={moduleStyles.videoWrapper}>{getVideoPlayer()}</div>
       <div className={moduleStyles.footer}>
         {showCaption && <Figcaption>{videoTitle}</Figcaption>}
         {videoFallback && (

--- a/frontend/packages/component-library/src/video/YoutubeVideo.tsx
+++ b/frontend/packages/component-library/src/video/YoutubeVideo.tsx
@@ -1,0 +1,38 @@
+import ReactPlayer from 'react-player/youtube';
+
+import Facade from '@/video/Facade';
+import PlayButton from '@/video/PlayButton';
+import {VideoProps} from '@/video/types';
+
+interface YouTubeVideoProps extends VideoProps {
+  src: string;
+  posterThumbnail: string;
+  onError: (error: Error) => void;
+}
+
+const YouTubeVideo = ({
+  src,
+  onError,
+  posterThumbnail,
+  videoTitle,
+}: YouTubeVideoProps) => {
+  const ariaLabel = `Play video ${videoTitle}`;
+
+  return (
+    <ReactPlayer
+      height={'100%'}
+      width={'100%'}
+      url={src}
+      onError={onError}
+      previewTabIndex={-1} // the play icon is the tabbable portion
+      light={<Facade posterThumbnail={posterThumbnail} alt={ariaLabel} />}
+      playIcon={<PlayButton label={ariaLabel} />}
+      controls={true}
+      config={{
+        playerVars: {autoplay: 1},
+      }}
+    />
+  );
+};
+
+export default YouTubeVideo;

--- a/frontend/packages/component-library/src/video/__tests__/Facade.test.tsx
+++ b/frontend/packages/component-library/src/video/__tests__/Facade.test.tsx
@@ -1,0 +1,18 @@
+import {render, screen} from '@testing-library/react';
+
+import Facade from '../Facade';
+
+describe('Facade Component', () => {
+  it('renders the component correctly', () => {
+    const {container} = render(<Facade alt={'Facade'} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('displays poster that is lazily loaded', () => {
+    render(<Facade alt={'Facade'} posterThumbnail="mock.png" />);
+    const poster = screen.getByAltText('Facade');
+    expect(poster).toHaveAttribute('loading', 'lazy');
+    expect(poster).toBeVisible();
+  });
+});

--- a/frontend/packages/component-library/src/video/__tests__/PlayButton.test.tsx
+++ b/frontend/packages/component-library/src/video/__tests__/PlayButton.test.tsx
@@ -1,0 +1,19 @@
+import {render, screen} from '@testing-library/react';
+
+import PlayButton from '../PlayButton';
+
+describe('PlayButton Component', () => {
+  it('renders the PlayButton component with the correct label', () => {
+    render(<PlayButton label="Play video" />);
+    const button = screen.getByRole('button', {name: 'Play video'});
+    expect(button).toBeVisible();
+    expect(button).toHaveAttribute('tabIndex', '0');
+  });
+
+  it('triggers focus when tabbed to', async () => {
+    render(<PlayButton label="Play video" />);
+    const button = screen.getByRole('button', {name: 'Play video'});
+    button.focus();
+    expect(button).toHaveFocus();
+  });
+});

--- a/frontend/packages/component-library/src/video/__tests__/PlayButton.test.tsx
+++ b/frontend/packages/component-library/src/video/__tests__/PlayButton.test.tsx
@@ -7,7 +7,6 @@ describe('PlayButton Component', () => {
     render(<PlayButton label="Play video" />);
     const button = screen.getByRole('button', {name: 'Play video'});
     expect(button).toBeVisible();
-    expect(button).toHaveAttribute('tabIndex', '0');
   });
 
   it('triggers focus when tabbed to', async () => {

--- a/frontend/packages/component-library/src/video/__tests__/Video.test.tsx
+++ b/frontend/packages/component-library/src/video/__tests__/Video.test.tsx
@@ -1,51 +1,155 @@
-import {render, screen} from '@testing-library/react';
-import '@testing-library/jest-dom';
+import {render, screen, act} from '@testing-library/react';
+import {ReactPlayerProps} from 'react-player';
+import ReactPlayer from 'react-player/file';
 
-import Video from '@/video';
+import Video from '../Video';
+
+ReactPlayer.canPlay = jest.fn();
+
+jest.mock('react-player/youtube', () => ({
+  __esModule: true,
+  default: ({light, playIcon, onError}: ReactPlayerProps) => (
+    <div>
+      YouTube Player
+      {light}
+      {playIcon}
+      <button onClick={onError}>Trigger Error</button>
+    </div>
+  ),
+  canPlay: jest.fn(),
+}));
+
+jest.mock('react-player/file', () => ({
+  __esModule: true,
+  default: ({light, playIcon, onError}: ReactPlayerProps) => (
+    <div>
+      Fallback Player
+      {light}
+      {playIcon}
+      <button onClick={onError}>Trigger Error</button>
+    </div>
+  ),
+  canPlay: jest.fn(),
+}));
 
 describe('Video Component', () => {
-  it('renders a YouTube video', async () => {
-    render(
-      <Video
-        youTubeId="nKIu9yen5nc"
-        videoTitle="What Most Schools Don't Teach"
-      />,
-    );
+  const defaultProps = {
+    youTubeId: 'dQw4w9WgXcQ',
+    videoTitle: 'Sample Video',
+    videoFallback: 'https://example.com/video.mp4',
+    showCaption: true,
+    downloadLabel: 'Download Video',
+    errorHeading: 'Error Heading',
+    errorBody: 'Error Body',
+    className: 'custom-class',
+  };
 
-    const iframe = await screen.findByTitle("What Most Schools Don't Teach");
-    expect(iframe).toBeInTheDocument();
-    expect(iframe).toHaveAttribute(
-      'src',
-      'https://www.youtube-nocookie.com/embed/nKIu9yen5nc',
-    );
+  it('renders YouTube video player by default', () => {
+    render(<Video {...defaultProps} />);
+    const player = screen.getByText('YouTube Player');
+    expect(player).toBeVisible();
+
+    const playButton = screen.getByLabelText('Play video Sample Video');
+    expect(playButton).toBeVisible();
   });
 
-  it('renders a caption', () => {
-    render(
-      <Video
-        youTubeId="nKIu9yen5nc"
-        videoTitle="What Most Schools Don't Teach"
-        showCaption
-      />,
-    );
-
-    const caption = screen.getByText("What Most Schools Don't Teach");
+  it('renders caption when showCaption is true', () => {
+    render(<Video {...defaultProps} />);
+    const caption = screen.getByText(defaultProps.videoTitle);
     expect(caption).toBeInTheDocument();
   });
 
-  it('renders a download button when fallback video is provided', () => {
-    render(
-      <Video
-        youTubeId="nKIu9yen5nc"
-        videoFallback="https://videos.code.org/social/what-most-schools-dont-teach.mp4"
-      />,
-    );
-
-    const downloadButton = screen.getByRole('link', {name: 'Download'});
+  it('renders download button when videoFallback is provided', () => {
+    render(<Video {...defaultProps} />);
+    const downloadButton = screen.getByRole('link', {
+      name: defaultProps.downloadLabel,
+    });
     expect(downloadButton).toBeInTheDocument();
-    expect(downloadButton).toHaveAttribute(
-      'href',
-      'https://videos.code.org/social/what-most-schools-dont-teach.mp4',
+    expect(downloadButton).toHaveAttribute('href', defaultProps.videoFallback);
+  });
+
+  it('renders native video player when YouTube video fails and fallback is valid', () => {
+    (ReactPlayer.canPlay as jest.Mock).mockReturnValue(true);
+    render(<Video {...defaultProps} />);
+    const player = screen.getByText('YouTube Player');
+    expect(player).toBeVisible();
+
+    const playButton = screen.getByLabelText('Play video Sample Video');
+    expect(playButton).toBeVisible();
+
+    const triggerErrorButton = screen.getByText('Trigger Error');
+
+    act(() => {
+      triggerErrorButton.click();
+    });
+
+    const fallbackPlayer = screen.getByText('Fallback Player');
+    expect(fallbackPlayer).toBeVisible();
+  });
+
+  it('renders error state when both YouTube and fallback video fail', () => {
+    (ReactPlayer.canPlay as jest.Mock).mockReturnValue(true);
+    render(<Video {...defaultProps} />);
+    const player = screen.getByText('YouTube Player');
+    expect(player).toBeVisible();
+
+    const playButton = screen.getByLabelText('Play video Sample Video');
+    expect(playButton).toBeVisible();
+
+    const triggerErrorButton = screen.getByText('Trigger Error');
+
+    act(() => {
+      triggerErrorButton.click();
+    });
+
+    const fallbackPlayer = screen.getByText('Fallback Player');
+    expect(fallbackPlayer).toBeVisible();
+
+    const nativeTriggerErrorButton = screen.getByText('Trigger Error');
+
+    act(() => {
+      nativeTriggerErrorButton.click();
+    });
+
+    const defaultErrorHeading = screen.getByText('Error Heading');
+    const defaultErrorBody = screen.getByText('Error Body');
+    expect(defaultErrorHeading).toBeInTheDocument();
+    expect(defaultErrorBody).toBeInTheDocument();
+  });
+
+  it('renders default error messages when errorHeading and errorBody are not provided', () => {
+    (ReactPlayer.canPlay as jest.Mock).mockReturnValue(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {errorHeading, errorBody, ...propsWithoutErrorMessages} =
+      defaultProps;
+    render(<Video {...propsWithoutErrorMessages} />);
+    const player = screen.getByText('YouTube Player');
+    expect(player).toBeVisible();
+
+    const playButton = screen.getByLabelText('Play video Sample Video');
+    expect(playButton).toBeVisible();
+
+    const triggerErrorButton = screen.getByText('Trigger Error');
+
+    act(() => {
+      triggerErrorButton.click();
+    });
+
+    const fallbackPlayer = screen.getByText('Fallback Player');
+    expect(fallbackPlayer).toBeVisible();
+
+    const nativeTriggerErrorButton = screen.getByText('Trigger Error');
+
+    act(() => {
+      nativeTriggerErrorButton.click();
+    });
+
+    const defaultErrorHeading = screen.getByText('Video unavailable');
+    const defaultErrorBody = screen.getByText(
+      'This video is blocked on your network.',
     );
+    expect(defaultErrorHeading).toBeInTheDocument();
+    expect(defaultErrorBody).toBeInTheDocument();
   });
 });

--- a/frontend/packages/component-library/src/video/index.ts
+++ b/frontend/packages/component-library/src/video/index.ts
@@ -4,5 +4,7 @@
 // Auto-import SASS generated CSS
 import './index.css';
 
-export {default as Video, VideoProps} from './Video';
+export {VideoProps} from './types';
+
+export {default as Video} from './Video';
 export {default as default} from './Video';

--- a/frontend/packages/component-library/src/video/stories/Video.story.tsx
+++ b/frontend/packages/component-library/src/video/stories/Video.story.tsx
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {within, expect} from '@storybook/test';
+import {within, expect, userEvent} from '@storybook/test';
 
 import Video from '../index';
 
@@ -17,13 +17,25 @@ export const DefaultVideo: Story = {
     videoTitle: "What Most Schools Don't Teach",
     youTubeId: 'nKIu9yen5nc',
   },
-  play: async ({canvasElement}) => {
+  parameters: {
+    eyes: {
+      // Skip eyes for video as this auto plays
+      include: false,
+    },
+  },
+  play: async ({canvasElement, args}) => {
     const canvas = within(canvasElement);
-    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    const playButton = await canvas.findByLabelText(
+      `Play video ${args.videoTitle}`,
+    );
+    await expect(playButton).toBeVisible();
+    await userEvent.click(playButton);
+
     const video = await canvas.findByTitle("What Most Schools Don't Teach");
 
     // check if video is visible
-    expect(video).toBeVisible();
+    await expect(video).toBeVisible();
   },
 };
 
@@ -33,22 +45,18 @@ export const VideoWithCaption: Story = {
     youTubeId: 'nKIu9yen5nc',
     showCaption: true,
   },
-  parameters: {
-    eyes: {
-      ignoreRegions: [{selector: '.ytp-impression-link'}],
-    },
-  },
-  play: async ({canvasElement}) => {
+  play: async ({canvasElement, args}) => {
     const canvas = within(canvasElement);
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    const video = await canvas.findByTitle("What Most Schools Don't Teach");
+
+    const playButton = await canvas.findByLabelText(
+      `Play video ${args.videoTitle}`,
+    );
+    await expect(playButton).toBeVisible();
+
     const caption = canvas.getByText("What Most Schools Don't Teach");
 
-    // check if video is visible
-    expect(video).toBeVisible();
-
     // check if caption is visible
-    expect(caption).toBeVisible();
+    await expect(caption).toBeVisible();
   },
 };
 
@@ -67,18 +75,24 @@ export const VideoWithFallback: Story = {
           'This is a video component with a fallback HTML video player. The fallback player will show up if YouTube is blocked, and a Download button will also show up. To test this block _www.youtube.com_ and _www.youtube-nocookie.com_ in the Network tab in DevTools.',
       },
     },
+    eyes: {
+      // Skip eyes for video as this auto plays
+      include: false,
+    },
   },
-  play: async ({canvasElement}) => {
+  play: async ({canvasElement, args}) => {
     const canvas = within(canvasElement);
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    const video = await canvas.findByTitle("What Most Schools Don't Teach");
+
+    const playButton = await canvas.findByLabelText(
+      `Play video ${args.videoTitle}`,
+    );
+    await expect(playButton).toBeVisible();
+    await userEvent.click(playButton);
+
     const download = canvas.getByRole('link');
 
-    // check if video is visible
-    expect(video).toBeVisible();
-
     // check if download button is visible
-    expect(download).toBeVisible();
+    await expect(download).toBeVisible();
   },
 };
 
@@ -92,18 +106,13 @@ export const VideoWithCaptionAndFallback: Story = {
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    const video = await canvas.findByTitle("What Most Schools Don't Teach");
     const caption = canvas.getByText("What Most Schools Don't Teach");
     const download = canvas.getByRole('link');
 
-    // check if video is visible
-    expect(video).toBeVisible();
-
     // check if caption is visible
-    expect(caption).toBeVisible();
+    await expect(caption).toBeVisible();
 
     // check if download button is visible
-    expect(download).toBeVisible();
+    await expect(download).toBeVisible();
   },
 };

--- a/frontend/packages/component-library/src/video/types.ts
+++ b/frontend/packages/component-library/src/video/types.ts
@@ -1,0 +1,20 @@
+export type RenderState = 'youtube' | 'native' | 'error';
+
+export interface VideoProps {
+  /** Video title */
+  videoTitle?: string;
+  /** Video YouTube ID */
+  youTubeId?: string;
+  /** Video fallback */
+  videoFallback?: string;
+  /** Show caption */
+  showCaption?: boolean;
+  /** Label for Download button */
+  downloadLabel?: string;
+  /** Error heading for placeholder  */
+  errorHeading?: string;
+  /** Error body for placeholder */
+  errorBody?: string;
+  /** Video custom className */
+  className?: string;
+}

--- a/frontend/packages/component-library/src/video/video.module.scss
+++ b/frontend/packages/component-library/src/video/video.module.scss
@@ -1,6 +1,7 @@
-@import '@code-dot-org/component-library-styles/colors.scss';
-@import '@code-dot-org/component-library-styles/typography.module.scss';
-@import '@code-dot-org/component-library-styles/variables.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/typography.module.scss';
+@use '@code-dot-org/component-library-styles/variables.scss' as variables;
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 
 // Video common styles
 .videoComponentContainer {
@@ -13,7 +14,7 @@
     width: 100%;
     padding-top: 56.25%; // This maintains a 16:9 aspect ratio
     border: 1px solid var(--background-neutral-tertiary);
-    border-radius: $regular-border-radius;
+    border-radius: variables.$regular-border-radius;
     box-sizing: content-box;
     display: block;
 
@@ -77,5 +78,51 @@
   // when there is no caption shown.
   &:not(:has(figcaption)) {
     justify-content: flex-end;
+  }
+}
+
+// Poster image styles
+:global(.react-player__preview) {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.posterImage {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+// Video play button
+$playButtonIconSize: 64px;
+
+.playButtonBackground {
+  height: $playButtonIconSize;
+  width: $playButtonIconSize;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  border-radius: 100px;
+  background: var(--neutral-base-white);
+  box-shadow:
+    0 3px 4px 0 rgb(255 255 255 / 0.23) inset,
+    0 -4px 4px 0 rgb(0 0 0 / 0.07) inset,
+    0 3px 6px 0 rgb(0 0 0 / 0.2);
+
+  &:focus-visible {
+    @include mixins.focus-styles;
+  }
+
+  .playButton {
+    font-size: 2rem;
+    color: var(--text-brand-purple-primary);
+    // Since the play button is the same in RTL, use margin-left
+    // instead of margin-inline-start which changes based on direction.
+    // This keeps the play button visually centered.
+    margin-left: 4px;
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1123,6 +1123,7 @@ __metadata:
     prettier: "npm:3.4.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
+    react-player: "npm:^3.0.0-canary.4"
     release-it: "npm:^18.1.2"
     rimraf: "npm:^6.0.1"
     stylelint: "npm:^16.14.1"
@@ -13013,6 +13014,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"load-script@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "load-script@npm:1.0.0"
+  checksum: 10c0/9919c777fe83f8a3a917f65c9c3ab186ad8b194248c57f413ef6e610194abc8484d123a6838d77ab33e5fa1a05a676b5dfe779c38cfe602bdd27c239423d0acd
+  languageName: node
+  linkType: hard
+
 "load-tsconfig@npm:^0.2.3":
   version: 0.2.5
   resolution: "load-tsconfig@npm:0.2.5"
@@ -13377,6 +13385,13 @@ __metadata:
   dependencies:
     fs-monkey: "npm:^1.0.4"
   checksum: 10c0/038fc81bce17ea92dde15aaa68fa0fdaf4960c721ce3ffc7c2cb87a259333f5159784ea48b3b72bf9e054254d9d0d0d5209d0fdc3d07d08653a09933b168fbd7
+  languageName: node
+  linkType: hard
+
+"memoize-one@npm:^5.1.1":
+  version: 5.2.1
+  resolution: "memoize-one@npm:5.2.1"
+  checksum: 10c0/fd22dbe9a978a2b4f30d6a491fc02fb90792432ad0dab840dc96c1734d2bd7c9cdeb6a26130ec60507eb43230559523615873168bcbe8fafab221c30b11d54c1
   languageName: node
   linkType: hard
 
@@ -15159,7 +15174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.8.1":
+"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -15439,6 +15454,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-fast-compare@npm:^3.0.1":
+  version: 3.2.2
+  resolution: "react-fast-compare@npm:3.2.2"
+  checksum: 10c0/0bbd2f3eb41ab2ff7380daaa55105db698d965c396df73e6874831dbafec8c4b5b08ba36ff09df01526caa3c61595247e3269558c284e37646241cba2b90a367
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -15457,6 +15479,23 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
+  languageName: node
+  linkType: hard
+
+"react-player@npm:^3.0.0-canary.4":
+  version: 3.0.0-canary.4
+  resolution: "react-player@npm:3.0.0-canary.4"
+  dependencies:
+    deepmerge: "npm:^4.0.0"
+    load-script: "npm:^1.0.0"
+    memoize-one: "npm:^5.1.1"
+    prop-types: "npm:^15.7.2"
+    react-fast-compare: "npm:^3.0.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18
+    react: ^17.0.2 || ^18
+    react-dom: ^17.0.2 || ^18
+  checksum: 10c0/efec3a88f70e93ae54659cda953baa8b7372f75704e1fb3d3f52b08c35affecfb070fbc7219c94f559b975558d3914704140f7cf36798ca52a9bdeb9de83b0d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Previously, the Video component directly used the YouTube iframe embed API to load the YouTube video page. This is a direct port of the existing Video loading mechanism in Pegasus. However, for pages that load many YouTube videos (such as /videos), the page loads very slowly due to the iframe necessitating the loading of the bundle for each frame.

Rather, following the Google Lighthouse best practice for [loading third-party resources](https://developer.chrome.com/docs/lighthouse/performance/third-party-facades), a new library has been added, `react-player`, which enables a facade of the video to be loaded. What this means, in effect, is that rather than loading frames of YouTube multiple times, the Video component will render out an image and a play button. Only when the user wishes to click on a specific video will the facade be substituted with the actual frame.

This solves a number of current issues we face for the Video component:

1. The YouTube logo frequently swaps between bottom left and bottom right resulting in test flakiness. This is fixed by using our own facade.
2. Pages with videos load very slowly due to network congestion caused by loading each YouTube frame optimistically.
3. When YouTube is blocked, whether due to school or geographic firewalls, or a computer/browser setting we do not gracefully fallback to the native video player in all circumstances. In this new implementation, the video player will fallback to the native player if any error (except `NotAllowedError`, which the user can self-service by clicking on the video).

---

# Testing

## New Experience

[Screencast From 2025-03-18 15-51-12.webm](https://github.com/user-attachments/assets/2bb5d11a-78f8-40ea-bd71-a2c8c5a628e4)

## Current Experience

[Screencast From 2025-03-18 15-49-29.webm](https://github.com/user-attachments/assets/a8a35036-5069-4d53-ab4b-d1c64bb91e36)

## Pegasus Experience

[Screencast From 2025-03-18 15-52-02.webm](https://github.com/user-attachments/assets/baf8961e-6b33-4dd6-b050-f50dd4088878)


