### PR TITLE
Update shard id generation

### DIFF
--- a/apps/src/netsim/NetSimLobby.js
+++ b/apps/src/netsim/NetSimLobby.js
@@ -601,10 +601,15 @@ NetSimLobby.prototype.makeShardIDFromSeed_ = function (seed) {
   const UNDERSCORE = '_';
   // md5 returns a 32-character hex string.
   const levelHash = md5(this.levelKey_);
-  return (NET_SIM_PREFIX + levelHash + UNDERSCORE + seed).substring(
-    0,
-    MAX_LENGTH
-  );
+  // Calculate the max possible length for the md5 hash so that seed is intact.
+  const maxHashLength =
+    MAX_LENGTH -
+    NET_SIM_PREFIX.length -
+    UNDERSCORE.length -
+    seed.toString().length;
+  // If necessary, truncate hash.
+  const truncatedLevelHash = levelHash.substring(0, maxHashLength);
+  return NET_SIM_PREFIX + truncatedLevelHash + UNDERSCORE + seed;
 };
 
 /**

--- a/apps/src/netsim/NetSimLobby.js
+++ b/apps/src/netsim/NetSimLobby.js
@@ -596,9 +596,18 @@ NetSimLobby.prototype.buildShardChoiceList_ = function (
  * @private
  */
 NetSimLobby.prototype.makeShardIDFromSeed_ = function (seed) {
-  // md5 returns a 32-character hex string so these should always be 35-character strings
-  // Previously we truncated to 48 characters
-  return 'ns_' + md5(this.levelKey_ + '_' + seed);
+  const MAX_LENGTH = 48;
+  const NET_SIM_PREFIX = 'ns_';
+  const UNDERSCORE = '_';
+  // md5 returns a 32-character hex string.
+  const hash = md5(this.levelKey_ + seed);
+  // Calculate the max possible length for the md5 hash so that seed is intact.
+  const maxHashLength =
+    MAX_LENGTH - NET_SIM_PREFIX.length - UNDERSCORE.length - seed.length;
+  // If necessary, truncate hash.
+  const truncatedHash = hash.substring(0, maxHashLength);
+
+  return NET_SIM_PREFIX + truncatedHash + UNDERSCORE + seed;
 };
 
 /**

--- a/apps/src/netsim/NetSimLobby.js
+++ b/apps/src/netsim/NetSimLobby.js
@@ -592,22 +592,19 @@ NetSimLobby.prototype.buildShardChoiceList_ = function (
 
 /**
  * Generate a unique shard key from the given seed
- * @param {string} seed
+ * @param {string} seed - either the section ID, random UUID, or shared shard seed.
  * @private
  */
 NetSimLobby.prototype.makeShardIDFromSeed_ = function (seed) {
   const MAX_LENGTH = 48;
-  const NET_SIM_PREFIX = 'ns_';
+  const NET_SIM_PREFIX = 'ns-';
   const UNDERSCORE = '_';
   // md5 returns a 32-character hex string.
-  const hash = md5(this.levelKey_ + seed);
-  // Calculate the max possible length for the md5 hash so that seed is intact.
-  const maxHashLength =
-    MAX_LENGTH - NET_SIM_PREFIX.length - UNDERSCORE.length - seed.length;
-  // If necessary, truncate hash.
-  const truncatedHash = hash.substring(0, maxHashLength);
-
-  return NET_SIM_PREFIX + truncatedHash + UNDERSCORE + seed;
+  const levelHash = md5(this.levelKey_);
+  return (NET_SIM_PREFIX + levelHash + UNDERSCORE + seed).substring(
+    0,
+    MAX_LENGTH
+  );
 };
 
 /**

--- a/apps/test/unit/netsim/NetSimLobbyTest.js
+++ b/apps/test/unit/netsim/NetSimLobbyTest.js
@@ -75,9 +75,13 @@ describe('NetSimLobby', () => {
       expect(shardID.startsWith('ns_')).toBe(true);
     });
 
-    it('should return a 35-character string', () => {
-      const shardID = lobby.makeShardIDFromSeed_('testSeed');
-      expect(shardID.length).toBe(35);
+    it('should return a string no longer than 48 characters with seed intact', () => {
+      // The md5 hash is 32 characters long so that if the seed length is greater than
+      // 13, the hash is truncated so that the seed is intact.
+      const seed = 'aVeryLongTestSeed'; // 17 characters
+      const shardID = lobby.makeShardIDFromSeed_(seed);
+      expect(shardID.length).toBeLessThanOrEqual(48);
+      expect(shardID.substring(shardID.length - seed.length)).toBe(seed);
     });
 
     it('should generate different shard IDs for different seeds', () => {

--- a/apps/test/unit/netsim/NetSimLobbyTest.js
+++ b/apps/test/unit/netsim/NetSimLobbyTest.js
@@ -84,11 +84,12 @@ describe('NetSimLobby', () => {
       expect(shardID.substring(shardID.length - seed.length)).toBe(seed);
     });
 
-    it('should return a string no longer than 48 characters with long shared seed', () => {
+    it('should return a string no longer than 48 characters with long shared seed with seed intact', () => {
       // seed has more than 13 characters.
       const seed = 'thisIsAVeryLongSharedShardSeed';
       const shardID = lobby.makeShardIDFromSeed_(seed);
       expect(shardID.length).toBeLessThanOrEqual(48);
+      expect(shardID.substring(shardID.length - seed.length)).toBe(seed);
     });
 
     it('should generate different shard IDs for different seeds', () => {

--- a/apps/test/unit/netsim/NetSimLobbyTest.js
+++ b/apps/test/unit/netsim/NetSimLobbyTest.js
@@ -70,18 +70,25 @@ describe('NetSimLobby', () => {
       lobby = createLobbyWithLevelKey(sampleLevelKey);
     });
 
-    it("should return a string starting with 'ns_'", () => {
+    it("should return a string starting with 'ns-'", () => {
       const shardID = lobby.makeShardIDFromSeed_('testSeed');
-      expect(shardID.startsWith('ns_')).toBe(true);
+      expect(shardID.startsWith('ns-')).toBe(true);
     });
 
-    it('should return a string no longer than 48 characters with seed intact', () => {
-      // The md5 hash is 32 characters long so that if the seed length is greater than
-      // 13, the hash is truncated so that the seed is intact.
-      const seed = 'aVeryLongTestSeed'; // 17 characters
+    it('should return a string no longer than 48 characters with section id seed intact', () => {
+      // The md5 hash is 32 characters long.
+      // seed is section ID which will be no longer than 13 characters.
+      const seed = '0123456789';
       const shardID = lobby.makeShardIDFromSeed_(seed);
       expect(shardID.length).toBeLessThanOrEqual(48);
       expect(shardID.substring(shardID.length - seed.length)).toBe(seed);
+    });
+
+    it('should return a string no longer than 48 characters with long shared seed', () => {
+      // seed has more than 13 characters.
+      const seed = 'thisIsAVeryLongSharedShardSeed';
+      const shardID = lobby.makeShardIDFromSeed_(seed);
+      expect(shardID.length).toBeLessThanOrEqual(48);
     });
 
     it('should generate different shard IDs for different seeds', () => {


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/64280 which resolved a bug that resulted from a long `levelKey` name that resulted in the seed (section ID) getting cutoff by the truncation logic. Thus all sections in the Networks pilot were getting assigned to the same session instead of being assigned to a session based on their teacher section.

However, this introduced a regression since in `doesUserOwnShard`, the [section ID is extracted from the `shardID`](https://github.com/code-dot-org/code-dot-org/blob/0c7148fb563b7fc79a2607a45132245d4cdace53/apps/src/netsim/NetSimUtils.js#L417-L428).

@ebeastlake [investigated this issue](https://docs.google.com/document/d/16ieshBR0-1R2lFzTRsVxVk50D8IGTUh6Uv7hY56BBT4/edit?tab=t.0) and looked into resolving this bug but passing the section ID. However, this entails making changes in multiple files - [WIP](https://github.com/code-dot-org/code-dot-org/pull/64646). She posed a question at the beginning of her doc - 'would it be easier to just redo the sharding logic?' which is what this PR proposes.

I hesitate to make updates in multiple files for the net sim so I propose that we make a small update so that the section ID is always intact at the end of the shard ID.



## Before update
Note there is no 'Reset Simulation' button nor 'Teacher View' button.
![before-update](https://github.com/user-attachments/assets/f6829805-6eee-4c9b-b2d3-b3fa21a19f72)

## After update
'Reset Simulation' and `Teacher View' buttons are displayed.
<img width="1131" alt="after-update" src="https://github.com/user-attachments/assets/27f8d537-2b3b-4010-89f9-d3c1cb610ed1" />

Screencast video of the router log via teacher view (student name is displayed) and the resetting of the simulation.

https://github.com/user-attachments/assets/de5a6041-644b-4d48-8545-09172c3c8de7



## Links

[jira](https://codedotorg.atlassian.net/browse/LABS-1405)
[Zendesk report](https://codeorg.zendesk.com/agent/tickets/531793)
[Emily's investigation](https://docs.google.com/document/d/16ieshBR0-1R2lFzTRsVxVk50D8IGTUh6Uv7hY56BBT4/edit?tab=t.0)
[Alternate approach](https://github.com/code-dot-org/code-dot-org/pull/64646)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
