### PR TITLE
SUM - add toggle to FR summary page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2791,6 +2791,7 @@
   "sharingBlockedByTeacher": "Sorry, you do not have permissions to share this project. If you want to be able to share your project, please ask your teacher to enable sharing of App Lab / Game Lab / Web Lab projects for your section from the 'Manage students' tab in their dashboard. They can do this by adding the project sharing column from the Actions settings menu.",
   "sharingDisabled": "Sorry, this project is not available for sharing. If this is your project or the project of one of your students, please [sign in]({sign_in_url}) to your account to view the project.",
   "show": "Show",
+  "showAiInsights": "Show AI Insights",
   "showAllLessons": "Show All Lessons",
   "showAnswer": "Show answer",
   "showAnswers": "Show answers",

--- a/apps/src/templates/levelSummary/FreeResponseResponses.jsx
+++ b/apps/src/templates/levelSummary/FreeResponseResponses.jsx
@@ -10,23 +10,11 @@ import React, {useEffect} from 'react';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {getFullName} from '@cdo/apps/templates/manageStudents/utils.ts';
-import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
-
-import FreeResponseAIEvaluation from './FreeResponseAIEvaluation';
 
 import styles from './summary.module.scss';
 
-const FreeResponseResponses = ({
-  responses,
-  showStudentNames,
-  eventData,
-  unitName,
-}) => {
-  const levelData = {
-    levelId: eventData.levelId,
-    unitId: eventData.unitId,
-  };
+const FreeResponseResponses = ({responses, showStudentNames, eventData}) => {
   const constructStudentName = response =>
     getFullName(response.student_display_name, response.student_family_name);
 
@@ -122,16 +110,6 @@ const FreeResponseResponses = ({
     </div>
   );
 
-  const AiEvaluationMVPUnits = ['csp4-2024', 'csp6-2024'];
-  const showAIAnalysis =
-    experiments.isEnabled(experiments.FREE_RESPONSE_AI_ANALYSIS) &&
-    AiEvaluationMVPUnits.includes(unitName);
-  const responsesForAi = responses.map(response => ({
-    studentId: response.user_id,
-    studentDisplayName: response.student_display_name,
-    studentWork: response.text,
-  }));
-
   return (
     <div className={styles.studentResponsesContent}>
       {pinnedResponses.length > 0 && (
@@ -225,12 +203,6 @@ const FreeResponseResponses = ({
             numHiddenResponses: hiddenResponses.length,
           })}
           type="gray"
-        />
-      )}
-      {showAIAnalysis && (
-        <FreeResponseAIEvaluation
-          responses={responsesForAi}
-          levelData={levelData}
         />
       )}
     </div>

--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -11,9 +11,9 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
+import FreeResponseAIEvaluation from './FreeResponseAIEvaluation';
 import FreeResponseResponses from './FreeResponseResponses';
 import MultiResponses from './MultiResponses';
-import FreeResponseAIEvaluation from './FreeResponseAIEvaluation';
 
 import styles from './summary.module.scss';
 

--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -8,10 +8,12 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {PredictQuestionType} from '@cdo/apps/lab2/levelEditors/types';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
 import FreeResponseResponses from './FreeResponseResponses';
 import MultiResponses from './MultiResponses';
+import FreeResponseAIEvaluation from './FreeResponseAIEvaluation';
 
 import styles from './summary.module.scss';
 
@@ -41,6 +43,7 @@ const SummaryResponses = ({
     predictSettings?.questionType === PredictQuestionType.MultipleChoice;
   const [showCorrectAnswer, setShowCorrectAnswer] = useState(false);
   const [showStudentNames, setShowStudentNames] = useState(false);
+  const [showAIAnalysis, setShowAIAnalysis] = useState(false);
 
   // To avoid confusion, if a teacher tries to view the summary as a student,
   // send them back to the level in Participant mode instead.
@@ -114,6 +117,29 @@ const SummaryResponses = ({
     setShowStudentNames(prevShowStudentNames => !prevShowStudentNames);
   };
 
+  const levelData = {
+    levelId: scriptData.levels[levelNumber].id,
+    unitId: scriptData.reportingData.unitId,
+  };
+  const toggleAIAnalysis = () => {
+    setShowAIAnalysis(prevShowAIAnalysis => !prevShowAIAnalysis);
+  };
+
+  const freeResponseResponses = isFreeResponse
+    ? scriptData.responses[levelNumber]
+    : null;
+
+  const responsesForAi = freeResponseResponses?.map(response => ({
+    studentId: response.user_id,
+    studentDisplayName: response.student_display_name,
+    studentWork: response.text,
+  }));
+
+  const AiEvaluationMVPUnits = ['csp4-2024', 'csp6-2024'];
+  const aiAnalysisAvailable =
+    experiments.isEnabled(experiments.FREE_RESPONSE_AI_ANALYSIS) &&
+    AiEvaluationMVPUnits.includes(scriptData.reportingData.unitName);
+
   return (
     <div className={styles.summaryContainer} id="summary-container">
       {/* Student Responses */}
@@ -163,22 +189,41 @@ const SummaryResponses = ({
             </div>
           )}
           {isFreeResponse && (
-            <Toggle
-              onChange={toggleNames}
-              checked={showStudentNames}
-              label={i18n.showStudentNames()}
-              position={'right'}
-              size={'s'}
-              name={'showStudentNames'}
-            />
+            <div className={styles.toggleGroup}>
+              <Toggle
+                onChange={toggleNames}
+                checked={showStudentNames}
+                label={i18n.showStudentNames()}
+                position={'right'}
+                size={'s'}
+                name={'showStudentNames'}
+              />
+              {aiAnalysisAvailable && (
+                <Toggle
+                  onChange={toggleAIAnalysis}
+                  checked={showAIAnalysis}
+                  label={i18n.showAiInsights()}
+                  position={'right'}
+                  size={'s'}
+                  name={'showAIAnalysis'}
+                />
+              )}
+            </div>
           )}
         </div>
+
+        {/* AI Analysis */}
+        {isFreeResponse && showAIAnalysis && (
+          <FreeResponseAIEvaluation
+            responses={responsesForAi}
+            levelData={levelData}
+          />
+        )}
 
         {/* Free response visualization */}
         {isFreeResponse && (
           <FreeResponseResponses
-            responses={scriptData.responses[levelNumber]}
-            unitName={scriptData.reportingData.unitName}
+            responses={freeResponseResponses}
             showStudentNames={showStudentNames}
             eventData={eventData}
           />

--- a/apps/src/templates/levelSummary/summary.module.scss
+++ b/apps/src/templates/levelSummary/summary.module.scss
@@ -75,6 +75,11 @@ label.sectionSelector {
   float: right;
 }
 
+.toggleGroup {
+  display: flex;
+  gap: 20px;
+}
+
 [dir='rtl'] .toggleContainer {
   float: left;
 }
@@ -129,7 +134,6 @@ label.sectionSelector {
     column-gap: 48px;
     padding-top: 40px;
     padding-bottom: 12px;
-
   }
 
   .pinResponsesSection {
@@ -173,7 +177,7 @@ label.sectionSelector {
   }
 
   .unpinnedResponse {
-    background-color: #F6EDFD;
+    background-color: #f6edfd;
   }
 
   .studentAnswer {


### PR DESCRIPTION
Adds working toggle to the FR summary page.

Video shows enabled and disabled experiment flag on FR and MC pages. 


https://github.com/user-attachments/assets/3ae1668a-c3ea-488d-a688-9f5e24a79b4b




To-dos:
- Add "Experiment" tag
- Modify UI for the AI summary.
- Add Unit tests

## Links

[Figma](https://www.figma.com/design/i3smpK0bu5Tnc1JgmmMfTI/Check-For-Understanding-Summaries?node-id=2702-9718&m=dev)
[Ticket](https://codedotorg.atlassian.net/browse/TEACH-1719)


## Testing story

I checked that the existing tests still work.  Once I have more of the functionality working I will add unit tests.