### PR TITLE
feat(Divider): set max-width to 960px in Contentful

### DIFF
--- a/frontend/apps/marketing/src/components/divider/Divider.tsx
+++ b/frontend/apps/marketing/src/components/divider/Divider.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import DSCODivider, {
+  DividerProps,
+} from '@code-dot-org/component-library/divider';
+
+import moduleStyles from './divider.module.scss';
+
+const Divider: React.FC<DividerProps> = ({...props}) => {
+  return <DSCODivider {...props} className={moduleStyles.divider} />;
+};
+
+export default Divider;

--- a/frontend/apps/marketing/src/components/divider/divider.module.scss
+++ b/frontend/apps/marketing/src/components/divider/divider.module.scss
@@ -1,0 +1,4 @@
+// Common divider style
+.divider {
+  max-width: 960px;
+}

--- a/frontend/apps/marketing/src/components/divider/index.ts
+++ b/frontend/apps/marketing/src/components/divider/index.ts
@@ -1,3 +1,3 @@
 // Export the Component Definition for use in Contentful Studio
 export {DividerContentfulComponentDefinition} from './dividerContentfulDefinition';
-export {default} from '@code-dot-org/component-library/divider';
+export {default} from './Divider';

--- a/frontend/packages/component-library/src/divider/divider.module.scss
+++ b/frontend/packages/component-library/src/divider/divider.module.scss
@@ -5,6 +5,7 @@
   border: 0;
   border-top: 1px solid;
   width: 100%;
+  margin-inline: auto;
 }
 
 // Divider colors
@@ -21,22 +22,22 @@
 // Divider margin
 .divider-margin {
   &-none {
-    margin: 0;
+    margin-block: 0;
   }
 
   &-xs {
-    margin: 0.5rem 0;
+    margin-block: 0.5rem;
   }
 
   &-s {
-    margin: 1rem 0;
+    margin-block: 1rem;
   }
 
   &-m {
-    margin: 2rem 0;
+    margin-block: 2rem;
   }
 
   &-l {
-    margin: 4rem 0;
+    margin-block: 4rem;
   }
 }


### PR DESCRIPTION
Sets the max-width of the Divider to `960px` in Contentful, and refactors the margin styles in DSCO to apply `margin-block: auto` styles to all margin props.

## Links
Jira ticket: [CMS-438](https://codedotorg.atlassian.net/browse/CMS-438)

## Testing story
Tested locally in Storybook and Contentful. I don't think this will have any effect on Eyes tests.

----

## Before
<img width="1388" alt="Before" src="https://github.com/user-attachments/assets/b1156c73-795e-40e4-9967-80d912681bf5" />


## After
<img width="1388" alt="After" src="https://github.com/user-attachments/assets/1f68d971-f3ec-42ce-a650-c1d2076ce303" />
