### PR TITLE
Fix for progress loading issue - specifically with 20 students and one duplicate follower

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -311,7 +311,12 @@ class ApiController < ApplicationController
     page = [params[:page].to_i, 1].max
     per = params[:per].to_i || 50
 
-    paged_students = section.students.page(page).per(per)
+    # Occassionaly, students will be double-added to a section. When this happens, errors can
+    # occur when we get the progress for the student twice.  We saw two issues that were caused by
+    # having duplicate students in a section AND the number of students being a multiple of the page amount
+    # Deduplicating students ensures all data for all students is pulled.
+    deduplicated_students = section.students.distinct
+    paged_students = deduplicated_students.page(page).per(per)
     # As designed, if there are 50 students, the client will ask for both
     # page 1 and page 2, even though page 2 is out of range. However, it should
     # never ask for page 3

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1241,6 +1241,30 @@ class ApiControllerTest < ActionController::TestCase
     assert_response 416
   end
 
+  test "section with duplicated students loads all data when per is equal to the number of unique students" do
+    duplicated_section_owner = create(:teacher)
+
+    # section will contain 7 unique students, but 8 followers - one of whom is a "duplicate"
+    duplicated_section = create(:section, user: duplicated_section_owner, login_type: 'word')
+
+    # add students in section
+    duplicated_students = []
+    7.times do |i|
+      student = create(:student, name: "duplicated_student_#{i}")
+      duplicated_students << student
+      create(:follower, section: duplicated_section, student_user: student)
+    end
+
+    # Create a duplicate follower for student_2 in duplicated_section
+    create(:follower, section: duplicated_section, student_user: duplicated_students[2])
+
+    sign_in duplicated_section_owner
+    get :section_level_progress, params: {section_id: duplicated_section.id, page: 1, per: 7}
+    assert_response :success
+    data = JSON.parse(@response.body)
+    assert_equal 7, data['student_progress'].keys.length
+  end
+
   test "should get section level progress with specific script" do
     script = Unit.find_by_name('algebra')
     get :section_level_progress, params: {


### PR DESCRIPTION
**Context:** There have been two reports in the last 3 years of progress not loading correctly for teachers.  The specifics of what causes this to happen are unique.  In both cases progress didn't load for the teacher when the section had exactly 20 students in the section.  In both of these scenarios, removing or adding a student to the section (so it had 19 or 21 students), would "fix" the loading issue.

**The problem:** We now believe this is because somehow a duplicate student was being stored in the backend but was not being stored in the redux store. Combine this with the fact that we "batch" retrieving progress in groups of 20 students, the last real student wouldn't have data loaded which would cause the page to crash. 

**What this PR does:** This PR checks for duplicate students before retrieving the user progress for a section.  It ensures that we get data only for unique users.

**What this PR does not do:** This does not fix the root issue of having a duplicate student in the back end.  Dave speculated in the thread below what could be causing duplicate students, but the reality is that it is a rare issue and the issue doesn't seem to have any/many trickle-down impacts to the user experience.  This fix modifies how the data is retrieved for loading section progress, it does not ensure there are no duplicate students in any section NOR prevent duplicate students from being added in the future.

## Links

[Slack Thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1742330328132669)
^ Links to both the Zen Desk issues


## Testing story

Added test unique to this scenario.  I checked to make sure that if we did not "deduplicate" users in `api_controller.rb` this test would fail. 