### PR TITLE
AI Chat: only load history since most recent clear event 

### DIFF
--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -82,7 +82,6 @@ const aichatSlice = createSlice({
       }
 
       if (lastResetIndex >= 0) {
-        state.chatEventsPast = action.payload.slice(0, lastResetIndex + 1);
         state.chatEventsCurrent = action.payload.slice(lastResetIndex + 1);
       } else {
         state.chatEventsCurrent = action.payload;

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -82,7 +82,7 @@ const aichatSlice = createSlice({
       }
 
       if (lastResetIndex >= 0) {
-        state.chatEventsCurrent = action.payload.slice(lastResetIndex + 1);
+        state.chatEventsCurrent = action.payload.slice(lastResetIndex);
       } else {
         state.chatEventsCurrent = action.payload;
       }


### PR DESCRIPTION
Instead of showing a user their entire history on a level, only include the history that will be included in the subsequent conversation history sent to the model.

This currently **does** ~~not~~ include the reset event itself in what the user sees. ~~I'm a bit torn on this, but it seems sensible for the majority case at least (ie, the top-most message will likely be a message that a user sent that marks the beginning of the current conversation).~~ Decided to include this, see discussion below.

## Links

- [Slack discussion](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1742504352170299?thread_ts=1742482983.291809&cid=C06FELVTV0Q)