### PR TITLE
Adds lang attribute (via Ryan)

### DIFF
--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -1,6 +1,6 @@
 !!! 5
 -require '../shared/middleware/helpers/experiments'
-%html{dir: locale_dir}
+%html{dir: locale_dir, lang: locale}
   %head
     = render partial: 'i18n/crowdin_in_context_tool'
     = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'onetrust_cookie_scripts.haml')), type: :haml, locals: {dashboard: true, domain: 'code.org'}


### PR DESCRIPTION
Simply resurrects [Ryan's PR](https://github.com/code-dot-org/code-dot-org/pull/49547/files) to add the `lang` attribute to the `html` tag.

## Links

- jira ticket: [P20-1439](https://codedotorg.atlassian.net/browse/P20-1439)
- jira ticket: [A11Y-16](https://codedotorg.atlassian.net/browse/A11Y-16)
- jira ticket: [CT-1004](https://codedotorg.atlassian.net/browse/CT-1004)
- jira ticket: [CT-1104](https://codedotorg.atlassian.net/browse/CT-1104)

## Testing story

In the prior effort, it was sunk by eyes tests. However, in the time since, we have implemented font fallbacks that should manage this and keep the fonts consistent.

We have manually tested this in a local development server and first saw it break as it did before when the fallbacks were not used and then fixed with the fallback fonts enabled (as they would be in production right now).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
