### PR TITLE
Add CSAIF facilitator course permission

### DIFF
--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -8,6 +8,7 @@ module Pd
       COURSE_FACILITATOR = 'Facilitator'.freeze,
       COURSE_ADMIN_COUNSELOR = 'Admin/Counselor Workshop'.freeze,
       COURSE_BUILD_YOUR_OWN = 'Build Your Own Workshop'.freeze,
+      COURSE_CSAIF = 'CS and AI Fundamentals'.freeze,
     ].freeze
 
     ARCHIVED_COURSES = [


### PR DESCRIPTION
Add CSAIF ("CS and AI Fundamentals") facilitator course permission.

CSAIF permission shows up in facilitator course permissions list:
![csaif option](https://github.com/user-attachments/assets/dd6b9d8e-d7a7-4f7f-ae7f-73c64183cce8)

CSAIF course permission can be assigned to a facilitator:
![can be added](https://github.com/user-attachments/assets/bd291d83-7fbe-47ea-963f-25bb41b1cc54)

CSAIF course permission shows up as one of the user's `courses_as_facilitator` after it's assigned:
![check backend](https://github.com/user-attachments/assets/9b90a84c-1a84-4cfa-9a3d-e59aabf66406)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3174)

## Testing story
Local testing.
