### PR TITLE
AI Chat: add missing parentheses in helper for alarms

### DIFF
--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmHelpers.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmHelpers.ts
@@ -58,7 +58,7 @@ export const createOpenaiSafetyMetricStat = (
 };
 
 export const metricsSumExpression = (metrics: { Id: string }[]): string => {
-  return `SUM[${metrics.map(m => m.Id).join(",")}]`;
+  return `SUM([${metrics.map(m => m.Id).join(",")}])`;
 };
 
 // Start(total) jobs metric configuration for a set of models


### PR DESCRIPTION
Missed a set of parentheses when [adding a helper in this PR](https://github.com/code-dot-org/code-dot-org/pull/64674#discussion_r2005957704).