### PR TITLE
Gen AI: allow recreating alarms with changing model list

### DIFF
--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
@@ -76,6 +76,16 @@ const failureMetrics = modelIds.map((modelId, index) => ({
   ),
 }));
 
+
+// Strings to sum the failure (eg, "m7, m8, m9, m10, m11, m12" if 6 models)
+// and total jobs (eg, "m1, m2, m3, m4, m5, m6" if 6 models) metrics for the alarm expressions.
+const failureMetricsSumString = modelIds
+  .map((_, index) => `m${index + modelIds.length + 1}`)
+  .join(', ');
+const totalJobsSumString = modelIds
+  .map((_, index) => `m${index + 1}`)
+  .join(', ');
+
 export const chatCompletionJobExecutionHighFailureRateConfiguration: PutMetricAlarmInput =
   {
     AlarmName: 'genai_chat_completion_job_execution_high_failure_rate',
@@ -105,14 +115,14 @@ export const chatCompletionJobExecutionHighFailureRateConfiguration: PutMetricAl
         Id: 'failures',
         Label: 'failures',
         ReturnData: false,
-        Expression: 'SUM([m6, m7, m8, m9, m10])',
+        Expression: `SUM([${failureMetricsSumString}])`,
       },
       ...failureMetrics,
       {
         Id: 'total',
         Label: 'total_jobs',
         ReturnData: false,
-        Expression: 'SUM([m1, m2, m3, m4, m5])',
+        Expression: `SUM([${totalJobsSumString}])`,
       },
       ...startMetrics,
     ],

--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
@@ -56,7 +56,7 @@ export const openaiSafetyHighFailureRateConfiguration: PutMetricAlarmInput = {
   ],
 };
 
-// Start(total) jobs metrics for each model (m1,...,m5).
+// Start(total) jobs metrics for each model
 const startMetrics = modelIds.map((modelId, index) => ({
   Id: `m${index + 1}`,
   ...createJobExecutionMetricStat(
@@ -66,9 +66,9 @@ const startMetrics = modelIds.map((modelId, index) => ({
   ),
 }));
 
-// Failure job metrics for each model (m6,...,m10).
+// Failure job metrics for each model (IDs are indexed to begin one after the total jobs metrics end)
 const failureMetrics = modelIds.map((modelId, index) => ({
-  Id: `m${index + 6}`,
+  Id: `m${index + 1 + modelIds.length}`,
   ...createJobExecutionMetricStat(
     'AichatRequestChatCompletionJob.Finish',
     'FAILURE',
@@ -80,7 +80,7 @@ const failureMetrics = modelIds.map((modelId, index) => ({
 // Strings to sum the failure (eg, "m7, m8, m9, m10, m11, m12" if 6 models)
 // and total jobs (eg, "m1, m2, m3, m4, m5, m6" if 6 models) metrics for the alarm expressions.
 const failureMetricsSumString = modelIds
-  .map((_, index) => `m${index + modelIds.length + 1}`)
+  .map((_, index) => `m${index + 1 + modelIds.length}`)
   .join(', ');
 const totalJobsSumString = modelIds
   .map((_, index) => `m${index + 1}`)

--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
@@ -76,15 +76,9 @@ const failureMetrics = modelIds.map((modelId, index) => ({
   ),
 }));
 
-
-// Strings to sum the failure (eg, "m7, m8, m9, m10, m11, m12" if 6 models)
-// and total jobs (eg, "m1, m2, m3, m4, m5, m6" if 6 models) metrics for the alarm expressions.
-const failureMetricsSumString = modelIds
-  .map((_, index) => `m${index + 1 + modelIds.length}`)
-  .join(', ');
-const totalJobsSumString = modelIds
-  .map((_, index) => `m${index + 1}`)
-  .join(', ');
+const metricsSumExpression = (metrics: { Id: string }[]): string => {
+  return `SUM[${metrics.map(m => m.Id).join(",")}]`;
+};
 
 export const chatCompletionJobExecutionHighFailureRateConfiguration: PutMetricAlarmInput =
   {
@@ -115,14 +109,14 @@ export const chatCompletionJobExecutionHighFailureRateConfiguration: PutMetricAl
         Id: 'failures',
         Label: 'failures',
         ReturnData: false,
-        Expression: `SUM([${failureMetricsSumString}])`,
+        Expression: metricsSumExpression(failureMetrics),
       },
       ...failureMetrics,
       {
         Id: 'total',
         Label: 'total_jobs',
         ReturnData: false,
-        Expression: `SUM([${totalJobsSumString}])`,
+        Expression: metricsSumExpression(startMetrics),
       },
       ...startMetrics,
     ],


### PR DESCRIPTION
Allows Gen AI alarms to be regenerated with an arbitrarily long set of models. We currently assume there are five total models. Context is that we've added support for gpt-4o-mini and want to include data generated by its usage in our alarming.

## Links

- Slack: https://codedotorg.slack.com/archives/C06FELVTV0Q/p1739924568941819

## Testing story

I manually tested the functions that create the strings, but not sure how to do a test run of creating the alarms themselves? 