### PR TITLE
Allow certain PII types through the filter

### DIFF
--- a/dashboard/app/controllers/ai_diff_controller.rb
+++ b/dashboard/app/controllers/ai_diff_controller.rb
@@ -65,6 +65,11 @@ class AiDiffController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
+  # Certain types of PII detected by Amazon Comprehend are actually allowed
+  # for use in chat messages. We allow teachers to ask about lessons themed
+  # on a favorite named celebrity, or how to help students at certain ages. etc.
+  ALLOWED_TYPES = %w[NAME AGE DATE_TIME USERNAME PIN].freeze
+
   private def contains_pii?
     client =  if (Rails.application.config.respond_to?(:stub_aichat_external_services) && Rails.application.config.stub_aichat_external_services) || [:development, :test].include?(rack_env)
                 Aws::Comprehend::Client.new(stub_responses: true)
@@ -88,7 +93,7 @@ class AiDiffController < ApplicationController
     #   ]
     # }
 
-    max_score = response.entities.map(&:score).max || 0
+    max_score = response.entities.reject {|entity| ALLOWED_TYPES.include?(entity.type)}.map(&:score).max || 0
 
     max_score > 0.9
   end


### PR DESCRIPTION
Our PII filtering was rejecting messages such as "Make this activity Taylor Swift" themed or "How can I help students under 13."

This PR changes the filtering to allow messages through if they are identified to contain only the following PII types and no others:
* Name
* Age
* Date/Time
* Username
* PIN

These are all things that Tess believed might be part of a valid conversation (or confused for such).

## Links

* [Amazon's list of PII types](https://docs.aws.amazon.com/comprehend/latest/dg/how-pii.html)
* [JIRA](https://codedotorg.atlassian.net/browse/AITT-964)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
