### PR TITLE
feat: add fields for additional info section

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/AdditionalInfo.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/AdditionalInfo.tsx
@@ -3,7 +3,7 @@ import FormFieldWrapper from '@code-dot-org/component-library/formFieldWrapper';
 import TextField from '@code-dot-org/component-library/textField';
 import {Heading2} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
-import React, {FC} from 'react';
+import React, {FC, useMemo} from 'react';
 
 import {ParticipantGroupTypes} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
@@ -18,6 +18,16 @@ export const AdditionalInfo: FC<SectionProps> = ({
   state,
   handleChange,
 }) => {
+  const participantGroupTypeOptions = useMemo(() => {
+    return [
+      {value: '', text: 'Select a cohort type'},
+      ...ParticipantGroupTypes.map(value => ({
+        value,
+        text: value,
+      })),
+    ];
+  }, []);
+
   return (
     <>
       <Heading2 visualAppearance="heading-sm">Additional Information</Heading2>
@@ -40,10 +50,7 @@ export const AdditionalInfo: FC<SectionProps> = ({
             name="participant group type"
             onChange={e => handleChange({participantGroupType: e.target.value})}
             styleAsFormField={true}
-            items={ParticipantGroupTypes.map(value => ({
-              value,
-              text: value,
-            }))}
+            items={participantGroupTypeOptions}
             selectedValue={state.participantGroupType}
             labelText="Cohort type"
             size="s"

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/AdditionalInfo.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/AdditionalInfo.tsx
@@ -1,12 +1,79 @@
+import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
+import FormFieldWrapper from '@code-dot-org/component-library/formFieldWrapper';
+import TextField from '@code-dot-org/component-library/textField';
 import {Heading2} from '@code-dot-org/component-library/typography';
+import classNames from 'classnames';
 import React, {FC} from 'react';
+
+import {ParticipantGroupTypes} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 import {SectionProps} from '../types';
 
-export const AdditionalInfo: FC<SectionProps> = ({state, handleChange}) => {
+import commonStyles from '../styles.module.scss';
+
+export const AdditionalInfo: FC<SectionProps> = ({
+  config: {
+    fields: {fee, participant_group_type, notes},
+  },
+  state,
+  handleChange,
+}) => {
   return (
-    <div>
-      <Heading2 visualAppearance="heading-sm">Additional Info</Heading2>
-    </div>
+    <>
+      <Heading2 visualAppearance="heading-sm">Additional Information</Heading2>
+      <div className={commonStyles.row}>
+        {fee && (
+          <TextField
+            name="cost"
+            helperMessage="You can leave this field blank if the workshop is free"
+            onChange={e => handleChange({fee: e.target.value})}
+            value={state.fee}
+            label="Workshop cost"
+            size="s"
+            className={classNames(commonStyles.item, {
+              [commonStyles.required]: fee.required,
+            })}
+          />
+        )}
+        {participant_group_type ? (
+          <SimpleDropdown
+            name="participant group type"
+            onChange={e => handleChange({participantGroupType: e.target.value})}
+            styleAsFormField={true}
+            items={ParticipantGroupTypes.map(value => ({
+              value,
+              text: value,
+            }))}
+            selectedValue={state.participantGroupType}
+            labelText="Cohort type"
+            size="s"
+            dropdownTextThickness="thin"
+            className={classNames(commonStyles.item, {
+              [commonStyles.required]: participant_group_type.required,
+            })}
+          />
+        ) : (
+          <div className={commonStyles.item} />
+        )}
+      </div>
+      <div className={commonStyles.row}>
+        {notes && (
+          <FormFieldWrapper
+            label="Attendee notes"
+            helperMessage="Notes for logistics like food, parking, or other event details."
+            size="s"
+            className={classNames(commonStyles.item, commonStyles.required)}
+          >
+            <textarea
+              id="notes"
+              name="notes"
+              onChange={e => handleChange({notes: e.target.value})}
+              value={state.notes}
+              placeholder="Enter attendee notes here"
+            />
+          </FormFieldWrapper>
+        )}
+      </div>
+    </>
   );
 };


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds fields for additional info section:
- cost (fee)
- cohort type (participant_group_type)
- attendee notes (notes)

![Screenshot 2025-03-24 at 8 49 22 AM](https://github.com/user-attachments/assets/b06c0755-1d20-44c8-ade6-afa6060e7330)

## Links

[jira](https://codedotorg.atlassian.net/browse/ACQ-3092)
[figma](https://www.figma.com/design/Km9JCLNbayBlTrlnKenumq/New-PL-Program?node-id=3814-21409&m=dev)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
