### PR TITLE
Fix color of codebridge settings button

### DIFF
--- a/apps/src/codebridge/Settings/SettingsButton.tsx
+++ b/apps/src/codebridge/Settings/SettingsButton.tsx
@@ -35,6 +35,7 @@ const SettingsButton: React.FunctionComponent = () => {
           icon={{iconStyle: 'solid', iconName: 'gear'}}
           size="xs"
           onClick={() => setIsOpen(true)}
+          color={'white'}
           type="tertiary"
           className={darkModeStyles.tertiaryButton}
           ariaLabel="Settings"


### PR DESCRIPTION
There's been some theming back and forth, which removed the dark theme from around the new settings button, so it changed from being white to purple. This specifies it as white. Once we add the dark theme back in we shouldn't need the color anymore (and in fact, setting a button as "white" in dark mode makes it black)
## Links
- [slack thread](https://codedotorg.slack.com/archives/C05HZFH7BED/p1743636038222759?thread_ts=1743635460.239829&cid=C05HZFH7BED)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
