### PR TITLE
Fix level edit page links not opening in new tab

### DIFF
--- a/apps/src/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/levelbuilder/lesson-editor/LevelToken.jsx
@@ -196,8 +196,8 @@ export class LevelTokenContents extends Component {
         <div
           style={styles.edit}
           onClick={() => {
-            const win = window.open(activeLevel.url, 'noopener', 'noreferrer');
-            win.focus();
+            window.open(activeLevel.url, '_blank', 'noreferrer');
+            // win.focus();
           }}
         >
           <i className="fa fa-pencil" />

--- a/apps/src/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/levelbuilder/lesson-editor/LevelToken.jsx
@@ -197,7 +197,6 @@ export class LevelTokenContents extends Component {
           style={styles.edit}
           onClick={() => {
             window.open(activeLevel.url, '_blank', 'noreferrer');
-            // win.focus();
           }}
         >
           <i className="fa fa-pencil" />

--- a/apps/src/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/levelbuilder/lesson-editor/LevelToken.jsx
@@ -196,7 +196,7 @@ export class LevelTokenContents extends Component {
         <div
           style={styles.edit}
           onClick={() => {
-            window.open(activeLevel.url, '_blank', 'noreferrer');
+            window.open(activeLevel.url, '_blank', 'noopener,noreferrer');
           }}
         >
           <i className="fa fa-pencil" />

--- a/apps/src/levelbuilder/unit-editor/LessonToken.jsx
+++ b/apps/src/levelbuilder/unit-editor/LessonToken.jsx
@@ -83,8 +83,8 @@ export class LessonTokenContents extends Component {
 
   handleEditLesson = () => {
     const url = this.props.lesson.lessonEditPath;
-    const win = window.open(url, 'noopener', 'noreferrer');
-    win.focus();
+    window.open(url, '_blank', 'noreferrer');
+    // win.focus();
   };
 
   handleDragStart = e => {

--- a/apps/src/levelbuilder/unit-editor/LessonToken.jsx
+++ b/apps/src/levelbuilder/unit-editor/LessonToken.jsx
@@ -83,7 +83,7 @@ export class LessonTokenContents extends Component {
 
   handleEditLesson = () => {
     const url = this.props.lesson.lessonEditPath;
-    window.open(url, '_blank', 'noreferrer');
+    window.open(url, '_blank', 'noopener,noreferrer');
   };
 
   handleDragStart = e => {

--- a/apps/src/levelbuilder/unit-editor/LessonToken.jsx
+++ b/apps/src/levelbuilder/unit-editor/LessonToken.jsx
@@ -84,7 +84,6 @@ export class LessonTokenContents extends Component {
   handleEditLesson = () => {
     const url = this.props.lesson.lessonEditPath;
     window.open(url, '_blank', 'noreferrer');
-    // win.focus();
   };
 
   handleDragStart = e => {


### PR DESCRIPTION
This update fixes an issue in levelbuilder causing the level edit page to not open in a new tab when the edit button is clicked.

https://github.com/user-attachments/assets/c7231966-ea80-4c1f-8f2c-94e8c09095d2

## Links
[TEACH-1662](https://codedotorg.atlassian.net/browse/TEACH-1662)

## Testing story

Manually tested. No new tests added.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
