### PR TITLE
Evaluate Student Learning: check if the level is template-backed when pulling student code

### DIFF
--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -82,13 +82,13 @@ class StudentWorkSampleController < ApplicationController
     end
 
     if student_work_params[:include_ai_evaluations]
-      fetch_student_code_samples_with_evaluations(level_id, unit_id, num_samples)
+      fetch_student_code_samples_with_evaluations(level, unit_id, num_samples)
     else
-      fetch_student_code_samples_without_evaluations(level_id, unit_id, num_samples)
+      fetch_student_code_samples_without_evaluations(level, unit_id, num_samples)
     end
   end
 
-  def fetch_student_code_samples_without_evaluations(level_id, unit_id, num_samples)
+  def fetch_student_code_samples_without_evaluations(level, unit_id, num_samples)
     # We want to pull samples from students who have been assigned to work on the level.
     sections = Section.where(script_id: unit_id)
     student_ids = Follower.where(section: sections).pluck(:student_user_id)
@@ -96,9 +96,9 @@ class StudentWorkSampleController < ApplicationController
     have_enough_samples = false
     student_ids.shuffle.each do |student_id|
       unless have_enough_samples
-        student_code = get_student_code(student_id, level_id, unit_id)
+        student_code = get_student_code(student_id, level, unit_id)
         if student_code[:student_code]
-          code_samples << {level_id: level_id, unit_id: unit_id, user_id: student_id, project_id: student_code[:project_id], student_code: student_code[:student_code]}
+          code_samples << {level_id: level.id, unit_id: unit_id, user_id: student_id, project_id: student_code[:project_id], student_code: student_code[:student_code]}
         end
         have_enough_samples = code_samples.length >= num_samples
       end
@@ -106,19 +106,19 @@ class StudentWorkSampleController < ApplicationController
     render json: code_samples
   end
 
-  def fetch_student_code_samples_with_evaluations(level_id, unit_id, num_samples)
-    evaluations = UserLevelEvaluation.where(level_id: level_id, script_id: unit_id)
+  def fetch_student_code_samples_with_evaluations(level, unit_id, num_samples)
+    evaluations = UserLevelEvaluation.where(level_id: level.id, script_id: unit_id)
     if evaluations.empty?
-      return render status: :not_found, json: "There are no evaluations for the level with id #{level_id} in unit with id #{unit_id}"
+      return render status: :not_found, json: "There are no evaluations for the level with id #{level.id} in unit with id #{unit_id}"
     end
     code_samples = []
     have_enough_samples = false
     evaluations.shuffle.each do |evaluation|
       unless have_enough_samples
-        student_code = get_student_code(evaluation.user_id, level_id, unit_id, evaluation.code_version)
+        student_code = get_student_code(evaluation.user_id, level.id, unit_id, evaluation.code_version)
         if student_code[:student_code]
           code_samples << {
-            level_id: level_id,
+            level_id: level.id,
             unit_id: unit_id,
             user_id: evaluation.user_id,
             project_id: student_code[:project_id],
@@ -135,14 +135,16 @@ class StudentWorkSampleController < ApplicationController
     render json: code_samples
   end
 
-  def get_student_code(user_id, level_id, unit_id, code_version = nil)
+  def get_student_code(user_id, level, unit_id, code_version = nil)
     s3 = Aws::S3::Client.new
     bucket = CDO.sources_s3_bucket
     base_dir = CDO.sources_s3_directory
 
     storage_id = storage_id_for_user_id(user_id)
-    channel_token = ChannelToken.where(storage_id: storage_id, level_id: level_id, script_id: unit_id).last
-    user_level = UserLevel.where(user_id: user_id, level_id: level_id, script_id: unit_id).last
+    # For project-template-backed levels, we need to use the channel_token for the associated project template level.
+    level_id_for_channel_token = level.project_template_level ? level.project_template_level.id : level.id
+    channel_token = ChannelToken.where(storage_id: storage_id, level_id: level_id_for_channel_token, script_id: unit_id).last
+    user_level = UserLevel.where(user_id: user_id, level_id: level.id, script_id: unit_id).last
     if user_level && channel_token
       storage_app_id = channel_token.storage_app_id
       channel_id = storage_encrypt_channel_id(storage_id, storage_app_id)


### PR DESCRIPTION
In the process of pulling student code samples for an external partner [TEACH-1718](https://codedotorg.atlassian.net/browse/TEACH-1718), I discovered that the Student Dataset Maker wasn't able to fetch student code for https://studio.code.org/s/csp4-2024/lessons/12/levels/8. 

I realized that this is because that level is project-template-backed, meaning that the there is a template level associated with this level and those previous in the progression that allows the student's code to be shared between levels for continuity. The student's code is connected to the project template level,  not on the level itself. In order to accommodate this situation, I now check if the level we're trying to retrieve code for has an associated project template level and if so, use the id of the project template level to find the channel token needed to fetch the student's code.

### Follow up 
- I bet that this same issue pops up when we fetch the starter code for levels that are project-template-backed. We should confirm if this is true and then adjust the helper function that retrieves starter code accordingly if needed.  [TEACH-1728](https://codedotorg.atlassian.net/browse/TEACH-1728)