### PR TITLE
[CMS-459] Add aria-label prop to button component

### DIFF
--- a/frontend/apps/marketing/src/components/button/Button.tsx
+++ b/frontend/apps/marketing/src/components/button/Button.tsx
@@ -25,6 +25,7 @@ type ButtonProps = {
   isLinkExternal?: boolean;
   /** Button left icon name */
   iconLeftName?: string;
+  /** Aria label for the button */
   ariaLabel?: EntryFields.Text;
 };
 

--- a/frontend/apps/marketing/src/components/button/Button.tsx
+++ b/frontend/apps/marketing/src/components/button/Button.tsx
@@ -1,3 +1,4 @@
+import {EntryFields} from 'contentful';
 import React, {useMemo} from 'react';
 
 import {
@@ -6,7 +7,10 @@ import {
   LinkButton,
 } from '@code-dot-org/component-library/button';
 
-import {fontAwesomeV6BrandIconsMap} from '@/components/common/constants';
+import {
+  externalLinkIconProps,
+  fontAwesomeV6BrandIconsMap,
+} from '@/components/common/constants';
 
 type ButtonProps = {
   /** Button text */
@@ -21,6 +25,7 @@ type ButtonProps = {
   isLinkExternal?: boolean;
   /** Button left icon name */
   iconLeftName?: string;
+  ariaLabel?: EntryFields.Text;
 };
 
 const Button: React.FunctionComponent<ButtonProps> = ({
@@ -29,6 +34,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
   type,
   href,
   isLinkExternal = false,
+  ariaLabel,
   iconLeftName,
 }) => {
   const isLeftIconBrand = useMemo(
@@ -43,6 +49,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
       target={isLinkExternal ? '_blank' : '_self'}
       type={type}
       color={color}
+      aria-label={ariaLabel}
       iconLeft={
         iconLeftName
           ? {
@@ -52,14 +59,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
             }
           : undefined
       }
-      iconRight={
-        isLinkExternal
-          ? {
-              iconName: 'up-right-from-square',
-              iconStyle: 'solid',
-            }
-          : undefined
-      }
+      iconRight={isLinkExternal ? externalLinkIconProps : undefined}
     />
   );
 };

--- a/frontend/apps/marketing/src/components/button/ButtonContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/button/ButtonContentfulDefinition.ts
@@ -58,7 +58,12 @@ export const ButtonContentfulComponentDefinition: ComponentDefinition = {
         'External links will be opened in a new tab, while internal links will be opened in the same tab.',
       type: 'Boolean',
       defaultValue: false,
-      group: 'style',
+      group: 'content',
+    },
+    ariaLabel: {
+      displayName: 'Aria Label',
+      type: 'Text',
+      group: 'content',
     },
     iconLeftName: {
       displayName: 'Left Icon Name',

--- a/frontend/apps/marketing/src/components/link/Link.tsx
+++ b/frontend/apps/marketing/src/components/link/Link.tsx
@@ -1,10 +1,12 @@
 import classNames from 'classnames';
+import {EntryFields} from 'contentful';
 import React, {ReactNode} from 'react';
 
 import {ComponentSizeXSToL} from '@code-dot-org/component-library/common/types';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {default as DSCOLink} from '@code-dot-org/component-library/link';
 
+import {externalLinkIconProps} from '@/components/common/constants';
 import {RemoveMarginBottomProps} from '@/components/common/types';
 
 import moduleStyles from './link.module.scss';
@@ -18,6 +20,8 @@ export type LinkProps = RemoveMarginBottomProps & {
   size: ComponentSizeXSToL;
   /** Whether Link is for internal code.org pages, or external web page. (external links are opened in new tab) */
   isLinkExternal: boolean;
+  /** Aria label for the link */
+  ariaLabel?: EntryFields.Text;
 };
 
 const Link: React.FunctionComponent<LinkProps> = ({
@@ -26,9 +30,11 @@ const Link: React.FunctionComponent<LinkProps> = ({
   size,
   isLinkExternal,
   removeMarginBottom,
+  ariaLabel,
 }) => (
   <DSCOLink
     href={href}
+    aria-label={ariaLabel}
     openInNewTab={isLinkExternal}
     size={size}
     className={classNames(
@@ -38,9 +44,7 @@ const Link: React.FunctionComponent<LinkProps> = ({
     )}
   >
     {children}
-    {isLinkExternal && (
-      <FontAwesomeV6Icon iconName="up-right-from-square" iconStyle="solid" />
-    )}
+    {isLinkExternal && <FontAwesomeV6Icon {...externalLinkIconProps} />}
   </DSCOLink>
 );
 

--- a/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
@@ -38,7 +38,7 @@ export const LinkContentfulComponentDefinition: ComponentDefinition = {
         'External links will be opened in a new tab, while internal links will be opened in the same tab.',
       type: 'Boolean',
       defaultValue: false,
-      group: 'style',
+      group: 'content',
     },
     href: {
       displayName: 'Link URL',
@@ -50,6 +50,11 @@ export const LinkContentfulComponentDefinition: ComponentDefinition = {
       displayName: 'Link Label',
       type: 'Text',
       defaultValue: 'Link',
+      group: 'content',
+    },
+    ariaLabel: {
+      displayName: 'Aria Label',
+      type: 'Text',
       group: 'content',
     },
   },

--- a/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
@@ -31,6 +31,17 @@ export const LinkContentfulComponentDefinition: ComponentDefinition = {
         ],
       },
     },
+    children: {
+      displayName: 'Link Label',
+      type: 'Text',
+      defaultValue: 'Link',
+      group: 'content',
+    },
+    href: {
+      displayName: 'Link URL',
+      type: 'Text',
+      group: 'content',
+    },
     isLinkExternal: {
       displayName:
         'Is this link external? (Does this link leave the code.org site?)',
@@ -40,18 +51,7 @@ export const LinkContentfulComponentDefinition: ComponentDefinition = {
       defaultValue: false,
       group: 'content',
     },
-    href: {
-      displayName: 'Link URL',
-      type: 'Text',
-      group: 'content',
-    },
     removeMarginBottom: {...removeMarginBottomDefinition},
-    children: {
-      displayName: 'Link Label',
-      type: 'Text',
-      defaultValue: 'Link',
-      group: 'content',
-    },
     ariaLabel: {
       displayName: 'Aria Label',
       type: 'Text',


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [CMS-459] Add aria-label prop to button component

* [feat(button): add ariaLabel support](https://github.com/code-dot-org/code-dot-org/commit/f3721f272384e74e54db44344e6e9ef6f12a1858)
* [feat(link): add ariaLabel support](https://github.com/code-dot-org/code-dot-org/commit/4d8831beec322d935e966338f63be73bb49eaac5)


https://github.com/user-attachments/assets/4f85a976-61a6-4137-bb5b-842d5708f7bb


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [CMS-459](https://codedotorg.atlassian.net/browse/CMS-459)

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
