### PR TITLE
CMS-427: Fix Accordion component clipped corners

### DIFF
--- a/frontend/packages/component-library/src/accordion/accordion.module.scss
+++ b/frontend/packages/component-library/src/accordion/accordion.module.scss
@@ -15,6 +15,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    overflow: hidden;
 
     border-radius: $regular-border-radius;
     border: 1px solid var(--borders-neutral-primary);
@@ -30,6 +31,7 @@
       background: var(--background-neutral-primary);
 
       i {
+        @include transition-all;
         color: var(--text-neutral-placeholder);
       }
 
@@ -64,7 +66,6 @@
     }
 
     summary:hover {
-      @include transition-all;
       background: var(--background-neutral-secondary);
 
       i {


### PR DESCRIPTION
|              | Accordion |
| ---:       | :---:           |
| Before | <img width="100%" alt="before" src="https://github.com/user-attachments/assets/2b4b2a88-a484-4b1a-919e-37ca3c2aceff" /> |
| After    | <img width="100%" alt="after" src="https://github.com/user-attachments/assets/af0b4598-1037-4741-85f4-58629c28e066" /> |

## Links
- JIRA task: [CMS-427](https://codedotorg.atlassian.net/browse/CMS-427)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/64200