### PR TITLE
Factor out level starter assets helper code

### DIFF
--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -4,15 +4,13 @@ class LevelStarterAssetsController < ApplicationController
   before_action :set_level
   skip_before_action :verify_authenticity_token, only: [:destroy]
 
-  S3_BUCKET = 'cdo-v3-assets'.freeze
-  S3_PREFIX = 'starter_assets/'.freeze
   VALID_FILE_EXTENSIONS = %w(.jpg .jpeg .gif .png .mp3 .wav .pdf)
 
   # GET /level_starter_assets/:level_name
   def show
     starter_assets = (@level&.project_template_level&.starter_assets || @level.starter_assets || []).filter_map do |friendly_name, uuid_name|
-      file_obj = get_object(uuid_name)
-      summarize(file_obj, friendly_name, uuid_name)
+      file_obj = LevelStarterAssetsHelper.get_object(uuid_name)
+      LevelStarterAssetsHelper.summarize(file_obj, friendly_name, uuid_name)
     end
 
     render json: {starter_assets: starter_assets}
@@ -25,11 +23,11 @@ class LevelStarterAssetsController < ApplicationController
     starter_assets = @level&.project_template_level&.starter_assets || @level&.starter_assets
     return head :not_found if starter_assets.nil_or_empty?
     uuid_name = starter_assets[friendly_name]
-    file_obj = get_object(uuid_name)
-    content_type = file_content_type(File.extname(uuid_name))
+    file_obj = LevelStarterAssetsHelper.get_object(uuid_name)
+    content_type = LevelStarterAssetsHelper.file_content_type(File.extname(uuid_name))
 
     expires_in 1.hour, public: true
-    send_data read_file(file_obj), type: content_type, disposition: 'inline'
+    send_data LevelStarterAssetsHelper.read_file(file_obj), type: content_type, disposition: 'inline'
   end
 
   # POST /level_starter_assets/:level_name
@@ -49,11 +47,11 @@ class LevelStarterAssetsController < ApplicationController
 
     # Replace the friendly file name with a UUID for storage in S3 to avoid naming conflicts.
     uuid_name = SecureRandom.uuid + file_ext
-    file_obj = get_object(uuid_name)
+    file_obj = LevelStarterAssetsHelper.get_object(uuid_name)
     success = file_obj&.upload_file(upload.tempfile.path)
 
     if success && @level.add_starter_asset!(friendly_name, uuid_name)
-      render json: summarize(file_obj, friendly_name, uuid_name)
+      render json: LevelStarterAssetsHelper.summarize(file_obj, friendly_name, uuid_name)
     else
       return head :unprocessable_entity
     end
@@ -71,53 +69,7 @@ class LevelStarterAssetsController < ApplicationController
     end
   end
 
-  #
-  # HELPERS
-  #
-
-  def summarize(file_obj, friendly_name, uuid_name)
-    if file_obj.blank?
-      nil
-    else
-      {
-        filename: friendly_name,
-        category: file_mime_type(File.extname(uuid_name)),
-        size: file_obj.size,
-        timestamp: file_obj.last_modified
-      }
-    end
-  end
-
-  def read_file(file_obj)
-    file_obj.get.body.read
-  end
-
-  def get_object(s3_filename)
-    path = prefix(s3_filename)
-    bucket.object(path)
-  end
-
   private def set_level
     @level = Level.cache_find(params[:level_name])
-  end
-
-  private def file_mime_type(extension)
-    type = MIME::Types.type_for(extension)&.first
-    if type == MIME::Types['application/pdf']
-      return 'pdf'
-    end
-    type&.raw_media_type
-  end
-
-  private def file_content_type(extension)
-    MIME::Types.type_for(extension)&.first&.content_type
-  end
-
-  private def prefix(key)
-    S3_PREFIX + key
-  end
-
-  private def bucket
-    Aws::S3::Bucket.new(S3_BUCKET)
   end
 end

