### PR TITLE
DIFF - remove parameter that's no longer needed 

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -194,7 +194,7 @@ module Services
       return metadata
     end
 
-    def self.add_metadata_to_ai_s3(file_path, metadata)
+    def self.add_metadata_to_ai_s3(metadata)
       full_metadata_json = {
         metadataAttributes: metadata
       }.to_json


### PR DESCRIPTION
[In changing the file names in this PR](https://github.com/code-dot-org/code-dot-org/pull/64571), we no longer need two parameters in this function.  This is causing issues with calling this function elsewhere.


