### PR TITLE
assign course and unit for eyes test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/local_nav_v2_standalone_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/local_nav_v2_standalone_eyes.feature
@@ -9,7 +9,7 @@ Feature: V2 teacher dashboard local navigation - standalone unit - Eyes
   Scenario: Local navigation on standalone Unit
     When I open my eyes to test "teacher local nav v2 - standalone unit overview"
     Given I create an authorized teacher-associated student named "Sally"
-    Given I am assigned to unit "interactive-games-animations-2024" with teacher "Teacher_Sally"
+    Given I am assigned to course "interactive-games-animations-2024" and unit "interactive-games-animations-2024" with teacher "Teacher_Sally"
 
     Given I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access


### PR DESCRIPTION
An eyes test failure during the standalone-unit migration revealed that this section was only being assigned the unit and not the new course it was a part of. This change assigns both unit and course to the section.

Follow-up work to include making sure the course is assigned when a unit in a single-unit course is assigned.
