### PR TITLE
Revert "Revert "Kaitie/rubric fix spacing in student rubric""

### DIFF
--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
@@ -113,7 +113,7 @@ export default function EvidenceLevelsForTeachersV2({
         <BodyThreeText className={style.evidenceLevelHeaderText}>
           <StrongText>{i18n.assignARubricScore()}</StrongText>
         </BodyThreeText>
-        <div className={style.evidenceLevelSetHorizontal} ref={ref}>
+        <div className={style.evidenceLevelSetHorizontalV2} ref={ref}>
           {evidenceLevels.map(evidenceLevel => (
             <button
               data-ai-suggested={

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -74,7 +74,7 @@
   align-items: center;
   flex-shrink: 0;
 
-  background: var(--sentiment-error-50, #E5311A);
+  background: var(--sentiment-error-50, #e5311a);
 }
 
 .countText {
@@ -82,7 +82,7 @@
   margin-bottom: 0 !important;
   padding: 0 2px;
 
-  color: var(--light-white, #FFF);
+  color: var(--light-white, #fff);
   font-variant-ligatures: no-common-ligatures;
 }
 
@@ -101,8 +101,8 @@
   gap: 20px;
 
   border-radius: 4px;
-  border: 1px solid var(--neutral-gray-20, #D1D4D8);
-  background: var(--neutral-base-white, #FFF);
+  border: 1px solid var(--neutral-gray-20, #d1d4d8);
+  background: var(--neutral-base-white, #fff);
 
   box-shadow: 0 4px 4px 0 rgb(0 0 0 / 0.25);
 }
@@ -113,7 +113,7 @@
   margin-left: 4px;
   margin-bottom: -24px;
 
-  color: var(--text-neutral-primary, #292F36);
+  color: var(--text-neutral-primary, #292f36);
   font-variant-ligatures: no-common-ligatures;
 }
 
@@ -129,11 +129,11 @@
   flex: 1 0 0;
 
   border-radius: 4px;
-  background: var(--brand-aqua-50, #3CFFF7) !important;
+  background: var(--brand-aqua-50, #3cfff7) !important;
 }
 
 .viewScoresText {
-  color: var(--light-black, #292F36);
+  color: var(--light-black, #292f36);
   font-variant-ligatures: no-common-ligatures;
 
   /* Button/Button 3 */
@@ -443,7 +443,7 @@ button.rubricHeaderTab {
     height: 40px;
     padding: 0 1rem 0 2rem;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     align-self: stretch;
     line-height: 154%;
     position: relative;
@@ -486,6 +486,7 @@ button.rubricHeaderTab {
   gap: 16px;
   font-size: 14px;
   padding-left: 10px;
+  padding-top: 0.5rem;
 }
 
 .learningGoalHeaderRightSide {
@@ -559,7 +560,6 @@ h2.studentName {
   display: flex;
   flex-direction: row;
   width: 100%;
-  height: 100px;
   gap: 8px;
   min-height: 92px;
 }
@@ -1113,6 +1113,7 @@ p.evidenceLevelHeaderText {
 .evidenceLevelSetHorizontalV2 {
   display: flex;
   flex-direction: row;
+  height: 100px;
   width: 100%;
   gap: 8px;
 }
@@ -1372,7 +1373,7 @@ p.detailsHidden {
   display: inline;
   margin-right: 17px;
   p {
-      margin-bottom: 0;
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#64737

Modified the student-facing rubrics styles so that the text did not clobber each other.

<img width="865" alt="image" src="https://github.com/user-attachments/assets/ec44d4d4-84a2-440d-9f3c-e84e85b9d0a3" />

Note: We had an issue with this change impacting the teacher view.  I reverted the PR and upon further inspection saw that we had a class `evidenceLevelSetHorizontalV2` that wasn't being used that I think was intended for the teacher view.  I used this instead for the teacher view and did a check that the two looked the same. 

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1668)

