### PR TITLE
Update 'Location' vs 'Format' on workshop enroll form

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -182,6 +182,7 @@ def main
         CSD_CUSTOM_WORKSHOP_MODULES
         PARTICIPANT_GROUP_TYPES
         PD_SESSION_FORMATS
+        WORKSHOP_FORMATS
         WORKSHOP_COURSE_CONFIGS
       ),
       source_module: Pd::SharedWorkshopConstants,

--- a/apps/src/code-studio/pd/workshop_enrollment/enrollmentConstants.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enrollmentConstants.jsx
@@ -16,6 +16,7 @@ const WorkshopPropType = PropTypes.shape({
     email: PropTypes.string,
   }),
   virtual: PropTypes.bool,
+  format: PropTypes.string,
   module: PropTypes.string,
   course_offerings: PropTypes.array,
 });

--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_details.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_details.jsx
@@ -4,6 +4,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {WorkshopFormats} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+
 import {COURSE_BUILD_YOUR_OWN} from '../workshop_dashboard/workshopConstants';
 
 import {WorkshopPropType} from './enrollmentConstants';
@@ -46,25 +48,42 @@ export default class WorkshopDetails extends React.Component {
     );
   }
 
+  format() {
+    return (
+      <>
+        <div className="row">
+          <div className="span2" style={styles.label}>
+            <strong>Format:</strong>
+          </div>
+          <div className="span2">{this.props.workshop.format}</div>
+        </div>
+        {[WorkshopFormats.in_person, WorkshopFormats.hybrid].includes(
+          this.props.workshop.format
+        ) && this.location()}
+      </>
+    );
+  }
+
   location() {
     return (
-      <div className="row">
-        <div className="span2" style={styles.label}>
-          <strong>Location:</strong>
+      <>
+        <div className="row">
+          <div className="span2" style={styles.label}>
+            <strong>Location Name:</strong>
+          </div>
+          <div className="span2">{this.props.workshop.location_name}</div>
         </div>
-        <div className="span2">
-          {this.props.workshop.virtual
-            ? 'Virtual'
-            : this.props.workshop.location_name}
-          {!this.props.workshop.virtual &&
-            this.props.workshop.location_address && (
-              <div>
-                <br />
-                {this.props.workshop.location_address}
-              </div>
-            )}
-        </div>
-      </div>
+        {this.props.workshop.location_address && (
+          <div className="row">
+            <div className="span2" style={styles.label}>
+              <strong>Location Address:</strong>
+            </div>
+            <div className="span2">
+              <div>{this.props.workshop.location_address}</div>
+            </div>
+          </div>
+        )}
+      </>
     );
   }
 
@@ -171,7 +190,7 @@ export default class WorkshopDetails extends React.Component {
           </div>
         </div>
         {this.sessionDates()}
-        {this.location()}
+        {this.format()}
         {this.props.workshop.course === COURSE_BUILD_YOUR_OWN
           ? this.buildYourOwnWSDetails()
           : this.courseAndSubject()}

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -90,8 +90,9 @@ class Pd::WorkshopEnrollmentController < ApplicationController
               course_url: @workshop.course_url,
               fee: @workshop.fee,
               properties: nil,
-              location_name: @workshop.friendly_location,
+              location_name: @workshop.location_name,
               virtual: @workshop.virtual?,
+              format: @workshop.format,
               course_offerings: @workshop.course_offerings
             }
           ),

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -134,6 +134,15 @@ class Pd::Workshop < ApplicationRecord
     sessions.any? {|session| session.session_format == "virtual"}
   end
 
+  def format
+    has_in_person_session = sessions.any? {|session| session.session_format == "in_person"}
+    if virtual?
+      has_in_person_session ? Pd::SharedWorkshopConstants::WORKSHOP_FORMATS[:hybrid] : Pd::SharedWorkshopConstants::WORKSHOP_FORMATS[:virtual]
+    else
+      Pd::SharedWorkshopConstants::WORKSHOP_FORMATS[:in_person]
+    end
+  end
+
   def sanitize_time_zone
     self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : nil
   end

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -305,6 +305,12 @@ module Pd
       {value: 'virtual', label: 'Virtual', enum_value: 1}
     ].freeze
 
+    WORKSHOP_FORMATS = {
+      in_person: 'In-Person',
+      hybrid: 'Hybrid',
+      virtual: 'Virtual'
+    }.freeze
+
     SESSION_FIELDS = {
       start: {
         required: true


### PR DESCRIPTION
This PR makes the workshop's format and location clearer on the enroll form. Currently, we list the location as "Virtual" for virtual workshops, but this is a more appropriate label for our concept of a workshop's "Format." So, this adds a "Format" row in the workshop details, and then lists the workshop's actual location name and address (if available) beneath that for in-person and hybrid workshops.

### In-Person Workshop (with address)
![in person](https://github.com/user-attachments/assets/e4fd0788-c6fb-4854-928b-5b9f85656f04)

### In-Person Workshop (without address)
![no address](https://github.com/user-attachments/assets/b08bbdb0-173a-4ce9-99fb-f3fb836377e6)

### Hybrid Workshop
![hybrid](https://github.com/user-attachments/assets/92027eed-f722-43ea-83bc-9bb91bd49f3c)

### Virtual Workshop
![virtual](https://github.com/user-attachments/assets/6ac63463-ec3f-4ece-bebf-9e0e1dfae59e)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3156)

## Testing story
Local testing.
