### PR TITLE
AI Chat: add product analytics to multimodal flow

### DIFF
--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -79,6 +79,7 @@ export const submitChatContents = createAsyncThunk(
       dispatch(
         sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_SUCCESS, {
           levelPath: window.location.pathname,
+          fileCount: newUserMessage.assets?.length || 0,
         })
       );
     } catch (error) {

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -76,10 +76,18 @@ export const submitChatContents = createAsyncThunk(
         aiCustomizations,
         aichatContext
       );
+
+      const fileCount = newUserMessage.assets?.length || 0;
+      const fileCountPdf =
+        newUserMessage.assets?.filter(asset => asset.filename.endsWith('.pdf'))
+          .length || 0;
+      const fileCountImage = fileCount - fileCountPdf;
       dispatch(
         sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_SUCCESS, {
           levelPath: window.location.pathname,
-          fileCount: newUserMessage.assets?.length || 0,
+          fileCount,
+          fileCountImage,
+          fileCountPdf,
         })
       );
     } catch (error) {

--- a/apps/src/aichat/types/assets.ts
+++ b/apps/src/aichat/types/assets.ts
@@ -1,5 +1,10 @@
 /** An asset file included with a chat message. */
 export interface ChatAsset {
   filename: string;
-  source: 'project' | 'level';
+  source: AssetSource;
+}
+
+export enum AssetSource {
+  PROJECT = 'project',
+  LEVEL = 'level',
 }

--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -5,9 +5,10 @@ import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import CopyButton from '@cdo/apps/aiComponentLibrary/copyButton/CopyButton';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {ValueOf} from '@cdo/apps/types/utils';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
+import {sendAnalytics} from '../redux';
 import {
   type ChatMessage as ChatMessageType,
   isCompletedChatMessage,
@@ -34,6 +35,8 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
   const {status, role, chatMessageText, assets} = chatMessage;
   const currentChannelId = useAppSelector(state => state.lab.channel?.id);
   const levelName = useAppSelector(state => state.lab.levelProperties?.name);
+
+  const dispatch = useAppDispatch();
 
   const displayText = getChatMessageDisplayText(
     status,
@@ -97,19 +100,18 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
           const url = getAssetUrl(asset, currentChannelId, levelName);
           return (
             <button
+              key={filename}
               type="button"
               className={styles.assetButton}
-              onClick={() => window.open(url, '_blank')}
+              onClick={() => {
+                dispatch(sendAnalytics());
+                window.open(url, '_blank');
+              }}
             >
               {filename.endsWith('.pdf') ? (
                 <FilePreview type="pdf" filename={filename} url={url} />
               ) : (
-                <img
-                  key={filename}
-                  alt=""
-                  className={styles.imagePreview}
-                  src={url}
-                />
+                <img alt="" className={styles.imagePreview} src={url} />
               )}
             </button>
           );

--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -5,10 +5,9 @@ import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import CopyButton from '@cdo/apps/aiComponentLibrary/copyButton/CopyButton';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {ValueOf} from '@cdo/apps/types/utils';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
-import {sendAnalytics} from '../redux';
 import {
   type ChatMessage as ChatMessageType,
   isCompletedChatMessage,
@@ -35,8 +34,6 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
   const {status, role, chatMessageText, assets} = chatMessage;
   const currentChannelId = useAppSelector(state => state.lab.channel?.id);
   const levelName = useAppSelector(state => state.lab.levelProperties?.name);
-
-  const dispatch = useAppDispatch();
 
   const displayText = getChatMessageDisplayText(
     status,
@@ -104,7 +101,6 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
               type="button"
               className={styles.assetButton}
               onClick={() => {
-                dispatch(sendAnalytics());
                 window.open(url, '_blank');
               }}
             >

--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -100,9 +100,7 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
               key={filename}
               type="button"
               className={styles.assetButton}
-              onClick={() => {
-                window.open(url, '_blank');
-              }}
+              onClick={() => window.open(url, '_blank')}
             >
               {filename.endsWith('.pdf') ? (
                 <FilePreview type="pdf" filename={filename} url={url} />

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -19,13 +19,9 @@ import {
   stagedFilesLimitExceeded,
   stagedFileUploadFinished,
 } from '../../redux';
+import {AssetSource} from '../../types';
 
 import styles from './upload-button.module.scss';
-
-const UPLOAD_TYPES = {
-  Device: 'device',
-  Library: 'library',
-};
 
 const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
   const dispatch = useAppDispatch();
@@ -102,7 +98,7 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
 
     dispatch(
       sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_STAGED, {
-        source: UPLOAD_TYPES.Device,
+        source: AssetSource.PROJECT,
         fileCountSuccess: uploadSuccessCount,
         fileCountFailureSizeLimitExceeded: sizeLimitExceededCount,
         fileCountFailureUnknownCause: uploadFailureCount,
@@ -117,7 +113,7 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
           key: `${asset.filename}-${Date.now()}`,
           asset: {
             filename: asset.filename,
-            source: 'level',
+            source: AssetSource.LEVEL,
           },
           loaded: true,
         })
@@ -126,7 +122,7 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
 
     dispatch(
       sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_STAGED, {
-        source: UPLOAD_TYPES.Library,
+        source: AssetSource.LEVEL,
         fileCountSuccess: assets.length,
       })
     );
@@ -142,7 +138,7 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
     openFileInput();
     dispatch(
       sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_OPENED, {
-        source: UPLOAD_TYPES.Device,
+        source: AssetSource.PROJECT,
       })
     );
   };
@@ -186,7 +182,7 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
               setShowAssetManager(true);
               dispatch(
                 sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_OPENED, {
-                  source: UPLOAD_TYPES.Library,
+                  source: AssetSource.LEVEL,
                 })
               );
             },

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -56,7 +56,9 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
       ]);
 
     for (const [key, filename] of allowedFiles) {
-      dispatch(addStagedFile({key, asset: {filename, source: 'project'}}));
+      dispatch(
+        addStagedFile({key, asset: {filename, source: AssetSource.PROJECT}})
+      );
     }
 
     let uploadSuccessCount = 0;

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -42,7 +42,8 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
     // Clear the alert, if any
     dispatch(clearStagedFilesAlert());
 
