### PR TITLE
Lab2: Bubble choice fix

### DIFF
--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -12,7 +12,11 @@ import React, {useEffect, useMemo, useRef} from 'react';
 import {navigateToLevelId} from '@cdo/apps/code-studio/progressRedux';
 import {levelById} from '@cdo/apps/code-studio/progressReduxSelectors';
 import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
-import {LabProps, BubbleChoiceLevelData} from '@cdo/apps/lab2/types';
+import {
+  LabProps,
+  BubbleChoiceLevelData,
+  BubbleChoiceSublevel,
+} from '@cdo/apps/lab2/types';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import {capitalizeFirstLetter} from '@cdo/apps/util/capitalizeFirstLetter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -39,6 +43,9 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
           sublevel.level_id
         )?.status || LevelStatus.not_tried
     )
+  );
+  const currentLessonId = useAppSelector(
+    state => state.progress.currentLessonId
   );
 
   const [containerWidth, setContainerWidth] = React.useState(0);
@@ -107,6 +114,14 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
     return level;
   };
 
+  const navigateToSublevel = (sublevel: BubbleChoiceSublevel) => {
+    if (currentLessonId) {
+      dispatch(navigateToLevelId(sublevel.level_id));
+    } else {
+      window.location.href = sublevel.url;
+    }
+  };
+
   return (
     <div id="bubble-choice" className={styles.bubbleChoiceContainer}>
       <div>
@@ -137,7 +152,7 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
               styles.sublevelButton,
               styles[`sublevelButton${backgroundSuffix}`]
             )}
-            onClick={() => dispatch(navigateToLevelId(sublevel.level_id))}
+            onClick={() => navigateToSublevel(sublevel)}
           >
             <div className={styles.sublevelImageContainer}>
               <img

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -245,6 +245,7 @@ export interface BubbleChoiceSublevel {
   display_name: string;
   level_id: string;
   thumbnail_url: string;
+  url: string;
 }
 
 // Addtional fields for videos that are linked as references in the


### PR DESCRIPTION
One fix for the Lab2 implementation of BubbleChoice levels added in https://github.com/code-dot-org/code-dot-org/pull/64344:

When viewing a level by ID (with a `/levels/[level_id]` URL), clicking on a sublevel now works.  Rather than attempting to switch level without a page reload, in this case the browser just navigates to the sublevel URL, which is also in the form of `/levels/[level_id]`.
