### PR TITLE
Add Id to teacher homepage promotion return

### DIFF
--- a/dashboard/engines/marketing/app/controllers/marketing/teacher/promotions_controller.rb
+++ b/dashboard/engines/marketing/app/controllers/marketing/teacher/promotions_controller.rb
@@ -16,6 +16,7 @@ module Marketing
         result = entry.fields.clone
         ads = result[:sidebar_ads].map do |ad|
           ad.fields.transform_values! {|v| v.is_a?(Contentful::Asset) ? v.image_url : v}
+          ad.fields.merge!(id: ad.id)
         end
 
         render json: ads

--- a/dashboard/engines/marketing/app/controllers/marketing/teacher/promotions_controller.rb
+++ b/dashboard/engines/marketing/app/controllers/marketing/teacher/promotions_controller.rb
@@ -15,8 +15,7 @@ module Marketing
 
         result = entry.fields.clone
         ads = result[:sidebar_ads].map do |ad|
-          ad.fields.transform_values! {|v| v.is_a?(Contentful::Asset) ? v.image_url : v}
-          ad.fields.merge!(id: ad.id)
+          ad.fields.transform_values {|v| v.is_a?(Contentful::Asset) ? v.image_url : v}.merge(id: ad.id)
         end
 
         render json: ads

--- a/dashboard/engines/marketing/test/controllers/promotions_controller_test.rb
+++ b/dashboard/engines/marketing/test/controllers/promotions_controller_test.rb
@@ -4,7 +4,7 @@ require 'contentful'
 class Marketing::Teacher::PromotionsControllerTest < ActionDispatch::IntegrationTest
   include Minitest::RSpecMocks
 
-  TestEntry = Struct.new(:content_type, :fields, keyword_init: true)
+  TestEntry = Struct.new(:id, :content_type, :fields, keyword_init: true)
   TestContentType = Struct.new(:id, keyword_init: true)
 
   describe '#show' do
@@ -17,11 +17,13 @@ class Marketing::Teacher::PromotionsControllerTest < ActionDispatch::Integration
         fields: {
           sidebar_ads: [
             TestEntry.new(
+              id: 1,
               fields: {
                 title: 'Ad 1',
               }
             ),
             TestEntry.new(
+              id: 2,
               fields: {
                 title: 'Ad 2',
               }
@@ -33,10 +35,12 @@ class Marketing::Teacher::PromotionsControllerTest < ActionDispatch::Integration
     let(:expected_result) do
       [
         {
-          title: 'Ad 1'
+          title: 'Ad 1',
+          id: 1
         },
         {
-          title: 'Ad 2'
+          title: 'Ad 2',
+          id: 2
         }
       ].to_json
     end


### PR DESCRIPTION
In order to have teachers permanently close promotions, we need to have a unique identifier for the promotion. Contentful already has an ID that we can use by returning it to the frontend in the show request.

This PR just adds the contentful content ID to the return of `GET /marketing/teacher/promotions/:id`.

## Links
https://codedotorg.slack.com/archives/C07UW4ED66Q/p1743092647648609