### PR TITLE
feat(Section): add id prop

### DIFF
--- a/frontend/apps/marketing/src/app/globals.css
+++ b/frontend/apps/marketing/src/app/globals.css
@@ -2,6 +2,7 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
+  scroll-behavior: smooth;
 }
 
 body {

--- a/frontend/apps/marketing/src/components/section/Section.tsx
+++ b/frontend/apps/marketing/src/components/section/Section.tsx
@@ -5,15 +5,16 @@ import DSCOSection, {
 // Import the background image used in the pattern backgrounds on Contentful
 import bgPatternImage from '@public/images/bg-pattern-lines.png';
 
-const Section: React.FC<SectionProps> = ({background, ...props}) => (
+const Section: React.FC<SectionProps> = ({background, id, ...props}) => (
   <DSCOSection
-    {...props}
+    id={id}
     background={background}
     backgroundImageUrl={
       background === 'patternDark' || background === 'patternPrimary'
         ? bgPatternImage.src
         : undefined
     }
+    {...props}
   />
 );
 

--- a/frontend/apps/marketing/src/components/section/Section.tsx
+++ b/frontend/apps/marketing/src/components/section/Section.tsx
@@ -5,9 +5,8 @@ import DSCOSection, {
 // Import the background image used in the pattern backgrounds on Contentful
 import bgPatternImage from '@public/images/bg-pattern-lines.png';
 
-const Section: React.FC<SectionProps> = ({background, id, ...props}) => (
+const Section: React.FC<SectionProps> = ({background, ...props}) => (
   <DSCOSection
-    id={id}
     background={background}
     backgroundImageUrl={
       background === 'patternDark' || background === 'patternPrimary'

--- a/frontend/apps/marketing/src/components/section/Section.tsx
+++ b/frontend/apps/marketing/src/components/section/Section.tsx
@@ -7,13 +7,13 @@ import bgPatternImage from '@public/images/bg-pattern-lines.png';
 
 const Section: React.FC<SectionProps> = ({background, ...props}) => (
   <DSCOSection
+    {...props}
     background={background}
     backgroundImageUrl={
       background === 'patternDark' || background === 'patternPrimary'
         ? bgPatternImage.src
         : undefined
     }
-    {...props}
   />
 );
 

--- a/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
@@ -60,5 +60,11 @@ export const SectionContentfulComponentDefinition: ComponentDefinition = {
         ],
       },
     },
+    id: {
+      displayName: 'Section ID',
+      type: 'Text',
+      group: 'content',
+      description: 'Adds a custom ID to a section.',
+    },
   },
 };

--- a/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
@@ -64,7 +64,7 @@ export const SectionContentfulComponentDefinition: ComponentDefinition = {
       displayName: 'Section ID',
       type: 'Text',
       group: 'content',
-      description: 'Adds a custom ID to a section.',
+      description: 'Adds a custom ID to a section; can be used for skip links.',
     },
   },
 };

--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -84,7 +84,6 @@ const Section: React.FC<SectionProps> = ({
         moduleStyles[`section-padding-${padding}`],
         className,
       )}
-      {...HTMLAttributes}
       style={{
         ...(hasPatternBackground
           ? backgroundImageUrl
@@ -96,6 +95,7 @@ const Section: React.FC<SectionProps> = ({
             : {}
           : {}),
       }}
+      {...HTMLAttributes}
     >
       <div className={classNames(moduleStyles.container)}>{children}</div>
     </section>

--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -35,6 +35,10 @@ export interface SectionProps extends HTMLAttributes<HTMLElement> {
   padding?: Exclude<SpacingNoneToL, SpacingNoneToS>;
   /** Section theme */
   theme?: 'Light' | 'Dark';
+  /** Section id */
+  id?: string;
+  /** Section className */
+  className?: string;
   /** Section content */
   children?: ReactNode;
 }
@@ -58,8 +62,10 @@ const Section: React.FC<SectionProps> = ({
   backgroundImageUrl,
   padding = 'l',
   theme = 'Light',
-  children,
+
+  id,
   className,
+  children,
   ...HTMLAttributes
 }: SectionProps) => {
   const hasPatternBackground =
@@ -71,6 +77,7 @@ const Section: React.FC<SectionProps> = ({
 
   return (
     <section
+      id={id}
       data-theme={hasPatternBackground || useDarkTheme ? 'Dark' : theme}
       className={classNames(
         moduleStyles.section,

--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -62,7 +62,6 @@ const Section: React.FC<SectionProps> = ({
   backgroundImageUrl,
   padding = 'l',
   theme = 'Light',
-
   id,
   className,
   children,

--- a/frontend/packages/component-library/src/cms/section/Section.tsx
+++ b/frontend/packages/component-library/src/cms/section/Section.tsx
@@ -35,7 +35,7 @@ export interface SectionProps extends HTMLAttributes<HTMLElement> {
   padding?: Exclude<SpacingNoneToL, SpacingNoneToS>;
   /** Section theme */
   theme?: 'Light' | 'Dark';
-  /** Section id */
+  /** Section ID */
   id?: string;
   /** Section className */
   className?: string;

--- a/frontend/packages/component-library/src/cms/section/__tests__/Section.test.tsx
+++ b/frontend/packages/component-library/src/cms/section/__tests__/Section.test.tsx
@@ -44,7 +44,7 @@ describe('Section Component', () => {
     );
   });
 
-  it('applies a custom id to the section', () => {
+  it('applies a custom ID to the section', () => {
     renderComponent({id: 'section-id'});
 
     const section = screen

--- a/frontend/packages/component-library/src/cms/section/__tests__/Section.test.tsx
+++ b/frontend/packages/component-library/src/cms/section/__tests__/Section.test.tsx
@@ -22,22 +22,36 @@ describe('Section Component', () => {
     const {rerender} = renderComponent({
       background: sectionBackground.secondary,
     });
+    const section = screen
+      .getByText('This is content.')
+      .closest('.container')?.parentElement;
 
     // check if background color is light gray
-    expect(screen.getByText('This is content.').parentElement).toHaveStyle(
+    expect(section).toHaveStyle(
       'background-color: var(--background-neutral-secondary)',
     );
 
     // change background color to light teal
     rerender(
-      <Section background="brandLightPrimary">
+      <Section background={sectionBackground.brandLightPrimary}>
         <div>This is content.</div>
       </Section>,
     );
 
     // check if background color is light teal
-    expect(screen.getByText('This is content.').parentElement).toHaveStyle(
+    expect(section).toHaveStyle(
       'background-color: var(--background-brand-light-primary)',
     );
+  });
+
+  it('applies a custom id to the section', () => {
+    renderComponent({id: 'section-id'});
+
+    const section = screen
+      .getByText('This is content.')
+      .closest('.container')?.parentElement;
+
+    // check if the section element has the correct id
+    expect(section).toHaveAttribute('id', 'section-id');
   });
 });


### PR DESCRIPTION
Adds an `id` prop to the Section component so skip links can be added in Contentful.

## Links
Jira ticket: [CMS-458](https://codedotorg.atlassian.net/browse/CMS-458)

## Testing story
Added a unit test and tested locally in Contentful

----


https://github.com/user-attachments/assets/0fbb8ba3-6a8d-4d7b-8f85-111e1101807b

