### PR TITLE
Add empty state buttons for section card

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2925,6 +2925,7 @@
   "studentsInSection": "Students in section: ",
   "studentNames": "Student names",
   "studentOverviewTableHeader": "Submission status",
+  "studentsAdded": "{numStudents, plural, one {# student} other {# students}} added",
   "studentsAnswered": "students answered",
   "studentsSuccessfullyMovedNotice": "Students successfully moved",
   "studentsSuccessfullyMovedDetails": "{numStudents} student(s) were successfully moved from this section to section \"{section}.\"",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -325,6 +325,7 @@
   "assessmentSettings": "Assessment Settings",
   "assign": "Assign",
   "assignACourse": "Assign a course to your classroom or start your own course.",
+  "assignACourseButton": "Assign a course",
   "assignARubricScore": "Assign a Rubric Score",
   "assignCourse": "Assign Course",
   "assignConfirm": "Are you sure you want to assign \"{assignmentName}\" to \"{sectionName}\"?",

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/EmptyStateButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/EmptyStateButton.tsx
@@ -1,0 +1,56 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {BodyThreeText} from '@code-dot-org/component-library/typography';
+import React from 'react';
+import {useNavigate} from 'react-router-dom';
+
+import {TEACHER_NAVIGATION_SECTIONS_URL} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
+
+import styles from './teacherHomepage.module.scss';
+
+interface EmptyStateButtonProps {
+  buttonText: string;
+  icon: string;
+  sectionId: number;
+  path: string;
+}
+
+/**
+ * EmptyStateButton component.
+ * Used to render a button that displays when a teacher has not assigned a course or added students to a section.
+ * @param buttonText - Text to display on the button.
+ * @param icon - FontAwesome Icon to display on the left of the button.
+ * @param sectionId - Section ID to navigate to in teacher dashboard
+ * @param path - Path to navigate to in teacher dashboard
+ */
+export const EmptyStateButton: React.FC<EmptyStateButtonProps> = ({
+  buttonText,
+  icon,
+  sectionId,
+  path,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <button
+      type={'button'}
+      className={styles.emptyStateButton}
+      onClick={() =>
+        navigate(`${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${path}`)
+      }
+    >
+      <div className={styles.taskButtonLeft}>
+        <FontAwesomeV6Icon
+          className={styles.emptyStateButtonIcon}
+          iconName={icon}
+          iconStyle={'solid'}
+        />
+        <BodyThreeText>{buttonText}</BodyThreeText>
+      </div>
+      <FontAwesomeV6Icon
+        className={styles.emptyStateButtonIcon}
+        iconName={'plus'}
+        iconStyle={'solid'}
+      />
+    </button>
+  );
+};

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCardBody.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCardBody.tsx
@@ -1,3 +1,5 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {BodyThreeText} from '@code-dot-org/component-library/typography';
 import React from 'react';
 
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
@@ -31,13 +33,26 @@ export const SectionCardBody: React.FC<SectionCardBodyProps> = ({section}) => {
         )}
       </div>
       <div className={styles.sectionCardBodyRight}>
