### PR TITLE
add alarm for high frontend memory usage

### DIFF
--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -271,7 +271,7 @@ frontend_device_name ||= '/dev/sda1'
         instances. Further investigation is required to identify the cause.
       ActionsEnabled: true
       AlarmActions:
-          - !Ref InfraUrgent
+          - !Ref <% rack_env?(:production) ? "InfraUrgent" : "InfraWorkdayUrgent" %>
       MetricName: mem_used_percent
       Namespace: CWAgent
       Statistic: Maximum

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -258,3 +258,29 @@ frontend_device_name ||= '/dev/sda1'
                 Action: 'sns:Publish'
                 Resource: !Ref WebServerHookTopicNew
       PermissionsBoundary: !ImportValue IAM-DevPermissions
+
+  FrontendHighMemoryAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}_web_server_high_memory
+      AlarmDescription: |
+        Memory on a Frontend web server instance is too high. Investigate to
+        see which instance is reporting high memory. Replace the instance. This
+        alarm may be caused by a memory leak or issue on one specific instance,
+        or as a result of particularly high memory consuming traffic across all
+        instances. Further investigation is required to identify the cause.
+      ActionsEnabled: true
+      AlarmActions:
+          - !Ref InfraUrgent
+      MetricName: mem_used_percent
+      Namespace: CWAgent
+      Statistic: Maximum
+      Dimensions:
+          - Name: AutoScalingGroupName
+            Value: !Ref Frontends
+      Period: 10
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 5
+      Threshold: 87
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: ignore


### PR DESCRIPTION
Moving a manually created alarm to Cloudformation. We're also switching this to notify InfraUrgent instead of the DOTD.

I chose to add this here instead of "alarms.yml.erb" because it is entirely associated with the autoscaling group created in "ami.yml.erb" and it eliminates the need for new conditional blocks in "alarms.yml.erb". Note that the "ami" resources are only loaded inside an `if frontends` block. We took a similar approach in "session-store.yml.erb".

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
