### PR TITLE
feat(TextField): add date inputType

### DIFF
--- a/frontend/packages/component-library/src/textField/TextField.tsx
+++ b/frontend/packages/component-library/src/textField/TextField.tsx
@@ -45,7 +45,7 @@ export interface TextFieldProps extends HTMLAttributes<HTMLInputElement> {
   maxLength?: number;
   /** min length of TextField */
   minLength?: number;
-  /** min length of TextField */
+  /** handle input autoComplete attribute */
   autoComplete?: string;
 }
 

--- a/frontend/packages/component-library/src/textField/TextField.tsx
+++ b/frontend/packages/component-library/src/textField/TextField.tsx
@@ -13,7 +13,7 @@ export interface TextFieldProps extends HTMLAttributes<HTMLInputElement> {
   /** TextField id */
   id?: string;
   /** Specifies the type of input; see included options below. */
-  inputType?: 'text' | 'email' | 'password' | 'number';
+  inputType?: 'text' | 'email' | 'password' | 'number' | 'date';
   /** The name attribute specifies the name of an input element.
      The name attribute is used to reference elements in a JavaScript,
      or to reference form data after a form is submitted.

--- a/frontend/packages/component-library/src/textField/stories/TextField.story.tsx
+++ b/frontend/packages/component-library/src/textField/stories/TextField.story.tsx
@@ -64,6 +64,14 @@ EmailTextField.args = {
   inputType: 'email',
 };
 
+export const DateTextField = SingleTemplate.bind({});
+DateTextField.args = {
+  ...defaultArgs,
+  name: 'textfield_date',
+  label: 'Date TextField Label',
+  inputType: 'date',
+};
+
 export const WithHelperMessageTextField = SingleTemplate.bind({});
 WithHelperMessageTextField.args = {
   ...defaultArgs,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

adds inputType `"date"` as an allowed prop type. the date input has native styling depending on the browser and is accessible by default. date inputs are supported by our browser versions.

## Links

[figma](https://www.figma.com/design/Km9JCLNbayBlTrlnKenumq/New-PL-Program?node-id=3814-21336&m=dev)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
