### PR TITLE
[HOME] Change from login-info to join link

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCard.tsx
@@ -5,7 +5,6 @@ import {
 import React from 'react';
 
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
-import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
 import {SectionCardBody} from './SectionCardBody';
@@ -32,7 +31,11 @@ export const SectionCard: React.FC<SectionCardProps> = ({
           <div className={styles.sectionCardCode}>
             <OverlineOneText>
               {i18n.classCode()}
-              <a href={teacherDashboardUrl(section.id, '/login_info')}>
+              <a
+                href={`/join/${section.code}`}
+                target="_blank"
+                rel="noreferrer"
+              >
                 {section.code}
               </a>
             </OverlineOneText>

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionCardTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionCardTest.tsx
@@ -1,4 +1,5 @@
-import {fireEvent, render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {Provider} from 'react-redux';
 import {
@@ -12,7 +13,6 @@ import {Store} from 'redux';
 import {getStore} from '@cdo/apps/redux';
 import {SectionCard} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/SectionCard';
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
-import * as urlHelpers from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import {TEACHER_NAVIGATION_PATHS} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
 
 describe('SectionCard', () => {
@@ -89,15 +89,10 @@ describe('SectionCard', () => {
     screen.getByText('Period 1');
   });
   it('renders section class code with login info link', () => {
-    const teacherDashboardUrlSpy = jest.spyOn(
-      urlHelpers,
-      'teacherDashboardUrl'
-    );
-
     renderComponent();
-    const link = screen.getByText('ABCDEF');
-    fireEvent.click(link);
-    expect(teacherDashboardUrlSpy).toHaveBeenCalled();
+    const link = screen.getByRole('link', {name: 'ABCDEF'});
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('href', '/join/ABCDEF');
   });
 
   it('renders section options dropdown', () => {


### PR DESCRIPTION
Section code on section card should copy link to join section, not open login info

<img width="297" alt="image" src="https://github.com/user-attachments/assets/a3c58bb9-d0c3-4354-bf85-054b6430f047" />


## Links
https://codedotorg.atlassian.net/browse/TEACH-1720