### PR TITLE
Use Dynamic rather than Hardcoded Waits When Checking Progress

### DIFF
--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -38,6 +38,5 @@ Scenario: Continue button and progress status shows up correctly
   And I press "uitest-validate-button"
   And I wait until element "#instructions-navigation" is visible
   And element "#instructions-navigation" contains text "Continue"
-  And I wait for 2 seconds
   Then I verify progress in the header of the current page is "perfect" for level 2
   Then I sign out

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -38,5 +38,6 @@ Scenario: Continue button and progress status shows up correctly
   And I press "uitest-validate-button"
   And I wait until element "#instructions-navigation" is visible
   And element "#instructions-navigation" contains text "Continue"
+  And I wait for 2 seconds
   Then I verify progress in the header of the current page is "perfect" for level 2
   Then I sign out

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -37,8 +37,9 @@ def verify_progress(selector, test_result, no_wait: false)
 
   # The data for progress bubbles can be loaded synchronously or
   # asynchronously, therefore unless we know the colors are set (such as when
-  # we're checking multiple not_tried bubbles in a row) we wait a bit before
-  # checking to ensure progress is loaded and the bubble is the correct color.
+  # we're checking multiple not_tried bubbles in a row) we keep checking until
+  # progress is loaded and the bubble is the correct color.
+  # TODO: check whether no_wait actually saves us time
   if no_wait
     steps %{
       And element "#{selector}" has css property "background-color" equal to "#{background_color}"
@@ -48,7 +49,7 @@ def verify_progress(selector, test_result, no_wait: false)
     steps "And I wait until jQuery Ajax requests are finished"
     wait_short_until do
       element_css_value(selector, 'background-color') == background_color &&
-        element_css_value(selector, 'border-color') == border_color
+        element_css_value(selector, 'border-top-color') == border_color
     end
   end
 end

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -14,7 +14,6 @@ end
 # nature of progress bubbles and can be slow, especially when verifying that a bubble
 # displays 'not_tried'. Passing no_wait=true skips all waits and immediately verifies
 # the bubble.
-# TODO: remove no_wait
 def verify_progress(selector, test_result, no_wait: false)
   case test_result
   when 'perfect'
@@ -34,17 +33,26 @@ def verify_progress(selector, test_result, no_wait: false)
     border_color = color_string('assessment')
   end
 
+  # The data for progress bubbles can be loaded synchronously or
+  # asynchronously, therefore unless we know the colors are set (such as when
+  # we're checking multiple not_tried bubbles in a row) we wait a bit before
+  # checking to ensure progress is loaded and the bubble is the correct color.
+  unless no_wait
+    steps %{
+      And I wait for 2 seconds
+      And I wait until jQuery Ajax requests are finished
+    }
+  end
+
+  verify_bubble_color(selector, background_color, border_color)
+end
+
+def verify_bubble_color(selector, background_color, border_color)
   steps %{
     And I wait until element "#{selector}" is visible
-    And I wait until jQuery Ajax requests are finished
+    And element "#{selector}" has css property "background-color" equal to "#{background_color}"
+    And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
   }
-
-  # The data for progress bubbles can be loaded  asynchronously, so keep
-  # checking until progress is loaded and the bubble is the correct color.
-  wait_short_until do
-    element_css_value(selector, 'background-color') == background_color &&
-      element_css_value(selector, 'border-top-color') == border_color
-  end
 end
 
 def verify_bubble_type(selector, type)

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -14,6 +14,7 @@ end
 # nature of progress bubbles and can be slow, especially when verifying that a bubble
 # displays 'not_tried'. Passing no_wait=true skips all waits and immediately verifies
 # the bubble.
+# TODO: remove no_wait
 def verify_progress(selector, test_result, no_wait: false)
   case test_result
   when 'perfect'
@@ -33,26 +34,17 @@ def verify_progress(selector, test_result, no_wait: false)
     border_color = color_string('assessment')
   end
 
-  # The data for progress bubbles can be loaded synchronously or
-  # asynchronously, therefore unless we know the colors are set (such as when
-  # we're checking multiple not_tried bubbles in a row) we wait a bit before
-  # checking to ensure progress is loaded and the bubble is the correct color.
-  unless no_wait
-    steps %{
-      And I wait for 2 seconds
-      And I wait until jQuery Ajax requests are finished
-    }
-  end
-
-  verify_bubble_color(selector, background_color, border_color)
-end
-
-def verify_bubble_color(selector, background_color, border_color)
   steps %{
     And I wait until element "#{selector}" is visible
-    And element "#{selector}" has css property "background-color" equal to "#{background_color}"
-    And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
+    And I wait until jQuery Ajax requests are finished
   }
+
+  # The data for progress bubbles can be loaded  asynchronously, so keep
+  # checking until progress is loaded and the bubble is the correct color.
+  wait_short_until do
+    element_css_value(selector, 'background-color') == background_color &&
+      element_css_value(selector, 'border-top-color') == border_color
+  end
 end
 
 def verify_bubble_type(selector, type)

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -11,11 +11,10 @@ end
 
 # Verifies that the given selector (which should be a progress bubble) is visible
 # and displays the expected test_result. This function accounts for the asynchronous
-# nature of progress bubbles and can be slow, especially when verifying that a bubble
-# displays 'not_tried'. Passing no_wait=true skips all waits and immediately verifies
-# the bubble.
-# TODO: remove no_wait
-def verify_progress(selector, test_result, no_wait: false)
+# nature of progress bubbles by repeatedly checking for the specified value for
+# up to 30 seconds; this means that successful checks should be reliable and
+# prompt, but failures will be slow.
+def verify_progress(selector, test_result)
   case test_result
   when 'perfect'
     background_color = color_string('perfect')
@@ -89,11 +88,11 @@ Then /^I verify progress in the drop down of the current page is "([^"]*)" for l
   verify_progress(selector, test_result)
 end
 
