### PR TITLE
feat(Link): add alignment built in style in Contentful

### DIFF
--- a/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
@@ -15,7 +15,7 @@ export const LinkContentfulComponentDefinition: ComponentDefinition = {
     imageUrl:
       'https://images.ctfassets.net/90t6bu6vlf76/2toB92KGYPO9yDK3bI3qD8/7bcfbe2819c43f6c5b9c89e6218bad10/component_link_tooltip.png',
   },
-  builtInStyles: [],
+  builtInStyles: ['cfTextAlign'],
   variables: {
     size: {
       displayName: 'Size',


### PR DESCRIPTION
Adds the `cfTextAlign` built in style to the Link component in Contentful.

## Links
Jira ticket: [CMS-464](https://codedotorg.atlassian.net/browse/CMS-464)

## Testing story
Tested locally in Contentful and will add these to the /all-the-things page once this is merged.

----


https://github.com/user-attachments/assets/ce091d12-7c6a-4899-ba17-ff33eda9e2c2

