### PR TITLE
Adding role and tab navigability to callout buttons

### DIFF
--- a/apps/src/templates/EnhancedSafeMarkdown.jsx
+++ b/apps/src/templates/EnhancedSafeMarkdown.jsx
@@ -93,7 +93,14 @@ export class ClickableTextWrapper extends React.Component {
       if (!clickableText.className.includes(extraClass)) {
         clickableText.className += extraClass;
       }
+      clickableText.setAttribute('role', 'button');
+      clickableText.setAttribute('tabIndex', '0');
       clickableText.onclick = () => this.props.handleInstructionsTextClick(id);
+      clickableText.onkeydown = event => {
+        if (event.key === 'Enter') {
+          clickableText.click();
+        }
+      };
     });
   }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4200,6 +4200,7 @@ a {
   .clickable-text {
     cursor: pointer;
     position: relative;
+    outline-offset: 2px;
 
     &-with-glow {
       animation: clickable-text-glow-keyframes 2s ease-in-out;


### PR DESCRIPTION
I'd like to hear feedback on how we should approach this if folks have better ideas. My goal was to fix the WCAG violation by making these buttons part of keyboard navigation. The non-sighted experience is a bit weird because the buttons are just for callout arrows, but I believe the keyboard and partially sighted experience is greatly enhanced with this update. Now, a user can tab to those callouts and see what the arrows are pointing to by pressing enter. Additionally, at least a screenreader will now no longer be confused by these items that had click events but no role.


https://github.com/user-attachments/assets/c9a421d9-1678-4b71-a2ee-3a5b97d689a3



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1007

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
