### PR TITLE
Add starter assets manager to AI Chat level edit page

### DIFF
--- a/apps/src/lab2/levelEditors/starterAssets/EditStarterAssets.tsx
+++ b/apps/src/lab2/levelEditors/starterAssets/EditStarterAssets.tsx
@@ -1,0 +1,23 @@
+import {Button} from '@code-dot-org/component-library/button';
+import React, {useState} from 'react';
+
+import StarterAssetsDialog from '../../views/components/starterAssetsDialog';
+
+const EditStarterAssets: React.FC<{levelName: string}> = ({levelName}) => {
+  const [showDialog, setShowDialog] = useState(false);
+
+  return (
+    <>
+      {showDialog && (
+        <StarterAssetsDialog
+          levelName={levelName}
+          mode="upload"
+          onClose={() => setShowDialog(false)}
+        />
+      )}
+      <Button text="Edit Starter Assets" onClick={() => setShowDialog(true)} />
+    </>
+  );
+};
+
+export default EditStarterAssets;

--- a/apps/src/lab2/levelEditors/starterAssets/EditStarterAssets.tsx
+++ b/apps/src/lab2/levelEditors/starterAssets/EditStarterAssets.tsx
@@ -3,17 +3,21 @@ import React, {useState} from 'react';
 
 import StarterAssetsDialog from '../../views/components/starterAssetsDialog';
 
+import styles from './edit-starter-assets.module.scss';
+
 const EditStarterAssets: React.FC<{levelName: string}> = ({levelName}) => {
   const [showDialog, setShowDialog] = useState(false);
 
   return (
     <>
       {showDialog && (
-        <StarterAssetsDialog
-          levelName={levelName}
-          mode="upload"
-          onClose={() => setShowDialog(false)}
-        />
+        <div className={styles.dialogContainer}>
+          <StarterAssetsDialog
+            levelName={levelName}
+            mode="upload"
+            onClose={() => setShowDialog(false)}
+          />
+        </div>
       )}
       <Button text="Edit Starter Assets" onClick={() => setShowDialog(true)} />
     </>

--- a/apps/src/lab2/levelEditors/starterAssets/edit-starter-assets.module.scss
+++ b/apps/src/lab2/levelEditors/starterAssets/edit-starter-assets.module.scss
@@ -1,0 +1,4 @@
+// Ensures the dialog and overlay are on top of other level editor content
+div.dialogContainer > div[role='presentation'] {
+  z-index: 5;
+}

--- a/apps/src/sites/studio/pages/levels/editors/fields/_starter_assets.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_starter_assets.js
@@ -1,0 +1,15 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import EditStarterAssets from '@cdo/apps/lab2/levelEditors/starterAssets/EditStarterAssets';
+
+$(document).ready(function () {
+  const script = document.querySelector(`script[data-levelname]`);
+  const levelName = script.dataset.levelname;
+
+  ReactDOM.render(
+    <EditStarterAssets levelName={levelName} />,
+    document.getElementById('starter-assets-editor')
+  );
+});

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -158,6 +158,7 @@ const INTERNAL_ENTRIES = {
   'levels/editors/fields/_predict_settings': './src/sites/studio/pages/levels/editors/fields/_predict_settings.js',
   'levels/editors/fields/_preload_assets': './src/sites/studio/pages/levels/editors/fields/_preload_assets.js',
   'levels/editors/fields/_special_level_types': './src/sites/studio/pages/levels/editors/fields/_special_level_types.js',
+  'levels/editors/fields/_starter_assets': './src/sites/studio/pages/levels/editors/fields/_starter_assets.js',
   'levels/editors/fields/_validation_code': './src/sites/studio/pages/levels/editors/fields/_validation_code.js',
   'levels/editors/fields/_validations': './src/sites/studio/pages/levels/editors/fields/_validations.js',
   'levels/editors/fields/_video': './src/sites/studio/pages/levels/editors/fields/_video.js',

--- a/dashboard/app/views/levels/editors/_aichat.html.haml
+++ b/dashboard/app/views/levels/editors/_aichat.html.haml
@@ -1,5 +1,6 @@
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/aichat_settings', locals: {f: f}
+= render partial: 'levels/editors/fields/starter_assets', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_starter_assets.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_starter_assets.html.haml
@@ -2,9 +2,6 @@
   Manage Starter Assets
 
 #starter-assets-container.in.collapse
-  %i Note: you may need to collapse other sections in order to view the dialog correctly due to view ordering issues.
-  %br
-  %br
   #starter-assets-editor
 
 - content_for :body_scripts do

--- a/dashboard/app/views/levels/editors/fields/_starter_assets.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_starter_assets.html.haml
@@ -1,0 +1,11 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#starter-assets-container"}}
+  Manage Starter Assets
+
+#starter-assets-container.in.collapse
+  %i Note: you may need to collapse other sections in order to view the dialog correctly due to view ordering issues.
+  %br
+  %br
+  #starter-assets-editor
+
+- content_for :body_scripts do
+  %script{src: webpack_asset_path('js/levels/editors/fields/_starter_assets.js'), data: {levelname: @level.name}}


### PR DESCRIPTION
Creates a new level editor field for managing starter assets (which is just a button that opens the Starter Asset Manager dialog from https://github.com/code-dot-org/code-dot-org/pull/64611), and adds it to the AI Chat level edit page. This can be added to other level edit pages as necessary.

Note: there's a quirk where if other editor sections are open under the dialog, they appear over the dialog/overlay. I think there's something going on with the z-indexing here but couldn't figure out an easy way to fix it. For now I've just included text that lets levelbuilders know to close other editor sections before opening the dialog.

Field section before clicking button:
<img width="1512" alt="Screenshot 2025-03-18 at 5 17 25 PM" src="https://github.com/user-attachments/assets/8acca52a-3b2a-438e-8646-9decaab46e1b" />

Dialog open:
<img width="1512" alt="Screenshot 2025-03-18 at 5 17 50 PM" src="https://github.com/user-attachments/assets/f8b89633-cf91-4447-aaad-4c73e18c3d34" />

## Links

Part of https://codedotorg.atlassian.net/browse/LABS-1387

## Testing story

Tested on AI Chat allthethings.