-Then /^I verify progress for lesson (\d+) level (\d+)( in detail view)? is "([^"]*)"( without waiting)?/ do |lesson, level, detail_view, test_result, without_waiting|
+Then /^I verify progress for lesson (\d+) level (\d+)( in detail view)? is "([^"]*)"/ do |lesson, level, detail_view, test_result|
   selector = detail_view.nil? ?
     ".uitest-summary-progress-table .uitest-summary-progress-row:eq(#{lesson.to_i - 1}) .progress-bubble:eq(#{level.to_i - 1})" :
     ".uitest-detail-progress-table .uitest-progress-lesson:eq(#{lesson.to_i - 1}) .progress-bubble:eq(#{level.to_i - 1})"
-  verify_progress(selector, test_result, no_wait: !!without_waiting)
+  verify_progress(selector, test_result)
 end
 
 Then /^I verify progress for the sublevel with selector "([^"]*)" is "([^"]*)"/ do |selector, test_result|

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -14,6 +14,7 @@ end
 # nature of progress bubbles and can be slow, especially when verifying that a bubble
 # displays 'not_tried'. Passing no_wait=true skips all waits and immediately verifies
 # the bubble.
+# TODO: remove no_wait
 def verify_progress(selector, test_result, no_wait: false)
   case test_result
   when 'perfect'
@@ -33,24 +34,16 @@ def verify_progress(selector, test_result, no_wait: false)
     border_color = color_string('assessment')
   end
 
-  steps "And I wait until element \"#{selector}\" is visible"
+  steps %{
+    And I wait until element "#{selector}" is visible
+    And I wait until jQuery Ajax requests are finished
+  }
 
-  # The data for progress bubbles can be loaded synchronously or
-  # asynchronously, therefore unless we know the colors are set (such as when
-  # we're checking multiple not_tried bubbles in a row) we keep checking until
-  # progress is loaded and the bubble is the correct color.
-  # TODO: check whether no_wait actually saves us time
-  if no_wait
-    steps %{
-      And element "#{selector}" has css property "background-color" equal to "#{background_color}"
-      And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
-    }
-  else
-    steps "And I wait until jQuery Ajax requests are finished"
-    wait_short_until do
-      element_css_value(selector, 'background-color') == background_color &&
-        element_css_value(selector, 'border-top-color') == border_color
-    end
+  # The data for progress bubbles can be loaded  asynchronously, so keep
+  # checking until progress is loaded and the bubble is the correct color.
+  wait_short_until do
+    element_css_value(selector, 'background-color') == background_color &&
+      element_css_value(selector, 'border-top-color') == border_color
   end
 end
 

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -33,26 +33,24 @@ def verify_progress(selector, test_result, no_wait: false)
     border_color = color_string('assessment')
   end
 
+  steps "And I wait until element \"#{selector}\" is visible"
+
   # The data for progress bubbles can be loaded synchronously or
   # asynchronously, therefore unless we know the colors are set (such as when
   # we're checking multiple not_tried bubbles in a row) we wait a bit before
   # checking to ensure progress is loaded and the bubble is the correct color.
-  unless no_wait
+  if no_wait
     steps %{
-      And I wait for 2 seconds
-      And I wait until jQuery Ajax requests are finished
+      And element "#{selector}" has css property "background-color" equal to "#{background_color}"
+      And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
     }
+  else
+    steps "And I wait until jQuery Ajax requests are finished"
+    wait_short_until do
+      element_css_value(selector, 'background-color') == background_color &&
+        element_css_value(selector, 'border-color') == border_color
+    end
   end
-
-  verify_bubble_color(selector, background_color, border_color)
-end
-
-def verify_bubble_color(selector, background_color, border_color)
-  steps %{
-    And I wait until element "#{selector}" is visible
-    And element "#{selector}" has css property "background-color" equal to "#{background_color}"
-    And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
-  }
 end
 
 def verify_bubble_type(selector, type)

--- a/dashboard/test/ui/features/teacher_tools/lesson_lock.feature
+++ b/dashboard/test/ui/features/teacher_tools/lesson_lock.feature
@@ -34,9 +34,9 @@ Scenario: Readonly view does not show teacher only boxes
   When I sign in as "bobby"
   And I am on "http://studio.code.org/s/allthethings"
   Then I verify the lesson named "Example CSP Assessment" is unlocked
-  Then I verify progress for lesson 47 level 1 is "not_tried" without waiting
-  Then I verify progress for lesson 47 level 2 is "not_tried" without waiting
-  Then I verify progress for lesson 47 level 3 is "not_tried" without waiting
+  Then I verify progress for lesson 47 level 1 is "not_tried"
+  Then I verify progress for lesson 47 level 2 is "not_tried"
+  Then I verify progress for lesson 47 level 3 is "not_tried"
 
   When I am on "http://studio.code.org/s/allthethings/lockable/3/levels/1/page/3"
   And I wait until element "h2:contains(CS Principles Unit 1 Assessment)" is visible
@@ -71,10 +71,10 @@ Scenario: Lock settings for students in survey
   When I sign in as "bobby"
   And I am on "http://studio.code.org/s/allthethings"
   Then I verify the lesson named "Anonymous student survey 2" is unlocked
-  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 1 is "not_tried"
+  Then I verify progress for lesson 31 level 2 is "not_tried"
+  Then I verify progress for lesson 31 level 3 is "not_tried"
+  Then I verify progress for lesson 31 level 4 is "not_tried"
 
   # student submits
 
@@ -104,10 +104,10 @@ Scenario: Lock settings for students in survey
   When I sign in as "bobby"
   And I am on "http://studio.code.org/s/allthethings"
   Then I verify the lesson named "Anonymous student survey 2" is unlocked
-  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 1 is "not_tried"
+  Then I verify progress for lesson 31 level 2 is "not_tried"
+  Then I verify progress for lesson 31 level 3 is "not_tried"
+  Then I verify progress for lesson 31 level 4 is "not_tried"
 
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/4"
   And I wait until element "h2:contains(Pre-survey)" is visible
@@ -141,10 +141,10 @@ Scenario: Lock settings for students who never submit
   When I sign in as "billy"
   And I am on "http://studio.code.org/s/allthethings"
   Then I verify the lesson named "Anonymous student survey 2" is unlocked
-  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 1 is "not_tried"
+  Then I verify progress for lesson 31 level 2 is "not_tried"
+  Then I verify progress for lesson 31 level 3 is "not_tried"
+  Then I verify progress for lesson 31 level 4 is "not_tried"
 
   # student does not submit assessment before teacher switches to readonly 
 
@@ -161,7 +161,7 @@ Scenario: Lock settings for students who never submit
   When I sign in as "billy"
   And I am on "http://studio.code.org/s/allthethings"
   Then I verify the lesson named "Anonymous student survey 2" is unlocked
-  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 1 is "not_tried"
+  Then I verify progress for lesson 31 level 2 is "not_tried"
+  Then I verify progress for lesson 31 level 3 is "not_tried"
+  Then I verify progress for lesson 31 level 4 is "not_tried"

--- a/dashboard/test/ui/features/teacher_tools/lesson_lock_retake.feature
+++ b/dashboard/test/ui/features/teacher_tools/lesson_lock_retake.feature
@@ -28,10 +28,10 @@ Scenario: Lock settings for retake not submit scenario
   When I sign in as "babby"
   And I am on "http://studio.code.org/s/allthethings"
   Then I verify the lesson named "Anonymous student survey 2" is unlocked
-  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 1 is "not_tried"
+  Then I verify progress for lesson 31 level 2 is "not_tried"
+  Then I verify progress for lesson 31 level 3 is "not_tried"
+  Then I verify progress for lesson 31 level 4 is "not_tried"
 
   # student does not submit assessment before teacher switches to locked 
 
@@ -105,10 +105,10 @@ Scenario: Lock settings for retake after submit scenario
   And I am on "http://studio.code.org/s/allthethings"
   And I wait until element ".uitest-summary-progress-row:contains(1. Jigsaw)" is visible
   Then I verify the lesson named "Anonymous student survey 2" is unlocked
-  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
-  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 1 is "not_tried"
+  Then I verify progress for lesson 31 level 2 is "not_tried"
+  Then I verify progress for lesson 31 level 3 is "not_tried"
+  Then I verify progress for lesson 31 level 4 is "not_tried"
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/4"
   And I click selector ".submitButton" once I see it
   And I wait to see a dialog titled "Submit your survey"

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -39,6 +39,7 @@ Feature: BubbleChoice
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
+    And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
   @no_firefox
@@ -83,6 +84,7 @@ Feature: BubbleChoice
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
+    And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
     # View progress from BubbleChoice sublevel activity page

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -39,7 +39,6 @@ Feature: BubbleChoice
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
-    And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
   @no_firefox
@@ -84,7 +83,6 @@ Feature: BubbleChoice
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
-    And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
     # View progress from BubbleChoice sublevel activity page

--- a/dashboard/test/ui/features/teacher_tools/level_types/free_response_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/free_response_contained_levels.feature
@@ -97,7 +97,6 @@ Scenario: Teacher can reset progress on free response contained level
   And I verify progress in the header of the current page is "perfect" for level 3
   Then I click selector "button:contains('Delete Answer')"
   And I wait until ".response" does not contain text "Here is my response!"
-  And I wait for 5 seconds
   And I verify progress in the header of the current page is "not_tried" for level 3
   And I press keys "Here is my response!" for element ".response"
   And element ".response" has value "Here is my response!"

--- a/dashboard/test/ui/features/teacher_tools/level_types/free_response_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/free_response_contained_levels.feature
@@ -97,6 +97,7 @@ Scenario: Teacher can reset progress on free response contained level
   And I verify progress in the header of the current page is "perfect" for level 3
   Then I click selector "button:contains('Delete Answer')"
   And I wait until ".response" does not contain text "Here is my response!"
+  And I wait for 5 seconds
   And I verify progress in the header of the current page is "not_tried" for level 3
   And I press keys "Here is my response!" for element ".response"
   And element ".response" has value "Here is my response!"

--- a/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
@@ -71,7 +71,6 @@ Scenario: Teacher can reset progress on multiple choice contained level
   Then I press "resetButton"
   Then I click selector "button:contains('Delete Answer')"
   And I wait until element "#unchecked_0" is visible
-  And I wait for 5 seconds
   And I verify progress in the header of the current page is "not_tried" for level 2
   Then I press "unchecked_1"
   And I wait up to 5 seconds for element "#checked_1" to be visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
@@ -71,6 +71,7 @@ Scenario: Teacher can reset progress on multiple choice contained level
   Then I press "resetButton"
   Then I click selector "button:contains('Delete Answer')"
   And I wait until element "#unchecked_0" is visible
+  And I wait for 5 seconds
   And I verify progress in the header of the current page is "not_tried" for level 2
   Then I press "unchecked_1"
   And I wait up to 5 seconds for element "#checked_1" to be visible


### PR DESCRIPTION
Currently, the `I verify progress for lesson` step in our UI tests will by default wait for an arbitrary 2 seconds in an attempt to accommodate the asynchronous nature of the progress bubble updates. We also have an optional `without waiting` option which will skip waits entirely.

Hardcoded waits are always fragile, and this is no exception; in particular, this has been by far the flakiest test I've been dealing with in the context of [the local selenium work](https://github.com/code-dot-org/code-dot-org/pull/64432).

To improve test stability, I update the default case to use `wait_short_until` to check every 0.2 seconds for up to 30 seconds, so we can not only accommodate delays of longer than 2 seconds but also be more responsive when delays are shorter. This does mean that failures will take quite a bit longer, but successes should be faster! I also removed the optional `without waiting` option entirely after verifying that the tests run just as fast with dynamic waits as they do with no waits at all.

## Links

- [our `wait_short_until` helper](https://github.com/code-dot-org/code-dot-org/blob/1396fb41b2d5b666d78181703cc788011c6816dc/dashboard/test/ui/features/step_definitions/steps.rb#L29)
- [underlying Selenium implementation of `Wait`](https://github.com/SeleniumHQ/selenium/blob/trunk/rb/lib/selenium/webdriver/common/wait.rb)

## Testing story

Relying on existing UI tests to verify the correctness of this test-tooling-only change.

I also kicked off a couple test runs to verify that this change does not negatively impact overall runtime. Notably:

- [A run of existing logic in staging](https://drone.cdn-code.org/code-dot-org/code-dot-org/27834) took 01:25:29
- [A run which just updated the default case but not the "no wait" case](https://drone.cdn-code.org/code-dot-org/code-dot-org/27834/2/1) took 01:25:15
- [A full run of all changes in this PR](https://drone.cdn-code.org/code-dot-org/code-dot-org/27835) took 01:26:54, and [a rerun of the same](https://drone.cdn-code.org/code-dot-org/code-dot-org/28247) took 01:23:24

All diffs are well within the range of normal test-to-test variation.

## Follow-up work

We have [quite a few more hardcoded waits](https://gist.github.com/Hamms/42baf609d6d76ec610c013563612380f) throughout our UI tests, and a few of them are flaky enough to be blocking further work on local selenium. I plan to address some of the most problematic ones myself, but I think we would benefit from some comprehensive cleanup here.

Possible hackathon candidate?
