### PR TITLE
Disable flaky teacher tools tests

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_completion.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_completion.feature
@@ -19,6 +19,7 @@ Scenario:
   And I see no difference for "level completion"
   And I close my eyes
 
+@skip
 Scenario:
   When I open my eyes to test "freeplay artist sharing"
   And I am on "http://studio.code.org/s/course3/lessons/21/levels/15?noautoplay=true"

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -1,5 +1,6 @@
 Feature: BubbleChoice
   @no_safari
+  @no_mobile
   Scenario: Viewing BubbleChoice progress
     Given I create a teacher-associated student named "Alice"
 


### PR DESCRIPTION
from [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1742342344443059):
* (UI) iPad_teacher_tools_level_types_bubble_choice "View progress from script overview page" ([S3 link](https://cucumber-logs.s3.amazonaws.com/test/test/iPad_teacher_tools_level_types_bubble_choice_output.html?versionId=h8pvDST6BvT.6F8ky3rGK9kDNQU0DUDz))
* (Eyes) Chrome_teacher_tools_level_completion_eyes ([Applitools link](https://eyes.applitools.com/app/test-results/00000251659964038691/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&hideBatchList=true))

Jira tickets to re enable:
* [TEACH-1703: re enable iPad_teacher_tools_level_types_bubble_choice ui test](https://codedotorg.atlassian.net/browse/TEACH-1703)
* [TEACH-1704: re enable Chrome_teacher_tools_level_completion_eyes](https://codedotorg.atlassian.net/browse/TEACH-1704)

