### PR TITLE
Update workshop table based on changes to workshop data

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment.jsx
@@ -21,7 +21,7 @@ export default class WorkshopEnrollment extends React.Component {
     enrollments: PropTypes.arrayOf(enrollmentShape).isRequired,
     workshopId: PropTypes.string.isRequired,
     workshopCourse: PropTypes.string.isRequired,
-    workshopSubject: PropTypes.string.isRequired,
+    workshopSubject: PropTypes.string,
     workshopDate: PropTypes.string.isRequired,
     numSessions: PropTypes.number.isRequired,
     accountRequiredForAttendance: PropTypes.bool.isRequired,

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -387,7 +387,7 @@ WorkshopEnrollmentSchoolInfo.propTypes = {
   onDelete: PropTypes.func.isRequired,
   onClickSelect: PropTypes.func.isRequired,
   workshopCourse: PropTypes.string.isRequired,
-  workshopSubject: PropTypes.string.isRequired,
+  workshopSubject: PropTypes.string,
   numSessions: PropTypes.number.isRequired,
   selectedEnrollments: PropTypes.array,
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -137,7 +137,7 @@ export default class WorkshopTable extends React.Component {
           transforms: [sortable],
         },
         cell: {
-          formatters: [this.formatBoolean],
+          formatters: [this.formatVirtualFormat],
         },
       },
       {
@@ -242,8 +242,8 @@ export default class WorkshopTable extends React.Component {
     return <SessionTimesList sessions={rowData.sessions} />;
   };
 
-  formatBoolean = bool => {
-    return bool ? 'Yes' : 'No';
+  formatVirtualFormat = isVirtual => {
+    return isVirtual ? 'Virtual' : 'In-person';
   };
 
   formatOrganizer = organizer => {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -243,7 +243,7 @@ export default class WorkshopTable extends React.Component {
   };
 
   formatVirtualFormat = isVirtual => {
-    return isVirtual ? 'Virtual' : 'In-person';
+    return isVirtual ? 'Virtual' : 'In-Person';
   };
 
   formatOrganizer = organizer => {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -117,6 +117,30 @@ export default class WorkshopTable extends React.Component {
         },
       },
       {
+        property: 'course',
+        header: {
+          label: 'Type',
+          transforms: [sortable],
+        },
+      },
+      {
+        property: 'subject',
+        header: {
+          label: 'Subjects/Topics',
+          transforms: [sortable],
+        },
+      },
+      {
+        property: 'virtual',
+        header: {
+          label: 'Format',
+          transforms: [sortable],
+        },
+        cell: {
+          formatters: [this.formatBoolean],
+        },
+      },
+      {
         property: 'location_name',
         header: {
           label: 'Location',
@@ -124,54 +148,26 @@ export default class WorkshopTable extends React.Component {
         },
       },
       {
-        property: 'on_map',
-        header: {
-          label: 'On Map',
-          transforms: [sortable],
-        },
-        cell: {
-          formatters: [this.formatBoolean],
-        },
-      },
-      {
-        property: 'funded',
-        header: {
-          label: 'Funded',
-          transforms: [sortable],
-        },
-        cell: {
-          formatters: [this.formatBoolean],
-        },
-      },
-      {
-        property: 'course',
-        header: {
-          label: 'Course',
-          transforms: [sortable],
-        },
-      },
-      {
-        property: 'subject',
-        header: {
-          label: 'Subject',
-          transforms: [sortable],
-        },
-      },
-      {
-        property: 'virtual',
-        header: {
-          label: 'Virtual',
-          transforms: [sortable],
-        },
-        cell: {
-          formatters: [this.formatBoolean],
-        },
-      },
-      {
         property: 'enrollments',
         header: {
           label: 'Signups',
           transforms: [sortable],
+        },
+      },
+      {
+        property: 'regional_partner_name',
+        header: {
+          label: 'Regional Partner',
+          transforms: [sortable],
+        },
+      },
+      {
+        property: 'facilitators',
+        header: {
+          label: 'Facilitators',
+        },
+        cell: {
+          formatters: [this.formatFacilitators],
         },
       }
     );
@@ -187,25 +183,6 @@ export default class WorkshopTable extends React.Component {
         },
       });
     }
-
-    columns.push(
-      {
-        property: 'facilitators',
-        header: {
-          label: 'Facilitators',
-        },
-        cell: {
-          formatters: [this.formatFacilitators],
-        },
-      },
-      {
-        property: 'regional_partner_name',
-        header: {
-          label: 'Regional Partner',
-          transforms: [sortable],
-        },
-      }
-    );
 
     columns.push();
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
@@ -19,7 +19,7 @@ import {COURSE_BUILD_YOUR_OWN} from '../workshopConstants';
 // Own workshop course offerings will be set as the workshop's subject.
 function ensureAllWorkshopsHaveSubjects(data) {
   let workshops = data.workshops;
-  workshops.forEach(ws => {
+  workshops?.forEach(ws => {
     if (ws.course === COURSE_BUILD_YOUR_OWN) {
       ws.subject = ws.course_offering_names;
     }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
@@ -17,15 +17,14 @@ import {COURSE_BUILD_YOUR_OWN} from '../workshopConstants';
 // To allow the workshop table to display/sort by Subjects/Topics, the subjects and topics have to all be
 // under the same field name. So, only for the purposes of displaying the info to the user, the Build Your
 // Own workshop course offerings will be set as the workshop's subject.
-function ensureAllWorkshopsHaveSubjects(data) {
-  let workshops = data.workshops;
-  workshops?.forEach(ws => {
+function processWorkshopData(workshopData) {
+  let updatedData = {...workshopData};
+  updatedData.workshops?.forEach(ws => {
     if (ws.course === COURSE_BUILD_YOUR_OWN) {
       ws.subject = ws.course_offering_names;
     }
   });
-  data.workshops = workshops;
-  return data;
+  return updatedData;
 }
 
 export default class WorkshopTableLoader extends React.Component {
@@ -85,7 +84,7 @@ export default class WorkshopTableLoader extends React.Component {
     }).done(data => {
       this.setState({
         loading: false,
-        workshops: ensureAllWorkshopsHaveSubjects(data),
+        workshops: processWorkshopData(data),
       });
     });
   };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
@@ -12,6 +12,21 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import Spinner from '../../../../sharedComponents/Spinner';
+import {COURSE_BUILD_YOUR_OWN} from '../workshopConstants';
+
+// To allow the workshop table to display/sort by Subjects/Topics, the subjects and topics have to all be
+// under the same field name. So, only for the purposes of displaying the info to the user, the Build Your
+// Own workshop course offerings will be set as the workshop's subject.
+function prepWorkshopData(data) {
+  let workshops = data.workshops;
+  workshops.forEach(ws => {
+    if (ws.course === COURSE_BUILD_YOUR_OWN) {
+      ws.subject = ws.course_offering_names;
+    }
+  });
+  data.workshops = workshops;
+  return data;
+}
 
 export default class WorkshopTableLoader extends React.Component {
   static propTypes = {
@@ -70,7 +85,7 @@ export default class WorkshopTableLoader extends React.Component {
     }).done(data => {
       this.setState({
         loading: false,
-        workshops: data,
+        workshops: prepWorkshopData(data),
       });
     });
   };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
@@ -18,13 +18,15 @@ import {COURSE_BUILD_YOUR_OWN} from '../workshopConstants';
 // under the same field name. So, only for the purposes of displaying the info to the user, the Build Your
 // Own workshop course offerings will be set as the workshop's subject.
 function processWorkshopData(workshopData) {
-  let updatedData = {...workshopData};
-  updatedData.workshops?.forEach(ws => {
-    if (ws.course === COURSE_BUILD_YOUR_OWN) {
-      ws.subject = ws.course_offering_names;
-    }
-  });
-  return updatedData;
+  return {
+    ...workshopData,
+    workshops: workshopData.workshops?.map(ws => {
+      if (ws.course === COURSE_BUILD_YOUR_OWN) {
+        ws.subject = ws.course_offering_names;
+      }
+      return ws;
+    }),
+  };
 }
 
 export default class WorkshopTableLoader extends React.Component {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
@@ -17,7 +17,7 @@ import {COURSE_BUILD_YOUR_OWN} from '../workshopConstants';
 // To allow the workshop table to display/sort by Subjects/Topics, the subjects and topics have to all be
 // under the same field name. So, only for the purposes of displaying the info to the user, the Build Your
 // Own workshop course offerings will be set as the workshop's subject.
-function prepWorkshopData(data) {
+function ensureAllWorkshopsHaveSubjects(data) {
   let workshops = data.workshops;
   workshops.forEach(ws => {
     if (ws.course === COURSE_BUILD_YOUR_OWN) {
@@ -85,7 +85,7 @@ export default class WorkshopTableLoader extends React.Component {
     }).done(data => {
       this.setState({
         loading: false,
-        workshops: prepWorkshopData(data),
+        workshops: ensureAllWorkshopsHaveSubjects(data),
       });
     });
   };

--- a/apps/src/code-studio/pd/workshop_dashboard/types.js
+++ b/apps/src/code-studio/pd/workshop_dashboard/types.js
@@ -9,6 +9,7 @@ const workshopShape = PropTypes.shape({
   funded: PropTypes.bool.isRequired,
   course: PropTypes.string.isRequired,
   subject: PropTypes.string,
+  course_offering_names: PropTypes.string,
   title: PropTypes.string,
   enrolled_teacher_count: PropTypes.number.isRequired,
   capacity: PropTypes.number.isRequired,

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_table_loaderTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_table_loaderTest.js
@@ -5,6 +5,30 @@ import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import WorkshopTableLoader from '@cdo/apps/code-studio/pd/workshop_dashboard/components/workshop_table_loader';
+import {
+  COURSE_CSF,
+  COURSE_BUILD_YOUR_OWN,
+} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshopConstants';
+
+const defaultFakeResponseData = {
+  limit: 100,
+  total_count: 2,
+  filters: '',
+  workshops: [
+    {
+      id: 1,
+      course: COURSE_CSF,
+      subject: 'Intro',
+      course_offering_names: null,
+    },
+    {
+      id: 2,
+      course: COURSE_BUILD_YOUR_OWN,
+      subject: '',
+      course_offering_names: 'Test Topic A, Test Topic B',
+    },
+  ],
+};
 
 describe('WorkshopTableLoader', () => {
   let server;
@@ -27,10 +51,6 @@ describe('WorkshopTableLoader', () => {
     server.restore();
   });
 
-  const getFakeWorkshopsData = () => {
-    return [{id: 1}, {id: 2}];
-  };
-
   it('Initially displays a spinner', () => {
     const Child = sinon.stub().returns(null);
     const loader = shallow(
@@ -44,8 +64,7 @@ describe('WorkshopTableLoader', () => {
   });
 
   it('Loads workshops over ajax and passes them to the child component', () => {
-    const fakeWorkshopsData = getFakeWorkshopsData();
-    const responseJson = JSON.stringify(fakeWorkshopsData);
+    const responseJson = JSON.stringify(defaultFakeResponseData);
     server.respondWith('GET', 'fake-query-url', [
       200,
       {'Content-Type': 'application/json'},
@@ -63,12 +82,16 @@ describe('WorkshopTableLoader', () => {
     expect(server.requests.length).to.equal(1);
     expect(server.requests[0].url).to.equal('fake-query-url');
 
+    // First workshop is not BYO so its subject should remain unchanged, while the second workshop is BYO
+    // so its subject should be its course offering names.
     expect(Child.calledOnce).to.be.true;
-    expect(Child.getCall(0).args[0].toString()).to.eql(
-      {
-        workshops: fakeWorkshopsData,
-        onDelete: null,
-      }.toString()
+    const returnedWorkshopSubjects =
+      Child.getCall(0).args[0].workshops.workshops;
+    expect(returnedWorkshopSubjects[0].subject).to.eql(
+      defaultFakeResponseData.workshops[0].subject
+    );
+    expect(returnedWorkshopSubjects[1].subject).to.eql(
+      defaultFakeResponseData.workshops[1].course_offering_names
     );
   });
 
@@ -94,7 +117,7 @@ describe('WorkshopTableLoader', () => {
   });
 
   it('Passes delete function to child when canDelete is true', () => {
-    const fakeWorkshopsData = getFakeWorkshopsData();
+    const fakeWorkshopsData = defaultFakeResponseData.workshops;
     const Child = sinon.stub().returns(null);
     const loader = mount(
       <WorkshopTableLoader queryUrl="fake-query-url" canDelete>

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_table_loaderTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_table_loaderTest.js
@@ -64,10 +64,12 @@ describe('WorkshopTableLoader', () => {
     expect(server.requests[0].url).to.equal('fake-query-url');
 
     expect(Child.calledOnce).to.be.true;
-    expect(Child.getCall(0).args[0]).to.eql({
-      workshops: fakeWorkshopsData,
-      onDelete: null,
-    });
+    expect(Child.getCall(0).args[0].toString()).to.eql(
+      {
+        workshops: fakeWorkshopsData,
+        onDelete: null,
+      }.toString()
+    );
   });
 
   it('Applies queryParams to the queryURL', () => {

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -4,8 +4,8 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
     :enrollment_code, :pre_workshop_survey_url, :attended, :on_map, :funded, :funding_type, :ready_to_close?,
     :workshop_starting_date, :date_and_location_name, :regional_partner_name, :regional_partner_id,
-    :scholarship_workshop?, :can_delete, :created_at, :virtual, :suppress_email, :third_party_provider, :course_offerings, :module,
-    :participant_group_type, :description, :registration_link, :prereq, :hidden, :grades, :time_zone
+    :scholarship_workshop?, :can_delete, :created_at, :virtual, :suppress_email, :third_party_provider, :course_offerings, :course_offering_names,
+    :module, :participant_group_type, :description, :registration_link, :prereq, :hidden, :grades, :time_zone
 
   def sessions
     object.sessions.map do |session|
@@ -28,6 +28,10 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
 
   def course_offerings
     object.course_offerings.map(&:id)
+  end
+
+  def course_offering_names
+    object.course_offerings&.map(&:display_name)&.join(', ')
   end
 
   def enrolled_teacher_count

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -31,7 +31,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
   end
 
   def course_offering_names
-    object.course_offerings&.map(&:display_name)&.join(', ')
+    object.course_offerings&.map(&:display_name)&.sort&.join(', ')
   end
 
   def enrolled_teacher_count


### PR DESCRIPTION
Makes several small updates to the workshop table based on changes to the workshop table and as cleanup:
- Update column headers:
   - Remove `on_map` column
   - Remove `funded` column
   - Rename "Course" column to "Type"
   - Rename "Subject" column to "Subjects/Topics"
   - Rename "Virtual" column to "Format" (and list its format instead of "Yes"/"No")
   - Reorder the columns to match [the Figma](https://www.figma.com/design/Km9JCLNbayBlTrlnKenumq/New-PL-Program?node-id=3814-21215&t=U0tZFh7qCVbF8RO6-0)
- For Build Your Own workshops, list its PL topics under "Subjects/Topics". Unfortunately, to easily allow the user to view/sort a mix of workshop types (i.e. some with subjects and some with topics), they all need to be under the same property name. So, only in the context of displaying the topics on the workshop table, I set each BYO workshop's `subject` to a joined array of its `course_offerings`.
- (cleanup item not listed in Jira ticket) While I was testing, I noticed errors in the console that I've seen on production complaining about some workshops not having a valid `subject` despite it being a required parameter. I made this parameter no longer required since BYO workshops don't have them.

### /workshops page
How the workshop table's headers used to look and be ordered:
![current column header and order](https://github.com/user-attachments/assets/f891aff1-e231-4eab-b843-36ed148b90c5)

The new look:
![new workshop dashboard](https://github.com/user-attachments/assets/dc1a31df-ca9e-4326-bfe6-d71244f837a2)

The user can sort by "Subjects/Topics" and it will properly sort a mix of BYO workshops and non-BYO workshops:
![can sort by subject topic](https://github.com/user-attachments/assets/261e7ae0-e07e-45ef-b476-657837323ef4)

### /workshops/filter page
How the workshop table's headers used to look and be ordered:
![current workshop filter header](https://github.com/user-attachments/assets/43b2f9b9-2faf-48b3-8783-63c7e8e2d902)

The new look:
![new filter](https://github.com/user-attachments/assets/35ecf1d6-4ede-450c-9e73-b23484e04b12)

The user can sort by "Subjects/Topics" and it will properly sort a mix of BYO workshops and non-BYO workshops:
![filter can also sort by subject topic](https://github.com/user-attachments/assets/8bd3313b-f6b4-43bb-ac88-458ae52d68d9)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3125)
Figma: [here](https://www.figma.com/design/Km9JCLNbayBlTrlnKenumq/New-PL-Program?node-id=3814-21215&t=U0tZFh7qCVbF8RO6-0)

## Testing story
Local testing.
