### PR TITLE
feat(marketing): upload static assets to s3

### DIFF
--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -131,7 +131,20 @@ jobs:
       run: |
         ruby ./deploy.rb
 
-    - name: "[Staging] Deploy Marketing App to AWS"
+    - name: "Download Built Docker Image"
+      run: |
+        docker pull ${{ needs.build-and-push-image.outputs.fullImageUri }}
+        docker create --name temp ${{ needs.build-and-push-image.outputs.fullImageUri }}
+
+    - name: "Extract Static Assets from Docker"
+      run: |
+        docker cp temp:/app/apps/marketing/.next/static/ ./static
+
+    - name: "[Test] Upload Static Assets to S3"
+      run: |
+        aws s3 cp static/ s3://cdo-marketing-static-assets-test/_next/static --recursive --quiet
+
+    - name: "[Test] Deploy Marketing App to AWS"
       uses: aws-actions/aws-cloudformation-github-deploy@v1
       with:
         name: ${{ vars.MARKETING_CLOUDFORMATION_STACK_NAME }}

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -141,15 +141,26 @@ jobs:
         docker cp temp:/app/apps/marketing/.next/static/ ./static
 
     - name: "[Test] Upload Static Assets to S3"
+      env:
+        BASE_DOMAIN: ${{ vars.MARKETING_BASE_DOMAIN }}
+        SUBDOMAIN_NAME: ${{ vars.MARKETING_SUBDOMAIN_NAME }}
       run: |
-        aws s3 cp static/ s3://cdo-marketing-static-assets-test/_next/static --recursive --quiet
+        if [ "$BASE_DOMAIN" = "dev-code.org" ]; then
+          BUCKET_NAME="cdo-dev-$SUBDOMAIN_NAME-static-assets"
+        else
+          BUCKET_NAME="cdo-$SUBDOMAIN_NAME-static-assets"
+        fi
+        
+        echo "Uploading static assets to $BUCKET_NAME"
+        
+        aws s3 cp static/ "s3://$BUCKET_NAME/_next/static" --recursive --quiet
 
     - name: "[Test] Deploy Marketing App to AWS"
       uses: aws-actions/aws-cloudformation-github-deploy@v1
       with:
         name: ${{ vars.MARKETING_CLOUDFORMATION_STACK_NAME }}
         template: ./aws/cloudformation/standalone/marketing/deployment/marketing.yml
-        parameter-overrides: "ContainerImageHashDigest=${{ needs.build-and-push-image.outputs.digest }}"
+        parameter-overrides: "ContainerImageHashDigest=${{ needs.build-and-push-image.outputs.digest }},BaseDomainName=${{ vars.MARKETING_BASE_DOMAIN }},SubdomainName=${{ vars.MARKETING_SUBDOMAIN_NAME }}"
         capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
 
   ui-tests:

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -6,6 +6,12 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Marketing App AWS resources
 
 Parameters:
+  BaseDomainName:
+    Type: String
+    Description: Base domain name (e.g. 'code.org' in 'marketing.code.org').
+  SubdomainName:
+    Type: String
+    Description: Subdomain name for marketing (e.g. 'marketing' in 'marketing.code.org').
   Environment:
     Type: String
     Default: "test"
@@ -14,6 +20,8 @@ Parameters:
     Type: String
     Description: "The sha256sum of the marketing container image."
 
+Conditions:
+  IsDevCondition: !Equals [!Ref BaseDomainName, "dev-code.org"]
 Resources:
   # Route 53 root hosted zone for marketing.dev-code.org
   RootHostedZone:
@@ -590,7 +598,11 @@ Resources:
   MarketingStaticAssetsBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "cdo-marketing-static-assets-${Environment}"
+      BucketName: !If [IsDevCondition, !Sub "cdo-dev-${SubdomainName}-static-assets", !Sub "cdo-${SubdomainName}-static-assets"]
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "AES256"
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -598,6 +610,12 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
+      IntelligentTieringConfigurations:
+        - Id: EntireBucket
+          Status: Enabled
+          Tierings:
+            - AccessTier: ARCHIVE_ACCESS
+              Days: 30
       LifecycleConfiguration:
         Rules:
           - Id: ExpireOldVersions

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -570,8 +570,8 @@ Resources:
               - "s3:PutObject"
               - "s3:ListBucket"
             Resource:
-              - !Sub "arn:aws:s3:::cdo-marketing-static-assets-${Environment}"
-              - !Sub "arn:aws:s3:::cdo-marketing-static-assets-${Environment}/*"
+              - !GetAtt MarketingStaticAssetsBucket.Arn
+              - !Sub "${MarketingStaticAssetsBucket.Arn}/*"
 
   MarketingGithubDeployerAccessKey:
     Type: AWS::IAM::AccessKey
@@ -610,12 +610,6 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
-      IntelligentTieringConfigurations:
-        - Id: EntireBucket
-          Status: Enabled
-          Tierings:
-            - AccessTier: ARCHIVE_ACCESS
-              Days: 90
       LifecycleConfiguration:
         Rules:
           - Id: ExpireOldVersions

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -615,7 +615,7 @@ Resources:
           Status: Enabled
           Tierings:
             - AccessTier: ARCHIVE_ACCESS
-              Days: 30
+              Days: 90
       LifecycleConfiguration:
         Rules:
           - Id: ExpireOldVersions

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -557,6 +557,13 @@ Resources:
               - 'ecs:DescribeServices'
               - 'ecs:UpdateService'
             Resource: !Ref FargateService
+          - Effect: Allow
+            Action:
+              - "s3:PutObject"
+              - "s3:ListBucket"
+            Resource:
+              - !Sub "arn:aws:s3:::cdo-marketing-static-assets-${Environment}"
+              - !Sub "arn:aws:s3:::cdo-marketing-static-assets-${Environment}/*"
 
   MarketingGithubDeployerAccessKey:
     Type: AWS::IAM::AccessKey
@@ -579,6 +586,24 @@ Resources:
             - '"}'
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
+
+  MarketingStaticAssetsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "cdo-marketing-static-assets-${Environment}"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireOldVersions
+            Status: Enabled
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 90
 
 Outputs:
   FargateServiceLoadBalancerDNS:


### PR DESCRIPTION
This PR adds the ability to upload the static assets within the nextjs marketing build output to S3 and enables switching over those assets from being served from the application to being served by a CDN. This PR does not implement the Cloudfront connection to S3, but rather it just adds the ability to upload the assets.

To accomplish multi-environment deployments, this PR uses the built docker image that is produced in the build step and during a deployment, extracts the static assets out from the image - effectively making the docker image the source of truth and enabling consistency when running on the Docker-only version and the cloud-optimized version on AWS.

To prevent this bucket from becoming a dumping ground, old assets will automatically be deleted after 90 days. Since assets are uploaded using `aws s3 cp`, even if an asset never changes, it will create a new version of that asset. After 90 days, the old versions of the asset are deleted as they are no longer current.