### PR TITLE
Ceara/aitt 971 general context prompts

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -2,7 +2,10 @@ import React, {useEffect, useRef, useState} from 'react';
 
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
-import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
+import {
+  AiInteractionStatus as Status,
+  AiDiffContext,
+} from '@cdo/generated-scripts/sharedConstants';
 
 import {EVENTS, PLATFORMS} from '../metrics/AnalyticsConstants';
 import analyticsReporter from '../metrics/AnalyticsReporter';
@@ -21,6 +24,11 @@ import {
   EXIT_TICKET_PROMPT,
   MINI_LESSON_PROMPT,
   LESSON_HOOK_PROMPT,
+  SUGGEST_CURRICULUM_PROMPT,
+  GET_STARTED_PROMPT,
+  PROFESSIONAL_LEARNING_PROMPT,
+  CREATE_SECTION_PROMPT,
+  ADDITIONAL_HELP_PROMPT,
 } from './AiDiffPredefinedPrompts';
 import AiDiffSuggestedPrompts from './AiDiffSuggestedPrompts';
 import {ChatItem, ChatPrompt} from './types';
@@ -46,6 +54,14 @@ const SUGGESTED_PROMPTS = [
   ],
 ];
 
+const GENERAL_SUGGESTED_PROMPTS = [
+  SUGGEST_CURRICULUM_PROMPT,
+  GET_STARTED_PROMPT,
+  PROFESSIONAL_LEARNING_PROMPT,
+  CREATE_SECTION_PROMPT,
+  ADDITIONAL_HELP_PROMPT,
+];
+
 const AI_DIFF_CHAT_MESSAGE_ENDPOINT = '/ai_diff/chat_completion';
 
 interface AiDiffChatProps {
@@ -66,7 +82,9 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
   unitDisplayName,
   chatResponseCallback = () => {},
   initialChatMessage = INITIAL_CHAT_MESSAGE,
-  suggestedPrompts = SUGGESTED_PROMPTS[0],
+  suggestedPrompts = context === AiDiffContext.GENERAL
+    ? GENERAL_SUGGESTED_PROMPTS
+    : SUGGESTED_PROMPTS[0],
   disableEndButtons = false,
 }) => {
   const reportingData = React.useMemo(() => {
@@ -113,7 +131,9 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
     setSuggestionPage(nextPage);
     setMessageHistory(prevMessages => [
       ...prevMessages,
-      SUGGESTED_PROMPTS[nextPage],
+      context === AiDiffContext.GENERAL
+        ? GENERAL_SUGGESTED_PROMPTS
+        : SUGGESTED_PROMPTS[nextPage],
     ]);
   };
 

--- a/apps/src/aiDifferentiation/AiDiffPredefinedPrompts.tsx
+++ b/apps/src/aiDifferentiation/AiDiffPredefinedPrompts.tsx
@@ -30,7 +30,7 @@ export const EXIT_TICKET_PROMPT = {
 
 export const MINI_LESSON_PROMPT = {
   label: 'Generate a mini lesson',
-  prompt: `I need a mini lesson.  You can ask me a follow-up question to find out what concept needs to be assessed and how much time they have. Ask about any known misconceptions in the class. 
+  prompt: `I need a mini lesson.  You can ask me a follow-up question to find out what concept needs to be assessed and how much time they have. Ask about any known misconceptions in the class.
 
     Create a 10-15 (adjust for time based on their answer) minute mini-lesson on [use the topic given by the teacher] for teaching computer science. Include:
     1. An engaging hook that connects to students' real-world experiences
@@ -70,7 +70,44 @@ export const DEBUG_MISTAKES_PROMPT = {
 
 export const REAL_WORLD_PROMPT = {
   label: 'Real world connection',
-  prompt: `I need real world connections to the curriculum I am teaching.  Feel free to clarify what concept we are creating real world connections to. 
+  prompt: `I need real world connections to the curriculum I am teaching.  Feel free to clarify what concept we are creating real world connections to.
 
     Create engaging examples that connect [topic given by user] to real-world applications students care about. Consider target age of curriculum as well as current technology trends, popular apps, games, and everyday problems that can be solved using this concept. Include discussion prompts that help students see how this concept is used in technology they interact with daily students to guide their debugging process.`,
+};
+
+export const SUGGEST_CURRICULUM_PROMPT = {
+  label: 'Suggest a curriculum',
+  prompt: `What Code.org curriculum should I use with my class? You can write a message asking me for the essential context about my class needed to give a suitable curriculum suggestion. Your message should:
+  - Request student age/grade level
+  - Ask about topics I want to cover in the curriculum
+  - Ask how often I see my students and how long the course should be
+
+  Use this information to find a few suitable Code.org curricula that I could teach my students
+
+  Format the questions as a clear, easy-to-read list`,
+};
+
+export const GET_STARTED_PROMPT = {
+  label: 'Get started with Code.org',
+  prompt: `How do I get started as a teacher on Code.org?`,
+};
+
+export const PROFESSIONAL_LEARNING_PROMPT = {
+  label: 'Learn about Professional Learning',
+  prompt: `What Code.org Professional Learning opportunities are available and where can I find them? You can ask me follow-up questions about what topics I want to learn about in order to suggest a professional learning course to me.`,
+};
+
+export const CREATE_SECTION_PROMPT = {
+  label: 'How to create a section?',
+  prompt: `How do I create a classroom section? You can write a message asking me for the essential context about my class needed to give me specific instructions for creating my classroom section. Your message should:
+
+  - Ask me if I use an LMS like Schoology, Clever, Canvas, or Google Classrooms, or if I want my students to have a log-in on Code.org
+  - Ask me what grade level my students are
+
+  Use this information to give me specific instructions on how to create a classroom section for the log-in type I need to use for my students.`,
+};
+
+export const ADDITIONAL_HELP_PROMPT = {
+  label: 'Get help using Code.org',
+  prompt: `Who can I go to if I have more questions about Code.org? Encourage me to ask you for help with most issues in the chat or look at the Code.org support center. The last part of your answer must include directing me to the "Submit a request" page at https://support.code.org/hc/en-us/requests/new to get support from a staff member at Code.org.`,
 };

--- a/apps/src/aiDifferentiation/welcome/AiDiffWelcome.tsx
+++ b/apps/src/aiDifferentiation/welcome/AiDiffWelcome.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import Confetti from 'react-dom-confetti';
 
 import HttpClient from '@cdo/apps/util/HttpClient';
+import {AiDiffContext} from '@cdo/generated-scripts/sharedConstants';
 import ai101Thumnail from '@cdo/static/ai-101-pl-course-thumbnail.png';
 import aiBotHappy from '@cdo/static/ai-bot-happy.png';
 import aiBotScanning from '@cdo/static/ai-bot-scanning.png';
@@ -31,6 +32,11 @@ import {
   EXIT_TICKET_PROMPT,
   MINI_LESSON_PROMPT,
   LESSON_HOOK_PROMPT,
+  SUGGEST_CURRICULUM_PROMPT,
+  GET_STARTED_PROMPT,
+  PROFESSIONAL_LEARNING_PROMPT,
+  CREATE_SECTION_PROMPT,
+  ADDITIONAL_HELP_PROMPT,
 } from '../AiDiffPredefinedPrompts';
 import {ChatPrompt} from '../types';
 
@@ -61,8 +67,7 @@ const SUGGESTED_PROMPTS_FOR_SELECTION: {
   [selection: string]: {initialMessage: string; suggestedPrompts: ChatPrompt[]};
 } = {
   plan: {
-    initialMessage:
-      'Lets iterate together! What would you like to change? Below are some of the tasks I can help you with.',
+    initialMessage: `Let's iterate together! What would you like to change? Below are some of the tasks I can help you with.`,
     suggestedPrompts: [
       EXPLAIN_CONCEPT_PROMPT,
       EXAMPLE_PROMPT,
@@ -72,14 +77,23 @@ const SUGGESTED_PROMPTS_FOR_SELECTION: {
     ],
   },
   create: {
-    initialMessage:
-      'Lets work together to create resources for your classroom! What would you like help creating? Below are some of the tasks I can help you with.',
+    initialMessage: `Let's work together to create resources for your classroom! What would you like help creating? Below are some of the tasks I can help you with.`,
     suggestedPrompts: [
       FINISH_EARLY_PROMPT,
       EXTRA_PRACTICE_PROMPT,
       EXIT_TICKET_PROMPT,
       MINI_LESSON_PROMPT,
       LESSON_HOOK_PROMPT,
+    ],
+  },
+  support: {
+    initialMessage: `Let's get started teaching on Code.org together! What would you like to do on the Code.org platform? Below are some of the tasks I can help you with.`,
+    suggestedPrompts: [
+      SUGGEST_CURRICULUM_PROMPT,
+      GET_STARTED_PROMPT,
+      PROFESSIONAL_LEARNING_PROMPT,
+      CREATE_SECTION_PROMPT,
+      ADDITIONAL_HELP_PROMPT,
     ],
   },
 };
@@ -180,7 +194,7 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
     React.useState(true);
 
   const [selectedOption, setSelectedOption] = React.useState<
-    'plan' | 'create' | null
+    'plan' | 'create' | 'support' | null
   >(null);
 
   const [confettiActive, setConfettiActive] = React.useState<boolean>(false);
@@ -225,6 +239,14 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
               <Heading6 className={style.selectOptionSubtitle}>
                 Using AI in multiple ways increases productivity.
               </Heading6>
+              {context === AiDiffContext.GENERAL &&
+                optionButton(
+                  selectedOption === 'support',
+                  () => setSelectedOption('support'),
+                  'rocket-launch',
+                  'Get Started',
+                  'Get help using the Code.org platform, learn about professional learning opportunities, suggest a curriculum, create a section'
+                )}
               {optionButton(
                 selectedOption === 'plan',
                 () => setSelectedOption('plan'),
@@ -245,7 +267,7 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
         </div>
       );
     },
-    [continueAndSkipButtons, selectedOption]
+    [continueAndSkipButtons, selectedOption, context]
   );
 
   React.useEffect(() => {

--- a/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
@@ -73,6 +73,22 @@ describe('AiDiffChat', () => {
     screen.getByRole('checkbox', {name: 'Write an exit ticket'});
   });
 
+  it('initial message and suggested prompts are rendered for general context', () => {
+    const overrideProps = {...defaultProps, context: AiDiffContext.GENERAL};
+    render(<AiDiffChat {...overrideProps} />);
+    const message = screen.getByLabelText(i18n.aiChatMessageBot());
+    expect(message).toHaveTextContent(
+      "Hi! I'm your AI Teaching Assistant. What can I help you with? Here are some things you can ask me."
+    );
+    //suggested prompts
+    expect(screen.getAllByRole('checkbox')).toHaveLength(5);
+    screen.getByRole('checkbox', {name: 'Suggest a curriculum'});
+    screen.getByRole('checkbox', {name: 'Get started with Code.org'});
+    screen.getByRole('checkbox', {name: 'Learn about Professional Learning'});
+    screen.getByRole('checkbox', {name: 'How to create a section?'});
+    screen.getByRole('checkbox', {name: 'Get help using Code.org'});
+  });
+
   it('Selecting a suggested prompt gives response', async () => {
     render(<AiDiffChat {...defaultProps} />);
 


### PR DESCRIPTION
Adds a set of predefined prompts for the general support context. These should be shown in the prompt chips on non-curriculum pages to prompt the user for platform support-related questions e.g. asking about how to create a section, learn about professional learning, suggesting curriculum.

This also adds a "Get Started" option to the welcome screen on non-curriculum pages

I checked all the user visible text/ icons (e.g. the chip labels, the text and icon on the welcome option, intro text) with Tess

Get started option on welcome page
<img width="520" alt="Screenshot 2025-03-31 at 5 05 05 PM" src="https://github.com/user-attachments/assets/f1b30e3d-3c14-47e0-b326-05b661c332b3" />

Welcome page with the get started into text and the new prompts
<img width="513" alt="Screenshot 2025-03-31 at 5 05 46 PM" src="https://github.com/user-attachments/assets/cba57bf3-3ddf-43dc-b93e-67068317c4ba" />

Regular chat on non-curriculum pages
<img width="510" alt="Screenshot 2025-03-31 at 5 07 20 PM" src="https://github.com/user-attachments/assets/2c551d9a-d8db-42b4-b3d0-1977fd95f7ec" />


Curriculum page still just has "create" and "ideate"
<img width="729" alt="Screenshot 2025-03-31 at 5 03 54 PM" src="https://github.com/user-attachments/assets/8203d8e5-9438-42c1-9197-caeb237e7ce2" />


## Links

Jira tickets: 
https://codedotorg.atlassian.net/browse/AITT-971
https://codedotorg.atlassian.net/browse/AITT-974

## Testing story

Added an apps unit test to make sure the new prompts are shown when the context is `GENERAL`


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
