### PR TITLE
Leave 20% MemAvailable when running apps tests

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -13,7 +13,7 @@ const {createWebpackConfig} = require('./webpack.config');
 const {ALL_APPS, appsEntriesFor} = require('./webpackEntryPoints');
 
 // Review every couple of years to see if an increase improves test performance
-const MEM_PER_KARMA_PROCESS_MB = 4300;
+const MEM_PER_TEST_PROCESS_MB = 4300;
 
 module.exports = function (grunt) {
   var config = {};
@@ -380,7 +380,7 @@ module.exports = function (grunt) {
       stdio: 'inherit',
       env: {
         ...process.env,
-        NODE_OPTIONS: `--max-old-space-size=${MEM_PER_KARMA_PROCESS_MB}`,
+        NODE_OPTIONS: `--max-old-space-size=${MEM_PER_TEST_PROCESS_MB}`,
       },
     });
   });
@@ -623,4 +623,4 @@ module.exports = function (grunt) {
 };
 
 // Exported for matching use in `run-tests-in-parallel.sh`
-module.exports.MEM_PER_KARMA_PROCESS_MB = MEM_PER_KARMA_PROCESS_MB;
+module.exports.MEM_PER_TEST_PROCESS_MB = MEM_PER_TEST_PROCESS_MB;

--- a/apps/run-tests-in-parallel.sh
+++ b/apps/run-tests-in-parallel.sh
@@ -7,8 +7,9 @@
 
 set -e
 
-MEM_PER_KARMA_PROCESS_MB=$(node -e "console.log(require('./Gruntfile').MEM_PER_KARMA_PROCESS_MB)" 2>/dev/null)
-NODE_OPTIONS="--max-old-space-size=${MEM_PER_KARMA_PROCESS_MB}"
+MEM_PER_TEST_PROCESS_MB=$(node -e "console.log(require('./Gruntfile').MEM_PER_TEST_PROCESS_MB)" 2>/dev/null)
+NODE_OPTIONS="--max-old-space-size=${MEM_PER_TEST_PROCESS_MB}"
+PERCENT_OF_MEM_AVAILABLE_TO_USE_FOR_TESTS=80
 
 function linuxNumProcs() {
   local nprocs=$(nproc)
@@ -21,7 +22,11 @@ function linuxNumProcs() {
   fi
 
   # Don't run more processes than can fit in free memory.
-  local mem_procs=$(awk "/${mem_metric}/ {printf \"%d\", \$2/1024/${MEM_PER_KARMA_PROCESS_MB}}" /proc/meminfo)
+  local mem_available_mb=$(
+    awk "/${mem_metric}/ {printf \"%d\", \$2 / 1024}" /proc/meminfo
+  )
+  local mem_you_can_use_mb=$(( mem_available_mb * PERCENT_OF_MEM_AVAILABLE_TO_USE_FOR_TESTS / 100 ))
+  local mem_procs=$(( mem_you_can_use_mb / MEM_PER_TEST_PROCESS_MB ))
   local procs=$(( ${mem_procs} < ${nprocs} ? ${mem_procs} : ${nprocs} ))
 
   if ((procs == 0)); then
@@ -43,7 +48,8 @@ function macMemAvailableMB() {
 }
 
 function macNumProcs() {
-  local mem_procs=$(( $(macMemAvailableMB) / MEM_PER_KARMA_PROCESS_MB ))
+  local mem_you_can_use=$(( $(macMemAvailableMB) * PERCENT_OF_MEM_AVAILABLE_TO_USE_FOR_TESTS / 100 ))
+  local mem_procs=$(( mem_you_can_use / MEM_PER_TEST_PROCESS_MB ))
   local procs=$(( ${mem_procs} < $(nproc) ? ${mem_procs} : $(nproc) ))
 
   # Run at least two copies in parallel
@@ -69,7 +75,7 @@ echo "#     Running test jobs with ${PROCS}x-parallelism     #"
 echo "##################################################"
 echo
 
-echo && echo "Starting jest"
+echo && echo "Starting jest with ${PROCS}x workers:"
 
 npx jest --silent --maxWorkers ${PROCS}
 


### PR DESCRIPTION
We've been running out of RAM while running apps tests on staging. This PR is intended to give a 20% unused RAM buffer while running apps tests, on all machines including staging and developer machines.

I've also renamed `MEM_PER_KARMA_PROCESS_MB` to `MEM_PER_TEST_PROCESS_MB` in Gruntfile.js, because it was misleading and no longer reflected of these limits applying to both jest and karma.

## History 
We'd been tweaking the `maxWorkers` setting in jest.config.js ([github](https://github.com/code-dot-org/code-dot-org/blob/ec4fe2f394ed4024c0761b6e32519fd4eb135508/apps/jest.config.js/#L98-L99)), but it wasn't working... because we override it in `apps/run-tests-in-parallel.sh` by directly invoking jest with `--maxWorkers ${N_PROCS}`.

This PR adjusts `run-tests-in-parallel.sh` calculations to hopefully not run us out of RAM.

## How run-tests-in-parallel.sh works

run-tests-in-parallel.sh computes the number of workers to spawn, both jest and karma, assuming a RAM limited not CPU limited environment (usually true of our tests). It uses MemAvailable from /proc/meminfo on linux, and computes the same value by hand using free pages on macOS. It then divides MemAvailable by MEM_PER_TEST_PROCESS_MB=4300MB, rounds down, and computes how many workers it can run.

Prior to this PR, it was written to use 100% of MemAvailable. But that's probably not what you want. And... well, it was doing that, on staging, triggering cloudwatch alerts for memory usage, and even triggering the linux kernel OOM in some cases.

## What's changed in this PR

This PR keeps the same (measured) assumption of `MEM_PER_TEST_PROCESS_MB=4300`, but introduces `PERCENT_OF_MEM_AVAILABLE_TO_USE_FOR_TESTS=80`, previously implicitly set to 100%. 

## Expected change to observe after this PR merges to staging

Lets say MemAvailable in /proc/meminfo (same as htop reports) is 40GB of 62GB total when apps tests start. 

Math.floor(40,000MB * 0.8 / 4300MB) => 7 workers, so jest should be run with `npx jest --silent --maxWorkers 7`.

At peak apps test memory usage in this scenario, if we have our 4300MB constant correct, we would expect there to  istill be 0.2 * 40GB = 8GB available on staging.

In other words, memory used percent in cloudwatch should peak at ~85%. This is close to the alarm threshold, but not quite hitting it.

## Testing

- I tested the full change locally on my mac running under bash, using docker running or not to wildly swing the MemAvailable. I checked that `function macNumProcs()` was returning correct values on Mac.
- I tested `linuxNumProcs()` (hardcoding MEM_PER_TEST_PROCESS_MB=4300) on both a docker VM on the mac (ubuntu 24.04) and directly on staging. It returned either 8 or 9 workers on staging, which seems about right, down from 10 or 11 prior to this PR.