### PR TITLE
[Levelbuilder] Option to change block id

### DIFF
--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -25,6 +25,43 @@ import {getBaseName, isDarkTheme} from '../utils';
 // Some options are only available to levelbuilders via start mode.
 // Literal strings are used for display text instead of translatable strings
 // as Levelbuilder can only be used in English.
+const registerOverrideBlockId = function (weight: number) {
+  const overrideIdOption = {
+    displayText: () => 'Override block id',
+    preconditionFn: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      if (Blockly.isStartMode || Blockly.isToolboxMode) {
+        return MenuOptionStates.ENABLED;
+      }
+      return MenuOptionStates.HIDDEN;
+    },
+    callback: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      const block = scope.block;
+      if (!block) return;
+
+      const currentId = block.id;
+      const currentOverride =
+        Blockly.blockIdOverrides?.[currentId] ?? currentId;
+
+      Blockly.dialog.prompt(
+        'Enter a new block id (requires saving):',
+        currentOverride,
+        newId => {
+          if (!Blockly.blockIdOverrides) {
+            Blockly.blockIdOverrides = {};
+          }
+          if (newId) {
+            Blockly.blockIdOverrides[currentId] = newId;
+          }
+        }
+      );
+    },
+    scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.BLOCK,
+    id: 'overrideBlockId',
+    weight,
+  };
+  GoogleBlockly.ContextMenuRegistry.registry.register(overrideIdOption);
+};
+
 const registerDeletable = function (weight: number) {
   const deletableOption = {
     displayText: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
@@ -705,6 +742,7 @@ function registerCustomBlockOptions() {
 
   // Custom block options. We increment the weight for each so they are automatically
   // sorted in the order listed here. The ++ incrementation happens after the value is accessed.
+  registerOverrideBlockId(nextWeight++);
   registerHelp(nextWeight++);
   registerDeletable(nextWeight++);
   registerMovable(nextWeight++);

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -183,6 +183,9 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
     pointerMetadataMap: PointerMetadataMap,
     imageSourceId: string
   ) => string;
+  blockIdOverrides: {
+    [originalBlockId: string]: string;
+  };
 }
 
 export type GoogleBlocklyInstance = typeof GoogleBlockly;

--- a/apps/src/lab2/views/dialogs/DialogManager.tsx
+++ b/apps/src/lab2/views/dialogs/DialogManager.tsx
@@ -51,11 +51,13 @@ interface DialogManagerProps {
 const DialogManager: React.FunctionComponent<DialogManagerProps> = ({
   children,
 }) => {
-  const [openDialog, setOpenDialog] = useState<DialogType | null>(null);
   const [shouldThrowOnCancel, setShouldThrowOnCancel] =
     useState<boolean>(false);
   const [promiseArgs, setPromiseArgs] = useState<unknown>();
-  const [dialogArgs, setDialogArgs] = useState<AnyDialogType>();
+  const [activeDialog, setActiveDialog] = useState<{
+    type: DialogType | null;
+    dialogArgs?: AnyDialogType;
+  } | null>(null);
   const [deferredPromiseObject, setDeferredPromiseObject] =
     useState<DeferredPromiseObject>(getDeferredPromise());
 
@@ -65,30 +67,33 @@ const DialogManager: React.FunctionComponent<DialogManagerProps> = ({
       setDeferredPromiseObject(newDeferredPromise);
       setPromiseArgs(undefined);
       setShouldThrowOnCancel(throwOnCancel);
-      setOpenDialog(type);
-      setDialogArgs(dialogArgs);
+      setActiveDialog({type, dialogArgs});
+
       return newDeferredPromise.deferred as Promise<DialogClosePromiseReturnType>;
     },
-    [setDialogArgs, setPromiseArgs]
+    [setActiveDialog]
   );
 
   const closeDialog = useCallback(
     (closeType: DialogCloseActionType) => {
-      setOpenDialog(null);
+      setActiveDialog(null);
       const resolver =
         shouldThrowOnCancel && closeType === 'cancel'
           ? deferredPromiseObject.reject
           : deferredPromiseObject.resolve;
       resolver?.({type: closeType, args: promiseArgs});
     },
-    [setOpenDialog, deferredPromiseObject, shouldThrowOnCancel, promiseArgs]
+    [setActiveDialog, deferredPromiseObject, shouldThrowOnCancel, promiseArgs]
   );
 
   // Allow the any because if it's NOT any, then line 63 with DialogView's args will toss an error.
   // Keep this until we have a better solution. ¯\_(ツ)_/¯
   // The typing on the `showDialog` function ensures the props are correct, so we're still safe'
   // eslint-disable-next-line
-  const DialogView: any = openDialog && dialogArgs && DialogViews[openDialog];
+  const DialogView: any =
+    activeDialog?.type &&
+    activeDialog?.dialogArgs &&
+    DialogViews[activeDialog.type];
 
   return (
     <DialogControlContext.Provider
@@ -102,7 +107,7 @@ const DialogManager: React.FunctionComponent<DialogManagerProps> = ({
     >
       {DialogView && (
         <div className={moduleStyles.dialogContainer}>
-          <DialogView {...dialogArgs} />
+          <DialogView {...activeDialog?.dialogArgs} />
         </div>
       )}
       {children}

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -543,6 +543,7 @@ export default class MusicBlocklyWorkspace {
         flyoutItems.push({
           kind: 'block',
           ...Blockly.serialization.blocks.save(block, {saveIds: false}),
+          id: Blockly.blockIdOverrides?.[block.id] || block.id,
           enabled: true,
         });
         currentCategory.contents = flyoutItems;

--- a/apps/src/music/blockly/blockUtils.js
+++ b/apps/src/music/blockly/blockUtils.js
@@ -218,3 +218,25 @@ export function validateBlockCategories(workspace) {
     }
   });
 }
+
+export function applyBlockIdOverrides(workspaceJson, overrides) {
+  function walkBlocks(block) {
+    if (block.id && overrides[block.id]) {
+      block.id = overrides[block.id];
+    }
+    if (block.next?.block) {
+      walkBlocks(block.next.block);
+    }
+    if (block.inputs) {
+      for (const stmt of Object.values(block.inputs)) {
+        if (stmt?.block) {
+          walkBlocks(stmt.block);
+        }
+      }
+    }
+  }
+
+  if (Array.isArray(workspaceJson.blocks?.blocks)) {
+    workspaceJson.blocks.blocks.forEach(walkBlocks);
+  }
+}

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -26,7 +26,10 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import AnalyticsReporter from '../analytics/AnalyticsReporter';
 import AppConfig from '../appConfig';
-import {installFunctionBlocks} from '../blockly/blockUtils';
+import {
+  applyBlockIdOverrides,
+  installFunctionBlocks,
+} from '../blockly/blockUtils';
 import MusicBlocklyWorkspace from '../blockly/MusicBlocklyWorkspace';
 import musicI18n from '../locale';
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
@@ -147,9 +150,16 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   useEffect(() => {
     if (isStartMode) {
       header.showLevelBuilderSaveButton(() => {
+        const workspaceSerialization = blocklyWorkspace.getCode();
+        if (Blockly.blockIdOverrides) {
+          applyBlockIdOverrides(
+            workspaceSerialization,
+            Blockly.blockIdOverrides
+          );
+        }
         const updatedLevelData = {
           ...levelData,
-          startSources: blocklyWorkspace.getCode(),
+          startSources: workspaceSerialization,
         };
         return {level_data: updatedLevelData};
       });


### PR DESCRIPTION
In Music Lab, the most flexible way to implement callouts relies on using the block's id as part of a selector. This is potentially tricky as Blockly auto-generates block ids of random characters. Currently the only way to change a block id for a level is to manually edit the start sources. This requires careful and precise editing of deeply-nested JSON values.

This branch adds a new context menu option to handle changing a block's id in start mode and toolbox mode. 

![image (276)](https://github.com/user-attachments/assets/7c2f1712-f404-4700-a3fc-ce64a8dcaab8)
![image (277)](https://github.com/user-attachments/assets/808efe3a-3a0a-4174-baf1-fc141c52791b)

The prompt is pre-populated with the block's current id. When a new value is submitted, we store it in a map of id overrides. Upon saving, we replace any overridden ids using the map. This is necessary because Blockly doesn't support actually changing an existing block's id. To modify the start sources, we use a util function to recursively walk through all the blocks in each stack. Toolbox mode is simpler because we save each block individually, so we can simply write the overridden id if one exists.

### Race Condition in the Dialog Manager
This PR addresses a race condition in the `DialogManager` where the dialog input sometimes lags one prompt behind. The issue stemmed from the order in which `dialogArgs` and `openDialog` were being set. Opening the dialog before setting its arguments was leading to stale values.

After discussing briefly with @molly-moen , I updated the state structure to combine `dialogArgs` and `openDialog` into a single `activeDialog` state object. This allows both to be updated simultaneously, preventing any intermediate render cycles where one is set without the other.


## Links

https://docs.google.com/document/d/1BppxCmxheTKDyQp6Y3QdBR97jV4BNFA77zw8OrfrRcw/edit?tab=t.0


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
