### PR TITLE
AI Chat: wrap asset previews when lots of uploads

### DIFF
--- a/apps/src/aichat/views/assets/staged-files-preview.module.scss
+++ b/apps/src/aichat/views/assets/staged-files-preview.module.scss
@@ -11,6 +11,7 @@
 
 .row {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   overflow-x: auto;
   padding-top: 8px;


### PR DESCRIPTION
Noticed an issue where asset previews would get squished if you tried to upload a large number of assets (say, 5). This wraps the previews onto a new line, no squishes.

**Before**

<img width="493" alt="image" src="https://github.com/user-attachments/assets/3a49261c-eabc-40ef-ac19-955cb920ccd1" />

**After**

<img width="432" alt="image" src="https://github.com/user-attachments/assets/47e759ab-1797-41d5-875d-44cf3aec13a1" />
