### PR TITLE
Add extra script seed in drone

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -172,7 +172,7 @@ namespace :ci do
 
     Dir.chdir('dashboard') do
       RakeUtils.rake_stream_output 'seed:cached_ui_test'
-      RakeUtils.rake_stream_output 'seed:scripts_ui_tests'
+      RakeUtils.rake_stream_output 'seed:single_script SCRIPT_NAME="allthemigratedthings"'
     end
   end
 end

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -172,6 +172,7 @@ namespace :ci do
 
     Dir.chdir('dashboard') do
       RakeUtils.rake_stream_output 'seed:cached_ui_test'
+      RakeUtils.rake_stream_output 'seed:scripts_ui_tests'
     end
   end
 end


### PR DESCRIPTION
This PR is to add an extra step to drone to seed resources and vocabulary for the `allthemigratedthings` script.

TLDR: Now that standalone-units are being migrated to units within courses, we need to seed twice for resources and vocabulary. The only unit that we use to test resources/vocab is `allthemigratedthings`, so we are only seeding that unit twice. This is a very quick rake task and drone runs indicate it takes less than a second.

## Background
Our seeding process does not seed resources and vocabulary for units in unit groups on the first seed. When units are being seeded, their unit groups, and therefore their course_versions, don't exist. Since resources/vocab are attached to the course_version, we can't seed them. 
https://github.com/code-dot-org/code-dot-org/blob/7e67fddbad1c77aae37858f2350774c58e864c1e/dashboard/lib/services/script_seed.rb#L431-L447

For standalone-units, the same logic did not apply, and resources/vocab were seeded during the first seed. This means that any tests we ran on resources/vocab were fine with only one seed. 

Now that we are migrating standalone-units to units within courses, we require a second seed for resources/vocab. 

The initial thought was to just re-seed ui-test scripts using `seed:scripts_ui_tests`
https://github.com/code-dot-org/code-dot-org/blob/90dc355b24e308f58fafcd346eb37e299483dd46/dashboard/lib/tasks/seed.rake#L286-L288
However, this breaks our [ui-test-specific course offerings](https://github.com/code-dot-org/code-dot-org/blob/90dc355b24e308f58fafcd346eb37e299483dd46/dashboard/lib/tasks/seed.rake#L414-L418). When `seed:scripts_ui_tests` is run, it also seeds a whole list of dependencies.
https://github.com/code-dot-org/code-dot-org/blob/90dc355b24e308f58fafcd346eb37e299483dd46/dashboard/lib/tasks/seed.rake#L249-L263
Included in this list are all course offerings. I believe we actually do need to seed all course offerings for tests since they populate our curriculum catalog. The issue with seeding all course offerings, however, is that this task deletes our ui-test-specific course offerings. 
https://github.com/code-dot-org/code-dot-org/blob/d3d2d6020d64ef2647a72add6262a918d70fc9d8/dashboard/app/models/course_offering.rb#L385-L396

I tried creating a seed task that seeds both `course_offerings_ui_tests` and `scripts_ui_tests`, but this still deleted the ui-test course offerings. I also tried re-seeding `course_offerings_ui_tests` after re-seeding `scripts_ui_tests`, but the scripts were no longer properly connected to the course offerings. 

After looking through our UI and Eyes tests, I realized that only `allthemigratedthings` was used to test resources/vocab. This was previously a standalone-unit and therefore did not need a second seed to have resources/vocab. I also saw that seeding a single script does not call any dependencies.  Since everything else is already seeded, we just need to seed the script again to be able to access resources/vocab. 
https://github.com/code-dot-org/code-dot-org/blob/90dc355b24e308f58fafcd346eb37e299483dd46/dashboard/lib/tasks/seed.rake#L265-L276

Adding this rake task to `ci.rake` fixes the issues I was seeing after migrating standalone-units to single-unit courses.

## Links
Standalone unit migration PR where this was initially needed: https://github.com/code-dot-org/code-dot-org/pull/64535
