### PR TITLE
CMS-469: Add `CurriculumSnapshot` component definition for Contentful

### DIFF
--- a/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/CurriculumSnapshot.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/CurriculumSnapshot.tsx
@@ -1,0 +1,142 @@
+import {useMemo} from 'react';
+
+import Snapshot, {
+  SnapshotProps,
+  SnapshotItem,
+} from '@code-dot-org/component-library/cms/snapshot';
+
+export interface CurriculumSnapshotProps extends SnapshotProps {
+  grades?: string[];
+  level?: string[];
+  duration?: string[];
+  devices?: string[];
+  topics?: string[];
+  programmingTools?: string[];
+  professionalLearning?: string[];
+  accessibility?: string[];
+  languagesSupported?: string[];
+}
+
+const CurriculumSnapshot: React.FunctionComponent<CurriculumSnapshotProps> = ({
+  grades,
+  level,
+  duration,
+  devices,
+  topics,
+  programmingTools,
+  professionalLearning,
+  accessibility,
+  languagesSupported,
+  ...props
+}) => {
+  const items = useMemo(() => {
+    const items: SnapshotItem[] = [];
+
+    if (grades?.length) {
+      items.push({
+        key: 'grades',
+        icon: {iconName: 'user'},
+        label: 'Grades',
+        content: grades.join(', '),
+      });
+    }
+
+    if (level?.length) {
+      items.push({
+        key: 'level',
+        icon: {iconName: 'arrow-up-wide-short'},
+        label: 'Level',
+        content: level.join(', '),
+      });
+    }
+
+    if (duration?.length) {
+      items.push({
+        key: 'duration',
+        icon: {iconName: 'clock'},
+        label: 'Duration',
+        content: duration.join(', '),
+      });
+    }
+
+    if (devices?.length) {
+      items.push({
+        key: 'devices',
+        icon: {iconName: 'desktop'},
+        label: 'Devices',
+        content: devices.join(', '),
+      });
+    }
+
+    if (topics?.length) {
+      items.push({
+        key: 'topics',
+        icon: {iconName: 'book'},
+        label: 'Topics',
+        content: topics.join(', '),
+      });
+    }
+
+    if (programmingTools?.length) {
+      items.push({
+        key: 'programmingTools',
+        icon: {iconName: 'screwdriver-wrench'},
+        label: 'Programming Tools',
+        content: programmingTools.join(', '),
+      });
+    }
+
+    if (professionalLearning?.length) {
+      items.push({
+        key: 'professionalLearning',
+        icon: {iconName: 'chalkboard-user'},
+        label: 'Professional Learning',
+        content: professionalLearning.join(', '),
+      });
+    }
+
+    if (accessibility?.length) {
+      items.push({
+        key: 'accessibility',
+        icon: {iconName: 'universal-access'},
+        label: 'Accessibility',
+        content: accessibility.join(', '),
+      });
+    }
+
+    if (languagesSupported?.length) {
+      items.push({
+        key: 'languagesSupported',
+        icon: {iconName: 'language'},
+        label: 'Languages supported',
+        content: languagesSupported.join(', '),
+      });
+    }
+
+    return items;
+  }, [
+    grades,
+    level,
+    duration,
+    devices,
+    topics,
+    programmingTools,
+    professionalLearning,
+    accessibility,
+    languagesSupported,
+  ]);
+
+  // Show placeholder text until a content entry is added
+  if (!items.length) {
+    return (
+      <em>
+        <strong>📓 Curriculum Snapshot placeholder.</strong> Please add a
+        "Curriculum" content type entry in the Content sidebar.
+      </em>
+    );
+  }
+
+  return <Snapshot {...props} items={items} />;
+};
+
+export default CurriculumSnapshot;

--- a/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/CurriculumSnapshot.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/CurriculumSnapshot.tsx
@@ -5,7 +5,7 @@ import Snapshot, {
   SnapshotItem,
 } from '@code-dot-org/component-library/cms/snapshot';
 
