### PR TITLE
feat(workshops): add emails reminders section

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -235,11 +235,14 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
         {...sectionProps}
       />
       <PartnerFacilitator
-        {...sectionProps}
         facilitators={workshopFormState.facilitators}
         regionalPartnerId={workshopFormState.regionalPartnerId}
+        {...sectionProps}
       />
-      <EmailsReminders {...sectionProps} />
+      <EmailsReminders
+        suppressEmail={workshopFormState.suppressEmail}
+        {...sectionProps}
+      />
       <AdditionalInfo
         fee={workshopFormState.fee}
         participantGroupType={workshopFormState.participantGroupType}

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
@@ -1,13 +1,108 @@
-import {Heading2} from '@code-dot-org/component-library/typography';
-import React, {FC, memo} from 'react';
+import {LinkButton} from '@code-dot-org/component-library/button';
+import Toggle from '@code-dot-org/component-library/toggle';
+import {
+  BodyFourText,
+  Heading2,
+  OverlineThreeText,
+} from '@code-dot-org/component-library/typography';
+import React, {FC, memo, useCallback} from 'react';
 
-import {SectionProps} from '../types';
+import {EmailsRemindersProps} from '../types';
 
-export const EmailsReminders: FC<SectionProps> = ({dispatchWorkshop}) => {
+import commonStyles from '../styles.module.scss';
+
+export const PreviewEmailLink: FC<{href?: string}> = ({href}) => {
+  if (!href) return null;
   return (
-    <div>
+    <LinkButton
+      href={href}
+      text="Preview email"
+      target="_blank"
+      color="black"
+      type="tertiary"
+      size="s"
+      iconRight={{
+        iconName: 'up-right-from-square',
+      }}
+    />
+  );
+};
+
+export const EmailsReminders: FC<EmailsRemindersProps> = ({
+  config: {fields},
+  suppressEmail,
+  dispatchWorkshop,
+}) => {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const {checked} = e.target;
+      dispatchWorkshop({
+        type: 'UPDATE_WORKSHOP',
+        payload: {
+          suppressEmail: !checked,
+        },
+      });
+    },
+    [dispatchWorkshop]
+  );
+  return (
+    <>
       <Heading2 visualAppearance="heading-sm">Emails & Reminders</Heading2>
-    </div>
+      <div className={commonStyles.row}>
+        <div className={commonStyles.col}>
+          <OverlineThreeText>pre-workshop emails</OverlineThreeText>
+          {fields.suppress_email && (
+            <div className={commonStyles.toggleWrapper}>
+              <div className={commonStyles.row}>
+                <Toggle
+                  label="3 and 10-days prior to start date"
+                  name="reminder emails"
+                  size="s"
+                  checked={!suppressEmail}
+                  onChange={handleChange}
+                />
+                <PreviewEmailLink href="" />
+              </div>
+            </div>
+          )}
+          <div className={commonStyles.toggleWrapper}>
+            <div className={commonStyles.row}>
+              <Toggle
+                label="Pre-workshop survey*"
+                name="pre-workshop survey email"
+                size="s"
+                checked={true}
+                onChange={() => {}}
+                disabled={true}
+              />
+              <PreviewEmailLink href="" />
+            </div>
+            <BodyFourText>
+              *We require this email for every workshop.
+            </BodyFourText>
+          </div>
+        </div>
+        <div className={commonStyles.col}>
+          <OverlineThreeText>post-workshop emails</OverlineThreeText>
+          <div className={commonStyles.toggleWrapper}>
+            <div className={commonStyles.row}>
+              <Toggle
+                label="Post-workshop survey*"
+                name="post-workshop survey email"
+                size="s"
+                checked={true}
+                onChange={() => {}}
+                disabled={true}
+              />
+              <PreviewEmailLink href="" />
+            </div>
+            <BodyFourText>
+              *We require this email for every workshop.
+            </BodyFourText>
+          </div>
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/styles.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/styles.module.scss
@@ -21,6 +21,24 @@
         height: 2rem;
       }
     }
+
+    .col {
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+  }
+
+  .toggleWrapper {
+    label {
+      padding: 0.25rem 0;
+    }
+    p {
+      margin-top: 0.25rem;
+    }
+    a {
+      flex: 0;
+      white-space: nowrap;
+    }
   }
 
   .card {

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -168,6 +168,10 @@ export interface AdditionalInfoProps
   extends SectionProps,
     Pick<WorkshopFormState, 'fee' | 'participantGroupType' | 'notes'> {}
 
+export interface EmailsRemindersProps
+  extends SectionProps,
+    Pick<WorkshopFormState, 'suppressEmail'> {}
+
 export interface ScheduleProps
   extends SectionProps,
     Pick<WorkshopFormState, 'timeZone'> {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds fields for the emails and reminders section. only one field is enabled for now, which toggles allowing the 3/10 day reminder emails. the pre/post surveys are required for all workshops.

![Screenshot 2025-03-27 at 3 31 52 PM](https://github.com/user-attachments/assets/ad220965-ba74-4ec2-80c8-417357ee65bc)

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3090)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
