### PR TITLE
feat(marketing): add validations to FAQ Accordion and Video Carousel components

### DIFF
--- a/frontend/apps/marketing/src/components/carousels/videoCarousel/videoCarouselContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/carousels/videoCarousel/videoCarouselContentfulDefinition.ts
@@ -19,6 +19,10 @@ export const VideoCarouselContentfulComponentDefinition: ComponentDefinition = {
     slides: {
       displayName: 'Video slides',
       type: 'Array',
+      validations: {
+        required: true,
+        bindingSourceType: ['entry'],
+      },
     },
   },
 };

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordionContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordionContentfulDefinition.ts
@@ -20,6 +20,10 @@ export const FAQAccordionContentfulComponentDefinition: ComponentDefinition = {
     faqs: {
       displayName: 'FAQs',
       type: 'Array',
+      validations: {
+        required: true,
+        bindingSourceType: ['entry'],
+      },
     },
   },
 };


### PR DESCRIPTION
Adds validations for `required` and `bindingSourceType` on the FAQ Accordion and Video Carousel components in Contentful. This will only allow content "Entries"  to be added, but not other types of content like Assets (media), Experiences (other page experiences), or Manual (text box) that don't fit within the component's structure or purpose.

## Links
Jira tickets: [CMS-431](https://codedotorg.atlassian.net/browse/CMS-431), [CMS-432](https://codedotorg.atlassian.net/browse/CMS-432)
Related GitHub comment: [here](https://github.com/code-dot-org/code-dot-org/pull/64593#discussion_r1999304528)

----

### FAQ Accordion
<img width="1733" alt="Screenshot 2025-03-24 at 12 22 48 PM" src="https://github.com/user-attachments/assets/ca2441f9-da97-4e5e-a9e1-29af40e1222b" />

## Video Carousel
<img width="1732" alt="Screenshot 2025-03-24 at 12 26 35 PM" src="https://github.com/user-attachments/assets/cc26cfc2-d24b-4505-a230-e7a5cd1b4dae" />
