### PR TITLE
[Levelbuilder] Hide unsupported Instructions fields for Music levels

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -710,7 +710,7 @@ class Level < ApplicationRecord
 
   def show_help_and_tips_in_level_editor?
     (uses_droplet? || is_a?(Blockly) || is_a?(Weblab) || is_a?(Ailab) || is_a?(Javalab)) &&
-      !(is_a?(NetSim) || is_a?(GamelabJr) || is_a?(Dancelab) || is_a?(BubbleChoice))
+      !(is_a?(NetSim) || is_a?(GamelabJr) || is_a?(Dancelab) || is_a?(BubbleChoice) || is_a?(Music))
   end
 
   def localized_teacher_markdown

--- a/dashboard/app/views/levels/editors/fields/_instructions.haml
+++ b/dashboard/app/views/levels/editors/fields/_instructions.haml
@@ -2,6 +2,6 @@
   Instructions
 
 #instructions.in.collapse
-  = render partial: 'levels/editors/fields/short_instructions', locals: {f: f} unless (@level.is_a?(Applab) || @level.instance_of?(Gamelab) || @level.is_a?(Weblab) || @level.is_a?(ExternalLink) || @level.is_a?(FreeResponse) || @level.is_a?(FrequencyAnalysis) || @level.is_a?(PublicKeyCryptography)|| @level.is_a?(Vigenere) || @level.is_a?(Javalab)) || @level.is_a?(Aichat)
+  = render partial: 'levels/editors/fields/short_instructions', locals: {f: f} unless (@level.is_a?(Applab) || @level.instance_of?(Gamelab) || @level.is_a?(Weblab) || @level.is_a?(ExternalLink) || @level.is_a?(FreeResponse) || @level.is_a?(FrequencyAnalysis) || @level.is_a?(PublicKeyCryptography)|| @level.is_a?(Vigenere) || @level.is_a?(Javalab)) || @level.is_a?(Aichat) || @level.is_a?(Music)
   = render partial: 'levels/editors/fields/long_instructions', locals: {f: f}
   = render partial: 'levels/editors/fields/tts', locals: {f: f} unless @level.is_a?(ExternalLink) || @level.is_a?(FreeResponse) || @level.is_a?(Widget)

--- a/dashboard/app/views/levels/editors/fields/_instructions_area.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_instructions_area.html.haml
@@ -6,4 +6,5 @@
   = render partial: 'levels/editors/fields/ailab_dynamic_instructions', locals: {f: f} if @level.is_a?(Ailab)
   = render partial: 'levels/editors/fields/help_and_tips', locals: {f: f} if @level.show_help_and_tips_in_level_editor?
   = render partial: 'levels/editors/fields/mini_rubric', locals: {f: f} if @level.uses_droplet? || @level.is_a?(Weblab) || @level.is_a?(Javalab)
-  = render partial: 'levels/editors/fields/authored_hints', locals: {f: f} if !@level.uses_droplet? && @level.is_a?(Blockly) && !@level.is_a?(NetSim)
+  = render partial: 'levels/editors/fields/authored_hints', locals: {f: f} if !@level.uses_droplet? && @level.is_a?(Blockly) && !@level.is_a?(NetSim) && !@level.is_a?(Music)
+

--- a/dashboard/app/views/levels/editors/fields/_tts.haml
+++ b/dashboard/app/views/levels/editors/fields/_tts.haml
@@ -4,7 +4,7 @@
   #tts-error.alert.alert-error{style: "display: none"}
     #alert-content
   .row
-    - unless (@level.is_a?(Applab) || @level.instance_of?(Gamelab) || @level.is_a?(Weblab) || @level.is_a?(Javalab)) || @level.is_a?(Aichat)
+    - unless (@level.is_a?(Applab) || @level.instance_of?(Gamelab) || @level.is_a?(Weblab) || @level.is_a?(Javalab)) || @level.is_a?(Aichat) || @level.is_a?(Music)
       .span6
         %h5 Short Instructions
         = f.text_area :tts_short_instructions_override, placeholder: '', rows: 4, class:"input-block-level"
@@ -16,7 +16,8 @@
     %div
       %select#level_tts_voice
     %div
-      %button.tts#tts-short-instructions{type: 'button'} Hear Short Instructions
+      - unless (@level.is_a?(Applab) || @level.instance_of?(Gamelab) || @level.is_a?(Weblab) || @level.is_a?(Javalab)) || @level.is_a?(Aichat) || @level.is_a?(Music)
+        %button.tts#tts-short-instructions{type: 'button'} Hear Short Instructions
       %button.tts#tts-long-instructions{type: 'button'} Hear Long Instructions
     %div
       %audio#tts-audio


### PR DESCRIPTION
Katie [reported](https://codedotorg.slack.com/archives/C07UT279KM1/p1742493863405419) an issue where several unsupported fields show up under the Instructions heading of Music levels on level edit pages. They are:

- Short Instructions (and Short Instructions TTS)
- Help and Tips
- Authored Hints

These were all added in bulk as part of `instructions_area`, even though the intention was only to support Long Instructions (https://github.com/code-dot-org/code-dot-org/pull/53413)

## Proposed Removals
![image](https://github.com/user-attachments/assets/7b113530-6dff-4045-af37-52a1c1203925)

## After
![image](https://github.com/user-attachments/assets/d229f4f5-1cfe-4d26-b2a8-9e0f1a9c1c54)

The like reason for this oversight is that `Music` levels are also `Blockly` levels, and all other `Blockly` levels support each of these features. Music Lab is unique in being our only Lab2 level type to use Blockly. I was able to quickly hide each of these fields by adding one more exception for each.

I made one other change to hide the `Hear Short Instructions` (TTS) button from all of the same level types that don't support Short Instructions. This should be remove a useless button from levels like Java Lab (shown below on Levelbuilder):

![image](https://github.com/user-attachments/assets/2fcc1133-087a-46f5-af45-8c38d67c9e08)
 

## Links

https://codedotorg.slack.com/archives/C07UT279KM1/p1742493863405419

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
