### PR TITLE
Revert "Music: play early"

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -446,7 +446,6 @@ export interface SoundData {
   path?: string;
   src: string;
   length: number;
-  pickupLength?: number;
   type: SoundType;
   note?: number;
   restricted?: boolean;

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -365,7 +365,6 @@ export default class MusicPlayer {
         id: event.id,
         sampleUrl: library.generateSoundUrl(folder, soundData),
         playbackPosition: event.when,
-        pickupLength: soundData.pickupLength,
         triggered: event.triggered,
         effects: event.effects,
         originalBpm: soundData.bpm || DEFAULT_BPM,

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -296,11 +296,7 @@ class ToneJSPlayer {
 
     player
       .sync()
-      .start(
-        this.playbackTimeToTransportTime(
-          sample.playbackPosition - (sample.pickupLength || 0)
-        )
-      );
+      .start(this.playbackTimeToTransportTime(sample.playbackPosition));
 
     this.activePlayers.push(player);
 
@@ -384,7 +380,7 @@ class ToneJSPlayer {
     transportTime: BarsBeatsSixteenths
   ): number {
     const [bar, beat, sixteenths] = transportTime.split(':').map(Number);
-    return bar + beat / 4 + sixteenths / 16;
+    return bar + 1 + beat / 4 + sixteenths / 16;
   }
 
   private playbackTimeToTransportTime(
@@ -395,7 +391,7 @@ class ToneJSPlayer {
     const sixteenths = (playbackPosition - bar - beat / 4) * 16;
     // Round sixteenths note value to 3 decimal places.
     const sixteenthsRounded = Math.round(sixteenths * 1000) / 1000;
-    return `${bar}:${beat}:${sixteenthsRounded}`;
+    return `${bar - 1}:${beat}:${sixteenthsRounded}`;
   }
 
   private createPlayer(

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -4,9 +4,6 @@ import {Effects} from './interfaces/Effects';
 export interface SampleEvent {
   // 1-based playback position in measures
   playbackPosition: number;
-  // The length of an optional "pickup" part of the sample, which is effectively how early to start
-  // playing it.  Specified as a fraction of one measure.
-  pickupLength?: number;
   // ID of the sound
   id: string;
   // URL of the sample


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#64703.  Previews for notes and drums were playing one measure late.  