### PR TITLE
GDPR dialog: color

### DIFF
--- a/apps/src/templates/GDPRDialog.jsx
+++ b/apps/src/templates/GDPRDialog.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import BaseDialog from './BaseDialog';
@@ -85,6 +86,7 @@ const styles = {
     paddingLeft: 20,
     paddingRight: 20,
     paddingBottom: 20,
+    color: color.default_text,
   },
   instructions: {
     marginTop: 20,


### PR DESCRIPTION
Set a default text color for the GDPR dialog, which makes one line more visible when viewed over a dark mode lab.

### before

<img width="799" alt="Screenshot 2025-03-31 at 2 05 35 PM" src="https://github.com/user-attachments/assets/b32e075e-9f29-4127-84c5-513397645bcb" />

### after

<img width="799" alt="Screenshot 2025-03-31 at 2 06 03 PM" src="https://github.com/user-attachments/assets/a2a84ac0-83f0-4224-888d-08263ac0e4f7" />
