### PR TITLE
fix(jest): set max workers to 50% to reduce memory footprint

### DIFF
--- a/apps/jest.config.js
+++ b/apps/jest.config.js
@@ -96,7 +96,7 @@ const config = {
   // globals: {},
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-  // maxWorkers: '100%',
+  maxWorkers: '50%',
 
   // An array of directory names to be searched recursively up from the requiring module's location
   // moduleDirectories: [


### PR DESCRIPTION
The staging server has 62gb of ram with a baseline of 17 GB consumption leaving ~41GB free.

Each node process takes up to 4GB of ram with 15 workers, that consumes 60 GB of RAM if each jest process consumes all the available ram within it. 

We prefer to maintain a memory consumption rate of less than 87% which equals ~54GB usage. This means jest can consume at most 37GB of RAM

Doing some math to try to figure worker count that fits 37GB / 4 GB = 9.25 workers or 60% workers

Setting to 50% to allow for some buffer room for other processes that may be running in the background