### PR TITLE
AI Chat: remove copy chat notification for everyone, load level for viewing own history

### DIFF
--- a/apps/i18n/aichat/en_us.json
+++ b/apps/i18n/aichat/en_us.json
@@ -18,8 +18,6 @@
   "aria_thumbsUp": "thumbs up",
   "aria_thumbsDown": "thumbs down",
   "chatComponentsHeader": "AI Chat Components",
-  "chatEventDescriptions_copyChat": "The user copied the chat history.",
-  "chatEventDescriptions_copyChatOwner": "You copied the chat history.",
   "chatEventDescriptions_clearChat": "The user cleared the chat workspace.",
   "chatEventDescriptions_clearChatOwner": "You cleared the chat workspace.",
   "chatEventDescriptions_loadLevel": "The user loaded the level.",

--- a/apps/src/aichat/api/validators.ts
+++ b/apps/src/aichat/api/validators.ts
@@ -14,6 +14,7 @@ const chatHistoryValidator: ResponseValidator<ServerChatEvent[]> = bodyJson => {
   }
 
   const events = bodyJson as ServerChatEvent[];
+  const filteredEvents = [];
   for (const event of events) {
     if (event.id === undefined) {
       throw fieldError('id');
@@ -33,8 +34,14 @@ const chatHistoryValidator: ResponseValidator<ServerChatEvent[]> = bodyJson => {
         );
       }
     }
+
+    // Filter out any copy chat events, which were logged historically.
+    if ((event as {descriptionKey?: string}).descriptionKey !== 'COPY_CHAT') {
+      filteredEvents.push(event);
+    }
   }
-  return events;
+
+  return filteredEvents;
 };
 
 function fieldError(fieldName: string) {

--- a/apps/src/aichat/api/validators.ts
+++ b/apps/src/aichat/api/validators.ts
@@ -13,8 +13,12 @@ const chatHistoryValidator: ResponseValidator<ServerChatEvent[]> = bodyJson => {
     throw new Error('Expected an array of chat events');
   }
 
-  const events = bodyJson as ServerChatEvent[];
-  const filteredEvents = [];
+  // Filter out any copy chat events, which were logged historically.
+  const events = bodyJson.filter(
+    event =>
+      (event as {descriptionKey?: unknown}).descriptionKey !== 'COPY_CHAT'
+  ) as ServerChatEvent[];
+
   for (const event of events) {
     if (event.id === undefined) {
       throw fieldError('id');
@@ -34,14 +38,9 @@ const chatHistoryValidator: ResponseValidator<ServerChatEvent[]> = bodyJson => {
         );
       }
     }
-
-    // Filter out any copy chat events, which were logged historically.
-    if ((event as {descriptionKey?: string}).descriptionKey !== 'COPY_CHAT') {
-      filteredEvents.push(event);
-    }
   }
 
-  return filteredEvents;
+  return events;
 };
 
 function fieldError(fieldName: string) {

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -63,8 +63,15 @@ const aichatSlice = createSlice({
       state.studentChatHistory = action.payload;
     },
     setOwnChatHistory: (state, action: PayloadAction<ServerChatEvent[]>) => {
+      // It's confusing / not helpful for users to see their own history of when they loaded the level.
+      // These events are exclusively for teachers to view their student's activity, so we exclude them
+      // when someone is looking at their own history.
+      const events = action.payload.filter(
+        event =>
+          !(isUserActionEvent(event) && event.descriptionKey === 'LOAD_LEVEL')
+      );
+
       // Find the last index of an event that marks the start a new conversation with the model.
-      const events = action.payload;
       let lastResetIndex = -1;
       for (let i = events.length - 1; i >= 0; i--) {
         const event = events[i];
@@ -82,9 +89,9 @@ const aichatSlice = createSlice({
       }
 
       if (lastResetIndex >= 0) {
-        state.chatEventsCurrent = action.payload.slice(lastResetIndex);
+        state.chatEventsCurrent = events.slice(lastResetIndex);
       } else {
-        state.chatEventsCurrent = action.payload;
+        state.chatEventsCurrent = events;
       }
     },
     setUserHasAichatAccess: (state, action: PayloadAction<boolean>) => {

--- a/apps/src/aichat/types/chatEvents.ts
+++ b/apps/src/aichat/types/chatEvents.ts
@@ -6,7 +6,7 @@ import {ChatAsset} from './assets';
 import {AiCustomizations} from './customizations';
 import {FeedbackValue} from './toxicity';
 
-export type ChatEventDescriptionKey = 'COPY_CHAT' | 'CLEAR_CHAT' | 'LOAD_LEVEL';
+export type ChatEventDescriptionKey = 'CLEAR_CHAT' | 'LOAD_LEVEL';
 
 /** Base type for all chat events that are displayed in the chat workspace or student chat history view */
 interface BaseChatEvent {

--- a/apps/src/aichat/views/ChatEventView.tsx
+++ b/apps/src/aichat/views/ChatEventView.tsx
@@ -23,13 +23,11 @@ import {AI_CUSTOMIZATIONS_LABELS} from './modelCustomization/constants';
 import styles from './chatWorkspace.module.scss';
 
 const chatEventDescriptionsOwner = {
-  COPY_CHAT: aichatI18n.chatEventDescriptions_copyChatOwner(),
   CLEAR_CHAT: aichatI18n.chatEventDescriptions_clearChatOwner(),
   LOAD_LEVEL: aichatI18n.chatEventDescriptions_loadLevelOwner(),
 } as const satisfies {[key in ChatEventDescriptionKey]: string};
 
 const chatEventDescriptionsStudent = {
-  COPY_CHAT: aichatI18n.chatEventDescriptions_copyChat(),
   CLEAR_CHAT: aichatI18n.chatEventDescriptions_clearChat(),
   LOAD_LEVEL: aichatI18n.chatEventDescriptions_loadLevel(),
 } as const satisfies {[key in ChatEventDescriptionKey]: string};

--- a/apps/src/aichat/views/CopyChatHistoryButton.tsx
+++ b/apps/src/aichat/views/CopyChatHistoryButton.tsx
@@ -2,11 +2,7 @@ import Button from '@code-dot-org/component-library/button';
 import React from 'react';
 import {useSelector} from 'react-redux';
 
-import {
-  addChatEvent,
-  selectAllVisibleMessages,
-  sendAnalytics,
-} from '@cdo/apps/aichat/redux';
+import {selectAllVisibleMessages, sendAnalytics} from '@cdo/apps/aichat/redux';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
@@ -41,13 +37,6 @@ const CopyChatHistoryButton: React.FunctionComponent<{isDisabled: boolean}> = ({
     dispatch(
       sendAnalytics(EVENTS.CHAT_ACTION, {
         action: 'Copy chat history',
-      })
-    );
-
-    dispatch(
-      addChatEvent({
-        timestamp: Date.now(),
-        descriptionKey: 'COPY_CHAT',
       })
     );
   };


### PR DESCRIPTION
Two updates to the user event history we show to users:
- the "load level" notification is only shown to teachers viewing student history, but not to users viewing their own history.
- the "copy chat" notification is no longer logged at all, and existing events that have been logged are no longer displayed.

## Links

- [Multimodal spec](https://docs.google.com/document/d/13uPKipIkpoqF-ZrncZG4X0M7AhFY2rwXIVRCKxc2PPM/edit?tab=t.0) (notes related to this are in the changelog at the bottom)
- [Slack discussion thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1742482983291809)

## Testing story

Tested manually as a teacher viewing my own history and while viewing a student's history.