### PR TITLE
CMS-430: Add `IconHighlight` component definition for Contentful

### DIFF
--- a/frontend/apps/marketing/src/components/iconHighlight/IconHighlight.tsx
+++ b/frontend/apps/marketing/src/components/iconHighlight/IconHighlight.tsx
@@ -1,0 +1,59 @@
+import {EntryFields} from 'contentful';
+import {useMemo} from 'react';
+
+import IconHighlight, {
+  IconHighlightLinkProps,
+  IconHighlightProps,
+} from '@code-dot-org/component-library/cms/iconHighlight';
+
+import {fontAwesomeV6BrandIconsMap} from '@/components/common/constants';
+
+export type IconHighlightContentfulLinkEntry = {
+  sys: {
+    id: EntryFields.Text;
+  };
+  fields: {
+    label: EntryFields.Text;
+    primaryTarget: EntryFields.Text;
+    ariaLabel?: EntryFields.Text;
+    isThisAnExternalLink?: EntryFields.Boolean;
+  };
+};
+
+export interface IconHighlightContentfulProps extends IconHighlightProps {
+  iconName: EntryFields.Text;
+  linkEntries?: IconHighlightContentfulLinkEntry[];
+}
+
+const IconHighlightContentful: React.FunctionComponent<
+  IconHighlightContentfulProps
+> = ({iconName, linkEntries = [], ...props}) => {
+  const links: IconHighlightLinkProps[] = useMemo(
+    () =>
+      linkEntries.filter(Boolean).map(linkEntry => ({
+        key: linkEntry.sys.id,
+        text: linkEntry.fields.label,
+        href: linkEntry.fields.primaryTarget,
+        external: linkEntry.fields.isThisAnExternalLink,
+        target: linkEntry.fields.isThisAnExternalLink ? '_blank' : undefined,
+        'aria-label': linkEntry.fields.ariaLabel || undefined,
+      })),
+    [linkEntries],
+  );
+
+  return (
+    <IconHighlight
+      {...props}
+      links={links}
+      icon={{
+        iconName,
+        iconStyle: 'solid',
+        iconFamily: fontAwesomeV6BrandIconsMap.has(iconName)
+          ? 'brands'
+          : undefined,
+      }}
+    />
+  );
+};
+
+export default IconHighlightContentful;

--- a/frontend/apps/marketing/src/components/iconHighlight/IconHighlightContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/iconHighlight/IconHighlightContentfulDefinition.ts
@@ -1,0 +1,59 @@
+// Creates a definition for the Icon Highlight component to be used in Contentful Studio
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+export const IconHighlightContentfulComponentDefinition: ComponentDefinition = {
+  id: 'iconHighlight',
+  name: 'Highlight Card',
+  category: '03: Basic',
+  thumbnailUrl:
+    'https://images.ctfassets.net/90t6bu6vlf76/1Hmduomo4RMBD7E3N3kWKc/5ced16462aa02176586777ccdd04f869/component_icon_highlight_thumbnail.png',
+  tooltip: {
+    description:
+      'Use to highlight information at a glance like key features and resources. Supports a custom icon and links.',
+    imageUrl:
+      'https://images.ctfassets.net/90t6bu6vlf76/55Tf3bhFiUdkvScJc7NHhu/3090d5797a14005ac69fe3a9cb9255c2/component_icon_highlight_tooltip.png',
+  },
+  // Adding an empty array here so no default style options show in the Design tab.
+  builtInStyles: [],
+  children: false,
+  variables: {
+    heading: {
+      displayName: 'Heading',
+      type: 'Text',
+      group: 'content',
+      defaultValue: 'Highlight Card Heading',
+      validations: {
+        required: true,
+      },
+    },
+    text: {
+      displayName: 'Text content',
+      type: 'Text',
+      group: 'content',
+      defaultValue: 'Highlight Card\nMultiline Text',
+      validations: {
+        required: true,
+      },
+    },
+    iconName: {
+      displayName: 'Icon name',
+      type: 'Text',
+      group: 'style',
+      description: 'Font Awesome icon name',
+      defaultValue: 'smile',
+      validations: {
+        required: true,
+      },
+    },
+    linkEntries: {
+      displayName: 'Links',
+      type: 'Array',
+      group: 'content',
+      description:
+        'Accepts only the "List" content type entry that contain "Link" entries',
+      validations: {
+        bindingSourceType: ['entry'],
+      },
+    },
+  },
+};