-export interface CurriculumSnapshotProps extends SnapshotProps {
+export interface CurriculumSnapshotProps extends Omit<SnapshotProps, 'items'> {
   grades?: string[];
   level?: string[];
   duration?: string[];
@@ -29,89 +29,34 @@ const CurriculumSnapshot: React.FunctionComponent<CurriculumSnapshotProps> = ({
   languagesSupported,
   ...props
 }) => {
+  const initItem = (
+    label: string,
+    iconName: string,
+    content: string[],
+  ): SnapshotItem => ({
+    key: label + iconName,
+    label: label,
+    icon: {iconName},
+    content: content.join(', '),
+  });
+
   const items = useMemo(() => {
     const items: SnapshotItem[] = [];
 
-    if (grades?.length) {
-      items.push({
-        key: 'grades',
-        icon: {iconName: 'user'},
-        label: 'Grades',
-        content: grades.join(', '),
-      });
-    }
+    const addItem = (label: string, iconName: string, content?: string[]) => {
+      if (Array.isArray(content) && content.length)
+        items.push(initItem(label, iconName, content));
+    };
 
-    if (level?.length) {
-      items.push({
-        key: 'level',
-        icon: {iconName: 'arrow-up-wide-short'},
-        label: 'Level',
-        content: level.join(', '),
-      });
-    }
-
-    if (duration?.length) {
-      items.push({
-        key: 'duration',
-        icon: {iconName: 'clock'},
-        label: 'Duration',
-        content: duration.join(', '),
-      });
-    }
-
-    if (devices?.length) {
-      items.push({
-        key: 'devices',
-        icon: {iconName: 'desktop'},
-        label: 'Devices',
-        content: devices.join(', '),
-      });
-    }
-
-    if (topics?.length) {
-      items.push({
-        key: 'topics',
-        icon: {iconName: 'book'},
-        label: 'Topics',
-        content: topics.join(', '),
-      });
-    }
-
-    if (programmingTools?.length) {
-      items.push({
-        key: 'programmingTools',
-        icon: {iconName: 'screwdriver-wrench'},
-        label: 'Programming Tools',
-        content: programmingTools.join(', '),
-      });
-    }
-
-    if (professionalLearning?.length) {
-      items.push({
-        key: 'professionalLearning',
-        icon: {iconName: 'chalkboard-user'},
-        label: 'Professional Learning',
-        content: professionalLearning.join(', '),
-      });
-    }
-
-    if (accessibility?.length) {
-      items.push({
-        key: 'accessibility',
-        icon: {iconName: 'universal-access'},
-        label: 'Accessibility',
-        content: accessibility.join(', '),
-      });
-    }
-
-    if (languagesSupported?.length) {
-      items.push({
-        key: 'languagesSupported',
-        icon: {iconName: 'language'},
-        label: 'Languages supported',
-        content: languagesSupported.join(', '),
-      });
-    }
+    addItem('Grades', 'user', grades);
+    addItem('Level', 'arrow-up-wide-short', level);
+    addItem('Duration', 'clock', duration);
+    addItem('Devices', 'desktop', devices);
+    addItem('Topics', 'book', topics);
+    addItem('Programming Tools', 'screwdriver-wrench', programmingTools);
+    addItem('Professional Learning', 'chalkboard-user', professionalLearning);
+    addItem('Accessibility', 'universal-access', accessibility);
+    addItem('Languages supported', 'language', languagesSupported);
 
     return items;
   }, [

--- a/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/CurriculumSnapshotContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/CurriculumSnapshotContentfulDefinition.ts
@@ -1,0 +1,93 @@
+// Creates a definition for the Curriculum Snapshot component to be used in Contentful Studio
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+export const CurriculumSnapshotContentfulComponentDefinition: ComponentDefinition =
+  {
+    id: 'curriculumSnapshot',
+    name: 'Curriculum Snapshot',
+    category: '04: Advanced',
+    thumbnailUrl:
+      'https://images.ctfassets.net/90t6bu6vlf76/2EWViyGBTdt0mXADkbonFA/f77fc4788be65bc013d40c6965d782a4/component_curriculum_snapshot_thumbnail.png',
+    tooltip: {
+      description:
+        'Displays key curriculum details at a glance, automatically pulled from a curriculum entry (e.g., grade level, devices).',
+      imageUrl:
+        'https://images.ctfassets.net/90t6bu6vlf76/79R7NhZ9XYliVAuQG7FPIt/8a96345c99647bb35e3a03195cec34db/component_curriculum_snapshot_tooltip.png',
+    },
+    // Adding an empty array here so no default style options show in the Design tab.
+    builtInStyles: [],
+    variables: {
+      grades: {
+        displayName: 'Grades',
+        type: 'Array',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['entry'],
+        },
+      },
+      level: {
+        displayName: 'Level',
+        type: 'Array',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['entry'],
+        },
+      },
+      duration: {
+        displayName: 'Duration',
+        type: 'Array',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['entry'],
+        },
+      },
+      devices: {
+        displayName: 'Devices',
+        type: 'Array',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['entry'],
+        },
+      },
+      topics: {
+        displayName: 'Topics',
+        type: 'Array',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['entry'],
+        },
+      },
+      programmingTools: {
+        displayName: 'Programming Tools',
+        type: 'Array',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['entry'],
+        },
+      },
+      professionalLearning: {
+        displayName: 'Professional Learning',
+        type: 'Array',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['entry'],
+        },
+      },
+      accessibility: {
+        displayName: 'Accessibility',
+        type: 'Array',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['entry'],
+        },
+      },
+      languagesSupported: {
+        displayName: 'Languages supported',
+        type: 'Array',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['entry'],
+        },
+      },
+    },
+  };

