### PR TITLE
Music: JavaScript editor

### DIFF
--- a/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
@@ -642,7 +642,7 @@ export default class CustomMarshalingInterpreter extends Interpreter {
         let stepCount = 0;
         while (interpreter.step() && stepCount++ < runMaxSteps);
         if (stepCount >= runMaxSteps) {
-          console.log('exceeded step count!');
+          console.log('evalWith: exceeded step count.');
         }
       } else {
         interpreter.run();

--- a/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
@@ -603,12 +603,13 @@ export default class CustomMarshalingInterpreter extends Interpreter {
    * @param code {string} - the code to evaluation
    * @param scope {Object} - An object of globals to be added to the scope of code being executed
    * @param {Object} opts - Additional options to control behavior
-   * @param {Array} opts.asyncFunctionList - list of functions to treat asynchronously
-   * @param {boolean} opts.legacy - If true, code will be run natively via an eval-like method,
+   * @param {Array} [opts.asyncFunctionList] - list of functions to treat asynchronously
+   * @param {boolean} [opts.legacy] - If true, code will be run natively via an eval-like method,
    *     otherwise it will use the js interpreter.
+   * @param {number} [opts.runMaxSteps] - Run up to this many steps.
    * @returns the interpreter instance unless legacy=true, in which case, it returns whatever the given code returns.
    */
-  static evalWith(code, scope, {asyncFunctionList, legacy} = {}) {
+  static evalWith(code, scope, {asyncFunctionList, legacy, runMaxSteps} = {}) {
     const globals = {
       executionInfo: DEFAULT_EXECUTION_INFO,
       ...scope,
@@ -637,7 +638,15 @@ export default class CustomMarshalingInterpreter extends Interpreter {
           interpreter.marshalNativeToInterpreterObject(globals, 5, scope);
         }
       );
-      interpreter.run();
+      if (runMaxSteps) {
+        let stepCount = 0;
+        while (interpreter.step() && stepCount++ < runMaxSteps);
+        if (stepCount >= runMaxSteps) {
+          console.log('exceeded step count!');
+        }
+      } else {
+        interpreter.run();
+      }
       return interpreter;
     }
   }

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -411,6 +411,14 @@ export default class MusicBlocklyWorkspace {
     console.log('Execution time: ', Date.now() - startTime);
   }
 
+  executeCode(code: string, scope: object) {
+    try {
+      CustomMarshalingInterpreter.evalWith(code, scope, {runMaxSteps: 1000});
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
   /**
    * Executes code for the specific trigger referenced by the ID. It is
    * assumed that {@link compileSong()} has already been called and all event

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -578,6 +578,7 @@ export default class MusicBlocklyWorkspace {
       return;
     }
     if (!this.workspace) {
+      return;
       this.metricsReporter.logWarning(
         'updateHighlightedBlocks called before workspace initialized.'
       );

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -17,6 +17,7 @@ import {ValueOf} from '@cdo/apps/types/utils';
 import {nameComparator} from '@cdo/apps/util/sort';
 
 import CustomMarshalingInterpreter from '../../lib/tools/jsinterpreter/CustomMarshalingInterpreter';
+import AppConfig from '../appConfig';
 import {BlockMode, Triggers} from '../constants';
 import musicI18n from '../locale';
 
@@ -577,8 +578,10 @@ export default class MusicBlocklyWorkspace {
     if (this.headlessMode) {
       return;
     }
-    if (!this.workspace) {
+    if (AppConfig.getValue('js-editor') === 'true') {
       return;
+    }
+    if (!this.workspace) {
       this.metricsReporter.logWarning(
         'updateHighlightedBlocks called before workspace initialized.'
       );

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -416,7 +416,7 @@ export default class MusicBlocklyWorkspace {
     try {
       CustomMarshalingInterpreter.evalWith(code, scope, {runMaxSteps: 1000});
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
   }
 

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -587,6 +587,7 @@ export default class MusicBlocklyWorkspace {
       );
       return;
     }
+
     // Clear all highlights.
     for (const block of this.workspace.getAllBlocks()) {
       (this.workspace as GoogleBlockly.WorkspaceSvg).highlightBlock(

--- a/apps/src/music/player/sequencer/AdvancedSequencer.ts
+++ b/apps/src/music/player/sequencer/AdvancedSequencer.ts
@@ -124,6 +124,6 @@ export default class AdvancedSequencer extends Sequencer {
   }
 
   getLastMeasure(): number {
-    return 0;
+    return 100;
   }
 }

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -72,8 +72,6 @@ export interface MusicState {
     id?: string;
     index: number;
   };
-  /** Current JS if we are showing a code editor. */
-  currentCode?: string;
 
   // State used by advanced controls (currently internal-only) with the ToneJS player
   loopEnabled: boolean;
@@ -109,7 +107,6 @@ const initialState: MusicState = {
     id: undefined,
     index: 0,
   },
-  currentCode: undefined,
   loopEnabled: false,
   loopStart: 1,
   loopEnd: 5,
@@ -242,9 +239,6 @@ const musicSlice = createSlice({
     clearCallout: state => {
       state.currentCallout.id = undefined;
     },
-    setCurrentCode: (state, action: PayloadAction<string>) => {
-      state.currentCode = action.payload;
-    },
     setLoopEnabled: (state, action: PayloadAction<boolean>) => {
       state.loopEnabled = action.payload;
     },
@@ -347,7 +341,6 @@ export const {
   setUndoStatus,
   showCallout,
   clearCallout,
-  setCurrentCode,
   setLoopEnabled,
   setLoopStart,
   setLoopEnd,

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -72,6 +72,8 @@ export interface MusicState {
     id?: string;
     index: number;
   };
+  /** Current JS if we are showing a code editor. */
+  currentCode?: string;
 
   // State used by advanced controls (currently internal-only) with the ToneJS player
   loopEnabled: boolean;
@@ -107,6 +109,7 @@ const initialState: MusicState = {
     id: undefined,
     index: 0,
   },
+  currentCode: undefined,
   loopEnabled: false,
   loopStart: 1,
   loopEnd: 5,
@@ -239,6 +242,9 @@ const musicSlice = createSlice({
     clearCallout: state => {
       state.currentCallout.id = undefined;
     },
+    setCurrentCode: (state, action: PayloadAction<string>) => {
+      state.currentCode = action.payload;
+    },
     setLoopEnabled: (state, action: PayloadAction<boolean>) => {
       state.loopEnabled = action.payload;
     },
@@ -341,6 +347,7 @@ export const {
   setUndoStatus,
   showCallout,
   clearCallout,
+  setCurrentCode,
   setLoopEnabled,
   setLoopStart,
   setLoopEnd,

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -1,3 +1,4 @@
+import {javascript} from '@codemirror/lang-javascript';
 import classNames from 'classnames';
 import React, {useCallback, useContext, useEffect} from 'react';
 import {useSelector} from 'react-redux';
@@ -16,6 +17,7 @@ import {
   getAppOptionsViewingExemplar,
 } from '@cdo/apps/lab2/projects/utils';
 import {BlocklySource, ExemplarSettings} from '@cdo/apps/lab2/types';
+import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
@@ -66,6 +68,7 @@ interface MusicLabViewProps {
   analyticsReporter: AnalyticsReporter;
   blocklyWorkspace: MusicBlocklyWorkspace;
   exemplarPlaybackEvents: PlaybackEvent[];
+  executeCode: (code: string) => void;
 }
 
 const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
@@ -84,6 +87,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   analyticsReporter,
   blocklyWorkspace,
   exemplarPlaybackEvents,
+  executeCode,
 }) => {
   const dialogControl = useDialogControl();
   useUpdatePlayer(player);
@@ -455,6 +459,14 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 {WARNING_BANNER_MESSAGES.TOOLBOX_MODE}
               </div>
             )}
+            <CodeEditor
+              darkMode={true}
+              onCodeChange={code => {
+                executeCode(code);
+              }}
+              startCode={'test'}
+              editorConfigExtensions={[javascript()]}
+            />
             <div role="application" id={blocklyDivId} />
             {showAdvancedControls && (
               <div className={moduleStyles.advancedControlsContainer}>

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -464,7 +464,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
               onCodeChange={code => {
                 executeCode(code);
               }}
-              startCode={'test'}
+              startCode={''}
               editorConfigExtensions={[javascript()]}
             />
             <div role="application" id={blocklyDivId} />

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -459,14 +459,16 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 {WARNING_BANNER_MESSAGES.TOOLBOX_MODE}
               </div>
             )}
-            <CodeEditor
-              darkMode={true}
-              onCodeChange={code => {
-                executeCode(code);
-              }}
-              startCode={''}
-              editorConfigExtensions={[javascript()]}
-            />
+            {AppConfig.getValue('js-editor') === 'true' && (
+              <CodeEditor
+                darkMode={true}
+                onCodeChange={code => {
+                  executeCode(code);
+                }}
+                startCode={''}
+                editorConfigExtensions={[javascript()]}
+              />
+            )}
             <div role="application" id={blocklyDivId} />
             {showAdvancedControls && (
               <div className={moduleStyles.advancedControlsContainer}>

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -462,9 +462,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
             {AppConfig.getValue('js-editor') === 'true' && (
               <CodeEditor
                 darkMode={true}
-                onCodeChange={code => {
-                  executeCode(code);
-                }}
+                onCodeChange={executeCode}
                 startCode={''}
                 editorConfigExtensions={[javascript()]}
               />

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -712,12 +712,11 @@ class UnconnectedMusicView extends React.Component {
     );
   };
 
-  // Execute a song that has already been compiled, presumably from Blockly sources.
+  // Execute a song that has already been compiled from Blockly sources.
   executeCompiledSong = () => {
     if (!this.sequencer) {
       return;
     }
-
     if (AppConfig.getValue('js-editor') === 'true') {
       return;
     }
@@ -732,9 +731,7 @@ class UnconnectedMusicView extends React.Component {
     const allTriggerEvents = this.sequencer.getPlaybackEvents();
 
     this.sequencer.clear();
-
     this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);
-
     this.props.addPlaybackEvents(this.sequencer.getPlaybackEvents());
     this.props.setLastMeasure(this.sequencer.getLastMeasure());
     this.props.addOrderedFunctions({
@@ -744,12 +741,11 @@ class UnconnectedMusicView extends React.Component {
     return this.preloadSounds(allTriggerEvents);
   };
 
-  // Execute some song code directly.  Currently called by the prototype JavaScript editor.
+  // Execute some song code directly.  Called by the JavaScript editor.
   executeSongCode = code => {
     if (!this.sequencer) {
       return;
     }
-
     if (AppConfig.getValue('js-editor') !== 'true') {
       return;
     }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -71,7 +71,6 @@ import {
   setSelectedTriggerId,
   clearSelectedTriggerId,
   getBlockMode,
-  setCurrentCode,
 } from '../redux/musicRedux';
 import {Key} from '../utils/Notes';
 import SoundUploader from '../utils/SoundUploader';
@@ -135,8 +134,6 @@ class UnconnectedMusicView extends React.Component {
     blockMode: PropTypes.string,
     playbackEvents: PropTypes.array,
     exemplarPlaybackEvents: PropTypes.array,
-    setCurrentCode: PropTypes.func,
-    currentCode: PropTypes.string,
     validationState: PropTypes.object,
   };
 
@@ -715,8 +712,13 @@ class UnconnectedMusicView extends React.Component {
     );
   };
 
+  // Execute a song that has already been compiled, presumably from Blockly sources.
   executeCompiledSong = () => {
     if (!this.sequencer) {
+      return;
+    }
+
+    if (AppConfig.getValue('js-editor') === 'true') {
       return;
     }
 
@@ -727,22 +729,11 @@ class UnconnectedMusicView extends React.Component {
     // Sequence out all possible trigger events to preload sounds if necessary.
     this.sequencer.clear();
     this.musicBlocklyWorkspace.executeAllTriggers();
-
-    this.musicBlocklyWorkspace.executeCode(this.props.currentCode, {
-      Sequencer: this.sequencer,
-    });
-
     const allTriggerEvents = this.sequencer.getPlaybackEvents();
 
     this.sequencer.clear();
 
-    if (AppConfig.getValue('js-editor') === 'true') {
-      this.musicBlocklyWorkspace.executeCode(this.props.currentCode, {
-        Sequencer: this.sequencer,
-      });
-    } else {
-      this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);
-    }
+    this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);
 
     this.props.addPlaybackEvents(this.sequencer.getPlaybackEvents());
     this.props.setLastMeasure(this.sequencer.getLastMeasure());
@@ -750,6 +741,38 @@ class UnconnectedMusicView extends React.Component {
       orderedFunctions: this.sequencer.getOrderedFunctions?.() || [],
     });
 
+    return this.preloadSounds(allTriggerEvents);
+  };
+
+  // Execute some song code directly.  Currently called by the prototype JavaScript editor.
+  executeSongCode = code => {
+    if (!this.sequencer) {
+      return;
+    }
+
+    if (AppConfig.getValue('js-editor') !== 'true') {
+      return;
+    }
+
+    // Clear the events list because it will be populated next.
+    this.props.clearPlaybackEvents();
+    this.props.clearOrderedFunctions();
+
+    this.sequencer.clear();
+
+    this.musicBlocklyWorkspace.executeCode(code, {
+      Sequencer: this.sequencer,
+    });
+
+    this.props.addPlaybackEvents(this.sequencer.getPlaybackEvents());
+    this.props.setLastMeasure(this.sequencer.getLastMeasure());
+
+    return this.preloadSounds();
+  };
+
+  // Preload sounds that the sequencer knows about.
+  // Called by executeCompiledSong and executeSongCode.
+  preloadSounds = (allTriggerEvents = []) => {
     return this.player.preloadSounds(
       [...this.sequencer.getPlaybackEvents(), ...allTriggerEvents],
       (loadTimeMs, soundsLoaded) => {
@@ -910,8 +933,7 @@ class UnconnectedMusicView extends React.Component {
           executeCode={
             AppConfig.getValue('js-editor') === 'true' &&
             (code => {
-              this.props.setCurrentCode(code);
-              this.executeCompiledSong();
+              this.executeSongCode(code);
             })
           }
         />
@@ -946,7 +968,6 @@ const MusicView = connect(
     isPlayView: state.lab.isShareView,
     playbackEvents: state.music.playbackEvents,
     validationState: state.lab.validationState,
-    currentCode: state.music.currentCode,
   }),
   dispatch => ({
     setPackId: packId => dispatch(setPackId(packId)),
@@ -976,7 +997,6 @@ const MusicView = connect(
     updateLoadProgress: value => dispatch(setSoundLoadingProgress(value)),
     setUndoStatus: value => dispatch(setUndoStatus(value)),
     clearCallout: id => dispatch(clearCallout()),
-    setCurrentCode: code => dispatch(setCurrentCode(code)),
   })
 )(UnconnectedMusicView);
 

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -71,6 +71,7 @@ import {
   setSelectedTriggerId,
   clearSelectedTriggerId,
   getBlockMode,
+  setCurrentCode,
 } from '../redux/musicRedux';
 import {Key} from '../utils/Notes';
 import SoundUploader from '../utils/SoundUploader';
@@ -326,6 +327,7 @@ class UnconnectedMusicView extends React.Component {
     this.props.setPackId(packId);
     this.setExemplarPlaybackEvents();
 
+    /*
     this.props.isPlayView
       ? this.musicBlocklyWorkspace.initHeadless()
       : this.musicBlocklyWorkspace.init(
@@ -337,6 +339,7 @@ class UnconnectedMusicView extends React.Component {
           this.props.blockMode,
           localizedToolboxDefinition
         );
+    */
 
     this.props.setShowInstructions(
       !!levelData?.text || !!this.props.longInstructions
@@ -717,11 +720,21 @@ class UnconnectedMusicView extends React.Component {
 
     // Sequence out all possible trigger events to preload sounds if necessary.
     this.sequencer.clear();
-    this.musicBlocklyWorkspace.executeAllTriggers();
+    //this.musicBlocklyWorkspace.executeAllTriggers();
+
+    this.musicBlocklyWorkspace.executeCode(this.props.currentCode, {
+      Sequencer: this.sequencer,
+    });
+
     const allTriggerEvents = this.sequencer.getPlaybackEvents();
 
     this.sequencer.clear();
-    this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);
+    //this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);
+
+    this.musicBlocklyWorkspace.executeCode(this.props.currentCode, {
+      Sequencer: this.sequencer,
+    });
+
     this.props.addPlaybackEvents(this.sequencer.getPlaybackEvents());
     this.props.setLastMeasure(this.sequencer.getLastMeasure());
     this.props.addOrderedFunctions({
@@ -885,6 +898,13 @@ class UnconnectedMusicView extends React.Component {
           analyticsReporter={this.analyticsReporter}
           blocklyWorkspace={this.musicBlocklyWorkspace}
           exemplarPlaybackEvents={this.getExemplarPlaybackEvents()}
+          executeCode={code => {
+            this.props.setCurrentCode(code);
+            this.executeCompiledSong();
+            //this.musicBlocklyWorkspace.executeCode(code, {
+            //  Sequencer: this.sequencer,
+            //});
+          }}
         />
         <Callouts />
       </AnalyticsContext.Provider>
@@ -917,6 +937,7 @@ const MusicView = connect(
     isPlayView: state.lab.isShareView,
     playbackEvents: state.music.playbackEvents,
     validationState: state.lab.validationState,
+    currentCode: state.music.currentCode,
   }),
   dispatch => ({
     setPackId: packId => dispatch(setPackId(packId)),
@@ -946,6 +967,7 @@ const MusicView = connect(
     updateLoadProgress: value => dispatch(setSoundLoadingProgress(value)),
     setUndoStatus: value => dispatch(setUndoStatus(value)),
     clearCallout: id => dispatch(clearCallout()),
+    setCurrentCode: code => dispatch(setCurrentCode(code)),
   })
 )(UnconnectedMusicView);
 

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -135,6 +135,8 @@ class UnconnectedMusicView extends React.Component {
     blockMode: PropTypes.string,
     playbackEvents: PropTypes.array,
     exemplarPlaybackEvents: PropTypes.array,
+    setCurrentCode: PropTypes.func,
+    currentCode: PropTypes.string,
     validationState: PropTypes.object,
   };
 
@@ -714,6 +716,10 @@ class UnconnectedMusicView extends React.Component {
   };
 
   executeCompiledSong = () => {
+    if (!this.sequencer) {
+      return;
+    }
+
     // Clear the events list because it will be populated next.
     this.props.clearPlaybackEvents();
     this.props.clearOrderedFunctions();

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -329,19 +329,19 @@ class UnconnectedMusicView extends React.Component {
     this.props.setPackId(packId);
     this.setExemplarPlaybackEvents();
 
-    /*
-    this.props.isPlayView
-      ? this.musicBlocklyWorkspace.initHeadless()
-      : this.musicBlocklyWorkspace.init(
-          document.getElementById(BLOCKLY_DIV_ID),
-          this.onBlockSpaceChange,
-          this.props.isReadOnlyWorkspace,
-          toolboxAllowList,
-          this.props.isRtl,
-          this.props.blockMode,
-          localizedToolboxDefinition
-        );
-    */
+    if (AppConfig.getValue('js-editor') !== 'true') {
+      this.props.isPlayView
+        ? this.musicBlocklyWorkspace.initHeadless()
+        : this.musicBlocklyWorkspace.init(
+            document.getElementById(BLOCKLY_DIV_ID),
+            this.onBlockSpaceChange,
+            this.props.isReadOnlyWorkspace,
+            toolboxAllowList,
+            this.props.isRtl,
+            this.props.blockMode,
+            localizedToolboxDefinition
+          );
+    }
 
     this.props.setShowInstructions(
       !!levelData?.text || !!this.props.longInstructions
@@ -726,7 +726,7 @@ class UnconnectedMusicView extends React.Component {
 
     // Sequence out all possible trigger events to preload sounds if necessary.
     this.sequencer.clear();
-    //this.musicBlocklyWorkspace.executeAllTriggers();
+    this.musicBlocklyWorkspace.executeAllTriggers();
 
     this.musicBlocklyWorkspace.executeCode(this.props.currentCode, {
       Sequencer: this.sequencer,
@@ -735,11 +735,14 @@ class UnconnectedMusicView extends React.Component {
     const allTriggerEvents = this.sequencer.getPlaybackEvents();
 
     this.sequencer.clear();
-    //this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);
 
-    this.musicBlocklyWorkspace.executeCode(this.props.currentCode, {
-      Sequencer: this.sequencer,
-    });
+    if (AppConfig.getValue('js-editor') === 'true') {
+      this.musicBlocklyWorkspace.executeCode(this.props.currentCode, {
+        Sequencer: this.sequencer,
+      });
+    } else {
+      this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);
+    }
 
     this.props.addPlaybackEvents(this.sequencer.getPlaybackEvents());
     this.props.setLastMeasure(this.sequencer.getLastMeasure());
@@ -904,13 +907,13 @@ class UnconnectedMusicView extends React.Component {
           analyticsReporter={this.analyticsReporter}
           blocklyWorkspace={this.musicBlocklyWorkspace}
           exemplarPlaybackEvents={this.getExemplarPlaybackEvents()}
-          executeCode={code => {
-            this.props.setCurrentCode(code);
-            this.executeCompiledSong();
-            //this.musicBlocklyWorkspace.executeCode(code, {
-            //  Sequencer: this.sequencer,
-            //});
-          }}
+          executeCode={
+            AppConfig.getValue('js-editor') === 'true' &&
+            (code => {
+              this.props.setCurrentCode(code);
+              this.executeCompiledSong();
+            })
+          }
         />
         <Callouts />
       </AnalyticsContext.Provider>

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -219,6 +219,14 @@ const optionsList = [
       {value: 'true', description: 'Original timeline.'},
     ],
   },
+  {
+    name: 'js-editor',
+    type: 'radio',
+    values: [
+      {value: 'false', description: 'Blockly editor (default).'},
+      {value: 'true', description: 'JavaScript text editor.'},
+    ],
+  },
 ];
 
 export default class MusicMenu extends React.Component {


### PR DESCRIPTION
This adds a prototype of a JavaScript text editor to Music Lab, accessed by using the `?js-editor=true` URL parameter.

It is purely for internal evaluation, and is very rough around the edges.  It doesn't save or load the code, doesn't have autocomplete for function parameters, etc.

But it does exhibit the speed and fluidity of being able to type JavaScript directly, with the timeline updating in realtime as the code is changed, even if the music is playing.

It uses the advanced model, so should be accessed via an appropriate level, such as https://studio.code.org/s/allthethings/lessons/46/levels/5?js-editor=true.  

### Video

Observe the timeline updating in realtime as the code is changed:

https://github.com/user-attachments/assets/f8867e7a-349c-494b-9372-c14480a411f1

### Sample code

Here is some sample code that can be pasted in:

```
var length = 12;

function playAt(offset) {
  for (var i = 0; i < length; i += 2) {
    Sequencer.playSoundAtMeasureById("electro/drum_beat_cowbell", offset + i, "0");
  }
    
  for (var i = 0; i < length; i += 4) {
    Sequencer.playSoundAtMeasureById("electro/bass_synth_glitter", offset + i, "0");
  }
}

playAt(1);
```

Credit to @mikeharv for this idea, and @ebeastlake for passing it on. 