### PR TITLE
Enable autosave for Blockly projects

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -546,20 +546,20 @@ StudioApp.prototype.init = function (config) {
       }, this)
     );
 
-    if (Blockly.getHiddenDefinitionWorkspace()) {
-      this.hiddenWorkspaceChangeListener =
-        Blockly.getHiddenDefinitionWorkspace().addChangeListener(
-          _.bind(function () {
-            this.updateBlockCount();
-          }, this)
-        );
-    }
+    this.hiddenWorkspaceChangeListener =
+      Blockly.getHiddenDefinitionWorkspace()?.addChangeListener(
+        _.bind(function () {
+          this.updateBlockCount();
+        }, this)
+      );
+
     this.mainWorkspaceChangeListener =
-      Blockly.getMainWorkspace().addChangeListener(
+      Blockly.getMainWorkspace()?.addChangeListener(
         _.bind(function () {
           project.projectChanged();
         }, this)
       );
+
     if (config.level.openFunctionDefinition) {
       this.openFunctionDefinition_(config);
     }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -554,6 +554,12 @@ StudioApp.prototype.init = function (config) {
           }, this)
         );
     }
+    this.mainWorkspaceChangeListener =
+      Blockly.getMainWorkspace().addChangeListener(
+        _.bind(function () {
+          project.projectChanged();
+        }, this)
+      );
     if (config.level.openFunctionDefinition) {
       this.openFunctionDefinition_(config);
     }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3471,6 +3471,9 @@ if (IN_UNIT_TEST) {
     if (instance.hiddenWorkspaceChangeListener) {
       Blockly.removeChangeListener(instance.hiddenWorkspaceChangeListener);
     }
+    if (instance.mainWorkspaceChangeListener) {
+      Blockly.removeChangeListener(instance.mainWorkspaceChangeListener);
+    }
     instance = __oldInstance;
     __oldInstance = null;
   };

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -393,6 +393,11 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return undefined;
   };
 
+  // CDO Blockly does not have support getMainWorkspace, so we return undefined here.
+  blocklyWrapper.getMainWorkspace = () => {
+    return undefined;
+  };
+
   // CDO Blockly does not have a separate workspace for the function editor,
   // so we return undefined here.
   blocklyWrapper.getFunctionEditorWorkspace = () => {

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -393,9 +393,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return undefined;
   };
 
-  // CDO Blockly does not have support getMainWorkspace, so we return undefined here.
+  // Translate to CDO Blockly's version of getMainWorkspace.
   blocklyWrapper.getMainWorkspace = () => {
-    return undefined;
+    return Blockly.mainBlockSpace;
   };
 
   // CDO Blockly does not have a separate workspace for the function editor,

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -393,9 +393,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return undefined;
   };
 
-  // Translate to CDO Blockly's version of getMainWorkspace.
+  // CDO Blockly does not have support getMainWorkspace, so we return undefined here.
   blocklyWrapper.getMainWorkspace = () => {
-    return Blockly.mainBlockSpace;
+    return undefined;
   };
 
   // CDO Blockly does not have a separate workspace for the function editor,

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -94,7 +94,7 @@ var firstSaveTimestamp;
 let lastNewSourceVersionTime = 0;
 // Force a new source version if it has been this many milliseconds since we
 // last did so.
-let newSourceVersionInterval = 5 * 60 * 1000; // 5 minutes
+let newSourceVersionInterval = 15 * 60 * 1000; // 15 minutes
 var currentAbuseScore = 0;
 var sharingDisabled = false;
 var currentHasPrivacyProfanityViolation = false;

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -46,7 +46,6 @@ var events = {
   // Fired when run state changes or we enter/exit design mode
   appModeChanged: 'appModeChanged',
   appInitialized: 'appInitialized',
-  workspaceChange: 'workspaceChange',
 };
 
 // Number of consecutive failed attempts to update the channel.
@@ -747,9 +746,6 @@ var projects = (module.exports = {
               });
           }.bind(this)
         );
