### PR TITLE
Marketing router lambda

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -29,6 +29,7 @@ Parameters:
     Description: Subdomain name for corporate web site ("Pegasus").
   MarketingDomainName:
     Type: String
+    # Todo: update to handle multiple envs once the app is in prod
     Default: 'dev.marketing.dev-code.org'
     Description: Subdomain name for marketing site.
   HourOfCodeBaseDomainName:
@@ -410,7 +411,9 @@ Resources:
     Properties:
       Description: 'Lambda for dynamically routing marketing traffic to different origins based on the URL path'
       FunctionName: !Sub "${AWS::StackName}-marketing-router"
-      Code: <%=zip_directory 'marketing-router'%>
+      # The JS file for this function depends on the Sub function to inject the value of MarketingDomainName
+      Code: 
+        ZipFile: !Sub <%=js 'lambdas/marketing-router/index.js'%>
       Handler: index.handler
       Runtime: nodejs22.x
       Role: !GetAtt MarketingRouterLambdaRole.Arn

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -413,7 +413,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-marketing-router"
       # The JS file for this function depends on the Sub function to inject the value of MarketingDomainName
       Code: 
-        ZipFile: !Sub <%=js 'lambdas/marketing-router/index.js'%>
+        ZipFile: !Sub <%=inline_js 'lambdas/marketing-router/index.js'%>
       Handler: index.handler
       Runtime: nodejs22.x
       Role: !GetAtt MarketingRouterLambdaRole.Arn

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -414,6 +414,9 @@ Resources:
       Handler: index.handler
       Runtime: nodejs22.x
       Role: !GetAtt MarketingRouterLambdaRole.Arn
+      LoggingConfig:
+        ApplicationLogLevel: "ERROR"
+        LogFormat: "JSON"
       Environment:
         Variables:
           MARKETING_DOMAIN: !Ref MarketingDomainName

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -27,6 +27,10 @@ Parameters:
     Type: String
     Default: <%=rack_env?(:production) ? '\'\'' : stack_name %>
     Description: Subdomain name for corporate web site ("Pegasus").
+  MarketingSubdomainName:
+    Type: String
+    Default: <%=rack_env?(:production) ? 'marketing' : "#{stack_name}-marketing" %>
+    Description: Subdomain name for marketing site.
   HourOfCodeBaseDomainName:
     Type: String
     Default: hourofcode.com
@@ -412,7 +416,7 @@ Resources:
       Role: !GetAtt MarketingRouterLambdaRole.Arn
       Environment:
         Variables:
-          MARKETING_DOMAIN: dev.marketing.dev-code.org
+          MARKETING_DOMAIN: !Sub "${MarketingSubdomainName}.${BaseDomainName}"
   MarketingRouterVersion:
     Type: AWS::Lambda::Version
     Properties:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -427,7 +427,7 @@ Resources:
       <%=service_role ['lambda', 'edgelambda']%>
       Path: /
       Policies:
-        - PolicyName: !Sub "${AWS::StackName}-marketing-lambda-execution-policy"
+        - PolicyName: Logging
           PolicyDocument:
             Version: "2012-10-17"
             Statement:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -401,6 +401,45 @@ Resources:
 
 <%   if cdn_enabled && app == 'Pegasus' -%>
 <%=    component 'www_redirect', app: app -%>
+  MarketingRouterLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: 'Lambda for dynamically routing marketing traffic to different origins based on the URL path'
+      FunctionName: <%="#{rack_env.to_s}-MarketingRouter"%>%
+      Code: <%=zip_directory 'marketing-router'%>
+      Handler: index.handler
+      Runtime: nodejs22.x
+      Role: !GetAtt MarketingRouterLambdaRole.Arn
+      Environment:
+        Variables:
+          MARKETING_DOMAIN: dev.marketing.dev-code.org
+  MarketingRouterVersion:
+    Type: AWS::Lambda::Version
+    Properties:
+      FunctionName: !Ref MarketingRouterLambda
+  MarketingRouterLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      <%=multiple_service_role ['lambda', 'edgelambda']%>
+      Path: /
+      Policies:
+        - PolicyName: <%="#{rack_env.to_s}-MarketingLambdaExecutionPolicy"%>%
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                Resource: 
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${MarketingRouterLambda.FunctionName}:*"
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${MarketingRouterLambda.FunctionName}:*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${MarketingRouterLambda.FunctionName}:log-stream:*"
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${MarketingRouterLambda.FunctionName}:log-stream:*"
 <%  end -%>
 
 <% end -%>
