### PR TITLE
Enable level starter asset uploads in multimodal AI Chat

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -7,6 +7,7 @@ import {
 import {Role} from '../aiComponentLibrary/chatMessage/types';
 import {ValueOf} from '../types/utils';
 
+import {chatHistoryValidator} from './api/validators';
 import {
   AiCustomizations,
   AichatContext,
@@ -133,7 +134,9 @@ export async function getUserChatHistory(
     scriptId: scriptId?.toString() || '',
   };
   const response = await HttpClient.fetchJson<ServerChatEvent[]>(
-    paths.CHAT_HISTORY_URL + '?' + new URLSearchParams(params)
+    paths.CHAT_HISTORY_URL + '?' + new URLSearchParams(params),
+    undefined,
+    chatHistoryValidator
   );
 
   return response.value;

--- a/apps/src/aichat/api/validators.ts
+++ b/apps/src/aichat/api/validators.ts
@@ -26,7 +26,7 @@ const chatHistoryValidator: ResponseValidator<ServerChatEvent[]> = bodyJson => {
         }
       }
 
-      // Clear out assets if they were stored in the wrong format.
+      // Clear out assets if they were stored an out of date format.
       if (event.assets && Array.isArray(event.assets)) {
         event.assets = event.assets.filter(
           asset => typeof asset === 'object' && asset.filename && asset.source

--- a/apps/src/aichat/api/validators.ts
+++ b/apps/src/aichat/api/validators.ts
@@ -1,0 +1,44 @@
+import {ResponseValidator} from '@cdo/apps/util/HttpClient';
+
+import {isChatMessage, ServerChatEvent} from '../types';
+
+/**
+ * Validates ChatEvents fetched by the user chat history API.
+ * Currently, this just checks for an ID, and ensures that chat messages are
+ * in the correct format.
+ * We may add more validation in the future to minimize the risk of breaking changes.
+ */
+const chatHistoryValidator: ResponseValidator<ServerChatEvent[]> = bodyJson => {
+  if (!Array.isArray(bodyJson)) {
+    throw new Error('Expected an array of chat events');
+  }
+
+  const events = bodyJson as ServerChatEvent[];
+  for (const event of events) {
+    if (event.id === undefined) {
+      throw fieldError('id');
+    }
+
+    if (isChatMessage(event)) {
+      for (const field of ['chatMessageText', 'role', 'status'] as const) {
+        if (event[field] === undefined) {
+          throw fieldError(field);
+        }
+      }
+
+      // Clear out assets if they were stored in the wrong format.
+      if (event.assets && Array.isArray(event.assets)) {
+        event.assets = event.assets.filter(
+          asset => typeof asset === 'object' && asset.filename && asset.source
+        );
+      }
+    }
+  }
+  return events;
+};
+
+function fieldError(fieldName: string) {
+  return new Error(`Missing required field: ${fieldName}`);
+}
+
+export {chatHistoryValidator};

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -21,6 +21,7 @@ import {
   ServerChatEvent,
   isCompletedChatMessage,
   PendingChatMessage,
+  ChatAsset,
 } from '../types';
 import {
   DEFAULT_VISIBILITIES,
@@ -249,11 +250,11 @@ const aichatSlice = createSlice({
     },
     addStagedFile(
       state,
-      action: PayloadAction<{key: string; filename: string}>
+      action: PayloadAction<{key: string; asset: ChatAsset; loaded?: boolean}>
     ) {
       state.stagedFiles.push({
         ...action.payload,
-        status: 'uploading',
+        status: action.payload.loaded ? 'uploaded' : 'uploading',
       });
     },
     stagedFileUploadFinished(

--- a/apps/src/aichat/redux/state.ts
+++ b/apps/src/aichat/redux/state.ts
@@ -1,6 +1,7 @@
 import {ModalTypes} from '../constants';
 import {
   AiCustomizations,
+  ChatAsset,
   ChatEvent,
   FieldVisibilities,
   PendingChatMessage,
@@ -34,7 +35,7 @@ export interface AichatState {
   // List of files that have been staged for upload to the model.
   stagedFiles: {
     key: string;
-    filename: string;
+    asset: ChatAsset;
     status: 'uploading' | 'uploaded';
   }[];
   // Alert to display for staged files if something went wrong.

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -22,6 +22,7 @@ import {
   isCompletedChatMessage,
   PendingChatMessage,
   CompletedChatMessage,
+  ChatAsset,
 } from '../../types';
 import {getNewRemoveId} from '../utils';
 
@@ -34,7 +35,10 @@ import {sendAnalytics} from './sendAnalytics';
 // the user messages.
 export const submitChatContents = createAsyncThunk(
   'aichat/submitChatContents',
-  async (newUserMessageInput: {text: string; assets?: string[]}, thunkAPI) => {
+  async (
+    newUserMessageInput: {text: string; assets?: ChatAsset[]},
+    thunkAPI
+  ) => {
     const dispatch = thunkAPI.dispatch as AppDispatch;
     const state = thunkAPI.getState() as RootState;
     const {savedAiCustomizations: aiCustomizations, chatEventsCurrent} =

--- a/apps/src/aichat/types/assets.ts
+++ b/apps/src/aichat/types/assets.ts
@@ -1,7 +1,5 @@
-export interface UploadAssetResponse {
-  category: string;
+/** An asset file included with a chat message. */
+export interface ChatAsset {
   filename: string;
-  size: number;
-  timestamp: string;
-  versionId: string;
+  source: 'project' | 'level';
 }

--- a/apps/src/aichat/types/chatEvents.ts
+++ b/apps/src/aichat/types/chatEvents.ts
@@ -2,6 +2,7 @@ import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {AiInteractionStatus} from '@cdo/generated-scripts/sharedConstants';
 
+import {ChatAsset} from './assets';
 import {AiCustomizations} from './customizations';
 import {FeedbackValue} from './toxicity';
 
@@ -17,7 +18,7 @@ interface BaseChatEvent {
 interface BaseChatMessage extends BaseChatEvent {
   chatMessageText: string;
   /** Asset file names to optionally send with text content */
-  assets?: string[];
+  assets?: ChatAsset[];
   role: Role;
   status: ValueOf<typeof AiInteractionStatus>;
 }

--- a/apps/src/aichat/utils.ts
+++ b/apps/src/aichat/utils.ts
@@ -1,5 +1,5 @@
 import {MAX_NAME_LENGTH} from './constants';
-import {AiCustomizations, ToxicityCheckedField} from './types';
+import {AiCustomizations, ChatAsset, ToxicityCheckedField} from './types';
 import {FIELDS_CHECKED_FOR_TOXICITY} from './views/modelCustomization/constants';
 
 export const getShortName = (studentName: string): string => {
@@ -22,3 +22,20 @@ export const extractFieldsToCheckForToxicity = (
     return acc;
   }, {} as {[key in ToxicityCheckedField]: string | string[]});
 };
+
+/**
+ * Generates a URL for the given asset.
+ */
+export function getAssetUrl(
+  asset: ChatAsset,
+  channelId?: string,
+  levelName?: string
+) {
+  if (asset.source === 'project') {
+    return `/v3/assets/${channelId}/${encodeURIComponent(asset.filename)}`;
+  } else {
+    return `/level_starter_assets/${levelName}/${encodeURIComponent(
+      asset.filename
+    )}`;
+  }
+}

--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -14,6 +14,7 @@ import {
   isCompletedChatMessage,
   isServerChatEvent,
 } from '../types';
+import {getAssetUrl} from '../utils';
 
 import CleanFeedbackFooter from './teacherFeedback/CleanFeedbackFooter';
 import ProfanityFeedbackFooter from './teacherFeedback/ProfanityFeedbackFooter';
@@ -32,6 +33,7 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
   const [showProfaneUserMessage, setShowProfaneUserMessage] = useState(false);
   const {status, role, chatMessageText, assets} = chatMessage;
   const currentChannelId = useAppSelector(state => state.lab.channel?.id);
+  const levelName = useAppSelector(state => state.lab.levelProperties?.name);
 
   const displayText = getChatMessageDisplayText(
     status,
@@ -90,20 +92,21 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
     footer = (
       <div className={styles.assetRow}>
         {assets.map(asset => {
-          return asset.endsWith('.pdf') ? (
-            <div key={asset} className={styles.pdfPreview}>
+          const filename = asset.filename;
+          return filename.endsWith('.pdf') ? (
+            <div key={filename} className={styles.pdfPreview}>
               <FontAwesomeV6Icon
                 iconName="file-pdf"
                 className={styles.pdfIcon}
               />
-              <span>{asset}</span>
+              <span>{filename}</span>
             </div>
           ) : (
             <img
-              key={asset}
+              key={filename}
               alt=""
               className={styles.imagePreview}
-              src={`/v3/assets/${currentChannelId}/${asset}`}
+              src={getAssetUrl(asset, currentChannelId, levelName)}
             />
           );
         })}

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -17,8 +17,8 @@ const UserChatMessageEditor: React.FunctionComponent<{
 
   const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
   const multimodalEnabled = useAppSelector(selectMultimodalEnabled);
-  const stagedFilenames = useAppSelector(state =>
-    state.aichat.stagedFiles.map(file => file.filename)
+  const chatAssets = useAppSelector(state =>
+    state.aichat.stagedFiles.map(file => file.asset)
   );
   const uploadsPending = useAppSelector(state =>
     state.aichat.stagedFiles.some(file => file.status === 'uploading')
@@ -35,14 +35,14 @@ const UserChatMessageEditor: React.FunctionComponent<{
           submitChatContents({
             text: userMessage,
             assets:
-              multimodalEnabled && stagedFilenames.length > 0
-                ? stagedFilenames
+              multimodalEnabled && chatAssets.length > 0
+                ? chatAssets
                 : undefined,
           })
         );
       }
     },
-    [isWaitingForChatResponse, multimodalEnabled, stagedFilenames, dispatch]
+    [isWaitingForChatResponse, multimodalEnabled, chatAssets, dispatch]
   );
 
   const disabled = isWaitingForChatResponse || saveInProgress || uploadsPending;

--- a/apps/src/aichat/views/assets/StagedFilesPreview.tsx
+++ b/apps/src/aichat/views/assets/StagedFilesPreview.tsx
@@ -1,4 +1,4 @@
-import Alert from '@code-dot-org/component-library/alert';
+import Alert, {type AlertProps} from '@code-dot-org/component-library/alert';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import {StrongText} from '@code-dot-org/component-library/typography';
@@ -10,6 +10,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {MAX_FILE_SIZE_MB, MAX_NUM_FILES} from '../../constants';
 import aichatI18n from '../../locale';
 import {clearStagedFilesAlert, removeStagedFile} from '../../redux';
+import {getAssetUrl} from '../../utils';
 
 import styles from './staged-files-preview.module.scss';
 
@@ -23,12 +24,13 @@ const alerts = {
     aichatI18n.uploadSizeLimitExceededAlert({maximum: MAX_FILE_SIZE_MB}),
     'danger',
   ] as const,
-};
+} satisfies {[key: string]: [string, AlertProps['type']]};
 
 const StagedFilesPreview: React.FC = () => {
   const dispatch = useAppDispatch();
   const stagedFiles = useAppSelector(state => state.aichat.stagedFiles);
   const currentChannelId = useAppSelector(state => state.lab.channel?.id);
+  const levelName = useAppSelector(state => state.lab.levelProperties?.name);
 
   const [alertMessage, style] = useAppSelector(state => {
     if (!state.aichat.stagedFilesAlert) {
@@ -45,14 +47,13 @@ const StagedFilesPreview: React.FC = () => {
   return (
     <div className={styles.container}>
       <div className={styles.row}>
-        {stagedFiles.map(({key, filename, status}) => {
+        {stagedFiles.map(({key, asset, status}) => {
+          const filename = asset.filename;
           return (
             <FilePreview
               key={key}
               type={filename.endsWith('.pdf') ? 'pdf' : 'image'}
-              url={`/v3/assets/${currentChannelId}/${encodeURIComponent(
-                filename
-              )}`}
+              url={getAssetUrl(asset, currentChannelId, levelName)}
               filename={filename}
               isLoading={status === 'uploading'}
               onRemove={() => dispatch(removeStagedFile(key))}

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -1,7 +1,11 @@
-import {Button} from '@code-dot-org/component-library/button';
-import React, {ChangeEvent, useCallback, useRef} from 'react';
+import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
+import classNames from 'classnames';
+import React, {ChangeEvent, useState} from 'react';
 
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import StarterAssetsDialog from '@cdo/apps/lab2/views/components/starterAssetsDialog';
+import {AssetData} from '@cdo/apps/lab2/views/components/starterAssetsDialog/types';
+import useHiddenFileInput from '@cdo/apps/util/hooks/useHiddenFileInput';
 import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -14,15 +18,19 @@ import {
   stagedFileUploadFinished,
 } from '../../redux';
 
+import styles from './upload-button.module.scss';
+
 const UploadButton: React.FC = () => {
   const dispatch = useAppDispatch();
-  const inputRef = useRef<HTMLInputElement>(null);
   const currentChannelId = useAppSelector(state => state.lab.channel?.id);
   const numStagedFiles = useAppSelector(
     state => state.aichat.stagedFiles.length
   );
+  const numAllowedFiles = MAX_NUM_FILES - numStagedFiles;
+  const levelName = useAppSelector(state => state.lab.levelProperties?.name);
+  const [showAssetManager, setShowAssetManager] = useState(false);
 
-  const onSelectFile = async (event: ChangeEvent<HTMLInputElement>) => {
+  const onUploadFiles = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (!files) {
       return;
@@ -30,8 +38,6 @@ const UploadButton: React.FC = () => {
 
     // Clear the alert, if any
     dispatch(clearStagedFilesAlert());
-
-    const numAllowedFiles = MAX_NUM_FILES - numStagedFiles;
 
     if (files.length > numAllowedFiles) {
       dispatch(stagedFilesLimitExceeded());
@@ -47,7 +53,7 @@ const UploadButton: React.FC = () => {
       ]);
 
     for (const [key, filename] of allowedFiles) {
-      dispatch(addStagedFile({key, filename}));
+      dispatch(addStagedFile({key, asset: {filename, source: 'project'}}));
     }
 
     for (const [key, filename, file] of allowedFiles) {
@@ -81,33 +87,69 @@ const UploadButton: React.FC = () => {
     }
   };
 
-  const onUploadClick = useCallback(() => {
-    if (inputRef.current) {
-      inputRef.current.click();
-      // Clear the value in case the same file is selected again.
-      inputRef.current.value = '';
+  const onSelectStarterAssets = (assets: AssetData[]) => {
+    for (const asset of assets) {
+      dispatch(
+        addStagedFile({
+          key: `${asset.filename}-${Date.now()}`,
+          asset: {
+            filename: asset.filename,
+            source: 'level',
+          },
+          loaded: true,
+        })
+      );
     }
-  }, [inputRef]);
+  };
+
+  const [openFileInput, FileInput] = useHiddenFileInput(
+    onUploadFiles,
+    ACCEPTED_FILE_TYPES.join(','),
+    true
+  );
+
+  if (!currentChannelId) {
+    return null;
+  }
 
   return (
     <>
-      <input
-        type="file"
-        id="file"
-        ref={inputRef}
-        style={{display: 'none'}}
-        onChange={onSelectFile}
-        accept={ACCEPTED_FILE_TYPES.join(',')}
-        multiple
-      />
-      <Button
-        text={aichatI18n.upload()}
-        iconLeft={{iconName: 'upload'}}
-        size="s"
-        type="secondary"
-        color="gray"
-        onClick={onUploadClick}
+      {levelName && showAssetManager && (
+        <StarterAssetsDialog
+          levelName={levelName}
+          onClose={() => setShowAssetManager(false)}
+          mode="select"
+          onSelect={onSelectStarterAssets}
+          limit={numAllowedFiles}
+        />
+      )}
+      <FileInput />
+      <ActionDropdown
+        name="uploadDropdown"
+        labelText={aichatI18n.upload()}
         disabled={numStagedFiles >= MAX_NUM_FILES}
+        size="s"
+        className={classNames(styles.upload, styles.dropdown)}
+        triggerButtonProps={{
+          type: 'secondary',
+          color: 'gray',
+          iconLeft: {iconName: 'upload'},
+          text: aichatI18n.upload(),
+        }}
+        options={[
+          {
+            value: 'fromLibrary',
+            label: 'From Library',
+            icon: {iconName: 'copy'},
+            onClick: () => setShowAssetManager(true),
+          },
+          {
+            value: 'fromDevice',
+            label: 'From Device',
+            icon: {iconName: 'file-magnifying-glass'},
+            onClick: openFileInput,
+          },
+        ]}
       />
     </>
   );

--- a/apps/src/aichat/views/assets/upload-button.module.scss
+++ b/apps/src/aichat/views/assets/upload-button.module.scss
@@ -1,0 +1,6 @@
+// Using multiple classnames to override ActionDropdown CSS specificity
+// so that the dropdown menu appears above the button.
+// TODO: Probably better if ActionDropdown supports this natively.
+div.upload.dropdown > div {
+  bottom: 35px;
+}

--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -89,7 +89,10 @@ export const SourceResponseValidator: ResponseValidator<
 export const LevelPropertiesValidator: ResponseValidator<
   LevelProperties
 > = response => {
-  if (Array.isArray(response) || !response.appName) {
+  if (Array.isArray(response)) {
+    throw new Error('Level properties should be an object (received array).');
+  }
+  if (!response.appName) {
     throw missingFieldError('appName');
   }
 

--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -121,7 +121,10 @@ function sourceValidatorHelper(
   response: Record<string, unknown> | unknown[],
   appSpecificValidator: (response: Record<string, unknown>) => void
 ): ProjectSources {
-  if (Array.isArray(response) || !response.source) {
+  if (Array.isArray(response)) {
+    throw new Error('Source response should be an object (received array).');
+  }
+  if (!response.source) {
     throw missingFieldError('source');
   }
   appSpecificValidator(response);

--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -24,7 +24,7 @@ const BlocklySourceResponseValidator: ResponseValidator<
       throw new ValidationError('Error parsing JSON: ' + e);
     }
     if (blocklySource.blocks === undefined) {
-      throwMissingFieldError('blocks');
+      throw missingFieldError('blocks');
     }
   };
 
@@ -89,8 +89,8 @@ export const SourceResponseValidator: ResponseValidator<
 export const LevelPropertiesValidator: ResponseValidator<
   LevelProperties
 > = response => {
-  if (!response.appName) {
-    throwMissingFieldError('appName');
+  if (Array.isArray(response) || !response.appName) {
+    throw missingFieldError('appName');
   }
 
   // Convert stringified booleans to actual booleans.
@@ -118,16 +118,16 @@ export class ValidationError extends Error {
 }
 
 function sourceValidatorHelper(
-  response: Record<string, unknown>,
+  response: Record<string, unknown> | unknown[],
   appSpecificValidator: (response: Record<string, unknown>) => void
 ): ProjectSources {
-  if (!response.source) {
-    throwMissingFieldError('source');
+  if (Array.isArray(response) || !response.source) {
+    throw missingFieldError('source');
   }
   appSpecificValidator(response);
   return response as unknown as ProjectSources;
 }
 
-function throwMissingFieldError(fieldName: string) {
-  throw new ValidationError('Missing required field: ' + fieldName);
+function missingFieldError(fieldName: string) {
+  return new ValidationError('Missing required field :' + fieldName);
 }

--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -129,5 +129,5 @@ function sourceValidatorHelper(
 }
 
 function missingFieldError(fieldName: string) {
-  return new ValidationError('Missing required field :' + fieldName);
+  return new ValidationError('Missing required field: ' + fieldName);
 }

--- a/apps/src/util/HttpClient.ts
+++ b/apps/src/util/HttpClient.ts
@@ -4,7 +4,7 @@ import {
 } from './AuthenticityTokenStore';
 
 export type ResponseValidator<ResponseType> = (
-  bodyJson: Record<string, unknown>
+  bodyJson: Record<string, unknown> | unknown[]
 ) => ResponseType;
 
 export type GetResponse<ResponseType> = {

--- a/dashboard/app/helpers/aichat_asset_helper.rb
+++ b/dashboard/app/helpers/aichat_asset_helper.rb
@@ -2,16 +2,14 @@
 module AichatAssetHelper
   ASSET_BUCKET = AssetBucket.new
 
-  def self.get_asset_url(channel_id, filename)
-    # TODO
-  end
-
   # Returns a list of data URIs in base64 format for the given asset.
-  def self.get_asset_data_uris(channel_id, filename)
-    result = ASSET_BUCKET.get(channel_id, filename)
+  def self.get_asset_data_uris(asset, channel_id, level_name)
+    filename = asset["filename"]
+    source = asset["source"]
+    result = fetch_asset(filename, source, channel_id, level_name)
 
     # TODO - error cases
-    return nil unless result[:status] == 'FOUND'
+    return [] unless result && result[:status] == 'FOUND'
 
     ext = File.extname(filename)
     return pdf_to_images(result) if ext == '.pdf'
@@ -40,5 +38,16 @@ module AichatAssetHelper
       data_uris << "data:image/jpeg;base64,#{data}"
     end
     data_uris
+  end
+
+  def self.fetch_asset(filename, source, channel_id, level_name)
+    return ASSET_BUCKET.get(channel_id, filename) if source == 'project'
+    if source == 'level'
+      level = Level.find_by(name: level_name)
+      uuid_name = (level&.starter_assets || level&.project_template_level&.starter_assets || {})&.dig(filename)
+      return nil if uuid_name.nil?
+      s3_object = LevelStarterAssetsHelper.get_object(uuid_name)
+      return {status: 'FOUND', body: s3_object.get.body} if s3_object
+    end
   end
 end

--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -24,7 +24,10 @@ module AichatOpenaiHelper
   end
 
   def self.format_messages(aichat_model_customizations, stored_messages, new_message, level_id, encrypted_channel_id)
-    level_system_prompt = Level.find_by(id: level_id)&.properties&.dig('aichat_settings', 'levelSystemPrompt') || ""
+    level = Level.find_by(id: level_id)
+    level_system_prompt = level&.properties&.dig('aichat_settings', 'levelSystemPrompt') || ""
+    level_name = level&.name
+
     instructions = get_instructions(
       aichat_model_customizations['systemPrompt'],
       level_system_prompt,
@@ -33,15 +36,15 @@ module AichatOpenaiHelper
 
     [
       {role: "system", content: instructions},
-      *stored_messages.map {|message| format_message(message, encrypted_channel_id)},
-      format_message(new_message, encrypted_channel_id)
+      *stored_messages.map {|message| format_message(message, encrypted_channel_id, level_name)},
+      format_message(new_message, encrypted_channel_id, level_name)
     ]
   end
 
-  def self.format_message(message, encrypted_channel_id)
+  def self.format_message(message, encrypted_channel_id, level_name)
     formatted = {role: message['role'], content: [{type: "text", text: message['chatMessageText']}]}
-    message['assets']&.each do |filename|
-      asset_uris = AichatAssetHelper.get_asset_data_uris(encrypted_channel_id, filename)
+    message['assets']&.each do |asset|
+      asset_uris = AichatAssetHelper.get_asset_data_uris(asset, encrypted_channel_id, level_name)
       asset_uris.each do |asset_uri|
         formatted[:content] << {type: "image_url", image_url: {url: asset_uri}}
       end


### PR DESCRIPTION
Finally, the last piece of starter assets support in multimodal AI Chat, which hooks up the previously created starter assets dialog to the upload flow, and allows level assets to be fetched, converted, and sent to the model like project assets. There are a few different pieces here that I unfortunately couldn't find a clean way to separate, but happy to explain further if anything is unclear. Main things:

- Instead of storing `assets: string[]` on the `ChatMessage` type, I created a `ChatAsset` type that has a `filename` and a `source` that can be either `"level"` or `"project"`, because the way we look up level and project assets differs. `ChatMessage`'s `assets` field is now a `ChatAsset[]` array. Updated relevant code to use this type instead of just storing the filename as a string. Very much open to feedback on a better/clearer naming convention if this is confusing 🙂 
- The Upload button in the chat UI now opens a dropdown (drop-up?) that has two options, "From Library" or "From Device". "From Device" opens the existing user upload flow while "From Library" opens the new starter assets picker.
- On the backend, updated helpers to handle the new `ChatAsset` format, and updated `AichatAssetHelper` to handle level assets, making use of the new `LevelStarterAssetsHelper`.

https://github.com/user-attachments/assets/b1ab9313-7f47-4b79-b4d6-891d4773e79f

## Links

https://codedotorg.atlassian.net/browse/LABS-1387

## Testing story

Tested locally on allthethings.
Note: created https://codedotorg.atlassian.net/browse/LABS-1406 to add tests for `AichatAssetHelper` since it's a little more complex now (and will probably continue to grow with actual error handling, etc).