### PR TITLE
AI Chat: log and monitor OpenAI usage metrics

### DIFF
--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -1,3 +1,5 @@
+require 'cdo/aws/metrics'
+
 # Prepares the input (user/level system prompt, context, existing chat history)
 # from AI Chat lab to be sent to the OpenAI API, and sends the request to the API.
 #
@@ -7,7 +9,7 @@ module AichatOpenaiHelper
   API_KEY = CDO.openai_student_learning_api_key
   MODEL = SharedConstants::AICHAT_MODEL_VERSION
 
-  def self.get_openai_assistant_response(aichat_model_customizations, stored_messages, new_message, level_id, encrypted_channel_id)
+  def self.get_openai_assistant_response(aichat_model_customizations, stored_messages, new_message, level_id, encrypted_channel_id, user_id)
     messages = format_messages(
       aichat_model_customizations,
       stored_messages,
@@ -17,10 +19,12 @@ module AichatOpenaiHelper
     )
 
     # We expose a temperature scale of 0.1-1 to users of AI Chat Lab, but OpenAI's API allows a scale of 0-2.
-    request_chat_completion(
+    response, usage = request_chat_completion(
       messages,
       aichat_model_customizations['temperature'].to_f * 2
     )
+    report_usage_metrics(usage, messages, level_id, encrypted_channel_id, user_id)
+    response
   end
 
   def self.format_messages(aichat_model_customizations, stored_messages, new_message, level_id, encrypted_channel_id)
@@ -61,7 +65,7 @@ module AichatOpenaiHelper
     raise StandardError.new(body['error']) if body['error']
     response = body&.dig("choices")&.first&.dig('message', 'content')
     raise StandardError.new("Unexpected response from OpenAI: #{body}") unless response
-    response
+    [response, body&.dig('usage')]
   end
 
   def self.get_instructions(system_prompt, level_system_prompt, retrieval_contexts)
@@ -70,6 +74,61 @@ module AichatOpenaiHelper
     instructions << (system_prompt + " ") unless system_prompt.empty?
     instructions << retrieval_contexts.join(" ") if retrieval_contexts
     instructions
+  end
+
+  # Reports and logs usage metrics to Cloudwatch
+  def self.report_usage_metrics(usage, messages, level_id, encrypted_channel_id, user_id)
+    return unless usage
+    messages_with_assets_count = 0
+    assets_count = 0
+    messages.each do |message|
+      next if message[:content].is_a?(String)
+      assets_count += message[:content].count {|content| content[:type] != 'text'}
+      messages_with_assets_count += 1 if assets_count > 0
+    end
+
+    is_multimodal = messages_with_assets_count > 0
+
+    input_rate = 0.15 / 1_000_000 # $0.15 per million tokens
+    output_rate = 0.60 / 1_000_000 # $0.60 per million tokens
+    input_cost = usage['prompt_tokens'] * input_rate
+    output_cost = usage['completion_tokens'] * output_rate
+    total_cost = input_cost + output_cost
+
+    log_payload = {
+      event: 'aichat_openai_usage',
+      multimodal: is_multimodal,
+      usage: usage,
+      messages: {
+        total: messages.count,
+        withAssets: messages_with_assets_count,
+        assets: assets_count
+      },
+      cost: {
+        input: "$#{format("%.6f", input_cost)}",
+        output: "$#{format("%.6f", output_cost)}",
+        total: "$#{format("%.6f", total_cost)}"
+      },
+      levelId: level_id,
+      channelId: encrypted_channel_id,
+      userId: user_id
+    }
+
+    CDO.log.info log_payload.to_json.to_s if DCDO.get('log_aichat_openai_usage', true)
+
+    metrics = ['prompt_tokens', 'completion_tokens'].map do |key|
+      {
+        metric_name: "AichatOpenaiRequest.#{key.camelize(:upper)}",
+        value: usage[key],
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: [
+          {name: 'Environment', value: CDO.rack_env},
+          {name: 'Multimodal', value: is_multimodal.to_s},
+        ]
+      }
+    end
+    Cdo::Metrics.push(SharedConstants::AICHAT_METRICS_NAMESPACE, metrics)
   end
 
   def self.client

--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -79,13 +79,11 @@ module AichatOpenaiHelper
   # Reports and logs usage metrics to Cloudwatch
   def self.report_usage_metrics(usage, messages, level_id, encrypted_channel_id, user_id)
     return unless usage
-    messages_with_assets_count = 0
-    assets_count = 0
-    messages.each do |message|
-      next if message[:content].is_a?(String)
-      assets_count += message[:content].count {|content| content[:type] != 'text'}
-      messages_with_assets_count += 1 if assets_count > 0
-    end
+
+    filtered = messages.reject {|message| message[:content].is_a?(String)}
+    messages_with_assets_count = filtered.count {|message| message[:content].any? {|c| c[:type] != 'text'}}
+    pdfs_count = filtered.sum {|message| message[:content].count {|c| c[:type] == 'file'}}
+    images_count = filtered.sum {|message| message[:content].count {|c| c[:type] == 'image_url'}}
 
     is_multimodal = messages_with_assets_count > 0
 
@@ -102,7 +100,8 @@ module AichatOpenaiHelper
       messages: {
         total: messages.count,
         withAssets: messages_with_assets_count,
-        assets: assets_count
+        pdfs: pdfs_count,
+        images: images_count,
       },
       cost: {
         input: "$#{format("%.6f", input_cost)}",

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -46,38 +46,34 @@ class AichatRequestChatCompletionJob < ApplicationJob
   end
 
   def perform(request:, locale:)
-    model_customizations = request.model_customizations
-    stored_messages = request.stored_messages
-    new_message = request.new_message
-    level_id = request.level_id
-    encrypted_channel_id = storage_encrypt_channel_id(storage_id_for_user_id(request.user_id), request.project_id)
-    status, response = get_execution_status_and_response(model_customizations, stored_messages, new_message, level_id, locale, encrypted_channel_id)
+    status, response = get_execution_status_and_response(request, locale)
     request.update!(response: response, execution_status: status)
   end
 
-  private def get_execution_status_and_response(model_customizations, stored_messages, new_message, level_id, locale, encrypted_channel_id)
+  private def get_execution_status_and_response(request, locale)
     # Moderate user input for toxicity.
-    user_toxicity = AichatSafetyHelper.find_toxicity('user', new_message['chatMessageText'], locale, level_id)
+    user_toxicity = AichatSafetyHelper.find_toxicity('user', request.new_message['chatMessageText'], locale, request.level_id)
     return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:USER_PROFANITY], user_toxicity.to_json] if user_toxicity
 