-        {section.studentCount > 0 ? (
+        {section.studentCount > 0 && section.courseId ? (
           <TaskButton
             buttonText={i18n.viewProgressButton()}
             icon={'chart-line'}
             sectionId={section.id}
             path={TEACHER_NAVIGATION_PATHS.progress}
           />
+        ) : section.studentCount > 0 && !section.courseId ? (
+          <div className={styles.studentsAddedAlert}>
+            <div className={styles.taskButtonLeft}>
+              <FontAwesomeV6Icon
+                className={styles.studentAddedAlertIcon}
+                iconName={'check-circle'}
+                iconStyle={'solid'}
+              />
+              <BodyThreeText>
+                {i18n.studentsAdded({numStudents: section.studentCount})}
+              </BodyThreeText>
+            </div>
+          </div>
         ) : (
           <EmptyStateButton
             buttonText={i18n.addStudents()}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCardBody.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCardBody.tsx
@@ -6,6 +6,7 @@ import i18n from '@cdo/locale';
 import {TEACHER_NAVIGATION_PATHS} from '../../teacherNavigation/TeacherNavigationPaths';
 
 import {CourseContentDropdown} from './CourseContentDropdown';
+import {EmptyStateButton} from './EmptyStateButton';
 import {TaskButton} from './TaskButton';
 
 import styles from './teacherHomepage.module.scss';
@@ -17,20 +18,42 @@ interface SectionCardBodyProps {
 export const SectionCardBody: React.FC<SectionCardBodyProps> = ({section}) => {
   return (
     <div className={styles.sectionCardBody}>
-      <CourseContentDropdown section={section} />
+      <div className={styles.sectionCardBodyLeft}>
+        {section.courseId ? (
+          <CourseContentDropdown section={section} />
+        ) : (
+          <EmptyStateButton
+            buttonText={i18n.assignACourseButton()}
+            icon={'book-open-cover'}
+            sectionId={section.id}
+            path={TEACHER_NAVIGATION_PATHS.settings}
+          />
+        )}
+      </div>
       <div className={styles.sectionCardBodyRight}>
-        <TaskButton
-          buttonText={i18n.viewProgressButton()}
-          icon={'chart-line'}
-          sectionId={section.id}
-          path={TEACHER_NAVIGATION_PATHS.progress}
-        />
-        <TaskButton
-          buttonText={i18n.viewLessonMaterialsButton()}
-          icon={'folder-open'}
-          sectionId={section.id}
-          path={TEACHER_NAVIGATION_PATHS.lessonMaterials}
-        />
+        {section.studentCount > 0 ? (
+          <TaskButton
+            buttonText={i18n.viewProgressButton()}
+            icon={'chart-line'}
+            sectionId={section.id}
+            path={TEACHER_NAVIGATION_PATHS.progress}
+          />
+        ) : (
+          <EmptyStateButton
+            buttonText={i18n.addStudents()}
+            icon={'users'}
+            sectionId={section.id}
+            path={TEACHER_NAVIGATION_PATHS.roster}
+          />
+        )}
+        {section.courseId && (
+          <TaskButton
+            buttonText={i18n.viewLessonMaterialsButton()}
+            icon={'folder-open'}
+            sectionId={section.id}
+            path={TEACHER_NAVIGATION_PATHS.lessonMaterials}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -110,14 +110,20 @@
   display: flex;
   flex-direction: row;
   gap: 16px;
-  align-items: stretch;
+  justify-content: space-between;
+}
+
+.sectionCardBodyLeft {
+  display: flex;
+  flex-direction: column;
+  width: 50%;
 }
 
 .sectionCardBodyRight {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  width: 375px;
+  width: 50%;
   gap: 16px;
 }
 
@@ -160,11 +166,12 @@
 .courseContentDropdownContainer {
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
   background-color: var(--neutral-base-white);
   border: 1px solid var(--neutral-gray-20);
   border-radius: 4px;
   padding: 12px;
-  width: 375px;
+  width: 100%;
   gap: 8px;
 
   p {
@@ -181,4 +188,24 @@
       border-color: var(--neutral-gray-40);
     }
   }
+}
+
+// Empty state button
+.emptyStateButton {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  height: 40px;
+  padding: 0 12px;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0;
+  width: 100%;
+  border: 1px dashed var(--brand-purple-50);
+  border-radius: 4px;
+  background-color: var(--neutral-gray-5);
+}
+
+.emptyStateButtonIcon {
+  color: var(--brand-purple-50);
 }

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -127,6 +127,25 @@
   gap: 16px;
 }
 
+.studentsAddedAlert {
+  display: flex;
+  flex-direction: row;
+  box-sizing: border-box;
+  gap: 8px;
+  height: 40px;
+  padding: 0 12px;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0;
+  width: 100%;
+  border-radius: 4px;
+  background-color: var(--sentiment-success-10);
+}
+
+.studentAddedAlertIcon {
+  color: var(--sentiment-success-50);
+}
+
 // Task Button
 .taskButtons {
   border: 1px solid var(--neutral-gray-40);

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionCardBodyTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionCardBodyTest.tsx
@@ -26,7 +26,7 @@ const LocationElement = () => {
 };
 
 describe('SectionCardBody', () => {
-  const section: Section = {
+  const defaultSection: Section = {
     id: 11,
     name: 'Period 1',
     hidden: false,
@@ -63,9 +63,86 @@ describe('SectionCardBody', () => {
     unitId: null,
   };
 
+  const noCourseSection: Section = {
+    id: 11,
+    name: 'Period 1',
+    hidden: false,
+    courseVersionName: '',
+    unitName: null,
+    aiTutorEnabled: false,
+    atRiskAgeGatedDate: new Date(),
+    atRiskAgeGatedUsState: 'xyz',
+    anyStudentHasProgress: false,
+    code: 'ABCDEF',
+    codeReviewExpiresAt: null,
+    course: null,
+    courseDisplayName: '',
+    courseId: null,
+    courseOfferingId: 192,
+    courseVersionId: 553,
+    createdAt: '2024-10-04T18:19:41.000Z',
+    grades: [],
+    isAssignedCSA: false,
+    isAssignedStandaloneCourse: false,
+    lessonExtras: false,
+    loginType: 'picture',
+    loginTypeName: 'Picture Password',
+    pairingAllowed: false,
+    participantType: undefined,
+    postMilestoneDisabled: false,
+    providerManaged: false,
+    restrictSection: false,
+    sectionInstructors: [],
+    sharingDisabled: false,
+    studentCount: 1,
+    syncEnabled: false,
+    ttsAutoplayEnabled: false,
+    unitId: null,
+  };
+
+  const noStudentsection: Section = {
+    id: 11,
+    name: 'Period 1',
+    hidden: false,
+    courseVersionName: 'csd-2024',
+    unitName: null,
+    aiTutorEnabled: false,
+    atRiskAgeGatedDate: new Date(),
+    atRiskAgeGatedUsState: 'xyz',
+    anyStudentHasProgress: false,
+    code: 'ABCDEF',
+    codeReviewExpiresAt: null,
+    course: null,
+    courseDisplayName: "Computer Science Discoveries ('24-'25)",
+    courseId: 52,
+    courseOfferingId: 192,
+    courseVersionId: 553,
+    createdAt: '2024-10-04T18:19:41.000Z',
+    grades: [],
+    isAssignedCSA: false,
+    isAssignedStandaloneCourse: false,
+    lessonExtras: false,
+    loginType: 'picture',
+    loginTypeName: 'Picture Password',
+    pairingAllowed: false,
+    participantType: undefined,
+    postMilestoneDisabled: false,
+    providerManaged: false,
+    restrictSection: false,
+    sectionInstructors: [],
+    sharingDisabled: false,
+    studentCount: 0,
+    syncEnabled: false,
+    ttsAutoplayEnabled: false,
+    unitId: null,
+  };
+
   const store: Store = getStore();
 
-  function renderComponent(initialRoute = '/teacher_dashboard/home') {
+  function renderComponent(
+    section = defaultSection,
+    initialRoute = '/teacher_dashboard/home'
+  ) {
     return render(
       <Provider store={store}>
         <RouterProvider
@@ -108,6 +185,22 @@ describe('SectionCardBody', () => {
                         </div>
                       }
                     />
+                    <Route
+                      path={TEACHER_NAVIGATION_PATHS.roster}
+                      element={
+                        <div>
+                          <LocationElement />
+                        </div>
+                      }
+                    />
+                    <Route
+                      path={TEACHER_NAVIGATION_PATHS.settings}
+                      element={
+                        <div>
+                          <LocationElement />
+                        </div>
+                      }
+                    />
                   </Route>
                 </Route>
               </Route>,
@@ -137,5 +230,15 @@ describe('SectionCardBody', () => {
     const materialsButton = screen.getByText('View lesson materials');
     fireEvent.click(materialsButton);
     screen.getByText('/sections/11/materials');
+  });
+
+  it('renders empty state button when no course is assigned', () => {
+    renderComponent(noCourseSection);
+    screen.getByText('Assign a course');
+  });
+
+  it('renders empty state button when no students have been added', () => {
+    renderComponent(noStudentsection);
+    screen.getByText('Add students');
   });
 });

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionCardBodyTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionCardBodyTest.tsx
@@ -94,7 +94,7 @@ describe('SectionCardBody', () => {
     restrictSection: false,
     sectionInstructors: [],
     sharingDisabled: false,
-    studentCount: 1,
+    studentCount: 2,
     syncEnabled: false,
     ttsAutoplayEnabled: false,
     unitId: null,
@@ -235,6 +235,11 @@ describe('SectionCardBody', () => {
   it('renders empty state button when no course is assigned', () => {
     renderComponent(noCourseSection);
     screen.getByText('Assign a course');
+  });
+
+  it('renders student count alert when no course is assigned but students are enrolled', () => {
+    renderComponent(noCourseSection);
+    screen.getByText('2 students added');
   });
 
   it('renders empty state button when no students have been added', () => {


### PR DESCRIPTION
This update adds empty state buttons to the section card for the following scenarios:
- No students added
- No course added

It also adds an alert featuring the student count in place of the "View progress" button when students are assigned but no course is assigned.

![image](https://github.com/user-attachments/assets/40a2a684-d09a-48f1-9364-56ad198ce3ce)

## Links
[TEACH-1699](https://codedotorg.atlassian.net/browse/TEACH-1699)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
