### PR TITLE
Lab2: Bubble choice fixes

### DIFF
--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -28,7 +28,7 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
   const background = useAppSelector(
     state => getCurrentLesson(state)?.background || null
   );
-  const backgroundSuffix = capitalizeFirstLetter(background || 'dark');
+  const backgroundSuffix = capitalizeFirstLetter(background || 'light');
   const levelBubbleChoice = levelProperties.levelData as BubbleChoiceLevelData;
   const sublevelsStatus = useAppSelector(state =>
     levelBubbleChoice.sublevels.map(

--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -16,6 +16,7 @@ import {LabProps, BubbleChoiceLevelData} from '@cdo/apps/lab2/types';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import {capitalizeFirstLetter} from '@cdo/apps/util/capitalizeFirstLetter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import {getCurrentLesson} from '../code-studio/progressReduxSelectors';
 import {commonI18n} from '../types/locale';
@@ -36,7 +37,7 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
           state.progress,
           state.progress.currentLessonId,
           sublevel.level_id
-        ).status
+        )?.status || LevelStatus.not_tried
     )
   );
 

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -43,7 +43,6 @@ class BubbleChoice < DSLDefined
       name '#{DEFAULT_LEVEL_NAME}'
       display_name 'level display_name here'
       description 'level description here'
-      uses_lab2 false
 
       sublevels
       level 'level1'


### PR DESCRIPTION
Three small fixes for the Lab2 implementation of `BubbleChoice` levels added in https://github.com/code-dot-org/code-dot-org/pull/64344:

- Viewing a level by ID (with a `/levels/[level_id]` URL) now works.  The code needed to handle the case of progress not being available.
- If the lesson doesn't explicitly specify a light or dark background, the heading and description text can now be seen.  The code needed to assume a light background, not a dark one, in this situation.
- Creating a new level (at `/levels/new?type=BubbleChoice`) now has valid DSL source.  An unnecessary (and invalid) line had been added. 