### PR TITLE
Replace older version history buttons with Design System buttons.

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -90,7 +90,7 @@ After setup, [configure your editor](#editor-configuration), read about our [cod
 ### For Code.org Staff
 
 Staff should see instructions for requesting AWS account access in our "AWS Account Access" doc linked from "Getting started as a Developer", and follow the setup steps in the "API access (for local development)" section.
-Some functionality will not work on your local site without this, for example, some project-backed level types such as <https://studio.code.org/projects/gamelab>. 
+Some functionality will not work on your local site without this, for example, some project-backed level types such as <https://studio.code.org/projects/gamelab>.
 ### For external contributors
 
 External contributors can supply alternate placeholder values for secrets normally retrieved from AWS Secrets Manager by creating a file named "locals.yml", copying contents from ["locals.yml.default"](locals.yml.default) and uncommenting following configurations to use placeholder values
@@ -98,7 +98,6 @@ External contributors can supply alternate placeholder values for secrets normal
 ```
 slack_bot_token: localoverride
 pardot_private_key: localoverride
-openai_student_learning_api_key: localoverride
 properties_encryption_key: ''
 ```
 
@@ -106,7 +105,7 @@ properties_encryption_key: ''
 
 ### macOS
 
-These steps are for Apple devices running **macOS 14.x**, including those running on [Apple Silicon (M1|M2|M3) ARM architecture CPUs](https://en.wikipedia.org/wiki/Apple_silicon#M_series). 
+These steps are for Apple devices running **macOS 14.x**, including those running on [Apple Silicon (M1|M2|M3) ARM architecture CPUs](https://en.wikipedia.org/wiki/Apple_silicon#M_series).
 
 1. Open a Terminal.
 
@@ -115,7 +114,7 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
     xcode-select --install
     ```
 
-1. Install **[brew](https://brew.sh/)**: 
+1. Install **[brew](https://brew.sh/)**:
    ```
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
    ```
@@ -138,7 +137,7 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
        ```
        ==> Successfully started `redis` (label: homebrew.mxcl.redis)
        ```
-   3. macOS will notify you that `redis` has been configured to start automatically upon user login. Confirm this in System Settings --> General --> Login Items --> `redis-server` 
+   3. macOS will notify you that `redis` has been configured to start automatically upon user login. Confirm this in System Settings --> General --> Login Items --> `redis-server`
 1. Setup your local **MySQL database server**
    1. Link MySQL 8
         ```
@@ -166,7 +165,7 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
         ```
 
 1.  Install **Ruby**
-    1. Configure zsh to load rbenv ([other shells](https://github.com/rbenv/rbenv#basic-git-checkoutshells)): 
+    1. Configure zsh to load rbenv ([other shells](https://github.com/rbenv/rbenv#basic-git-checkoutshells)):
         ```
         echo 'eval "$(rbenv init - zsh)"' >> ~/.zshrc && source ~/.zshrc
         ```
@@ -213,7 +212,7 @@ Note: Virtual Machine Users should check the [Alternative note](#alternative-use
 1. `sudo apt-get update`
 1. `sudo apt-get install -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-11-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk enscript build-essential redis-server rbenv chromium-browser parallel python3-pip`
     * **Hit enter and select default options for any configuration popups, leaving mysql passwords blank**
-    <details> 
+    <details>
       <summary>Troubleshoot: <code>E: Package 'pdftk' has no installation candidate</code>.</summary>
       - If you run into this error, remove `pdftk` from the previous command and run it again. Then try installing `pdftk` another way:
           - Ubuntu 18.04: `sudo snap install pdftk`.
@@ -226,10 +225,10 @@ Note: Virtual Machine Users should check the [Alternative note](#alternative-use
         ```
         if [ -f ~/.bashrc ]; then
           source ~/.bashrc
-        fi     
+        fi
         ```
 1. Install git-lfs >= 3.0
-    1. The default version of git-lfs in Ubuntu 20.04 is 2.9. This does not have support for Git SSH operations. Therefore, you'll want to add packagecloud.io apt repositories to your system to get a newer version of Git LFS (this step is not required if using Ubuntu >= 22.04): 
+    1. The default version of git-lfs in Ubuntu 20.04 is 2.9. This does not have support for Git SSH operations. Therefore, you'll want to add packagecloud.io apt repositories to your system to get a newer version of Git LFS (this step is not required if using Ubuntu >= 22.04):
         `curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash`
     1. `apt-get install git-lfs`
     1. Ensure `git-lfs --version` is >= 3.0. Git LFS < 3.0 only supports HTTPS, not SSH.
@@ -278,7 +277,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
     1. `wsl --set-default-version 2`
         1. You may need to [update the WSL 2 Linux kernel](https://docs.microsoft.com/en-us/windows/wsl/wsl2-kernel)
 1. Make sure virtualization is turned on your BIOS settings.
-1. Install [Ubuntu 20.04](https://www.microsoft.com/store/productId/9NBLGGH4MSV6) or [Ubuntu 22.04.3 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW) 
+1. Install [Ubuntu 20.04](https://www.microsoft.com/store/productId/9NBLGGH4MSV6) or [Ubuntu 22.04.3 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW)
     * If you want to follow the Ubuntu setup exactly, Ubuntu 18.04 is available from the [Microsoft docs](https://docs.microsoft.com/en-us/windows/wsl/install-manual).
 1. From the command line, run `wsl`, or from the Start menu, find and launch 'Ubuntu'. When this runs for the first time, WSL will complete installation in the resulting terminal window.
 1. Optionally configure your **zsh** experience. [instructions](https://itsfoss.com/zsh-ubuntu/)
@@ -293,7 +292,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
             1. `wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb`
             1. `sudo apt install ./google-chrome-stable_current_amd64.deb`
             1. Add `export CHROME_BIN=$(which google-chrome)` to your `~/.bashrc` or desired shell configuration file.
-        
+
 1. Follow the [Ubuntu instructions](#ubuntu-2004) to install required tools on the Ubuntu instance, _with the following modifications_:
     * There is an ongoing clock skew issue going on with wsl. This can cause issues with `apt update`, ssl certs, among other things. You can force your clock to sync with `sudo hwclock -s` to fix these issues temporarily. See the [megathread](https://github.com/microsoft/WSL/issues/10006) for more details.
     * Skip exporting `CHROME_BIN` since you already did so above.
@@ -318,7 +317,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
   1. From the [EC2 Homepage](https://console.aws.amazon.com/ec2), click on "Launch Instance" and follow the wizard:
      * **Step 1: Choose AMI**: Select Ubuntu Server 20.04
      * **Step 2: Choose instance type**: Choose at least 16 GiB memory (e.g. `t2.xlarge`)
-     * **Step 3: Configure Instance**: 
+     * **Step 3: Configure Instance**:
        * Set IAM Instance Profile to `DeveloperEC2`
        * Set VPC to `vpc-a48462c3`
      * **Step 4: Storage**: Increase storage to 100GiB
@@ -326,7 +325,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
   1. Connect to the instance by selecting the instance in the AWS EC2 dashboard and clicking "Connect". Follow the provided instructions in order to connect via ssh or PuTTY. Upon completing this step, you should be able to connect to your instance via a command like `ssh -i <keyname>.pem <public-dns-name>`.
   1. Optionally, update your ssh config so that you can connect using a shorter command:
      * move your private key to `~/.ssh/<keyname>.pem`
-     * add the following lines to ~/.ssh/config:     
+     * add the following lines to ~/.ssh/config:
        ```
        Host yourname-ec2
          Hostname <public-dns-name>
@@ -342,7 +341,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
 
 ## Piskel
 ### Local Development Between code-dot-org and forked piskel repo
-If you want the Code.org repo to point to the local version of the Piskel you are working on, your apps package must be linked to a local development copy of the Piskel repository with a complete dev build. 
+If you want the Code.org repo to point to the local version of the Piskel you are working on, your apps package must be linked to a local development copy of the Piskel repository with a complete dev build.
 
 **[You can also find the steps below in apps/Gruntfile.js of the code-dot-org repo](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/Gruntfile.js)**
 
@@ -412,7 +411,7 @@ Wondering where to start?  See our [contribution guidelines](CONTRIBUTING.md) fo
 
 **Note:** Most developers won't need to peronsonalize certificates locally, but some will.  Here are notes on getting this working on macOS.
 
-Certificates have been greatly improved with the ability to apply text in many languages.  
+Certificates have been greatly improved with the ability to apply text in many languages.
 
 This is done by using “pango”.  It seems on Linux machines, ImageMagick already contains Pango, but on macOS it doesn’t... at least as installed using brew.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -90,7 +90,7 @@ After setup, [configure your editor](#editor-configuration), read about our [cod
 ### For Code.org Staff
 
 Staff should see instructions for requesting AWS account access in our "AWS Account Access" doc linked from "Getting started as a Developer", and follow the setup steps in the "API access (for local development)" section.
-Some functionality will not work on your local site without this, for example, some project-backed level types such as <https://studio.code.org/projects/gamelab>.
+Some functionality will not work on your local site without this, for example, some project-backed level types such as <https://studio.code.org/projects/gamelab>. 
 ### For external contributors
 
 External contributors can supply alternate placeholder values for secrets normally retrieved from AWS Secrets Manager by creating a file named "locals.yml", copying contents from ["locals.yml.default"](locals.yml.default) and uncommenting following configurations to use placeholder values
@@ -105,7 +105,7 @@ properties_encryption_key: ''
 
 ### macOS
 
-These steps are for Apple devices running **macOS 14.x**, including those running on [Apple Silicon (M1|M2|M3) ARM architecture CPUs](https://en.wikipedia.org/wiki/Apple_silicon#M_series).
+These steps are for Apple devices running **macOS 14.x**, including those running on [Apple Silicon (M1|M2|M3) ARM architecture CPUs](https://en.wikipedia.org/wiki/Apple_silicon#M_series). 
 
 1. Open a Terminal.
 
@@ -114,7 +114,7 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
     xcode-select --install
     ```
 
-1. Install **[brew](https://brew.sh/)**:
+1. Install **[brew](https://brew.sh/)**: 
    ```
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
    ```
@@ -137,7 +137,7 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
        ```
        ==> Successfully started `redis` (label: homebrew.mxcl.redis)
        ```
-   3. macOS will notify you that `redis` has been configured to start automatically upon user login. Confirm this in System Settings --> General --> Login Items --> `redis-server`
+   3. macOS will notify you that `redis` has been configured to start automatically upon user login. Confirm this in System Settings --> General --> Login Items --> `redis-server` 
 1. Setup your local **MySQL database server**
    1. Link MySQL 8
         ```
@@ -165,7 +165,7 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
         ```
 
 1.  Install **Ruby**
-    1. Configure zsh to load rbenv ([other shells](https://github.com/rbenv/rbenv#basic-git-checkoutshells)):
+    1. Configure zsh to load rbenv ([other shells](https://github.com/rbenv/rbenv#basic-git-checkoutshells)): 
         ```
         echo 'eval "$(rbenv init - zsh)"' >> ~/.zshrc && source ~/.zshrc
         ```
@@ -212,7 +212,7 @@ Note: Virtual Machine Users should check the [Alternative note](#alternative-use
 1. `sudo apt-get update`
 1. `sudo apt-get install -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-11-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk enscript build-essential redis-server rbenv chromium-browser parallel python3-pip`
     * **Hit enter and select default options for any configuration popups, leaving mysql passwords blank**
-    <details>
+    <details> 
       <summary>Troubleshoot: <code>E: Package 'pdftk' has no installation candidate</code>.</summary>
       - If you run into this error, remove `pdftk` from the previous command and run it again. Then try installing `pdftk` another way:
           - Ubuntu 18.04: `sudo snap install pdftk`.
@@ -225,10 +225,10 @@ Note: Virtual Machine Users should check the [Alternative note](#alternative-use
         ```
         if [ -f ~/.bashrc ]; then
           source ~/.bashrc
-        fi
+        fi     
         ```
 1. Install git-lfs >= 3.0
-    1. The default version of git-lfs in Ubuntu 20.04 is 2.9. This does not have support for Git SSH operations. Therefore, you'll want to add packagecloud.io apt repositories to your system to get a newer version of Git LFS (this step is not required if using Ubuntu >= 22.04):
+    1. The default version of git-lfs in Ubuntu 20.04 is 2.9. This does not have support for Git SSH operations. Therefore, you'll want to add packagecloud.io apt repositories to your system to get a newer version of Git LFS (this step is not required if using Ubuntu >= 22.04): 
         `curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash`
     1. `apt-get install git-lfs`
     1. Ensure `git-lfs --version` is >= 3.0. Git LFS < 3.0 only supports HTTPS, not SSH.
@@ -277,7 +277,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
     1. `wsl --set-default-version 2`
         1. You may need to [update the WSL 2 Linux kernel](https://docs.microsoft.com/en-us/windows/wsl/wsl2-kernel)
 1. Make sure virtualization is turned on your BIOS settings.
-1. Install [Ubuntu 20.04](https://www.microsoft.com/store/productId/9NBLGGH4MSV6) or [Ubuntu 22.04.3 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW)
+1. Install [Ubuntu 20.04](https://www.microsoft.com/store/productId/9NBLGGH4MSV6) or [Ubuntu 22.04.3 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW) 
     * If you want to follow the Ubuntu setup exactly, Ubuntu 18.04 is available from the [Microsoft docs](https://docs.microsoft.com/en-us/windows/wsl/install-manual).
 1. From the command line, run `wsl`, or from the Start menu, find and launch 'Ubuntu'. When this runs for the first time, WSL will complete installation in the resulting terminal window.
 1. Optionally configure your **zsh** experience. [instructions](https://itsfoss.com/zsh-ubuntu/)
@@ -292,7 +292,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
             1. `wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb`
             1. `sudo apt install ./google-chrome-stable_current_amd64.deb`
             1. Add `export CHROME_BIN=$(which google-chrome)` to your `~/.bashrc` or desired shell configuration file.
-
+        
 1. Follow the [Ubuntu instructions](#ubuntu-2004) to install required tools on the Ubuntu instance, _with the following modifications_:
     * There is an ongoing clock skew issue going on with wsl. This can cause issues with `apt update`, ssl certs, among other things. You can force your clock to sync with `sudo hwclock -s` to fix these issues temporarily. See the [megathread](https://github.com/microsoft/WSL/issues/10006) for more details.
     * Skip exporting `CHROME_BIN` since you already did so above.
@@ -317,7 +317,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
   1. From the [EC2 Homepage](https://console.aws.amazon.com/ec2), click on "Launch Instance" and follow the wizard:
      * **Step 1: Choose AMI**: Select Ubuntu Server 20.04
      * **Step 2: Choose instance type**: Choose at least 16 GiB memory (e.g. `t2.xlarge`)
-     * **Step 3: Configure Instance**:
+     * **Step 3: Configure Instance**: 
        * Set IAM Instance Profile to `DeveloperEC2`
        * Set VPC to `vpc-a48462c3`
      * **Step 4: Storage**: Increase storage to 100GiB
@@ -325,7 +325,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
   1. Connect to the instance by selecting the instance in the AWS EC2 dashboard and clicking "Connect". Follow the provided instructions in order to connect via ssh or PuTTY. Upon completing this step, you should be able to connect to your instance via a command like `ssh -i <keyname>.pem <public-dns-name>`.
   1. Optionally, update your ssh config so that you can connect using a shorter command:
      * move your private key to `~/.ssh/<keyname>.pem`
-     * add the following lines to ~/.ssh/config:
+     * add the following lines to ~/.ssh/config:     
        ```
        Host yourname-ec2
          Hostname <public-dns-name>
@@ -341,7 +341,7 @@ It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 
 
 ## Piskel
 ### Local Development Between code-dot-org and forked piskel repo
-If you want the Code.org repo to point to the local version of the Piskel you are working on, your apps package must be linked to a local development copy of the Piskel repository with a complete dev build.
+If you want the Code.org repo to point to the local version of the Piskel you are working on, your apps package must be linked to a local development copy of the Piskel repository with a complete dev build. 
 
 **[You can also find the steps below in apps/Gruntfile.js of the code-dot-org repo](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/Gruntfile.js)**
 
@@ -411,7 +411,7 @@ Wondering where to start?  See our [contribution guidelines](CONTRIBUTING.md) fo
 
 **Note:** Most developers won't need to peronsonalize certificates locally, but some will.  Here are notes on getting this working on macOS.
 
-Certificates have been greatly improved with the ability to apply text in many languages.
+Certificates have been greatly improved with the ability to apply text in many languages.  
 
 This is done by using “pango”.  It seems on Linux machines, ImageMagick already contains Pango, but on macOS it doesn’t... at least as installed using brew.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -98,6 +98,7 @@ External contributors can supply alternate placeholder values for secrets normal
 ```
 slack_bot_token: localoverride
 pardot_private_key: localoverride
+openai_student_learning_api_key: localoverride
 properties_encryption_key: ''
 ```
 

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -73,7 +73,7 @@ module.exports = FeedbackUtils;
  */
 
 /**
- * @typedef {{err, lineNumber: number}} ExecutionError
+ * @typedef {{ err, lineNumber: number}} ExecutionError
  */
 
 /**

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -73,7 +73,7 @@ module.exports = FeedbackUtils;
  */
 
 /**
- * @typedef {{ err, lineNumber: number}} ExecutionError
+ * @typedef {{err, lineNumber: number}} ExecutionError
  */
 
 /**

--- a/apps/src/templates/VersionHistory.jsx
+++ b/apps/src/templates/VersionHistory.jsx
@@ -1,3 +1,4 @@
+import {Button} from '@code-dot-org/component-library/button';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -212,14 +213,12 @@ export default class VersionHistory extends React.Component {
                       <p>{i18n.versionHistory_initialVersion_label()}</p>
                     </td>
                     <td width="250" style={{textAlign: 'right'}}>
-                      <button
-                        type="button"
-                        className="btn-danger"
+                      <Button
+                        text={i18n.versionHistory_clearProgress_confirm()}
+                        color="destructive"
+                        className="version-clear-progress"
                         onClick={this.onConfirmClearPuzzle}
-                        style={{float: 'right'}}
-                      >
-                        {i18n.versionHistory_clearProgress_confirm()}
-                      </button>
+                      />
                     </td>
                   </tr>
                 )}

--- a/apps/src/templates/VersionRow.jsx
+++ b/apps/src/templates/VersionRow.jsx
@@ -88,9 +88,9 @@ export default class VersionRow extends React.Component {
     } else {
       buttons.push(
         <LinkButton
-          key="disabled-view-button"
+          key={this.props.isSelectedVersion ? "disabled-view-button" : "not-selected-version-button"}
           color="purple"
-          disabled={true}
+          disabled={this.props.isSelectedVersion}
           href={
             location.origin + location.pathname + '?' + this.getQueryParams()
           }

--- a/apps/src/templates/VersionRow.jsx
+++ b/apps/src/templates/VersionRow.jsx
@@ -73,32 +73,20 @@ export default class VersionRow extends React.Component {
       );
     }
 
-    if (!this.props.isSelectedVersion) {
-      buttons.push(
-        <LinkButton
-          key="not-selected-version-button"
-          color="purple"
-          href={
-            location.origin + location.pathname + '?' + this.getQueryParams()
-          }
-          text={msg.view()}
-          target="_blank"
-        />
-      );
-    } else {
-      buttons.push(
-        <LinkButton
-          key={this.props.isSelectedVersion ? "disabled-view-button" : "not-selected-version-button"}
-          color="purple"
-          disabled={this.props.isSelectedVersion}
-          href={
-            location.origin + location.pathname + '?' + this.getQueryParams()
-          }
-          text={msg.view()}
-          target="_blank"
-        />
-      );
-    }
+    buttons.push(
+      <LinkButton
+        key={
+          this.props.isSelectedVersion
+            ? 'disabled-view-button'
+            : 'not-selected-version-button'
+        }
+        color="purple"
+        disabled={this.props.isSelectedVersion}
+        href={location.origin + location.pathname + '?' + this.getQueryParams()}
+        text={msg.view()}
+        target="_blank"
+      />
+    );
 
     return (
       <tr

--- a/apps/src/templates/VersionRow.jsx
+++ b/apps/src/templates/VersionRow.jsx
@@ -1,3 +1,4 @@
+import {Button, LinkButton} from '@code-dot-org/component-library/button';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
@@ -51,58 +52,51 @@ export default class VersionRow extends React.Component {
     let buttons = [];
     if (this.props.isLatest) {
       buttons.push(
-        <button
-          key={'latest-version-message'}
-          type="button"
-          className="btn-default"
-          disabled="disabled"
-          style={{cursor: 'default', background: 'none', border: 'none'}}
-        >
-          {msg.latestVersion()}
-        </button>
+        <Button
+          key="latest-version-message"
+          color="black"
+          type="tertiary"
+          onClick={() => {}}
+          text={msg.latestVersion()}
+        />
       );
     } else if (!this.props.isReadOnly) {
-      const className = this.props.isSelectedVersion
-        ? 'btn-info'
-        : 'img-upload';
       buttons.push(
-        <button
-          key={'restore-version-button'}
-          type="button"
-          className={className}
+        <Button
+          key="restore-version-button"
+          color="black"
+          type="secondary"
           onClick={this.props.onChoose}
-        >
-          {msg.restore()}
-        </button>
+          className="version-restore"
+          text={msg.restore()}
+        />
       );
     }
 
     if (!this.props.isSelectedVersion) {
       buttons.push(
-        <a
-          key={'not-selected-version-button'}
+        <LinkButton
+          key="not-selected-version-button"
+          color="purple"
           href={
             location.origin + location.pathname + '?' + this.getQueryParams()
           }
+          text={msg.view()}
           target="_blank"
-          rel="noopener noreferrer"
-        >
-          <button type="button" className="btn-info">
-            {msg.view()}
-          </button>
-        </a>
+        />
       );
     } else {
       buttons.push(
-        <button
-          key={'disabled-view-button'}
-          type="button"
-          className="btn-default"
-          disabled="disabled"
-          style={{cursor: 'default', color: 'white'}}
-        >
-          {msg.view()}
-        </button>
+        <LinkButton
+          key="disabled-view-button"
+          color="purple"
+          disabled={true}
+          href={
+            location.origin + location.pathname + '?' + this.getQueryParams()
+          }
+          text={msg.view()}
+          target="_blank"
+        />
       );
     }
 
@@ -120,7 +114,10 @@ export default class VersionRow extends React.Component {
             })}
           </p>
         </td>
-        <td width="275" height="52" style={{textAlign: 'right'}}>
+        <td
+          width="275"
+          style={{display: 'flex', justifyContent: 'flex-end', gap: '10px'}}
+        >
           {buttons}
         </td>
       </tr>

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1168,6 +1168,7 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
   }
   td {
     vertical-align: middle;
+    padding: 5px;
   }
   tr.highlight {
     background-color: $lightest_purple;

--- a/apps/test/unit/templates/VersionHistoryTest.jsx
+++ b/apps/test/unit/templates/VersionHistoryTest.jsx
@@ -165,14 +165,14 @@ describe('VersionHistory', () => {
       finishVersionHistoryLoad();
       expect(restoreSpy()).not.toHaveBeenCalled();
 
-      wrapper.find('.img-upload').first().simulate('click');
+      wrapper.find('.version-restore button').first().simulate('click');
       expect(restoreSpy()).toHaveBeenCalledTimes(1);
     });
 
     it('renders an error on failed restore', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
-      wrapper.find('.img-upload').first().simulate('click');
+      wrapper.find('.version-restore button').first().simulate('click');
 
       failRestoreVersion();
       expect(wrapper.text()).toContain('An error occurred.');
@@ -181,7 +181,7 @@ describe('VersionHistory', () => {
     it('reloads the page on successful restore', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
-      wrapper.find('.img-upload').first().simulate('click');
+      wrapper.find('.version-restore button').first().simulate('click');
       expect(utils.reload).not.toHaveBeenCalled();
 
       finishRestoreVersion();
@@ -193,7 +193,7 @@ describe('VersionHistory', () => {
       finishVersionHistoryLoad();
 
       // Click "Start Over"
-      wrapper.find('.btn-danger').simulate('click');
+      wrapper.find('.version-clear-progress button').simulate('click');
 
       // Expect confirmation to show
       expect(
@@ -219,7 +219,7 @@ describe('VersionHistory', () => {
       finishVersionHistoryLoad();
 
       // Click "Start Over"
-      wrapper.find('.btn-danger').simulate('click');
+      wrapper.find('.version-clear-progress button').simulate('click');
 
       // Expect confirmation to show
       expect(
@@ -251,7 +251,7 @@ describe('VersionHistory', () => {
       finishVersionHistoryLoad();
 
       // Click "Start Over"
-      wrapper.find('.btn-danger').simulate('click');
+      wrapper.find('.version-clear-progress button').simulate('click');
 
       expect(wrapper.find('.template-level-warning')).toBeDefined();
     });
@@ -270,7 +270,7 @@ describe('VersionHistory', () => {
           <VersionHistory {...props} handleClearPuzzle={handleClearPuzzle} />
         );
         finishVersionHistoryLoad();
-        wrapper.find('.btn-danger').simulate('click');
+        wrapper.find('.version-clear-progress button').simulate('click');
         wrapper.find('#start-over-button').simulate('click');
       });
 

--- a/apps/test/unit/templates/VersionRowTest.jsx
+++ b/apps/test/unit/templates/VersionRowTest.jsx
@@ -1,4 +1,5 @@
-import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {Button, LinkButton} from '@code-dot-org/component-library/button';
+import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
@@ -11,10 +12,11 @@ describe('VersionRow', () => {
   const MINIMUM_PROPS = {
     versionId: 'abcdef',
     lastModified: new Date(),
+    onChoose: () => {},
   };
 
   it('renders preview and restore buttons for a non-latest version', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <VersionRow
         {...MINIMUM_PROPS}
         isLatest={false}
@@ -24,21 +26,15 @@ describe('VersionRow', () => {
     );
     expect(wrapper).to.not.have.className('highlight');
     expect(wrapper).to.containMatchingElement(
-      <a target="_blank">
-        <button type="button" className="btn-info">
-          {msg.view()}
-        </button>
-      </a>
+      <LinkButton color="purple" text={msg.view()} target="_blank" />
     );
     expect(wrapper).to.containMatchingElement(
-      <button type="button" className="img-upload">
-        {msg.restore()}
-      </button>
+      <Button color="black" type="secondary" text={msg.restore()} />
     );
   });
 
   it('renders restore button and disabled view button for selected version', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <VersionRow
         {...MINIMUM_PROPS}
         isLatest={false}
@@ -48,19 +44,20 @@ describe('VersionRow', () => {
     );
     expect(wrapper).to.have.className('highlight');
     expect(wrapper).to.containMatchingElement(
-      <button type="button" className="btn-default">
-        {msg.view()}
-      </button>
+      <LinkButton
+        color="purple"
+        disabled={true}
+        text={msg.view()}
+        target="_blank"
+      />
     );
     expect(wrapper).to.containMatchingElement(
-      <button type="button" className="btn-info">
-        {msg.restore()}
-      </button>
+      <Button color="black" type="secondary" text={msg.restore()} />
     );
   });
 
   it('renders a disabled button for the latest version', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <VersionRow
         {...MINIMUM_PROPS}
         isLatest={true}
@@ -68,22 +65,15 @@ describe('VersionRow', () => {
         isReadOnly={false}
       />
     );
+
     expect(wrapper).to.containMatchingElement(
-      <button
-        key={'latest-version-message'}
-        type="button"
-        className="btn-default"
-        disabled="disabled"
-        style={{cursor: 'default', background: 'none', border: 'none'}}
-      >
-        {msg.latestVersion()}
-      </button>
+      <Button color="black" type="tertiary" text={msg.latestVersion()} />
     );
   });
 
   it('calls onChoose when restore button is clicked', () => {
     const onChoose = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = mount(
       <VersionRow
         {...MINIMUM_PROPS}
         isLatest={false}
@@ -94,7 +84,7 @@ describe('VersionRow', () => {
     );
     expect(onChoose).not.to.have.been.called;
 
-    wrapper.find('.img-upload').simulate('click');
+    wrapper.find('.version-restore button').simulate('click');
     expect(onChoose).to.have.been.calledOnce;
   });
 });

--- a/dashboard/test/ui/features/star_labs/applab/versions.feature
+++ b/dashboard/test/ui/features/star_labs/applab/versions.feature
@@ -67,7 +67,7 @@ Scenario: Project Load and Reload
   And I wait until element "div:contains(Latest Version)" is visible
 
   Then ".versionRow:nth-child(2) p" contains the saved text
-  And element ".versionRow:nth-child(2) .img-upload" contains text "Restore"
+  And element ".versionRow:nth-child(2) .version-restore button" contains text "Restore"
 
   And element "#showVersionsModal tr:contains(a minute ago):contains(Restore):eq(1)" is not visible
 
@@ -100,7 +100,7 @@ Scenario: Project Version Checkpoints
   # The version containing "comment A" is saved as a checkpoint, because the
   # project version interval time period had passed.
   Then ".versionRow:nth-child(2) p" contains the saved text
-  And element ".versionRow:nth-child(2) .img-upload" contains text "Restore"
+  And element ".versionRow:nth-child(2) .version-restore button" contains text "Restore"
 
 @no_mobile
 Scenario: Project page refreshes when other client adds a newer version

--- a/dashboard/test/ui/features/teacher_tools/version_history.feature
+++ b/dashboard/test/ui/features/teacher_tools/version_history.feature
@@ -24,7 +24,7 @@ Scenario: Teacher can view student versions
   And I press "versions-header"
   And I wait until element "div:contains(Latest Version)" is visible
   Then ".versionRow:nth-child(2) p" contains the saved text
-  And element ".versionRow:nth-child(2) .img-upload" contains text "Restore"
+  And element ".versionRow:nth-child(2) .version-restore button" contains text "Restore"
 
   # Teacher cannot restore a version
   Then I sign in as "Teacher_Ron"
@@ -35,8 +35,8 @@ Scenario: Teacher can view student versions
   And I dismiss the teacher panel
   And I press "versions-header"
   And I wait until element "div:contains(Latest Version)" is visible
-  And element ".versionRow:nth-child(1) .img-upload" does not contain text "Restore"
-  And element ".versionRow:nth-child(2) .img-upload" does not contain text "Restore"
+  And element ".versionRow:nth-child(1) .version-restore button" does not contain text "Restore"
+  And element ".versionRow:nth-child(2) .version-restore button" does not contain text "Restore"
 
 Scenario: Teacher can view own versions
   Given I create an authorized teacher-associated student named "Ron"
@@ -56,5 +56,5 @@ Scenario: Teacher can view own versions
   And I press "show-code-header"
   And I press "versions-header"
   And I wait until element "div:contains(Latest Version)" is visible
-  And element ".versionRow:nth-child(2) .img-upload" contains text "Restore"
+  And element ".versionRow:nth-child(2) .version-restore button" contains text "Restore"
   And I close the dialog

--- a/pegasus/sites.v3/code.org/public/project-ideas.md.partial
+++ b/pegasus/sites.v3/code.org/public/project-ideas.md.partial
@@ -95,7 +95,7 @@ students. Programming in a brand new environment can be challenging and
 intimidating. We recommend giving yourself sufficient time to learn to use
 them. Don't give up! Below you can find an overview of each tool and also how
 to practice using it. For more information about full course offerings, check
-out [CS Discoveries](https://code.org/educate/csd) for middle school or [CS
+out [CS Discoveries](https://code.org/educate/csd)for middle school or [CS
 Principles](https://code.org/educate/csp) for high school.
 
 ## [**Web Lab**](https://code.org/educate/weblab)

--- a/pegasus/sites.v3/code.org/public/project-ideas.md.partial
+++ b/pegasus/sites.v3/code.org/public/project-ideas.md.partial
@@ -95,7 +95,7 @@ students. Programming in a brand new environment can be challenging and
 intimidating. We recommend giving yourself sufficient time to learn to use
 them. Don't give up! Below you can find an overview of each tool and also how
 to practice using it. For more information about full course offerings, check
-out [CS Discoveries](https://code.org/educate/csd)for middle school or [CS
+out [CS Discoveries](https://code.org/educate/csd) for middle school or [CS
 Principles](https://code.org/educate/csp) for high school.
 
 ## [**Web Lab**](https://code.org/educate/weblab)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This change updates the buttons in the Version History modal to use buttons from the Design System Component Library, which better matches the styling in other parts of the site:

![Screenshot 2025-03-24 at 4 16 46 PM](https://github.com/user-attachments/assets/8031b1c5-e9c5-4268-a521-fd0486d0ba26)
<a href="https://github.com/user-attachments/assets/8031b1c5-e9c5-4268-a521-fd0486d0ba26" target="_blank">Click to see zoomed-in image</a>

I also made a few small corrections to issues I found while making the above change:
- Minor updates to SETUP.md, that should help future contributors with codebase setup.
- A text typo fix on the Project Ideas page.

## Links

No relevant links. 

## Testing story

Existing Unit tests and UI tests have been updated to target the updated components.

## Deployment strategy

## Follow-up work

No follow-up work is required for this, but the buttons in the "Start over" section of the modal are a natural next place to make this updates (since they are found in the same files):

![image](https://github.com/user-attachments/assets/2632ac78-80b8-4e9f-9b15-98753a8e2644)

## Privacy

No privacy impact.

## Security

No security impact.

## Caching

No caching impact.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
