### PR TITLE
revert sandbox-pl-cv levelbuilder files

### DIFF
--- a/dashboard/config/courses/sandbox-pl-cv.course
+++ b/dashboard/config/courses/sandbox-pl-cv.course
@@ -1,7 +1,7 @@
 {
   "name": "sandbox-pl-cv",
   "script_names": [
-    "sandbox-pl-cv"
+
   ],
   "published_state": "in_development",
   "instruction_type": "self_paced",
@@ -9,6 +9,7 @@
   "instructor_audience": "facilitator",
   "properties": {
     "family_name": "sandbox-pl-cv",
+    "has_numbered_units": true,
     "version_year": "unversioned"
   },
   "resources": [

--- a/dashboard/config/scripts_json/sandbox-pl-cv.script_json
+++ b/dashboard/config/scripts_json/sandbox-pl-cv.script_json
@@ -6,15 +6,17 @@
     "properties": {
       "content_area": "other",
       "curriculum_umbrella": "Other",
-      "is_migrated": true
+      "is_course": true,
+      "is_migrated": true,
+      "version_year": "unversioned"
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2025-03-26 14:37:32 UTC",
-    "published_state": null,
-    "instruction_type": null,
-    "instructor_audience": null,
-    "participant_audience": null,
+    "family_name": "sandbox-pl-cv",
+    "serialized_at": "2024-11-19 01:19:28 UTC",
+    "published_state": "in_development",
+    "instruction_type": "self_paced",
+    "instructor_audience": "facilitator",
+    "participant_audience": "teacher",
     "seeding_key": {
       "script.name": "sandbox-pl-cv"
     }


### PR DESCRIPTION
These levelbuilder file changes were accidentally pushed in [standalone unit migration part 1](https://github.com/code-dot-org/code-dot-org/pull/64728). We don't want to migrate this unit right now, and will deal with migrating this unit as well as a handful of other units down the line.
