### PR TITLE
Codebridge: add check for selected version before cancelling

### DIFF
--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -303,7 +303,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
   // if the user is viewing an old version, then close the dropdown.
   const handleCancel = useCallback(() => {
     // Go back to current version if we are viewing an old version
-    if (!isLatestVersion(selectedVersion)) {
+    if (selectedVersion && !isLatestVersion(selectedVersion)) {
       dispatch(resetToCurrentVersion());
     }
     closeDropdown();

--- a/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryDropdownTest.tsx
+++ b/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryDropdownTest.tsx
@@ -65,7 +65,7 @@ describe('VersionHistoryButton', () => {
           buttonRef={{} as jest.Mocked<React.RefObject<HTMLDivElement>>}
           listLoading={false}
           listLoadError={false}
-          selectedVersion={''}
+          selectedVersion={'abc'}
           setSelectedVersion={setSelectedVersion}
         />
       </Provider>


### PR DESCRIPTION
I noticed that if you have no versions in your version history, open version history, then click cancel, the screen blanks out. This was likely introduced by #64269, because we no longer save immediately on load. The fix is to ensure we have a selected version before trying to revert to the current version.

## Links

- jira ticket: [CT-1148](https://codedotorg.atlassian.net/browse/CT-1148)

## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