@@ -779,3 +818,6 @@ Outputs:
     Value: <%=cdn_enabled ? subdomain('origin') : stack_name%>
     Description: SSH server name
 <%end-%>
+  MarketingRouterVersion:
+    Value: !Ref MarketingRouterVersion
+    Export: {Name: MarketingRouterVersion}

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -27,9 +27,9 @@ Parameters:
     Type: String
     Default: <%=rack_env?(:production) ? '\'\'' : stack_name %>
     Description: Subdomain name for corporate web site ("Pegasus").
-  MarketingSubdomainName:
+  MarketingDomainName:
     Type: String
-    Default: <%=rack_env?(:production) ? 'marketing' : "#{stack_name}-marketing" %>
+    Default: 'dev.marketing.dev-code.org'
     Description: Subdomain name for marketing site.
   HourOfCodeBaseDomainName:
     Type: String
@@ -416,7 +416,7 @@ Resources:
       Role: !GetAtt MarketingRouterLambdaRole.Arn
       Environment:
         Variables:
-          MARKETING_DOMAIN: !Sub "${MarketingSubdomainName}.${BaseDomainName}"
+          MARKETING_DOMAIN: !Sub "${MarketingDomainName}"
   MarketingRouterVersion:
     Type: AWS::Lambda::Version
     Properties:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -405,7 +405,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Description: 'Lambda for dynamically routing marketing traffic to different origins based on the URL path'
-      FunctionName: <%="#{rack_env.to_s}-MarketingRouter"%>%
+      FunctionName: !Sub "${AWS::StackName}-marketing-router"
       Code: <%=zip_directory 'marketing-router'%>
       Handler: index.handler
       Runtime: nodejs22.x
@@ -423,7 +423,7 @@ Resources:
       <%=multiple_service_role ['lambda', 'edgelambda']%>
       Path: /
       Policies:
-        - PolicyName: <%="#{rack_env.to_s}-MarketingLambdaExecutionPolicy"%>%
+        - PolicyName: !Sub "${AWS::StackName}-marketing-lambda-execution-policy"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -420,7 +420,7 @@ Resources:
   MarketingRouterLambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      <%=multiple_service_role ['lambda', 'edgelambda']%>
+      <%=service_role ['lambda', 'edgelambda']%>
       Path: /
       Policies:
         - PolicyName: !Sub "${AWS::StackName}-marketing-lambda-execution-policy"

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -410,7 +410,7 @@ Resources:
     Properties:
       Description: 'Lambda for dynamically routing marketing traffic to different origins based on the URL path'
       FunctionName: !Sub "${AWS::StackName}-marketing-router"
-      Code: <%=js 'marketing-router'%>
+      Code: <%=zip_directory 'marketing-router'%>
       Handler: index.handler
       Runtime: nodejs22.x
       Role: !GetAtt MarketingRouterLambdaRole.Arn

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -406,7 +406,7 @@ Resources:
     Properties:
       Description: 'Lambda for dynamically routing marketing traffic to different origins based on the URL path'
       FunctionName: !Sub "${AWS::StackName}-marketing-router"
-      Code: <%=zip_directory 'marketing-router'%>
+      Code: <%=js 'marketing-router'%>
       Handler: index.handler
       Runtime: nodejs22.x
       Role: !GetAtt MarketingRouterLambdaRole.Arn

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -416,7 +416,7 @@ Resources:
       Role: !GetAtt MarketingRouterLambdaRole.Arn
       Environment:
         Variables:
-          MARKETING_DOMAIN: !Sub "${MarketingDomainName}"
+          MARKETING_DOMAIN: !Ref MarketingDomainName
   MarketingRouterVersion:
     Type: AWS::Lambda::Version
     Properties:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -417,9 +417,6 @@ Resources:
       LoggingConfig:
         ApplicationLogLevel: "ERROR"
         LogFormat: "JSON"
-      Environment:
-        Variables:
-          MARKETING_DOMAIN: !Ref MarketingDomainName
   MarketingRouterVersion:
     Type: AWS::Lambda::Version
     Properties:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -447,6 +447,7 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${AWS::StackName}-marketing-router:log-stream:*"
                   - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${AWS::StackName}-marketing-router:log-stream:*"
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
 <%  end -%>
 
 <% end -%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -435,15 +435,15 @@ Resources:
                 Action:
                   - logs:CreateLogGroup
                 Resource: 
