### PR TITLE
Codemirror: remove foldGutter

### DIFF
--- a/apps/src/lab2/views/components/editor/editorConfig.ts
+++ b/apps/src/lab2/views/components/editor/editorConfig.ts
@@ -14,7 +14,6 @@ import {
 } from '@codemirror/commands';
 import {
   indentOnInput,
-  foldGutter,
   foldKeymap,
   defaultHighlightStyle,
   bracketMatching,
@@ -51,7 +50,6 @@ const editorConfig = [
   lineNumbers(),
   highlightSpecialChars(),
   history(),
-  foldGutter(),
   drawSelection(),
   EditorState.allowMultipleSelections.of(true),
   indentOnInput(),


### PR DESCRIPTION
The fold gutter in codemirror was causing vpat failures. We decided it was not a worthwhile feature to keep, since we don't own this code. This removes the fold gutter everywhere we use codemirror 6, which is Java Lab, Python Lab, and Web Lab 2.

This will cause eyes diffs for all eyes tests that look at a Java or Python Lab level (I don't think we have a web lab 2 one at this point), because the gutter has shrunk slightly (and does not have any carats).

## Before

### Fold/Unfold in Java 
The fold gutter is the little carat next to the line numbers
![Screenshot 2025-03-26 at 12 26 21 PM](https://github.com/user-attachments/assets/f204d7f4-8e2b-4c90-931a-70084f7f2a6d)
![Screenshot 2025-03-26 at 12 26 17 PM](https://github.com/user-attachments/assets/7ff4c777-cb37-40bd-84fe-ff7ec3a3ae14)

### Fold/unfold in Python

![Screenshot 2025-03-26 at 12 26 52 PM](https://github.com/user-attachments/assets/f25be7a3-bdec-48cb-8689-9c1ea9669d2b)
![Screenshot 2025-03-26 at 12 26 48 PM](https://github.com/user-attachments/assets/186099a9-bf41-4f7d-9e59-de812a84135f)

## After
![Screenshot 2025-03-26 at 12 26 35 PM](https://github.com/user-attachments/assets/681e8e1b-6d02-42d0-862f-39cd29bb9f2a)
![Screenshot 2025-03-26 at 12 26 27 PM](https://github.com/user-attachments/assets/e0222d93-6389-471c-8b61-2a1552f34836)

## Links

- jira ticket: [CT-1085](https://codedotorg.atlassian.net/browse/CT-1085), [CT-1108](https://codedotorg.atlassian.net/browse/CT-1108)


## Testing story
Confirmed the fold gutter is gone, and nothing else changed.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