-    if (files.length > numAllowedFiles) {
+    const excessFileCount = files.length - numAllowedFiles;
+    if (excessFileCount > 0) {
       dispatch(stagedFilesLimitExceeded());
     }
 
@@ -104,6 +105,7 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
         fileCountSuccess: uploadSuccessCount,
         fileCountFailureSizeLimitExceeded: sizeLimitExceededCount,
         fileCountFailureUnknownCause: uploadFailureCount,
+        fileCountFailureNumberExceeded: Math.max(excessFileCount, 0),
       })
     );
   };

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -149,8 +149,6 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
     return null;
   }
 
-  // need to figure out how to have onclick for analytics event,
-  // as well as default onclick that opens/closes dropdown
   return (
     <>
       {levelName && showAssetManager && (

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -112,6 +112,8 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
     return null;
   }
 
+  // need to figure out how to have onclick for analytics event,
+  // as well as default onclick that opens/closes dropdown
   return (
     <>
       {levelName && showAssetManager && (
@@ -135,6 +137,7 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
           color: 'gray',
           iconLeft: {iconName: 'upload'},
           text: aichatI18n.upload(),
+          onClick: () => console.log('hello'),
         }}
         options={[
           {

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -5,6 +5,7 @@ import React, {ChangeEvent, useState} from 'react';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import StarterAssetsDialog from '@cdo/apps/lab2/views/components/starterAssetsDialog';
 import {AssetData} from '@cdo/apps/lab2/views/components/starterAssetsDialog/types';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import useHiddenFileInput from '@cdo/apps/util/hooks/useHiddenFileInput';
 import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -14,11 +15,17 @@ import aichatI18n from '../../locale';
 import {
   addStagedFile,
   clearStagedFilesAlert,
+  sendAnalytics,
   stagedFilesLimitExceeded,
   stagedFileUploadFinished,
 } from '../../redux';
 
 import styles from './upload-button.module.scss';
+
+const UPLOAD_TYPES = {
+  Device: 'device',
+  Library: 'library',
+};
 
 const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
   const dispatch = useAppDispatch();
@@ -56,18 +63,25 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
       dispatch(addStagedFile({key, asset: {filename, source: 'project'}}));
     }
 
+    let uploadSuccessCount = 0;
+    let sizeLimitExceededCount = 0;
+    let uploadFailureCount = 0;
     for (const [key, filename, file] of allowedFiles) {
       try {
         await HttpClient.put(
           `/v3/assets/${currentChannelId}/${encodeURIComponent(filename)}`,
           file
         );
+        uploadSuccessCount += 1;
+
         dispatch(stagedFileUploadFinished({key, status: 'uploaded'}));
       } catch (error) {
         let status: 'sizeLimitExceeded' | 'uploadFailed' = 'uploadFailed';
         if (error instanceof NetworkError && error.response.status === 413) {
+          sizeLimitExceededCount += 1;
           status = 'sizeLimitExceeded';
         } else {
+          uploadFailureCount += 1;
           status = 'uploadFailed';
           // Only log if not a size limit exceeded error
           Lab2Registry.getInstance()
@@ -85,6 +99,15 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
         );
       }
     }
+
+    dispatch(
+      sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_STAGED, {
+        source: UPLOAD_TYPES.Device,
+        fileCountSuccess: uploadSuccessCount,
+        fileCountFailureSizeLimitExceeded: sizeLimitExceededCount,
+        fileCountFailureUnknownCause: uploadFailureCount,
+      })
+    );
   };
 
   const onSelectStarterAssets = (assets: AssetData[]) => {
@@ -100,6 +123,13 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
         })
       );
     }