-                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${MarketingRouterLambda.FunctionName}:*"
-                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${MarketingRouterLambda.FunctionName}:*"
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${AWS::StackName}-marketing-router:*"
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${AWS::StackName}-marketing-router:*"
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${MarketingRouterLambda.FunctionName}:log-stream:*"
-                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${MarketingRouterLambda.FunctionName}:log-stream:*"
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${AWS::StackName}-marketing-router:log-stream:*"
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${AWS::StackName}-marketing-router:log-stream:*"
 <%  end -%>
 
 <% end -%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -818,6 +818,3 @@ Outputs:
     Value: <%=cdn_enabled ? subdomain('origin') : stack_name%>
     Description: SSH server name
 <%end-%>
-  MarketingRouterVersion:
-    Value: !Ref MarketingRouterVersion
-    Export: {Name: MarketingRouterVersion}

--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -319,6 +319,43 @@ Resources:
                 Action: 'secretsmanager:GetSecretValue'
                 Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:CfnStack/*/db_endpoint_writer-??????"
       PermissionsBoundary: !ImportValue IAM-DevPermissions
+  MarketingRouterLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: 'Lambda for dynamically routing marketing traffic to different origins based on the URL path'
+      FunctionName: MarketingRouter
+      Code: <%=zip_directory 'marketing-router'%>
+      Handler: index.handler
+      Runtime: nodejs22.x
+      Role: !GetAtt MarketingRouterLambdaRole.Arn
+  MarketingRouterVersion:
+    Type: AWS::Lambda::Version
+    Properties:
+      FunctionName: !Ref MarketingRouterLambda
+  MarketingRouterLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      <%=multiple_service_role ['lambda', 'edgelambda']%>
+      Path: /
+      Policies:
+        - PolicyName: MarketingLambdaExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                Resource: 
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${MarketingRouterLambda.FunctionName}:*"
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${MarketingRouterLambda.FunctionName}:*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${MarketingRouterLambda.FunctionName}:log-stream:*"
+                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${MarketingRouterLambda.FunctionName}:log-stream:*"
+
 
   LambdaSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -350,3 +387,6 @@ Outputs:
   S3LogsRole:
     Value: !GetAtt S3LogsRole.Arn
     Export: {Name: S3LogsRole}
+  MarketingRouterVersion:
+    Value: !Ref MarketingRouterVersion
+    Export: {Name: MarketingRouterVersion}

--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -319,43 +319,6 @@ Resources:
                 Action: 'secretsmanager:GetSecretValue'
                 Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:CfnStack/*/db_endpoint_writer-??????"
       PermissionsBoundary: !ImportValue IAM-DevPermissions
-  MarketingRouterLambda:
-    Type: AWS::Lambda::Function
-    Properties:
-      Description: 'Lambda for dynamically routing marketing traffic to different origins based on the URL path'
-      FunctionName: MarketingRouter
-      Code: <%=zip_directory 'marketing-router'%>
-      Handler: index.handler
-      Runtime: nodejs22.x
-      Role: !GetAtt MarketingRouterLambdaRole.Arn
-  MarketingRouterVersion:
-    Type: AWS::Lambda::Version
-    Properties:
-      FunctionName: !Ref MarketingRouterLambda
-  MarketingRouterLambdaRole:
-    Type: AWS::IAM::Role
-    Properties:
-      <%=multiple_service_role ['lambda', 'edgelambda']%>
-      Path: /
-      Policies:
-        - PolicyName: MarketingLambdaExecutionPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                Resource: 
-                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${MarketingRouterLambda.FunctionName}:*"
-                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${MarketingRouterLambda.FunctionName}:*"
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource:
-                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/us-east-1.${MarketingRouterLambda.FunctionName}:log-stream:*"
-                  - !Sub "arn:aws:logs:*:*:log-group:/aws/lambda/${MarketingRouterLambda.FunctionName}:log-stream:*"
-
 
   LambdaSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -387,6 +350,3 @@ Outputs:
   S3LogsRole:
     Value: !GetAtt S3LogsRole.Arn
     Export: {Name: S3LogsRole}
-  MarketingRouterVersion:
-    Value: !Ref MarketingRouterVersion
-    Export: {Name: MarketingRouterVersion}

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -7,7 +7,7 @@ const marketingPaths = {
   // e.g. '/videos': true,
 }
 
