### PR TITLE
skip updating schema cache on non-staging environments

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -63,9 +63,13 @@ namespace :build do
         ChatClient.log 'Migrating <b>dashboard</b> database...'
         RakeUtils.rake 'db:setup_or_migrate'
 
-        # Update the schema cache file, except for production which always uses the cache,
-        # and on adhoc where updating schema cache can cause merge conflicts.
-        unless [:production, :adhoc].include?(rack_env)
+        # Update the schema cache file only on the staging branch, because the
+        # staging system's Rails database is the source of truth for dashboard's
+        # schema. In the future we could also generate it on the test machine,
+        # but that is not practical as of April 2025 because the database schema
+        # on test differs from other environments due to utf8mb3 vs utf8mb4
+        # issues.
+        if rack_env?(:staging)
           schema_cache_file = dashboard_dir('db/schema_cache.yml')
           RakeUtils.rake 'db:schema:cache:dump'
           # NOTE: Temporarily commenting the `else` check below (and ignoring

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -63,8 +63,9 @@ namespace :build do
         ChatClient.log 'Migrating <b>dashboard</b> database...'
         RakeUtils.rake 'db:setup_or_migrate'
 
-        # Update the schema cache file, except for production which always uses the cache.
-        unless rack_env?(:production)
+        # Update the schema cache file, except for production which always uses the cache,
+        # and on adhoc where updating schema cache can cause merge conflicts.
+        unless [:production, :adhoc].include?(rack_env)
           schema_cache_file = dashboard_dir('db/schema_cache.yml')
           RakeUtils.rake 'db:schema:cache:dump'
           # NOTE: Temporarily commenting the `else` check below (and ignoring


### PR DESCRIPTION
problems: 
* schema_cache.yml diffs on adhocs cause deploys to adhocs to fail (not on initial deploy, but on subsequent deploys)
* schema_cache.yml diffs on test cause DTTs to fail (any time someone merges a db migration / schema change)

fix: stop generating updates to schema_cache.yml on non-staging environments.

because of the following kind of warning, I'm assuming that an outdated `schema_cache.yml` file will safely be ignored:
```
Ignoring /Users/dsb/src/cdo/dashboard/db/schema_cache.yml because it has expired. The current schema version is 20250331202624, but the one in the cache is 20250321190657.
```

## Testing story

### before
this adhoc's branch has the same contents as staging.
```
ubuntu@adhoc-yes-use-schema-cache-dump:~/adhoc$ git status
On branch yes-use-schema-cache-dump
Your branch is up to date with 'origin/yes-use-schema-cache-dump'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   dashboard/db/schema_cache.yml

no changes added to commit (use "git add" and/or "git commit -a")
```

```diff
ubuntu@adhoc-yes-use-schema-cache-dump:~/adhoc$ git diff
diff --git a/dashboard/db/schema_cache.yml b/dashboard/db/schema_cache.yml
index 1274a7d0f..07a55c666 100644
--- a/dashboard/db/schema_cache.yml
+++ b/dashboard/db/schema_cache.yml
@@ -8,32 +8,32 @@ columns:
         sql_type: int
         type: :integer
         limit: 4
-        precision:
-        scale:
+        precision:
+        scale:
       extra: auto_increment
     'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    default:
+    default_function:
+    collation:
+    comment:
   - &16 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
...
```

### after
```
ubuntu@adhoc-no-use-schema-cache-dump:~/adhoc$ git status
On branch no-use-schema-cache-dump
Your branch is up to date with 'origin/no-use-schema-cache-dump'.

nothing to commit, working tree clean
```

