### PR TITLE
chore(marketing): prepare eyes branch baselines

### DIFF
--- a/frontend/apps/marketing/playwright.config.ts
+++ b/frontend/apps/marketing/playwright.config.ts
@@ -36,7 +36,6 @@ export default defineConfig<EyesFixture>({
       },
       sendDom: true,
       failTestsOnDiff: 'afterEach',
-      branchName: 'staging',
       // Additional configuration options...
     },
   },


### PR DESCRIPTION
This PR removes the hard coded eyes branch for baselines to prepare for the Github/Eyes app which replaces it with its own specified branch strategy. This effectively moves the branch, temporarily, to the `default` branch.