### PR TITLE
Evaluate Student Learning: StudentWorkEvaluationSummaries table

### DIFF
--- a/dashboard/app/models/student_work_evaluation_summary.rb
+++ b/dashboard/app/models/student_work_evaluation_summary.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: student_work_evaluation_summaries
+#
+#  id                                 :bigint           not null, primary key
+#  student_work_evaluation_id         :bigint           not null
+#  student_work_evaluation_summary_id :bigint           not null
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
+#
+# Indexes
+#
+#  fk_rails_49598559b9  (student_work_evaluation_id)
+#  fk_rails_d50fa61780  (student_work_evaluation_summary_id)
+#
+class StudentWorkEvaluationSummary < ApplicationRecord
+  # student_work_evaluation_id is the ID of the StudentWorkEvaluation that was summarized
+  # student_work_evaluation_summary_id is the ID of the StudentWorkEvaluation that is the summary
+  # For example, if a UserLevelEvaluation is based on the roll-up of multiple UserSkillEvaluations,
+  # then student_work_evaluation_id is the ID of one of the UserLevelSkillEvaluations and
+  # student_work_evaluation_summary_id is the ID of the UserLevelEvaluation.
+  belongs_to :student_work_evaluation
+  belongs_to :student_work_evaluation_summary, class_name: 'StudentWorkEvaluation'
+end

--- a/dashboard/db/migrate/20250403150349_create_student_work_evaluation_summaries.rb
+++ b/dashboard/db/migrate/20250403150349_create_student_work_evaluation_summaries.rb
@@ -1,0 +1,14 @@
+class CreateStudentWorkEvaluationSummaries < ActiveRecord::Migration[6.1]
+  def change
+    drop_table :student_work_evaluation_summaries
+    create_table :student_work_evaluation_summaries do |t|
+      t.bigint :student_work_evaluation_id, null: false
+      t.bigint :student_work_evaluation_summary_id, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :student_work_evaluation_summaries, :student_work_evaluations, column: :student_work_evaluation_id
+    add_foreign_key :student_work_evaluation_summaries, :student_work_evaluations, column: :student_work_evaluation_summary_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -2545,7 +2545,7 @@ ActiveRecord::Schema.define(version: 2025_04_03_150349) do
     t.string "cap_status", limit: 1
     t.datetime "cap_status_date"
     t.index ["birthday"], name: "index_users_on_birthday"
-    t.index ["cap_status", "cap_status_date"], name: "index_users_on_cap_status_and_cap_statusq_date"
+    t.index ["cap_status", "cap_status_date"], name: "index_users_on_cap_status_and_cap_status_date"
     t.index ["current_sign_in_at"], name: "index_users_on_current_sign_in_at"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email", "deleted_at"], name: "index_users_on_email_and_deleted_at"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_04_02_215215) do
+ActiveRecord::Schema.define(version: 2025_04_03_150349) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2181,6 +2181,15 @@ ActiveRecord::Schema.define(version: 2025_04_02_215215) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
+  create_table "student_work_evaluation_summaries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "student_work_evaluation_id", null: false
+    t.bigint "student_work_evaluation_summary_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["student_work_evaluation_id"], name: "fk_rails_49598559b9"
+    t.index ["student_work_evaluation_summary_id"], name: "fk_rails_d50fa61780"
+  end
+
   create_table "student_work_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.integer "student_id"
@@ -2536,7 +2545,7 @@ ActiveRecord::Schema.define(version: 2025_04_02_215215) do
     t.string "cap_status", limit: 1
     t.datetime "cap_status_date"
     t.index ["birthday"], name: "index_users_on_birthday"
-    t.index ["cap_status", "cap_status_date"], name: "index_users_on_cap_status_and_cap_status_date"
+    t.index ["cap_status", "cap_status_date"], name: "index_users_on_cap_status_and_cap_statusq_date"
     t.index ["current_sign_in_at"], name: "index_users_on_current_sign_in_at"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email", "deleted_at"], name: "index_users_on_email_and_deleted_at"
@@ -2625,6 +2634,8 @@ ActiveRecord::Schema.define(version: 2025_04_02_215215) do
   add_foreign_key "section_instructors", "users", column: "instructor_id"
   add_foreign_key "section_instructors", "users", column: "invited_by_id"
   add_foreign_key "sections", "lti_integrations"
+  add_foreign_key "student_work_evaluation_summaries", "student_work_evaluations"
+  add_foreign_key "student_work_evaluation_summaries", "student_work_evaluations", column: "student_work_evaluation_summary_id"
   add_foreign_key "survey_results", "users"
   add_foreign_key "user_geos", "users"
   add_foreign_key "user_proficiencies", "users"


### PR DESCRIPTION
### Links
Continuation of #64942 and https://github.com/code-dot-org/code-dot-org/pull/64948 
[Problem overview with a handy little chart ](https://docs.google.com/document/d/1pPb-LiWZuhDolIoTiKOmTFkKCDHKZOY6fB31XJPXLu4/edit?tab=t.0)of all the "types" of evaluations we'll likely need 
[FigJam with more detailed ERD](https://www.figma.com/board/S8H82OKJ3gDboYrIoQZCsu/Measures-of-Learning-ERD-brainstorms?node-id=0-1&p=f&t=V5XfUKd6IMY4xTpg-0) See ERD 2.0 Skills, Summaries & Feedback option 2 in pink 

### Summary 
Now that we have a generic StudentWorkEvaluation table that is flexible enough to store evaluations of different granularity, there are times when we'll need to know which evaluations are related to one another. For example, if a UserLevelEvaluation is based on the roll-up of multiple UserSkillEvaluations, we want to be able to associate those UserSkillEvaluations with the UserLevelEvaluation to troubleshoot any accuracy issues we find. Similarly, for SectionLevelEvaluations based on UserLevelEvaluations we'll need a record of which UserLevelEvaluations were summarized. 

We're planning to write to the StudentWorkEvaluationSummaries table in 2 scenarios: 1.) The summary evaluation is Ai-generated or 2.) We're collecting user feedback on a programmatically-generated (e.g. algorithmically determined based on counts of different evaluations "great", "ok" etc) summary. This is because we're primarily interested in diagnosing any inaccuracies in AI generated evaluations and gauging utility. 

### Follow up work 
- write to StudentWorkEvaluationSummaries
- switch reads to StudentWorkEvaluations 