### PR TITLE
[Music] fix any function condition

### DIFF
--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -1,3 +1,4 @@
+import {Triggers} from '../constants';
 import musicI18n from '../locale';
 
 import {backupFunctionDefinitons} from './blockUtils';
@@ -63,7 +64,9 @@ export function setUpBlocklyForMusicLab() {
     Blockly.JavaScript.forBlock[blockType] = blockConfig.generator;
   }
 
-  Blockly.JavaScript.addReservedWords('Sequencer');
+  Blockly.JavaScript.addReservedWords(
+    ['Sequencer', 'when_run', ...Triggers.map(trigger => trigger.id)].join(',')
+  );
 
   Blockly.fieldRegistry.register(FIELD_SOUNDS_TYPE, FieldSounds);
   Blockly.fieldRegistry.register(FIELD_PATTERN_TYPE, FieldPattern);

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -126,9 +126,11 @@ export default class MusicValidator extends Validator {
           }
 
           if (eventData.functionContext) {
-            this.conditionsChecker.addSatisfiedCondition({
-              name: MusicConditions.PLAYED_SOUND_IN_ANY_FUNCTION.name,
-            });
+            if (eventData.functionContext.name !== 'when_run') {
+              this.conditionsChecker.addSatisfiedCondition({
+                name: MusicConditions.PLAYED_SOUND_IN_ANY_FUNCTION.name,
+              });
+            }
             this.conditionsChecker.addSatisfiedCondition({
               name: MusicConditions.PLAYED_SOUND_IN_FUNCTION.name,
               value: eventData.functionContext.name,

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -12,7 +12,7 @@ import {
   FunctionDefinitionBlockTypes,
   LoopBlockTypes,
 } from '../blockly/blockTypes';
-import {PATTERN_AI_NUM_SEED_EVENTS} from '../constants';
+import {PATTERN_AI_NUM_SEED_EVENTS, Triggers} from '../constants';
 import {isChordEvent} from '../player/interfaces/ChordEvent';
 import {isInstrumentEvent} from '../player/interfaces/InstrumentEvent';
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
@@ -126,7 +126,13 @@ export default class MusicValidator extends Validator {
           }
 
           if (eventData.functionContext) {
-            if (eventData.functionContext.name !== 'when_run') {
+            if (
+              // Exclude 'when run' and trigger contexts.
+              eventData.functionContext.name !== 'when_run' &&
+              !Triggers.map(trigger => trigger.id).includes(
+                eventData.functionContext.name
+              )
+            ) {
               this.conditionsChecker.addSatisfiedCondition({
                 name: MusicConditions.PLAYED_SOUND_IN_ANY_FUNCTION.name,
               });


### PR DESCRIPTION
This is a quick fix for a broken validation condition introduced here:
- https://github.com/code-dot-org/code-dot-org/pull/61755

From @dancodedotorg:
> New topic - [can you double-check I'm using validation correctly in this level](https://levelbuilder-studio.code.org/levels/73402/)? My intent is:
> 1. Check that they're using a function anywhere. If so: continue to...
> 2. Check exemplar validation
> But (1) doesn't seem to be working since I can press "Run" right away and it passes. So I think either I did something wrong, or the `played_sound_in_any_function` validation isn't working how I'd expect?

The intent of the condition is to check whether the student has used a function by looking at the function context of playback events. When I did the initial work, I somehow missed that _all_ Simple2 playback events have a function context, so my truthy check wasn't actually doing anything. This results in the condition passing if any sound is played. 

As a workaround the curriculum team has been using the `'played_anything_in_same_function'` condition with a value of `1` instead. That condition was introduced here:
- https://github.com/code-dot-org/code-dot-org/pull/61997

To fix this, we should include the `'when_run'` context as well as `'trigger1'` through `'trigger4'`.

With this fix, the check actually works to require functions:
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/dd66eb9d-d7a0-4ad5-858a-942eea8cd8a1" />

Doing this work made me wonder if we might have a potential issue if a student creates a function named 'trigger1' or 'when_run':

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/da5734ab-1adf-4d81-9285-8848988c3061" />

This can be handled by adding these reserved function context names to the Blockly JS generator's reserved words list. This puts Blockly in charge of adjusting the actual function names (and therefore the function context names). For example, a student function called 'when_run' will be automatically adjusted to 'when_run1'.

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/5ad6bb93-1934-432f-8b59-7d62e153cd43" />



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
