### PR TITLE
Fixes a regression in neighborhood dark mode

### DIFF
--- a/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
@@ -58,7 +58,6 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
             type={'tertiary'}
             className={classNames(darkModeStyles.tertiaryButton)}
             isIconOnly={true}
-            color={'white'}
             ariaLabel={
               isMaximized
                 ? codebridgeI18n.minimizePreview()

--- a/apps/src/codebridge/Workspace/BaseOutput.tsx
+++ b/apps/src/codebridge/Workspace/BaseOutput.tsx
@@ -85,6 +85,7 @@ const BaseOutput: React.FunctionComponent<OutputProps> = ({
       )}
       style={style}
       ref={resizeContainerRef}
+      data-theme="Dark"
     >
       <div style={miniAppStyle} className={moduleStyles.flexShrink0}>
         <MiniAppPreview


### PR DESCRIPTION
Fixes a regression caused by https://github.com/code-dot-org/code-dot-org/pull/64933

Had to add dark mode to the one console place we haven't yet added it, and then had to remove the white in that expand button for it to take. Those are the two lines in this PR:)

Adds dark mode (and removes white label) to turn all buttons white again for console:

Before:
<img width="1435" alt="Screenshot 2025-04-02 at 2 41 23 PM" src="https://github.com/user-attachments/assets/5f5d0895-dd59-43c7-884f-68a734fa9e92" />


After:
<img width="926" alt="Screenshot 2025-04-02 at 2 38 31 PM" src="https://github.com/user-attachments/assets/ddda0d65-cc1f-456b-8c52-e4df677e04dc" />


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