--- a/dashboard/app/helpers/level_starter_assets_helper.rb
+++ b/dashboard/app/helpers/level_starter_assets_helper.rb
@@ -1,0 +1,46 @@
+module LevelStarterAssetsHelper
+  S3_BUCKET = 'cdo-v3-assets'.freeze
+  S3_PREFIX = 'starter_assets/'.freeze
+
+  def self.summarize(file_obj, friendly_name, uuid_name)
+    if file_obj.blank?
+      nil
+    else
+      {
+        filename: friendly_name,
+        category: file_mime_type(File.extname(uuid_name)),
+        size: file_obj.size,
+        timestamp: file_obj.last_modified
+      }
+    end
+  end
+
+  def self.read_file(file_obj)
+    file_obj.get.body.read
+  end
+
+  def self.get_object(s3_filename)
+    path = prefix(s3_filename)
+    bucket.object(path)
+  end
+
+  def self.file_mime_type(extension)
+    type = MIME::Types.type_for(extension)&.first
+    if type == MIME::Types['application/pdf']
+      return 'pdf'
+    end
+    type&.raw_media_type
+  end
+
+  def self.file_content_type(extension)
+    MIME::Types.type_for(extension)&.first&.content_type
+  end
+
+  def self.prefix(key)
+    S3_PREFIX + key
+  end
+
+  def self.bucket
+    Aws::S3::Bucket.new(S3_BUCKET)
+  end
+end

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -32,7 +32,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
       MockS3ObjectSummary.new(key_2, 321, 2.days.ago),
       MockS3ObjectSummary.new(key_3, 111, 3.days.ago)
     ]
-    LevelStarterAssetsController.any_instance.
+    LevelStarterAssetsHelper.
       expects(:get_object).times(3).
       returns(file_objs[0], file_objs[1], file_objs[2])
     level_starter_assets = {
@@ -67,7 +67,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     file_objs = [
       MockS3ObjectSummary.new(key_1, 123, 1.day.ago)
     ]
-    LevelStarterAssetsController.any_instance.
+    LevelStarterAssetsHelper.
       expects(:get_object).once.
       returns(file_objs[0])
     level_starter_asset_1 = {
@@ -93,11 +93,11 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
   end
 
   test 'file: returns requested file' do
-    LevelStarterAssetsController.any_instance.
+    LevelStarterAssetsHelper.
       expects(:get_object).
       with(@uuid_name).
       returns(@file_obj)
-    LevelStarterAssetsController.any_instance.
+    LevelStarterAssetsHelper.
       expects(:read_file).
       with(@file_obj).
       returns('hello, world!')
@@ -114,7 +114,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
   end
 
   test 'file: returns 404 if level has no starter assets' do
-    LevelStarterAssetsController.any_instance.expects(:get_object).never
+    LevelStarterAssetsHelper.expects(:get_object).never
     level = create(:applab, starter_assets: nil)
 
     get :file, params: {level_name: level.name, filename: 'ty', format: 'png'}
@@ -145,7 +145,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
   end
 
   test 'upload: returns unprocessable_entity if file extension is invalid' do
-    LevelStarterAssetsController.any_instance.expects(:get_object).never
+    LevelStarterAssetsHelper.expects(:get_object).never
 
     # File must exist in order to use fixture_file_upload.
     invalid_filename = 'invalid.exe'
@@ -162,9 +162,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
   end
 
   test 'upload: returns unprocessable_entity if file fails to upload' do
-    LevelStarterAssetsController.any_instance.
-      expects(:get_object).
-      returns(@file_obj)
+    LevelStarterAssetsHelper.expects(:get_object).returns(@file_obj)
     @file_obj.expects(:upload_file).returns(false)
 
     sign_in create(:levelbuilder)
@@ -174,9 +172,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
   end
 
   test 'upload: raises if file uploads but starter asset is not added' do
-    LevelStarterAssetsController.any_instance.
-      expects(:get_object).
-      returns(@file_obj)
+    LevelStarterAssetsHelper.expects(:get_object).returns(@file_obj)
     @file_obj.expects(:upload_file).returns(true)
     Level.any_instance.expects(:valid?).twice.returns(true, false)
 
@@ -187,9 +183,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
   end
 
   test 'upload: returns summary if file uploads and starter asset is added' do
-    LevelStarterAssetsController.any_instance.
-      expects(:get_object).
-      returns(@file_obj)
+    LevelStarterAssetsHelper.expects(:get_object).returns(@file_obj)
     @file_obj.expects(:upload_file).returns(true)
 
     sign_in create(:levelbuilder)
@@ -206,9 +200,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
   end
 
   test 'upload: can successfully upload files with single- and double- quotes in filenames' do
-    LevelStarterAssetsController.any_instance.
-      expects(:get_object).twice.
-      returns(@file_obj)
+    LevelStarterAssetsHelper.expects(:get_object).twice.returns(@file_obj)
     @file_obj.expects(:upload_file).twice.returns(true)
     sign_in create(:levelbuilder)
     level = create :applab


### PR DESCRIPTION
This factors out all helper code related to level starter assets from the `LevelStarterAssetsController` into a `LevelStarterAssetsHelper`, so it can be used by other components (namely, AI Chat in an upcoming PR). All these functions were already under a `# HELPERS` heading in the controller; no code changes, just copy-paste.

## Links

Part of https://codedotorg.atlassian.net/browse/LABS-1387

## Testing story

Tested locally (verified all controller actions still work as expected) + unit