### PR TITLE
[HOME] Add static promotions to homepage

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/PermanentPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/PermanentPromotions.tsx
@@ -1,0 +1,70 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import Link from '@code-dot-org/component-library/link';
+import {
+  BodyFourText,
+  BodyTwoText,
+  StrongText,
+} from '@code-dot-org/component-library/typography';
+import React from 'react';
+
+import bookWithBulb from './images/book_with_bulb.png';
+import magnifierWithBackground from './images/magnifier_with_background.png';
+
+import styles from './teacherHomepage.module.scss';
+
+const PermanentPromotions: React.FC = () => {
+  const promotions = [
+    {
+      id: '1',
+      title: 'Grow your knowledge',
+      description:
+        'Empower your teaching with workshops and self-paced learning.',
+      buttonLabel: 'Explore professional learning',
+      buttonTarget: '/my-professional-learning',
+      image: (
+        <img
+          src={bookWithBulb}
+          alt=""
+          className={styles.staticPromotionImage}
+        />
+      ),
+    },
+    {
+      id: '2',
+      title: 'Help improve Code.org',
+      description:
+        'Participate in user research to help us improve our platform for everyone.',
+      buttonLabel: 'Join the user research program',
+      buttonTarget: 'https://greatquestion.co/codedotorg/userresearch',
+      image: (
+        <img
+          src={magnifierWithBackground}
+          alt=""
+          className={styles.staticPromotionImage}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <div className={styles.staticPromotions}>
+      {promotions.map(promotion => (
+        <div key={promotion.id} className={styles.staticPromotion}>
+          <div className={styles.staticPromotionText}>
+            <BodyTwoText>
+              <StrongText>{promotion.title}</StrongText>
+            </BodyTwoText>
+            <BodyFourText>{promotion.description}</BodyFourText>
+            <Link href={promotion.buttonTarget} size="xs" openInNewTab={true}>
+              {promotion.buttonLabel}
+              <FontAwesomeV6Icon iconName="up-right-from-square" />
+            </Link>
+          </div>
+          {promotion.image}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PermanentPromotions;

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import HttpClient from '@cdo/apps/util/HttpClient';
 
+import PermanentPromotions from './PermanentPromotions';
 import TeacherPromo, {TeacherPromoInfo} from './TeacherPromo';
 
 import styles from './teacherHomepage.module.scss';
@@ -72,6 +73,7 @@ const TeacherPromotions: React.FC = () => {
       {promotions.map(promotion => (
         <TeacherPromo {...promotion} onClose={closePromotionCallback} />
       ))}
+      <PermanentPromotions />
     </div>
   );
 };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/images/book_with_bulb.png
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/images/book_with_bulb.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19ae0d12234883ade031b30d4029c598b9630a5201bd18856338d52f1cc31e65
+size 9730

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/images/magnifier_with_background.png
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/images/magnifier_with_background.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee3505c1e6836c3effadf5ad3916608d45cb72ec3bd54a68f78fcecac3b4391
+size 12714

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -280,3 +280,34 @@
   top: 8px;
   inset-inline-end: 8px;
 }
+
+.staticPromotions {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.staticPromotion {
+  border: solid 1px var(--borders-neutral-primary);
+  background-color: var(--background-neutral-primary);
+  border-radius: 4px;  width: 280px;
+  max-width: 280px;
+  padding: 20px;
+  display: flex;
+  flex-direction: row;
+
+  p {
+    margin-bottom: 8px;
+  }
+
+  a {
+    text-decoration: none;
+  }
+}
+
+.staticPromotionImage {
+  width: 50px;
+  min-height: 50px;
+  height: fit-content;
+  margin-inline-start: 8px;
+}

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/PermanentPromotionsTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/PermanentPromotionsTest.tsx
@@ -1,0 +1,42 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import PermanentPromotions from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/PermanentPromotions';
+
+describe('PermanentPromotions', () => {
+  beforeEach(() => {
+    render(<PermanentPromotions />);
+  });
+
+  it('renders the first promotion with correct title, description, and link', () => {
+    expect(screen.getByText('Grow your knowledge')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Empower your teaching with workshops and self-paced learning.'
+      )
+    ).toBeInTheDocument();
+
+    const link = screen.getByRole('link', {
+      name: 'Explore professional learning',
+    });
+    expect(link).toHaveAttribute('href', '/my-professional-learning');
+  });
+
+  it('renders the second promotion with correct title, description, and link', () => {
+    expect(screen.getByText('Help improve Code.org')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Participate in user research to help us improve our platform for everyone.'
+      )
+    ).toBeInTheDocument();
+
+    const link = screen.getByRole('link', {
+      name: 'Join the user research program',
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://greatquestion.co/codedotorg/userresearch'
+    );
+  });
+});


### PR DESCRIPTION
Adds two permanent static promotions to the new homepage. These are not served by contentful and are permanent
![image](https://github.com/user-attachments/assets/9bab9f48-ac87-4aea-92dd-ff1884929ba8)

## Links
https://codedotorg.atlassian.net/browse/TEACH-1742