### PR TITLE
[Music] Allow disabling next connection on rest blocks

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -217,6 +217,7 @@ export const playRestAtCurrentLocationSimple2 = {
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockRestTooltip(),
     helpUrl: DOCS_BASE_URL + 'rest',
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block =>
     `Sequencer.rest(${block.getFieldValue(FIELD_REST_DURATION_NAME)});`,


### PR DESCRIPTION
> In Start Mode, when right-clicking on blocks, there’s an option to “Disable Next Connection”, which helps make the code look cleaner. The Rest block is missing this.


https://github.com/user-attachments/assets/7dab1a57-223b-4a33-b73a-d35464e3357f

In fact, this was intentionally left off of rest blocks as it was thought they wouldn't typically be used at the bottom of a stack of blocks:
- https://github.com/code-dot-org/code-dot-org/pull/63005

However, @dancodedotorg clarified:
> since Rest blocks have tight controls over the amount of measures, once we learn loops, we tell students they can use loops with `Rest 1 measure` to rest as many measures as they want. And so things like this are where the dangling connection is off

![image (271)](https://github.com/user-attachments/assets/93cd3393-3ff3-4ec4-a335-3e6311fd7f1f)

Fortunately, enabling this feature for these blocks is as simple as providing them with the appropriate mutator.
<img width="284" alt="image" src="https://github.com/user-attachments/assets/e09e6b52-3100-4b38-8a6c-07255318f607" />


## Links
https://codedotorg.atlassian.net/browse/LABS-1400

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
