### PR TITLE
Music: responsive timeline height

### DIFF
--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -1,5 +1,11 @@
 import classNames from 'classnames';
-import React, {MouseEvent, useCallback, useRef} from 'react';
+import React, {
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {isPredictResponseSubmitted} from '@cdo/apps/lab2/redux/predictLevelRedux';
@@ -21,9 +27,6 @@ import {useMusicSelector} from './types';
 
 import moduleStyles from './timeline.module.scss';
 
-// The height of the primary timeline area for drawing events.  This is the height of each measure's
-// vertical bar.
-const timelineHeight = 136;
 // The width of one measure.
 const barWidth = 60;
 // A little room on the left.
@@ -32,33 +35,6 @@ const paddingOffset = 10;
 const playheadScrollThreshold = 0.75;
 // How many extra measures to show at the end.
 const extraMeasures = 8;
-
-// Get the height that each event should occupy.  This is inclusive of empty vertical space at the bottom.
-const getEventHeight = (
-  numUniqueRows: number,
-  availableHeight = timelineHeight
-) => {
-  // While we might not actually have this many rows to show,
-  // we will limit each row's height to the size that would allow
-  // this many to be shown at once.
-  const minVisible = 5;
-
-  const maxVisible = 45;
-
-  // We might not actually have this many rows to show, but
-  // we will size the bars so that this many rows would show.
-  const numSoundsToShow = Math.max(
-    Math.min(numUniqueRows, maxVisible),
-    minVisible
-  );
-
-  return Math.floor(availableHeight / numSoundsToShow);
-};
-
-// How how much of the event height should be left as empty vertical space at the bottom.
-const getEventVerticalSpace = (eventHeight: number) => {
-  return eventHeight > 8 ? 3 : eventHeight > 6 ? 2 : 1;
-};
 
 /**
  * Renders the music playback timeline.
@@ -100,6 +76,37 @@ const Timeline: React.FunctionComponent = () => {
     : startingPlayheadPosition;
   const playHeadOffsetInPixels = (positionToUse - 1) * barWidth;
 
+  // The height of the primary timeline area for drawing events.  This is the height of each measure's
+  // vertical bar.
+  const [availableHeight, setAvailableHeight] = useState(0);
+
+  // Get the height that each event should occupy.  This is inclusive of empty vertical space at the bottom.
+  const getEventHeight = (
+    numUniqueRows: number
+    //availableHeight = timelineHeight
+  ) => {
+    // While we might not actually have this many rows to show,
+    // we will limit each row's height to the size that would allow
+    // this many to be shown at once.
+    const minVisible = 5;
+
+    const maxVisible = 45;
+
+    // We might not actually have this many rows to show, but
+    // we will size the bars so that this many rows would show.
+    const numSoundsToShow = Math.max(
+      Math.min(numUniqueRows, maxVisible),
+      minVisible
+    );
+
+    return Math.floor(availableHeight / numSoundsToShow);
+  };
+
+  // How how much of the event height should be left as empty vertical space at the bottom.
+  const getEventVerticalSpace = (eventHeight: number) => {
+    return eventHeight > 8 ? 3 : eventHeight > 6 ? 2 : 1;
+  };
+
   const timelineElementProps = {
     paddingOffset,
     barWidth,
@@ -121,7 +128,6 @@ const Timeline: React.FunctionComponent = () => {
       if (!currentlyAllowChangeStartingPlayheadPosition) {
         return;
       }
-
       const offset =
         event.clientX -
         (event.target as Element).getBoundingClientRect().x -
@@ -139,7 +145,6 @@ const Timeline: React.FunctionComponent = () => {
       if (!currentlyAllowChangeStartingPlayheadPosition) {
         return;
       }
-
       dispatch(setStartingPlayheadPosition(measureNumber));
     },
     [dispatch, currentlyAllowChangeStartingPlayheadPosition]
@@ -153,7 +158,6 @@ const Timeline: React.FunctionComponent = () => {
     if (!timelineRef.current || !playheadRef.current) {
       return;
     }
-
     const playheadOffset =
       playheadRef.current.getBoundingClientRect().left -
       timelineRef.current.getBoundingClientRect().left;
@@ -174,6 +178,21 @@ const Timeline: React.FunctionComponent = () => {
     state => state.lab.levelProperties?.predictSettings?.isPredictLevel
   );
   const canPopulateTimeline = !isPredictLevel || predictResponseSubmitted;
+
+  const firstBarLineRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!firstBarLineRef.current) {
+      return;
+    }
+    const resizeObserver = new ResizeObserver(() => {
+      setAvailableHeight(firstBarLineRef.current?.offsetHeight || 0);
+    });
+    resizeObserver.observe(firstBarLineRef?.current);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
 
   return (
     <div
@@ -221,6 +240,8 @@ const Timeline: React.FunctionComponent = () => {
                 {measure}
               </div>
               <div
+                id={index === 0 ? 'timeline-first-barline' : undefined}
+                ref={index === 0 ? firstBarLineRef : undefined}
                 className={classNames(
                   moduleStyles.barLine,
                   measure === Math.floor(currentPlayheadPosition) &&

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -81,10 +81,7 @@ const Timeline: React.FunctionComponent = () => {
   const [availableHeight, setAvailableHeight] = useState(0);
 
   // Get the height that each event should occupy.  This is inclusive of empty vertical space at the bottom.
-  const getEventHeight = (
-    numUniqueRows: number
-    //availableHeight = timelineHeight
-  ) => {
+  const getEventHeight = (numUniqueRows: number) => {
     // While we might not actually have this many rows to show,
     // we will limit each row's height to the size that would allow
     // this many to be shown at once.


### PR DESCRIPTION
This makes the timeline rendering responsive to the available height, which can vary depending on whether "classic" scrollbars are shown or not.

Previously, the rendering of events in the timeline assumed a fixed available height.  However, on browsers showing "classic" scrollbars (in contrast to "overlay" scrollbars, as defined [here](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter)), the available height was slightly smaller, resulting in timeline elements partially hidden by the scrollbar.  

The vertical measure bars were already responsive to the available height, so we simply measure the first one of them to determine the available height, and re-measure if that height changes.

Here, we can see the same events rendered both with and without a "classic" scrollbar on Chrome on macOS.

### without scrollbar
<img width="1006" alt="Screenshot 2025-04-02 at 10 22 20 AM" src="https://github.com/user-attachments/assets/660e59d2-3606-4365-a05d-89b3e1554707" />

### with scrollbar
<img width="1006" alt="Screenshot 2025-04-02 at 10 22 26 AM" src="https://github.com/user-attachments/assets/7ab3e8fd-b321-4ccd-881a-fe49b7263693" />

###

Also tested on Chrome on Windows 10.