### PR TITLE
[Music] Refactor MusicPlayer Sharing & Optimize Exemplar Validation

### DIFF
--- a/apps/src/lab2/progress/ProgressManager.ts
+++ b/apps/src/lab2/progress/ProgressManager.ts
@@ -93,9 +93,19 @@ export default class ProgressManager {
     const shouldValidateExemplar =
       !getAppOptionsEditingExemplar() && exemplarSettings?.validationEnabled;
 
+    // Compute exemplar validation result and message only once if needed.
+    let passedExemplar = false;
+    let exemplarMessage = '';
+    if (shouldValidateExemplar) {
+      passedExemplar = this.validator.didPassExemplarValidation();
+      exemplarMessage = passedExemplar
+        ? exemplarSettings!.validationSuccessMessage!
+        : exemplarSettings!.validationFailureMessage!;
+    }
+
     // If there are no validations, we still might run the exemplar validation.
     if (!this.currentValidations?.length && shouldValidateExemplar) {
-      this.setValidationStateWithExemplar();
+      this.setValidationStateWithExemplar(passedExemplar, exemplarMessage);
       this.onProgressChange();
       return;
     }
@@ -136,7 +146,10 @@ export default class ProgressManager {
             this.currentValidationState.callout = validation.callout;
             if (this.currentValidationState.satisfied && validation.next) {
               if (shouldValidateExemplar) {
-                this.setValidationStateWithExemplar();
+                this.setValidationStateWithExemplar(
+                  passedExemplar,
+                  exemplarMessage
+                );
               }
             }
             this.onProgressChange();
@@ -175,16 +188,15 @@ export default class ProgressManager {
     this.onProgressChange();
   }
 
-  private setValidationStateWithExemplar(): void {
-    if (this.exemplarSettings) {
-      const passed = this.validator!.didPassExemplarValidation();
-      this.currentValidationState = {
-        ...this.currentValidationState,
-        satisfied: passed,
-        message: passed
-          ? this.exemplarSettings.validationSuccessMessage!
-          : this.exemplarSettings.validationFailureMessage!,
-      };
-    }
+  // Set exemplar validation status using precomputed exemplar values.
+  private setValidationStateWithExemplar(
+    passedExemplar: boolean,
+    exemplarMessage: string
+  ): void {
+    this.currentValidationState = {
+      ...this.currentValidationState,
+      satisfied: passedExemplar,
+      message: exemplarMessage,
+    };
   }
 }

--- a/apps/src/music/views/ExemplarPlayerView.tsx
+++ b/apps/src/music/views/ExemplarPlayerView.tsx
@@ -1,6 +1,6 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import classNames from 'classnames';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
@@ -13,62 +13,53 @@ import MusicPlayer from '../player/MusicPlayer';
 import {setIsPlaying} from '../redux/musicRedux';
 
 import moduleStyles from './ExemplarPlayer.module.scss';
+
 interface ExemplarPlayerViewProps {
   playbackEvents: PlaybackEvent[];
   title: string;
+  player: MusicPlayer;
 }
 
 const ExemplarPlayerView: React.FunctionComponent<ExemplarPlayerViewProps> = ({
   playbackEvents,
   title,
+  player,
 }) => {
   const dispatch = useAppDispatch();
   const isPlaying = useAppSelector(state => state.music.isPlaying);
-
-  const playerRef = useRef<MusicPlayer | null>(null);
-  if (playerRef.current === null) {
-    playerRef.current = new MusicPlayer();
-  }
   const [exemplarIsPlaying, setExemplarIsPlaying] = useState<boolean>(false);
 
   const onMount = useCallback(async () => {
-    await playerRef.current?.preloadSounds(playbackEvents, () => {});
-  }, [playbackEvents]);
+    await player.preloadSounds(playbackEvents, () => {});
+  }, [player, playbackEvents]);
 
   useEffect(() => {
     onMount();
   }, [onMount]);
 
-  // Play the already compiled song with the pre-loads sounds.
+  // Play the already compiled song with the pre-loaded sounds.
   const onPlaySong = useCallback(async () => {
     Blockly.getMainWorkspace().hideChaff();
     // Stop the main lab view player.
     dispatch(setIsPlaying(false));
-    playerRef.current?.stopSong();
+    player.stopSong();
 
-    const currentLibrary = MusicLibrary.getInstance();
-    if (currentLibrary) {
-      playerRef.current?.updateConfiguration(
-        currentLibrary.getBPM(),
-        currentLibrary.getKey()
-      );
-    }
-
+    // Since the player is shared, it should already have the correct configuration.
     // Play the song using the compiled events.
-    playerRef.current?.playSong(playbackEvents);
+    player.playSong(playbackEvents);
 
     setExemplarIsPlaying(true);
-  }, [dispatch, playbackEvents]);
+  }, [dispatch, player, playbackEvents]);
 
   // Stop the exemplar song, updating Redux and local state.
   const onStopSong = useCallback(() => {
     if (!isPlaying) {
       // If the player was stopped by the Run button, we do not want to interfere with
       // MusicLabView's control of the player.
-      playerRef.current?.stopSong();
+      player.stopSong();
     }
     setExemplarIsPlaying(false);
-  }, [isPlaying]);
+  }, [isPlaying, player]);
 
   useLifecycleNotifier(LifecycleEvent.LevelChangeRequested, () => {
     if (exemplarIsPlaying) {

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -300,6 +300,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 <ExemplarPlayerView
                   playbackEvents={exemplarPlaybackEvents}
                   title={exemplarSettings.playerTitle!}
+                  player={player}
                 />
               )}
           </PanelContainer>
@@ -313,6 +314,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
       isEditingExemplar,
       onInstructionsTextClick,
       exemplarPlaybackEvents,
+      player,
     ]
   );
 


### PR DESCRIPTION
Follow-up to:
- https://github.com/code-dot-org/code-dot-org/pull/64565

When merged, the above PR had two outstanding comments from @sanchitmalhotra126 still to be addressed:

> As a follow-up we may want to consider just passing in the music player reference as a prop into (`ExemplarPlayerView`) that way, we don't have to separately set the BPM and key here. Since we don't want the exemplar and main player to ever be playing at the same time, sharing the same instance may also help enforce that behavior.
https://github.com/code-dot-org/code-dot-org/pull/64565#discussion_r1999780101

> Should we store `didPassExemplarValidation` and the appropriate exemplar validation message so we don't have to compute it twice?
https://github.com/code-dot-org/code-dot-org/pull/64565#discussion_r1999794972

This PR refactors both components to maintain consistent behavior of the music player and improves efficiency in exemplar validation by computing the values once and reusing them.

Details:

-ExemplarPlayerView Update:
 - Remove local instantiation of `MusicPlayer`.
 - Pass the shared `MusicPlayer` instance as a prop from `MusicLabView`.
 - Centralize BPM/key configuration.
 
- ProgressManager Update:
 - Compute the exemplar validation result and message once at the start of `updateProgress`.
 - Reuse these precomputed values for both early exit and within the validation loop.


## Testing story

Manually tested the player and validation in a level that uses a song with non-default tempo and key.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
