### PR TITLE
Restrict Load Balancer to Only Permit HTTP Requests from CloudFront

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -262,10 +262,7 @@ Resources:
 
 <% if load_balancer -%>
   # ---------------------------------------------
-  # Load Balancers
-  #
-  # TODO
-  # - hourofcode.com and csedweek.org load balancers should be added to this template.
+  # Load Balancer (shared by code.org, studio.code.org, and hourofcode.com)
   # ---------------------------------------------
 <% raise "LoadBalancer name [#{stack_name}] cannot be longer than 32 characters" if stack_name.length > 32 -%>
 
@@ -273,7 +270,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Name: !Ref AWS::StackName
-      SecurityGroups: [!ImportValue VPC-ELBSecurityGroup]
+      SecurityGroups: [!ImportValue VPC-ALBSecurityGroup]
       Subnets: <%= public_subnets.to_json %>
       LoadBalancerAttributes:
         - Key: deletion_protection.enabled
@@ -286,17 +283,6 @@ Resources:
           Value: !Sub ${AWS::StackName}-alb-access-logs
         - Key: waf.fail_open.enabled
           Value: true
-
-  HTTPListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      LoadBalancerArn: !Ref ALB
-      Port: 80
-      Protocol: HTTP
-      DefaultActions:
-      - Type: forward
-        TargetGroupArn: !Ref ALBTargetGroup
-
   HTTPSListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:


### PR DESCRIPTION
Switch Load Balancer to Security Group that only permits HTTP requests forwarded from CloudFront Distributions.
https://codedotorg.atlassian.net/browse/INF-1593

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Provision a Full Stack adhoc:
 `bundle exec rake adhoc:full_stack:start RAILS_ENV=adhoc STACK_NAME=adhoc-test-restrict-requests ALARMS=yes VERBOSE=true`

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
