### PR TITLE
[AI Tutor] Refactor auto-scrolling to bottom when suggested prompts are rendered

### DIFF
--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -29,32 +29,35 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
     [storedMessages]
   );
   const isLastMessageFromAssistant =
+    lastAssistantMessageIndex !== -1 &&
     lastAssistantMessageIndex === storedMessages.length - 1;
+
+  const scrollToBottom = useCallback(() => {
+    conversationContainerRef.current?.scrollTo({
+      top: conversationContainerRef.current.scrollHeight,
+      behavior: 'smooth',
+    });
+  }, []);
 
   const handleSuggestedPromptsRef = useCallback(
     (node: HTMLDivElement | null) => {
-      if (node !== null) {
+      const isNewMessage =
+        storedMessages.length !== prevMessagesCountRef.current;
+      if (node !== null && !isNewMessage) {
         setTimeout(() => {
           scrollToBottom();
         }, 100);
       }
     },
-    []
+    [scrollToBottom, storedMessages.length]
   );
 
-  const scrollToBottom = () => {
-    conversationContainerRef.current?.scrollTo({
-      top: conversationContainerRef.current.scrollHeight,
-      behavior: 'smooth',
-    });
-  };
-
-  const scrollToAssistantMessage = () => {
+  const scrollToAssistantMessage = useCallback(() => {
     lastAssistantMessageRef.current?.scrollIntoView({
       behavior: 'smooth',
       block: 'start',
     });
-  };
+  }, []);
 
   useEffect(() => {
     if (!conversationContainerRef.current) {
@@ -66,11 +69,12 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
     const isFeedbackOpened =
       feedbackDetailsOpen && !prevFeedbackDetailsOpenRef.current;
 
-    if (isNewMessage) {
-      isLastMessageFromAssistant
-        ? scrollToAssistantMessage()
-        : scrollToBottom();
-    } else if (isFeedbackOpened) {
+    if (isNewMessage && isLastMessageFromAssistant) {
+      scrollToAssistantMessage();
+      return;
+    }
+
+    if (isNewMessage || isFeedbackOpened) {
       scrollToBottom();
     }
 
@@ -78,7 +82,13 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
     // assistant feedback details is open.
     prevMessagesCountRef.current = storedMessages.length;
     prevFeedbackDetailsOpenRef.current = feedbackDetailsOpen;
-  }, [storedMessages.length, feedbackDetailsOpen, isLastMessageFromAssistant]);
+  }, [
+    storedMessages.length,
+    feedbackDetailsOpen,
+    isLastMessageFromAssistant,
+    scrollToAssistantMessage,
+    scrollToBottom,
+  ]);
 
   return (
     <div id="ai-tutor-chat-workspace" className={style.aiTutorChatWorkspace}>

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -34,9 +34,9 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   const handleSuggestedPromptsRef = useCallback(
     (node: HTMLDivElement | null) => {
       if (node !== null) {
-        requestAnimationFrame(() => {
+        setTimeout(() => {
           scrollToBottom();
-        });
+        }, 100);
       }
     },
     []

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState, useCallback} from 'react';
 
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
@@ -19,9 +19,6 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
   );
-  const showSuggestedPrompts = useAppSelector(
-    state => state.aiTutor.showSuggestedPrompts
-  );
 
   const [feedbackDetailsOpen, setFeedbackDetailsOpen] = useState(false);
   const prevMessagesCountRef = useRef(storedMessages.length);
@@ -33,6 +30,17 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
   );
   const isLastMessageFromAssistant =
     lastAssistantMessageIndex === storedMessages.length - 1;
+
+  const handleSuggestedPromptsRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node !== null) {
+        requestAnimationFrame(() => {
+          scrollToBottom();
+        });
+      }
+    },
+    []
+  );
 
   const scrollToBottom = () => {
     conversationContainerRef.current?.scrollTo({
@@ -58,26 +66,19 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
     const isFeedbackOpened =
       feedbackDetailsOpen && !prevFeedbackDetailsOpenRef.current;
 
-    setTimeout(() => {
-      if (isNewMessage) {
-        isLastMessageFromAssistant
-          ? scrollToAssistantMessage()
-          : scrollToBottom();
-      } else if (isFeedbackOpened || showSuggestedPrompts) {
-        scrollToBottom();
-      }
+    if (isNewMessage) {
+      isLastMessageFromAssistant
+        ? scrollToAssistantMessage()
+        : scrollToBottom();
+    } else if (isFeedbackOpened) {
+      scrollToBottom();
+    }
 
-      // Update refs to track changes in number of stored messages and whether
-      // assistant feedback details is open.
-      prevMessagesCountRef.current = storedMessages.length;
-      prevFeedbackDetailsOpenRef.current = feedbackDetailsOpen;
-    }, 200); // Small delay to allow DOM updates
-  }, [
-    storedMessages.length,
-    showSuggestedPrompts,
-    feedbackDetailsOpen,
-    isLastMessageFromAssistant,
-  ]);
+    // Update refs to track changes in number of stored messages and whether
+    // assistant feedback details is open.
+    prevMessagesCountRef.current = storedMessages.length;
+    prevFeedbackDetailsOpenRef.current = feedbackDetailsOpen;
+  }, [storedMessages.length, feedbackDetailsOpen, isLastMessageFromAssistant]);
 
   return (
     <div id="ai-tutor-chat-workspace" className={style.aiTutorChatWorkspace}>
@@ -110,7 +111,7 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
           );
         })}
         <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
