### PR TITLE
Python Lab: show error if we fail to load packages

### DIFF
--- a/apps/i18n/pythonlab/en_us.json
+++ b/apps/i18n/pythonlab/en_us.json
@@ -3,6 +3,7 @@
   "codeEditor": "Code Editor",
   "console": "Console",
   "inputFailed": "We're sorry, input is unavailable at this time. Input may not work in a private or incognito window. If you are in a standard browser window, please try refreshing the page. If the issue persists, contact support@code.org.",
+  "loadFailed": "We're sorry, we hit an issue setting up Python Lab, and you may see errors. Please try refreshing the page. If the issue persists, contact support@code.org.",
   "noCode": "You have no code to run.",
   "noFileToRun": "You have no {fileName} to run.",
   "moduleNotSupported": "ModuleNotFoundError: The module {module} is not supported in Python Lab.",

--- a/apps/src/codebridge/Console/ConsoleManager.ts
+++ b/apps/src/codebridge/Console/ConsoleManager.ts
@@ -66,7 +66,8 @@ export default class ConsoleManager {
 
   public writeErrorMessage(message: string) {
     // This colors the message red in the terminal
-    this.writeConsoleMessage(`\x1b[31m${message}\x1b[0m`);
+    // Reference for color codes: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+    this.writeConsoleMessage(`\x1b[38;5;203m${message}\x1b[0m`);
   }
 
   public writeSystemError(message: string, appName: string) {

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -44,7 +44,7 @@ async function loadPyodideAndPackages() {
     loadErrors = await loadPackages();
     if (loadErrors.length > 0) {
       postMessage({
-        type: 'internal_error',
+        type: 'load_failed',
         message: `Error(s) loading python packages: ${loadErrors.join('\n')}`,
         id: 'startup',
       });

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -101,6 +101,12 @@ const setUpPyodideWorker = () => {
           .getMetricsReporter()
           .logError('Python Lab Internal Error', undefined, {message});
         break;
+      case 'load_failed':
+        Lab2Registry.getInstance()
+          .getMetricsReporter()
+          .logError('Failed to load packages', undefined, {message});
+        consoleManager?.writeErrorMessage(pythonlabI18n.loadFailed());
+        break;
       case 'loading_pyodide':
         getStore().dispatch(setLoadedCodeEnvironment(false));
         break;

--- a/apps/src/pythonlab/types.ts
+++ b/apps/src/pythonlab/types.ts
@@ -23,4 +23,5 @@ export type MessageType =
   | 'internal_error'
   | 'system_error'
   | 'loading_pyodide'
-  | 'loaded_pyodide';
+  | 'loaded_pyodide'
+  | 'load_failed';


### PR DESCRIPTION
Follow up to #64662.
We are still seeing occasional failures where users are trying to load old versions of the python lab packages. My best guess is they need to refresh the page to get the new version of the web worker, since now everything they need to load _should_ be versioned. This adds an error message to the user indicating that they should refresh the page.

As part of this, I also looked at the color of the error message, since I heard in a classroom it could be hard to read. The color contrast did pass WCAG AA guidelines for normal text, but I decided to lighten it anyway since I also found it a bit hard to read. Now it passes AAA guidelines. 

## New error message
<img width="1180" alt="Screenshot 2025-03-24 at 1 21 25 PM" src="https://github.com/user-attachments/assets/12617ff0-afd2-4021-b463-6002857d02e7" />

## Color Before
<img width="339" alt="Screenshot 2025-03-24 at 1 19 52 PM" src="https://github.com/user-attachments/assets/9d51f923-da0b-4d3e-b6b4-3f52ec53c966" />

## Color After
<img width="339" alt="Screenshot 2025-03-24 at 1 19 56 PM" src="https://github.com/user-attachments/assets/0535837b-13c7-4aaf-b4ef-a82fe9eb4e14" />


## Testing story
Tested locally that the new message showed up when I simulated a load failure, but in normal operation it does not.


## Follow-up work
Check the logs to see if the errors decrease after this is deployed.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