-export const handler = (event, context, callback) => {
+module.exports.handler = (event, context, callback) => {
   const request = event?.Records?.[0]?.cf?.request;
   const uri = request?.uri;
 

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -8,8 +8,8 @@ const marketingPaths = {
 }
 
 export const handler = (event, context, callback) => {
-  const request = event.Records[0].cf.request;
-  const uri = request.uri;
+  const request = event?.Records?.[0]?.cf?.request;
+  const uri = request?.uri;
 
   // Set CMS origin if the requested path matches
   if (marketingPaths[uri]) {

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -1,14 +1,17 @@
 'use strict';
 
-const cmsDomain = 'marketing.code.org'; // Change to the CMS Cloudfront or ALB
+// const cmsDomain = 'd1zjy2ptvqjefb.cloudfront.net'; // Change to the CMS Cloudfront or ALB
+const cmsDomain = 'dev.marketing.dev-code.org';
 
 const cmsPaths = {
   '/about': true,
+  '/en-US/videos': true,
 }
 
-exports.handler = (event, context, callback) => {
+export const handler = (event, context, callback) => {
   const request = event.Records[0].cf.request;
   const uri = request.uri;
+  console.log('Request URI:', uri);
 
   // Set CMS origin if the requested path matches
   if (cmsPaths[uri]) {

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const { MARKETING_DOMAIN } = process.env;
+const MARKETING_DOMAINS = {
+  'marketing-test': 'dev.marketing.dev-code.org',
+};
 
 const marketingPaths = {
   // Add key-value pairs for each path that should be served by the CMS
@@ -9,13 +11,15 @@ const marketingPaths = {
 
 module.exports.handler = (event, context, callback) => {
   const request = event?.Records?.[0]?.cf?.request;
+  const requestEnvHeader = request?.origin?.custom?.customHeaders?.['x-cdo-env']?.[0]?.value;
+  const marketingDomain = MARKETING_DOMAINS[requestEnvHeader];
   const uri = request?.uri;
 
   // Set CMS origin if the requested path matches
   if (marketingPaths[uri]) {
     request.origin = {
       custom: {
-        domainName: MARKETING_DOMAIN,
+        domainName: marketingDomain,
         port: 443,
         protocol: 'https',
         path: '',
@@ -27,7 +31,7 @@ module.exports.handler = (event, context, callback) => {
     };
 
     // Update the Host header to match the new origin
-    request.headers['host'] = [{ key: 'Host', value: MARKETING_DOMAIN }];
+    request.headers['host'] = [{ key: 'Host', value: marketingDomain }];
   }
 
   callback(null, request);

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -1,23 +1,20 @@
 'use strict';
 
-// const cmsDomain = 'd1zjy2ptvqjefb.cloudfront.net'; // Change to the CMS Cloudfront or ALB
-const cmsDomain = 'dev.marketing.dev-code.org';
+const { MARKETING_DOMAIN } = process.env;
 
-const cmsPaths = {
-  '/about': true,
+const marketingPaths = {
   '/en-US/videos': true,
 }
 
 export const handler = (event, context, callback) => {
   const request = event.Records[0].cf.request;
   const uri = request.uri;
-  console.log('Request URI:', uri);
 
   // Set CMS origin if the requested path matches
-  if (cmsPaths[uri]) {
+  if (marketingPaths[uri]) {
     request.origin = {
       custom: {
-        domainName: cmsDomain,
+        domainName: MARKETING_DOMAIN,
         port: 443,
         protocol: 'https',
         path: '',
@@ -29,7 +26,7 @@ export const handler = (event, context, callback) => {
     };
 
     // Update the Host header to match the new origin
-    request.headers['host'] = [{ key: 'Host', value: cmsDomain }];
+    request.headers['host'] = [{ key: 'Host', value: MARKETING_DOMAIN }];
   }
 
   callback(null, request);

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const MARKETING_DOMAINS = {
-  'marketing-test': 'dev.marketing.dev-code.org',
-};
+// This variable is injected via CloudFormation string substitution. This file must be used
+// in conjunction with the CloudFormation Sub function to set the value of MarketingDomainName.
+const marketingDomain = '${MarketingDomainName}'
 
 const marketingPaths = {
   // Add key-value pairs for each path that should be served by the CMS
@@ -11,8 +11,6 @@ const marketingPaths = {
 
 module.exports.handler = (event, context, callback) => {
   const request = event?.Records?.[0]?.cf?.request;
-  const requestEnvHeader = request?.origin?.custom?.customHeaders?.['x-cdo-env']?.[0]?.value;
-  const marketingDomain = MARKETING_DOMAINS[requestEnvHeader];
   const uri = request?.uri;
 
   // Set CMS origin if the requested path matches

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -10,27 +10,34 @@ const marketingPaths = {
 }
 
 module.exports.handler = (event, context, callback) => {
-  const request = event?.Records?.[0]?.cf?.request;
-  const uri = request?.uri;
+  try {
+    const request = event?.Records?.[0]?.cf?.request;
+    const uri = request?.uri;
+  
+    // Set CMS origin if the requested path matches
+    if (marketingPaths[uri]) {
+      request.origin = {
+        custom: {
+          domainName: marketingDomain,
+          port: 443,
+          protocol: 'https',
+          path: '',
+          sslProtocols: ['TLSv1.2'],
+          readTimeout: 30,
+          keepaliveTimeout: 5,
+          customHeaders: {},
+        },
+      };
+  
+      // Update the Host header to match the new origin
+      request.headers['host'] = [{ key: 'Host', value: marketingDomain }];
+    }
+  
+    callback(null, request);
+  } catch (error) {
+    console.error('Marketing router lambda error:', error);
 
-  // Set CMS origin if the requested path matches
-  if (marketingPaths[uri]) {
-    request.origin = {
-      custom: {
-        domainName: marketingDomain,
-        port: 443,
-        protocol: 'https',
-        path: '',
-        sslProtocols: ['TLSv1.2'],
-        readTimeout: 30,
-        keepaliveTimeout: 5,
-        customHeaders: {},
-      },
-    };
-
-    // Update the Host header to match the new origin
-    request.headers['host'] = [{ key: 'Host', value: marketingDomain }];
+    // If an error occurs, don't block. Pass through the request.
+    callback(null, request);
   }
-
-  callback(null, request);
 };

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const cmsDomain = 'marketing.code.org'; // Change to the CMS Cloudfront or ALB
+
+const cmsPaths = {
+  '/about': true,
+}
+
+exports.handler = (event, context, callback) => {
+  const request = event.Records[0].cf.request;
+  const uri = request.uri;
+
+  // Set CMS origin if the requested path matches
+  if (cmsPaths[uri]) {
+    request.origin = {
+      custom: {
+        domainName: cmsDomain,
+        port: 443,
+        protocol: 'https',
+        path: '',
+        sslProtocols: ['TLSv1.2'],
+        readTimeout: 30,
+        keepaliveTimeout: 5,
+        customHeaders: {},
+      },
+    };
+
+    // Update the Host header to match the new origin
+    request.headers['host'] = [{ key: 'Host', value: cmsDomain }];
+  }
+
+  callback(null, request);
+};

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -3,7 +3,8 @@
 const { MARKETING_DOMAIN } = process.env;
 
 const marketingPaths = {
-  '/en-US/videos': true,
+  // Add key-value pairs for each path that should be served by the CMS
+  // e.g. '/videos': true,
 }
 
 export const handler = (event, context, callback) => {

--- a/lib/cdo/cloud_formation/stack_template.rb
+++ b/lib/cdo/cloud_formation/stack_template.rb
@@ -50,6 +50,18 @@ module Cdo::CloudFormation
       "AssumeRolePolicyDocument: #{document.to_json}"
     end
 
+    # Generate a trust policy for multiple AWS services.
+    private def multiple_service_role(services)
+      document = {
+        Statement: [
+          Effect: 'Allow',
+          Action: 'sts:AssumeRole',
+          Principal: {Service: services.map {|service| "#{service}.amazonaws.com"}},
+        ]
+      }
+      "AssumeRolePolicyDocument: #{document.to_json}"
+    end
+
     private def erb_file(filename, vars = {})
       file = File.expand_path filename
       erb_eval(File.read(file), file, vars)

--- a/lib/cdo/cloud_formation/stack_template.rb
+++ b/lib/cdo/cloud_formation/stack_template.rb
@@ -39,19 +39,8 @@ module Cdo::CloudFormation
     end
 
     # Generate boilerplate Trust Policy for an AWS Service Role.
-    private def service_role(service)
-      document = {
-        Statement: [
-          Effect: 'Allow',
-          Action: 'sts:AssumeRole',
-          Principal: {Service: ["#{service}.amazonaws.com"]}
-        ]
-      }
-      "AssumeRolePolicyDocument: #{document.to_json}"
-    end
-
-    # Generate a trust policy for multiple AWS services.
-    private def multiple_service_role(services)
+    private def service_role(services)
+      services = Array(services)
       document = {
         Statement: [
           Effect: 'Allow',


### PR DESCRIPTION
First PR for adding the infrastructure needed to dynamically route requests to the marketing app instead of Pegasus. This PR only includes the lambda function itself and the execution role. Once this is merged, I'll follow up with a 2nd PR adding the function association to the Cloudfront distribution.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested that the cloudformation is valid using `adhoc:cdn:validate`. Ultimately we'll have to deploy for real to test this fully.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
