### PR TITLE
Add Alias for Renamed Rake Task

### DIFF
--- a/lib/rake/infra.rake
+++ b/lib/rake/infra.rake
@@ -121,6 +121,12 @@ namespace :infra do
   end
 end
 
+# Temporarily support invoking this task with either `rake ci` or `rake
+# infra:ci` until the latter method has been deployed everywhere, so our
+# persistent managed servers don't break during the transition.
+# TODO infra: remove this once the `infra:ci` implementation has been deployed
+timed_task_with_logging ci: ['infra:ci']
+
 # Returns true if upgrade succeeded, false if failed.
 def upgrade_frontend(name, hostname)
   ChatClient.log "Upgrading <b>#{name}</b> (#{hostname})..."


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/64647, which renamed the Rake `ci` task to `infra:ci` for better discoverability. Unfortunately, I forgot that our persistent managed servers will still need to be able to invoke the task at its original name in order for their first build with the new name to pass.

The original change has already landed on the staging and test servers, and we manually restarted their builds. This PR is intended to make that not necessary for tomorrow's DTP.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1743022154800669)

## Testing story

Tested locally that `rake ci` and `rake infra:ci` both work, and both invoke the same task.

A more thorough test would be to spin up an adhoc based on staging, then merge this change in and confirm that it's able to successfully rebuild. I have not done that for the sake of expediency; please let me know if you think it's worth taking the time.