### PR TITLE
Re-add calendar to un-assigned unit page

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -138,7 +138,10 @@ class UnitOverviewTopRow extends React.Component {
           )}
 
           <div style={styles.resourcesRow}>
-            {!showV2TeacherDashboard() &&
+            {!(
+              showV2TeacherDashboard() &&
+              location.pathname.includes('teacher_dashboard')
+            ) &&
               showCalendar &&
               viewAs === ViewType.Instructor && (
                 <UnitCalendarButton


### PR DESCRIPTION
Re-add the calendar button with a popup to the unassigned unit page

Unassigned unit page:
![image](https://github.com/user-attachments/assets/7f035c86-60ae-4c2d-bb25-d8dfd68ddaed)

## Links
https://codedotorg.atlassian.net/browse/TEACH-1694