### PR TITLE
Codebridge: Improve version history logic for current version

### DIFF
--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -80,9 +80,10 @@ const VersionHistoryDropdown: React.FunctionComponent<
   const menuRef = useOutsideClick<HTMLDivElement>(closeDropdown);
   const previousListLoaded = useRef<boolean>(listLoaded);
   const latestVersion = useMemo(
-    () => versionList?.find(v => v.isLatest)?.versionId || '',
+    () => versionList?.find(v => v.isLatest)?.versionId || INITIAL_VERSION_ID,
     [versionList]
   );
+
   const viewingOldVersion = useAppSelector(
     state => state.lab2Project.viewingOldVersion
   );
@@ -133,7 +134,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (selectedVersion === '' && versionList.length > 0) {
+    if (selectedVersion === '' && latestVersion !== '') {
       setSelectedVersion(latestVersion);
     }
   }, [versionList, selectedVersion, latestVersion, setSelectedVersion]);
@@ -309,6 +310,29 @@ const VersionHistoryDropdown: React.FunctionComponent<
     closeDropdown();
   }, [closeDropdown, dispatch, isLatestVersion, selectedVersion]);
 
+  const renderLatestTag = () => {
+    return (
+      <Tags
+        tagsList={[
+          {
+            label: commonI18n.current(),
+            icon: {
+              iconName: 'check',
+              iconStyle: 'regular',
+              title: 'check',
+              placement: 'left',
+            },
+            tooltipContent: commonI18n.current(),
+            tooltipId: 'current-version-tag',
+            ariaLabel: commonI18n.current(),
+          },
+        ]}
+        className={moduleStyles.latestTag}
+        size="s"
+      />
+    );
+  };
+
   return createPortal(
     <FocusTrap
       focusTrapOptions={{
@@ -366,26 +390,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
                     checked={selectedVersion === version.versionId}
                     className={moduleStyles.versionHistoryRow}
                   >
-                    {version.isLatest && (
-                      <Tags
-                        tagsList={[
-                          {
-                            label: commonI18n.current(),
-                            icon: {
-                              iconName: 'check',
-                              iconStyle: 'regular',
-                              title: 'check',
-                              placement: 'left',
-                            },
-                            tooltipContent: commonI18n.current(),
-                            tooltipId: 'current-version-tag',
-                            ariaLabel: commonI18n.current(),
-                          },
-                        ]}
-                        className={moduleStyles.latestTag}
-                        size="s"
-                      />
-                    )}
+                    {version.isLatest && renderLatestTag()}
                   </RadioButton>
                 </div>
               ))}
@@ -397,7 +402,9 @@ const VersionHistoryDropdown: React.FunctionComponent<
                   onChange={onVersionChange}
                   checked={selectedVersion === INITIAL_VERSION_ID}
                   className={moduleStyles.versionHistoryRow}