-        <AITutorSuggestedPrompts />
+        <AITutorSuggestedPrompts innerRef={handleSuggestedPromptsRef} />
       </div>
       <WarningModal />
     </div>

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -41,15 +41,11 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
 
   const handleSuggestedPromptsRef = useCallback(
     (node: HTMLDivElement | null) => {
-      const isNewMessage =
-        storedMessages.length !== prevMessagesCountRef.current;
-      if (node !== null && !isNewMessage) {
-        setTimeout(() => {
-          scrollToBottom();
-        }, 100);
+      if (node !== null) {
+        scrollToBottom();
       }
     },
-    [scrollToBottom, storedMessages.length]
+    [scrollToBottom]
   );
 
   const scrollToAssistantMessage = useCallback(() => {

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -42,7 +42,13 @@ const useLabSelectors = () => {
   }));
 };
 
-const AITutorSuggestedPrompts: React.FunctionComponent = () => {
+interface AITutorSuggestedPromptsProps {
+  innerRef?: React.Ref<HTMLDivElement>;
+}
+
+const AITutorSuggestedPrompts: React.FunctionComponent<
+  AITutorSuggestedPromptsProps
+> = ({innerRef}) => {
   const {
     isWaitingForChatResponse,
     level,
@@ -184,7 +190,9 @@ const AITutorSuggestedPrompts: React.FunctionComponent = () => {
   // we do not show a suggested prompt again until the user clicks on the 'Run' or
   // 'Validate'/'Test' buttons.
   return showSuggestedPrompts ? (
-    <SuggestedPrompts suggestedPrompts={suggestedPrompts} />
+    <div ref={innerRef}>
+      <SuggestedPrompts suggestedPrompts={suggestedPrompts} />
+    </div>
   ) : null;
 };
 

--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -189,7 +189,7 @@ const AITutorSuggestedPrompts: React.FunctionComponent<
   // `showSuggestedPrompts` ensures that if the user clicks on a suggested prompt,
   // we do not show a suggested prompt again until the user clicks on the 'Run' or
   // 'Validate'/'Test' buttons.
-  return showSuggestedPrompts ? (
+  return showSuggestedPrompts && suggestedPrompts.length > 0 ? (
     <div ref={innerRef}>
       <SuggestedPrompts suggestedPrompts={suggestedPrompts} />
     </div>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR refactors the auto-scrolling in AI Tutor and follows up https://github.com/code-dot-org/code-dot-org/pull/64407 (added auto-scrolling) and https://github.com/code-dot-org/code-dot-org/pull/64476 (updated auto-scrolling so that for latest assistant response was scrolled to top of message).

This PR removes the arbitrary time delay for the scrolling which was added since the rendering of the suggested prompts occurred a bit after `showSuggestedPrompts` was set to `true`. Retrieving the suggested prompts includes waiting for the `hasPythonlabError` and `validatonState.satisfied` values (i.e., waiting for program to run and parsing the output).

To resolve this, I added an optional `innerRef` prop to `AITutorSuggestedPrompt` so that  `AITutorChatWorkspace` can detect when the child component was added to the DOM and auto-scroll to it. The key change alongside adding this `innerRef` was to not render the suggested prompts unless `suggestedPrompts` array was non-empty. Before I added this update, the `div` would render since `showSuggestedPrompts` is  set to `true` more quickly.

I also did a little bit of clean-up/refactoring:
- wrapped `scrollToBottom` and `scrollToAssistantMessage` in a `useCallback`,
- check to make sure `lastAssistantMessageIndex` is not equal to `-1`.

## After update

No change in functionality - tested in both `pythonlab` and `javalab`.

In `pythonlab`:

https://github.com/user-attachments/assets/47e47ad3-58b3-4c41-b121-d910f5e04560




## Links
[jira](https://codedotorg.atlassian.net/browse/CT-1140)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
