### PR TITLE
feat(Button): add title attribute to both button and anchor elements in BaseButton

### DIFF
--- a/frontend/packages/component-library/src/button/_BaseButton.tsx
+++ b/frontend/packages/component-library/src/button/_BaseButton.tsx
@@ -235,7 +235,7 @@ const BaseButton: React.FunctionComponent<_BaseButtonProps> = ({
           download,
           title,
         }
-      : {type: buttonTagTypeAttribute, onClick, value, name};
+      : {type: buttonTagTypeAttribute, onClick, value, name, title};
 
   // Check if correct props combination is passed
   useMemo(


### PR DESCRIPTION
previously the `title` attribute was only being passed to the underlying html element when the Button component has the `useAsLink` prop set to true

native tooltip title when hovering on icon button:
<img width="238" alt="Screenshot 2025-03-21 at 2 00 24 PM" src="https://github.com/user-attachments/assets/2908e7e5-e7a0-4a79-a642-97525d6eddc4" />

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
