### PR TITLE
Lab2: use props for Panels and StandaloneVideo

### DIFF
--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -30,8 +30,6 @@ import useWindowSize from '../util/hooks/useWindowSize';
 import PanelsView from './PanelsView';
 import {PanelsLevelProperties} from './types';
 
-const appName = 'panels';
-
 // Temporary solution for sending analytics for Hour of Code 2024.
 // We are also temporarily sending panel analytics for the Elementary Music Lab Pilot
 // TODO: Remove/consolidate reporters
@@ -75,23 +73,15 @@ const updateAnalyticsProperty = (key: string, value: string) => {
   identify(identifyEvent);
 };
 
-const PanelsLabView: React.FunctionComponent<LabProps> = () => {
+const PanelsLabView: React.FunctionComponent<
+  LabProps<PanelsLevelProperties>
+> = ({levelProperties}) => {
   const dispatch = useAppDispatch();
 
-  const panels = useAppSelector(
-    state =>
-      (state.lab.levelProperties as PanelsLevelProperties | undefined)?.panels
-  );
-  const currentAppName = useAppSelector(
-    state => state.lab.levelProperties?.appName
-  );
+  const {panels, appName, skipUrl, offerBrowserTts} = levelProperties;
   const background = useAppSelector(
     state => getCurrentLesson(state)?.background || null
   );
-  const skipUrl = useAppSelector(state => state.lab.levelProperties?.skipUrl);
-  const offerBrowserTts =
-    useAppSelector(state => state.lab.levelProperties?.offerBrowserTts) ||
-    queryParams('show-tts') === 'true';
   const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
 
   const dialogControl = useDialogControl();
@@ -107,7 +97,7 @@ const PanelsLabView: React.FunctionComponent<LabProps> = () => {
         dispatch(continueOrFinishLesson());
       }
     },
-    [dispatch]
+    [dispatch, appName]
   );
 
   const onSkip = useCallback(() => {
@@ -174,7 +164,7 @@ const PanelsLabView: React.FunctionComponent<LabProps> = () => {
 
   const [windowWidth, windowHeight] = useWindowSize();
 
-  if (!panels || currentAppName !== appName) {
+  if (!panels) {
     return <div />;
   }
 
@@ -186,7 +176,7 @@ const PanelsLabView: React.FunctionComponent<LabProps> = () => {
       onSkip={skipUrl ? onSkip : undefined}
       targetWidth={windowWidth}
       targetHeight={windowHeight}
-      offerBrowserTts={offerBrowserTts}
+      offerBrowserTts={offerBrowserTts || queryParams('show-tts') === 'true'}
       levelId={currentLevelId}
       onChangePanel={onChangePanel}
       onClickContinue={onClickContinue}

--- a/apps/src/panels/types.ts
+++ b/apps/src/panels/types.ts
@@ -1,7 +1,7 @@
 import {LevelProperties} from '../lab2/types';
 
 export interface PanelsLevelProperties extends LevelProperties {
-  panels: Panel[];
+  panels?: Panel[];
 }
 
 export type PanelLayout =

--- a/apps/src/standaloneVideo/StandaloneVideo.tsx
+++ b/apps/src/standaloneVideo/StandaloneVideo.tsx
@@ -5,14 +5,12 @@
 // they will get an older-style level implemented with a HAML page and some
 // non-React JS code.
 
-import React, {useEffect} from 'react';
-import {useSelector} from 'react-redux';
+import React from 'react';
 
 import {
   sendSuccessReport,
   navigateToNextLevel,
 } from '@cdo/apps/code-studio/progressRedux';
-import {LabState} from '@cdo/apps/lab2/lab2Redux';
 import {LabProps, VideoLevelData} from '@cdo/apps/lab2/types';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
@@ -21,38 +19,20 @@ import Video from './Video';
 
 import styles from './video.module.scss';
 
-const StandaloneVideo: React.FunctionComponent<LabProps> = () => {
+const StandaloneVideo: React.FunctionComponent<LabProps> = ({
+  levelProperties,
+}) => {
   const dispatch = useAppDispatch();
-  const levelData = useSelector(
-    (state: {lab: LabState}) => state.lab.levelProperties?.levelData
-  );
-  const currentAppName = useSelector(
-    (state: {lab: LabState}) => state.lab.levelProperties?.appName
-  );
-
-  const [levelVideo, setLevelVideo] = React.useState<VideoLevelData | null>(
-    null
-  );
-
-  useEffect(() => {
-    if (currentAppName === 'standalone_video' && levelData) {
-      setLevelVideo(levelData as VideoLevelData);
-    }
-  }, [currentAppName, levelData]);
+  const levelVideo = levelProperties.levelData as VideoLevelData | undefined;
 
   const nextButtonPressed = () => {
-    const appType = 'standalone_video';
-    dispatch(sendSuccessReport(appType));
+    dispatch(sendSuccessReport(levelProperties.appName));
     dispatch(navigateToNextLevel());
   };
 
   return (
     <div id="standalone-video">
-      <Video
-        src={levelVideo?.src}
-        download={levelVideo?.download}
-        thumbnail={levelVideo?.thumbnail}
-      >
+      <Video {...levelVideo}>
         <button
           id="standalone-video-continue-button"
           type="button"

--- a/apps/src/standaloneVideo/Video.tsx
+++ b/apps/src/standaloneVideo/Video.tsx
@@ -10,9 +10,9 @@ type VideoChoiceType = undefined | 'youtube' | 'fallback';
 
 interface VideoProps {
   children: React.ReactNode;
-  src: string | undefined;
-  download: string | undefined;
-  thumbnail: string | undefined;
+  src?: string;
+  download?: string;
+  thumbnail?: string;
 }
 
 function useWindowSize() {

--- a/apps/src/standaloneVideo/locale.ts
+++ b/apps/src/standaloneVideo/locale.ts
@@ -4,6 +4,6 @@
  */
 import {Locale} from '@cdo/apps/types/locale';
 
-export default require('@cdo/aichat/locale') as Locale<
+export default require('@cdo/standaloneVideo/locale') as Locale<
   typeof import('@cdo/i18n/standaloneVideo/en_us.json')
 >;

--- a/apps/src/standaloneVideo/locale.ts
+++ b/apps/src/standaloneVideo/locale.ts
@@ -1,9 +1,9 @@
 /**
- * A TypeScript wrapper for the StandaloneVideolocale object which casts
- * it to the {@link StandaloneVideoLocale} type.
+ * A TypeScript wrapper for the StandaloneVideoLocale object which casts
+ * it to the {@link Locale} type.
  */
-import {StandaloneVideoLocale} from './types';
+import {Locale} from '@cdo/apps/types/locale';
 
-const standaloneVideoLocale = require('@cdo/standaloneVideo/locale');
-
-export default standaloneVideoLocale as StandaloneVideoLocale;
+export default require('@cdo/aichat/locale') as Locale<
+  typeof import('@cdo/i18n/standaloneVideo/en_us.json')
+>;

--- a/apps/src/standaloneVideo/types.ts
+++ b/apps/src/standaloneVideo/types.ts
@@ -1,9 +1,0 @@
-// TODO: Ideally this type would only contain keys present in
-// translated string JSON files (ex. apps/i18n/standaloneVideo/en_us.json).
-// However, this requires depending on files outside of apps/src,
-// so this approach is still being investigated. For now, this type
-// is an object whose keys are all functions which return strings,
-// matching what we expect for a locale object.
-export type StandaloneVideoLocale = {
-  [key: string]: () => string;
-};


### PR DESCRIPTION
Converts Panels and StandaloneVideo to use the new lab2 props (as introduced in https://github.com/code-dot-org/code-dot-org/pull/63974). Also cleans up some StandaloneVideo types related to locale.

## Testing story

Tested locally; no functional changes.