### PR TITLE
CMS-468: DSCO - Add CMS `Snapshot` component

### DIFF
--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -133,6 +133,14 @@
       "require": "./dist/cjs/cms/section/index.js"
     },
     "./cms/section/index.css": "./dist/esm/cms/section/index.css",
+    "./cms/snapshot": {
+      "types": {
+        "import": "./dist/esm/cms/snapshot/index.d.ts",
+        "require": "./dist/cjs/cms/snapshot/index.d.ts"
+      },
+      "import": "./dist/esm/cms/snapshot/index.mjs",
+      "require": "./dist/cjs/cms/snapshot/index.js"
+    },
     "./cms/tabGroup": {
       "types": {
         "import": "./dist/esm/cms/tabGroup/index.d.ts",

--- a/frontend/packages/component-library/src/cms/snapshot/README.md
+++ b/frontend/packages/component-library/src/cms/snapshot/README.md
@@ -1,0 +1,17 @@
+# `component-library/cms/snapshot`
+
+## Consuming This Component
+
+This package exports one styled React component: [Snapshot](Snapshot.tsx).
+You can import it like this:
+
+```javascript
+import Snapshot from '@code-dot-org/component-library/cms/snapshot';
+```
+
+_Note:_ This component is used primarily for the Contentful CMS.
+
+For guidelines on how to use this component and the features it
+offers, [visit Storybook](https://code-dot-org.github.io/code-dot-org/component-library-storybook/?path=/docs/cms-snapshot--docs).
+Or run storybook locally and go
+to [CMS / Snapshot](http://localhost:6006/?path=/docs/cms-snapshot--docs).

--- a/frontend/packages/component-library/src/cms/snapshot/Snapshot.tsx
+++ b/frontend/packages/component-library/src/cms/snapshot/Snapshot.tsx
@@ -1,0 +1,63 @@
+import classNames from 'classnames';
+import {Key, HTMLAttributes, ReactNode} from 'react';
+
+import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
+
+import moduleStyles from './snapshot.module.scss';
+
+export type SnapshotItem = {
+  key: Key;
+  icon: FontAwesomeV6IconProps;
+  label: string | ReactNode;
+  content: string | ReactNode;
+};
+
+export interface SnapshotProps extends HTMLAttributes<HTMLDListElement> {
+  /** Snapshot items */
+  items: SnapshotItem[];
+  /** Snapshot class */
+  className?: string;
+}
+
+/**
+ * ## Production-ready Checklist:
+ *  * (✔) implementation of component approved by design team;
+ *  * (✔) has storybook, covered with stories and documentation;
+ *  * (✔) has tests: test every prop, every state and every interaction that's js related;
+ *  * (see ./__tests__/Snapshot.test.tsx)
+ *  * (✔) passes accessibility checks;
+ *
+ * ### Status: ```Ready for dev```
+ *
+ * Design System: Snapshot Component.
+ * Acts as a container for snapshot details.
+ */
+const Snapshot: React.FC<SnapshotProps> = ({
+  items,
+  className,
+  ...HTMLAttributes
+}: SnapshotProps) => (
+  <dl
+    className={classNames(moduleStyles.snapshot, className)}
+    {...HTMLAttributes}
+  >
+    {items.map(({key, icon, label, content}) => (
+      <div key={key} className={moduleStyles.snapshotItem}>
+        <FontAwesomeV6Icon
+          {...icon}
+          aria-hidden="true"
+          className={classNames(moduleStyles.snapshotItemIcon, icon.className)}
+        />
+
+        <dt className={moduleStyles.snapshotItemLabel}>
+          {label}
+          <span aria-hidden="true">:&nbsp;</span>
+        </dt>
+
+        <dd className={moduleStyles.snapshotItemContent}>{content}</dd>
+      </div>
+    ))}
+  </dl>
+);
+
+export default Snapshot;

--- a/frontend/packages/component-library/src/cms/snapshot/Snapshot.tsx
+++ b/frontend/packages/component-library/src/cms/snapshot/Snapshot.tsx
@@ -51,7 +51,7 @@ const Snapshot: React.FC<SnapshotProps> = ({
         />
 
         <BodyTwoText className={moduleStyles.snapshotItemContent}>
-          <StrongText>{label}:</StrongText> <span>{content}</span>
+          <StrongText>{label}:</StrongText> {content}
         </BodyTwoText>
       </li>
     ))}

--- a/frontend/packages/component-library/src/cms/snapshot/Snapshot.tsx
+++ b/frontend/packages/component-library/src/cms/snapshot/Snapshot.tsx
@@ -41,7 +41,7 @@ const Snapshot: React.FC<SnapshotProps> = ({
     className={classNames(moduleStyles.snapshot, className)}
     {...HTMLAttributes}
   >
-    {items.map(({key, icon, label, content}) => (
+    {items?.map(({key, icon, label, content}) => (
       <div key={key} className={moduleStyles.snapshotItem}>
         <FontAwesomeV6Icon
           {...icon}

--- a/frontend/packages/component-library/src/cms/snapshot/Snapshot.tsx
+++ b/frontend/packages/component-library/src/cms/snapshot/Snapshot.tsx
@@ -2,13 +2,14 @@ import classNames from 'classnames';
 import {Key, HTMLAttributes, ReactNode} from 'react';
 
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
+import {BodyTwoText, StrongText} from '@/typography';
 
 import moduleStyles from './snapshot.module.scss';
 
 export type SnapshotItem = {
   key: Key;
   icon: FontAwesomeV6IconProps;
-  label: string | ReactNode;
+  label: string;
   content: string | ReactNode;
 };
 
@@ -37,27 +38,24 @@ const Snapshot: React.FC<SnapshotProps> = ({
   className,
   ...HTMLAttributes
 }: SnapshotProps) => (
-  <dl
+  <ul
     className={classNames(moduleStyles.snapshot, className)}
     {...HTMLAttributes}
   >
     {items?.map(({key, icon, label, content}) => (
-      <div key={key} className={moduleStyles.snapshotItem}>
+      <li key={key} className={moduleStyles.snapshotItem}>
         <FontAwesomeV6Icon
           {...icon}
           aria-hidden="true"
           className={classNames(moduleStyles.snapshotItemIcon, icon.className)}
         />
 
-        <dt className={moduleStyles.snapshotItemLabel}>
-          {label}
-          <span aria-hidden="true">:&nbsp;</span>
-        </dt>
-
-        <dd className={moduleStyles.snapshotItemContent}>{content}</dd>
-      </div>
+        <BodyTwoText className={moduleStyles.snapshotItemContent}>
+          <StrongText>{label}:</StrongText> <span>{content}</span>
+        </BodyTwoText>
+      </li>
     ))}
-  </dl>
+  </ul>
 );
 
 export default Snapshot;

--- a/frontend/packages/component-library/src/cms/snapshot/__tests__/Snapshot.test.tsx
+++ b/frontend/packages/component-library/src/cms/snapshot/__tests__/Snapshot.test.tsx
@@ -26,13 +26,11 @@ describe('CMS Snapshot', () => {
     const snapshot = getSnapshot();
     expect(snapshot).toBeVisible();
 
-    const itemLabel = within(snapshot).getByText(items[0].label as string);
+    const itemLabel = within(snapshot).getByText(items[0].label + ':');
     expect(itemLabel).toBeVisible();
-    expect(itemLabel).toHaveRole('term');
 
     const itemContent = within(snapshot).getByText(items[0].content as string);
     expect(itemContent).toBeVisible();
-    expect(itemContent).toHaveRole('definition');
   });
 
   it('renders snapshot section with provided className styles', () => {

--- a/frontend/packages/component-library/src/cms/snapshot/__tests__/Snapshot.test.tsx
+++ b/frontend/packages/component-library/src/cms/snapshot/__tests__/Snapshot.test.tsx
@@ -1,0 +1,54 @@
+import {render, screen, within} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Snapshot, {SnapshotItem, SnapshotProps} from '../Snapshot';
+
+describe('CMS Snapshot', () => {
+  const title = 'Snapshot Title';
+  const items: SnapshotItem[] = [
+    {
+      key: 'grades',
+      icon: {iconName: 'user'},
+      label: 'Grades',
+      content: 'K-5',
+    },
+  ];
+
+  const renderSnapshot = (props: Partial<SnapshotProps> = {}) => {
+    render(<Snapshot {...props} title={title} items={items} />);
+  };
+
+  const getSnapshot = () => screen.getByTitle(title);
+
+  it('renders snapshot section with provided items', () => {
+    renderSnapshot();
+
+    const snapshot = getSnapshot();
+    expect(snapshot).toBeVisible();
+
+    const itemLabel = within(snapshot).getByText(items[0].label as string);
+    expect(itemLabel).toBeVisible();
+    expect(itemLabel).toHaveRole('term');
+
+    const itemContent = within(snapshot).getByText(items[0].content as string);
+    expect(itemContent).toBeVisible();
+    expect(itemContent).toHaveRole('definition');
+  });
+
+  it('renders snapshot section with provided className styles', () => {
+    const className = 'customClass';
+    const classStyle = 'color: red;';
+
+    renderSnapshot({className});
+    const snapshot = getSnapshot();
+
+    expect(snapshot).not.toHaveStyle(classStyle);
+
+    // Add custom CSS directly in the test
+    const style = document.createElement('style');
+    style.innerHTML = `.${className} { ${classStyle} }`;
+    document.head.appendChild(style);
+
+    expect(snapshot).toHaveStyle(classStyle);
+  });
+});

--- a/frontend/packages/component-library/src/cms/snapshot/index.ts
+++ b/frontend/packages/component-library/src/cms/snapshot/index.ts
@@ -1,0 +1,4 @@
+import './index.css';
+
+export type {SnapshotItem, SnapshotProps} from './Snapshot';
+export {default as default} from './Snapshot';

--- a/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
+++ b/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
@@ -6,10 +6,8 @@
 
 // SnapshotSection common styles
 .snapshot {
-  border-radius: variables.$regular-border-radius;
-  border: 1px solid var(--borders-neutral-primary);
+  @include mixins.border-styles;
   background: var(--background-neutral-primary);
-
   column-count: 2;
   column-width: 180px;
   column-gap: 1.5rem;

--- a/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
+++ b/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
@@ -1,0 +1,55 @@
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
+
+// SnapshotSection common styles
+.snapshot {
+  $layout-breakpoint-width: 426px;
+  $columns-count: 2;
+  $gap: 1.5rem;
+
+  // Calculate the min column width at which the layout switches to a single column
+  column-width: calc(
+    ($layout-breakpoint-width - ($gap * ($columns-count + 1))) / $columns-count
+  );
+  column-count: $columns-count;
+  column-gap: $gap;
+  padding: $gap;
+  margin: 0;
+
+  border-radius: 0.25rem;
+  border: 1px solid var(--borders-neutral-primary);
+  background: var(--background-neutral-primary);
+
+  .snapshotItem {
+    display: table;
+    break-inside: avoid-column;
+    width: 100%;
+
+    &:not(:last-child) {
+      margin-bottom: 1.25rem;
+    }
+
+    .snapshotItemIcon {
+      @include mixins.icon-dimensions(var(--font-size-body-md));
+      color: var(--text-neutral-primary);
+      display: table-cell;
+      text-align: center;
+      line-height: 1.48;
+      padding-inline-end: 0.5rem;
+    }
+
+    .snapshotItemLabel {
+      @include typography.heading-xs;
+      display: inline;
+      margin: 0;
+    }
+
+    .snapshotItemContent {
+      @include typography.body-two;
+      display: inline;
+      margin: 0;
+    }
+  }
+}

--- a/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
+++ b/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
@@ -2,10 +2,11 @@
 @use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 @use '@code-dot-org/component-library-styles/typography.module.scss' as
   typography;
+@use '@code-dot-org/component-library-styles/variables.scss' as variables;
 
 // SnapshotSection common styles
 .snapshot {
-  border-radius: 0.25rem;
+  border-radius: variables.$regular-border-radius;
   border: 1px solid var(--borders-neutral-primary);
   background: var(--background-neutral-primary);
 

--- a/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
+++ b/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
@@ -15,9 +15,9 @@
   margin: 0;
 
   .snapshotItem {
-    display: table;
+    display: flex;
     break-inside: avoid-column;
-    width: 100%;
+    column-gap: 0.5rem;
 
     &:not(:last-child) {
       margin-bottom: 1.25rem;
@@ -26,21 +26,12 @@
     .snapshotItemIcon {
       @include mixins.icon-dimensions(var(--font-size-body-md));
       color: var(--text-neutral-primary);
-      display: table-cell;
       text-align: center;
       line-height: 1.48;
-      padding-inline-end: 0.5rem;
-    }
-
-    .snapshotItemLabel {
-      @include typography.heading-xs;
-      display: inline;
-      margin: 0;
+      flex-shrink: 0;
     }
 
     .snapshotItemContent {
-      @include typography.body-two;
-      display: inline;
       margin: 0;
     }
   }

--- a/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
+++ b/frontend/packages/component-library/src/cms/snapshot/snapshot.module.scss
@@ -5,22 +5,15 @@
 
 // SnapshotSection common styles
 .snapshot {
-  $layout-breakpoint-width: 426px;
-  $columns-count: 2;
-  $gap: 1.5rem;
-
-  // Calculate the min column width at which the layout switches to a single column
-  column-width: calc(
-    ($layout-breakpoint-width - ($gap * ($columns-count + 1))) / $columns-count
-  );
-  column-count: $columns-count;
-  column-gap: $gap;
-  padding: $gap;
-  margin: 0;
-
   border-radius: 0.25rem;
   border: 1px solid var(--borders-neutral-primary);
   background: var(--background-neutral-primary);
+
+  column-count: 2;
+  column-width: 180px;
+  column-gap: 1.5rem;
+  padding: 1.5rem;
+  margin: 0;
 
   .snapshotItem {
     display: table;

--- a/frontend/packages/component-library/src/cms/snapshot/stories/Snapshot.story.tsx
+++ b/frontend/packages/component-library/src/cms/snapshot/stories/Snapshot.story.tsx
@@ -1,0 +1,79 @@
+import type {Meta, StoryObj} from '@storybook/react';
+
+import Snapshot, {SnapshotProps} from '../Snapshot';
+
+type Story = StoryObj<typeof Snapshot>;
+
+export default {
+  title: 'CMS/Snapshot',
+  component: Snapshot,
+} as Meta<SnapshotProps>;
+
+const defaultArgs: SnapshotProps = {
+  items: [
+    {
+      key: 'grades',
+      icon: {iconName: 'user'},
+      label: 'Grades',
+      content: 'K-5',
+    },
+    {
+      key: 'level',
+      icon: {iconName: 'arrow-up-wide-short'},
+      label: 'Level',
+      content: 'Beginner',
+    },
+    {
+      key: 'duration',
+      icon: {iconName: 'clock'},
+      label: 'Duration',
+      content: 'Month, semester, or year',
+    },
+    {
+      key: 'devices',
+      icon: {iconName: 'desktop'},
+      label: 'Devices',
+      content: 'Laptop, Chromebook',
+    },
+    {
+      key: 'topics',
+      icon: {iconName: 'book'},
+      label: 'Topics',
+      content:
+        'Artificial Intelligence, Data, Web Design, Physical Computing, App Design, Games and Animations, Art and Design, Programming',
+    },
+    {
+      key: 'programming-tools',
+      icon: {iconName: 'screwdriver-wrench'},
+      label: 'Programming Tools',
+      content: 'App Lab, Game Lab, AI Lab, Web Lab',
+    },
+    {
+      key: 'professional-learning',
+      icon: {iconName: 'chalkboard-user'},
+      label: 'Professional Learning',
+      content: 'Facilitator-led workshops, self-paced learning',
+    },
+    {
+      key: 'accessibility',
+      icon: {iconName: 'universal-access'},
+      label: 'Accessibility',
+      content: 'Text-to-speech, closed captioning, immersive reader',
+    },
+    {
+      key: 'languages-supported',
+      icon: {iconName: 'language'},
+      label: 'Languages supported',
+      content: 'Italiano, Español (LATAM), Português (Brasil), Slovenčina',
+    },
+  ],
+};
+
+//
+// STORIES
+//
+export const Playground: Story = {
+  args: {
+    ...defaultArgs,
+  },
+};

--- a/frontend/packages/component-library/src/cms/snapshot/stories/Snapshot.story.tsx
+++ b/frontend/packages/component-library/src/cms/snapshot/stories/Snapshot.story.tsx
@@ -10,6 +10,7 @@ export default {
 } as Meta<SnapshotProps>;
 
 const defaultArgs: SnapshotProps = {
+  title: 'Curriculum Snapshot',
   items: [
     {
       key: 'grades',


### PR DESCRIPTION
## Preview
<img alt="preview" src="https://github.com/user-attachments/assets/161c1dd5-7b11-4b11-9267-d79494940a15" />

## Links
- JIRA task: [CMS-468](https://codedotorg.atlassian.net/browse/CMS-468)
- Figma: [Snapshot](https://www.figma.com/design/l7PsQAs2pitCNP8zUHWEuy/DSCO-CMS?node-id=4505-5586)
