### PR TITLE
Disable progress UI test on iphone because of flaky test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/progress.feature
+++ b/dashboard/test/ui/features/teacher_tools/progress.feature
@@ -1,3 +1,4 @@
+@no_phone
 Feature: Level Progress
 
   Scenario: Progress is saved for signed-in student


### PR DESCRIPTION
Disabling the progress UI test on iphone because of flakiness. The step `And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"` is not snapping the blocks together and then the test times out

## Links

Slack thread: https://codedotorg.slack.com/archives/C0T0PNTM3/p1743005424766199
Jira ticket for a similar issue on another test- looks like this issue started after a blockly update? https://codedotorg.atlassian.net/browse/LABS-1368

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
