### PR TITLE
pull in associated models when populating course cache miss

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -508,13 +508,12 @@ class UnitGroup < ApplicationRecord
       course_cache_from_cache || course_cache_from_db
   end
 
-  def self.get_without_cache(id_or_name, with_associated_models: false)
+  def self.get_without_cache(id_or_name)
     # a bit of trickery so we support both ids which are numbers and
     # names which are strings that may contain numbers (eg. 2-3)
     find_by = (id_or_name.to_i.to_s == id_or_name.to_s) ? :id : :name
     # unlike script cache, we don't throw on miss
-    model = with_associated_models ? UnitGroup.with_associated_models : UnitGroup
-    model.find_by(find_by => id_or_name)
+    UnitGroup.find_by(find_by => id_or_name)
   end
 
   def self.get_from_cache(id_or_name)
@@ -522,7 +521,7 @@ class UnitGroup < ApplicationRecord
 
     course_cache.fetch(id_or_name.to_s) do
       # Populate cache on miss.
-      course_cache[id_or_name.to_s] = get_without_cache(id_or_name, with_associated_models: true)
+      course_cache[id_or_name.to_s] = get_without_cache(id_or_name)
     end
   end
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -508,12 +508,13 @@ class UnitGroup < ApplicationRecord
       course_cache_from_cache || course_cache_from_db
   end
 
-  def self.get_without_cache(id_or_name)
+  def self.get_without_cache(id_or_name, with_associated_models: false)
     # a bit of trickery so we support both ids which are numbers and
     # names which are strings that may contain numbers (eg. 2-3)
     find_by = (id_or_name.to_i.to_s == id_or_name.to_s) ? :id : :name
     # unlike script cache, we don't throw on miss
-    UnitGroup.find_by(find_by => id_or_name)
+    model = with_associated_models ? UnitGroup.with_associated_models : UnitGroup
+    model.find_by(find_by => id_or_name)
   end
 
   def self.get_from_cache(id_or_name)
@@ -521,7 +522,7 @@ class UnitGroup < ApplicationRecord
 
     course_cache.fetch(id_or_name.to_s) do
       # Populate cache on miss.
-      course_cache[id_or_name.to_s] = get_without_cache(id_or_name)
+      course_cache[id_or_name.to_s] = get_without_cache(id_or_name, with_associated_models: true)
     end
   end
 

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -12,11 +12,14 @@ class UnitGroupTest < ActiveSupport::TestCase
       File.stubs(:write)
     end
 
-    def populate_cache_and_disconnect_db
+    def populate_cache
       UnitGroup.stubs(:should_cache?).returns true
       @@course_cache ||= UnitGroup.course_cache_to_cache
       UnitGroup.course_cache
+    end
 
+    def populate_cache_and_disconnect_db
+      populate_cache
       # NOTE: ActiveRecord collection association still references an active DB connection,
       # even when the data is already eager loaded.
       # Best we can do is ensure that no queries are executed on the active connection.
@@ -41,6 +44,37 @@ class UnitGroupTest < ActiveSupport::TestCase
 
       assert_equal uncached_unit_group, UnitGroup.get_from_cache('acourse')
       assert_equal uncached_unit_group, UnitGroup.get_from_cache(unit_group.id)
+    end
+
+    test "course cache should include associated models" do
+      unit_group = create(:unit_group, name: 'course-x')
+      unit = create :script, name: 'course-x-unit-1'
+      create(:unit_group_unit, unit_group: unit_group, position: 1, script: unit)
+      unit = create :script, name: 'course-x-unit-2'
+      create(:unit_group_unit, unit_group: unit_group, position: 2, script: unit)
+
+      UnitGroup.get_from_cache(unit_group.name)
+
+      populate_cache
+
+      unit_group = create(:unit_group, name: 'course-y')
+      unit = create :script, name: 'course-y-unit-1'
+      create(:unit_group_unit, unit_group: unit_group, position: 1, script: unit)
+      unit = create :script, name: 'course-y-unit-2'
+      create(:unit_group_unit, unit_group: unit_group, position: 2, script: unit)
+
+      # prepopulated unit group should have cached associations on first access
+      assert_queries(0, ignore_filters: []) do
+        unit_group = UnitGroup.get_from_cache('course-x')
+        assert_equal 2, unit_group.default_unit_group_units.length
+      end
+
+      # unit groups populated on cache miss should have cached associations
+      # on second access.
+      assert_cached_queries(0, ignore_filters: []) do
+        unit_group = UnitGroup.get_from_cache('course-y')
+        assert_equal 2, unit_group.default_unit_group_units.length
+      end
     end
   end
 


### PR DESCRIPTION
we use `Unit.script_cache` and `UnitGroup.course_cache` to minimize database queries for curriculum data. we use the `with_associated_models` scope to ensure that various associations on the Unit and UnitGroup objects are pulled into those caches. the two ways things can be loaded into the cache are on initial load, and on cache miss. The vast majority of the time, this curriculum data is static between deploys, and so most requests hit cache data that was populated on initial load. However, when new courses or units are modified, there can be a period of time when the caches can be populated via the "cache miss" codepaths.

Today, the script_cache correctly uses `with_associated_models` in both cases, however the course_cache fails to pull in associated models on cache miss. This PR fixes that by copying the approach already use for the script_cache:https://github.com/code-dot-org/code-dot-org/blob/85448580a17944aa6643b107acdc326630867a1e/dashboard/app/models/unit.rb#L530

This is a speculative fix for performance issues observed on an adhoc while stress testing this chain of migration PRs:
* https://github.com/code-dot-org/code-dot-org/pull/64727
* https://github.com/code-dot-org/code-dot-org/pull/64728
* https://github.com/code-dot-org/code-dot-org/pull/64729
