### PR TITLE
refactor(workshops): reduce re-renders of form section components

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
@@ -49,17 +49,10 @@ export const SessionsEditor: FC<{
       {sessions.map((session, i) => (
         <SessionPart
           key={`${session.date}-${session.start}-${session.end}`}
-          date={session.date}
-          start={session.start}
-          end={session.end}
-          format={session.format}
-          locationName={session.locationName}
-          locationAddress={session.locationAddress}
-          meetingLink={session.meetingLink}
-          sameAsPrevious={session.sameAsPrevious}
           showSameAsPrevious={i > 0}
           dispatchSessions={dispatchSessions}
           index={i}
+          {...session}
         />
       ))}
       <div className={commonStyles.row}>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
@@ -5,12 +5,12 @@ import TextField from '@code-dot-org/component-library/textField';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import classNames from 'classnames';
 import moment from 'moment-timezone';
-import React, {Dispatch, FC, useCallback, useMemo} from 'react';
+import React, {ChangeEvent, Dispatch, FC, useCallback, useMemo} from 'react';
 
 import {PdSessionFormats} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 import {DATE_FORMAT, TIME_FORMAT} from '../../../workshopConstants';
-import {SessionAction, SessionFormat, SessionFormState} from '../../types';
+import {SessionAction, SessionFormState} from '../../types';
 
 import styles from './styles.module.scss';
 import commonStyles from '../../styles.module.scss';
@@ -146,7 +146,17 @@ export const SessionPart: FC<{
         payload: updatedSession,
       });
     },
