### PR TITLE
Codebridge/Lab2: use props rather than level properties

### DIFF
--- a/apps/src/codebridge/InfoPanel/ForTeachersOnly.tsx
+++ b/apps/src/codebridge/InfoPanel/ForTeachersOnly.tsx
@@ -6,11 +6,11 @@ import TeacherOnlyMarkdown from '@cdo/apps/templates/instructions/TeacherOnlyMar
 
 const ForTeachersOnly: React.FunctionComponent = () => {
   const {levelProperties} = useCodebridgeContext();
-  const teacherMarkdown = levelProperties.teacherMarkdown;
+  const {teacherMarkdown, predictSettings} = levelProperties;
 
   return (
     <div>
-      <PredictSolution />
+      <PredictSolution predictSettings={predictSettings} />
       <TeacherOnlyMarkdown content={teacherMarkdown} hideContainer={true} />
     </div>
   );

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -90,7 +90,7 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
           className={darkModeStyles.tertiaryButton}
         />
       )}
-      <VersionHistoryButton startSources={startSources} />
+      <VersionHistoryButton startSources={startSources} appName={appName} />
       {appName === 'pythonlab' && (
         <WithTooltip tooltipProps={feedbackTooltipProps}>
           <Button

--- a/apps/src/lab2/hooks/useHorizontalLayout.ts
+++ b/apps/src/lab2/hooks/useHorizontalLayout.ts
@@ -8,7 +8,6 @@ import {
   ColumnPanelConfig,
   RowPanelConfig,
 } from '@cdo/apps/lab2/views/components/layout/types';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 // The top Y coordinate of the panel. This is the height of the main page header.
 const PANEL_TOP_COORDINATE = 50;
@@ -18,6 +17,7 @@ interface UseHorizontalLayoutProps {
   rightTopPanel: RowPanelConfig;
   rightBottomPanel: RowPanelConfig;
   minRightPanelWidth: number;
+  appName: string;
 }
 /**
  * Hook that manages the layout of a lab with 3 resizable panels.
@@ -33,6 +33,7 @@ export const useHorizontalLayout = ({
   rightTopPanel,
   rightBottomPanel,
   minRightPanelWidth,
+  appName,
 }: UseHorizontalLayoutProps) => {
   const [rightPanelWidth, setRightPanelWidth] = useState<number | undefined>(
     undefined
@@ -46,7 +47,6 @@ export const useHorizontalLayout = ({
   const [rightBottomPanelHeight, setrightBottomPanelHeight] = useState<
     number | undefined
   >(rightBottomPanel.initialHeight);
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   const {
     position: rawLeftPanelWidth,

--- a/apps/src/lab2/hooks/useVerticalLayout.ts
+++ b/apps/src/lab2/hooks/useVerticalLayout.ts
@@ -4,7 +4,6 @@ import {useResizable} from 'react-resizable-layout';
 import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
 import {RESIZE_BAR_SIZE_PX} from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import {ColumnPanelConfig} from '@cdo/apps/lab2/views/components/layout/types';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 const TWO_RESIZE_BARS = RESIZE_BAR_SIZE_PX * 2;
 
@@ -12,6 +11,7 @@ interface UseVerticalLayoutProps {
   leftPanel: ColumnPanelConfig;
   middlePanel: ColumnPanelConfig;
   rightPanel: ColumnPanelConfig;
+  appName: string;
 }
 
 /**
@@ -25,6 +25,7 @@ export const useVerticalLayout = ({
   leftPanel,
   middlePanel,
   rightPanel,
+  appName,
 }: UseVerticalLayoutProps) => {
   const [leftPanelWidth, setLeftPanelWidth] = useState<number | undefined>(
     leftPanel.initialWidth
@@ -35,7 +36,6 @@ export const useVerticalLayout = ({
   const [rightPanelWidth, setRightPanelWidth] = useState<number | undefined>(
     rightPanel.initialWidth
   );
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   const {
     position: rawLeftPanelWidth,

--- a/apps/src/lab2/views/components/PredictSolution.tsx
+++ b/apps/src/lab2/views/components/PredictSolution.tsx
@@ -8,28 +8,19 @@ import {
   LevelPredictSettings,
   PredictQuestionType,
 } from '@cdo/apps/lab2/levelEditors/types';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import commonI18n from '@cdo/locale';
 
 import moduleStyles from './predict.module.scss';
 
 // Component that displays the solution to a predict question.
 // The backend will only send the solution if the user has permission to see it.
-const PredictSolution: React.FunctionComponent = () => {
-  const predictSettings = useAppSelector(
-    state => state.lab.levelProperties?.predictSettings
-  );
-
-  return <UnconnectedPredictSolution predictSettings={predictSettings} />;
-};
-
-interface UnconnectedPredictSolutionProps {
+interface PredictSolutionProps {
   predictSettings: LevelPredictSettings | undefined;
 }
 
-export const UnconnectedPredictSolution: React.FunctionComponent<
-  UnconnectedPredictSolutionProps
-> = ({predictSettings}) => {
+export const PredictSolution: React.FunctionComponent<PredictSolutionProps> = ({
+  predictSettings,
+}) => {
   if (!predictSettings?.solution) {
     return null;
   }

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
@@ -18,6 +18,7 @@ import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
 interface VersionHistoryProps {
   startSources: ProjectSources;
   updatedSourceCallback?: (source: ProjectSources) => void;
+  appName: string;
 }
 
 /**
@@ -26,6 +27,7 @@ interface VersionHistoryProps {
 const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
   startSources,
   updatedSourceCallback,
+  appName,
 }) => {
   const [isVersionListLoaded, setIsVersionListLoaded] = useState(false);
   const [versionList, setVersionList] = useState<ProjectVersion[]>([]);
@@ -117,6 +119,7 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
           listLoading={loading}
           selectedVersion={selectedVersion}
           setSelectedVersion={setSelectedVersion}
+          appName={appName}
         />
       )}
     </div>

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -50,6 +50,7 @@ interface VersionHistoryDropdownProps {
   listLoadError: boolean;
   selectedVersion: string;
   setSelectedVersion: (version: string) => void;
+  appName: string;
 }
 
 const INITIAL_VERSION_ID = 'initial-version';
@@ -73,6 +74,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
   listLoadError,
   selectedVersion,
   setSelectedVersion,
+  appName,
 }) => {
   const [versionLoadError, setVersionLoadError] = useState(false);
   const [versionLoading, setVersionLoading] = useState(false);
@@ -87,7 +89,6 @@ const VersionHistoryDropdown: React.FunctionComponent<
   const viewingOldVersion = useAppSelector(
     state => state.lab2Project.viewingOldVersion
   );
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
   const [dropdownStyles, setDropdownStyles] = useState<React.CSSProperties>({});
 
   // If this is a teacher viewing a student's project, we hide the restore button,

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -42,6 +42,7 @@ const HorizontalLayout: React.FunctionComponent = () => {
       name: 'output',
     },
     minRightPanelWidth: MIN_RIGHT_PANEL_WIDTH,
+    appName: 'pythonlab',
   });
 
   return (

--- a/apps/src/pythonlab/layout/VerticalLayout.tsx
+++ b/apps/src/pythonlab/layout/VerticalLayout.tsx
@@ -39,6 +39,7 @@ const VerticalLayout: React.FunctionComponent = () => {
       minWidth: MIN_OUTPUT_WIDTH,
       name: 'output',
     },
+    appName: 'pythonlab',
   });
 
   return (

--- a/apps/src/weblab2/layout/HorizontalLayout.tsx
+++ b/apps/src/weblab2/layout/HorizontalLayout.tsx
@@ -39,6 +39,7 @@ const HorizontalLayout: React.FunctionComponent = () => {
       name: 'preview',
     },
     minRightPanelWidth: MIN_RIGHT_PANEL_WIDTH,
+    appName: 'weblab2',
   });
 
   return (

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -36,6 +36,7 @@ const VerticalLayout: React.FunctionComponent = () => {
       initialWidth: INITIAL_PREVIEW_WIDTH,
       name: 'preview',
     },
+    appName: 'weblab2',
   });
 
   return (

--- a/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryButtonTest.tsx
+++ b/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryButtonTest.tsx
@@ -75,7 +75,10 @@ describe('VersionHistoryButton', () => {
   function renderDefault() {
     return render(
       <Provider store={store}>
-        <VersionHistoryButton startSources={{source: ''}} />
+        <VersionHistoryButton
+          startSources={{source: ''}}
+          appName={'pythonlab'}
+        />
       </Provider>
     );
   }

--- a/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryDropdownTest.tsx
+++ b/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryDropdownTest.tsx
@@ -68,6 +68,7 @@ describe('VersionHistoryButton', () => {
           listLoadError={false}
           selectedVersion={'abc'}
           setSelectedVersion={setSelectedVersion}
+          appName={'pythonlab'}
         />
       </Provider>
     );
@@ -104,6 +105,7 @@ describe('VersionHistoryButton', () => {
           listLoadError={false}
           selectedVersion={'2'}
           setSelectedVersion={setSelectedVersion}
+          appName={'pythonlab'}
         />
       </Provider>
     );

--- a/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryDropdownTest.tsx
+++ b/apps/test/unit/lab2/views/components/versionHistory/VersionHistoryDropdownTest.tsx
@@ -145,6 +145,7 @@ describe('VersionHistoryButton', () => {
           listLoadError={false}
           selectedVersion={'initial-version'}
           setSelectedVersion={setSelectedVersion}
+          appName={'pythonlab'}
         />
       </Provider>
     );
@@ -168,6 +169,7 @@ describe('VersionHistoryButton', () => {
           listLoadError={false}
           selectedVersion={'3'} // 3 is latest version
           setSelectedVersion={setSelectedVersion}
+          appName={'pythonlab'}
         />
       </Provider>
     );


### PR DESCRIPTION
Update shared lab2 components that are only used by codebridge to take in specific props rather than fetching fields from the redux level properties. This updates the following components/hooks:
- `useVerticalLayout`/`useHorizontalLayout`: take in an `appName` prop
- `VersionHistoryButton`/`VersionHistoryDropdown`: take in `appName`
- `PredictSolution`: take in `predictSettings`

## Links

- jira ticket: [CT-1127](https://codedotorg.atlassian.net/browse/CT-1127)


## Testing story
Tested locally and via unit tests.

## Follow-up work
There are some remaining shared lab2 components/thunks that fetch level properties from redux, but they are all shared components. So I am leaving them as-is until we have converted the other lab2 labs.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
