### PR TITLE
Add index on script_id to sections table

### DIFF
--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -28,10 +28,11 @@
 #
 # Indexes
 #
-#  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_f0d4df9901        (lti_integration_id)
-#  index_sections_on_code     (code) UNIQUE
-#  index_sections_on_user_id  (user_id)
+#  fk_rails_20b1e5de46          (course_id)
+#  fk_rails_f0d4df9901          (lti_integration_id)
+#  index_sections_on_code       (code) UNIQUE
+#  index_sections_on_script_id  (script_id)
+#  index_sections_on_user_id    (user_id)
 #
 
 class CleverSection < OmniAuthSection

--- a/dashboard/app/models/sections/email_section.rb
+++ b/dashboard/app/models/sections/email_section.rb
@@ -28,10 +28,11 @@
 #
 # Indexes
 #
-#  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_f0d4df9901        (lti_integration_id)
-#  index_sections_on_code     (code) UNIQUE
-#  index_sections_on_user_id  (user_id)
+#  fk_rails_20b1e5de46          (course_id)
+#  fk_rails_f0d4df9901          (lti_integration_id)
+#  index_sections_on_code       (code) UNIQUE
+#  index_sections_on_script_id  (script_id)
+#  index_sections_on_user_id    (user_id)
 #
 
 class EmailSection < Section

--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -28,10 +28,11 @@
 #
 # Indexes
 #
-#  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_f0d4df9901        (lti_integration_id)
-#  index_sections_on_code     (code) UNIQUE
-#  index_sections_on_user_id  (user_id)
+#  fk_rails_20b1e5de46          (course_id)
+#  fk_rails_f0d4df9901          (lti_integration_id)
+#  index_sections_on_code       (code) UNIQUE
+#  index_sections_on_script_id  (script_id)
+#  index_sections_on_user_id    (user_id)
 #
 
 class GoogleClassroomSection < OmniAuthSection

--- a/dashboard/app/models/sections/lti_v1_section.rb
+++ b/dashboard/app/models/sections/lti_v1_section.rb
@@ -28,10 +28,11 @@
 #
 # Indexes
 #
-#  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_f0d4df9901        (lti_integration_id)
-#  index_sections_on_code     (code) UNIQUE
-#  index_sections_on_user_id  (user_id)
+#  fk_rails_20b1e5de46          (course_id)
+#  fk_rails_f0d4df9901          (lti_integration_id)
+#  index_sections_on_code       (code) UNIQUE
+#  index_sections_on_script_id  (script_id)
+#  index_sections_on_user_id    (user_id)
 #
 
 class LtiV1Section < Section

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -28,10 +28,11 @@
 #
 # Indexes
 #
-#  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_f0d4df9901        (lti_integration_id)
-#  index_sections_on_code     (code) UNIQUE
-#  index_sections_on_user_id  (user_id)
+#  fk_rails_20b1e5de46          (course_id)
+#  fk_rails_f0d4df9901          (lti_integration_id)
+#  index_sections_on_code       (code) UNIQUE
+#  index_sections_on_script_id  (script_id)
+#  index_sections_on_user_id    (user_id)
 #
 
 class OmniAuthSection < Section

--- a/dashboard/app/models/sections/picture_section.rb
+++ b/dashboard/app/models/sections/picture_section.rb
@@ -28,10 +28,11 @@
 #
 # Indexes
 #
-#  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_f0d4df9901        (lti_integration_id)
-#  index_sections_on_code     (code) UNIQUE
-#  index_sections_on_user_id  (user_id)
+#  fk_rails_20b1e5de46          (course_id)
+#  fk_rails_f0d4df9901          (lti_integration_id)
+#  index_sections_on_code       (code) UNIQUE
+#  index_sections_on_script_id  (script_id)
+#  index_sections_on_user_id    (user_id)
 #
 
 class PictureSection < Section

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -28,10 +28,11 @@
 #
 # Indexes
 #
-#  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_f0d4df9901        (lti_integration_id)
-#  index_sections_on_code     (code) UNIQUE
-#  index_sections_on_user_id  (user_id)
+#  fk_rails_20b1e5de46          (course_id)
+#  fk_rails_f0d4df9901          (lti_integration_id)
+#  index_sections_on_code       (code) UNIQUE
+#  index_sections_on_script_id  (script_id)
+#  index_sections_on_user_id    (user_id)
 #
 
 require 'full-name-splitter'

--- a/dashboard/app/models/sections/word_section.rb
+++ b/dashboard/app/models/sections/word_section.rb
@@ -28,10 +28,11 @@
 #
 # Indexes
 #
-#  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_f0d4df9901        (lti_integration_id)
-#  index_sections_on_code     (code) UNIQUE
-#  index_sections_on_user_id  (user_id)
+#  fk_rails_20b1e5de46          (course_id)
+#  fk_rails_f0d4df9901          (lti_integration_id)
+#  index_sections_on_code       (code) UNIQUE
+#  index_sections_on_script_id  (script_id)
+#  index_sections_on_user_id    (user_id)
 #
 
 class WordSection < Section

--- a/dashboard/db/migrate/20250319204416_add_index_to_sections_script_id.rb
+++ b/dashboard/db/migrate/20250319204416_add_index_to_sections_script_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToSectionsScriptId < ActiveRecord::Migration[6.1]
+  def change
+    add_index :sections, :script_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_03_14_144822) do
+ActiveRecord::Schema.define(version: 2025_03_19_204416) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2097,6 +2097,7 @@ ActiveRecord::Schema.define(version: 2025_03_14_144822) do
     t.index ["code"], name: "index_sections_on_code", unique: true
     t.index ["course_id"], name: "fk_rails_20b1e5de46"
     t.index ["lti_integration_id"], name: "fk_rails_f0d4df9901"
+    t.index ["script_id"], name: "index_sections_on_script_id"
     t.index ["user_id"], name: "index_sections_on_user_id"
   end
 


### PR DESCRIPTION
This db migration is needed to ensure that our standalone-unit migration runs more efficiently. For more information about the standalone-unit migration, view the [PR here](https://github.com/code-dot-org/code-dot-org/pull/64727).

Updating sections is the script's biggest slowdown. We have about 5.16 million sections in production. To update sections to reflect assignments to the new UnitGroup, we needed to search by `script_id` and update the `course_id`. Without an index on `script_id`, the standalone-unit migration took extremely long on a production-cloned db on an adhoc. 


For reference: 
Before adding this index, for 290 units with the least amount of sections assigned to them (250 of which had 0 sections to update), the standalone-unit migration took about 45 minutes (~10s/unit). 

Applying the db migration containing this index took about 20 seconds on the adhoc with the production-cloned db. 

After the index was added, migrating the remaining 240 standalone-units, many of which had tens to hundreds of thousands of sections assigned, took about 15 minutes (~3s/unit)

Re-running the standalone-unit migration on 540 units took 16 minutes.

## Links
Standalone Unit Migration PR: [migrate-standalone-units](https://github.com/code-dot-org/code-dot-org/pull/64727)
