### PR TITLE
Music: play early

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -446,6 +446,7 @@ export interface SoundData {
   path?: string;
   src: string;
   length: number;
+  early?: number;
   type: SoundType;
   note?: number;
   restricted?: boolean;

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -446,7 +446,7 @@ export interface SoundData {
   path?: string;
   src: string;
   length: number;
-  early?: number;
+  pickupLength?: number;
   type: SoundType;
   note?: number;
   restricted?: boolean;

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -365,6 +365,7 @@ export default class MusicPlayer {
         id: event.id,
         sampleUrl: library.generateSoundUrl(folder, soundData),
         playbackPosition: event.when,
+        early: soundData.early,
         triggered: event.triggered,
         effects: event.effects,
         originalBpm: soundData.bpm || DEFAULT_BPM,

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -365,7 +365,7 @@ export default class MusicPlayer {
         id: event.id,
         sampleUrl: library.generateSoundUrl(folder, soundData),
         playbackPosition: event.when,
-        early: soundData.early,
+        pickupLength: soundData.pickupLength,
         triggered: event.triggered,
         effects: event.effects,
         originalBpm: soundData.bpm || DEFAULT_BPM,

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -296,7 +296,11 @@ class ToneJSPlayer {
 
     player
       .sync()
-      .start(this.playbackTimeToTransportTime(sample.playbackPosition));
+      .start(
+        this.playbackTimeToTransportTime(
+          sample.playbackPosition - (sample.early || 0)
+        )
+      );
 
     this.activePlayers.push(player);
 
@@ -380,7 +384,7 @@ class ToneJSPlayer {
     transportTime: BarsBeatsSixteenths
   ): number {
     const [bar, beat, sixteenths] = transportTime.split(':').map(Number);
-    return bar + 1 + beat / 4 + sixteenths / 16;
+    return bar + beat / 4 + sixteenths / 16;
   }
 
   private playbackTimeToTransportTime(
@@ -391,7 +395,7 @@ class ToneJSPlayer {
     const sixteenths = (playbackPosition - bar - beat / 4) * 16;
     // Round sixteenths note value to 3 decimal places.
     const sixteenthsRounded = Math.round(sixteenths * 1000) / 1000;
-    return `${bar - 1}:${beat}:${sixteenthsRounded}`;
+    return `${bar}:${beat}:${sixteenthsRounded}`;
   }
 
   private createPlayer(

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -298,7 +298,7 @@ class ToneJSPlayer {
       .sync()
       .start(
         this.playbackTimeToTransportTime(
-          sample.playbackPosition - (sample.early || 0)
+          sample.playbackPosition - (sample.pickupLength || 0)
         )
       );
 

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -4,8 +4,9 @@ import {Effects} from './interfaces/Effects';
 export interface SampleEvent {
   // 1-based playback position in measures
   playbackPosition: number;
-  // How early to play the sample, in which case it has extra sound that should play before its scheduled time.
-  early?: number;
+  // The length of an optional "pickup" part of the sample, which is effectively how early to start
+  // playing it.  Specified as a fraction of one measure.
+  pickupLength?: number;
   // ID of the sound
   id: string;
   // URL of the sample

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -4,6 +4,8 @@ import {Effects} from './interfaces/Effects';
 export interface SampleEvent {
   // 1-based playback position in measures
   playbackPosition: number;
+  // How early to play the sample, in which case it has extra sound that should play before its scheduled time.
+  early?: number;
   // ID of the sound
   id: string;
   // URL of the sample


### PR DESCRIPTION
This allows a sound to be played early, which might be useful for sounds which have a "pickup" (or anacrusis) portion which we want to start playing before the official beginning of the scheduled sound event.  Such portions could be considered complementary to the audio "tails" which some sounds already have.

ToneJS's player doesn't like being given a negative start time, so to make these sounds work even from the first measure of a song, this change adjusts our ToneJS player to internally work with 1-based start times.  This allows a sound to begin up to 1 measure earlier than its scheduled time.

The music library JSON simply needs a sound to have an `"pickupLength"` field, with a value specifying how early it starts in measures.  This value can be a fraction of a measure.  It should not exceed 1.