### PR TITLE
[Music] fix for "Allow multiple tries" (Predict settings)

### DIFF
--- a/apps/src/lab2/redux/predictLevelRedux.ts
+++ b/apps/src/lab2/redux/predictLevelRedux.ts
@@ -84,6 +84,9 @@ export const isPredictAnswerLocked = createSelector(
   }
 );
 
+export const isPredictResponseSubmitted = (state: RootState) =>
+  state.predictLevel.hasSubmittedResponse;
+
 // REDUCER
 const predictSlice = createSlice({
   name: 'predictLevel',

--- a/apps/src/lab2/redux/predictLevelRedux.ts
+++ b/apps/src/lab2/redux/predictLevelRedux.ts
@@ -70,6 +70,8 @@ export const submitPredictResponse =
   };
 
 // SELECTORS
+export const isPredictResponseSubmitted = (state: RootState) =>
+  state.predictLevel.hasSubmittedResponse;
 
 // The predict answer is locked if the level does not allow multiple predict attempts
 // and the user has already submitted a response.
@@ -77,15 +79,12 @@ export const isPredictAnswerLocked = createSelector(
   [
     (state: RootState) =>
       state.lab.levelProperties?.predictSettings?.allowMultipleAttempts,
-    (state: RootState) => state.predictLevel.hasSubmittedResponse,
+    isPredictResponseSubmitted,
   ],
   (allowMultipleAttempts, hasSubmittedResponse) => {
     return !allowMultipleAttempts && hasSubmittedResponse;
   }
 );
-
-export const isPredictResponseSubmitted = (state: RootState) =>
-  state.predictLevel.hasSubmittedResponse;
 
 // REDUCER
 const predictSlice = createSlice({

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React, {MouseEvent, useCallback, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
-import {isPredictAnswerLocked} from '@cdo/apps/lab2/redux/predictLevelRedux';
+import {isPredictResponseSubmitted} from '@cdo/apps/lab2/redux/predictLevelRedux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import appConfig from '../appConfig';
@@ -169,11 +169,11 @@ const Timeline: React.FunctionComponent = () => {
   }, [playheadRef]);
 
   usePlaybackUpdate(scrollPlayheadForward, scrollToPlayhead, scrollToPlayhead);
-  const predictAnswerLocked = useAppSelector(isPredictAnswerLocked);
+  const predictResponseSubmitted = useAppSelector(isPredictResponseSubmitted);
   const isPredictLevel = useAppSelector(
     state => state.lab.levelProperties?.predictSettings?.isPredictLevel
   );
-  const canPopulateTimeline = !isPredictLevel || predictAnswerLocked;
+  const canPopulateTimeline = !isPredictLevel || predictResponseSubmitted;
 
   return (
     <div

--- a/dashboard/config/levels/custom/music/Music Predict Level 2.level
+++ b/dashboard/config/levels/custom/music/Music Predict Level 2.level
@@ -70,7 +70,7 @@
       "isPredictLevel": true,
       "solution": "A drum beat and a bass line at the same time",
       "questionType": "multipleChoice",
-      "allowMultipleAttempts": false,
+      "allowMultipleAttempts": true,
       "multipleChoiceOptions": [
         "A drum beat",
         "A bass line",
@@ -79,9 +79,13 @@
       ],
       "codeEditableAfterSubmit": false
     },
+    "exemplar_settings": {
+      "playerEnabled": false,
+      "validationEnabled": false
+    },
     "preload_asset_list": null
   },
-  "audit_log": "[{\"changed_at\":\"2025-03-06T16:40:34.774-05:00\",\"changed\":[\"cloned from \\\"Music Predict Level 1\\\"\"],\"cloned_from\":\"Music Predict Level 1\"},{\"changed_at\":\"2025-03-06 17:12:18 -0500\",\"changed\":[\"long_instructions\",\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2025-03-06T16:40:34.774-05:00\",\"changed\":[\"cloned from \\\"Music Predict Level 1\\\"\"],\"cloned_from\":\"Music Predict Level 1\"},{\"changed_at\":\"2025-03-06 17:12:18 -0500\",\"changed\":[\"long_instructions\",\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"},{\"changed_at\":\"2025-03-21 13:47:12 -0400\",\"changed\":[\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"}]"
 }]]></config>
   <blocks/>
 </Music>


### PR DESCRIPTION
Follow-up to:
- https://github.com/code-dot-org/code-dot-org/pull/64560

The new Predict Settings went live on levelbuilder this morning and @amy-b quickly noticed a bug where the Timeline events would never be populated if "Allow multiple tries" was checked: 
https://codedotorg.slack.com/archives/C07UT279KM1/p1742578070211439?thread_ts=1742500408.533849&cid=C07UT279KM1
![Screenshot 2025-03-21 at 10 27 04 AM](https://github.com/user-attachments/assets/25edf432-0b35-4683-8237-accbad160a24)

The cause of the bug is that we were checking whether the predict answer was _locked_, rather than just submitted. The former only applies when `allowMultipleAttempts` is false. To solve this problem, I simply created a new selector that checks that the predict level has had a response submitted. Now the timeline is populated as expected. I also updated the level at `/s/allthethings/lessons/46/levels/9` to use this setting so we can check it quickly if needed.

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