+
+    dispatch(
+      sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_STAGED, {
+        source: UPLOAD_TYPES.Library,
+        fileCountSuccess: assets.length,
+      })
+    );
   };
 
   const [openFileInput, FileInput] = useHiddenFileInput(
@@ -107,6 +137,15 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
     ACCEPTED_FILE_TYPES.join(','),
     true
   );
+
+  const onDeviceUploadClick = () => {
+    openFileInput();
+    dispatch(
+      sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_OPENED, {
+        source: UPLOAD_TYPES.Device,
+      })
+    );
+  };
 
   if (!currentChannelId) {
     return null;
@@ -137,20 +176,26 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
           color: 'gray',
           iconLeft: {iconName: 'upload'},
           text: aichatI18n.upload(),
-          onClick: () => console.log('hello'),
         }}
         options={[
           {
             value: 'fromLibrary',
             label: 'From Library',
             icon: {iconName: 'copy'},
-            onClick: () => setShowAssetManager(true),
+            onClick: () => {
+              setShowAssetManager(true);
+              dispatch(
+                sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_OPENED, {
+                  source: UPLOAD_TYPES.Library,
+                })
+              );
+            },
           },
           {
             value: 'fromDevice',
             label: 'From Device',
             icon: {iconName: 'file-magnifying-glass'},
-            onClick: openFileInput,
+            onClick: onDeviceUploadClick,
           },
         ]}
       />

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -453,6 +453,7 @@ const EVENTS = {
   SUBMIT_AICHAT_REQUEST_UNAUTHORIZED:
     'Unauthorized user attempts to submit aichat request or model customizations and fails',
   SUBMIT_AICHAT_TEACHER_FEEDBACK: 'Teacher submits feedback on aichat message',
+
   // Codebridge - File broswer-related events
   CODEBRIDGE_DELETE_FILE: 'Delete file on codebridge',
   CODEBRIDGE_DELETE_FOLDER: 'Delete folder on codebridge',

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -453,6 +453,8 @@ const EVENTS = {
   SUBMIT_AICHAT_REQUEST_UNAUTHORIZED:
     'Unauthorized user attempts to submit aichat request or model customizations and fails',
   SUBMIT_AICHAT_TEACHER_FEEDBACK: 'Teacher submits feedback on aichat message',
+  AICHAT_MULTIMODAL_UPLOAD_OPENED: 'User clicks to upload multimodal assets',
+  AICHAT_MULTIMODAL_UPLOAD_STAGED: 'User stages multimodal assets',
 
   // Codebridge - File broswer-related events
   CODEBRIDGE_DELETE_FILE: 'Delete file on codebridge',


### PR DESCRIPTION
Adds Statsig analytics at a couple of points in the multimodal flow:
- Opening the asset upload dialog (detail on whether Device or Library upload was chosen) 
- Staging assets (detail on # of assets successfully staged vs. not)
- Sending a messages including assets (give the asset count, with splits by PDF vs image)

## Links

- jira ticket: [LABS-1409](https://codedotorg.atlassian.net/browse/LABS-1409)

## Testing story

Tested manually that at each point in the flow that I saw appropriate events being logged to the console (typical analytics behavior in development).