-    [dispatchSessions, index]
+    [dispatchSessions, handleSession, index]
+  );
+
+  const updateSession = useCallback(
+    (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      const update = {
+        [event.target.name]: event.target.value,
+      };
+      handleSession(update);
+    },
+    [handleSession]
   );
 
   return (
@@ -159,16 +169,12 @@ export const SessionPart: FC<{
           size="s"
           className={classNames(commonStyles.item, commonStyles.required)}
           value={date}
-          onChange={e => {
-            handleSession({date: e.target.value});
-          }}
+          onChange={updateSession}
         />
         <SimpleDropdown
-          name="start time"
+          name="start"
           labelText="Start Time"
-          onChange={e => {
-            handleSession({start: e.target.value});
-          }}
+          onChange={updateSession}
           iconLeft={{iconName: 'clock'}}
           selectedValue={start}
           items={timeOptions}
@@ -181,11 +187,9 @@ export const SessionPart: FC<{
           )}
         />
         <SimpleDropdown
-          name="end time"
+          name="end"
           labelText="End Time"
-          onChange={e => {
-            handleSession({end: e.target.value});
-          }}
+          onChange={updateSession}
           iconLeft={{iconName: 'clock'}}
           selectedValue={end}
           items={timeOptions}
@@ -200,10 +204,7 @@ export const SessionPart: FC<{
         <SimpleDropdown
           name="format"
           labelText="Format"
-          onChange={e => {
-            const format = e.target.value as SessionFormat;
-            handleSession({format});
-          }}
+          onChange={updateSession}
           selectedValue={format}
           items={PdSessionFormats.map(({value, label}) => ({
             value,
@@ -239,24 +240,18 @@ export const SessionPart: FC<{
             <>
               <TextField
                 label="Location name"
-                name="location name"
+                name="locationName"
                 size="s"
                 className={classNames(commonStyles.item, commonStyles.required)}
-                onChange={e => {
-                  handleSession({locationName: e.target.value});
-                }}
+                onChange={updateSession}
                 value={locationName}
               />
               <TextField
                 label="Location address"
-                name="location address"
+                name="locationAddress"
                 size="s"
                 className={classNames(commonStyles.item, commonStyles.required)}
-                onChange={e => {
-                  handleSession({
-                    locationAddress: e.target.value,
-                  });
-                }}
+                onChange={updateSession}
                 value={locationAddress}
               />
             </>
@@ -265,12 +260,10 @@ export const SessionPart: FC<{
             <>
               <TextField
                 label="Meeting link"
-                name="meeting link"
+                name="meetingLink"
                 size="s"
                 className={classNames(commonStyles.item, commonStyles.required)}
-                onChange={e => {
-                  handleSession({meetingLink: e.target.value});
-                }}
+                onChange={updateSession}
                 value={meetingLink}
               />
               {/* blank space */}
@@ -285,7 +278,7 @@ export const SessionPart: FC<{
               name={`${sameAsPreviousLabel} same as previous`}
               checked={sameAsPrevious}
               size="s"
-              onChange={e => handleSameAsPrevious(e.target.checked)}
+              onChange={handleSameAsPrevious}
             />
           </div>
         )}

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
@@ -2,14 +2,15 @@ import Button from '@code-dot-org/component-library/button';
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import TextField from '@code-dot-org/component-library/textField';
+import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import classNames from 'classnames';
 import moment from 'moment-timezone';
-import React, {FC, useMemo} from 'react';
+import React, {Dispatch, FC, useCallback, useMemo} from 'react';
 
 import {PdSessionFormats} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 import {DATE_FORMAT, TIME_FORMAT} from '../../../workshopConstants';
-import {SessionFormat, SessionFormState} from '../../types';
+import {SessionAction, SessionFormat, SessionFormState} from '../../types';
 
 import styles from './styles.module.scss';
 import commonStyles from '../../styles.module.scss';
@@ -37,40 +38,11 @@ export const generateNewSession = (
 
 export const SessionsEditor: FC<{
   sessions: SessionFormState[];
-  handleSessions: (sessions: SessionFormState[]) => void;
-}> = ({sessions, handleSessions}) => {
-  const getHandleSession = (index: number) => (session: SessionFormState) => {
-    const newSessions = [...sessions];
-    newSessions[index] = session;
-    handleSessions(newSessions);
-  };
-
-  const getDeleteSession = (index: number) => () => {
-    const newSessions = [...sessions];
-    newSessions.splice(index, 1);
-    handleSessions(newSessions);
-  };
-
-  const getHandleSameAsPrevious =
-    (index: number) => (sameAsPrevious: boolean) => {
-      const currentSession = {...sessions[index]};
-      currentSession.sameAsPrevious = sameAsPrevious;
-      const prevSession = sessions[index - 1];
-      if (sameAsPrevious && prevSession) {
-        currentSession.locationAddress = prevSession.locationAddress;
-        currentSession.locationName = prevSession.locationName;
-        currentSession.meetingLink = prevSession.meetingLink;
-      }
-      const newSessions = [...sessions];
-      newSessions.splice(index, 1, currentSession);
-      handleSessions(newSessions);
-    };
-
-  const addSession = () => {
-    const newSessions = [...sessions];
-    newSessions.push(generateNewSession(sessions[sessions.length - 1]));
-    handleSessions(newSessions);
-  };
+  dispatchSessions: Dispatch<SessionAction>;
+}> = ({sessions, dispatchSessions}) => {
+  const addSession = useCallback(() => {
+    dispatchSessions({type: 'ADD_SESSION'});
+  }, [dispatchSessions]);
 
   return (
     <>
@@ -144,14 +116,38 @@ export const SessionPart: FC<{
   }, []);
 
   const sameAsPreviousLabel = useMemo(() => {
-    if (session.format === 'in_person') {
-      return 'Location';
+    switch (format) {
+      case 'in_person':
+        return 'Location';
+      case 'virtual':
+        return 'Meeting link';
+      default:
+        return '';
     }
-    if (session.format === 'virtual') {
-      return 'Meeting link';
-    }
-    return '';
-  }, [session.format]);
+  }, [format]);
+
+  const handleSession = useCallback(
+    (update: Partial<SessionFormState>) => {
+      dispatchSessions({type: 'UPDATE_SESSION', index, payload: update});
+    },
+    [dispatchSessions, index]
+  );
+
+  const deleteSession = useCallback(() => {
+    dispatchSessions({type: 'DELETE_SESSION', index});
+  }, [dispatchSessions, index]);
+
+  const handleSameAsPrevious = useCallback(
+    (sameAsPrevious: boolean) => {
+      const updatedSession: Partial<SessionFormState> = {sameAsPrevious};
+      dispatchSessions({
+        type: 'UPDATE_SESSION',
+        index,
+        payload: updatedSession,
+      });
+    },
+    [dispatchSessions, index]
+  );
 
   return (
     <>
@@ -217,16 +213,25 @@ export const SessionPart: FC<{
           size="s"
           className={classNames(commonStyles.item, commonStyles.required)}
         />
-        <Button
-          icon={{iconName: 'minus'}}
-          onClick={deleteSession}
-          isIconOnly={true}
-          className={styles.deleteButton}
-          type="secondary"
-          color="destructive"
-          title="delete workshop session"
-          aria-label="delete workshop session"
-        />
+        <WithTooltip
+          tooltipProps={{
+            tooltipId: `${date}-${start}-${end}`,
+            size: 'xs',
+            text: 'delete workshop session',
+          }}
+        >
+          <Button
+            icon={{iconName: 'minus'}}
+            onClick={deleteSession}
+            isIconOnly={true}
+            className={styles.deleteButton}
+            type="secondary"
+            color="destructive"
+            title="delete workshop session"
+            aria-label="delete workshop session"
+            aria-describedby={`${date}-${start}-${end}`}
+          />
+        </WithTooltip>
       </div>
       <div className={commonStyles.card}>
         <div className={commonStyles.row}>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
@@ -76,12 +76,18 @@ export const SessionsEditor: FC<{
     <>
       {sessions.map((session, i) => (
         <SessionPart
-          key={i}
-          session={session}
-          handleSession={getHandleSession(i)}
-          deleteSession={getDeleteSession(i)}
+          key={`${session.date}-${session.start}-${session.end}`}
+          date={session.date}
+          start={session.start}
+          end={session.end}
+          format={session.format}
+          locationName={session.locationName}
+          locationAddress={session.locationAddress}
+          meetingLink={session.meetingLink}
+          sameAsPrevious={session.sameAsPrevious}
           showSameAsPrevious={i > 0}
-          handleSameAsPrevious={getHandleSameAsPrevious(i)}
+          dispatchSessions={dispatchSessions}
+          index={i}
         />
       ))}
       <div className={commonStyles.row}>
@@ -98,17 +104,29 @@ export const SessionsEditor: FC<{
 };
 
 export const SessionPart: FC<{
-  session: SessionFormState;
-  handleSession: (session: SessionFormState) => void;
-  deleteSession: () => void;
-  handleSameAsPrevious: (checked: boolean) => void;
+  date: SessionFormState['date'];
+  start: SessionFormState['start'];
+  end: SessionFormState['end'];
+  format: SessionFormState['format'];
+  locationName: SessionFormState['locationName'];
+  locationAddress: SessionFormState['locationAddress'];
+  meetingLink: SessionFormState['meetingLink'];
+  sameAsPrevious: SessionFormState['sameAsPrevious'];
   showSameAsPrevious: boolean;
+  dispatchSessions: Dispatch<SessionAction>;
+  index: number;
 }> = ({
-  session,
-  handleSession,
-  deleteSession,
+  date,
+  start,
+  end,
+  format,
+  locationName,
+  locationAddress,
+  meetingLink,
+  sameAsPrevious,
   showSameAsPrevious,
-  handleSameAsPrevious,
+  dispatchSessions,
+  index,
 }) => {
   const timeOptions = useMemo(() => {
     const startTime = moment().startOf('day').add(7, 'hours');
@@ -144,19 +162,19 @@ export const SessionPart: FC<{
           inputType="date"
           size="s"
           className={classNames(commonStyles.item, commonStyles.required)}
-          value={session.date}
+          value={date}
           onChange={e => {
-            handleSession({...session, date: e.target.value});
+            handleSession({date: e.target.value});
           }}
         />
         <SimpleDropdown
           name="start time"
           labelText="Start Time"
           onChange={e => {
-            handleSession({...session, start: e.target.value});
+            handleSession({start: e.target.value});
           }}
           iconLeft={{iconName: 'clock'}}
-          selectedValue={session.start}
+          selectedValue={start}
           items={timeOptions}
           dropdownTextThickness="thin"
           size="s"
@@ -170,10 +188,10 @@ export const SessionPart: FC<{
           name="end time"
           labelText="End Time"
           onChange={e => {
-            handleSession({...session, end: e.target.value});
+            handleSession({end: e.target.value});
           }}
           iconLeft={{iconName: 'clock'}}
-          selectedValue={session.end}
+          selectedValue={end}
           items={timeOptions}
           dropdownTextThickness="thin"
           size="s"
@@ -188,9 +206,9 @@ export const SessionPart: FC<{
           labelText="Format"
           onChange={e => {
             const format = e.target.value as SessionFormat;
-            handleSession({...session, format});
+            handleSession({format});
           }}
-          selectedValue={session.format}
+          selectedValue={format}
           items={PdSessionFormats.map(({value, label}) => ({
             value,
             text: label,
@@ -212,7 +230,7 @@ export const SessionPart: FC<{
       </div>
       <div className={commonStyles.card}>
         <div className={commonStyles.row}>
-          {session.format === 'in_person' && (
+          {format === 'in_person' && (
             <>
               <TextField
                 label="Location name"
@@ -220,9 +238,9 @@ export const SessionPart: FC<{
                 size="s"
                 className={classNames(commonStyles.item, commonStyles.required)}
                 onChange={e => {
-                  handleSession({...session, locationName: e.target.value});
+                  handleSession({locationName: e.target.value});
                 }}
-                value={session.locationName}
+                value={locationName}
               />
               <TextField
                 label="Location address"
@@ -230,13 +248,15 @@ export const SessionPart: FC<{
                 size="s"
                 className={classNames(commonStyles.item, commonStyles.required)}
                 onChange={e => {
-                  handleSession({...session, locationAddress: e.target.value});
+                  handleSession({
+                    locationAddress: e.target.value,
+                  });
                 }}
-                value={session.locationAddress}
+                value={locationAddress}
               />
             </>
           )}
-          {session.format === 'virtual' && (
+          {format === 'virtual' && (
             <>
               <TextField
                 label="Meeting link"
@@ -244,9 +264,9 @@ export const SessionPart: FC<{
                 size="s"
                 className={classNames(commonStyles.item, commonStyles.required)}
                 onChange={e => {
-                  handleSession({...session, meetingLink: e.target.value});
+                  handleSession({meetingLink: e.target.value});
                 }}
-                value={session.meetingLink}
+                value={meetingLink}
               />
               {/* blank space */}
               <div className={commonStyles.item} />
@@ -258,7 +278,7 @@ export const SessionPart: FC<{
             <Checkbox
               label={`${sameAsPreviousLabel} same as previous`}
               name={`${sameAsPreviousLabel} same as previous`}
-              checked={session.sameAsPrevious}
+              checked={sameAsPrevious}
               size="s"
               onChange={e => handleSameAsPrevious(e.target.checked)}
             />

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
@@ -138,13 +138,15 @@ export const SessionPart: FC<{
   }, [dispatchSessions, index]);
 
   const handleSameAsPrevious = useCallback(
-    (sameAsPrevious: boolean) => {
-      const updatedSession: Partial<SessionFormState> = {sameAsPrevious};
-      dispatchSessions({
-        type: 'UPDATE_SESSION',
-        index,
-        payload: updatedSession,
-      });
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (event.target.checked) {
+        dispatchSessions({
+          type: 'UPDATE_SESSION_SAME_AS_PREVIOUS',
+          index,
+        });
+      } else {
+        handleSession({sameAsPrevious: false});
+      }
     },
     [dispatchSessions, handleSession, index]
   );

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
@@ -18,6 +18,7 @@ import commonStyles from '../../styles.module.scss';
 export const generateNewSession = (
   prevSession?: SessionFormState
 ): SessionFormState => ({
+  id: `new-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
   date: prevSession
     ? moment(prevSession.date, DATE_FORMAT).add(1, 'day').format(DATE_FORMAT)
     : moment().format(DATE_FORMAT),
@@ -48,10 +49,9 @@ export const SessionsEditor: FC<{
     <>
       {sessions.map((session, i) => (
         <SessionPart
-          key={`${session.date}-${session.start}-${session.end}`}
+          key={session.id}
           showSameAsPrevious={i > 0}
           dispatchSessions={dispatchSessions}
-          index={i}
           {...session}
         />
       ))}
@@ -69,6 +69,7 @@ export const SessionsEditor: FC<{
 };
 
 export const SessionPart: FC<{
+  id: SessionFormState['id'];
   date: SessionFormState['date'];
   start: SessionFormState['start'];
   end: SessionFormState['end'];
@@ -79,8 +80,8 @@ export const SessionPart: FC<{
   sameAsPrevious: SessionFormState['sameAsPrevious'];
   showSameAsPrevious: boolean;
   dispatchSessions: Dispatch<SessionAction>;
-  index: number;
 }> = ({
+  id,
   date,
   start,
   end,
@@ -91,7 +92,6 @@ export const SessionPart: FC<{
   sameAsPrevious,
   showSameAsPrevious,
   dispatchSessions,
-  index,
 }) => {
   const timeOptions = useMemo(() => {
     const startTime = moment().startOf('day').add(7, 'hours');
@@ -121,27 +121,27 @@ export const SessionPart: FC<{
 
   const handleSession = useCallback(
     (update: Partial<SessionFormState>) => {
-      dispatchSessions({type: 'UPDATE_SESSION', index, payload: update});
+      dispatchSessions({type: 'UPDATE_SESSION', id, payload: update});
     },
-    [dispatchSessions, index]
+    [dispatchSessions, id]
   );
 
   const deleteSession = useCallback(() => {
-    dispatchSessions({type: 'DELETE_SESSION', index});
-  }, [dispatchSessions, index]);
+    dispatchSessions({type: 'DELETE_SESSION', id});
+  }, [dispatchSessions, id]);
 
   const handleSameAsPrevious = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (event.target.checked) {
         dispatchSessions({
           type: 'UPDATE_SESSION_SAME_AS_PREVIOUS',
-          index,
+          id,
         });
       } else {
         handleSession({sameAsPrevious: false});
       }
     },
-    [dispatchSessions, handleSession, index]
+    [dispatchSessions, handleSession, id]
   );
 
   const updateSession = useCallback(
@@ -212,7 +212,7 @@ export const SessionPart: FC<{
         <WithTooltip
           tooltipOverlayClassName={styles.deleteButtonContainer}
           tooltipProps={{
-            tooltipId: `${date}-${start}-${end}`,
+            tooltipId: `delete-session-tooltip-${id}`,
             size: 'xs',
             text: 'delete workshop session',
           }}
@@ -226,7 +226,7 @@ export const SessionPart: FC<{
             color="destructive"
             title="delete workshop session"
             aria-label="delete workshop session"
-            aria-describedby={`${date}-${start}-${end}`}
+            aria-describedby={`delete-session-tooltip-${id}`}
           />
         </WithTooltip>
       </div>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/index.tsx
@@ -217,6 +217,7 @@ export const SessionPart: FC<{
           className={classNames(commonStyles.item, commonStyles.required)}
         />
         <WithTooltip
+          tooltipOverlayClassName={styles.deleteButtonContainer}
           tooltipProps={{
             tooltipId: `${date}-${start}-${end}`,
             size: 'xs',

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/styles.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/styles.module.scss
@@ -2,10 +2,15 @@
 
 .sessionRow {
   align-items: flex-end;
-  button.deleteButton {
+
+  div.deleteButtonContainer {
     flex: 0;
     height: 2rem;
     min-width: 2rem;
+
+    button.deleteButton {
+      min-width: 100%;
+    }
   }
 
   .timeDropdown {

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -1,13 +1,6 @@
 import {Heading1} from '@code-dot-org/component-library/typography';
 import moment from 'moment-timezone';
-import React, {
-  FC,
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  useState,
-} from 'react';
+import React, {FC, useCallback, useEffect, useMemo, useReducer} from 'react';
 import {useParams} from 'react-router-dom';
 
 import {useFetch} from '@cdo/apps/util/useFetch';
@@ -28,6 +21,7 @@ import {
   SessionAction,
   SessionFormState,
   Workshop,
+  WorkshopAction,
   WorkshopFormState,
   WorkshopFormTemplateProps,
 } from './types';
@@ -72,6 +66,58 @@ export const sessionDataToState = (
     sameAsPrevious: false,
   }));
 
+export const workshopReducer = (
+  state: WorkshopFormState,
+  action: WorkshopAction
+): WorkshopFormState => {
+  switch (action.type) {
+    case 'UPDATE_WORKSHOP':
+      return {...state, ...action.payload};
+    case 'ADD_GRADE': {
+      const newGrades = state.grades.concat(action.payload);
+      newGrades.sort((a, b) => {
+        // sort 'K' to beginning
+        if (a === 'K') return -1;
+        if (b === 'K') return 1;
+        // sort 'Other' to end
+        if (a === 'Other') return 1;
+        if (b === 'Other') return -1;
+        const numA = Number(a);
+        const numB = Number(b);
+        if (isNaN(numA) || isNaN(numB)) return 0;
+        return numA - numB;
+      });
+      return {...state, grades: newGrades};
+    }
+    case 'REMOVE_GRADE':
+      return {
+        ...state,
+        grades: state.grades.filter(grade => grade !== action.payload),
+      };
+    case 'ADD_COURSE_OFFERING':
+      return {
+        ...state,
+        courseOfferings: [...state.courseOfferings, action.payload],
+      };
+    case 'REMOVE_COURSE_OFFERING':
+      return {
+        ...state,
+        courseOfferings: state.courseOfferings.filter(
+          offering => offering !== action.payload
+        ),
+      };
+    case 'SET_COURSE_OFFERINGS':
+      return {
+        ...state,
+        courseOfferings: action.payload,
+      };
+    case 'SET_WORKSHOP':
+      return action.payload;
+    default:
+      return state;
+  }
+};
+
 export const sessionReducer = (
   state: SessionFormState[],
   action: SessionAction
@@ -113,29 +159,27 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
     workshopId ? `/api/v1/pd/workshops/${workshopId}` : ''
   );
 
-  const [workshopFormState, setWorkshopFormState] = useState<WorkshopFormState>(
-    {
-      course: '',
-      capacity: '',
-      description: '',
-      facilitators: [],
-      fee: '',
-      grades: [],
-      hidden: false,
-      name: '',
-      notes: '',
-      organizerId: null,
-      prereq: '',
-      hasPrereq: false,
-      regionalPartnerId: null,
-      registrationLink: '',
-      subject: '',
-      suppressEmail: false,
-      courseOfferings: [],
-      participantGroupType: '',
-      timeZone: userTimeZone,
-    }
-  );
+  const [workshopFormState, dispatchWorkshop] = useReducer(workshopReducer, {
+    course: '',
+    capacity: '',
+    description: '',
+    facilitators: [],
+    fee: '',
+    grades: [],
+    hidden: false,
+    name: '',
+    notes: '',
+    organizerId: null,
+    prereq: '',
+    hasPrereq: false,
+    regionalPartnerId: null,
+    registrationLink: '',
+    subject: '',
+    suppressEmail: false,
+    courseOfferings: [],
+    participantGroupType: '',
+    timeZone: userTimeZone,
+  });
 
   const [sessionFormState, dispatchSessions] = useReducer(sessionReducer, [
     generateNewSession(),
@@ -143,7 +187,10 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
 
   useEffect(() => {
     if (workshop) {
-      setWorkshopFormState(workshopDataToState(workshop));
+      dispatchWorkshop({
+        type: 'SET_WORKSHOP',
+        payload: workshopDataToState(workshop),
+      });
       dispatchSessions({
         type: 'SET_SESSIONS',
         payload: sessionDataToState(
@@ -154,18 +201,6 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
     }
   }, [workshop, userTimeZone]);
 
-  const handleChange = useCallback(
-    <K extends keyof WorkshopFormState>(
-      update: Record<K, WorkshopFormState[K]>
-    ) => {
-      setWorkshopFormState(prevState => ({
-        ...prevState,
-        ...update,
-      }));
-    },
-    []
-  );
-
   const publish = useCallback(() => {}, []);
   const cancel = useCallback(() => {}, []);
 
@@ -173,10 +208,10 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
 
   const sectionProps = useMemo(
     () => ({
-      handleChange,
+      dispatchWorkshop,
       config,
     }),
-    [handleChange, config]
+    [dispatchWorkshop, config]
   );
 
   return (

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -21,6 +21,7 @@ import {
   Facilitator,
   RegionalPartner,
   Session,
+  SessionAction,
   SessionFormState,
   Workshop,
   WorkshopFormState,
@@ -67,6 +68,30 @@ export const sessionDataToState = (
     sameAsPrevious: false,
   }));
 
+const sessionReducer = (
+  state: SessionFormState[],
+  action: SessionAction
+): SessionFormState[] => {
+  switch (action.type) {
+    case 'ADD_SESSION':
+      return state.concat(generateNewSession(state[state.length - 1]));
+
+    case 'UPDATE_SESSION':
+      return state.map((session, i) =>
+        i === action.index ? {...session, ...action.payload} : session
+      );
+
+    case 'DELETE_SESSION':
+      return state.filter((_, i) => i !== action.index);
+
+    case 'SET_SESSIONS':
+      return action.payload;
+
+    default:
+      return state;
+  }
+};
+
 export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
   config,
 }) => {
@@ -101,19 +126,20 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
     }
   );
 
-  const [sessionFormState, setSessionFormState] = useState<SessionFormState[]>([
+  const [sessionFormState, dispatchSessions] = useReducer(sessionReducer, [
     generateNewSession(),
   ]);
 
   useEffect(() => {
     if (workshop) {
       setWorkshopFormState(workshopDataToState(workshop));
-      setSessionFormState(
-        sessionDataToState(
+      dispatchSessions({
+        type: 'SET_SESSIONS',
+        payload: sessionDataToState(
           workshop.sessions,
           workshop.time_zone ?? userTimeZone
-        )
-      );
+        ),
+      });
     }
   }, [workshop, userTimeZone]);
 
@@ -141,7 +167,7 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
         state={workshopFormState}
         handleChange={handleChange}
         sessions={sessionFormState}
-        handleSessions={setSessionFormState}
+        dispatchSessions={dispatchSessions}
         config={config}
       />
       <PartnerFacilitator

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -72,7 +72,7 @@ export const sessionDataToState = (
     sameAsPrevious: false,
   }));
 
-const sessionReducer = (
+export const sessionReducer = (
   state: SessionFormState[],
   action: SessionAction
 ): SessionFormState[] => {
@@ -83,6 +83,13 @@ const sessionReducer = (
     case 'UPDATE_SESSION':
       return state.map((session, i) =>
         i === action.index ? {...session, ...action.payload} : session
+      );
+
+    case 'UPDATE_SESSION_SAME_AS_PREVIOUS':
+      return state.map((session, i) =>
+        i === action.index
+          ? {...session, ...(state[i - 1] ?? {}), sameAsPrevious: true}
+          : session
       );
 
     case 'DELETE_SESSION':

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -154,45 +154,47 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
 
   const heading = workshopLabel(`New ${config.label}`);
 
+  const sectionProps = useMemo(
+    () => ({
+      handleChange,
+      config,
+    }),
+    [handleChange, config]
+  );
+
   return (
     <form id="workshop-form-template" className={styles.container}>
       <Heading1 visualAppearance="heading-xl">{heading}</Heading1>
       <Basics
-        state={workshopFormState}
-        courseOfferings={courseOfferings}
-        handleChange={handleChange}
-        config={config}
+        capacity={workshopFormState.capacity}
+        description={workshopFormState.description}
+        prereq={workshopFormState.prereq}
+        hasPrereq={workshopFormState.hasPrereq}
+        subject={workshopFormState.subject}
+        grades={workshopFormState.grades}
+        courseOfferings={workshopFormState.courseOfferings}
+        name={workshopFormState.name}
+        {...sectionProps}
       />
       <Schedule
-        state={workshopFormState}
-        handleChange={handleChange}
+        timeZone={workshopFormState.timeZone}
         sessions={sessionFormState}
         dispatchSessions={dispatchSessions}
-        config={config}
+        {...sectionProps}
       />
       <PartnerFacilitator
-        state={workshopFormState}
-        regionalPartners={regionalPartners}
-        facilitators={facilitators}
-        handleChange={handleChange}
-        config={config}
+        {...sectionProps}
+        facilitators={workshopFormState.facilitators}
+        regionalPartnerId={workshopFormState.regionalPartnerId}
       />
-      <EmailsReminders
-        state={workshopFormState}
-        handleChange={handleChange}
-        config={config}
-      />
+      <EmailsReminders {...sectionProps} />
       <AdditionalInfo
-        state={workshopFormState}
-        handleChange={handleChange}
-        config={config}
+        fee={workshopFormState.fee}
+        participantGroupType={workshopFormState.participantGroupType}
+        notes={workshopFormState.notes}
+        {...sectionProps}
       />
-      <PublishSettings
-        state={workshopFormState}
-        handleChange={handleChange}
-        config={config}
-      />
-      <PublishCancelButtons publish={() => {}} cancel={() => {}} />
+      <PublishSettings {...sectionProps} />
     </form>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -1,6 +1,13 @@
 import {Heading1} from '@code-dot-org/component-library/typography';
 import moment from 'moment-timezone';
-import React, {FC, useEffect, useState} from 'react';
+import React, {
+  FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+} from 'react';
 import {useParams} from 'react-router-dom';
 
 import {useFetch} from '@cdo/apps/util/useFetch';
@@ -17,9 +24,6 @@ import {PublishCancelButtons} from './sections/PublishCancelButtons';
 import {PublishSettings} from './sections/PublishSettings';
 import {Schedule} from './sections/Schedule';
 import {
-  CourseOffering,
-  Facilitator,
-  RegionalPartner,
   Session,
   SessionAction,
   SessionFormState,
@@ -143,14 +147,20 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
     }
   }, [workshop, userTimeZone]);
 
-  const handleChange = <K extends keyof WorkshopFormState>(
-    update: Record<K, WorkshopFormState[K]>
-  ) => {
-    setWorkshopFormState(prevState => ({
-      ...prevState,
-      ...update,
-    }));
-  };
+  const handleChange = useCallback(
+    <K extends keyof WorkshopFormState>(
+      update: Record<K, WorkshopFormState[K]>
+    ) => {
+      setWorkshopFormState(prevState => ({
+        ...prevState,
+        ...update,
+      }));
+    },
+    []
+  );
+
+  const publish = useCallback(() => {}, []);
+  const cancel = useCallback(() => {}, []);
 
   const heading = workshopLabel(`New ${config.label}`);
 
@@ -195,6 +205,7 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
         {...sectionProps}
       />
       <PublishSettings {...sectionProps} />
+      <PublishCancelButtons publish={publish} cancel={cancel} />
     </form>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -118,7 +118,7 @@ export const workshopReducer = (
   }
 };
 
-export const sessionReducer = (
+export const sessionsReducer = (
   state: SessionFormState[],
   action: SessionAction
 ): SessionFormState[] => {
@@ -181,7 +181,7 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
     timeZone: userTimeZone,
   });
 
-  const [sessionFormState, dispatchSessions] = useReducer(sessionReducer, [
+  const [sessionFormState, dispatchSessions] = useReducer(sessionsReducer, [
     generateNewSession(),
   ]);
 

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -55,7 +55,7 @@ export const sessionDataToState = (
   timeZone: string
 ): SessionFormState[] =>
   data.map(session => ({
-    id: session.id,
+    id: `existing-${session.id}`,
     date: moment(session.start).tz(timeZone).format(DATE_FORMAT),
     start: moment(session.start).tz(timeZone).format(TIME_FORMAT),
     end: moment(session.end).tz(timeZone).format(TIME_FORMAT),
@@ -127,19 +127,19 @@ export const sessionsReducer = (
       return state.concat(generateNewSession(state[state.length - 1]));
 
     case 'UPDATE_SESSION':
-      return state.map((session, i) =>
-        i === action.index ? {...session, ...action.payload} : session
+      return state.map(session =>
+        session.id === action.id ? {...session, ...action.payload} : session
       );
 
     case 'UPDATE_SESSION_SAME_AS_PREVIOUS':
       return state.map((session, i) =>
-        i === action.index
+        session.id === action.id
           ? {...session, ...(state[i - 1] ?? {}), sameAsPrevious: true}
           : session
       );
 
     case 'DELETE_SESSION':
-      return state.filter((_, i) => i !== action.index);
+      return state.filter(session => session.id !== action.id);
 
     case 'SET_SESSIONS':
       return action.payload;

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -73,27 +73,9 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
   const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const {workshopId} = useParams();
 
-  const workshopUrl = workshopId ? `/api/v1/pd/workshops/${workshopId}` : '';
-
-  const {data: workshop} = useFetch<Workshop>(workshopUrl);
-
-  const courseOfferingsUrl = config.fields.course_offerings
-    ? '/course_offerings/self_paced_pl_course_offerings'
-    : '';
-
-  const {data: courseOfferings} =
-    useFetch<CourseOffering[]>(courseOfferingsUrl);
-
-  const regionalPartnersUrl = '/api/v1/regional_partners';
-
-  const {data: regionalPartners} =
-    useFetch<RegionalPartner[]>(regionalPartnersUrl);
-
-  const facilitatorsUrl = `/api/v1/pd/course_facilitators?course=${encodeURIComponent(
-    config.label
-  )}`;
-
-  const {data: facilitators} = useFetch<Facilitator[]>(facilitatorsUrl);
+  const {data: workshop} = useFetch<Workshop>(
+    workshopId ? `/api/v1/pd/workshops/${workshopId}` : ''
+  );
 
   const [workshopFormState, setWorkshopFormState] = useState<WorkshopFormState>(
     {

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/AdditionalInfo.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/AdditionalInfo.tsx
@@ -7,15 +7,15 @@ import React, {FC, useMemo} from 'react';
 
 import {ParticipantGroupTypes} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
-import {SectionProps} from '../types';
+import {AdditionalInfoProps} from '../types';
 
 import commonStyles from '../styles.module.scss';
 
-export const AdditionalInfo: FC<SectionProps> = ({
-  config: {
-    fields: {fee, participant_group_type, notes},
-  },
-  state,
+export const AdditionalInfo: FC<AdditionalInfoProps> = ({
+  config: {fields},
+  fee,
+  participantGroupType,
+  notes,
   handleChange,
 }) => {
   const participantGroupTypeOptions = useMemo(() => {
@@ -27,36 +27,35 @@ export const AdditionalInfo: FC<SectionProps> = ({
       })),
     ];
   }, []);
-
   return (
     <>
       <Heading2 visualAppearance="heading-sm">Additional Information</Heading2>
       <div className={commonStyles.row}>
-        {fee && (
+        {fields.fee && (
           <TextField
             name="cost"
             helperMessage="You can leave this field blank if the workshop is free"
             onChange={e => handleChange({fee: e.target.value})}
-            value={state.fee}
+            value={fee}
             label="Workshop cost"
             size="s"
             className={classNames(commonStyles.item, {
-              [commonStyles.required]: fee.required,
+              [commonStyles.required]: fields.fee.required,
             })}
           />
         )}
-        {participant_group_type ? (
+        {fields.participant_group_type ? (
           <SimpleDropdown
             name="participant group type"
             onChange={e => handleChange({participantGroupType: e.target.value})}
             styleAsFormField={true}
             items={participantGroupTypeOptions}
-            selectedValue={state.participantGroupType}
+            selectedValue={participantGroupType}
             labelText="Cohort type"
             size="s"
             dropdownTextThickness="thin"
             className={classNames(commonStyles.item, {
-              [commonStyles.required]: participant_group_type.required,
+              [commonStyles.required]: fields.participant_group_type.required,
             })}
           />
         ) : (
@@ -64,18 +63,20 @@ export const AdditionalInfo: FC<SectionProps> = ({
         )}
       </div>
       <div className={commonStyles.row}>
-        {notes && (
+        {fields.notes && (
           <FormFieldWrapper
             label="Attendee notes"
             helperMessage="Notes for logistics like food, parking, or other event details."
             size="s"
-            className={classNames(commonStyles.item, commonStyles.required)}
+            className={classNames(commonStyles.item, {
+              [commonStyles.required]: fields.notes.required,
+            })}
           >
             <textarea
               id="notes"
               name="notes"
               onChange={e => handleChange({notes: e.target.value})}
-              value={state.notes}
+              value={notes}
               placeholder="Enter attendee notes here"
             />
           </FormFieldWrapper>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/AdditionalInfo.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/AdditionalInfo.tsx
@@ -3,7 +3,7 @@ import FormFieldWrapper from '@code-dot-org/component-library/formFieldWrapper';
 import TextField from '@code-dot-org/component-library/textField';
 import {Heading2} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
-import React, {FC, useMemo} from 'react';
+import React, {ChangeEvent, FC, useMemo} from 'react';
 
 import {ParticipantGroupTypes} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
@@ -16,7 +16,7 @@ export const AdditionalInfo: FC<AdditionalInfoProps> = ({
   fee,
   participantGroupType,
   notes,
-  handleChange,
+  dispatchWorkshop,
 }) => {
   const participantGroupTypeOptions = useMemo(() => {
     return [
@@ -27,15 +27,26 @@ export const AdditionalInfo: FC<AdditionalInfoProps> = ({
       })),
     ];
   }, []);
+
+  const handleChange = (
+    event: ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
+  ) => {
+    dispatchWorkshop({
+      type: 'UPDATE_WORKSHOP',
+      payload: {[event.target.name]: event.target.value},
+    });
+  };
   return (
     <>
       <Heading2 visualAppearance="heading-sm">Additional Information</Heading2>
       <div className={commonStyles.row}>
         {fields.fee && (
           <TextField
-            name="cost"
+            name="fee"
             helperMessage="You can leave this field blank if the workshop is free"
-            onChange={e => handleChange({fee: e.target.value})}
+            onChange={handleChange}
             value={fee}
             label="Workshop cost"
             size="s"
@@ -46,8 +57,8 @@ export const AdditionalInfo: FC<AdditionalInfoProps> = ({
         )}
         {fields.participant_group_type ? (
           <SimpleDropdown
-            name="participant group type"
-            onChange={e => handleChange({participantGroupType: e.target.value})}
+            name="participantGroupType"
+            onChange={handleChange}
             styleAsFormField={true}
             items={participantGroupTypeOptions}
             selectedValue={participantGroupType}
@@ -75,7 +86,7 @@ export const AdditionalInfo: FC<AdditionalInfoProps> = ({
             <textarea
               id="notes"
               name="notes"
-              onChange={e => handleChange({notes: e.target.value})}
+              onChange={handleChange}
               value={notes}
               placeholder="Enter attendee notes here"
             />

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
@@ -7,12 +7,12 @@ import Tags from '@code-dot-org/component-library/tags';
 import TextField from '@code-dot-org/component-library/textField';
 import {Heading2} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
-import React, {ChangeEvent, FC, useMemo} from 'react';
+import React, {ChangeEvent, FC, useCallback, useMemo} from 'react';
 
 import {useFetch} from '@cdo/apps/util/useFetch';
 import {StudentGradeLevels} from '@cdo/generated-scripts/sharedConstants';
 
-import {BasicsProps, CourseOffering} from '../types';
+import {BasicsProps, CourseOffering, WorkshopFormState} from '../types';
 
 import commonStyles from '../styles.module.scss';
 
@@ -26,7 +26,7 @@ export const Basics: FC<BasicsProps> = ({
   capacity,
   description,
   courseOfferings,
-  handleChange,
+  dispatchWorkshop,
 }) => {
   const {data: fetchedCourseOfferings} = useFetch<CourseOffering[]>(
     fields.course_offerings
@@ -46,12 +46,65 @@ export const Basics: FC<BasicsProps> = ({
     [fetchedCourseOfferings]
   );
 
+  const handleChange = useCallback(
+    (
+      e: React.ChangeEvent<
+        HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+      >
+    ) => {
+      const payload: Partial<WorkshopFormState> = {
+        [e.target.name]: e.target.value,
+      };
+      if (e.target.name === 'hasPrereq') {
+        const hasPrereq = e.target.value === 'true';
+        payload[e.target.name] = hasPrereq;
+        if (!hasPrereq) {
+          payload.prereq = '';
+        }
+      }
+      dispatchWorkshop({
+        type: 'UPDATE_WORKSHOP',
+        payload,
       });
-    } else {
-      selectedGrades = selectedGrades.filter(g => g !== e.target.value);
-    }
-    handleChange({grades: selectedGrades});
-  };
+    },
+    [dispatchWorkshop]
+  );
+
+  const handleGradesChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      dispatchWorkshop({
+        type: e.target.checked ? 'ADD_GRADE' : 'REMOVE_GRADE',
+        payload: e.target.value,
+      });
+    },
+    [dispatchWorkshop]
+  );
+
+  const handleCourseOfferingsChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      dispatchWorkshop({
+        type: e.target.checked
+          ? 'ADD_COURSE_OFFERING'
+          : 'REMOVE_COURSE_OFFERING',
+        payload: e.target.value,
+      });
+    },
+    [dispatchWorkshop]
+  );
+
+  const handleSelectAllCourseOfferings = useCallback(() => {
+    dispatchWorkshop({
+      type: 'SET_COURSE_OFFERINGS',
+      payload: fetchedCourseOfferings?.map(({id}) => id.toString()) ?? [],
+    });
+  }, [dispatchWorkshop, fetchedCourseOfferings]);
+
+  const handleClearAllCourseOfferings = useCallback(() => {
+    dispatchWorkshop({
+      type: 'SET_COURSE_OFFERINGS',
+      payload: [],
+    });
+  }, [dispatchWorkshop]);
 
   const handleRemoveCourseOffering = useCallback(
     (offeringId: string) => () => {
@@ -80,7 +133,7 @@ export const Basics: FC<BasicsProps> = ({
         {fields.name && (
           <TextField
             name="name"
-            onChange={e => handleChange({name: e.target.value})}
+            onChange={handleChange}
             value={name}
             label="Workshop name"
             size="s"
@@ -111,7 +164,7 @@ export const Basics: FC<BasicsProps> = ({
         {fields.subject && (
           <SimpleDropdown
             name="subject"
-            onChange={e => handleChange({subject: e.target.value})}
+            onChange={handleChange}
             styleAsFormField={true}
             items={subjectOptions}
             selectedValue={subject}
@@ -127,14 +180,8 @@ export const Basics: FC<BasicsProps> = ({
       <div className={commonStyles.row}>
         {fields.prereq && (
           <SimpleDropdown
-            name="has-prereq"
-            onChange={e => {
-              const updatedHasPrereq = e.target.value === 'true';
-              handleChange({
-                hasPrereq: updatedHasPrereq,
-                prereq: updatedHasPrereq ? prereq : '',
-              });
-            }}
+            name="hasPrereq"
+            onChange={handleChange}
             styleAsFormField={true}
             items={[
               {value: 'true', text: 'Has prerequisites'},
@@ -154,7 +201,7 @@ export const Basics: FC<BasicsProps> = ({
           <TextField
             inputType="number"
             name="capacity"
-            onChange={e => handleChange({capacity: e.target.value})}
+            onChange={handleChange}
             value={capacity?.toString()}
             label="Capacity"
             helperMessage="Maximum number of attendees allowed."
@@ -172,7 +219,7 @@ export const Basics: FC<BasicsProps> = ({
           <div className={commonStyles.card}>
             <TextField
               name="prereq"
-              onChange={e => handleChange({prereq: e.target.value})}
+              onChange={handleChange}
               value={prereq}
               label="Workshop prerequisites"
               size="s"
@@ -194,7 +241,7 @@ export const Basics: FC<BasicsProps> = ({
             <textarea
               id="description"
               name="description"
-              onChange={e => handleChange({description: e.target.value})}
+              onChange={handleChange}
               value={description}
               placeholder="Enter description here"
             />
@@ -204,19 +251,12 @@ export const Basics: FC<BasicsProps> = ({
       <div className={commonStyles.row}>
         {fields.course_offerings && (
           <CheckboxDropdown
-            name="course_offerings"
+            name="courseOfferings"
             onChange={handleCourseOfferingsChange}
-            onSelectAll={() =>
-              handleChange({
-                courseOfferings:
-                  fetchedCourseOfferings?.map(({id}) => id.toString()) ?? [],
-              })
-            }
+            onSelectAll={handleSelectAllCourseOfferings}
             selectAllText="Select all"
             clearAllText="Clear all"
-            onClearAll={() => {
-              handleChange({courseOfferings: []});
-            }}
+            onClearAll={handleClearAllCourseOfferings}
             styleAsFormField={true}
             checkedOptions={courseOfferings}
             allOptions={

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
@@ -7,29 +7,26 @@ import Tags from '@code-dot-org/component-library/tags';
 import TextField from '@code-dot-org/component-library/textField';
 import {Heading2} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
-import React, {FC, useMemo} from 'react';
+import React, {ChangeEvent, FC, useMemo} from 'react';
 
+import {useFetch} from '@cdo/apps/util/useFetch';
 import {StudentGradeLevels} from '@cdo/generated-scripts/sharedConstants';
 
-import {SectionProps} from '../types';
+import {BasicsProps, CourseOffering} from '../types';
 
 import commonStyles from '../styles.module.scss';
 
-export const Basics: FC<SectionProps> = ({
-  config: {
-    fields: {
-      name,
-      grades,
-      subject,
-      prereq,
-      capacity,
-      description,
-      course_offerings,
-    },
-  },
-  state,
-  handleChange,
+export const Basics: FC<BasicsProps> = ({
+  config: {fields},
+  name,
+  grades,
+  subject,
+  prereq,
+  hasPrereq,
+  capacity,
+  description,
   courseOfferings,
+  handleChange,
 }) => {
   const {data: fetchedCourseOfferings} = useFetch<CourseOffering[]>(
     fields.course_offerings
@@ -38,7 +35,7 @@ export const Basics: FC<SectionProps> = ({
   );
 
   const handleGradesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    let selectedGrades = [...state.grades];
+    let selectedGrades = [...grades];
     if (e.target.checked) {
       selectedGrades.push(e.target.value);
       selectedGrades.sort((a, b) => {
@@ -59,10 +56,8 @@ export const Basics: FC<SectionProps> = ({
     handleChange({grades: selectedGrades});
   };
 
-  const handleCourseOfferingsChange = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    let selectedCourseOfferings = [...state.courseOfferings];
+  const handleCourseOfferingsChange = (e: ChangeEvent<HTMLInputElement>) => {
+    let selectedCourseOfferings = [...courseOfferings];
     if (e.target.checked) {
       selectedCourseOfferings.push(e.target.value);
     } else {
@@ -75,43 +70,43 @@ export const Basics: FC<SectionProps> = ({
 
   const removeCourseOffering = (id: string) => {
     handleChange({
-      courseOfferings: state.courseOfferings.filter(co => co !== id),
+      courseOfferings: courseOfferings.filter(co => co !== id),
     });
   };
 
   const subjectOptions = useMemo(() => {
     let options = [{value: '', text: 'Select a subject'}];
-    if (subject?.options) {
+    if (fields.subject?.options) {
       options = options.concat(
-        subject.options.map(({value, label}) => ({value, text: label}))
+        fields.subject.options.map(({value, label}) => ({value, text: label}))
       );
     }
     return options;
-  }, [subject?.options]);
+  }, [fields.subject?.options]);
 
   return (
     <>
       <Heading2 visualAppearance="heading-sm">Workshop Basics</Heading2>
       <div className={commonStyles.row}>
-        {name && (
+        {fields.name && (
           <TextField
             name="name"
             onChange={e => handleChange({name: e.target.value})}
-            value={state.name}
+            value={name}
             label="Workshop name"
             size="s"
             className={classNames(commonStyles.item, {
-              [commonStyles.required]: name.required,
+              [commonStyles.required]: fields.name.required,
             })}
           />
         )}
-        {grades && (
+        {fields.grades && (
           <CheckboxDropdown
             name="grades"
             onChange={handleGradesChange}
             styleAsFormField={true}
             hideControls
-            checkedOptions={state.grades}
+            checkedOptions={grades}
             allOptions={StudentGradeLevels.map(value => ({
               value,
               label: value,
@@ -120,35 +115,35 @@ export const Basics: FC<SectionProps> = ({
             size="s"
             helperMessage="Select applicable grade levels for this workshop."
             className={classNames(commonStyles.item, {
-              [commonStyles.required]: grades.required,
+              [commonStyles.required]: fields.grades.required,
             })}
           />
         )}
-        {subject && (
+        {fields.subject && (
           <SimpleDropdown
             name="subject"
             onChange={e => handleChange({subject: e.target.value})}
             styleAsFormField={true}
             items={subjectOptions}
-            selectedValue={state.subject}
+            selectedValue={subject}
             labelText="Subject"
             size="s"
             dropdownTextThickness="thin"
             className={classNames(commonStyles.item, {
-              [commonStyles.required]: subject.required,
+              [commonStyles.required]: fields.subject.required,
             })}
           />
         )}
       </div>
       <div className={commonStyles.row}>
-        {prereq && (
+        {fields.prereq && (
           <SimpleDropdown
             name="has-prereq"
             onChange={e => {
-              const hasPrereq = e.target.value === 'true';
+              const updatedHasPrereq = e.target.value === 'true';
               handleChange({
-                hasPrereq,
-                prereq: hasPrereq ? state.prereq : '',
+                hasPrereq: updatedHasPrereq,
+                prereq: updatedHasPrereq ? prereq : '',
               });
             }}
             styleAsFormField={true}
@@ -156,27 +151,27 @@ export const Basics: FC<SectionProps> = ({
               {value: 'true', text: 'Has prerequisites'},
               {value: 'false', text: 'No experience needed'},
             ]}
-            selectedValue={state.hasPrereq.toString()}
+            selectedValue={hasPrereq.toString()}
             labelText="Experience needed"
             helperMessage="Indicate if this workshop requires previous experience."
             size="s"
             dropdownTextThickness="thin"
             className={classNames(commonStyles.item, {
-              [commonStyles.required]: prereq.required,
+              [commonStyles.required]: fields.prereq.required,
             })}
           />
         )}
-        {capacity && (
+        {fields.capacity && (
           <TextField
             inputType="number"
             name="capacity"
             onChange={e => handleChange({capacity: e.target.value})}
-            value={state.capacity?.toString()}
+            value={capacity?.toString()}
             label="Capacity"
             helperMessage="Maximum number of attendees allowed."
             size="s"
             className={classNames(commonStyles.item, {
-              [commonStyles.required]: capacity.required,
+              [commonStyles.required]: fields.capacity.required,
             })}
           />
         )}
@@ -184,16 +179,16 @@ export const Basics: FC<SectionProps> = ({
         {subject && <div className={commonStyles.item} />}
       </div>
       <div className={commonStyles.row}>
-        {prereq && state.hasPrereq && (
+        {fields.prereq && hasPrereq && (
           <div className={commonStyles.card}>
             <TextField
               name="prereq"
               onChange={e => handleChange({prereq: e.target.value})}
-              value={state.prereq}
+              value={prereq}
               label="Workshop prerequisites"
               size="s"
               className={classNames(commonStyles.item, {
-                [commonStyles.required]: prereq.required,
+                [commonStyles.required]: fields.prereq.required,
               })}
             />
           </div>
@@ -211,21 +206,21 @@ export const Basics: FC<SectionProps> = ({
               id="description"
               name="description"
               onChange={e => handleChange({description: e.target.value})}
-              value={state.description}
+              value={description}
               placeholder="Enter description here"
             />
           </FormFieldWrapper>
         )}
       </div>
       <div className={commonStyles.row}>
-        {course_offerings && (
+        {fields.course_offerings && (
           <CheckboxDropdown
             name="course_offerings"
             onChange={handleCourseOfferingsChange}
             onSelectAll={() =>
               handleChange({
                 courseOfferings:
-                  courseOfferings?.map(({id}) => id.toString()) ?? [],
+                  fetchedCourseOfferings?.map(({id}) => id.toString()) ?? [],
               })
             }
             selectAllText="Select all"
@@ -234,9 +229,9 @@ export const Basics: FC<SectionProps> = ({
               handleChange({courseOfferings: []});
             }}
             styleAsFormField={true}
-            checkedOptions={state.courseOfferings}
+            checkedOptions={courseOfferings}
             allOptions={
-              courseOfferings?.map(({id, display_name}) => ({
+              fetchedCourseOfferings?.map(({id, display_name}) => ({
                 value: id.toString(),
                 label: display_name,
               })) ?? []
@@ -244,17 +239,17 @@ export const Basics: FC<SectionProps> = ({
             labelText="Select workshop topic(s)"
             size="s"
             className={classNames(commonStyles.item, {
-              [commonStyles.required]: course_offerings.required,
+              [commonStyles.required]: fields.course_offerings.required,
             })}
           />
         )}
       </div>
       <div>
-        {courseOfferings &&
-          state.courseOfferings.map(id => {
+        {fetchedCourseOfferings &&
+          courseOfferings.map(id => {
             const topic =
-              courseOfferings.find(co => co.id === Number(id))?.display_name ??
-              '';
+              fetchedCourseOfferings.find(co => co.id === Number(id))
+                ?.display_name ?? '';
             return (
               <div className={commonStyles.tag_button_container}>
                 <Tags

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
@@ -12,7 +12,7 @@ import React, {ChangeEvent, FC, useCallback, useMemo} from 'react';
 import {useFetch} from '@cdo/apps/util/useFetch';
 import {StudentGradeLevels} from '@cdo/generated-scripts/sharedConstants';
 
-import {BasicsProps, CourseOffering, WorkshopFormState} from '../types';
+import {BasicsProps, CourseOffering} from '../types';
 
 import commonStyles from '../styles.module.scss';
 
@@ -52,19 +52,12 @@ export const Basics: FC<BasicsProps> = ({
         HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
       >
     ) => {
-      const payload: Partial<WorkshopFormState> = {
-        [e.target.name]: e.target.value,
-      };
-      if (e.target.name === 'hasPrereq') {
-        const hasPrereq = e.target.value === 'true';
-        payload[e.target.name] = hasPrereq;
-        if (!hasPrereq) {
-          payload.prereq = '';
-        }
-      }
+      const {name, value} = e.target;
       dispatchWorkshop({
         type: 'UPDATE_WORKSHOP',
-        payload,
+        payload: {
+          [name]: name === 'hasPrereq' ? value === 'true' : value,
+        },
       });
     },
     [dispatchWorkshop]

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
@@ -31,6 +31,12 @@ export const Basics: FC<SectionProps> = ({
   handleChange,
   courseOfferings,
 }) => {
+  const {data: fetchedCourseOfferings} = useFetch<CourseOffering[]>(
+    fields.course_offerings
+      ? '/course_offerings/self_paced_pl_course_offerings'
+      : ''
+  );
+
   const handleGradesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let selectedGrades = [...state.grades];
     if (e.target.checked) {

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Basics.tsx
@@ -34,21 +34,18 @@ export const Basics: FC<BasicsProps> = ({
       : ''
   );
 
-  const handleGradesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    let selectedGrades = [...grades];
-    if (e.target.checked) {
-      selectedGrades.push(e.target.value);
-      selectedGrades.sort((a, b) => {
-        // sort 'K' to beginning
-        if (a === 'K') return -1;
-        if (b === 'K') return 1;
-        // sort 'Other' to end
-        if (a === 'Other') return 1;
-        if (b === 'Other') return -1;
-        const numA = Number(a);
-        const numB = Number(b);
-        if (isNaN(numA) || isNaN(numB)) return 0;
-        return numA - numB;
+  const courseOfferingsById = useMemo(
+    () =>
+      fetchedCourseOfferings?.reduce(
+        (acc: Record<number, CourseOffering>, curr) => {
+          acc[curr.id] = curr;
+          return acc;
+        },
+        {}
+      ),
+    [fetchedCourseOfferings]
+  );
+
       });
     } else {
       selectedGrades = selectedGrades.filter(g => g !== e.target.value);
@@ -56,23 +53,15 @@ export const Basics: FC<BasicsProps> = ({
     handleChange({grades: selectedGrades});
   };
 
-  const handleCourseOfferingsChange = (e: ChangeEvent<HTMLInputElement>) => {
-    let selectedCourseOfferings = [...courseOfferings];
-    if (e.target.checked) {
-      selectedCourseOfferings.push(e.target.value);
-    } else {
-      selectedCourseOfferings = selectedCourseOfferings.filter(
-        co => co !== e.target.value
-      );
-    }
-    handleChange({courseOfferings: selectedCourseOfferings});
-  };
-
-  const removeCourseOffering = (id: string) => {
-    handleChange({
-      courseOfferings: courseOfferings.filter(co => co !== id),
-    });
-  };
+  const handleRemoveCourseOffering = useCallback(
+    (offeringId: string) => () => {
+      dispatchWorkshop({
+        type: 'REMOVE_COURSE_OFFERING',
+        payload: offeringId,
+      });
+    },
+    [dispatchWorkshop]
+  );
 
   const subjectOptions = useMemo(() => {
     let options = [{value: '', text: 'Select a subject'}];
@@ -244,36 +233,16 @@ export const Basics: FC<BasicsProps> = ({
           />
         )}
       </div>
-      <div>
-        {fetchedCourseOfferings &&
-          courseOfferings.map(id => {
-            const topic =
-              fetchedCourseOfferings.find(co => co.id === Number(id))
-                ?.display_name ?? '';
-            return (
-              <div className={commonStyles.tag_button_container}>
-                <Tags
-                  key={id}
-                  tagsList={[
-                    {
-                      label: topic,
-                      icon: {
-                        iconName: 'close',
-                        title: 'remove topic',
-                        iconStyle: 'regular',
-                        placement: 'right',
-                      },
-                    },
-                  ]}
-                />
-                <button
-                  type="button"
-                  onClick={() => removeCourseOffering(id)}
-                />
-              </div>
-            );
-          })}
-      </div>
+      {courseOfferingsById && (
+        <Tags
+          className={commonStyles.wrapContainer}
+          tagsList={courseOfferings.map(offeringId => ({
+            type: 'closable',
+            onClose: handleRemoveCourseOffering(offeringId),
+            label: courseOfferingsById[Number(offeringId)]?.display_name ?? '',
+          }))}
+        />
+      )}
     </>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
@@ -3,7 +3,7 @@ import React, {FC} from 'react';
 
 import {SectionProps} from '../types';
 
-export const EmailsReminders: FC<SectionProps> = ({handleChange}) => {
+export const EmailsReminders: FC<SectionProps> = ({dispatchWorkshop}) => {
   return (
     <div>
       <Heading2 visualAppearance="heading-sm">Emails & Reminders</Heading2>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
@@ -3,7 +3,7 @@ import React, {FC} from 'react';
 
 import {SectionProps} from '../types';
 
-export const EmailsReminders: FC<SectionProps> = ({state, handleChange}) => {
+export const EmailsReminders: FC<SectionProps> = ({handleChange}) => {
   return (
     <div>
       <Heading2 visualAppearance="heading-sm">Emails & Reminders</Heading2>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
@@ -3,19 +3,18 @@ import {Heading2} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import React, {FC, useMemo} from 'react';
 
+import {useFetch} from '@cdo/apps/util/useFetch';
+
 import {MultiSelectInput} from '../components/MultiSelectInput';
-import {SectionProps} from '../types';
+import {Facilitator, PartnerFacilitatorProps, RegionalPartner} from '../types';
 
 import commonStyles from '../styles.module.scss';
 
-export const PartnerFacilitator: FC<SectionProps> = ({
-  config: {
-    fields: {regional_partner_id, facilitators},
-  },
-  state,
+export const PartnerFacilitator: FC<PartnerFacilitatorProps> = ({
+  config: {label, fields},
+  facilitators,
+  regionalPartnerId,
   handleChange,
-  regionalPartners,
-  facilitators: fetchedFacilitators,
 }) => {
   const {data: regionalPartners} = useFetch<RegionalPartner[]>(
     '/api/v1/regional_partners'
@@ -52,7 +51,7 @@ export const PartnerFacilitator: FC<SectionProps> = ({
         Partner and Facilitator Information
       </Heading2>
       <div className={commonStyles.row}>
-        {regional_partner_id && (
+        {fields.regional_partner_id && (
           <SimpleDropdown
             name="regional_partner_id"
             onChange={e =>
@@ -64,27 +63,25 @@ export const PartnerFacilitator: FC<SectionProps> = ({
             }
             styleAsFormField={true}
             items={regionalPartnerOptions}
-            selectedValue={state.regionalPartnerId?.toString() ?? ''}
+            selectedValue={regionalPartnerId?.toString() ?? ''}
             labelText="Regional partner"
             size="s"
             dropdownTextThickness="thin"
             className={classNames(commonStyles.item, {
-              [commonStyles.required]: regional_partner_id.required,
+              [commonStyles.required]: fields.regional_partner_id.required,
             })}
           />
         )}
-        {facilitators && (
+        {fields.facilitators && (
           <MultiSelectInput
             label="Select facilitator(s)"
             options={facilitatorOptions ?? []}
-            selectedOptions={state.facilitators}
+            selectedOptions={facilitators}
             setSelectedOptions={newFacilitators =>
               handleChange({facilitators: newFacilitators.map(Number)})
             }
             placeholder={
-              state.facilitators.length
-                ? 'Type to filter'
-                : 'Enter name or email'
+              facilitators.length ? 'Type to filter' : 'Enter name or email'
             }
           />
         )}

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
@@ -17,6 +17,13 @@ export const PartnerFacilitator: FC<SectionProps> = ({
   regionalPartners,
   facilitators: fetchedFacilitators,
 }) => {
+  const {data: regionalPartners} = useFetch<RegionalPartner[]>(
+    '/api/v1/regional_partners'
+  );
+
+  const {data: fetchedFacilitators} = useFetch<Facilitator[]>(
+    `/api/v1/pd/course_facilitators?course=${encodeURIComponent(label)}`
+  );
   const regionalPartnerOptions = useMemo(() => {
     const options = [{value: '', text: 'None'}];
 

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
@@ -1,11 +1,11 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import {Heading2} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
-import React, {FC, useMemo} from 'react';
+import React, {ChangeEvent, FC, useCallback, useMemo} from 'react';
 
 import {useFetch} from '@cdo/apps/util/useFetch';
 
-import {MultiSelectInput} from '../components/MultiSelectInput';
+import {MultiSelectInput, OptionId} from '../components/MultiSelectInput';
 import {Facilitator, PartnerFacilitatorProps, RegionalPartner} from '../types';
 
 import commonStyles from '../styles.module.scss';
@@ -14,7 +14,7 @@ export const PartnerFacilitator: FC<PartnerFacilitatorProps> = ({
   config: {label, fields},
   facilitators,
   regionalPartnerId,
-  handleChange,
+  dispatchWorkshop,
 }) => {
   const {data: regionalPartners} = useFetch<RegionalPartner[]>(
     '/api/v1/regional_partners'
@@ -36,14 +36,40 @@ export const PartnerFacilitator: FC<PartnerFacilitatorProps> = ({
     return options;
   }, [regionalPartners]);
 
-  const facilitatorOptions = useMemo(() => {
-    return fetchedFacilitators?.map(({id, name, email}) => ({
-      id,
-      label: name,
-      secondaryLabel: email,
-      searchText: [name, email],
-    }));
-  }, [fetchedFacilitators]);
+  const facilitatorOptions = useMemo(
+    () =>
+      fetchedFacilitators?.map(({id, name, email}) => ({
+        id,
+        label: name,
+        secondaryLabel: email,
+        searchText: [name, email],
+      })) ?? [],
+    [fetchedFacilitators]
+  );
+
+  const handleFacilitators = useCallback(
+    (newFacilitators: OptionId[]) => {
+      dispatchWorkshop({
+        type: 'UPDATE_WORKSHOP',
+        payload: {facilitators: newFacilitators.map(Number)},
+      });
+    },
+    [dispatchWorkshop]
+  );
+
+  const handleRegionalPartner = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      dispatchWorkshop({
+        type: 'UPDATE_WORKSHOP',
+        payload: {
+          regionalPartnerId: event.target.value
+            ? Number(event.target.value)
+            : null,
+        },
+      });
+    },
+    [dispatchWorkshop]
+  );
 
   return (
     <>
@@ -54,13 +80,7 @@ export const PartnerFacilitator: FC<PartnerFacilitatorProps> = ({
         {fields.regional_partner_id && (
           <SimpleDropdown
             name="regional_partner_id"
-            onChange={e =>
-              handleChange({
-                regionalPartnerId: e.target.value
-                  ? Number(e.target.value)
-                  : null,
-              })
-            }
+            onChange={handleRegionalPartner}
             styleAsFormField={true}
             items={regionalPartnerOptions}
             selectedValue={regionalPartnerId?.toString() ?? ''}
@@ -75,11 +95,9 @@ export const PartnerFacilitator: FC<PartnerFacilitatorProps> = ({
         {fields.facilitators && (
           <MultiSelectInput
             label="Select facilitator(s)"
-            options={facilitatorOptions ?? []}
+            options={facilitatorOptions}
             selectedOptions={facilitators}
-            setSelectedOptions={newFacilitators =>
-              handleChange({facilitators: newFacilitators.map(Number)})
-            }
+            setSelectedOptions={handleFacilitators}
             placeholder={
               facilitators.length ? 'Type to filter' : 'Enter name or email'
             }

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Schedule.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Schedule.tsx
@@ -9,7 +9,7 @@ export const Schedule: FC<ScheduleProps> = ({
   state: {timeZone},
   handleChange,
   sessions,
-  handleSessions,
+  dispatchSessions,
 }) => {
   return (
     <>
@@ -19,7 +19,7 @@ export const Schedule: FC<ScheduleProps> = ({
         timeZone={timeZone}
         handleChange={tz => handleChange({timeZone: tz})}
       />
-      <SessionsEditor sessions={sessions} handleSessions={handleSessions} />
+      <SessionsEditor sessions={sessions} dispatchSessions={dispatchSessions} />
     </>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Schedule.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Schedule.tsx
@@ -6,7 +6,7 @@ import {TimeZoneEditor} from '../components/TimeZoneEditor';
 import {ScheduleProps} from '../types';
 
 export const Schedule: FC<ScheduleProps> = ({
-  state: {timeZone},
+  timeZone,
   handleChange,
   sessions,
   dispatchSessions,

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Schedule.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/Schedule.tsx
@@ -1,5 +1,5 @@
 import {Heading2} from '@code-dot-org/component-library/typography';
-import React, {FC} from 'react';
+import React, {FC, useCallback} from 'react';
 
 import {SessionsEditor} from '../components/SessionsEditor';
 import {TimeZoneEditor} from '../components/TimeZoneEditor';
@@ -7,17 +7,22 @@ import {ScheduleProps} from '../types';
 
 export const Schedule: FC<ScheduleProps> = ({
   timeZone,
-  handleChange,
   sessions,
+  dispatchWorkshop,
   dispatchSessions,
 }) => {
+  const handleChange = useCallback(
+    (tz: string) =>
+      dispatchWorkshop({type: 'UPDATE_WORKSHOP', payload: {timeZone: tz}}),
+    [dispatchWorkshop]
+  );
   return (
     <>
       <Heading2 visualAppearance="heading-sm">Schedule</Heading2>
       <TimeZoneEditor
         text="Workshop time(s) will be set to your timezone:"
         timeZone={timeZone}
-        handleChange={tz => handleChange({timeZone: tz})}
+        handleChange={handleChange}
       />
       <SessionsEditor sessions={sessions} dispatchSessions={dispatchSessions} />
     </>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/styles.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/styles.module.scss
@@ -67,20 +67,8 @@
     }
   }
 
-  .tag_button_container {
-    position: relative;
-    display: inline-block;
-    margin-top: 0.5rem;
-    margin-right: 0.5rem;
-
-    button {
-      all: unset;
-      position: absolute;
-      right: 0;
-      top: 0;
-      bottom: 0;
-      width: 20px;
-      cursor: pointer;
-    }
+  .wrapContainer {
+    flex-wrap: wrap;
+    row-gap: 0.5rem;
   }
 }

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -69,7 +69,7 @@ export interface Session {
 }
 
 export interface SessionFormState {
-  id?: number;
+  id: string;
   date: string;
   start: string;
   end: string;
@@ -182,10 +182,10 @@ export interface PublishCancelButtonsProps {
 
 export type SessionAction =
   | {type: 'ADD_SESSION'}
-  | {type: 'UPDATE_SESSION'; payload: Partial<SessionFormState>; index: number}
+  | {type: 'UPDATE_SESSION'; payload: Partial<SessionFormState>; id: string}
   | {type: 'SET_SESSIONS'; payload: SessionFormState[]}
-  | {type: 'DELETE_SESSION'; index: number}
-  | {type: 'UPDATE_SESSION_SAME_AS_PREVIOUS'; index: number};
+  | {type: 'DELETE_SESSION'; id: string}
+  | {type: 'UPDATE_SESSION_SAME_AS_PREVIOUS'; id: string};
 
 export type WorkshopAction =
   | {type: 'UPDATE_WORKSHOP'; payload: Partial<WorkshopFormState>}

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -142,17 +142,37 @@ export interface WorkshopFormState {
 }
 
 export interface SectionProps {
-  state: WorkshopFormState;
   handleChange: <K extends keyof WorkshopFormState>(
     update: Record<K, WorkshopFormState[K]>
   ) => void;
   config: WorkshopCourseConfig;
-  courseOfferings?: CourseOffering[] | null;
-  regionalPartners?: RegionalPartner[] | null;
-  facilitators?: Facilitator[] | null;
 }
 
-export interface ScheduleProps extends SectionProps {
+export interface BasicsProps
+  extends SectionProps,
+    Pick<
+      WorkshopFormState,
+      | 'name'
+      | 'grades'
+      | 'subject'
+      | 'prereq'
+      | 'hasPrereq'
+      | 'capacity'
+      | 'description'
+      | 'courseOfferings'
+    > {}
+
+export interface PartnerFacilitatorProps
+  extends SectionProps,
+    Pick<WorkshopFormState, 'facilitators' | 'regionalPartnerId'> {}
+
+export interface AdditionalInfoProps
+  extends SectionProps,
+    Pick<WorkshopFormState, 'fee' | 'participantGroupType' | 'notes'> {}
+
+export interface ScheduleProps
+  extends SectionProps,
+    Pick<WorkshopFormState, 'timeZone'> {
   sessions: SessionFormState[];
   dispatchSessions: Dispatch<SessionAction>;
 }

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -142,9 +142,7 @@ export interface WorkshopFormState {
 }
 
 export interface SectionProps {
-  handleChange: <K extends keyof WorkshopFormState>(
-    update: Record<K, WorkshopFormState[K]>
-  ) => void;
+  dispatchWorkshop: Dispatch<WorkshopAction>;
   config: WorkshopCourseConfig;
 }
 
@@ -188,3 +186,12 @@ export type SessionAction =
   | {type: 'SET_SESSIONS'; payload: SessionFormState[]}
   | {type: 'DELETE_SESSION'; index: number}
   | {type: 'UPDATE_SESSION_SAME_AS_PREVIOUS'; index: number};
+
+export type WorkshopAction =
+  | {type: 'UPDATE_WORKSHOP'; payload: Partial<WorkshopFormState>}
+  | {type: 'ADD_GRADE'; payload: string}
+  | {type: 'REMOVE_GRADE'; payload: string}
+  | {type: 'ADD_COURSE_OFFERING'; payload: string}
+  | {type: 'REMOVE_COURSE_OFFERING'; payload: string}
+  | {type: 'SET_COURSE_OFFERINGS'; payload: string[]}
+  | {type: 'SET_WORKSHOP'; payload: WorkshopFormState};

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -186,4 +186,5 @@ export type SessionAction =
   | {type: 'ADD_SESSION'}
   | {type: 'UPDATE_SESSION'; payload: Partial<SessionFormState>; index: number}
   | {type: 'SET_SESSIONS'; payload: SessionFormState[]}
-  | {type: 'DELETE_SESSION'; index: number};
+  | {type: 'DELETE_SESSION'; index: number}
+  | {type: 'UPDATE_SESSION_SAME_AS_PREVIOUS'; index: number};

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -1,3 +1,5 @@
+import {Dispatch} from 'react';
+
 export interface Option {
   value: string;
   label: string;
@@ -152,10 +154,16 @@ export interface SectionProps {
 
 export interface ScheduleProps extends SectionProps {
   sessions: SessionFormState[];
-  handleSessions: (sessions: SessionFormState[]) => void;
+  dispatchSessions: Dispatch<SessionAction>;
 }
 
 export interface PublishCancelButtonsProps {
   publish: () => void;
   cancel: () => void;
 }
+
+export type SessionAction =
+  | {type: 'ADD_SESSION'}
+  | {type: 'UPDATE_SESSION'; payload: Partial<SessionFormState>; index: number}
+  | {type: 'SET_SESSIONS'; payload: SessionFormState[]}
+  | {type: 'DELETE_SESSION'; index: number};

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditorTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditorTest.jsx
@@ -8,7 +8,7 @@ import {
   DATE_FORMAT,
   TIME_FORMAT,
 } from '@cdo/apps/code-studio/pd/workshop_dashboard/workshopConstants';
-import {sessionReducer} from '@cdo/apps/code-studio/pd/workshop_dashboard/WorkshopFormTemplate';
+import {sessionsReducer} from '@cdo/apps/code-studio/pd/workshop_dashboard/WorkshopFormTemplate';
 import {
   SessionsEditor,
   SessionPart,
@@ -124,7 +124,7 @@ describe('SessionPart', () => {
   };
 
   const SessionPartWithState = (props = {}) => {
-    const [sessions, dispatch] = useReducer(sessionReducer, [
+    const [sessions, dispatch] = useReducer(sessionsReducer, [
       props?.session ?? mockSession,
     ]);
     if (!sessions.length) return null;

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditorTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditorTest.jsx
@@ -2,12 +2,13 @@ import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {useReducer} from 'react';
 
 import {
   DATE_FORMAT,
   TIME_FORMAT,
 } from '@cdo/apps/code-studio/pd/workshop_dashboard/workshopConstants';
+import {sessionReducer} from '@cdo/apps/code-studio/pd/workshop_dashboard/WorkshopFormTemplate';
 import {
   SessionsEditor,
   SessionPart,
@@ -15,7 +16,7 @@ import {
 } from '@cdo/apps/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor';
 
 describe('generateNewSession', () => {
-  it('should generate a new session with default values', () => {
+  it('generates a new session with default values', () => {
     const newSession = generateNewSession();
 
     expect(newSession.date).toEqual(moment().format(DATE_FORMAT));
@@ -32,7 +33,7 @@ describe('generateNewSession', () => {
     expect(newSession.sameAsPrevious).toEqual(false);
   });
 
-  it('should generate a new session based on the previous session', () => {
+  it('generates a new session based on the previous session', () => {
     const prevSession = {
       date: '2025-03-28',
       start: '8:00am',
@@ -59,7 +60,7 @@ describe('generateNewSession', () => {
 });
 
 describe('SessionsEditor', () => {
-  const mockHandleSessions = jest.fn();
+  const mockDispatchSessions = jest.fn();
   const initialSessions = [
     {
       date: '2025-03-28',
@@ -75,66 +76,25 @@ describe('SessionsEditor', () => {
   const user = userEvent.setup();
 
   beforeEach(() => {
-    mockHandleSessions.mockClear();
+    mockDispatchSessions.mockClear();
   });
 
-  it('should render', () => {
+  it('renders', () => {
     render(
       <SessionsEditor
         sessions={initialSessions}
-        handleSessions={mockHandleSessions}
+        dispatchSessions={mockDispatchSessions}
       />
     );
 
     expect(screen.getByText('Add Date')).toBeInTheDocument();
   });
 
-  it('should call handleSessions when a session is updated', async () => {
+  it('adds a new session when "Add Date" is clicked', async () => {
     render(
       <SessionsEditor
         sessions={initialSessions}
-        handleSessions={mockHandleSessions}
-      />
-    );
-
-    const dateInput = screen.getByLabelText('Date');
-    fireEvent.change(dateInput, {target: {value: '2025-03-29'}});
-
-    await waitFor(() => {
-      expect(mockHandleSessions).toHaveBeenCalledTimes(1);
-      expect(mockHandleSessions).toHaveBeenCalledWith([
-        {
-          ...initialSessions[0],
-          date: '2025-03-29',
-        },
-      ]);
-    });
-  });
-
-  it('should call handleSessions when a session is deleted', async () => {
-    render(
-      <SessionsEditor
-        sessions={initialSessions}
-        handleSessions={mockHandleSessions}
-      />
-    );
-
-    const deleteButton = screen.getByRole('button', {
-      name: 'delete workshop session',
-    });
-    await user.click(deleteButton);
-
-    await waitFor(() => {
-      expect(mockHandleSessions).toHaveBeenCalledTimes(1);
-      expect(mockHandleSessions).toHaveBeenCalledWith([]);
-    });
-  });
-
-  it('should add a new session when "Add Date" is clicked', async () => {
-    render(
-      <SessionsEditor
-        sessions={initialSessions}
-        handleSessions={mockHandleSessions}
+        dispatchSessions={mockDispatchSessions}
       />
     );
 
@@ -142,64 +102,16 @@ describe('SessionsEditor', () => {
     await user.click(addButton);
 
     await waitFor(() => {
-      expect(mockHandleSessions).toHaveBeenCalledTimes(1);
-      expect(mockHandleSessions).toHaveBeenCalledWith([
-        ...initialSessions,
-        generateNewSession(initialSessions[0]),
-      ]);
-    });
-  });
-
-  it('should update sameAsPrevious and copy data from previous session', async () => {
-    const sessions = [
-      {
-        date: '2025-03-28',
-        start: '8:00am',
-        end: '5:00pm',
-        locationAddress: '123 Main St',
-        locationName: 'Test Location',
-        meetingLink: '',
-        format: 'in_person',
-        sameAsPrevious: false,
-      },
-      {
-        date: '2025-03-29',
-        start: '9:00am',
-        end: '6:00pm',
-        locationAddress: '',
-        locationName: '',
-        meetingLink: '',
-        format: 'in_person',
-        sameAsPrevious: false,
-      },
-    ];
-    render(
-      <SessionsEditor sessions={sessions} handleSessions={mockHandleSessions} />
-    );
-
-    const checkbox = screen.getByLabelText('Location same as previous');
-    await user.click(checkbox);
-
-    await waitFor(() => {
-      expect(mockHandleSessions).toHaveBeenCalledTimes(1);
-      expect(mockHandleSessions).toHaveBeenCalledWith([
-        sessions[0],
-        {
-          ...sessions[1],
-          sameAsPrevious: true,
-          locationAddress: sessions[0].locationAddress,
-          locationName: sessions[0].locationName,
-          meetingLink: sessions[0].meetingLink,
-        },
-      ]);
+      expect(mockDispatchSessions).toHaveBeenCalledTimes(1);
+      expect(mockDispatchSessions).toHaveBeenCalledWith({
+        type: 'ADD_SESSION',
+      });
     });
   });
 });
 
 describe('SessionPart', () => {
-  const mockHandleSession = jest.fn();
-  const mockDeleteSession = jest.fn();
-  const mockHandleSameAsPrevious = jest.fn();
+  const dispatchSessions = jest.fn();
   const mockSession = {
     date: '2025-03-28',
     start: '8:00am',
@@ -212,35 +124,34 @@ describe('SessionPart', () => {
   };
 
   const SessionPartWithState = (props = {}) => {
-    const [session, setSession] = useState(props?.session ?? mockSession);
+    const [sessions, dispatch] = useReducer(sessionReducer, [
+      props?.session ?? mockSession,
+    ]);
+    if (!sessions.length) return null;
     return (
       <SessionPart
-        handleSession={mockHandleSession.mockImplementation(setSession)}
-        deleteSession={mockDeleteSession}
-        handleSameAsPrevious={mockHandleSameAsPrevious}
+        dispatchSessions={dispatchSessions.mockImplementation(dispatch)}
         showSameAsPrevious={true}
+        index={0}
         {...props}
-        session={session}
+        {...sessions[0]}
       />
     );
   };
   SessionPartWithState.propTypes = {
     session: PropTypes.object,
-    handleSession: PropTypes.func,
-    deleteSession: PropTypes.func,
-    handleSameAsPrevious: PropTypes.func,
+    dispatchSessions: PropTypes.func,
     showSameAsPrevious: PropTypes.bool,
+    index: PropTypes.number,
   };
 
   const user = userEvent.setup();
 
   beforeEach(() => {
-    mockHandleSession.mockClear();
-    mockDeleteSession.mockClear();
-    mockHandleSameAsPrevious.mockClear();
+    dispatchSessions.mockClear();
   });
 
-  it('should render without crashing', () => {
+  it('renders with form fields', () => {
     render(<SessionPartWithState />);
 
     expect(screen.getByLabelText('Date')).toBeInTheDocument();
@@ -251,67 +162,79 @@ describe('SessionPart', () => {
     expect(screen.getByLabelText('Location address')).toBeInTheDocument();
   });
 
-  it('should call handleSession when date changes', async () => {
+  it('dispatches UPDATE_SESSION when date changes', async () => {
     render(<SessionPartWithState />);
 
     const dateInput = screen.getByLabelText('Date');
     fireEvent.change(dateInput, {target: {value: '2025-03-29'}});
 
     await waitFor(() => {
-      expect(mockHandleSession).toHaveBeenCalledTimes(1);
-      expect(mockHandleSession).toHaveBeenCalledWith({
-        ...mockSession,
-        date: '2025-03-29',
+      expect(dispatchSessions).toHaveBeenCalledTimes(1);
+      expect(dispatchSessions).toHaveBeenCalledWith({
+        index: 0,
+        type: 'UPDATE_SESSION',
+        payload: {
+          date: '2025-03-29',
+        },
       });
     });
   });
 
-  it('should call handleSession when start time changes', async () => {
+  it('dispatches UPDATE_SESSION when start time changes', async () => {
     render(<SessionPartWithState />);
 
     const startTimeDropdown = screen.getByLabelText('Start Time');
     await user.selectOptions(startTimeDropdown, '8:30am');
 
     await waitFor(() => {
-      expect(mockHandleSession).toHaveBeenCalledTimes(1);
-      expect(mockHandleSession).toHaveBeenCalledWith({
-        ...mockSession,
-        start: '8:30am',
+      expect(dispatchSessions).toHaveBeenCalledTimes(1);
+      expect(dispatchSessions).toHaveBeenCalledWith({
+        index: 0,
+        type: 'UPDATE_SESSION',
+        payload: {
+          start: '8:30am',
+        },
       });
     });
   });
 
-  it('should call handleSession when end time changes', async () => {
+  it('dispatches UPDATE_SESSION when end time changes', async () => {
     render(<SessionPartWithState />);
 
     const endTimeDropdown = screen.getByLabelText('End Time');
     await user.selectOptions(endTimeDropdown, '5:30pm');
 
     await waitFor(() => {
-      expect(mockHandleSession).toHaveBeenCalledTimes(1);
-      expect(mockHandleSession).toHaveBeenCalledWith({
-        ...mockSession,
-        end: '5:30pm',
+      expect(dispatchSessions).toHaveBeenCalledTimes(1);
+      expect(dispatchSessions).toHaveBeenCalledWith({
+        index: 0,
+        type: 'UPDATE_SESSION',
+        payload: {
+          end: '5:30pm',
+        },
       });
     });
   });
 
-  it('should call handleSession when format changes', async () => {
+  it('dispatches UPDATE_SESSION when format changes', async () => {
     render(<SessionPartWithState />);
 
     const formatDropdown = screen.getByLabelText('Format');
     await user.selectOptions(formatDropdown, 'virtual');
 
     await waitFor(() => {
-      expect(mockHandleSession).toHaveBeenCalledTimes(1);
-      expect(mockHandleSession).toHaveBeenCalledWith({
-        ...mockSession,
-        format: 'virtual',
+      expect(dispatchSessions).toHaveBeenCalledTimes(1);
+      expect(dispatchSessions).toHaveBeenCalledWith({
+        index: 0,
+        type: 'UPDATE_SESSION',
+        payload: {
+          format: 'virtual',
+        },
       });
     });
   });
 
-  it('should call deleteSession when delete button is clicked', async () => {
+  it('dispatches DELETE_SESSION when delete button is clicked', async () => {
     render(<SessionPartWithState />);
 
     const deleteButton = screen.getByRole('button', {
@@ -319,10 +242,14 @@ describe('SessionPart', () => {
     });
     await user.click(deleteButton);
 
-    expect(mockDeleteSession).toHaveBeenCalledTimes(1);
+    expect(dispatchSessions).toHaveBeenCalledTimes(1);
+    expect(dispatchSessions).toHaveBeenCalledWith({
+      index: 0,
+      type: 'DELETE_SESSION',
+    });
   });
 
-  it('should call handleSession when location name changes', async () => {
+  it('dispatches UPDATE_SESSION when location name changes', async () => {
     render(<SessionPartWithState />);
 
     const locationNameInput = screen.getByLabelText('Location name');
@@ -331,15 +258,18 @@ describe('SessionPart', () => {
     await user.type(locationNameInput, newLocation);
 
     await waitFor(() => {
-      expect(mockHandleSession).toHaveBeenCalledTimes(newLocation.length + 1);
-      expect(mockHandleSession).toHaveBeenCalledWith({
-        ...mockSession,
-        locationName: newLocation,
+      expect(dispatchSessions).toHaveBeenCalledTimes(newLocation.length + 1);
+      expect(dispatchSessions).toHaveBeenCalledWith({
+        index: 0,
+        type: 'UPDATE_SESSION',
+        payload: {
+          locationName: newLocation,
+        },
       });
     });
   });
 
-  it('should call handleSession when location address changes', async () => {
+  it('dispatches UPDATE_SESSION when location address changes', async () => {
     render(<SessionPartWithState />);
 
     const locationAddressInput = screen.getByLabelText('Location address');
@@ -348,15 +278,18 @@ describe('SessionPart', () => {
     await user.type(locationAddressInput, newAddress);
 
     await waitFor(() => {
-      expect(mockHandleSession).toHaveBeenCalledTimes(newAddress.length + 1);
-      expect(mockHandleSession).toHaveBeenCalledWith({
-        ...mockSession,
-        locationAddress: newAddress,
+      expect(dispatchSessions).toHaveBeenCalledTimes(newAddress.length + 1);
+      expect(dispatchSessions).toHaveBeenCalledWith({
+        index: 0,
+        type: 'UPDATE_SESSION',
+        payload: {
+          locationAddress: newAddress,
+        },
       });
     });
   });
 
-  it('should call handleSession when meeting link changes', async () => {
+  it('dispatches UPDATE_SESSION when meeting link changes', async () => {
     const virtualSession = {
       ...mockSession,
       format: 'virtual',
@@ -370,27 +303,51 @@ describe('SessionPart', () => {
     await user.type(meetingLinkInput, newLink);
 
     await waitFor(() => {
-      expect(mockHandleSession).toHaveBeenCalledTimes(newLink.length + 1);
-      expect(mockHandleSession).toHaveBeenCalledWith({
-        ...virtualSession,
-        meetingLink: newLink,
+      expect(dispatchSessions).toHaveBeenCalledTimes(newLink.length + 1);
+      expect(dispatchSessions).toHaveBeenCalledWith({
+        index: 0,
+        type: 'UPDATE_SESSION',
+        payload: {
+          meetingLink: newLink,
+        },
       });
     });
   });
 
-  it('should call handleSameAsPrevious when same as previous checkbox is clicked', async () => {
+  it('dispatches UPDATE_SESSION when same as previous checkbox is unchecked', async () => {
+    render(
+      <SessionPartWithState session={{...mockSession, sameAsPrevious: true}} />
+    );
+
+    const checkbox = screen.getByLabelText('Location same as previous');
+    await user.click(checkbox);
+
+    await waitFor(() => {
+      expect(dispatchSessions).toHaveBeenCalledTimes(1);
+      expect(dispatchSessions).toHaveBeenCalledWith({
+        index: 0,
+        type: 'UPDATE_SESSION',
+        payload: {sameAsPrevious: false},
+      });
+    });
+  });
+
+  it('dispatches UPDATE_SESSION_SAME_AS_PREVIOUS when same as previous checkbox is checked', async () => {
     render(<SessionPartWithState />);
 
     const checkbox = screen.getByLabelText('Location same as previous');
     await user.click(checkbox);
 
     await waitFor(() => {
-      expect(mockHandleSameAsPrevious).toHaveBeenCalledTimes(1);
-      expect(mockHandleSameAsPrevious).toHaveBeenCalledWith(true);
+      expect(dispatchSessions).toHaveBeenCalledTimes(1);
+      expect(dispatchSessions).toHaveBeenCalledWith({
+        index: 0,
+        type: 'UPDATE_SESSION_SAME_AS_PREVIOUS',
+      });
     });
   });
 
-  it('should update same as previous label when session format changes', async () => {
+  it('updates same as previous label when session format changes', async () => {
     render(<SessionPartWithState />);
 
     expect(
@@ -405,7 +362,7 @@ describe('SessionPart', () => {
     ).toBeInTheDocument();
   });
 
-  it('should not show same as previous checkbox when showSameAsPrevious is false', () => {
+  it('does not show same as previous checkbox when showSameAsPrevious is false', () => {
     render(<SessionPartWithState showSameAsPrevious={false} />);
 
     expect(
@@ -413,7 +370,7 @@ describe('SessionPart', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should show meeting link when format is virtual', () => {
+  it('shows meeting link when format is virtual', () => {
     const virtualSession = {
       ...mockSession,
       format: 'virtual',

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditorTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditorTest.jsx
@@ -16,9 +16,11 @@ import {
 } from '@cdo/apps/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor';
 
 describe('generateNewSession', () => {
+  const newIdRegex = /^new-\d+-\w+$/;
   it('generates a new session with default values', () => {
     const newSession = generateNewSession();
 
+    expect(newSession.id).toMatch(newIdRegex);
     expect(newSession.date).toEqual(moment().format(DATE_FORMAT));
     expect(newSession.start).toEqual(
       moment().startOf('day').add(7, 'hours').format(TIME_FORMAT)
@@ -35,6 +37,7 @@ describe('generateNewSession', () => {
 
   it('generates a new session based on the previous session', () => {
     const prevSession = {
+      id: 'new-123-abc',
       date: '2025-03-28',
       start: '8:00am',
       end: '5:00pm',
@@ -49,6 +52,8 @@ describe('generateNewSession', () => {
     expect(newSession.date).toEqual(
       moment('2025-03-28', DATE_FORMAT).add(1, 'day').format(DATE_FORMAT)
     );
+    expect(newSession.id).toMatch(newIdRegex);
+    expect(newSession.id).not.toEqual(prevSession.id);
     expect(newSession.start).toEqual('8:00am');
     expect(newSession.end).toEqual('5:00pm');
     expect(newSession.locationAddress).toEqual('123 Main St');
@@ -63,6 +68,7 @@ describe('SessionsEditor', () => {
   const mockDispatchSessions = jest.fn();
   const initialSessions = [
     {
+      id: 'new-123-abc',
       date: '2025-03-28',
       start: '8:00am',
       end: '5:00pm',
@@ -113,6 +119,7 @@ describe('SessionsEditor', () => {
 describe('SessionPart', () => {
   const dispatchSessions = jest.fn();
   const mockSession = {
+    id: 'new-123-abc',
     date: '2025-03-28',
     start: '8:00am',
     end: '5:00pm',
@@ -171,7 +178,7 @@ describe('SessionPart', () => {
     await waitFor(() => {
       expect(dispatchSessions).toHaveBeenCalledTimes(1);
       expect(dispatchSessions).toHaveBeenCalledWith({
-        index: 0,
+        id: mockSession.id,
         type: 'UPDATE_SESSION',
         payload: {
           date: '2025-03-29',
@@ -189,7 +196,7 @@ describe('SessionPart', () => {
     await waitFor(() => {
       expect(dispatchSessions).toHaveBeenCalledTimes(1);
       expect(dispatchSessions).toHaveBeenCalledWith({
-        index: 0,
+        id: mockSession.id,
         type: 'UPDATE_SESSION',
         payload: {
           start: '8:30am',
@@ -207,7 +214,7 @@ describe('SessionPart', () => {
     await waitFor(() => {
       expect(dispatchSessions).toHaveBeenCalledTimes(1);
       expect(dispatchSessions).toHaveBeenCalledWith({
-        index: 0,
+        id: mockSession.id,
         type: 'UPDATE_SESSION',
         payload: {
           end: '5:30pm',
@@ -225,7 +232,7 @@ describe('SessionPart', () => {
     await waitFor(() => {
       expect(dispatchSessions).toHaveBeenCalledTimes(1);
       expect(dispatchSessions).toHaveBeenCalledWith({
-        index: 0,
+        id: mockSession.id,
         type: 'UPDATE_SESSION',
         payload: {
           format: 'virtual',
@@ -244,7 +251,7 @@ describe('SessionPart', () => {
 
     expect(dispatchSessions).toHaveBeenCalledTimes(1);
     expect(dispatchSessions).toHaveBeenCalledWith({
-      index: 0,
+      id: mockSession.id,
       type: 'DELETE_SESSION',
     });
   });
@@ -260,7 +267,7 @@ describe('SessionPart', () => {
     await waitFor(() => {
       expect(dispatchSessions).toHaveBeenCalledTimes(newLocation.length + 1);
       expect(dispatchSessions).toHaveBeenCalledWith({
-        index: 0,
+        id: mockSession.id,
         type: 'UPDATE_SESSION',
         payload: {
           locationName: newLocation,
@@ -280,7 +287,7 @@ describe('SessionPart', () => {
     await waitFor(() => {
       expect(dispatchSessions).toHaveBeenCalledTimes(newAddress.length + 1);
       expect(dispatchSessions).toHaveBeenCalledWith({
-        index: 0,
+        id: mockSession.id,
         type: 'UPDATE_SESSION',
         payload: {
           locationAddress: newAddress,
@@ -305,7 +312,7 @@ describe('SessionPart', () => {
     await waitFor(() => {
       expect(dispatchSessions).toHaveBeenCalledTimes(newLink.length + 1);
       expect(dispatchSessions).toHaveBeenCalledWith({
-        index: 0,
+        id: mockSession.id,
         type: 'UPDATE_SESSION',
         payload: {
           meetingLink: newLink,
@@ -325,7 +332,7 @@ describe('SessionPart', () => {
     await waitFor(() => {
       expect(dispatchSessions).toHaveBeenCalledTimes(1);
       expect(dispatchSessions).toHaveBeenCalledWith({
-        index: 0,
+        id: mockSession.id,
         type: 'UPDATE_SESSION',
         payload: {sameAsPrevious: false},
       });
@@ -341,7 +348,7 @@ describe('SessionPart', () => {
     await waitFor(() => {
       expect(dispatchSessions).toHaveBeenCalledTimes(1);
       expect(dispatchSessions).toHaveBeenCalledWith({
-        index: 0,
+        id: mockSession.id,
         type: 'UPDATE_SESSION_SAME_AS_PREVIOUS',
       });
     });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

There are several attempts at reducing form component re-renders in this pr:
- pass individual workshop state properties as props to just the section components that need them
  - primitive values passed as props are more easily compared to the next props after a change
  - requires section components to be wrapped in `React.memo`, which will be done in a follow-up [pr](https://github.com/code-dot-org/code-dot-org/pull/64852)
- wrap functions passed as props in `useCallback` with only the dispatch function (stable) as a dependency
- avoid anonymous functions passed as props, which would trigger child re-renders whenever a parent component re-renders
- move data fetching to sections that use the data

general improvements also included:
- move state to a reducer pattern (makes state handlers in child components much less complex, moves complexity to the reducers)
- generate string ids for new sessions (prefixed with `new-`) and existing sessions (prefixed with `existing-`) and use the ids rather than the session index
- adds tooltip to the delete session buttons and fix layout styles
- update course offerings Tags component to use new onClose handler

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3182)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
