### PR TITLE
fix(Image): fix decoration prop in Contentful

### DIFF
--- a/frontend/apps/marketing/src/components/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/image/Image.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import DSCOImage, {ImageProps} from '@code-dot-org/component-library/cms/image';
 
-const Image: React.FC<ImageProps> = ({src}) => {
+const Image: React.FC<ImageProps> = ({src, ...props}) => {
   // Show placeholder text until a content entry is added
   if (src == null) {
     return (
@@ -15,7 +15,7 @@ const Image: React.FC<ImageProps> = ({src}) => {
     );
   }
 
-  return <DSCOImage src={src} />;
+  return <DSCOImage src={src} {...props} />;
 };
 
 export default Image;

--- a/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
@@ -6,6 +6,7 @@ type Section =
   | 'Button'
   | 'Divider'
   | 'Heading'
+  | 'Image'
   | 'Localization'
   | 'Overline'
   | 'Paragraph'


### PR DESCRIPTION
Fixes an issue introduced in [this PR](https://github.com/code-dot-org/code-dot-org/pull/64637) that cause the `decoration` prop to stop working in Contentful.

## Link
Jira ticket: [CMS-476](https://codedotorg.atlassian.net/browse/CMS-476)

## Testing story
Tested locally in Contentful, added to `all-the-things.ts` and /all-the-things page.

----


https://github.com/user-attachments/assets/aff30d35-cc30-421f-aba7-3390026d5ddf