-    user_pii = find_pii(new_message['chatMessageText'], locale)
+    user_pii = find_pii(request.new_message['chatMessageText'], locale)
     return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:USER_PII], "PII detected in user input: #{user_pii}"] if user_pii
 
     # Make the request.
     begin
-      response = model_customizations['selectedModelId'] == SharedConstants::AI_CHAT_MODEL_IDS[:CHATGPT] ?
+      response = request.model_customizations['selectedModelId'] == SharedConstants::AI_CHAT_MODEL_IDS[:CHATGPT] ?
         AichatOpenaiHelper.get_openai_assistant_response(
-          model_customizations,
-          stored_messages,
-          new_message,
-          level_id,
-          encrypted_channel_id
+          request.model_customizations,
+          request.stored_messages,
+          request.new_message,
+          request.level_id,
+          storage_encrypt_channel_id(storage_id_for_user_id(request.user_id), request.project_id),
+          request.user_id
         ) :
         AichatSagemakerHelper.get_sagemaker_assistant_response(
-          model_customizations,
-          stored_messages,
-          new_message,
-          level_id
+          request.model_customizations,
+          request.stored_messages,
+          request.new_message,
+          request.level_id
         )
     rescue Aws::SageMakerRuntime::Errors::ModelError => exception
       # If the user input was too large, return a USER_INPUT_TOO_LARGE status code. Otherwise, re-raise the exception.
@@ -89,7 +85,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
     end
 
     # Moderate model output for toxicity.
-    model_toxicity = AichatSafetyHelper.find_toxicity('assistant', response, locale, level_id)
+    model_toxicity = AichatSafetyHelper.find_toxicity('assistant', response, locale, request.level_id)
     return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:MODEL_PROFANITY], model_toxicity.to_json] if model_toxicity
 
     model_pii = find_pii(response, locale)


### PR DESCRIPTION
Publishes a JSON log and emits a few metrics for tracking OpenAI usage, specifically relevant for the upcoming multimodal AI Chat CSAIF pilot. We'd like to use this to get an initial read on token usage in pilot classrooms, and use that to further inform our estimates for launch.

Longer term, we may consider migrating this JSON data to our DB so it's more easily query-able, and compatible with tools like Trevor. For now, we will just pull JSON from cloudwatch and run reports from there.

@sureshc suggested that we used the dashboard logger (`CDO.log`) which logs to the machine and forwards logs to Cloudwatch. I've also gated it behind a DCDO flag, in case we're worried about flooding our system logs. Note that this log statement is only published once after every successful OpenAI request; with 1100 students in the pilot, I don't expect the volume to be that large as compared to other log statements we publish, but let me know if we need tighter controls.

Log payload example:
<img width="564" alt="Screenshot 2025-03-31 at 3 55 01 PM" src="https://github.com/user-attachments/assets/5c3d548d-c57f-49ff-874f-b20e6b4d44c5" />

Metrics:
![Screenshot 2025-03-31 at 3 04 11 PM](https://github.com/user-attachments/assets/2f912987-670c-48da-b223-5f0aeed5d197)


## Links

https://codedotorg.atlassian.net/browse/LABS-1403

## Testing story

Tested locally + adhoc