### PR TITLE
fix(storybook): add build target

### DIFF
--- a/frontend/apps/design-system-storybook/package.json
+++ b/frontend/apps/design-system-storybook/package.json
@@ -17,7 +17,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "scripts": {
-    "build-storybook": "storybook build -o dist/component-library-storybook",
+    "build": "storybook build -o dist/component-library-storybook",
     "clean": "rimraf dist",
     "dev": "yarn run storybook",
     "eyes-storybook": "tsx ./scripts/eyes-storybook.ts",

--- a/frontend/apps/design-system-storybook/scripts/test-storybook.sh
+++ b/frontend/apps/design-system-storybook/scripts/test-storybook.sh
@@ -5,7 +5,7 @@
 set -x
 
 # Build a production version of Storybook
-yarn build-storybook --quiet
+yarn build --quiet
 
 # Wait for Storybook to be available and then execute the tests
 npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -45,6 +45,7 @@
       "dependsOn": ["^test"]
     },
     "test:ui:ci": {
+      "cache": false,
       "dependsOn": ["^test:ui:ci"],
       "env": ["STAGE"]
     },


### PR DESCRIPTION
The component library was failing to deploy because the `test:ui:ci` target was being cached in previous runs. To address this, do not cache a UI test which requires revalidation due to its dependencies potentialyl changing.

Additionally, the deployment also failed because the deployment requires the `dist` folder to be created. The `build` target is supposed to generate this folder but it wasn't defined for storybook. Instead, `test:ui:ci` generated the folder by way of the `build-storybook` target. Since the `test:ui:ci` target was cached, it never generates the `dist` folder.