--- a/frontend/apps/marketing/src/components/iconHighlight/__tests__/IconHighlight.test.tsx
+++ b/frontend/apps/marketing/src/components/iconHighlight/__tests__/IconHighlight.test.tsx
@@ -1,0 +1,113 @@
+import {render, screen, within} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import IconHighlight, {
+  IconHighlightContentfulLinkEntry,
+  IconHighlightContentfulProps,
+} from '@/components/iconHighlight/IconHighlight';
+
+describe('IconHighlight component', () => {
+  const heading = 'Highlight Card Heading';
+  const text = 'Highlight Card Text';
+  const iconName = 'message';
+
+  const renderCardContainer = (
+    props: Partial<IconHighlightContentfulProps> = {},
+  ) => {
+    render(
+      <IconHighlight
+        {...props}
+        heading={heading}
+        text={text}
+        iconName={iconName}
+      />,
+    );
+  };
+
+  it('renders card', () => {
+    renderCardContainer();
+    expect(screen.getByRole('complementary')).toBeVisible();
+  });
+
+  it('renders card icon', () => {
+    renderCardContainer();
+
+    const cardIcon = screen.getByRole('complementary')?.firstElementChild;
+
+    expect(cardIcon).toBeVisible();
+    expect(cardIcon).toHaveRole('presentation');
+  });
+
+  it('renders card heading', () => {
+    renderCardContainer();
+    expect(screen.getByRole('heading', {name: heading})).toBeVisible();
+  });
+
+  it('renders card text', () => {
+    renderCardContainer();
+    expect(screen.getByText(text)).toBeVisible();
+  });
+
+  it('does not render card link list when no links provided', () => {
+    renderCardContainer();
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('renders card link list with provided link entries', () => {
+    const internalLinkEntry: IconHighlightContentfulLinkEntry = {
+      sys: {
+        id: 'internal-link',
+      },
+      fields: {
+        label: 'Internal Link',
+        primaryTarget: 'https://code.org/internal-link',
+        ariaLabel: 'Internal Link aria label',
+        isThisAnExternalLink: false,
+      },
+    };
+    const externalLinkEntry: IconHighlightContentfulLinkEntry = {
+      sys: {
+        id: 'external-link',
+      },
+      fields: {
+        label: 'External Link',
+        primaryTarget: 'https://code.org/external-link',
+        ariaLabel: 'External Link aria label',
+        isThisAnExternalLink: true,
+      },
+    };
+
+    renderCardContainer({linkEntries: [internalLinkEntry, externalLinkEntry]});
+
+    const linkList = screen.getByRole('list');
+    expect(linkList).toBeVisible();
+
+    const internalLink = within(linkList).getByRole('link', {
+      name: internalLinkEntry.fields.ariaLabel,
+    });
+    expect(internalLink).toBeVisible();
+    expect(internalLink).toHaveTextContent(internalLinkEntry.fields.label);
+    expect(internalLink).toHaveAttribute(
+      'href',
+      internalLinkEntry.fields.primaryTarget,
+    );
+    expect(internalLink).not.toHaveAttribute('target');
+    expect(
+      within(internalLink).queryByRole('img', {name: 'external link'}),
+    ).not.toBeInTheDocument();
+
+    const externalLink = within(linkList).getByRole('link', {
+      name: externalLinkEntry.fields.ariaLabel,
+    });
+    expect(externalLink).toBeVisible();
+    expect(externalLink).toHaveTextContent(externalLinkEntry.fields.label);
+    expect(externalLink).toHaveAttribute(
+      'href',
+      externalLinkEntry.fields.primaryTarget,
+    );
+    expect(externalLink).toHaveAttribute('target', '_blank');
+    expect(
+      within(externalLink).queryByRole('img', {name: 'external link'}),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/marketing/src/components/iconHighlight/index.ts
+++ b/frontend/apps/marketing/src/components/iconHighlight/index.ts
@@ -1,0 +1,3 @@
+// Export the Component Definition for use in Contentful Studio
+export {IconHighlightContentfulComponentDefinition} from './IconHighlightContentfulDefinition';
+export {default} from './IconHighlight';

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -18,6 +18,9 @@ import FAQAccordion, {
 import Heading, {
   HeadingContentfulComponentDefinition,
 } from '@/components/heading';
+import IconHighlight, {
+  IconHighlightContentfulComponentDefinition,
+} from '@/components/iconHighlight';
 import Iframe, {IframeContentfulComponentDefinition} from '@/components/iframe';
 import Image, {ImageContentfulComponentDefinition} from '@/components/image';
 import Link, {LinkContentfulComponentDefinition} from '@/components/link';
@@ -56,6 +59,10 @@ defineComponents(
     {
       component: Heading,
       definition: HeadingContentfulComponentDefinition,
+    },
+    {
+      component: IconHighlight,
+      definition: IconHighlightContentfulComponentDefinition,
     },
     {
       component: Iframe,


### PR DESCRIPTION
## Component
<img width="100%" alt="component" src="https://github.com/user-attachments/assets/bd061b87-0965-467e-8976-61e1dd63db45" />

## Preview
<img width="100%" alt="preview" src="https://github.com/user-attachments/assets/5190c317-160f-46e0-a54c-e36b0f409dfa" />

## Options
| Design | Content | 
| ------- | -------- |
| <img alt="design-options" src="https://github.com/user-attachments/assets/fc18234a-78af-4e5e-9f5c-b3313bf5504c" /> | <img alt="content-options" src="https://github.com/user-attachments/assets/515ba7a7-16e4-4073-ac44-4da0b57c9e4f" /> |

## Links
- JIRA task: [CMS-430](https://codedotorg.atlassian.net/browse/CMS-430)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/64689