### PR TITLE
Codebridge: use level properties from context, not redux

### DIFF
--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -11,6 +11,7 @@ import {
   SetConfigFunction,
   OnRunFunction,
   SendConsoleInputFunction,
+  CodebridgeLevelProperties,
 } from '@codebridge/types';
 import classNames from 'classnames';
 import React, {useEffect, useMemo, useReducer, useRef} from 'react';
@@ -34,6 +35,7 @@ type CodebridgeProps = {
   projectVersion: number;
   labConfig?: LabConfig;
   sendConsoleInput?: SendConsoleInputFunction;
+  levelProperties: CodebridgeLevelProperties;
 };
 
 export const Codebridge = React.memo(
@@ -48,6 +50,7 @@ export const Codebridge = React.memo(
     projectVersion,
     labConfig,
     sendConsoleInput,
+    levelProperties,
   }: CodebridgeProps) => {
     const reducerWithCallback = useReducerWithCallback(
       sourceReducer,
@@ -78,7 +81,7 @@ export const Codebridge = React.memo(
       return config.layoutComponents[currentLayout];
     }, [config.activeLayout, config.layoutComponents, isShareView]);
 
-    const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+    const appName = levelProperties.appName;
 
     const backpackApi = useMemo(
       () => new BackpackClientApi(appName, null),
@@ -98,6 +101,7 @@ export const Codebridge = React.memo(
           ...sourceUtilities,
           labConfig,
           sendConsoleInput,
+          levelProperties,
         }}
       >
         <BackpackAPIContext.Provider value={backpackApi}>

--- a/apps/src/codebridge/Console/Console.tsx
+++ b/apps/src/codebridge/Console/Console.tsx
@@ -11,8 +11,6 @@ import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-
 import '@xterm/xterm/css/xterm.css';
 
 import ConsoleManager from './ConsoleManager';
@@ -25,8 +23,8 @@ import moduleStyles from './console.module.scss';
 const Console: React.FunctionComponent = () => {
   const terminalRef = useRef<HTMLDivElement>(null);
   const [didInit, setDidInit] = useState(false);
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
-  const {labConfig, sendConsoleInput} = useCodebridgeContext();
+  const {labConfig, sendConsoleInput, levelProperties} = useCodebridgeContext();
+  const appName = levelProperties.appName;
   const hasMiniApp = !!labConfig?.miniApp?.name;
 
   const clearOutput = useCallback(

--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -33,9 +33,10 @@ import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
 // Can be extended in the future to include a test button.
 const ControlButtons: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
-  const {onRun, onStop, labConfig} = useCodebridgeContext();
+  const {onRun, onStop, labConfig, levelProperties} = useCodebridgeContext();
+  const {id: levelId, appName, predictSettings} = levelProperties;
+  const isPredictLevel = predictSettings?.isPredictLevel;
 
-  const levelId = useAppSelector(state => state.lab.levelProperties?.id);
   const scriptId = useAppSelector(state => state.lab.scriptId);
   const source = useAppSelector(
     state => state.lab2Project.projectSources?.source
@@ -43,15 +44,11 @@ const ControlButtons: React.FunctionComponent = () => {
   const hasPredictResponse = useAppSelector(
     state => !!state.predictLevel.response
   );
-  const isPredictLevel = useAppSelector(
-    state => state.lab.levelProperties?.predictSettings?.isPredictLevel
-  );
   const hasLoadedEnvironment = useAppSelector(
     state => state.lab2System.loadedCodeEnvironment
   );
   const isRunning = useAppSelector(state => state.lab2System.isRunning);
   const isValidating = useAppSelector(state => state.lab2System.isValidating);
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 

--- a/apps/src/codebridge/FileBrowser/FileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowser.tsx
@@ -31,9 +31,9 @@ import {DragDataType, DropDataType} from './types';
 import moduleStyles from './styles/filebrowser.module.scss';
 
 export const FileBrowser = React.memo(() => {
-  const {source, setFileType} = useCodebridgeContext();
+  const {source, setFileType, levelProperties} = useCodebridgeContext();
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const appName = levelProperties.appName;
 
   const [dragData, setDragData] = useState<DragDataType | undefined>(undefined);
   const [dropData, setDropData] = useState<DropDataType | undefined>(undefined);

--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {useBackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {
   useFileUploader,
@@ -21,10 +20,9 @@ export const FileBrowserHeaderPopUpButton = () => {
   const {
     source,
     config: {validMimeTypes},
+    levelProperties,
   } = useCodebridgeContext();
-  const validationFile = useAppSelector(
-    state => state.lab.levelProperties?.validationFile
-  );
+  const validationFile = levelProperties.validationFile;
 
   const uploadErrorCallback = useFileUploadErrorCallback();
   const handleFileUpload = useHandleFileUpload(source.files);

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/useFileRowOptions.ts
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/useFileRowOptions.ts
@@ -14,7 +14,6 @@ import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {ProjectFileType} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useBackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useStartModeFileRowOptions} from './useStartModeFileRowOptions';
 
@@ -47,6 +46,7 @@ export const useFileRowOptions = (
   const {
     source: {files: projectFiles, folders: projectFolders},
     config: {editableFileTypes},
+    levelProperties,
   } = useCodebridgeContext();
 
   const backpackApi = useBackpackAPIContext();
@@ -58,7 +58,7 @@ export const useFileRowOptions = (
     openSaveToBackpackPrompt,
   } = usePrompts();
 
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const appName = levelProperties.appName;
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 
   const isLocked = !isStartMode && file.type === ProjectFileType.LOCKED_STARTER;

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -11,7 +11,6 @@ import {
 } from '@cdo/apps/lab2/hooks';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 type UseFileUploaderArgs = Exclude<FileUploaderProps, 'sendAnalyticsEvent'>;
 
@@ -19,12 +18,9 @@ export const useFileUploader = (
   args: UseFileUploaderArgs,
   folderId: string
 ) => {
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
-  const {source} = useCodebridgeContext();
+  const {source, levelProperties} = useCodebridgeContext();
+  const {appName, validationFile} = levelProperties;
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
-  const validationFile = useAppSelector(
-    state => state.lab.levelProperties?.validationFile
-  );
 
   const sendAnalyticsEvent = useCallback(
     (eventName: string, payload: Record<string, string>) => {

--- a/apps/src/codebridge/FileBrowser/hooks/useHandleDragEnd.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/useHandleDragEnd.ts
@@ -10,7 +10,6 @@ import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {usePartialApply, PAFunctionArgs} from '@cdo/apps/lab2/hooks';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {DragType} from '../types';
 
@@ -20,12 +19,11 @@ import {DragType} from '../types';
  * @returns A function that handles the DragOverEvent from `@dnd-kit/core`.
  */
 export const useHandleDragEnd = () => {
-  const {source, moveFile, moveFolder} = useCodebridgeContext();
+  const {source, moveFile, moveFolder, levelProperties} =
+    useCodebridgeContext();
 
   const dialogControl = useDialogControl();
-  const validationFile = useAppSelector(
-    state => state.lab.levelProperties?.validationFile
-  );
+  const validationFile = levelProperties.validationFile;
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 
   const validateFileName = usePartialApply(globalValidateFileName, {

--- a/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
@@ -8,18 +8,14 @@ import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 export const useHandleFileUpload = (
   projectFiles: Record<string, ProjectFile>
 ) => {
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const {newFile, levelProperties} = useCodebridgeContext();
+  const {appName, validationFile} = levelProperties;
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
-  const validationFile = useAppSelector(
-    state => state.lab.levelProperties?.validationFile
-  );
 
-  const {newFile} = useCodebridgeContext();
   const dialogControl = useDialogControl();
   return useCallback(
     (fileName: string, contents: string, folderIdArg: unknown) => {

--- a/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
@@ -19,7 +19,7 @@ import {usePartialApply, PAFunctionArgs} from '@cdo/apps/lab2/hooks';
 import {setOverrideValidations} from '@cdo/apps/lab2/lab2Redux';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {useDialogControl} from '@cdo/apps/lab2/views/dialogs';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 /**
  * Provides functions to open new file or folder prompts within the application.
@@ -35,14 +35,6 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
  *   - **openSaveToBackpackPrompt:** Opens a prompt for saving a file to the user's backpack.
  */
 export const usePrompts = () => {
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
-  const validationFile = useAppSelector(
-    state => state.lab.levelProperties?.validationFile
-  );
-  const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
-  const dialogControl = useDialogControl();
-  const dispatch = useAppDispatch();
-
   const {
     source,
     deleteFile,
@@ -54,7 +46,12 @@ export const usePrompts = () => {
     renameFile,
     renameFolder,
     saveFile,
+    levelProperties,
   } = useCodebridgeContext();
+  const {appName, validationFile} = levelProperties;
+  const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+  const dialogControl = useDialogControl();
+  const dispatch = useAppDispatch();
 
   const sendCodebridgeAnalyticsEvent = useCallback(
     (event: string) => globalSendCodebridgeAnalyticsEvent(event, appName),

--- a/apps/src/codebridge/InfoPanel/ForTeachersOnly.tsx
+++ b/apps/src/codebridge/InfoPanel/ForTeachersOnly.tsx
@@ -1,13 +1,12 @@
+import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import React from 'react';
 
 import PredictSolution from '@cdo/apps/lab2/views/components/PredictSolution';
 import TeacherOnlyMarkdown from '@cdo/apps/templates/instructions/TeacherOnlyMarkdown';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 const ForTeachersOnly: React.FunctionComponent = () => {
-  const teacherMarkdown = useAppSelector(
-    state => state.lab.levelProperties?.teacherMarkdown
-  );
+  const {levelProperties} = useCodebridgeContext();
+  const teacherMarkdown = levelProperties.teacherMarkdown;
 
   return (
     <div>

--- a/apps/src/codebridge/InfoPanel/HelpAndTips.tsx
+++ b/apps/src/codebridge/InfoPanel/HelpAndTips.tsx
@@ -1,18 +1,11 @@
+import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import React from 'react';
 
 import HelpTabContents from '@cdo/apps/templates/instructions/HelpTabContents';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 const HelpAndTips: React.FunctionComponent = () => {
-  const mapReference = useAppSelector(
-    state => state.lab.levelProperties?.mapReference
-  );
-  const referenceLinks = useAppSelector(
-    state => state.lab.levelProperties?.referenceLinks
-  );
-  const helpVideos = useAppSelector(
-    state => state.lab.levelProperties?.helpVideos
-  );
+  const {levelProperties} = useCodebridgeContext();
+  const {mapReference, referenceLinks, helpVideos} = levelProperties;
   const helpVideo = helpVideos ? helpVideos[0] : null;
   return (
     <HelpTabContents

--- a/apps/src/codebridge/InfoPanel/InfoPanel.tsx
+++ b/apps/src/codebridge/InfoPanel/InfoPanel.tsx
@@ -9,6 +9,7 @@ import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/use
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {UserLevelInteractions} from '@cdo/generated-scripts/sharedConstants';
 
+import {useCodebridgeContext} from '../codebridgeContext';
 import {sendCodebridgeAnalyticsEvent} from '../utils/analyticsReporterHelper';
 
 import ForTeachersOnly from './ForTeachersOnly';
@@ -56,17 +57,16 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
   style,
   className,
 }) => {
-  const levelId = useAppSelector(state => state.lab.levelProperties?.id);
+  const {levelProperties} = useCodebridgeContext();
+  const {
+    id: levelId,
+    mapReference,
+    referenceLinks,
+    teacherMarkdown,
+    predictSettings,
+    appName,
+  } = levelProperties;
   const scriptId = useAppSelector(state => state.lab.scriptId);
-  const mapReference = useAppSelector(
-    state => state.lab.levelProperties?.mapReference
-  );
-  const referenceLinks = useAppSelector(
-    state => state.lab.levelProperties?.referenceLinks
-  );
-  const teacherMarkdown = useAppSelector(
-    state => state.lab.levelProperties?.teacherMarkdown
-  );
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
   const [currentPanel, setCurrentPanel] = useState(Panels.Instructions);
   const [currentPanelHeader, setCurrentPanelHeader] = useState(
@@ -76,10 +76,7 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
   const [panelOptions, setPanelOptions] = useState<Panels[]>([
     Panels.Instructions,
   ]);
-  const hasPredictSolution = useAppSelector(
-    state => !!state.lab.levelProperties?.predictSettings?.solution
-  );
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const hasPredictSolution = predictSettings?.solution;
 
   useEffect(() => {
     // For now, always include Instructions panel.

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -75,20 +75,21 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
   handleInstructionsTextClick,
   className,
 }) => {
-  const {onRun, onStop} = useCodebridgeContext();
+  const {onRun, onStop, levelProperties} = useCodebridgeContext();
   const dialogControl = useDialogControl();
 
-  const levelId = useAppSelector(state => state.lab.levelProperties?.id);
+  const {
+    id: levelId,
+    longInstructions: instructionsText,
+    predictSettings,
+    submittable: isSubmittable,
+    appName: appType,
+  } = levelProperties;
+
   const scriptId = useAppSelector(state => state.lab.scriptId);
-  const instructionsText = useAppSelector(
-    state => state.lab.levelProperties?.longInstructions
-  );
   const hasNextLevel = useSelector(state => nextLevelId(state) !== undefined);
   const {hasConditions, validationResults, satisfied} = useAppSelector(
     state => state.lab.validationState
-  );
-  const predictSettings = useAppSelector(
-    state => state.lab.levelProperties?.predictSettings
   );
   const predictResponse = useAppSelector(state => state.predictLevel.response);
   const predictAnswerLocked = useAppSelector(isPredictAnswerLocked);
@@ -96,14 +97,10 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
   const hasSubmitted = useAppSelector(
     state => getCurrentLevel(state)?.status === LevelStatus.submitted
   );
-  const isSubmittable = useAppSelector(
-    state => state.lab.levelProperties?.submittable
-  );
   const source = useAppSelector(
     state => state.lab2Project.projectSources?.source
   ) as MultiFileSource | undefined;
 
-  const appType = useAppSelector(state => state.lab.levelProperties?.appName);
   const isValidating = useAppSelector(state => state.lab2System.isValidating);
   const hasLoadedEnvironment = useAppSelector(
     state => state.lab2System.loadedCodeEnvironment

--- a/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
@@ -14,7 +14,7 @@ import {MazeCell} from '@cdo/apps/lab2/types';
 import skins from '@cdo/apps/maze/skins';
 import Neighborhood from '@cdo/apps/miniApps/neighborhood/Neighborhood';
 import NeighborhoodVisualization from '@cdo/apps/miniApps/neighborhood/NeighborhoodVisualization';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import {DEFAULT_MINI_APP_SIZE} from '../Workspace/constants';
 import {scaleMiniApp} from '../Workspace/outputHelpers';

--- a/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
@@ -29,8 +29,7 @@ interface NeighborhoodPreviewProps {
 const NeighborhoodPreview: React.FunctionComponent<
   NeighborhoodPreviewProps
 > = ({handleScaling}) => {
-  const levelProperties = useAppSelector(state => state.lab.levelProperties);
-  const {source, config} = useCodebridgeContext();
+  const {source, config, levelProperties} = useCodebridgeContext();
   const serializedMaze = findFile(
     source,
     MAZE_FILE_NAME,

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -23,13 +23,9 @@ import moduleStyles from './workspace.module.scss';
 import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
 
 const WorkspaceHeaderButtons: React.FunctionComponent = () => {
-  const {startSources} = useCodebridgeContext();
+  const {startSources, levelProperties} = useCodebridgeContext();
+  const {appName, enableMicroBit, skipUrl} = levelProperties;
 
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
-  const enableMicroBit = useAppSelector(
-    state => state.lab.levelProperties?.enableMicroBit || false
-  );
-  const skipUrl = useAppSelector(state => state.lab.levelProperties?.skipUrl);
   const dialogControl = useDialogControl();
   const source = useAppSelector(
     state => state.lab2Project.projectSources?.source

--- a/apps/src/codebridge/Workspace/HorizontalOutput.tsx
+++ b/apps/src/codebridge/Workspace/HorizontalOutput.tsx
@@ -32,7 +32,7 @@ const HorizontalOutput: React.FunctionComponent<HorizontalOutputProps> = ({
   setOutputHeight,
   className,
 }) => {
-  const {labConfig} = useCodebridgeContext();
+  const {labConfig, levelProperties} = useCodebridgeContext();
   const miniApp = labConfig?.miniApp?.name;
   const style = {
     height,
@@ -41,7 +41,7 @@ const HorizontalOutput: React.FunctionComponent<HorizontalOutputProps> = ({
   const [consoleWidth, setConsoleWidth] = useState<number | undefined>(
     undefined
   );
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const appName = levelProperties.appName;
   const [isMaximized, setIsMaximized] = useState<boolean>(false);
   const [miniAppMinimizeWidth, setMiniAppMinimizeWidth] = useState(
     DEFAULT_MINI_APP_SIZE

--- a/apps/src/codebridge/Workspace/HorizontalOutput.tsx
+++ b/apps/src/codebridge/Workspace/HorizontalOutput.tsx
@@ -6,7 +6,6 @@ import React, {useRef, useState, useCallback, useMemo, useEffect} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
 import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import BaseOutput from './BaseOutput';
 import {

--- a/apps/src/codebridge/Workspace/VerticalOutput.tsx
+++ b/apps/src/codebridge/Workspace/VerticalOutput.tsx
@@ -6,7 +6,6 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
 import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import BaseOutput from './BaseOutput';
 import {

--- a/apps/src/codebridge/Workspace/VerticalOutput.tsx
+++ b/apps/src/codebridge/Workspace/VerticalOutput.tsx
@@ -30,7 +30,7 @@ const VerticalOutput: React.FunctionComponent<VerticalOutputProps> = ({
   width,
   setOutputWidth,
 }) => {
-  const {labConfig} = useCodebridgeContext();
+  const {labConfig, levelProperties} = useCodebridgeContext();
   const miniApp = labConfig?.miniApp?.name;
   const style = {
     width,
@@ -39,7 +39,7 @@ const VerticalOutput: React.FunctionComponent<VerticalOutputProps> = ({
   const [consoleHeight, setConsoleHeight] = useState<number | undefined>(
     undefined
   );
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const appName = levelProperties.appName;
   const [isMaximized, setIsMaximized] = useState<boolean>(false);
   const [miniAppMinimizeHeight, setMiniAppMinimizeHeight] = useState(
     DEFAULT_MINI_APP_SIZE

--- a/apps/src/codebridge/codebridgeContext/codebridgeContext.tsx
+++ b/apps/src/codebridge/codebridgeContext/codebridgeContext.tsx
@@ -10,6 +10,7 @@ import {
   OnRunFunction,
   OnStopFunction,
   SendConsoleInputFunction,
+  CodebridgeLevelProperties,
 } from '../types';
 
 import {
@@ -54,6 +55,7 @@ export type CodebridgeContextType = {
   startSources: ProjectSources;
   labConfig?: LabConfig;
   sendConsoleInput?: SendConsoleInputFunction;
+  levelProperties: CodebridgeLevelProperties;
 };
 
 export const CodebridgeContext = createContext<CodebridgeContextType | null>(

--- a/apps/src/codebridge/components/SwapLayoutDropdown.tsx
+++ b/apps/src/codebridge/components/SwapLayoutDropdown.tsx
@@ -19,8 +19,8 @@ import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
 */
 
 const SwapLayoutDropdown: React.FunctionComponent = () => {
-  const {config, setConfig} = useCodebridgeContext();
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const {config, setConfig, levelProperties} = useCodebridgeContext();
+  const appName = levelProperties.appName;
   // Disable toggling while the program is running, as it could cause data loss.
   const isRunningOrValidating = useAppSelector(
     state => state.lab2System.isRunning || state.lab2System.isValidating

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -176,6 +176,7 @@ const PythonlabView: React.FunctionComponent<
           projectVersion={projectVersion}
           labConfig={labConfig}
           sendConsoleInput={sendInput}
+          levelProperties={levelProperties}
         />
       )}
     </div>

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -157,6 +157,7 @@ const Weblab2View: React.FC<
             setConfig={setConfig}
             startSources={startSources}
             projectVersion={projectVersion}
+            levelProperties={levelProperties}
           />
         )}
       </div>

--- a/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
+++ b/apps/test/unit/codebridge/ValidatedInstructions/ValidatedInstructionsTest.tsx
@@ -8,10 +8,13 @@ import progress, {
   mergeResults,
   setCurrentLevelId,
 } from '@cdo/apps/code-studio/progressRedux';
-import {CodebridgeContextProvider} from '@cdo/apps/codebridge';
+import {
+  CodebridgeContextProvider,
+  CodebridgeLevelProperties,
+} from '@cdo/apps/codebridge';
 import ValidatedInstructions from '@cdo/apps/codebridge/InfoPanel/ValidatedInstructions';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
-import lab, {onLevelChange, setValidationState} from '@cdo/apps/lab2/lab2Redux';
+import lab, {setValidationState} from '@cdo/apps/lab2/lab2Redux';
 import lab2Project, {setHasEdited} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import predictLevel from '@cdo/apps/lab2/redux/predictLevelRedux';
 import lab2System, {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
@@ -55,10 +58,12 @@ describe('ValidatedInstructions', () => {
     restoreRedux();
   });
 
-  function renderDefault() {
+  function renderDefault(levelProperties: CodebridgeLevelProperties) {
     render(
       <Provider store={store}>
-        <CodebridgeContextProvider value={getDefaultCodebridgeContext()}>
+        <CodebridgeContextProvider
+          value={{...getDefaultCodebridgeContext(), levelProperties}}
+        >
           <ValidatedInstructions />
         </CodebridgeContextProvider>
       </Provider>
@@ -66,9 +71,8 @@ describe('ValidatedInstructions', () => {
   }
 
   it('Continue button is visible for an already-passed level', () => {
-    store.dispatch(onLevelChange({levelProperties: validatedLevelProperties}));
     // Default progress state is on a level that has already passed.
-    renderDefault();
+    renderDefault(validatedLevelProperties);
 
     // Continue button should be present.
     screen.getByRole('button', {name: commonI18n.continue()});
@@ -77,10 +81,7 @@ describe('ValidatedInstructions', () => {
   it('Buttons are correct for a non-validated level', () => {
     // Level 1 in the progression, which is "in progress"
     store.dispatch(setCurrentLevelId('1'));
-    store.dispatch(
-      onLevelChange({levelProperties: nonValidatedLevelProperties})
-    );
-    renderDefault();
+    renderDefault(nonValidatedLevelProperties);
 
     expect(
       screen.queryByRole('button', {name: commonI18n.continue()})
@@ -96,7 +97,6 @@ describe('ValidatedInstructions', () => {
   it('Buttons are correct for a validated level', () => {
     // Level 3 in the progression is validated and not yet passed
     store.dispatch(setCurrentLevelId('3'));
-    store.dispatch(onLevelChange({levelProperties: validatedLevelProperties}));
     store.dispatch(
       setValidationState({
         hasConditions: true,
@@ -105,7 +105,7 @@ describe('ValidatedInstructions', () => {
         index: 0,
       })
     );
-    renderDefault();
+    renderDefault(validatedLevelProperties);
 
     // To start theere should be no continue button but there should be a validate button.
     expect(
@@ -130,9 +130,8 @@ describe('ValidatedInstructions', () => {
   it('Buttons are correct on a predict level', () => {
     // Level 5 is a predict level that has not yet passed
     store.dispatch(setCurrentLevelId('5'));
-    store.dispatch(onLevelChange({levelProperties: predictLevelProperties}));
 
-    renderDefault();
+    renderDefault(predictLevelProperties);
 
     // No continue button to start
     expect(
@@ -149,11 +148,8 @@ describe('ValidatedInstructions', () => {
   it('Buttons are correct on a submittable level', () => {
     // Make Level 7 a submittable level without validation that has not yet passed.
     store.dispatch(setCurrentLevelId('7'));
-    store.dispatch(
-      onLevelChange({levelProperties: submittableLevelProperties})
-    );
 
-    renderDefault();
+    renderDefault(submittableLevelProperties);
 
     // No submit or unsubmit button to start
     expect(
@@ -184,11 +180,8 @@ describe('ValidatedInstructions', () => {
   it('shows finish button when on the last level', () => {
     // Make level 7 a level without validation.
     store.dispatch(setCurrentLevelId('7'));
-    store.dispatch(
-      onLevelChange({levelProperties: nonValidatedLevelProperties})
-    );
 
-    renderDefault();
+    renderDefault(nonValidatedLevelProperties);
 
     // No finish button to start
     expect(

--- a/apps/test/unit/codebridge/test_utils.ts
+++ b/apps/test/unit/codebridge/test_utils.ts
@@ -109,6 +109,11 @@ export const getDefaultCodebridgeContext = () => {
     setFileType: (fileId: FileId, type: ProjectFileType) => {},
     rearrangeFiles: (fileIds: FileId[]) => {},
     startSources: {source: smallProject},
+    levelProperties: {
+      id: 0,
+      name: '',
+      appName: 'pythonlab',
+    },
   };
   return context;
 };


### PR DESCRIPTION
This converts codebridge to store the level properties in the codebridge context and have all child components fetch the level properties from the context, not from redux. This is part of the work to move from using level properties from redux in lab2 labs.

## Links

- jira ticket: [CT-1127](https://codedotorg.atlassian.net/browse/CT-1127)


## Testing story
Tested locally and via automated tests.

## Follow-up work
There are some components used by codebridge (such as version history) that fetch some level property from redux and are in the lab2 folder. I will follow up with an update for those to receive the relevant property from props rather than redux. If any component is also used by Music Lab/another lab that does not yet use the new version of level properties, I'll leave it as is. This will be tracked via CT-1127.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
