### PR TITLE
add ai pdfs into S3 during build process

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -223,10 +223,12 @@ module Services
             generate_lesson_pdf(lesson, dir, student_facing: true)
             any_pdf_generated = true
 
-            # Generate metadata
-            metadata = generate_metadata_for_ai(script, lesson)
-            add_metadata_to_ai_s3(metadata)
-            add_pdf_to_ai_s3(pdf_pathname, metadata)
+            if lesson.has_lesson_plan
+              # Generate metadata
+              metadata = generate_metadata_for_ai(script, lesson)
+              add_metadata_to_ai_s3(metadata)
+              add_pdf_to_ai_s3(pdf_pathname, metadata)
+            end
           end
 
           if !script_overview_pdf_exists_for?(script) && should_generate_overview_pdf?(script)

--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -219,9 +219,14 @@ module Services
 
           get_pdfless_lessons(script).each do |lesson|
             puts "Generating missing Lesson PDFs for #{lesson.key} (from #{script.name})"
-            generate_lesson_pdf(lesson, dir)
+            pdf_pathname = generate_lesson_pdf(lesson, dir)
             generate_lesson_pdf(lesson, dir, student_facing: true)
             any_pdf_generated = true
+
+            # Generate metadata
+            metadata = generate_metadata_for_ai(script, lesson)
+            add_metadata_to_ai_s3(metadata)
+            add_pdf_to_ai_s3(pdf_pathname, metadata)
           end
 
           if !script_overview_pdf_exists_for?(script) && should_generate_overview_pdf?(script)


### PR DESCRIPTION
Whenever a lesson plan PDF is created during the build process, we want that lesson PDF to be added into our AI_S3 bucket automatically.

This PR builds on previous work where we could manually run a script to add these lesson PDFs to the AI_S3 bucket.  We use the same logic in the `generate_missing_pdfs` which is run as part of the build process. 

## Links

[Ticket](https://codedotorg.atlassian.net/browse/AITT-878)