--- a/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/__tests__/CurriculumSnapshot.test.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/__tests__/CurriculumSnapshot.test.tsx
@@ -1,0 +1,132 @@
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import CurriculumSnapshot, {
+  CurriculumSnapshotProps,
+} from '@/components/snapshots/curriculumSnapshot/CurriculumSnapshot';
+
+describe('CurriculumSnapshot component', () => {
+  const title = 'Curriculum Snapshot';
+
+  const renderSnapshot = (props: Partial<CurriculumSnapshotProps> = {}) => {
+    render(<CurriculumSnapshot {...props} title={title} />);
+  };
+
+  it('renders empty list placeholder', () => {
+    renderSnapshot();
+
+    const placeholder = screen.getByText(
+      (_, node) =>
+        node?.tagName === 'EM' &&
+        !!node?.textContent?.includes('Curriculum Snapshot placeholder'),
+    );
+
+    expect(placeholder).toBeVisible();
+  });
+
+  it('renders snapshot Grades item', () => {
+    const grades = ['K-1', '2'];
+
+    renderSnapshot({grades});
+
+    const gradesItem = screen.getByText('Grades:').parentElement;
+    expect(gradesItem).toBeVisible();
+    expect(gradesItem).toHaveTextContent('Grades: K-1, 2');
+  });
+
+  it('renders snapshot Level item', () => {
+    const level = ['Beginner'];
+
+    renderSnapshot({level});
+
+    const levelItem = screen.getByText('Level:').parentElement;
+    expect(levelItem).toBeVisible();
+    expect(levelItem).toHaveTextContent('Level: Beginner');
+  });
+
+  it('renders snapshot Duration item', () => {
+    const duration = ['School Year'];
+
+    renderSnapshot({duration});
+
+    const durationItem = screen.getByText('Duration:').parentElement;
+    expect(durationItem).toBeVisible();
+    expect(durationItem).toHaveTextContent('Duration: School Year');
+  });
+
+  it('renders snapshot Devices item', () => {
+    const devices = ['Computer', 'Chromebook'];
+
+    renderSnapshot({devices});
+
+    const devicesItem = screen.getByText('Devices:').parentElement;
+    expect(devicesItem).toBeVisible();
+    expect(devicesItem).toHaveTextContent('Devices: Computer, Chromebook');
+  });
+
+  it('renders snapshot Topics item', () => {
+    const topics = ['Data', 'Programming'];
+
+    renderSnapshot({topics});
+
+    const topicsItem = screen.getByText('Topics:').parentElement;
+    expect(topicsItem).toBeVisible();
+    expect(topicsItem).toHaveTextContent('Topics: Data, Programming');
+  });
+
+  it('renders snapshot Programming Tools item', () => {
+    const programmingTools = ['App Lab'];
+
+    renderSnapshot({programmingTools});
+
+    const programmingToolsItem =
+      screen.getByText('Programming Tools:').parentElement;
+    expect(programmingToolsItem).toBeVisible();
+    expect(programmingToolsItem).toHaveTextContent(
+      'Programming Tools: App Lab',
+    );
+  });
+
+  it('renders snapshot Professional Learning item', () => {
+    const professionalLearning = [
+      'Facilitator-led Workshops',
+      'Self-paced Modules',
+    ];
+
+    renderSnapshot({professionalLearning});
+
+    const professionalLearningItem = screen.getByText(
+      'Professional Learning:',
+    ).parentElement;
+    expect(professionalLearningItem).toBeVisible();
+    expect(professionalLearningItem).toHaveTextContent(
+      'Professional Learning: Facilitator-led Workshops, Self-paced Modules',
+    );
+  });
+
+  it('renders snapshot Accessibility item', () => {
+    const accessibility = ['Text to Speech', 'Closed captioning'];
+
+    renderSnapshot({accessibility});
+
+    const accessibilityItem = screen.getByText('Accessibility:').parentElement;
+    expect(accessibilityItem).toBeVisible();
+    expect(accessibilityItem).toHaveTextContent(
+      'Accessibility: Text to Speech, Closed captioning',
+    );
+  });
+
+  it('renders snapshot Languages supported item', () => {
+    const languagesSupported = ['English', 'Ukrainian'];
+
+    renderSnapshot({languagesSupported});
+
+    const languagesSupportedItem = screen.getByText(
+      'Languages supported:',
+    ).parentElement;
+    expect(languagesSupportedItem).toBeVisible();
+    expect(languagesSupportedItem).toHaveTextContent(
+      'Languages supported: English, Ukrainian',
+    );
+  });
+});

