### PR TITLE
fix(prettier): bump prettier to fix esm errors

### DIFF
--- a/frontend/apps/design-system-storybook/package.json
+++ b/frontend/apps/design-system-storybook/package.json
@@ -58,7 +58,7 @@
     "eslint": "^9.16.0",
     "globals": "^15.13.0",
     "http-server": "^14.1.1",
-    "prettier": "3.3.3",
+    "prettier": "3.4.2",
     "sass-loader": "^16.0.3",
     "storybook": "^8.4.4",
     "storybook-addon-rtl": "^1.0.1",

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -63,7 +63,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "playwright-core": "~1.49.1",
-    "prettier": "3.3.3",
+    "prettier": "3.4.2",
     "stylelint": "^16.14.1",
     "ts-node": "^10.9.2",
     "typescript": "^5"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "@axe-core/playwright": "^4.10.1",
     "@storybook/test-runner": "^0.19.1",
     "lint-staged": "^15.4.3",
-    "prettier": "3.3.3",
+    "prettier": "3.4.2",
     "rimraf": "^6.0.1",
     "turbo": "^2.3.0",
     "typescript": "5.5.4"

--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -414,7 +414,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.49",
     "postcss-modules": "^6.0.1",
-    "prettier": "3.3.3",
+    "prettier": "3.4.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "release-it": "^18.1.2",

--- a/frontend/packages/fonts/package.json
+++ b/frontend/packages/fonts/package.json
@@ -83,7 +83,7 @@
     "@fontsource/noto-sans-sc": "^5.1.1",
     "@fontsource/noto-sans-tc": "^5.1.1",
     "eslint": "^9.16.0",
-    "prettier": "3.3.3",
+    "prettier": "3.4.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sass": "^1.85.0",

--- a/frontend/packages/lint-config/package.json
+++ b/frontend/packages/lint-config/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.2",
     "globals": "^15.12.0",
-    "prettier": "3.3.3",
+    "prettier": "3.4.2",
     "prettier-plugin-packagejson": "^2.5.5",
     "stylelint": "^16.14.1",
     "stylelint-config-standard-scss": "^14.0.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1120,7 +1120,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     postcss: "npm:^8.4.49"
     postcss-modules: "npm:^6.0.1"
-    prettier: "npm:3.3.3"
+    prettier: "npm:3.4.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     release-it: "npm:^18.1.2"
@@ -1166,7 +1166,7 @@ __metadata:
     eslint: "npm:^9.16.0"
     globals: "npm:^15.13.0"
     http-server: "npm:^14.1.1"
-    prettier: "npm:3.3.3"
+    prettier: "npm:3.4.2"
     sass-loader: "npm:^16.0.3"
     storybook: "npm:^8.4.4"
     storybook-addon-rtl: "npm:^1.0.1"
@@ -1208,7 +1208,7 @@ __metadata:
     "@fontsource/noto-sans-sc": "npm:^5.1.1"
     "@fontsource/noto-sans-tc": "npm:^5.1.1"
     eslint: "npm:^9.16.0"
-    prettier: "npm:3.3.3"
+    prettier: "npm:3.4.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     sass: "npm:^1.85.0"
@@ -1227,7 +1227,7 @@ __metadata:
     "@axe-core/playwright": "npm:^4.10.1"
     "@storybook/test-runner": "npm:^0.19.1"
     lint-staged: "npm:^15.4.3"
-    prettier: "npm:3.3.3"
+    prettier: "npm:3.4.2"
     rimraf: "npm:^6.0.1"
     turbo: "npm:^2.3.0"
     typescript: "npm:5.5.4"
@@ -1246,7 +1246,7 @@ __metadata:
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-react: "npm:^7.37.2"
     globals: "npm:^15.12.0"
-    prettier: "npm:3.3.3"
+    prettier: "npm:3.4.2"
     prettier-plugin-packagejson: "npm:^2.5.5"
     stylelint: "npm:^16.14.1"
     stylelint-config-standard-scss: "npm:^14.0.0"
@@ -1283,7 +1283,7 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     next: "npm:^15.1.2"
     playwright-core: "npm:~1.49.1"
-    prettier: "npm:3.3.3"
+    prettier: "npm:3.4.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     stylelint: "npm:^16.14.1"
@@ -15036,7 +15036,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.3.3, prettier@npm:^3.1.1":
+"prettier@npm:3.4.2":
+  version: 3.4.2
+  resolution: "prettier@npm:3.4.2"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/99e076a26ed0aba4ebc043880d0f08bbb8c59a4c6641cdee6cdadf2205bdd87aa1d7823f50c3aea41e015e99878d37c58d7b5f0e663bba0ef047f94e36b96446
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.1.1":
   version: 3.3.3
   resolution: "prettier@npm:3.3.3"
   bin:


### PR DESCRIPTION
Pulls in fix from https://github.com/prettier/prettier/pull/16857 due to Node [20.19](https://nodejs.org/en/blog/release/v20.19.0)