### PR TITLE
Disable two UI tests that flaked

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -42,7 +42,7 @@ Feature: BubbleChoice
     And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
-  # Mobile re-enable ticket: https://codedotorg.atlassian.net/browse/TEACH-1751
+  # Mobile re-enable ticket: https://codedotorg.atlassian.net/browse/TEACH-1752
   @no_mobile
   @no_firefox
   Scenario: Lab2 BubbleChoice progress

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -42,6 +42,8 @@ Feature: BubbleChoice
     And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
+  # Mobile re-enable ticket: https://codedotorg.atlassian.net/browse/TEACH-1751
+  @no_mobile
   @no_firefox
   Scenario: Lab2 BubbleChoice progress
     Given I create a teacher-associated student named "Alice"

--- a/dashboard/test/ui/features/teacher_tools/progress.feature
+++ b/dashboard/test/ui/features/teacher_tools/progress.feature
@@ -1,4 +1,5 @@
-@no_phone
+@no_mobile
+# Re-enable ticket: https://codedotorg.atlassian.net/browse/TEACH-1751
 Feature: Level Progress
 
   Scenario: Progress is saved for signed-in student


### PR DESCRIPTION
https://codedotorg.slack.com/archives/C0T0PNTM3/p1743602565005279

These two tests flaked yesterday. We are going to disable them and track re-enabling.

## Links
Tracking tickets:
https://codedotorg.atlassian.net/browse/TEACH-1752
https://codedotorg.atlassian.net/browse/TEACH-1751