-                />
+                >
+                  {latestVersion === INITIAL_VERSION_ID && renderLatestTag()}
+                </RadioButton>
               </div>
             </div>
             {versionLoadError && (
@@ -421,7 +428,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
                   color={'white'}
                   size={'s'}
                   onClick={restoreSelectedVersion}
-                  disabled={versionLoading}
+                  disabled={versionLoading || latestVersion === selectedVersion}
                   className={moduleStyles.actionButton}
                   type={'primary'}
                 />

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -134,7 +134,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (selectedVersion === '' && latestVersion !== '') {
+    if (selectedVersion === '') {
       setSelectedVersion(latestVersion);
     }
   }, [versionList, selectedVersion, latestVersion, setSelectedVersion]);

--- a/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryButtonTest.tsx
+++ b/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryButtonTest.tsx
@@ -145,6 +145,30 @@ describe('VersionHistoryButton', () => {
     expect(latestVersion.checked).toBe(true);
   });
 
+  it('selects initial version if there is no version list', async () => {
+    mockedProjectManager = {
+      getVersionList: jest.fn(() => Promise.resolve([])),
+    } as unknown as jest.Mocked<ProjectManager>;
+    Lab2Registry.getInstance().setProjectManager(mockedProjectManager);
+
+    const {getByDisplayValue} = renderDefault();
+    const button = await screen.findByRole('button', {name: 'Version History'});
+
+    const user = userEvent.setup();
+    await act(async () => {
+      user.click(button);
+    });
+    await waitFor(
+      () => expect(mockedProjectManager.getVersionList).toHaveBeenCalled(),
+      {timeout: 2000}
+    );
+
+    const initialVersion = getByDisplayValue(
+      'initial-version'
+    ) as HTMLInputElement;
+    expect(initialVersion.checked).toBe(true);
+  });
+
   it('restores selected version on restore', async () => {
     const {getByDisplayValue, getByRole, queryByRole} = renderDefault();
 

--- a/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryDropdownTest.tsx
+++ b/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryDropdownTest.tsx
@@ -1,5 +1,6 @@
 import {render, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
 import React from 'react';
 import {Provider} from 'react-redux';
 import {Store} from 'redux';
@@ -127,5 +128,60 @@ describe('VersionHistoryButton', () => {
     await user.click(closeButton);
     expect(mockedProjectManager.loadSources).not.toHaveBeenCalled();
     expect(closeDropdown).toHaveBeenCalled();
+  });
+
+  it('disables restore button when initial version is latest', () => {
+    const {getByRole} = render(
+      <Provider store={store}>
+        <VersionHistoryDropdown
+          versionList={[]}
+          startSources={{source: ''}}
+          closeDropdown={closeDropdown}
+          listLoaded={true}
+          buttonRef={{} as jest.Mocked<React.RefObject<HTMLDivElement>>}
+          listLoading={false}
+          listLoadError={false}
+          selectedVersion={'initial-version'}
+          setSelectedVersion={setSelectedVersion}
+        />
+      </Provider>
+    );
+
+    const restoreButton = getByRole('button', {
+      name: 'Restore',
+    });
+    () => expect(restoreButton).toBeDisabled();
+  });
+
+  it('disables restore button when selected version is latest', async () => {
+    const {getByRole} = render(
+      <Provider store={store}>
+        <VersionHistoryDropdown
+          versionList={SAMPLE_VERSION_LIST}
+          startSources={{source: ''}}
+          closeDropdown={closeDropdown}
+          listLoaded={true}
+          buttonRef={{} as jest.Mocked<React.RefObject<HTMLDivElement>>}
+          listLoading={false}
+          listLoadError={false}
+          selectedVersion={'3'} // 3 is latest version
+          setSelectedVersion={setSelectedVersion}
+        />
+      </Provider>
+    );
+
+    const restoreButton = getByRole('button', {
+      name: 'Restore',
+    });
+    expect(restoreButton).toBeDisabled();
+  });
+
+  it('enables restore button when selected version is not latest', async () => {
+    const {getByRole} = renderDefault();
+
+    const restoreButton = getByRole('button', {
+      name: 'Restore',
+    });
+    expect(restoreButton).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
This improves a couple pieces of version history behavior:
- If you have no versions, when version history is opened, select "initial version" as the currently-selected version, and label it as the current version
- If you have your current version selected (whether it is the initial version or you've done work), disable the restore button, because restoring the current version does nothing.

## Before
### No versions case
<img width="414" alt="Screenshot 2025-03-21 at 2 59 40 PM" src="https://github.com/user-attachments/assets/c81292d9-745c-4c48-b82c-07eab9024f76" />

### Selected current version
<img width="414" alt="Screenshot 2025-03-21 at 3 03 57 PM" src="https://github.com/user-attachments/assets/de6d58d2-0eaa-4c75-907d-3edfa6c78ceb" />

## After
### No versions
<img width="416" alt="Screenshot 2025-03-21 at 2 38 59 PM" src="https://github.com/user-attachments/assets/5ab3d799-f870-4683-95d7-162a36a59c93" />

### Selecting versions (restore button enables/disables)
https://github.com/user-attachments/assets/8a575131-e88a-4b71-b133-5bb42e05d386


## Links

- jira ticket: [CT-1149](https://codedotorg.atlassian.net/browse/CT-1149)


## Testing story
Tested locally and updated unit tests.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
