### PR TITLE
temporarily add check to avoid issues during standalone-unit migration

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -321,7 +321,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
                 else
                   params[:unit_id] ? Unit.get_from_cache(params[:unit_id]) : nil
                 end
-        return head :bad_request if @unit && @course.id != @unit.unit_group.try(:id)
+        return head :bad_request if @unit && !@course.single_unit_course? && @course.id != @unit.unit_group.try(:id)
       when 'Unit'
         unit_id = course_version.content_root_id
         @unit = Unit.get_from_cache(unit_id)


### PR DESCRIPTION
During the time between the standalone-unit migration and the completion of the DTP, standalone-units cannot be assigned to sections due to a mismatch between the database and the script cache. This temporary addition does not return an error when the `course.id` doesn't match the `unit.unit_group.id` if the course being assigned is a single-unit course. We can revert this change after the [Part 2 Standalone-Unit Migration](https://github.com/code-dot-org/code-dot-org/pull/64729).

## Links
Part 2 Migration: #64729 
Jira: [TEACH-1536](https://codedotorg.atlassian.net/browse/TEACH-1536)

## Testing story
The following was manually verified on an [adhoc](https://adhoc-migrate-standalone-units-studio.cdn-code.org/). To replicate the conditions, the migration was performed, but the server was not restarted, leaving the cache from before the migration.

- [x] I can assign a "normal" course and unit to an existing section
- [x] I can create a section that is assigned a "normal" course and unit 
- [x] I can assign a migrated standalone-unit (`coursea-2024`, for example) to an existing section
- [x] I can create a section that is assigned a migrated standalone-unit
- [x] I can make progress in the assigned standalone-unit as a student
- [x] I can view student progress in the assigned standalone-unit as a teacher
- [x] A section that was assigned the standalone-unit prior to migration has no differences

 After the above checks were complete, the server was restarted with `sudo systemctl restart dashboard`. The remaining tests were performed to ensure that everything still worked post-migration.

- [x] I can assign a "normal" course and unit to an existing section
- [x] I can create a section that is assigned a "normal" course and unit 
- [x] I can assign a migrated standalone-unit (`coursea-2024`, for example) to an existing section
- [x] I can create a section that is assigned a migrated standalone-unit
- [x] I can make progress in the assigned standalone-unit as a student
- [x] I can view student progress in the assigned standalone-unit as a teacher
- [x] A section that was assigned the standalone-unit prior to migration still has no differences


## Follow-up work
While this line will need to change anyway for the upcoming modularity work, we should revert this change in the meantime to avoid assigning units with unit_group.ids that don't match the assigned course.
