### PR TITLE
P20-1431 / Platform / Global Edition / Fix global edition projects

### DIFF
--- a/dashboard/test/ui/features/platform/global_edition/region_select.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_select.feature
@@ -74,14 +74,14 @@ Feature: Global Edition - Region Select
 
     When I select the "فارسی" option in dropdown named "locale" to load a new page
     And I wait for the lab page to fully load
-    Then check that the URL matches "/global/fa/projects/artist/.*/edit\?lang=fa-IR"
+    Then check that the URL matches "/projects/artist/.*/edit\?lang=fa-IR"
     And I wait until element ".uitest-instructionsTab" contains text "دستورالعمل"
     And element "#localeForm option:contains(فارسی)" is checked
     And element "#localeForm" has escaped text "Englishفارسی"
 
     When I select the "English" option in dropdown named "locale" to load a new page
     And I wait for the lab page to fully load
-    Then check that the URL matches "/global/fa/projects/artist/.*/edit\?lang=en-US"
+    Then check that the URL matches "/projects/artist/.*/edit\?lang=en-US"
     And I wait until element ".uitest-instructionsTab" contains text "Instructions"
     And element "#localeForm option:contains(English)" is checked
     And element "#localeForm" has escaped text "Englishفارسی"

--- a/lib/cdo/rack/global_edition.rb
+++ b/lib/cdo/rack/global_edition.rb
@@ -30,6 +30,7 @@ module Rack
         "/v3/assets/",
         "/v3/animations/",
         "/api/v1/animation-library/",
+        "/api/v1/sound-library/",
         "/datablock_storage/",
       ].compact.freeze
 

--- a/lib/cdo/rack/global_edition.rb
+++ b/lib/cdo/rack/global_edition.rb
@@ -23,6 +23,14 @@ module Rack
         # it is more efficient to remove the Global Edition prefix and treat the request as a standard route.
         # Additionally, preventing OAuth routes from being redirected, ensuring the authentication process is not disrupted.
         ::OmniAuth.config.path_prefix, # e.g. `/users/auth`
+        # Projects and datasets are supplied by ancient middleware that does not play well with our prefixes [P20-1431]
+        "/projects/",
+        "/v3/sources/",
+        "/v3/channels/",
+        "/v3/assets/",
+        "/v3/animations/",
+        "/api/v1/animation-library/",
+        "/datablock_storage/",
       ].compact.freeze
 
       attr_reader :app, :env

--- a/lib/cdo/rack/global_edition.rb
+++ b/lib/cdo/rack/global_edition.rb
@@ -74,6 +74,7 @@ module Rack
           setup_region_redirect(request.cookies[REGION_KEY])
         elsif (locale_region = Cdo::GlobalEdition.region_locked_locales[request.cookies[LOCALE_KEY]])
           # Redirects to the regional version of the locale if it is possible.
+          setup_region(locale_region)
           setup_region_redirect(locale_region)
         end
 


### PR DESCRIPTION
The `/projects/*` paths that serve generic `*-lab` workspaces would not correctly load in a global edition such as `/global/fa/projects/...`, causing errors and many support tickets related to students that accidentally went into the global edition.

This is because projects are served by a set of Sinatra middleware that does not play well with the Global Edition middleware and due to assumptions in the code supporting some of the labs that assume that the assets and such can be served from a root path (e.g. `/v3/assets`) and do not redirect.

This simply adds exceptions to the Global Edition router that won't route `/projects/...` paths to the `/global/*/` prefix along with other API paths that read sources and assets from such labs and student content.

## Links

- jira ticket: [P20-1431](https://codedotorg.atlassian.net/browse/P20-1431)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
