### PR TITLE
CMS-21: Prevent SimpleList icon width shrink on label wrap

### DIFF
--- a/frontend/packages/component-library/src/list/simpleList/simpleList.module.scss
+++ b/frontend/packages/component-library/src/list/simpleList/simpleList.module.scss
@@ -18,6 +18,7 @@
     align-items: center;
 
     .simpleListItemIcon {
+      flex-shrink: 0;
       text-align: center;
     }
 


### PR DESCRIPTION
## Before
<img alt="before" src="https://github.com/user-attachments/assets/572bed6a-88f4-44c7-98fc-bc5908829a41" />

## After
<img alt="after" src="https://github.com/user-attachments/assets/d1de4bcb-01b7-4d08-b1e5-b332ade4c87c" />

## Links
- JIRA task: [CMS-21](https://codedotorg.atlassian.net/browse/CMS-21)
- Figma: [Text List Group](https://www.figma.com/design/l7PsQAs2pitCNP8zUHWEuy/DSCO-CMS?node-id=2719-196)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/64557