### PR TITLE
P20/add lang attribute to pegasus and hoc

### DIFF
--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -1,6 +1,6 @@
 !!! 5
 -require '../shared/middleware/helpers/experiments'
-%html{dir: locale_dir}
+%html{dir: locale_dir, lang: locale}
   %head
     = render partial: 'i18n/crowdin_in_context_tool'
     = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'onetrust_cookie_scripts.haml')), type: :haml, locals: {dashboard: true, domain: 'code.org'}

--- a/pegasus/sites.v3/code.org/themes/default.haml
+++ b/pegasus/sites.v3/code.org/themes/default.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html
+%html{lang: request.locale}
   %head
     = render inline: File.read(deploy_dir('shared/haml/onetrust_cookie_scripts.haml')), type: :haml, locals: {domain: 'code.org'}
 

--- a/pegasus/sites.v3/code.org/themes/responsive.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive.haml
@@ -3,7 +3,7 @@
 - if @header['set_dir']
   - dir = language_dir_class
 
-%html{dir: dir}
+%html{dir: dir, lang: request.locale}
   %head
     = render inline: File.read(deploy_dir('shared/haml/onetrust_cookie_scripts.haml')), type: :haml, locals: {domain: 'code.org'}
 

--- a/pegasus/sites.v3/code.org/themes/responsive_full_width.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive_full_width.haml
@@ -3,7 +3,7 @@
 - if ! @header['set_dir']
   - dir = language_dir_class
 
-%html{dir: dir}
+%html{dir: dir, lang: request.locale}
   %head
     = render inline: File.read(deploy_dir('shared/haml/onetrust_cookie_scripts.haml')), type: :haml, locals: {domain: 'code.org'}
 

--- a/pegasus/sites.v3/code.org/themes/responsive_wide.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive_wide.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html
+%html{lang: request.locale}
   %head
     = render inline: File.read(deploy_dir('shared/haml/onetrust_cookie_scripts.haml')), type: :haml, locals: {domain: 'code.org'}
 

--- a/pegasus/sites.v3/hourofcode.com/themes/default.haml
+++ b/pegasus/sites.v3/hourofcode.com/themes/default.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{dir: language_dir_class(hoc_get_locale_code)}
+%html{dir: language_dir_class(hoc_get_locale_code), lang: hoc_get_locale_code}
   %head
     = render inline: File.read(deploy_dir('shared/haml/onetrust_cookie_scripts.haml')), type: :haml, locals: {domain: 'hourofcode.com'}
 


### PR DESCRIPTION
This just adds the necessary `lang` attribute information to the `<html>` tags for the various layouts Pegasus uses (and for the root content for the `hourofcode.com` site)

## Links

- jira ticket: [P20-1439](https://codedotorg.atlassian.net/browse/P20-1439)
- jira ticket: [A11Y-16](https://codedotorg.atlassian.net/browse/A11Y-16)
- jira ticket: [CT-1004](https://codedotorg.atlassian.net/browse/CT-1004)
- jira ticket: [CT-1104](https://codedotorg.atlassian.net/browse/CT-1104)

## Testing story

This might likely cause some issues in eyes tests if we haven't supplied specific fallback fonts for locales since this is a big hint to browsers to switch their local system font.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
