### PR TITLE
AI Chat: enable multimodal per level

### DIFF
--- a/apps/src/aichat/redux/selectors/index.ts
+++ b/apps/src/aichat/redux/selectors/index.ts
@@ -1,9 +1,9 @@
 import {createSelector} from '@reduxjs/toolkit';
 
-import {queryParams} from '@cdo/apps/code-studio/utils';
 import type {RootState} from '@cdo/apps/types/redux';
-import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
+import {modelDescriptions} from '../../constants';
+import type {AichatLevelProperties} from '../../types';
 import {
   allFieldsHidden,
   anyFieldsChanged,
@@ -48,9 +48,14 @@ export const selectHavePropertiesChanged = (state: RootState) =>
     state.aichat.currentAiCustomizations
   ).length > 0;
 
-export const selectMultimodalEnabled = (state: RootState) => {
-  const isChatGpt =
-    state.aichat.currentAiCustomizations.selectedModelId ===
-    AiChatModelIds.CHATGPT;
-  return isChatGpt && queryParams('multimodal') === 'true';
+export const selectMultimodalEnabled = ({aichat, lab}: RootState) => {
+  const multimodalSupported = modelDescriptions.find(
+    model => model.id === aichat.savedAiCustomizations.selectedModelId
+  )?.multimodal;
+
+  const multimodalEnabled = (
+    lab.levelProperties as AichatLevelProperties | undefined
+  )?.aichatSettings?.multimodalEnabled;
+
+  return multimodalSupported && multimodalEnabled;
 };

--- a/apps/src/aichat/types/customizations.ts
+++ b/apps/src/aichat/types/customizations.ts
@@ -1,5 +1,6 @@
 import {ValueOf} from '@cdo/apps/types/utils';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
+import modelsJson from '@cdo/static/aichat/modelDescriptions.json';
 
 /** Model customizations and model card information for aichat levels.
  *  selectedModelId is a foreign key to ModelDescription.id */
@@ -29,12 +30,9 @@ export interface ModelCardInfo {
 }
 
 /** Metadata about a given model, common across all aichat levels */
-export interface ModelDescription {
+export type ModelDescription = (typeof modelsJson)[number] & {
   id: ValueOf<typeof AiChatModelIds>;
-  name: string;
-  overview: string;
-  trainingData: string;
-}
+};
 
 // Visibility for AI customization fields set by levelbuilders.
 export enum Visibility {

--- a/apps/src/aichat/types/levelProperties.ts
+++ b/apps/src/aichat/types/levelProperties.ts
@@ -28,4 +28,6 @@ export interface LevelAichatSettings {
   hidePresentationPanel: boolean;
   /** list of ModelDescription.ids to limit the models available to choose from in the level */
   availableModelIds: ValueOf<typeof AiChatModelIds>[];
+  /** If multimodal chat should be enabled for this level. Requires that all available model IDs support multimodal input. */
+  multimodalEnabled?: boolean;
 }

--- a/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
@@ -4,7 +4,7 @@ import {
   BodyThreeText,
   BodyTwoText,
 } from '@code-dot-org/component-library/typography';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useState} from 'react';
 
 import {modelDescriptions} from '@cdo/apps/aichat/constants';
 import {
@@ -37,7 +37,7 @@ import VisibilityDropdown from './VisibilityDropdown';
 
 import moduleStyles from './edit-aichat-settings.module.scss';
 
-function sanitizeSettings(settings: LevelAichatSettings) {
+function sanitizeSettings(settings: LevelAichatSettings): LevelAichatSettings {
   const sanitizedModelCardInfo = sanitizeField(
     settings.initialCustomizations.modelCardInfo,
     EMPTY_MODEL_CARD_INFO
@@ -56,6 +56,10 @@ function sanitizeSettings(settings: LevelAichatSettings) {
     modelDescriptions.some(model => model.id === id)
   );
 
+  const multimodalIncluded = (settings.availableModelIds || []).some(
+    id => modelDescriptions.find(model => model.id === id)?.multimodal
+  );
+
   return {
     ...settings,
     availableModelIds: filteredModelIds,
@@ -64,15 +68,17 @@ function sanitizeSettings(settings: LevelAichatSettings) {
       modelCardInfo: sanitizedModelCardInfo,
     },
     visibilities: sanitizedVisibilities,
+    // Disable multimodal if no multimodal models are available
+    multimodalEnabled: !multimodalIncluded ? false : settings.multimodalEnabled,
   };
 }
 
-function sanitizeField<F extends object>(field: F, defaults: F) {
+function sanitizeField<F extends object>(field: F, defaults: F): F {
   // Iterate over default keys, keeping the value from the field if present, and otherwise using the default.
   // This removes any extraneous keys and retains only expected keys.
   return getTypedKeys<keyof F>(defaults).reduce(
     (newField, key) => ({...newField, [key]: field[key] ?? defaults[key]}),
-    {}
+    {} as F
   );
 }
 
@@ -157,21 +163,15 @@ const EditAichatSettings: React.FunctionComponent<{
     [aichatSettings, setAichatSettings]
   );
 
-  const allModelsMultimodal = useMemo(() => {
-    return aichatSettings.availableModelIds.every(
-      id => modelDescriptions.find(model => model.id === id)?.multimodal
-    );
-  }, [aichatSettings.availableModelIds]);
-
-  // If not all available models support multimodal, automatically uncheck the setting.
-  useEffect(() => {
-    if (!allModelsMultimodal && aichatSettings.multimodalEnabled) {
+  const setMultimodalEnabled = useCallback(
+    (value: boolean) => {
       setAichatSettings({
         ...aichatSettings,
-        multimodalEnabled: false,
+        multimodalEnabled: value,
       });
-    }
-  }, [allModelsMultimodal, aichatSettings]);
+    },
+    [aichatSettings, setAichatSettings]
+  );
 
   return (
     <UpdateContext.Provider
@@ -181,6 +181,7 @@ const EditAichatSettings: React.FunctionComponent<{
         setPropertyValue,
         setModelCardPropertyValue,
         setModelSelectionValues,
+        setMultimodalEnabled,
       }}
     >
       <div>
@@ -328,32 +329,6 @@ const EditAichatSettings: React.FunctionComponent<{
                   setAichatSettings({
                     ...aichatSettings,
                     hidePresentationPanel: e.target.checked,
-                  });
-                }}
-              />
-            </div>
-            <br />
-            <BodyFourText>
-              <i>
-                Enables multimodal chat. Only available if all the available
-                models support multimodal inputs (like Chat GPT 4o-mini).
-              </i>
-            </BodyFourText>
-            <div className={moduleStyles.fieldRow}>
-              <label
-                htmlFor="multimodalEnabled"
-                className={moduleStyles.inlineLabel}
-              >
-                Enable Multimodal Chat
-              </label>
-              <Checkbox
-                name="multimodalEnabled"
-                disabled={!allModelsMultimodal}
-                checked={aichatSettings.multimodalEnabled || false}
-                onChange={e => {
-                  setAichatSettings({
-                    ...aichatSettings,
-                    multimodalEnabled: e.target.checked,
                   });
                 }}
               />

--- a/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
@@ -4,7 +4,7 @@ import {
   BodyThreeText,
   BodyTwoText,
 } from '@code-dot-org/component-library/typography';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {modelDescriptions} from '@cdo/apps/aichat/constants';
 import {
@@ -156,6 +156,22 @@ const EditAichatSettings: React.FunctionComponent<{
     },
     [aichatSettings, setAichatSettings]
   );
+
+  const allModelsMultimodal = useMemo(() => {
+    return aichatSettings.availableModelIds.every(
+      id => modelDescriptions.find(model => model.id === id)?.multimodal
+    );
+  }, [aichatSettings.availableModelIds]);
+
+  // If not all available models support multimodal, automatically uncheck the setting.
+  useEffect(() => {
+    if (!allModelsMultimodal && aichatSettings.multimodalEnabled) {
+      setAichatSettings({
+        ...aichatSettings,
+        multimodalEnabled: false,
+      });
+    }
+  }, [allModelsMultimodal, aichatSettings]);
 
   return (
     <UpdateContext.Provider
@@ -312,6 +328,32 @@ const EditAichatSettings: React.FunctionComponent<{
                   setAichatSettings({
                     ...aichatSettings,
                     hidePresentationPanel: e.target.checked,
+                  });
+                }}
+              />
+            </div>
+            <br />
+            <BodyFourText>
+              <i>
+                Enables multimodal chat. Only available if all the available
+                models support multimodal inputs (like Chat GPT 4o-mini).
+              </i>
+            </BodyFourText>
+            <div className={moduleStyles.fieldRow}>
+              <label
+                htmlFor="multimodalEnabled"
+                className={moduleStyles.inlineLabel}
+              >
+                Enable Multimodal Chat
+              </label>
+              <Checkbox
+                name="multimodalEnabled"
+                disabled={!allModelsMultimodal}
+                checked={aichatSettings.multimodalEnabled || false}
+                onChange={e => {
+                  setAichatSettings({
+                    ...aichatSettings,
+                    multimodalEnabled: e.target.checked,
                   });
                 }}
               />

--- a/apps/src/lab2/levelEditors/aichatSettings/ModelSelectionFields.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/ModelSelectionFields.tsx
@@ -1,7 +1,7 @@
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import SimpleDropdown from '@code-dot-org/component-library/dropdown/simpleDropdown';
 import {BodyFourText} from '@code-dot-org/component-library/typography';
-import React, {useContext, useState, useCallback} from 'react';
+import React, {useContext, useState, useCallback, useMemo} from 'react';
 
 import {modelDescriptions} from '@cdo/apps/aichat/constants';
 import {Visibility} from '@cdo/apps/aichat/types';
@@ -18,7 +18,8 @@ const modelDropdownItems = modelDescriptions.map(model => {
 });
 
 const ModelSelectionFields: React.FunctionComponent = () => {
-  const {setModelSelectionValues, aichatSettings} = useContext(UpdateContext);
+  const {setModelSelectionValues, setMultimodalEnabled, aichatSettings} =
+    useContext(UpdateContext);
   const shouldDisableAdditionalModelSelection =
     aichatSettings.visibilities.selectedModelId !== Visibility.EDITABLE;
   const selectedModelId = aichatSettings.initialCustomizations.selectedModelId;
@@ -56,6 +57,12 @@ const ModelSelectionFields: React.FunctionComponent = () => {
     },
     [additionalAvailableModelIds, selectedModelId, setModelSelectionValues]
   );
+
+  const multimodalIncluded = useMemo(() => {
+    return aichatSettings.availableModelIds.some(
+      id => modelDescriptions.find(model => model.id === id)?.multimodal
+    );
+  }, [aichatSettings.availableModelIds]);
 
   return (
     <CollapsibleFieldSection
@@ -102,6 +109,31 @@ const ModelSelectionFields: React.FunctionComponent = () => {
               </div>
             );
           })}
+          <br />
+          {multimodalIncluded && (
+            <>
+              <BodyFourText>
+                <i>
+                  Enables multimodal chat. Note that the list of models must
+                  include a multimodal model for this feature to be available to
+                  students (currently only GPT 4o-mini).
+                </i>
+              </BodyFourText>
+              <div className={moduleStyles.fieldRow}>
+                <label
+                  htmlFor="multimodalEnabled"
+                  className={moduleStyles.inlineLabel}
+                >
+                  Enable Multimodal Chat
+                </label>
+                <Checkbox
+                  name="multimodalEnabled"
+                  checked={aichatSettings.multimodalEnabled || false}
+                  onChange={e => setMultimodalEnabled(e.target.checked)}
+                />
+              </div>
+            </>
+          )}
         </>
       }
     />

--- a/apps/src/lab2/levelEditors/aichatSettings/UpdateContext.ts
+++ b/apps/src/lab2/levelEditors/aichatSettings/UpdateContext.ts
@@ -27,4 +27,5 @@ export const UpdateContext = createContext({
     additionalModelIds: ValueOf<typeof AiChatModelIds>[],
     selectedModelId: ValueOf<typeof AiChatModelIds>
   ) => {},
+  setMultimodalEnabled: (value: boolean) => {},
 });

--- a/apps/static/aichat/modelDescriptions.json
+++ b/apps/static/aichat/modelDescriptions.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48df3cd7933600e18559fae4c7a41bd7b7b1b7da55616bb7c6e800ca1c62ed1d
-size 2354
+oid sha256:2fd33fbad3754fecc1bfe9d18a479f0888b99ad32884f575411ca4a81e6090e9
+size 2378


### PR DESCRIPTION
Makes opting into multimodal chat a level setting. Requires that all available models in the AI Chat settings support multimodal inputs. Also adds a `"multimodal": true|false` field to the model descriptions JSON (currently only true for GPT 4o-mini)

<img width="792" alt="Screenshot 2025-03-21 at 1 03 59 PM" src="https://github.com/user-attachments/assets/99bc68d4-3846-46e6-86a8-dc02d9ccf01b" />

https://github.com/user-attachments/assets/1792658f-dc17-44e6-815e-5d67e8a11c42


## Links

https://codedotorg.atlassian.net/browse/LABS-1396
https://codedotorg.atlassian.net/browse/LABS-1399

## Testing story

Tested locally on allthethings level.