### PR TITLE
fix(Video): fixes overflow issue causing misalignment

### DIFF
--- a/frontend/packages/component-library/src/video/video.module.scss
+++ b/frontend/packages/component-library/src/video/video.module.scss
@@ -12,10 +12,10 @@
     position: relative;
     overflow: hidden;
     width: 100%;
-    padding-top: 56.25%; // This maintains a 16:9 aspect ratio
+    aspect-ratio: 16 / 9; // Default aspect ratio for videos
     border: 1px solid var(--background-neutral-tertiary);
     border-radius: variables.$regular-border-radius;
-    box-sizing: content-box;
+    box-sizing: border-box;
     display: block;
 
     iframe,


### PR DESCRIPTION
Fixes an issue where the video overflows the container that I think was introduced in https://github.com/code-dot-org/code-dot-org/pull/64642

## Links
Jira ticket: [CMS-496](https://codedotorg.atlassian.net/browse/CMS-496)

----

## Before
<img width="1027" alt="Screenshot 2025-03-31 at 12 28 35 PM" src="https://github.com/user-attachments/assets/bb0a1fee-f7c7-4594-a45b-294a92bca5f0" />

<img width="1019" alt="Screenshot 2025-03-31 at 12 29 39 PM" src="https://github.com/user-attachments/assets/2a3a3a7e-f370-4cb8-b67c-06480ea0422e" />

## After
<img width="1027" alt="Screenshot 2025-03-31 at 12 28 55 PM" src="https://github.com/user-attachments/assets/c1ddfc37-54ab-434d-a550-c4700b4e4cbd" />


<img width="1019" alt="Screenshot 2025-03-31 at 12 29 28 PM" src="https://github.com/user-attachments/assets/837b9e25-d9f5-4eda-82fe-f8f020fe4f1f" />
