### PR TITLE
[HOME] Close promotions semi-permanently using a cookie

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
@@ -42,7 +42,9 @@ const serverPromotionConverter = (serverPromotion: ServerPromotion) => ({
 const TEACHER_PROMOTION_LOCAL_STORAGE_KEY = 'teacherPromotionClosed';
 
 const TeacherPromotions: React.FC = () => {
-  const [promotions, setPromotions] = React.useState<TeacherPromoInfo[]>([]);
+  const [unfilteredPromotions, setUnfilteredPromotions] = React.useState<
+    TeacherPromoInfo[]
+  >([]);
 
   const [isLoading, setIsLoading] = React.useState(true);
 
@@ -60,15 +62,7 @@ const TeacherPromotions: React.FC = () => {
     HttpClient.fetchJson<ServerPromotion[]>(TEACHER_PROMOTION_URL)
       .then(response => response?.value)
       .then(data => {
-        setPromotions(
-          data
-            .map(serverPromotionConverter)
-            .filter(
-              promotion =>
-                !promotion.isClosable ||
-                !closedPromotions.includes(promotion.id)
-            )
-        );
+        setUnfilteredPromotions(data.map(serverPromotionConverter));
         setIsLoading(false);
       })
       .catch(error => {
@@ -77,10 +71,16 @@ const TeacherPromotions: React.FC = () => {
       });
   }, [closedPromotions]);
 
+  const promotions = React.useMemo<TeacherPromoInfo[]>(
+    () =>
+      unfilteredPromotions.filter(
+        promotion => !closedPromotions.includes(promotion.id)
+      ),
+    [unfilteredPromotions, closedPromotions]
+  );
+
   const closePromotionCallback = React.useCallback(
     (id: string) => {
-      setPromotions(promotions.filter(promotion => promotion.id !== id));
-
       setClosedPromotions([...closedPromotions, id]);
 
       // We don't want the promotions cookie to store old promotions.

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import HttpClient from '@cdo/apps/util/HttpClient';
+import {trySetLocalStorage, tryGetLocalStorage} from '@cdo/apps/utils';
 
 import TeacherPromo, {TeacherPromoInfo} from './TeacherPromo';
 
@@ -38,31 +39,55 @@ const serverPromotionConverter = (serverPromotion: ServerPromotion) => ({
   partnerLogo: serverPromotion.partner_logo || null,
 });
 
+const TEACHER_PROMOTION_LOCAL_STORAGE_KEY = 'teacherPromotionClosed';
+
 const TeacherPromotions: React.FC = () => {
   const [promotions, setPromotions] = React.useState<TeacherPromoInfo[]>([]);
 
   const [isLoading, setIsLoading] = React.useState(true);
 
+  const [closedPromotions, setClosedPromotions] = React.useState<string[]>(
+    () => {
+      const stringPromotions = tryGetLocalStorage(
+        TEACHER_PROMOTION_LOCAL_STORAGE_KEY,
+        '[]'
+      );
+      return JSON.parse(stringPromotions) as string[];
+    }
+  );
+
   React.useEffect(() => {
     HttpClient.fetchJson<ServerPromotion[]>(TEACHER_PROMOTION_URL)
       .then(response => response?.value)
       .then(data => {
-        setPromotions(data.map(serverPromotionConverter));
+        setPromotions(
+          data
+            .map(serverPromotionConverter)
+            .filter(
+              promotion =>
+                !promotion.isClosable ||
+                !closedPromotions.includes(promotion.id)
+            )
+        );
         setIsLoading(false);
       })
       .catch(error => {
         console.error('Error retrieving marketing promotions', {error});
         setIsLoading(false);
       });
-  }, []);
+  }, [closedPromotions]);
 
   const closePromotionCallback = React.useCallback(
     (id: string) => {
       setPromotions(promotions.filter(promotion => promotion.id !== id));
 
-      // TODO(lfm): Send a POST request to the server to mark the promotion as closed
+      setClosedPromotions([...closedPromotions, id]);
+      trySetLocalStorage(
+        TEACHER_PROMOTION_LOCAL_STORAGE_KEY,
+        JSON.stringify([...closedPromotions, id])
+      );
     },
-    [promotions]
+    [promotions, closedPromotions]
   );
 
   return (

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
@@ -52,7 +52,7 @@ const TeacherPromotions: React.FC = () => {
         TEACHER_PROMOTION_LOCAL_STORAGE_KEY,
         '[]'
       );
-      return JSON.parse(stringPromotions) as string[];
+      return (JSON.parse(stringPromotions) as string[]) || [];
     }
   );
 

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
@@ -82,9 +82,19 @@ const TeacherPromotions: React.FC = () => {
       setPromotions(promotions.filter(promotion => promotion.id !== id));
 
       setClosedPromotions([...closedPromotions, id]);
+
+      // We don't want the promotions cookie to store old promotions.
+      // So only save the promotions that are currently active and have been closed.
+      const newClosedPromotions =
+        promotions.length > 0
+          ? closedPromotions.filter(promotion =>
+              promotions.map(p => p.id).includes(promotion)
+            )
+          : closedPromotions;
+      newClosedPromotions.push(id);
       trySetLocalStorage(
         TEACHER_PROMOTION_LOCAL_STORAGE_KEY,
-        JSON.stringify([...closedPromotions, id])
+        JSON.stringify(newClosedPromotions)
       );
     },
     [promotions, closedPromotions]

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherPromoTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherPromoTest.tsx
@@ -17,6 +17,7 @@ describe('TeacherPromo', () => {
     description: 'Description for Promotion 1',
     image: '/image1.png',
     isClosable: true,
+    partnerLogo: '/partner_logo.png',
   };
 
   const onCloseMock = jest.fn();

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherPromotionsTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherPromotionsTest.tsx
@@ -4,13 +4,18 @@ import React from 'react';
 
 import TeacherPromotions from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/TeacherPromotions';
 import HttpClient from '@cdo/apps/util/HttpClient';
+import * as localStorageUtils from '@cdo/apps/utils';
 
 jest.mock('@cdo/apps/util/HttpClient');
+jest.mock('@cdo/apps/utils', () => ({
+  trySetLocalStorage: jest.fn(),
+  tryGetLocalStorage: jest.fn().mockReturnValue(null),
+}));
 
 describe('TeacherPromotions', () => {
   const mockPromotions = [
     {
-      id: 1,
+      id: '1',
       announcement_type: 'New Curriculum',
       background_color: 'Blue',
       title: 'Promotion 1',
@@ -21,7 +26,7 @@ describe('TeacherPromotions', () => {
       is_closable: true,
     },
     {
-      id: 2,
+      id: '2',
       announcement_type: 'Announcement',
       background_color: 'Gray',
       title: 'Promotion 2',
@@ -94,6 +99,70 @@ describe('TeacherPromotions', () => {
     await waitFor(() => {
       expect(screen.queryByText('Promotion 1')).toBeNull();
       expect(screen.queryByText('Promotion 2')).toBeNull();
+    });
+  });
+
+  it('does not show closed promotions', async () => {
+    jest.spyOn(localStorageUtils, 'tryGetLocalStorage').mockReturnValue(
+      JSON.stringify(['1']) // Promotion with ID 1 is closed
+    );
+
+    fetchSpy.mockResolvedValue({
+      value: mockPromotions,
+      response: new Response(),
+    });
+
+    render(<TeacherPromotions />);
+
+    await screen.findByText('Promotion 2'); // Only Promotion 2 should be visible
+    expect(screen.queryByText('Promotion 1')).toBeNull();
+  });
+
+  it('calls trySetLocalStorage when a promotion is closed', async () => {
+    jest.spyOn(localStorageUtils, 'tryGetLocalStorage').mockReturnValue('[]');
+
+    fetchSpy.mockResolvedValue({
+      value: mockPromotions,
+      response: new Response(),
+    });
+
+    render(<TeacherPromotions />);
+
+    await screen.findByText('Promotion 1');
+
+    const closeButton = screen.getByRole('button', {name: 'Close'});
+    userEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(localStorageUtils.trySetLocalStorage).toHaveBeenCalledWith(
+        'teacherPromotionClosed',
+        JSON.stringify(['1'])
+      );
+    });
+  });
+
+  it('removes closed promotions from local storage if not in received promotions', async () => {
+    jest.spyOn(localStorageUtils, 'tryGetLocalStorage').mockReturnValue(
+      JSON.stringify(['3']) // Promotion with ID 3 is no longer valid
+    );
+
+    fetchSpy.mockResolvedValue({
+      value: mockPromotions,
+      response: new Response(),
+    });
+
+    render(<TeacherPromotions />);
+
+    await screen.findByText('Promotion 1');
+
+    const closeButton = screen.getByRole('button', {name: 'Close'});
+    userEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(localStorageUtils.trySetLocalStorage).toHaveBeenCalledWith(
+        'teacherPromotionClosed',
+        JSON.stringify(['1'])
+      );
     });
   });
 });


### PR DESCRIPTION
Uses a local storage cookie to close promotions on the teacher homepage

## Links
https://codedotorg.atlassian.net/browse/TEACH-1580
[discussion](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1743092647648609)