### PR TITLE
[Music] Option to default to 'sounds' in Sounds Panel

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -225,9 +225,29 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
             name="showSoundFilters"
             label="Show Sound Filters in Sound Picker"
             onChange={event => {
+              const showSoundFilters = event.target.checked;
               setLevelData({
                 ...levelData,
-                showSoundFilters: event.target.checked,
+                showSoundFilters,
+                ...(showSoundFilters
+                  ? {}
+                  : {showSoundsPanelInSoundsMode: false}),
+              });
+            }}
+            size="s"
+          />
+          <Checkbox
+            checked={!!levelData.showSoundsPanelInSoundsMode}
+            name="showSoundsPanelInSoundsMode"
+            label="Default to 'Sounds' mode in Sound Picker"
+            onChange={event => {
+              const showSoundsPanelInSoundsMode = event.target.checked;
+              setLevelData({
+                ...levelData,
+                showSoundsPanelInSoundsMode,
+                ...(showSoundsPanelInSoundsMode
+                  ? {showSoundFilters: true}
+                  : {}),
               });
             }}
             size="s"

--- a/apps/src/music/MusicRegistry.ts
+++ b/apps/src/music/MusicRegistry.ts
@@ -11,6 +11,7 @@ class MusicRegistry {
   private analyticsReporterRef: AnalyticsReporter | null = null;
 
   public showSoundFilters: boolean = false;
+  public showSoundsPanelInSoundsMode: boolean = false;
   public hideAiTemperature: boolean = false;
   public showAiTemperatureExplanation: boolean = false;
   public showAiGenerateAgainHelp: boolean = false;

--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -143,12 +143,17 @@ class FieldSounds extends GoogleBlockly.Field {
       return;
     }
 
+    const defaultMode = MusicRegistry.showSoundsPanelInSoundsMode
+      ? 'sounds'
+      : 'packs';
+
     ReactDOM.render(
       <SoundsPanel
         library={MusicLibrary.getInstance()}
         currentValue={this.getValue()}
         playingPreview={this.playingPreview}
         showSoundFilters={MusicRegistry.showSoundFilters}
+        defaultMode={defaultMode}
         onPreview={value => {
           this.playingPreview = value;
           this.renderContent();

--- a/apps/src/music/types.ts
+++ b/apps/src/music/types.ts
@@ -13,6 +13,7 @@ export interface MusicLevelData extends ProjectLevelData {
   library?: string;
   packId?: string;
   showSoundFilters?: boolean;
+  showSoundsPanelInSoundsMode?: boolean;
   blockMode?: ValueOf<typeof BlockMode>;
   hideAiTemperature?: boolean;
   showAiTemperatureExplanation?: boolean;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -397,6 +397,9 @@ class UnconnectedMusicView extends React.Component {
       (AppConfig.getValue('show-sound-filters') === 'true' ||
         levelData?.showSoundFilters);
 
+    MusicRegistry.showSoundsPanelInSoundsMode =
+      !!levelData?.showSoundsPanelInSoundsMode;
+
     MusicRegistry.hideAiTemperature =
       levelData?.hideAiTemperature ||
       AppConfig.getValue('hide-ai-temperature') === 'true';

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -230,6 +230,7 @@ interface SoundsPanelProps {
   currentValue: string;
   playingPreview: string;
   showSoundFilters: boolean;
+  defaultMode: Mode;
   onSelect: (path: string) => void;
   onPreview: (path: string) => void;
 }
@@ -239,6 +240,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   currentValue,
   playingPreview,
   showSoundFilters,
+  defaultMode,
   onSelect,
   onPreview,
 }) => {
@@ -248,7 +250,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   const [selectedFolder, setSelectedFolder] = useState<SoundFolder>(
     library.getAllowedFolderForSoundId(currentValue) || folders[0]
   );
-  const [mode, setMode] = useState<Mode>('packs');
+  const [mode, setMode] = useState<Mode>(defaultMode);
   const [filter, setFilter] = useState<Filter>('all');
   const [isFocusSet, setIsFocusSet] = useState(false);
 


### PR DESCRIPTION
The curriculum team has asked us to enable levelbuilders to set which play sound tab (packs vs sounds) is the default for a given level:
![Screenshot 2025-03-14 at 1 18 52 PM](https://github.com/user-attachments/assets/b45a8981-97fb-414e-83cf-23c8a1b8b1bc)

@amy-b suggested that we add one more checkbox in the "Interface" section editor that will open the sound dropdown menu in the "Sounds" tab instead of the "Packs" tab.

This new option depends up on "Show Sound Filters in Sound Picker" also being checked, so I've set the two checkboxes to respond to each other dynamically as shown:
![2025-03-19 13-45-33 2025-03-19 13_46_07](https://github.com/user-attachments/assets/c27d1dbe-de24-4c51-97e4-b60974d730de)

## Links
Slack thread: 
https://codedotorg.slack.com/archives/C04TH8400AU/p1741983596468539
Tooling spec: https://docs.google.com/document/d/1BppxCmxheTKDyQp6Y3QdBR97jV4BNFA77zw8OrfrRcw/edit?tab=t.0

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
