### PR TITLE
Music: preview library in levelbuilder

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -26,7 +26,12 @@ import RawJsonEditor from './RawJsonEditor';
 
 import moduleStyles from './edit-music-level-data.module.scss';
 
-const VALID_LIBRARIES = [DEFAULT_LIBRARY, 'launch2024', 'curriculum2024'];
+const VALID_LIBRARIES = [
+  DEFAULT_LIBRARY,
+  'launch2024',
+  'launch2024-preview',
+  'curriculum2024',
+];
 const RECOMMENDED_LIBRARY = 'launch2024';
 
 const JSON_FIELDS = [['startSources', 'Start Sources']] as const;
@@ -122,10 +127,10 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
               instead!
             </li>
             <li>
-              The curriculum2024 library is currently just a staging ground for
-              sounds that we want to test out in scripts not intended for full
-              launch. Once those sounds are finalized, they will be put into the
-              launch2024 library in the appropriate form.
+              The launch2024-preview and curriculum2024 libraries are just
+              staging grounds for sounds that we want to test out in scripts not
+              intended for full launch. Once those sounds are finalized, they
+              will be put into the launch2024 library in the appropriate form.
             </li>
           </ul>
           <div>


### PR DESCRIPTION
This adds the `launch2024-preview` library as an option for Music Lab levels in levelbuilder.  Like `curriculum2024`, it's intended to try sounds that aren't yet in the `launch2024` library, which levels should use before curriculum is published.

This library has the slight advantage over `curriculum2024` that it uses the same path on S3 as `launch2024`, meaning assets don't need to be duplicated on S3.


