### PR TITLE
prevent PL sections from showing in section list

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
@@ -47,7 +47,9 @@ export const SectionList: React.FC<SectionListProps> = ({showHiddenOnly}) => {
 
   const filteredSectionList = React.useMemo(() => {
     const sectionElementList: JSX.Element[] = [];
-    for (const [k, section] of Object.entries(sections)) {
+    for (const [k, section] of Object.entries(sections).filter(
+      section => section[1].participantType === 'student'
+    )) {
       if (showHiddenOnly === section.hidden) {
         sectionElementList.push(
           <SectionCard

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionListTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionListTest.tsx
@@ -27,6 +27,7 @@ describe('SectionList', () => {
       courseVersionName: 'csd-2024',
       unitName: null,
       studentCount: 0,
+      participantType: 'student',
     },
     {
       id: 12,
@@ -34,6 +35,7 @@ describe('SectionList', () => {
       hidden: false,
       courseVersionName: 'csd-2023',
       unitName: null,
+      participantType: 'student',
     },
     {
       id: 13,
@@ -41,6 +43,7 @@ describe('SectionList', () => {
       hidden: false,
       courseVersionName: 'csd-2022',
       unitName: 'csd3-2022',
+      participantType: 'student',
     },
     {
       id: 14,
@@ -48,12 +51,21 @@ describe('SectionList', () => {
       hidden: false,
       courseVersionName: 'csd-2022',
       unitName: 'csd6-2022',
+      participantType: 'student',
     },
     {
       id: 15,
       name: 'hidden',
       hidden: true,
       unitName: null,
+      participantType: 'student',
+    },
+    {
+      id: 16,
+      name: 'PL Section',
+      hidden: false,
+      unitName: null,
+      participantType: 'teacher',
     },
   ];
 
@@ -81,7 +93,7 @@ describe('SectionList', () => {
     );
   }
 
-  it('renders list of teacher section cards', async () => {
+  it('renders list of teacher section cards without displaying PL or hidden sections', async () => {
     renderComponent();
     screen.getByText('Period 1');
     screen.getByText('Period 2');

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -35,6 +35,8 @@ describe('TeacherHomepage', () => {
       hidden: false,
       courseVersionName: 'csd-2024',
       unitName: null,
+      studentCount: 0,
+      participantType: 'student',
     },
     {
       id: 12,
@@ -42,6 +44,7 @@ describe('TeacherHomepage', () => {
       hidden: false,
       courseVersionName: 'csd-2023',
       unitName: null,
+      participantType: 'student',
     },
     {
       id: 13,
@@ -49,6 +52,7 @@ describe('TeacherHomepage', () => {
       hidden: false,
       courseVersionName: 'csd-2022',
       unitName: 'csd3-2022',
+      participantType: 'student',
     },
     {
       id: 14,
@@ -56,12 +60,21 @@ describe('TeacherHomepage', () => {
       hidden: false,
       courseVersionName: 'csd-2022',
       unitName: 'csd6-2022',
+      participantType: 'student',
     },
     {
       id: 15,
       name: 'hidden',
       hidden: true,
       unitName: null,
+      participantType: 'student',
+    },
+    {
+      id: 16,
+      name: 'PL Section',
+      hidden: false,
+      unitName: null,
+      participantType: 'teacher',
     },
   ];
 

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -97,7 +97,7 @@ describe('TeacherHomepage', () => {
   });
 
   afterEach(() => {
-    fetchSpy.mockRestore();
+    jest.restoreAllMocks();
     restoreRedux();
   });
 


### PR DESCRIPTION
This update fixes a bug that allowed PL sections to be displayed on the new teacher homepage.

## Links
[TEACH-1696](https://codedotorg.atlassian.net/browse/TEACH-1696)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Updated unit test to confirm PL sections are not displayed

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