--- a/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/__tests__/CurriculumSnapshot.test.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/__tests__/CurriculumSnapshot.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, within} from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import CurriculumSnapshot, {
@@ -24,109 +24,36 @@ describe('CurriculumSnapshot component', () => {
     expect(placeholder).toBeVisible();
   });
 
-  it('renders snapshot Grades item', () => {
-    const grades = ['K-1', '2'];
+  it('renders curriculum details in the correct order', () => {
+    renderSnapshot({
+      grades: ['1', '1st'],
+      level: ['2', '2nd'],
+      duration: ['3', '3rd'],
+      devices: ['4', '4th'],
+      topics: ['5', '5th'],
+      programmingTools: ['6', '6th'],
+      professionalLearning: ['7', '7th'],
+      accessibility: ['8', '8th'],
+      languagesSupported: ['9', '9th'],
+    });
 
-    renderSnapshot({grades});
+    const curriculumSnapshot = screen.getByTitle(title);
+    expect(curriculumSnapshot).toBeVisible();
 
-    const gradesItem = screen.getByText('Grades:').parentElement;
-    expect(gradesItem).toBeVisible();
-    expect(gradesItem).toHaveTextContent('Grades: K-1, 2');
-  });
-
-  it('renders snapshot Level item', () => {
-    const level = ['Beginner'];
-
-    renderSnapshot({level});
-
-    const levelItem = screen.getByText('Level:').parentElement;
-    expect(levelItem).toBeVisible();
-    expect(levelItem).toHaveTextContent('Level: Beginner');
-  });
-
-  it('renders snapshot Duration item', () => {
-    const duration = ['School Year'];
-
-    renderSnapshot({duration});
-
-    const durationItem = screen.getByText('Duration:').parentElement;
-    expect(durationItem).toBeVisible();
-    expect(durationItem).toHaveTextContent('Duration: School Year');
-  });
-
-  it('renders snapshot Devices item', () => {
-    const devices = ['Computer', 'Chromebook'];
-
-    renderSnapshot({devices});
-
-    const devicesItem = screen.getByText('Devices:').parentElement;
-    expect(devicesItem).toBeVisible();
-    expect(devicesItem).toHaveTextContent('Devices: Computer, Chromebook');
-  });
-
-  it('renders snapshot Topics item', () => {
-    const topics = ['Data', 'Programming'];
-
-    renderSnapshot({topics});
-
-    const topicsItem = screen.getByText('Topics:').parentElement;
-    expect(topicsItem).toBeVisible();
-    expect(topicsItem).toHaveTextContent('Topics: Data, Programming');
-  });
-
-  it('renders snapshot Programming Tools item', () => {
-    const programmingTools = ['App Lab'];
-
-    renderSnapshot({programmingTools});
-
-    const programmingToolsItem =
-      screen.getByText('Programming Tools:').parentElement;
-    expect(programmingToolsItem).toBeVisible();
-    expect(programmingToolsItem).toHaveTextContent(
-      'Programming Tools: App Lab',
+    const curriculumDetails =
+      within(curriculumSnapshot).getAllByRole('listitem');
+    expect(curriculumDetails[0]).toHaveTextContent('Grades: 1, 1st');
+    expect(curriculumDetails[1]).toHaveTextContent('Level: 2, 2nd');
+    expect(curriculumDetails[2]).toHaveTextContent('Duration: 3, 3rd');
+    expect(curriculumDetails[3]).toHaveTextContent('Devices: 4, 4th');
+    expect(curriculumDetails[4]).toHaveTextContent('Topics: 5, 5th');
+    expect(curriculumDetails[5]).toHaveTextContent('Programming Tools: 6, 6th');
+    expect(curriculumDetails[6]).toHaveTextContent(
+      'Professional Learning: 7, 7th',
     );
-  });
-
-  it('renders snapshot Professional Learning item', () => {
-    const professionalLearning = [
-      'Facilitator-led Workshops',
-      'Self-paced Modules',
-    ];
-
-    renderSnapshot({professionalLearning});
-
-    const professionalLearningItem = screen.getByText(
-      'Professional Learning:',
-    ).parentElement;
-    expect(professionalLearningItem).toBeVisible();
-    expect(professionalLearningItem).toHaveTextContent(
-      'Professional Learning: Facilitator-led Workshops, Self-paced Modules',
-    );
-  });
-
-  it('renders snapshot Accessibility item', () => {
-    const accessibility = ['Text to Speech', 'Closed captioning'];
-
-    renderSnapshot({accessibility});
-
-    const accessibilityItem = screen.getByText('Accessibility:').parentElement;
-    expect(accessibilityItem).toBeVisible();
-    expect(accessibilityItem).toHaveTextContent(
-      'Accessibility: Text to Speech, Closed captioning',
-    );
-  });
-
-  it('renders snapshot Languages supported item', () => {
-    const languagesSupported = ['English', 'Ukrainian'];
-
-    renderSnapshot({languagesSupported});
-
-    const languagesSupportedItem = screen.getByText(
-      'Languages supported:',
-    ).parentElement;
-    expect(languagesSupportedItem).toBeVisible();
-    expect(languagesSupportedItem).toHaveTextContent(
-      'Languages supported: English, Ukrainian',
+    expect(curriculumDetails[7]).toHaveTextContent('Accessibility: 8, 8th');
+    expect(curriculumDetails[8]).toHaveTextContent(
+      'Languages supported: 9, 9th',
     );
   });
 });

--- a/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/index.ts
+++ b/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/index.ts
@@ -1,0 +1,3 @@
+// Export the Component Definition for use in Contentful Studio
+export {CurriculumSnapshotContentfulComponentDefinition} from './CurriculumSnapshotContentfulDefinition';
+export {default} from './CurriculumSnapshot';

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -42,6 +42,9 @@ import Section, {
 import SimpleList, {
   SimpleListContentfulComponentDefinition,
 } from '@/components/simpleList';
+import CurriculumSnapshot, {
+  CurriculumSnapshotContentfulComponentDefinition,
+} from '@/components/snapshots/curriculumSnapshot';
 import TabGroup, {
   TabGroupContentfulComponentDefinition,
 } from '@/components/tabGroup';
@@ -117,6 +120,10 @@ defineComponents(
     {
       component: SimpleList,
       definition: SimpleListContentfulComponentDefinition,
+    },
+    {
+      component: CurriculumSnapshot,
+      definition: CurriculumSnapshotContentfulComponentDefinition,
     },
     {component: TabGroup, definition: TabGroupContentfulComponentDefinition},
     {


### PR DESCRIPTION
## Component
<img alt="component" src="https://github.com/user-attachments/assets/16f6941a-42d1-419d-aaa9-f0263e607431" />

## Preview
<img alt="preview" src="https://github.com/user-attachments/assets/917aa559-174a-4c9b-9633-2d9d301b4e6d" />

## Empty list
<img alt="empty-list" src="https://github.com/user-attachments/assets/8ad81251-cadb-4708-90df-3e6eaaaad009" />

## Links
- JIRA task: [CMS-469](https://codedotorg.atlassian.net/browse/CMS-469)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/64877


