### PR TITLE
Evaluate Student Learning: move old UserLevelEvaluations to StudentWorkEvaluations

### DIFF
--- a/bin/oneoff/move_user_level_evaluations_to_student_work_evaluations.rb
+++ b/bin/oneoff/move_user_level_evaluations_to_student_work_evaluations.rb
@@ -1,0 +1,43 @@
+# This script finds all of the UserLevelEvaluation records and migrates them to StudentWorkEvaluations
+# with type "UserLevelEvaluation"
+
+require_relative '../../dashboard/config/environment'
+require src_dir 'database'
+
+count_evaluations_moved = 0
+all_old_ules = UserLevelEvaluationOld.all
+all_old_ules_count = all_old_ules.count
+
+puts "There are #{all_old_ules_count} UserLevelEvaluationOld records to move to StudentWorkEvaluations."
+puts "Moving UserLevelEvaluationOld records to StudentWorkEvaluations..."
+
+time_taken = Benchmark.realtime do
+  ActiveRecord::Base.transaction do
+    all_old_ules.each do |old_ule|
+      new_swe = StudentWorkEvaluation.new(
+        type: "UserLevelEvaluation",
+        student_id: old_ule.user_id,
+        level_id: old_ule.level_id,
+        unit_id: old_ule.script_id,
+        school_year: old_ule.school_year,
+        evaluator: "AI",
+        evaluation_criteria: old_ule.evaluation_criteria,
+        reasoning: old_ule.ai_reasoning,
+        evaluation: old_ule.ai_evaluation,
+        ai_model_version: old_ule.ai_model_version,
+        code_version: old_ule.code_version,
+        created_at: old_ule.created_at,
+        updated_at: old_ule.updated_at,
+      )
+      if new_swe.save
+        puts "."
+        old_ule.destroy
+        count_evaluations_moved += 1
+      else
+        raise "Failed to save StudentWorkEvaluation: #{new_swe.errors.full_messages}"
+      end
+    end
+  end
+end
+
+puts "It took #{time_taken} seconds to move #{count_evaluations_moved} evaluations."


### PR DESCRIPTION
 ### Links
Continuation of #64948 
[Problem overview with a handy little chart ](https://docs.google.com/document/d/1pPb-LiWZuhDolIoTiKOmTFkKCDHKZOY6fB31XJPXLu4/edit?tab=t.0)of all the "types" of evaluations we'll likely need 
[FigJam with more detailed ERD](https://www.figma.com/board/S8H82OKJ3gDboYrIoQZCsu/Measures-of-Learning-ERD-brainstorms?node-id=0-1&p=f&t=V5XfUKd6IMY4xTpg-0) See ERD 2.0 Skills, Summaries & Feedback option 2 in pink 

### Summary 
Now that we have a generic StudentWorkEvaluation table that is flexible enough to store evaluations of different granularity, this PR takes the UserLevelEvalationOlds that are currently in the user_level_evaluation table and moves them into the StudentWorkEvaluation table with  type == "UserLevelEvaluation"


### Follow up work 
- run this script on production 
- create EvaluationSummary table to join individual evaluations with their summarizer evaluation
- switch reads to StudentWorkEvaluations 

### Deployment Plan 
I ran this locally and got this output => "It took 1.400895999991917 seconds to move 745 evaluations." which makes me think this isn't too scary to run on prod. There are currently 11,773 UserLevelEvaluation records on production. I'll need to run this script _after_ https://github.com/code-dot-org/code-dot-org/pull/64948 is deployed since it renames the model from UserLevelEvaluation to UserLevelEvaluationOld