### PR TITLE
Fix error on new teacher homepage when teacher has no sections

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -131,7 +131,11 @@ $(document).ready(function () {
   };
 
   const getV2TeacherDashboard = () => {
-    if (sections.length > 0) {
+    // If a teacher has no sections, we will send them directly to the homepage to bypass
+    // all of the section loading logic in the TeacherNavigationRouter.
+    if (sections.length === 0) {
+      return <TeacherHomepage />;
+    } else {
       const selectedSectionFromList = window.location.pathname.includes(
         '/teacher_dashboard/home'
       )
@@ -149,8 +153,6 @@ $(document).ready(function () {
           showAITutorTab={showAITutorTab}
         />
       );
-    } else {
-      return <TeacherHomepage />;
     }
   };
 

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -24,6 +24,7 @@ import sectionAssessments from '@cdo/apps/templates/sectionAssessments/sectionAs
 import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import sectionStandardsProgress from '@cdo/apps/templates/sectionProgress/standards/sectionStandardsProgressRedux';
 import progressV2Feedback from '@cdo/apps/templates/sectionProgressV2/progressV2FeedbackRedux';
+import {TeacherHomepage} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/TeacherHomepage';
 import stats from '@cdo/apps/templates/teacherDashboard/statsRedux';
 import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashboard';
 import teacherSections, {
@@ -130,23 +131,27 @@ $(document).ready(function () {
   };
 
   const getV2TeacherDashboard = () => {
-    const selectedSectionFromList = window.location.pathname.includes(
-      '/teacher_dashboard/home'
-    )
-      ? sections[0]
-      : sections.find(s => s.id === section.id);
-    const selectedSection = {...selectedSectionFromList, ...section};
+    if (sections.length > 0) {
+      const selectedSectionFromList = window.location.pathname.includes(
+        '/teacher_dashboard/home'
+      )
+        ? sections[0]
+        : sections.find(s => s.id === section.id);
+      const selectedSection = {...selectedSectionFromList, ...section};
 
-    store.dispatch(selectSection(selectedSection.id));
+      store.dispatch(selectSection(selectedSection.id));
 
-    setSelectedSectionData(selectedSection);
+      setSelectedSectionData(selectedSection);
 
-    return (
-      <TeacherNavigationRouter
-        studioUrlPrefix={scriptData.studioUrlPrefix}
-        showAITutorTab={showAITutorTab}
-      />
-    );
+      return (
+        <TeacherNavigationRouter
+          studioUrlPrefix={scriptData.studioUrlPrefix}
+          showAITutorTab={showAITutorTab}
+        />
+      );
+    } else {
+      return <TeacherHomepage />;
+    }
   };
 
   ReactDOM.render(

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -14,10 +14,12 @@ class TeacherDashboardController < ApplicationController
 
   def show
     @sections = current_user.sections_instructed.map(&:concise_summarize)
-    if @section.nil?
-      @section = Section.find(@sections.first[:id])
+    unless @sections.empty?
+      if @section.nil?
+        @section = Section.find(@sections.first[:id])
+      end
+      @section_summary = @section.selected_section_summarize
     end
-    @section_summary = @section.selected_section_summarize
     @locale_code = request.locale
     view_options(full_width: true, no_padding_container: true)
   end


### PR DESCRIPTION
This update fixes an error that caused the new teacher homepage to crash when a teacher has no sections to render. The error was due to the teacher dashboard attempting to retrieve sections from the backend and load them into redux. This fix bypasses the teacher dashboard to load the homepage directly if the teacher has no sections.

## Links
[TEACH-1749](https://codedotorg.atlassian.net/browse/TEACH-1749)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
