### PR TITLE
add pilot experiment to new unit group

### DIFF
--- a/dashboard/lib/services/standalone_unit_migrator.rb
+++ b/dashboard/lib/services/standalone_unit_migrator.rb
@@ -125,6 +125,7 @@ module Services
         instruction_type: @unit.instruction_type,
         instructor_audience: @unit.instructor_audience,
         participant_audience: @unit.participant_audience,
+        pilot_experiment: @unit.pilot_experiment,
         has_numbered_units: false
       )
       unless @unit_group.save


### PR DESCRIPTION
It was found that users were unable to assign migrated standalone-units in pilot to sections. This was because the `pilot_experiment` was not added to the unit group created during migration. 

This PR needs to go in before #64729 so that we can manually migrate the remaining units in production before the DTP.

## Links
Jira: [TEACH-1536](https://codedotorg.atlassian.net/browse/TEACH-1536)

## Testing story
This change is being tested on an adhoc