### PR TITLE
Evaluate Student Learning: skip AI if the student didn't do any work

### DIFF
--- a/apps/src/aiEvaluation/evaluationApi.ts
+++ b/apps/src/aiEvaluation/evaluationApi.ts
@@ -83,7 +83,7 @@ async function evaluationFromOpenAI(
   evaluationType?: EvaluationType
 ): Promise<OpenaiChatCompletionMessage | null> {
   const payload = {
-    studentWork: [{role: Role.USER, content: studentWork}],
+    studentWork: studentWork,
     levelId: levelId,
     unitId: unitId,
     evaluationType: evaluationType,

--- a/apps/src/aiEvaluation/evaluationApi.ts
+++ b/apps/src/aiEvaluation/evaluationApi.ts
@@ -1,4 +1,3 @@
-import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {AiEvaluationTypes} from '@cdo/generated-scripts/sharedConstants';
 

--- a/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
@@ -40,8 +40,7 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
   };
 
   const evaluateStudentResponse = async (studentAnswer: StudentAnswer) => {
-    let aiResponse: AIResponse;
-    aiResponse = await evaluateStudentWork(
+    const aiResponse = await evaluateStudentWork(
       studentAnswer,
       levelData.levelId,
       levelData.unitId

--- a/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
@@ -44,11 +44,19 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
   };
 
   const evaluateStudentResponse = async (studentAnswer: StudentAnswer) => {
-    const aiResponse = await evaluateStudentWork(
-      studentAnswer,
-      levelData.levelId,
-      levelData.unitId
-    );
+    let aiResponse: AIResponse;
+    if (studentAnswer.studentWork === '') {
+      aiResponse = {
+        aiEvaluation: 'no attempt',
+        aiReasoning: 'The student did not submit a response',
+      };
+    } else {
+      aiResponse = await evaluateStudentWork(
+        studentAnswer,
+        levelData.levelId,
+        levelData.unitId
+      );
+    }
     const evaluation = {
       ...studentAnswer,
       aiEvaluation: aiResponse.aiEvaluation,

--- a/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
@@ -37,6 +37,9 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
     const responsePromises = responses.map(async studentResponse => {
       return evaluateStudentResponse(studentResponse);
     });
+    await Promise.allSettled(responsePromises).then(() =>
+      summarizeStudentEvaluations(evaluations)
+    );
   };
 
   const evaluateStudentResponse = async (studentAnswer: StudentAnswer) => {
@@ -76,7 +79,6 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
   useEffect(() => {
     if (evaluationComplete) {
       setEvaluationsPending(false);
-      summarizeStudentEvaluations(evaluations);
     }
   }, [evaluationComplete]);
 

--- a/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
@@ -37,26 +37,15 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
     const responsePromises = responses.map(async studentResponse => {
       return evaluateStudentResponse(studentResponse);
     });
-
-    await Promise.allSettled(responsePromises).then(() =>
-      summarizeStudentEvaluations(evaluations)
-    );
   };
 
   const evaluateStudentResponse = async (studentAnswer: StudentAnswer) => {
     let aiResponse: AIResponse;
-    if (studentAnswer.studentWork === '') {
-      aiResponse = {
-        aiEvaluation: 'no attempt',
-        aiReasoning: 'The student did not submit a response',
-      };
-    } else {
-      aiResponse = await evaluateStudentWork(
-        studentAnswer,
-        levelData.levelId,
-        levelData.unitId
-      );
-    }
+    aiResponse = await evaluateStudentWork(
+      studentAnswer,
+      levelData.levelId,
+      levelData.unitId
+    );
     const evaluation = {
       ...studentAnswer,
       aiEvaluation: aiResponse.aiEvaluation,
@@ -88,6 +77,7 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
   useEffect(() => {
     if (evaluationComplete) {
       setEvaluationsPending(false);
+      summarizeStudentEvaluations(evaluations);
     }
   }, [evaluationComplete]);
 

--- a/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
@@ -37,6 +37,7 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
     const responsePromises = responses.map(async studentResponse => {
       return evaluateStudentResponse(studentResponse);
     });
+
     await Promise.allSettled(responsePromises).then(() =>
       summarizeStudentEvaluations(evaluations)
     );

--- a/dashboard/app/controllers/openai_evaluate_controller.rb
+++ b/dashboard/app/controllers/openai_evaluate_controller.rb
@@ -8,10 +8,10 @@ class OpenaiEvaluateController < ApplicationController
 
   # POST /openai/evaluate
   def evaluate
-    level_id = params[:levelId]
-    unit_id = params[:unitId]
-    student_work = params[:studentWork]
-    evaluation_type = params[:evaluationType]
+    level_id = evaluate_params[:level_id]
+    unit_id = evaluate_params[:unit_id]
+    student_work = evaluate_params[:student_work]
+    evaluation_type = evaluate_params[:evaluation_type]
 
     begin
       level = Level.find(level_id)
@@ -32,12 +32,14 @@ class OpenaiEvaluateController < ApplicationController
       aiEvaluation: "No attempt",
       evaluationCriteria: "Did the student attempt the level?",
     }
+
     if level.is_a?(FreeResponse) && student_work.delete(' ').empty?
-      no_attempt_response[:aiReasoning] = "The student's response was blank."
+      no_attempt_response[:aiReasoning] = "The student response was blank."
       # mimic the format of the response from AI
       json_response = {"content" => no_attempt_response.to_json}
       return render(status: :ok, json: json_response)
     elsif level.upper_grades_programming_level? && level.get_starter_code == student_work
+      puts "we are here!"
       no_attempt_response[:aiReasoning] = "The student did not change the starter code."
       # mimic the format of the response from AI
       json_response = {"content" => no_attempt_response.to_json}
@@ -52,6 +54,10 @@ class OpenaiEvaluateController < ApplicationController
       evaluation =  {status: response.code, json: response_body}
       return render(status: evaluation[:status], json: evaluation[:json])
     end
+  end
+
+  private def evaluate_params
+    params.transform_keys(&:underscore).permit(:level_id, :unit_id, :student_work, :evaluation_type)
   end
 
   private def client

--- a/dashboard/app/controllers/openai_evaluate_controller.rb
+++ b/dashboard/app/controllers/openai_evaluate_controller.rb
@@ -39,7 +39,6 @@ class OpenaiEvaluateController < ApplicationController
       json_response = {"content" => no_attempt_response.to_json}
       return render(status: :ok, json: json_response)
     elsif level.upper_grades_programming_level? && level.get_starter_code == student_work
-      puts "we are here!"
       no_attempt_response[:aiReasoning] = "The student did not change the starter code."
       # mimic the format of the response from AI
       json_response = {"content" => no_attempt_response.to_json}

--- a/dashboard/app/controllers/openai_evaluate_controller.rb
+++ b/dashboard/app/controllers/openai_evaluate_controller.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 class OpenaiEvaluateController < ApplicationController
   authorize_resource class: false
 
@@ -8,6 +10,9 @@ class OpenaiEvaluateController < ApplicationController
   def evaluate
     level_id = params[:levelId]
     unit_id = params[:unitId]
+    student_work = params[:studentWork]
+    evaluation_type = params[:evaluationType]
+
     begin
       level = Level.find(level_id)
     rescue ActiveRecord::RecordNotFound
@@ -20,14 +25,33 @@ class OpenaiEvaluateController < ApplicationController
       return render status: :not_found, json: "Unit with id #{unit_id}"
     end
 
-    evaluation_type = params[:evaluationType]
-    system_prompt = AiSystemPrompts::EvaluateSystemPromptHelper.get_system_prompt(level, unit, evaluation_type)
-    student_work = prepend_system_prompt(system_prompt, params[:studentWork])
-    response = client.request_evaluation(student_work)
-    response_body = JSON.parse(response.body)
-    response_body = response_body['choices'][0]['message'] if response.code == 200
-    evaluation =  {status: response.code, json: response_body}
-    return render(status: evaluation[:status], json: evaluation[:json])
+    # If the student did not do any work on the level, we don't need to send it to AI
+    # for evaluation. Instead, return a custom response explaining why the student's
+    # work was not evaluated.
+    no_attempt_response = {
+      aiEvaluation: "No attempt",
+      evaluationCriteria: "Did the student attempt the level?",
+    }
+    if level.is_a?(FreeResponse) && student_work.delete(' ').empty?
+      no_attempt_response[:aiReasoning] = "The student's response was blank."
+      # mimic the format of the response from AI
+      json_response = {"content" => no_attempt_response.to_json}
+      return render(status: :ok, json: json_response)
+    elsif level.upper_grades_programming_level? && level.get_starter_code == student_work
+      no_attempt_response[:aiReasoning] = "The student did not change the starter code."
+      # mimic the format of the response from AI
+      json_response = {"content" => no_attempt_response.to_json}
+      return render(status: :ok, json: json_response)
+    else
+      system_prompt = AiSystemPrompts::EvaluateSystemPromptHelper.get_system_prompt(level, unit, evaluation_type)
+      student_work_message = [{role: "user", content: student_work}]
+      messages = prepend_system_prompt(system_prompt, student_work_message)
+      response = client.request_evaluation(messages)
+      response_body = JSON.parse(response.body)
+      response_body = response_body['choices'][0]['message'] if response.code == 200
+      evaluation =  {status: response.code, json: response_body}
+      return render(status: evaluation[:status], json: evaluation[:json])
+    end
   end
 
   private def client

--- a/dashboard/test/controllers/openai_evaluate_controller_test.rb
+++ b/dashboard/test/controllers/openai_evaluate_controller_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class OpenaiEvaluateControllerTest < ActionController::TestCase
+  setup do
+    @controller = OpenaiEvaluateController.new
+  end
+
+  # level not found
+  # test 'evaluate returns not found for bogus level",' do
+  #   student = create(:student)
+  #   sign_in(student)
+  #   unit = create(:script)
+  #   get :evaluate, params: {level_id: 18976, unit_id: unit.id, student_work: "This is a good answer.", evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}
+  #   assert_response :not_found
+  # end
+
+  # # unit not found
+  # test 'evaluate returns not found for bogus unit",' do
+  #   student = create(:student)
+  #   sign_in(student)
+  #   level = create(:level)
+  #   get :evaluate, params: {level_id: level.id, unit_id: 9478, student_work: "This is a good answer.", evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}
+  #   assert_response :not_found
+  # end
+
+  # student did not attempt free response level
+  test 'evaluate returns custom `no attempt` for empty free response",' do
+    student = create(:student)
+    sign_in(student)
+    level = create(:free_response, :with_script)
+    unit = level.script_levels.first.script
+    get :evaluate, params: {level_id: level.id, unit_id: unit.id, student_work: " ", evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}
+    assert_response :ok
+    custom_response = JSON.parse(json_response["content"])
+    assert_equal custom_response["aiEvaluation"], "No attempt"
+    assert_equal custom_response["aiReasoning"], "The student response was blank."
+  end
+
+  # student did not change starter code on programming level
+  test 'evaluate returns custom `no attempt` for unchanged starter code on programming level",' do
+    student = create(:student)
+    sign_in(student)
+    level = create(:applab, :with_script, :with_starter_code)
+    unit = level.script_levels.first.script
+    get :evaluate, params: {level_id: level.id, unit_id: unit.id, student_work: level.get_starter_code, evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}
+    assert_response :ok
+    custom_response = JSON.parse(json_response["content"])
+    assert_equal custom_response["aiEvaluation"], "No attempt"
+    assert_equal custom_response["aiReasoning"], "The student did not change the starter code."
+  end
+end

--- a/dashboard/test/controllers/openai_evaluate_controller_test.rb
+++ b/dashboard/test/controllers/openai_evaluate_controller_test.rb
@@ -6,22 +6,22 @@ class OpenaiEvaluateControllerTest < ActionController::TestCase
   end
 
   # level not found
-  # test 'evaluate returns not found for bogus level",' do
-  #   student = create(:student)
-  #   sign_in(student)
-  #   unit = create(:script)
-  #   get :evaluate, params: {level_id: 18976, unit_id: unit.id, student_work: "This is a good answer.", evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}
-  #   assert_response :not_found
-  # end
+  test 'evaluate returns not found for bogus level",' do
+    student = create(:student)
+    sign_in(student)
+    unit = create(:script)
+    get :evaluate, params: {level_id: 18976, unit_id: unit.id, student_work: "This is a good answer.", evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}
+    assert_response :not_found
+  end
 
   # # unit not found
-  # test 'evaluate returns not found for bogus unit",' do
-  #   student = create(:student)
-  #   sign_in(student)
-  #   level = create(:level)
-  #   get :evaluate, params: {level_id: level.id, unit_id: 9478, student_work: "This is a good answer.", evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}
-  #   assert_response :not_found
-  # end
+  test 'evaluate returns not found for bogus unit",' do
+    student = create(:student)
+    sign_in(student)
+    level = create(:level)
+    get :evaluate, params: {level_id: level.id, unit_id: 9478, student_work: "This is a good answer.", evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}
+    assert_response :not_found
+  end
 
   # student did not attempt free response level
   test 'evaluate returns custom `no attempt` for empty free response",' do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -831,6 +831,13 @@ FactoryBot.define do
       end
     end
 
+    trait :with_starter_code do
+      after(:create) do |level|
+        level.properties['start_blocks'] = 'const isCode = true;'
+        level.save!
+      end
+    end
+
     factory :sublevel do
       sequence(:name) {|n| "sub_level_#{n}"}
     end


### PR DESCRIPTION
[TEACH-1715](https://codedotorg.atlassian.net/browse/TEACH-1715)
[TEACH-1716](https://codedotorg.atlassian.net/browse/TEACH-1716)

To save resources, we want to avoid sending empty free response answers or student code that hasn't changed from the level's starter code to AI for evaluation. We want to do this on the backend because we still want to create the `UserLevelEvaluation` that stores the information that the student did not attempt the level for eventual reporting purposes. This PR adds code to the openai_evaluate controller that handles these "empty" student work requests by mimicking the AI's response with a custom "no attempt" message. Basic tests for these empty cases are included. 