### PR TITLE
Python Lab: name the web worker and service worker

### DIFF
--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -26,8 +26,15 @@ let lastInputId = '';
 let setupPromise: Promise<void> | undefined;
 
 const setUpPyodideWorker = () => {
-  // @ts-expect-error because TypeScript does not like this syntax.
-  const worker = new Worker(new URL('./pyodideWebWorker.ts', import.meta.url));
+  // The web worker is versioned to ensure the correct version is loaded.
+  // Update the version if you update the web worker.
+  const worker = new Worker(
+    /* webpackChunkName: "pyodide-web-worker-1.0.0" */ new URL(
+      './pyodideWebWorker.ts',
+      // @ts-expect-error because TypeScript does not like this syntax.
+      import.meta.url
+    )
+  );
 
   callbacks = {};
 
@@ -127,8 +134,11 @@ const registerServiceWorker = async () => {
     try {
       // Do not move the url into a variable, because webpack needs it to be passed as
       // a parmaeter to register() directly in order to set up inputServiceWorker as a service worker.
+      // The service worker is versioned to ensure the correct version is loaded.
+      // Update the version if you update the service worker.
       const registration = await navigator.serviceWorker.register(
         new URL(
+          /* webpackChunkName: "input-service-worker-1.0.0" */
           './inputServiceWorker.js',
           // @ts-expect-error because TypeScript does not like this syntax.
           import.meta.url


### PR DESCRIPTION
I noticed after upgrading a python lab package, we saw some errors from users where they were trying to load an older version. This implied to me that they were using an old version of the web worker. After consulting with infra, they said it was probable that the web worker asset was being cached.

To get around this, we can use a webpack magic comment to name the web worker (and input service worker, for good measure), with a versioned name. Then when we update the web worker, we can update the version to ensure users get the correct web worker code.

## Links

- [slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1742403034446609)
- [sample logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-86400~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'fields*20*40message*0a*7c*20filter*20level*20*3d*20*22SEVERE*22*20and*20message.appName*20*3d*20*27pythonlab*27*20and*20message.errorMessage*20*3d*20*22Python*20Lab*20Internal*20Error*22*0a~queryId~'ff799bd6-b909-410a-aa98-27f0f3e40f42~source~(~'production-browser-events)~lang~'CWLI))


## Testing story
I confirmed that after making this change the webpack chunks were named with the names I provided.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
