### PR TITLE
feat(workshops): add publish settings section

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -249,7 +249,11 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
         notes={workshopFormState.notes}
         {...sectionProps}
       />
-      <PublishSettings {...sectionProps} />
+      <PublishSettings
+        registrationLink={workshopFormState.registrationLink}
+        hidden={workshopFormState.hidden}
+        {...sectionProps}
+      />
       <PublishCancelButtons publish={publish} cancel={cancel} />
     </form>
   );

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
@@ -61,6 +61,7 @@ export const EmailsReminders: FC<EmailsRemindersProps> = ({
                   checked={!suppressEmail}
                   onChange={handleChange}
                 />
+                {/* TODO: blank href for now until we have mailjet email preview links */}
                 <PreviewEmailLink href="" />
               </div>
             </div>
@@ -75,6 +76,7 @@ export const EmailsReminders: FC<EmailsRemindersProps> = ({
                 onChange={() => {}}
                 disabled={true}
               />
+              {/* TODO: blank href for now until we have mailjet email preview links */}
               <PreviewEmailLink href="" />
             </div>
             <BodyFourText>
@@ -94,6 +96,7 @@ export const EmailsReminders: FC<EmailsRemindersProps> = ({
                 onChange={() => {}}
                 disabled={true}
               />
+              {/* TODO: blank href for now until we have mailjet email preview links */}
               <PreviewEmailLink href="" />
             </div>
             <BodyFourText>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PublishSettings.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PublishSettings.tsx
@@ -1,13 +1,62 @@
+import Checkbox from '@code-dot-org/component-library/checkbox';
+import FormFieldWrapper from '@code-dot-org/component-library/formFieldWrapper';
+import TextField from '@code-dot-org/component-library/textField';
 import {Heading2} from '@code-dot-org/component-library/typography';
-import React, {FC, memo} from 'react';
+import classNames from 'classnames';
+import React, {ChangeEvent, FC, memo} from 'react';
 
-import {SectionProps} from '../types';
+import {PublishSettingsProps} from '../types';
 
-export const PublishSettings: FC<SectionProps> = () => {
+import commonStyles from '../styles.module.scss';
+
+export const PublishSettings: FC<PublishSettingsProps> = ({
+  config: {fields},
+  registrationLink,
+  hidden,
+  dispatchWorkshop,
+}) => {
+  const handleChange = (
+    event: ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
+  ) => {
+    dispatchWorkshop({
+      type: 'UPDATE_WORKSHOP',
+      payload: {[event.target.name]: event.target.value},
+    });
+  };
   return (
-    <div>
+    <>
       <Heading2 visualAppearance="heading-sm">Publish Settings</Heading2>
-    </div>
+      <div className={commonStyles.row}>
+        {fields.registration_link && (
+          <TextField
+            name="registrationLink"
+            helperMessage="You can provide a custom URL for registration. Participants must still enroll in our system later for attendance and surveys. Leave blank to use the default process."
+            onChange={handleChange}
+            value={registrationLink}
+            label="Custom registration link"
+            size="s"
+            className={classNames(commonStyles.item, {
+              [commonStyles.required]: fields.registration_link.required,
+            })}
+          />
+        )}
+        {fields.hidden ? (
+          <FormFieldWrapper label="Catalog visibility" size="s">
+            <Checkbox
+              label="Hide this workshop from the public workshop catalog"
+              name="hidden"
+              checked={hidden}
+              size="s"
+              onChange={handleChange}
+            />
+          </FormFieldWrapper>
+        ) : (
+          <div className={commonStyles.item} />
+        )}
+      </div>
+    </>
   );
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -172,6 +172,10 @@ export interface EmailsRemindersProps
   extends SectionProps,
     Pick<WorkshopFormState, 'suppressEmail'> {}
 
+export interface PublishSettingsProps
+  extends SectionProps,
+    Pick<WorkshopFormState, 'registrationLink' | 'hidden'> {}
+
 export interface ScheduleProps
   extends SectionProps,
     Pick<WorkshopFormState, 'timeZone'> {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds the publish settings section containing the custom registration link field and checkbox to hide the workshop from the course catalog.

![Screenshot 2025-03-27 at 3 31 13 PM](https://github.com/user-attachments/assets/80edd10e-0d8d-4299-8607-02ce44cb49cd)

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3113)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
