### PR TITLE
AI Chat: throw error if asset not found

### DIFF
--- a/dashboard/app/helpers/aichat_asset_helper.rb
+++ b/dashboard/app/helpers/aichat_asset_helper.rb
@@ -8,8 +8,11 @@ module AichatAssetHelper
     source = asset["source"]
     result = fetch_asset(filename, source, channel_id, level_name)
 
-    # TODO - error cases
-    return nil unless result && result[:status] == 'FOUND'
+    unless result && result[:status] == 'FOUND'
+      raise StandardError.new(
+        "Error fetching asset #{{**asset, channel_id: channel_id, level_name: level_name, **result}}"
+        )
+    end
 
     data = Base64.encode64(result[:body].read)
     mime_type = Rack::Mime.mime_type(File.extname(filename))


### PR DESCRIPTION
This just raises an error if we're not able to find an asset file for a chat message. I was initially thinking we'd do something a little more fancy and handle different error codes in different ways, but it seems like in most cases the error status is just `NOT_FOUND`, and this way we can just bubble this up to our active job code and let it get handled and reported there.

## Links

https://codedotorg.atlassian.net/browse/LABS-1382

## Testing story

Tested locally by manually changing file name.