### PR TITLE
[CMS-441] Update paragraph to use M by default

### DIFF
--- a/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
@@ -20,7 +20,7 @@ export const ParagraphContentfulComponentDefinition: ComponentDefinition = {
     visualAppearance: {
       displayName: 'Visual Appearance',
       type: 'Text',
-      defaultValue: 'body-one',
+      defaultValue: 'body-two',
       group: 'style',
       validations: {
         in: [


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [CMS-441] Update paragraph to use M by default

* chore(paragraph): set body-two (M) size as a default size

Before:

https://github.com/user-attachments/assets/a239c7aa-07e4-41b3-ab2c-4993d65457cf


After:

https://github.com/user-attachments/assets/891a1ace-38a6-404c-a2d6-73b73ae0ae02



## Links
- jira ticket: [CMS-441](https://codedotorg.atlassian.net/browse/CMS-441)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