-        $(window).on(events.workspaceChange, function () {
-          hasProjectChanged = true;
-        });
 
         if (!appOptions.level.skipAutosave) {
           // Autosave every AUTOSAVE_INTERVAL milliseconds

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1506,12 +1506,6 @@ var projects = (module.exports = {
       callCallback();
       return;
     }
-    // `getLevelSource()` is expensive for Blockly so only call
-    // after `workspaceChange` has fired
-    if (!appOptions.droplet && !hasProjectChanged) {
-      callCallback();
-      return;
-    }
 
     if ($('#designModeViz .ui-draggable-dragging').length !== 0) {
       callCallback();

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1502,6 +1502,9 @@ var projects = (module.exports = {
       callCallback();
       return;
     }
+
+    // `getLevelSource()` is expensive for Blockly so only call
+    // if the project workspace has changed.
     if (!appOptions.droplet && !hasProjectChanged) {
       callCallback();
       return;

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1502,6 +1502,10 @@ var projects = (module.exports = {
       callCallback();
       return;
     }
+    if (!appOptions.droplet && !hasProjectChanged) {
+      callCallback();
+      return;
+    }
 
     if ($('#designModeViz .ui-draggable-dragging').length !== 0) {
       callCallback();

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -95,7 +95,7 @@ var firstSaveTimestamp;
 let lastNewSourceVersionTime = 0;
 // Force a new source version if it has been this many milliseconds since we
 // last did so.
-let newSourceVersionInterval = 15 * 60 * 1000; // 15 minutes
+let newSourceVersionInterval = 5 * 60 * 1000; // 5 minutes
 var currentAbuseScore = 0;
 var sharingDisabled = false;
 var currentHasPrivacyProfanityViolation = false;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates `project.js` so that autosaving is enabled for Blockly lab projects. In labs such as `artist`, the visualization updates as the user adds code to the workspace so that a user can work on code and receive feedback without clicking on the 'Run' button. However, the project does not save unless the user clicks on the 'Run' button. This [Zendesk user](https://codeorg.zendesk.com/agent/tickets/529087) worked on an `artist` project for ~15 minutes, and the saved thumbnail image reflected this pretty involved work. 


![thumbnail](https://github.com/user-attachments/assets/265172ce-3f1d-4fea-b1f6-efb39628785a)

However, the project source was not updated since they did not run the program so the work was lost. For context, whenever there’s [a code change](https://github.com/code-dot-org/code-dot-org/blob/6a103001014078f690d5de1442d76d5b12949b49/apps/src/turtle/artist.js#L396-L401) in the `artist` workspace, the [preview (animation) is updated](https://github.com/code-dot-org/code-dot-org/blob/6a103001014078f690d5de1442d76d5b12949b49/apps/src/turtle/artist.js#L937) and a [new thumbnail image](https://github.com/code-dot-org/code-dot-org/blob/6a103001014078f690d5de1442d76d5b12949b49/apps/src/turtle/artist.js#L1028) is saved (without a corresponding change in sources). This explains why for the Zendesk user, the thumbnail image was updated but `main.json` was not. 

We've received many Zendesk tickets in the past about lost project progress - we even have [a macro](https://codedotorg.slack.com/archives/C03DBDN67B7/p1673371656561469?thread_ts=1673308506.133429&cid=C03DBDN67B7) that explains how to 'force a save'. However, one of the conditions is not quite accurate - '15 minutes have passed while one is actively working on their code'. This is currently not true for Blockly lab projects. For Droplet lab projects, projects auto-save every 30 seconds ([if there is a change in the workspace](https://github.com/code-dot-org/code-dot-org/blob/6fbb56efca5bd08e6f034f476766e31d80d441ab/apps/src/code-studio/initApp/project.js#L1522)). 15 minutes is the time elapsed before a new source version is generated.

Initially, I thought that the issue reported by the Zendesk user was that the time interval that we force a new source version for legacy app projects was 15 minutes and that the user worked for ~15 minutes without running the program. However, with `autosave`, `main.json` should've reflected the latest updates [every 30 seconds](https://github.com/code-dot-org/code-dot-org/blob/51ced60d26c7513b8215200ce012a82f2c9bea6b/apps/src/code-studio/initApp/project.js#L32). So the actual cause of lost progress is that we currently do not autosave Blockly lab projects. The question about decreasing the time interval for generating a new source version was raised, and with implication for increasing storage on S3, we decided to keep `newSourceVersionInterval` at 15 minutes.

## Before update

Screenshot of thumbnail updates from Zendesk user:

![Screenshot 2025-03-20 at 5 16 46 PM](https://github.com/user-attachments/assets/012c9081-568f-448f-9dd9-58b8d8382080)


Screenshot of source updates from Zendesk user:

![source-versions](https://github.com/user-attachments/assets/44001e3a-465c-46ae-b0ad-d8bcd921927b)


## After update
Screenshot of source versions for an `artist` project:


<img width="1042" alt="first-screenshot" src="https://github.com/user-attachments/assets/321955d9-3567-4793-a011-7a86a0132548" />

Screenshot after I updated `artist` workspace without clicking on 'Run' button:

<img width="1038" alt="second-screenshot" src="https://github.com/user-attachments/assets/38394d58-0464-4c2c-a96c-9ab299d9f2d3" />




## Links
[jira](https://codedotorg.atlassian.net/browse/CT-1136)
[Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/529087)
[Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1742394620450679?thread_ts=1740521887.636699&cid=C03DBDN67B7)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally on `spritelab`, `artist` and `applab` projects.
After the update, I saw that for both Blockly and Applab projects, `main.json` was updated every 30 seconds if there were changes to workspace without running the program (the version ID updates when `main.json` updates). A new version is still generated every `newSourceVersionInterval` ms.



<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
