### PR TITLE
Keep TA window on the screen

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -1,7 +1,7 @@
 import Button from '@code-dot-org/component-library/button';
 import Tags from '@code-dot-org/component-library/tags';
 import classNames from 'classnames';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import Draggable, {DraggableEventHandler} from 'react-draggable';
 
 import i18n from '@cdo/locale';

--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -1,7 +1,7 @@
 import Button from '@code-dot-org/component-library/button';
 import Tags from '@code-dot-org/component-library/tags';
 import classNames from 'classnames';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import Draggable, {DraggableEventHandler} from 'react-draggable';
 
 import i18n from '@cdo/locale';
@@ -52,11 +52,31 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
   );
 
   useEffect(() => {
+    const ensureDraggableIsVisible = () => {
+      if (window.innerWidth < positionX + 100) {
+        setPositionX(window.innerWidth - 100);
+      }
+    };
+    ensureDraggableIsVisible();
+    window.addEventListener('resize', ensureDraggableIsVisible);
     trySetSessionStorage(AI_DIFF_POSITION_X, String(positionX));
+    return () => {
+      window.removeEventListener('resize', ensureDraggableIsVisible);
+    };
   }, [positionX]);
 
   useEffect(() => {
+    const ensureDraggableIsVisible = () => {
+      if (positionY + window.innerHeight < 760) {
+        setPositionY(760 - window.innerHeight);
+      }
+    };
+    ensureDraggableIsVisible();
+    window.addEventListener('resize', ensureDraggableIsVisible);
     trySetSessionStorage(AI_DIFF_POSITION_Y, String(positionY));
+    return () => {
+      window.removeEventListener('resize', ensureDraggableIsVisible);
+    };
   }, [positionY]);
 
   const onStopHandler: DraggableEventHandler = (e, data) => {
@@ -67,7 +87,7 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
   return (
     <Draggable
       handle=".ai_diff_handle"
-      defaultPosition={{x: positionX, y: positionY}}
+      position={{x: positionX, y: positionY}}
       onStop={onStopHandler}
     >
       <div

--- a/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
@@ -1,4 +1,4 @@
-import {act, render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {Provider} from 'react-redux';
@@ -74,13 +74,11 @@ describe('AiDiffContainer', () => {
     const element = screen.getByTestId('draggable-test-id');
     expect(element.style.transform).toEqual('translate(0px,0px)');
 
-    await act(async () => {
-      userEvent.pointer([
-        {keys: '[MouseLeft>]', target: handle_element},
-        {keys: '[MouseLeft>]', target: handle_element, coords: {x: 50, y: 50}},
-        '[/MouseLeft]',
-      ]);
-    });
+    userEvent.pointer([
+      {keys: '[MouseLeft>]', target: handle_element},
+      {keys: '[MouseLeft>]', target: handle_element, coords: {x: 50, y: 50}},
+      '[/MouseLeft]',
+    ]);
 
     await waitFor(() => {
       const newPosition = element.style.transform;
@@ -96,13 +94,11 @@ describe('AiDiffContainer', () => {
     const element = screen.getByTestId('draggable-test-id');
     expect(element.style.transform).toEqual('translate(0px,0px)');
 
-    await act(async () => {
-      userEvent.pointer([
-        {keys: '[MouseLeft>]', target: handle},
-        {keys: '[MouseLeft>]', target: handle, coords: {x: 5000, y: -5000}},
-        '[/MouseLeft]',
-      ]);
-    });
+    userEvent.pointer([
+      {keys: '[MouseLeft>]', target: handle},
+      {keys: '[MouseLeft>]', target: handle, coords: {x: 5000, y: -5000}},
+      '[/MouseLeft]',
+    ]);
 
     await waitFor(() => {
       const newPosition = element.style.transform;

--- a/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
@@ -68,10 +68,10 @@ describe('AiDiffContainer', () => {
 
   it('moves TA container when user clicks and drags component', async () => {
     renderDefault();
-    const handle_element = await screen.getByText('AI Teaching Assistant');
+    const handle_element = screen.getByText('AI Teaching Assistant');
     // We want to check that the ID is set correctly for dragging.
     // eslint-disable-next-line no-restricted-properties
-    const element = await screen.getByTestId('draggable-test-id');
+    const element = screen.getByTestId('draggable-test-id');
     expect(element.style.transform).toEqual('translate(0px,0px)');
 
     await act(async () => {
@@ -90,10 +90,10 @@ describe('AiDiffContainer', () => {
 
   it('snaps TA container back on screen when dragged off', async () => {
     renderDefault();
-    const handle = await screen.getByText('AI Teaching Assistant');
+    const handle = screen.getByText('AI Teaching Assistant');
     // We want to check that the ID is set correctly for dragging.
     // eslint-disable-next-line no-restricted-properties
-    const element = await screen.getByTestId('draggable-test-id');
+    const element = screen.getByTestId('draggable-test-id');
     expect(element.style.transform).toEqual('translate(0px,0px)');
 
     await act(async () => {

--- a/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
@@ -1,4 +1,5 @@
-import {render, screen, fireEvent} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {Provider} from 'react-redux';
 
@@ -65,23 +66,50 @@ describe('AiDiffContainer', () => {
     screen.getByText('Experiment');
   });
 
-  it('moves rubric container when user clicks and drags component', () => {
+  it('moves TA container when user clicks and drags component', async () => {
     renderDefault();
-    const handle_element = screen.getByText('AI Teaching Assistant');
+    const handle_element = await screen.getByText('AI Teaching Assistant');
     // We want to check that the ID is set correctly for dragging.
     // eslint-disable-next-line no-restricted-properties
-    const element = screen.getByTestId('draggable-test-id');
+    const element = await screen.getByTestId('draggable-test-id');
+    expect(element.style.transform).toEqual('translate(0px,0px)');
 
-    const initialPosition = element.style.transform;
+    await act(async () => {
+      userEvent.pointer([
+        {keys: '[MouseLeft>]', target: handle_element},
+        {keys: '[MouseLeft>]', target: handle_element, coords: {x: 50, y: 50}},
+        '[/MouseLeft]',
+      ]);
+    });
 
-    // simulate dragging
-    fireEvent.mouseDown(handle_element, {clientX: 0, clientY: 0});
-    fireEvent.mouseMove(handle_element, {clientX: 100, clientY: 100});
-    fireEvent.mouseUp(handle_element);
+    await waitFor(() => {
+      const newPosition = element.style.transform;
+      expect(newPosition).toEqual('translate(50px,50px)');
+    });
+  });
 
-    const newPosition = element.style.transform;
+  it('snaps TA container back on screen when dragged off', async () => {
+    renderDefault();
+    const handle = await screen.getByText('AI Teaching Assistant');
+    // We want to check that the ID is set correctly for dragging.
+    // eslint-disable-next-line no-restricted-properties
+    const element = await screen.getByTestId('draggable-test-id');
+    expect(element.style.transform).toEqual('translate(0px,0px)');
 
-    expect(newPosition).not.toEqual(initialPosition);
+    await act(async () => {
+      userEvent.pointer([
+        {keys: '[MouseLeft>]', target: handle},
+        {keys: '[MouseLeft>]', target: handle, coords: {x: 5000, y: -5000}},
+        '[/MouseLeft]',
+      ]);
+    });
+
+    await waitFor(() => {
+      const newPosition = element.style.transform;
+      const expectedX = window.innerWidth - 100;
+      const expectedY = 760 - window.innerHeight;
+      expect(newPosition).toEqual(`translate(${expectedX}px,${expectedY}px)`);
+    });
   });
 
   it('Shows the welcome experience when user property is false', () => {


### PR DESCRIPTION
This change repositions the TA popup as necessary to ensure that the top draggable area is visible. This problem could show up when you're opening the TA for the first time on a small window, or when you're resizing the window, or even when you open some Code.org page on a window that's smaller than what you used last time (the position of the TA is persisted between page loads).

Before view: if the window is too small (vertically) the draggable area can go off the top of the screen and become unusable. If the window becomes too small (horizontally) the TA can disappear entirely.

https://github.com/user-attachments/assets/fb712319-a207-41ac-9606-e1bce2a71754

After view: if the window becomes too small the TA locks in place on the top and right side of the window so it can still be dragged around.

https://github.com/user-attachments/assets/a3dd714f-3a15-4efa-a2dc-a60bc9a5ea87


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
