### PR TITLE
Add python to editor languages for code docs

### DIFF
--- a/apps/src/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -13,7 +13,7 @@ import ImageInput from '../ImageInput';
 
 import OrderableList from './OrderableList';
 
-const EDITOR_LANGUAGES = ['blockly', 'droplet', 'html/css', 'java'];
+const EDITOR_LANGUAGES = ['blockly', 'droplet', 'html/css', 'java', 'python'];
 
 const useProgrammingEnvironment = initialProgrammingEnvironment => {
   const [programmingEnvironment, setProgrammingEnvironment] = useState(

--- a/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
@@ -49,7 +49,7 @@ describe('ProgrammingEnvironmentEditor', () => {
 
     const editorLanguageSelect = wrapper.find('select').at(0);
     expect(editorLanguageSelect.props().value).to.equal('blockly');
-    expect(editorLanguageSelect.find('option').length).to.equal(4);
+    expect(editorLanguageSelect.find('option').length).to.equal(5);
 
     const blockPoolInput = wrapper.find('input').at(3);
     expect(blockPoolInput.props().value).to.equal('GamelabJr');


### PR DESCRIPTION
Add python to the editor languages for code docs in levelbuilder

<img width="655" alt="Screenshot 2025-04-01 at 4 31 02 PM" src="https://github.com/user-attachments/assets/f2f80fbe-68c7-48c4-b8b1-24cd530501f7" />

## Links

Jira: https://codedotorg.atlassian.net/browse/AITT-980
Slack thread: https://codedotorg.slack.com/archives/C045UAX4WKH/p1742324250212939

## Testing story

Confirmed `python` shows up in the dropdown on the edit page, updated unit test

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
