### PR TITLE
Codebridge: part 1 of using level properties from props

### DIFF
--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -1,5 +1,10 @@
 import {getNextFileId} from '@codebridge/codebridgeContext';
 import {DEFAULT_FOLDER_ID, MAZE_FILE_NAME} from '@codebridge/constants';
+import {
+  CodebridgeLevelProperties,
+  CodebridgeProjectSources,
+  MazeCell,
+} from '@codebridge/types';
 import {combineStartSourcesAndValidation, findFile} from '@codebridge/utils';
 import {useCallback, useMemo} from 'react';
 
@@ -10,13 +15,10 @@ import {
   getAppOptionsViewingExemplar,
 } from '@cdo/apps/lab2/projects/utils';
 import {
-  MazeCell,
   MultiFileSource,
   ProjectFileType,
   ProjectSources,
 } from '@cdo/apps/lab2/types';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-
 /**
  * Custom hook that determines the initial sources for the current level.
  * It selects various sources including from the student's project, the start sources
@@ -32,29 +34,13 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
  * @returns {ProjectSources} - The initial sources to use.
  */
 
-export const useInitialSources = (defaultSources: ProjectSources) => {
-  const labInitialSources = useAppSelector(state => state.lab.initialSources);
-  const levelSource = useAppSelector(
-    state => state.lab.levelProperties?.startSources
-  );
-  const templateSource = useAppSelector(
-    state => state.lab.levelProperties?.templateSources
-  );
-
-  const exemplarSource = useAppSelector(
-    state => state.lab.levelProperties?.exemplarSources
-  ) as MultiFileSource | undefined;
-  const validationFile = useAppSelector(
-    state => state.lab.levelProperties?.validationFile
-  );
+export const useInitialSources = (
+  defaultSources: ProjectSources,
+  levelProperties: CodebridgeLevelProperties,
+  initialServerSource: CodebridgeProjectSources | undefined
+) => {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
-  const serializedMaze = useAppSelector(
-    state => state.lab.levelProperties?.serializedMaze
-  );
-  const miniApp = useAppSelector(state => state.lab.levelProperties?.miniApp);
-  const isPredictLevel = useAppSelector(
-    state => state.lab.levelProperties?.predictSettings?.isPredictLevel
-  );
+  const exemplarSources = levelProperties.exemplarSources as MultiFileSource;
 
   const generateMazeFile = (mazeContents: MazeCell[][], fileId: string) => {
     return {
@@ -72,9 +58,12 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
       // If we have a serialized maze, we need to add it to the project sources so
       // it is accessible when running/sharing/remixing the code. We save it as a
       // system support file.
-      if (serializedMaze) {
+      if (levelProperties.serializedMaze) {
         const mazeFileId = getNextFileId(Object.values(startCode.files));
-        const mazeFile = generateMazeFile(serializedMaze, mazeFileId);
+        const mazeFile = generateMazeFile(
+          levelProperties.serializedMaze,
+          mazeFileId
+        );
         startCode = {
           ...startCode,
           files: {
@@ -85,31 +74,41 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
       }
 
       const source = isStartMode
-        ? combineStartSourcesAndValidation(startCode, validationFile)
+        ? combineStartSourcesAndValidation(
+            startCode,
+            levelProperties.validationFile
+          )
         : startCode;
 
-      const labConfig = miniApp ? {miniApp: {name: miniApp}} : undefined;
+      const labConfig = levelProperties.miniApp
+        ? {miniApp: {name: levelProperties.miniApp}}
+        : undefined;
 
       return {source, labConfig};
     },
-    [isStartMode, miniApp, serializedMaze, validationFile]
+    [
+      isStartMode,
+      levelProperties.miniApp,
+      levelProperties.serializedMaze,
+      levelProperties.validationFile,
+    ]
   );
 
   // We memoize these objects so that they don't cause an unexpected re-render.
   const levelStartSources: ProjectSources | undefined = useMemo(
     () =>
-      levelSource
-        ? generateProjectSourceFromStartSource(levelSource)
+      levelProperties.startSources
+        ? generateProjectSourceFromStartSource(levelProperties.startSources)
         : undefined,
-    [levelSource, generateProjectSourceFromStartSource]
+    [generateProjectSourceFromStartSource, levelProperties.startSources]
   );
 
   const templateStartSources: ProjectSources | undefined = useMemo(
     () =>
-      templateSource
-        ? generateProjectSourceFromStartSource(templateSource)
+      levelProperties.templateSources
+        ? generateProjectSourceFromStartSource(levelProperties.templateSources)
         : undefined,
-    [generateProjectSourceFromStartSource, templateSource]
+    [generateProjectSourceFromStartSource, levelProperties.templateSources]
   );
 
   const parsedDefaultSources = useMemo(
@@ -130,34 +129,37 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
     if (isStartMode) {
       return startSources;
     }
-    if (isPredictLevel) {
+    if (levelProperties.predictSettings?.isPredictLevel) {
       // Predict levels never use sources loaded from the server, only the start sources.
       return templateSources || startSources;
     }
     if (isEditingExemplar || isViewingExemplar) {
       // Show the existing exemplar sources when editing or viewing exemplar sources,
       // if they exist.
-      if (exemplarSource) {
+      if (exemplarSources) {
         const parsedExemplarSource: ProjectSources = {
-          source: exemplarSource,
+          source: exemplarSources,
           labConfig: levelStartSources?.labConfig,
         };
-        if (serializedMaze) {
+        if (levelProperties.serializedMaze) {
           // If there is an existing maze file, we will replace it with the current maze.
           // Otherwise, we will create a new maze file.
           const existingMazeFile = findFile(
-            exemplarSource,
+            exemplarSources,
             MAZE_FILE_NAME,
             DEFAULT_FOLDER_ID
           );
           const mazeFileId =
             existingMazeFile?.id ||
-            getNextFileId(Object.values(exemplarSource.files));
-          const mazeFile = generateMazeFile(serializedMaze, mazeFileId);
+            getNextFileId(Object.values(exemplarSources.files));
+          const mazeFile = generateMazeFile(
+            levelProperties.serializedMaze,
+            mazeFileId
+          );
           parsedExemplarSource.source = {
-            ...exemplarSource,
+            ...exemplarSources,
             files: {
-              ...exemplarSource.files,
+              ...exemplarSources.files,
               [mazeFileId]: mazeFile,
             },
           };
@@ -170,19 +172,19 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
       return templateSources || startSources;
     }
 
-    const projectSources = labInitialSources;
+    const projectSources = initialServerSource;
     return projectSources || templateSources || startSources;
   }, [
+    initialServerSource,
+    isEditingExemplar,
+    isStartMode,
+    isViewingExemplar,
+    exemplarSources,
+    levelProperties.predictSettings?.isPredictLevel,
+    levelProperties.serializedMaze,
     levelStartSources,
     parsedDefaultSources,
     templateStartSources,
-    isStartMode,
-    isPredictLevel,
-    isEditingExemplar,
-    isViewingExemplar,
-    labInitialSources,
-    exemplarSource,
-    serializedMaze,
   ]);
 
   return {

--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -37,6 +37,14 @@ export const useInitialSources = (
 ) => {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const exemplarSources = levelProperties.exemplarSources as MultiFileSource;
+  const {
+    serializedMaze,
+    miniApp,
+    validationFile,
+    startSources,
+    templateSources,
+    predictSettings,
+  } = levelProperties;
 
   const generateMazeFile = (mazeContents: MazeCell[][], fileId: string) => {
     return {
@@ -54,12 +62,9 @@ export const useInitialSources = (
       // If we have a serialized maze, we need to add it to the project sources so
       // it is accessible when running/sharing/remixing the code. We save it as a
       // system support file.
-      if (levelProperties.serializedMaze) {
+      if (serializedMaze) {
         const mazeFileId = getNextFileId(Object.values(startCode.files));
-        const mazeFile = generateMazeFile(
-          levelProperties.serializedMaze,
-          mazeFileId
-        );
+        const mazeFile = generateMazeFile(serializedMaze, mazeFileId);
         startCode = {
           ...startCode,
           files: {
@@ -70,41 +75,31 @@ export const useInitialSources = (
       }
 
       const source = isStartMode
-        ? combineStartSourcesAndValidation(
-            startCode,
-            levelProperties.validationFile
-          )
+        ? combineStartSourcesAndValidation(startCode, validationFile)
         : startCode;
 
-      const labConfig = levelProperties.miniApp
-        ? {miniApp: {name: levelProperties.miniApp}}
-        : undefined;
+      const labConfig = miniApp ? {miniApp: {name: miniApp}} : undefined;
 
       return {source, labConfig};
     },
-    [
-      isStartMode,
-      levelProperties.miniApp,
-      levelProperties.serializedMaze,
-      levelProperties.validationFile,
-    ]
+    [isStartMode, miniApp, serializedMaze, validationFile]
   );
 
   // We memoize these objects so that they don't cause an unexpected re-render.
   const levelStartSources: ProjectSources | undefined = useMemo(
     () =>
-      levelProperties.startSources
-        ? generateProjectSourceFromStartSource(levelProperties.startSources)
+      startSources
+        ? generateProjectSourceFromStartSource(startSources)
         : undefined,
-    [generateProjectSourceFromStartSource, levelProperties.startSources]
+    [generateProjectSourceFromStartSource, startSources]
   );
 
   const templateStartSources: ProjectSources | undefined = useMemo(
     () =>
-      levelProperties.templateSources
-        ? generateProjectSourceFromStartSource(levelProperties.templateSources)
+      templateSources
+        ? generateProjectSourceFromStartSource(templateSources)
         : undefined,
-    [generateProjectSourceFromStartSource, levelProperties.templateSources]
+    [generateProjectSourceFromStartSource, templateSources]
   );
 
   const parsedDefaultSources = useMemo(
@@ -125,7 +120,7 @@ export const useInitialSources = (
     if (isStartMode) {
       return startSources;
     }
-    if (levelProperties.predictSettings?.isPredictLevel) {
+    if (predictSettings?.isPredictLevel) {
       // Predict levels never use sources loaded from the server, only the start sources.
       return templateSources || startSources;
     }
@@ -137,7 +132,7 @@ export const useInitialSources = (
           source: exemplarSources,
           labConfig: levelStartSources?.labConfig,
         };
-        if (levelProperties.serializedMaze) {
+        if (serializedMaze) {
           // If there is an existing maze file, we will replace it with the current maze.
           // Otherwise, we will create a new maze file.
           const existingMazeFile = findFile(
@@ -148,10 +143,7 @@ export const useInitialSources = (
           const mazeFileId =
             existingMazeFile?.id ||
             getNextFileId(Object.values(exemplarSources.files));
-          const mazeFile = generateMazeFile(
-            levelProperties.serializedMaze,
-            mazeFileId
-          );
+          const mazeFile = generateMazeFile(serializedMaze, mazeFileId);
           parsedExemplarSource.source = {
             ...exemplarSources,
             files: {
@@ -171,16 +163,16 @@ export const useInitialSources = (
     const projectSources = initialServerSource;
     return projectSources || templateSources || startSources;
   }, [
-    initialServerSource,
-    isEditingExemplar,
-    isStartMode,
-    isViewingExemplar,
-    exemplarSources,
-    levelProperties.predictSettings?.isPredictLevel,
-    levelProperties.serializedMaze,
     levelStartSources,
     parsedDefaultSources,
     templateStartSources,
+    isStartMode,
+    predictSettings?.isPredictLevel,
+    isEditingExemplar,
+    isViewingExemplar,
+    initialServerSource,
+    exemplarSources,
+    serializedMaze,
   ]);
 
   return {

--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -1,10 +1,6 @@
 import {getNextFileId} from '@codebridge/codebridgeContext';
 import {DEFAULT_FOLDER_ID, MAZE_FILE_NAME} from '@codebridge/constants';
-import {
-  CodebridgeLevelProperties,
-  CodebridgeProjectSources,
-  MazeCell,
-} from '@codebridge/types';
+import {CodebridgeLevelProperties, MazeCell} from '@codebridge/types';
 import {combineStartSourcesAndValidation, findFile} from '@codebridge/utils';
 import {useCallback, useMemo} from 'react';
 
@@ -37,7 +33,7 @@ import {
 export const useInitialSources = (
   defaultSources: ProjectSources,
   levelProperties: CodebridgeLevelProperties,
-  initialServerSource: CodebridgeProjectSources | undefined
+  initialServerSource: ProjectSources | undefined
 ) => {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const exemplarSources = levelProperties.exemplarSources as MultiFileSource;

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -1,3 +1,7 @@
+import {
+  CodebridgeLevelProperties,
+  CodebridgeProjectSources,
+} from '@codebridge/types';
 import {prepareSourceForLevelbuilderSave} from '@codebridge/utils';
 import {debounce, isEqual} from 'lodash';
 import {useEffect, useMemo, useRef} from 'react';
@@ -27,7 +31,11 @@ import {useInitialSources} from './useInitialSources';
 // Hook for handling the project source for the current level.
 // Returns the current project source and a function to save the source.
 // This also handles displaying the levelbuilder save button in start mode.
-export const useSource = (defaultSources: ProjectSources) => {
+export const useSource = (
+  defaultSources: ProjectSources,
+  levelProperties: CodebridgeLevelProperties,
+  initiaServerSources: CodebridgeProjectSources | undefined
+) => {
   const dispatch = useAppDispatch();
   const projectSource = useAppSelector(
     state => state.lab2Project.projectSources
@@ -40,13 +48,9 @@ export const useSource = (defaultSources: ProjectSources) => {
     levelStartSources,
     templateStartSources,
     parsedDefaultSources,
-  } = useInitialSources(defaultSources);
+  } = useInitialSources(defaultSources, levelProperties, initiaServerSources);
   const previousLevelIdRef = useRef<number | null>(null);
   const previousInitialSources = useRef<ProjectSources | null>(null);
-  const validationFile = useAppSelector(
-    state => state.lab.levelProperties?.validationFile
-  );
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   // keep track of whatever project the user has set locally. This happens after any change in CodeBridge
   // in the setSource function below
@@ -54,7 +58,6 @@ export const useSource = (defaultSources: ProjectSources) => {
   // keep an internal version number for the project used in the <Codebridge/> component.
   // This lets us replace the project if it was swapped out externally.
   const projectVersionRef = useRef(0);
-  const levelId = useAppSelector(state => state.lab.levelProperties?.id);
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
   const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
   const currentLevel = useAppSelector(state => getCurrentLevel(state));
@@ -70,8 +73,10 @@ export const useSource = (defaultSources: ProjectSources) => {
   );
 
   const debouncedProgressReport = debounce(() => {
-    if (appName) {
-      dispatch(sendProgressReport(appName, TestResults.LEVEL_STARTED));
+    if (levelProperties.appName) {
+      dispatch(
+        sendProgressReport(levelProperties.appName, TestResults.LEVEL_STARTED)
+      );
     }
   }, 100);
 
@@ -135,17 +140,18 @@ export const useSource = (defaultSources: ProjectSources) => {
       header.showLevelBuilderSaveButton(
         () => ({exemplar_sources: source}),
         'Levelbuilder: Edit Exemplar',
-        `/levels/${levelId}/update_exemplar_code`
+        `/levels/${levelProperties.id}/update_exemplar_code`
       );
     }
-  }, [isStartMode, isEditingExemplarMode, levelId, source]);
+  }, [isStartMode, isEditingExemplarMode, source, levelProperties.id]);
 
   useEffect(() => {
     // We reset the project when the levelId changes, as this means we are on a new level.
     // We also reset if the initialSources changed; this could occur if we are a teacher
     // viewing a student's project.
     if (
-      (levelId && previousLevelIdRef.current !== levelId) ||
+      (levelProperties.id &&
+        previousLevelIdRef.current !== levelProperties.id) ||
       initialSources !== previousInitialSources.current
     ) {
       if (initialSources) {
@@ -159,12 +165,12 @@ export const useSource = (defaultSources: ProjectSources) => {
           ?.setLastSource(initialSources);
         setSourceHelper(initialSources);
       }
-      if (levelId) {
-        previousLevelIdRef.current = levelId;
+      if (levelProperties.id) {
+        previousLevelIdRef.current = levelProperties.id;
       }
       previousInitialSources.current = initialSources;
     }
-  }, [initialSources, levelId, setSourceHelper]);
+  }, [initialSources, levelProperties.id, setSourceHelper]);
 
   // If the source retrieved from redux is the same as our localProject, then there haven't been any external
   // changes so we don't increment the key and keep the current layout in place.
@@ -185,7 +191,7 @@ export const useSource = (defaultSources: ProjectSources) => {
     setProject,
     startSources,
     projectVersion,
-    validationFile,
+    validationFile: levelProperties.validationFile,
     labConfig: projectSource?.labConfig,
   };
 };

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -1,7 +1,4 @@
-import {
-  CodebridgeLevelProperties,
-  CodebridgeProjectSources,
-} from '@codebridge/types';
+import {CodebridgeLevelProperties} from '@codebridge/types';
 import {prepareSourceForLevelbuilderSave} from '@codebridge/utils';
 import {debounce, isEqual} from 'lodash';
 import {useEffect, useMemo, useRef} from 'react';
@@ -34,7 +31,7 @@ import {useInitialSources} from './useInitialSources';
 export const useSource = (
   defaultSources: ProjectSources,
   levelProperties: CodebridgeLevelProperties,
-  initiaServerSources: CodebridgeProjectSources | undefined
+  initiaServerSources: ProjectSources | undefined
 ) => {
   const dispatch = useAppDispatch();
   const projectSource = useAppSelector(

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -58,6 +58,7 @@ export const useSource = (
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
   const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
   const currentLevel = useAppSelector(state => getCurrentLevel(state));
+  const {appName, id: levelId} = levelProperties;
 
   const setSourceHelper = useMemo(
     () => (newProjectSource: ProjectSources) => {
@@ -70,10 +71,8 @@ export const useSource = (
   );
 
   const debouncedProgressReport = debounce(() => {
-    if (levelProperties.appName) {
-      dispatch(
-        sendProgressReport(levelProperties.appName, TestResults.LEVEL_STARTED)
-      );
+    if (appName) {
+      dispatch(sendProgressReport(appName, TestResults.LEVEL_STARTED));
     }
   }, 100);
 
@@ -137,18 +136,17 @@ export const useSource = (
       header.showLevelBuilderSaveButton(
         () => ({exemplar_sources: source}),
         'Levelbuilder: Edit Exemplar',
-        `/levels/${levelProperties.id}/update_exemplar_code`
+        `/levels/${levelId}/update_exemplar_code`
       );
     }
-  }, [isStartMode, isEditingExemplarMode, source, levelProperties.id]);
+  }, [isStartMode, isEditingExemplarMode, source, levelId]);
 
   useEffect(() => {
     // We reset the project when the levelId changes, as this means we are on a new level.
     // We also reset if the initialSources changed; this could occur if we are a teacher
     // viewing a student's project.
     if (
-      (levelProperties.id &&
-        previousLevelIdRef.current !== levelProperties.id) ||
+      (levelId && previousLevelIdRef.current !== levelId) ||
       initialSources !== previousInitialSources.current
     ) {
       if (initialSources) {
@@ -162,12 +160,12 @@ export const useSource = (
           ?.setLastSource(initialSources);
         setSourceHelper(initialSources);
       }
-      if (levelProperties.id) {
-        previousLevelIdRef.current = levelProperties.id;
+      if (levelId) {
+        previousLevelIdRef.current = levelId;
       }
       previousInitialSources.current = initialSources;
     }
-  }, [initialSources, levelProperties.id, setSourceHelper]);
+  }, [initialSources, levelId, setSourceHelper]);
 
   // If the source retrieved from redux is the same as our localProject, then there haven't been any external
   // changes so we don't increment the key and keep the current layout in place.

--- a/apps/src/codebridge/types.ts
+++ b/apps/src/codebridge/types.ts
@@ -87,7 +87,3 @@ export interface MazeCell {
   value: number;
   assetId: number;
 }
-
-export interface CodebridgeProjectSources extends ProjectSources {
-  source: MultiFileSource;
-}

--- a/apps/src/codebridge/types.ts
+++ b/apps/src/codebridge/types.ts
@@ -2,6 +2,7 @@ import {LanguageSupport} from '@codemirror/language';
 import {AnyAction, Dispatch} from 'redux';
 
 import {
+  LevelProperties,
   MultiFileSource,
   ProjectFile,
   ProjectSources,
@@ -71,3 +72,22 @@ export type ReducerAction = {
 };
 
 export type EditorTheme = 'light' | 'dark';
+
+export interface CodebridgeLevelProperties extends LevelProperties {
+  validationFile?: ProjectFile;
+  enableMicroBit?: boolean;
+  miniApp?: string;
+  serializedMaze?: MazeCell[][];
+  startDirection?: number;
+}
+
+// Python Lab specific property
+export interface MazeCell {
+  tileType: number;
+  value: number;
+  assetId: number;
+}
+
+export interface CodebridgeProjectSources extends ProjectSources {
+  source: MultiFileSource;
+}

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -1,7 +1,11 @@
 // Pythonlab view
 import {Codebridge} from '@codebridge/Codebridge';
 import {useSource} from '@codebridge/hooks/useSource';
-import {ConfigType} from '@codebridge/types';
+import {
+  CodebridgeLevelProperties,
+  CodebridgeProjectSources,
+  ConfigType,
+} from '@codebridge/types';
 import {python} from '@codemirror/lang-python';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useContext, useEffect, useState} from 'react';
@@ -98,7 +102,9 @@ const defaultConfig: ConfigType = {
   },
 };
 
-const PythonlabView: React.FunctionComponent<LabProps> = () => {
+const PythonlabView: React.FunctionComponent<
+  LabProps<CodebridgeLevelProperties, CodebridgeProjectSources>
+> = ({levelProperties, initialSources}) => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
   const {
     source,
@@ -107,25 +113,22 @@ const PythonlabView: React.FunctionComponent<LabProps> = () => {
     projectVersion,
     validationFile,
     labConfig,
-  } = useSource(defaultProject);
-  const isPredictLevel = useAppSelector(
-    state => state.lab.levelProperties?.predictSettings?.isPredictLevel
-  );
+  } = useSource(defaultProject, levelProperties, initialSources);
+  const isPredictLevel = levelProperties.predictSettings?.isPredictLevel;
   const predictResponse = useAppSelector(state => state.predictLevel.response);
   const predictAnswerLocked = useAppSelector(isPredictAnswerLocked);
   const progressManager = useContext(ProgressManagerContext);
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 
   const currentLevel = useAppSelector(state => getCurrentLevel(state));
 
   useEffect(() => {
-    if (progressManager && appName === 'pythonlab') {
+    if (progressManager && levelProperties.appName === 'pythonlab') {
       progressManager.setValidator(
         new PythonValidator(PythonValidationTracker.getInstance())
       );
     }
-  }, [progressManager, appName]);
+  }, [progressManager, levelProperties.appName]);
 
   // Ensure any in-progress program is stopped when the level is switched.
   useLifecycleNotifier(
@@ -158,7 +161,12 @@ const PythonlabView: React.FunctionComponent<LabProps> = () => {
     ) {
       // If this is not a predict level and the current status is not tried,
       // send a level started progress report.
-      dispatch(sendProgressReport(appName || '', TestResults.LEVEL_STARTED));
+      dispatch(
+        sendProgressReport(
+          levelProperties.appName || '',
+          TestResults.LEVEL_STARTED
+        )
+      );
     }
     // Only send a predict level report if this is a predict level and the predict
     // answer was not locked.

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -1,11 +1,7 @@
 // Pythonlab view
 import {Codebridge} from '@codebridge/Codebridge';
 import {useSource} from '@codebridge/hooks/useSource';
-import {
-  CodebridgeLevelProperties,
-  CodebridgeProjectSources,
-  ConfigType,
-} from '@codebridge/types';
+import {CodebridgeLevelProperties, ConfigType} from '@codebridge/types';
 import {python} from '@codemirror/lang-python';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useContext, useEffect, useState} from 'react';
@@ -103,7 +99,7 @@ const defaultConfig: ConfigType = {
 };
 
 const PythonlabView: React.FunctionComponent<
-  LabProps<CodebridgeLevelProperties, CodebridgeProjectSources>
+  LabProps<CodebridgeLevelProperties, ProjectSources>
 > = ({levelProperties, initialSources}) => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
   const {

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -3,7 +3,11 @@
 import './styles/Weblab2View.css';
 
 import {Codebridge} from '@codebridge/Codebridge';
-import {ConfigType} from '@codebridge/types';
+import {
+  CodebridgeLevelProperties,
+  CodebridgeProjectSources,
+  ConfigType,
+} from '@codebridge/types';
 import {css} from '@codemirror/lang-css';
 import {html} from '@codemirror/lang-html';
 import {LanguageSupport} from '@codemirror/language';
@@ -136,10 +140,15 @@ const defaultSource: MultiFileSource = {
 
 const defaultProject: ProjectSources = {source: defaultSource};
 
-const Weblab2View: React.FC<LabProps> = () => {
+const Weblab2View: React.FC<
+  LabProps<CodebridgeLevelProperties, CodebridgeProjectSources>
+> = ({levelProperties, initialSources}) => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
-  const {source, setProject, startSources, projectVersion} =
-    useSource(defaultProject);
+  const {source, setProject, startSources, projectVersion} = useSource(
+    defaultProject,
+    levelProperties,
+    initialSources
+  );
 
   return (
     <div className="app-wrapper">

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -3,11 +3,7 @@
 import './styles/Weblab2View.css';
 
 import {Codebridge} from '@codebridge/Codebridge';
-import {
-  CodebridgeLevelProperties,
-  CodebridgeProjectSources,
-  ConfigType,
-} from '@codebridge/types';
+import {CodebridgeLevelProperties, ConfigType} from '@codebridge/types';
 import {css} from '@codemirror/lang-css';
 import {html} from '@codemirror/lang-html';
 import {LanguageSupport} from '@codemirror/language';
@@ -141,7 +137,7 @@ const defaultSource: MultiFileSource = {
 const defaultProject: ProjectSources = {source: defaultSource};
 
 const Weblab2View: React.FC<
-  LabProps<CodebridgeLevelProperties, CodebridgeProjectSources>
+  LabProps<CodebridgeLevelProperties, ProjectSources>
 > = ({levelProperties, initialSources}) => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
   const {source, setProject, startSources, projectVersion} = useSource(

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -3,11 +3,7 @@ import React from 'react';
 import {Provider} from 'react-redux';
 import {Store} from 'redux';
 
-import {
-  CodebridgeLevelProperties,
-  CodebridgeProjectSources,
-  MazeCell,
-} from '@cdo/apps/codebridge';
+import {CodebridgeLevelProperties, MazeCell} from '@cdo/apps/codebridge';
 import {
   DEFAULT_FOLDER_ID,
   MAZE_FILE_NAME,
@@ -18,6 +14,7 @@ import {
   MultiFileSource,
   ProjectFile,
   ProjectFileType,
+  ProjectSources,
 } from '@cdo/apps/lab2/types';
 import {
   getStore,
@@ -96,7 +93,7 @@ describe('useInitialSources', () => {
 
   function renderDefault(
     levelProperties?: CodebridgeLevelProperties,
-    initialServerSources?: CodebridgeProjectSources
+    initialServerSources?: ProjectSources
   ) {
     const wrapper = ({children}: {children?: React.ReactNode}) => (
       <Provider store={store}>{children}</Provider>

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -4,13 +4,17 @@ import {Provider} from 'react-redux';
 import {Store} from 'redux';
 
 import {
+  CodebridgeLevelProperties,
+  CodebridgeProjectSources,
+  MazeCell,
+} from '@cdo/apps/codebridge';
+import {
   DEFAULT_FOLDER_ID,
   MAZE_FILE_NAME,
 } from '@cdo/apps/codebridge/constants';
 import {useInitialSources} from '@cdo/apps/codebridge/hooks';
-import lab, {onLevelChange} from '@cdo/apps/lab2/lab2Redux';
+import lab from '@cdo/apps/lab2/lab2Redux';
 import {
-  MazeCell,
   MultiFileSource,
   ProjectFile,
   ProjectFileType,
@@ -25,6 +29,7 @@ import {
 import {
   neighborhoodLevelProperties,
   nonValidatedLevelProperties,
+  noStartSourcesLevelProperties,
   predictLevelProperties,
   smallProject,
   smallProjectSources,
@@ -89,13 +94,24 @@ describe('useInitialSources', () => {
     jest.resetAllMocks();
   });
 
-  function renderDefault() {
+  function renderDefault(
+    levelProperties?: CodebridgeLevelProperties,
+    initialServerSources?: CodebridgeProjectSources
+  ) {
     const wrapper = ({children}: {children?: React.ReactNode}) => (
       <Provider store={store}>{children}</Provider>
     );
-    const {result} = renderHook(() => useInitialSources(smallProjectSources), {
-      wrapper,
-    });
+    const {result} = renderHook(
+      () =>
+        useInitialSources(
+          smallProjectSources,
+          levelProperties || noStartSourcesLevelProperties,
+          initialServerSources
+        ),
+      {
+        wrapper,
+      }
+    );
     const {
       initialSources,
       levelStartSources,
@@ -124,15 +140,12 @@ describe('useInitialSources', () => {
   });
 
   it('returns start sources for a non-template level', () => {
-    store.dispatch(
-      onLevelChange({levelProperties: nonValidatedLevelProperties})
-    );
     const {
       initialSources,
       levelStartSources,
       templateStartSources,
       parsedDefaultSources,
-    } = renderDefault();
+    } = renderDefault(nonValidatedLevelProperties);
     const expectedSources = {
       source: nonValidatedLevelProperties.startSources,
       labConfig: undefined,
@@ -144,15 +157,12 @@ describe('useInitialSources', () => {
   });
 
   it('returns template sources for a template-backed level', () => {
-    store.dispatch(
-      onLevelChange({levelProperties: templateBackedLevelProperties})
-    );
     const {
       initialSources,
       levelStartSources,
       templateStartSources,
       parsedDefaultSources,
-    } = renderDefault();
+    } = renderDefault(templateBackedLevelProperties);
     const expectedLevelSources = {
       source: templateBackedLevelProperties.startSources,
       labConfig: undefined,
@@ -168,15 +178,12 @@ describe('useInitialSources', () => {
   });
 
   it('populates labConfig and serializedMaze for a neighborhood level', () => {
-    store.dispatch(
-      onLevelChange({levelProperties: neighborhoodLevelProperties})
-    );
     const {
       initialSources,
       levelStartSources,
       templateStartSources,
       parsedDefaultSources,
-    } = renderDefault();
+    } = renderDefault(neighborhoodLevelProperties);
     const expectedSources = getExpectedMazeSources(
       neighborhoodLevelProperties.startSources,
       neighborhoodLevelProperties.serializedMaze!,
@@ -199,13 +206,12 @@ describe('useInitialSources', () => {
     const levelProperties = {...neighborhoodLevelProperties};
     levelProperties.templateSources =
       templateBackedLevelProperties.templateSources;
-    store.dispatch(onLevelChange({levelProperties}));
     const {
       initialSources,
       levelStartSources,
       templateStartSources,
       parsedDefaultSources,
-    } = renderDefault();
+    } = renderDefault(levelProperties);
     const expectedLevelSources = getExpectedMazeSources(
       levelProperties.startSources,
       levelProperties.serializedMaze!,
@@ -228,18 +234,12 @@ describe('useInitialSources', () => {
   });
 
   it('sets initial sources as lab initial sources if they exist', () => {
-    store.dispatch(
-      onLevelChange({
-        levelProperties: nonValidatedLevelProperties,
-        initialSources: sampleInitialSources,
-      })
-    );
     const {
       initialSources,
       levelStartSources,
       templateStartSources,
       parsedDefaultSources,
-    } = renderDefault();
+    } = renderDefault(nonValidatedLevelProperties, sampleInitialSources);
 
     const expectedStartSources = {
       source: nonValidatedLevelProperties.startSources,
@@ -253,14 +253,11 @@ describe('useInitialSources', () => {
 
   it('sets start sources as initial sources in start mode', () => {
     mockAppOptions({editBlocks: 'start_sources'});
-    store.dispatch(
-      onLevelChange({
-        levelProperties: nonValidatedLevelProperties,
-        initialSources: sampleInitialSources,
-      })
-    );
 
-    const {initialSources} = renderDefault();
+    const {initialSources} = renderDefault(
+      nonValidatedLevelProperties,
+      sampleInitialSources
+    );
 
     const expectedStartSources = {
       source: nonValidatedLevelProperties.startSources,
@@ -271,13 +268,10 @@ describe('useInitialSources', () => {
 
   it('uses exemplar code in exemplar mode', () => {
     mockAppOptions({isEditingExemplar: true});
-    store.dispatch(
-      onLevelChange({
-        levelProperties: withExemplarLevelProperties,
-        initialSources: sampleInitialSources,
-      })
+    const {initialSources} = renderDefault(
+      withExemplarLevelProperties,
+      sampleInitialSources
     );
-    const {initialSources} = renderDefault();
 
     const expectedInitialSources = {
       source: withExemplarLevelProperties.exemplarSources,
@@ -289,13 +283,10 @@ describe('useInitialSources', () => {
 
   it('uses exemplar code in viewing exemplar mode', () => {
     mockAppOptions({isViewingExemplar: true});
-    store.dispatch(
-      onLevelChange({
-        levelProperties: withExemplarLevelProperties,
-        initialSources: sampleInitialSources,
-      })
+    const {initialSources} = renderDefault(
+      withExemplarLevelProperties,
+      sampleInitialSources
     );
-    const {initialSources} = renderDefault();
 
     const expectedInitialSources = {
       source: withExemplarLevelProperties.exemplarSources,
@@ -306,13 +297,10 @@ describe('useInitialSources', () => {
   });
 
   it('does not use exemplar in standard mode', () => {
-    store.dispatch(
-      onLevelChange({
-        levelProperties: withExemplarLevelProperties,
-        initialSources: sampleInitialSources,
-      })
+    const {initialSources} = renderDefault(
+      withExemplarLevelProperties,
+      sampleInitialSources
     );
-    const {initialSources} = renderDefault();
 
     expect(initialSources).toEqual(sampleInitialSources);
   });
@@ -330,7 +318,6 @@ describe('useInitialSources', () => {
         '1': generateMazeFile([[]], '1'),
       },
     };
-    store.dispatch(onLevelChange({levelProperties}));
 
     mockAppOptions({isViewingExemplar: true});
 
@@ -339,20 +326,16 @@ describe('useInitialSources', () => {
       levelProperties.serializedMaze!,
       '1'
     );
-    const {initialSources} = renderDefault();
+    const {initialSources} = renderDefault(levelProperties);
 
     expect(initialSources).toEqual(expectedInitialSources);
   });
 
   it('predict levels always use start code', () => {
-    store.dispatch(
-      onLevelChange({
-        levelProperties: predictLevelProperties,
-        initialSources: sampleInitialSources,
-      })
+    const {initialSources} = renderDefault(
+      predictLevelProperties,
+      sampleInitialSources
     );
-
-    const {initialSources} = renderDefault();
     const expectedInitialSources = {
       source: predictLevelProperties.startSources,
       labConfig: undefined,

--- a/apps/test/unit/codebridge/hooks/useSourceTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useSourceTest.tsx
@@ -4,8 +4,9 @@ import {Provider} from 'react-redux';
 import {Store} from 'redux';
 
 import progress from '@cdo/apps/code-studio/progressRedux';
+import {CodebridgeLevelProperties} from '@cdo/apps/codebridge';
 import {useSource} from '@cdo/apps/codebridge/hooks/useSource';
-import lab, {onLevelChange, setChannel} from '@cdo/apps/lab2/lab2Redux';
+import lab, {setChannel} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import ProjectManager from '@cdo/apps/lab2/projects/ProjectManager';
 import lab2Project from '@cdo/apps/lab2/redux/lab2ProjectRedux';
@@ -66,13 +67,21 @@ describe('useSource', () => {
     jest.resetAllMocks();
   });
 
-  function renderDefault() {
+  function renderDefault(levelProperties?: CodebridgeLevelProperties) {
     const wrapper = ({children}: {children?: React.ReactNode}) => (
       <Provider store={store}>{children}</Provider>
     );
-    const {result} = renderHook(() => useSource(defaultSources), {
-      wrapper,
-    });
+    const {result} = renderHook(
+      () =>
+        useSource(
+          defaultSources,
+          levelProperties || nonValidatedLevelProperties,
+          undefined
+        ),
+      {
+        wrapper,
+      }
+    );
     return result.current;
   }
 
@@ -115,10 +124,7 @@ describe('useSource', () => {
 
   it('returns level start sources in start mode', () => {
     mockAppOptions({editBlocks: 'start_sources'});
-    store.dispatch(
-      onLevelChange({levelProperties: templateBackedLevelProperties})
-    );
-    const {startSources} = renderDefault();
+    const {startSources} = renderDefault(templateBackedLevelProperties);
     const expectedStartSources = {
       source: templateBackedLevelProperties.startSources,
       labConfig: undefined,
@@ -127,10 +133,7 @@ describe('useSource', () => {
   });
 
   it('returns template start sources in standard mode', () => {
-    store.dispatch(
-      onLevelChange({levelProperties: templateBackedLevelProperties})
-    );
-    const {startSources} = renderDefault();
+    const {startSources} = renderDefault(templateBackedLevelProperties);
     const expectedStartSources = {
       source: templateBackedLevelProperties.templateSources,
       labConfig: undefined,
@@ -139,23 +142,11 @@ describe('useSource', () => {
   });
 
   it('updates source on level change', () => {
-    store.dispatch(
-      onLevelChange({
-        levelProperties: templateBackedLevelProperties,
-        channel: ownedChannel,
-      })
-    );
-    renderDefault();
+    store.dispatch(setChannel(ownedChannel));
+    renderDefault(templateBackedLevelProperties);
     expect(mockedProjectManager.save).toHaveBeenCalledTimes(1);
     expect(mockedProjectManager.setLastSource).toHaveBeenCalledTimes(1);
-    act(() => {
-      store.dispatch(
-        onLevelChange({
-          levelProperties: nonValidatedLevelProperties,
-          channel: ownedChannel,
-        })
-      );
-    });
+    renderDefault(nonValidatedLevelProperties);
     expect(mockedProjectManager.save).toHaveBeenCalledTimes(2);
     expect(mockedProjectManager.setLastSource).toHaveBeenCalledTimes(2);
     const expectedNewSources = {

--- a/apps/test/unit/codebridge/test-files/index.ts
+++ b/apps/test/unit/codebridge/test-files/index.ts
@@ -1,33 +1,31 @@
-import {ProjectFile} from '@codebridge/types';
+import {CodebridgeLevelProperties, ProjectFile} from '@codebridge/types';
 
-import {
-  LevelProperties,
-  MultiFileSource,
-  ProjectSources,
-} from '@cdo/apps/lab2/types';
+import {MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
 import {InitProgressPayload, LevelResults} from '@cdo/apps/types/progressTypes';
 
 const initProgressPayload: InitProgressPayload = require('./initProgressPayload.json');
 const levelResults: LevelResults = require('./levelResults.json');
-const neighborhoodLevelProperties: LevelProperties = require('./neighborhoodLevelProperties.json');
-const nonValidatedLevelProperties: LevelProperties = require('./nonValidatedLevelProperties.json');
-const predictLevelProperties: LevelProperties = require('./predictLevelProperties.json');
+const neighborhoodLevelProperties: CodebridgeLevelProperties = require('./neighborhoodLevelProperties.json');
+const nonValidatedLevelProperties: CodebridgeLevelProperties = require('./nonValidatedLevelProperties.json');
+const noStartSourcesLevelProperties: CodebridgeLevelProperties = require('./noStartSourcesLevelProperties.json');
+const predictLevelProperties: CodebridgeLevelProperties = require('./predictLevelProperties.json');
 const testProject: MultiFileSource = require('./project.json');
 const smallProject: MultiFileSource = require('./smallProject.json');
 const smallProjectSources: ProjectSources = require('./smallProjectSources.json');
 const starterFile: ProjectFile = require('./starterFile.json');
-const submittableLevelProperties: LevelProperties = require('./submittableLevelProperties.json');
+const submittableLevelProperties: CodebridgeLevelProperties = require('./submittableLevelProperties.json');
 const supportFile: ProjectFile = require('./supportFile.json');
-const templateBackedLevelProperties: LevelProperties = require('./templateBackedLevelProperties.json');
-const validatedLevelProperties: LevelProperties = require('./validatedLevelProperties.json');
+const templateBackedLevelProperties: CodebridgeLevelProperties = require('./templateBackedLevelProperties.json');
+const validatedLevelProperties: CodebridgeLevelProperties = require('./validatedLevelProperties.json');
 const validationFile: ProjectFile = require('./validationFile.json');
-const withExemplarLevelProperties: LevelProperties = require('./withExemplarLevelProperties.json');
+const withExemplarLevelProperties: CodebridgeLevelProperties = require('./withExemplarLevelProperties.json');
 
 export {
   initProgressPayload,
   levelResults,
   neighborhoodLevelProperties,
   nonValidatedLevelProperties,
+  noStartSourcesLevelProperties,
   predictLevelProperties,
   testProject,
   smallProject,

--- a/apps/test/unit/codebridge/test-files/noStartSourcesLevelProperties.json
+++ b/apps/test/unit/codebridge/test-files/noStartSourcesLevelProperties.json
@@ -1,0 +1,25 @@
+{
+  "encrypted": false,
+  "longInstructions": "## Welcome to Python Lab\r\n\r\nPress the Run button and see what happens.",
+  "hideShareAndRemix": true,
+  "referenceLinks": [
+    "/courses/csa-2023/guides/instantiating-objects"
+  ],
+  "mapReference": "/docs/concepts/html/",
+  "teacherMarkdown": "Teachers should see this extra info.",
+  "aiTutorAvailable": true,
+  "submittable": false,
+  "predictSettings": {
+    "isPredictLevel": false
+  },
+  "containedLevelNames": null,
+  "id": 28050,
+  "helpVideos": [],
+  "type": "Pythonlab",
+  "appName": "pythonlab",
+  "useRestrictedSongs": false,
+  "usesProjects": true,
+  "finishUrl": "/s/allthethings/lessons/50/levels/2",
+  "exampleSolutions": [],
+  "exemplarSources": null
+}


### PR DESCRIPTION
Part 1 of starting to use the level properties and initial sources from props rather than redux in Codebridge (see #63974 for initial work on this). I opted here to start using them in the outer view components, and in the source hooks. This already was a fair amount of code by itself. The props are right now just passed-in versions of the redux values, so I think it's safe for us to convert piecemeal to avoid a mega-PR. 

## Links

- jira ticket: [CT-1127](https://codedotorg.atlassian.net/browse/CT-1127)

## Testing story
Tested locally and updated source hook unit tests.


## Follow-up work
My plan for the next steps is to add the level properties to the codebridge context provider, so we can access them from there rather than redux, and convert all our redux store access to level properties to use the context version. I'll keep the above jira ticket open to cover this work.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
