### PR TITLE
CMS-495: Add  `LabSnapshot` component definition for Contentful

### DIFF
--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
@@ -1,4 +1,3 @@
-import {castArray} from 'lodash';
 import {useMemo} from 'react';
 
 import Snapshot, {
@@ -29,12 +28,12 @@ const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
   const initItem = (
     label: string,
     iconName: string,
-    content: string[],
+    content: string | string[],
   ): SnapshotItem => ({
     key: label + iconName,
     label: label,
     icon: {iconName},
-    content: content.join(', '),
+    content: Array.isArray(content) ? content.join(', ') : content,
   });
 
   const items = useMemo(() => {
@@ -45,8 +44,7 @@ const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
       iconName: string,
       content?: string | string[],
     ) => {
-      if (content?.length)
-        items.push(initItem(label, iconName, castArray(content)));
+      if (content?.length) items.push(initItem(label, iconName, content));
     };
 
     addItem('Ages', 'user', ages);

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
@@ -1,0 +1,78 @@
+import {castArray} from 'lodash';
+import {useMemo} from 'react';
+
+import Snapshot, {
+  SnapshotProps,
+  SnapshotItem,
+} from '@code-dot-org/component-library/cms/snapshot';
+
+export interface LabSnapshotProps extends Omit<SnapshotProps, 'items'> {
+  ages?: string[];
+  level?: string[];
+  creation?: string;
+  devices?: string[];
+  browsers?: string[];
+  accessibility?: string[];
+  languages?: string[];
+}
+
+const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
+  ages,
+  level,
+  devices,
+  creation,
+  browsers,
+  accessibility,
+  languages,
+  ...props
+}) => {
+  console.log('accessibility', accessibility);
+
+  const initItem = (
+    label: string,
+    iconName: string,
+    content: string[],
+  ): SnapshotItem => ({
+    key: label + iconName,
+    label: label,
+    icon: {iconName},
+    content: content.join(', '),
+  });
+
+  const items = useMemo(() => {
+    const items: SnapshotItem[] = [];
+
+    const addItem = (
+      label: string,
+      iconName: string,
+      content?: string | string[],
+    ) => {
+      if (content?.length)
+        items.push(initItem(label, iconName, castArray(content)));
+    };
+
+    addItem('Ages', 'user', ages);
+    addItem('Level', 'arrow-up-wide-short', level);
+    addItem('What you can make', 'paintbrush', creation);
+    addItem('Devices', 'desktop', devices);
+    addItem('Browsers', 'globe', browsers);
+    addItem('Accessibility', 'universal-access', accessibility);
+    addItem('Languages supported', 'language', languages);
+
+    return items;
+  }, [ages, level, devices, creation, browsers, accessibility, languages]);
+
+  // Show placeholder text until a content entry is added
+  if (!items.length) {
+    return (
+      <em>
+        <strong>🧪 Lab Snapshot placeholder.</strong> Please add a "Lab" content
+        type entry in the Content sidebar.
+      </em>
+    );
+  }
+
+  return <Snapshot {...props} items={items} />;
+};
+
+export default LabSnapshot;

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
@@ -26,8 +26,6 @@ const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
   languages,
   ...props
 }) => {
-  console.log('accessibility', accessibility);
-
   const initItem = (
     label: string,
     iconName: string,

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
@@ -1,11 +1,11 @@
 import {useMemo} from 'react';
 
 import Snapshot, {
-  SnapshotProps,
   SnapshotItem,
 } from '@code-dot-org/component-library/cms/snapshot';
 
-export interface LabSnapshotProps extends Omit<SnapshotProps, 'items'> {
+export interface LabSnapshotProps {
+  label?: string;
   ages?: string[];
   level?: string[];
   creation?: string;
@@ -16,6 +16,7 @@ export interface LabSnapshotProps extends Omit<SnapshotProps, 'items'> {
 }
 
 const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
+  label,
   ages,
   level,
   devices,
@@ -23,7 +24,6 @@ const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
   browsers,
   accessibility,
   languages,
-  ...props
 }) => {
   const initItem = (
     label: string,
@@ -69,7 +69,7 @@ const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
     );
   }
 
-  return <Snapshot {...props} items={items} />;
+  return <Snapshot aria-label={label} items={items} />;
 };
 
 export default LabSnapshot;

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
@@ -25,17 +25,6 @@ const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
   accessibility,
   languages,
 }) => {
-  const initItem = (
-    label: string,
-    iconName: string,
-    content: string | string[],
-  ): SnapshotItem => ({
-    key: label + iconName,
-    label: label,
-    icon: {iconName},
-    content: Array.isArray(content) ? content.join(', ') : content,
-  });
-
   const items = useMemo(() => {
     const items: SnapshotItem[] = [];
 
@@ -45,7 +34,13 @@ const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
       content?: string | string[],
     ) => {
       // Avoid pushing empty arrays and empty strings
-      if (content?.length) items.push(initItem(label, iconName, content));
+      if (content?.length)
+        items.push({
+          key: label + iconName,
+          label: label,
+          icon: {iconName},
+          content: Array.isArray(content) ? content.join(', ') : content,
+        });
     };
 
     addItem('Ages', 'user', ages);

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshot.tsx
@@ -44,6 +44,7 @@ const LabSnapshot: React.FunctionComponent<LabSnapshotProps> = ({
       iconName: string,
       content?: string | string[],
     ) => {
+      // Avoid pushing empty arrays and empty strings
       if (content?.length) items.push(initItem(label, iconName, content));
     };
 

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshotContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshotContentfulDefinition.ts
@@ -1,0 +1,76 @@
+// Creates a definition for the Lab Snapshot component to be used in Contentful Studio
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+export const LabSnapshotContentfulComponentDefinition: ComponentDefinition = {
+  id: 'labSnapshot',
+  name: 'Lab Snapshot',
+  category: '04: Advanced',
+  thumbnailUrl:
+    'https://images.ctfassets.net/90t6bu6vlf76/19yZ1MYtW4OTGM8Stz3XIz/01ca4f9c1be7ce150bf42275b07182bd/component_lab_snapshot_thumbnail.png',
+  tooltip: {
+    description:
+      'Shows essential lab information, such as ages, what you can make, and compatibility, pulled directly from a lab entry.',
+    imageUrl:
+      'https://images.ctfassets.net/90t6bu6vlf76/4fjwt72cQecN3RakUuZPBu/ed24d0f2ea15329268900e102f57c80f/component_lab_snapshot_tooltip.png',
+  },
+  // Adding an empty array here so no default style options show in the Design tab.
+  builtInStyles: [],
+  variables: {
+    ages: {
+      displayName: 'Ages',
+      type: 'Array',
+      group: 'content',
+      validations: {
+        bindingSourceType: ['entry'],
+      },
+    },
+    level: {
+      displayName: 'Level',
+      type: 'Array',
+      group: 'content',
+      validations: {
+        bindingSourceType: ['entry'],
+      },
+    },
+    creation: {
+      displayName: 'What you can make',
+      type: 'Text',
+      group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
+    },
+    devices: {
+      displayName: 'Devices',
+      type: 'Array',
+      group: 'content',
+      validations: {
+        bindingSourceType: ['entry'],
+      },
+    },
+    browsers: {
+      displayName: 'Browsers',
+      type: 'Array',
+      group: 'content',
+      validations: {
+        bindingSourceType: ['entry'],
+      },
+    },
+    accessibility: {
+      displayName: 'Accessibility',
+      type: 'Array',
+      group: 'content',
+      validations: {
+        bindingSourceType: ['entry'],
+      },
+    },
+    languages: {
+      displayName: 'Languages supported',
+      type: 'Array',
+      group: 'content',
+      validations: {
+        bindingSourceType: ['entry'],
+      },
+    },
+  },
+};

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshotContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/LabSnapshotContentfulDefinition.ts
@@ -16,6 +16,14 @@ export const LabSnapshotContentfulComponentDefinition: ComponentDefinition = {
   // Adding an empty array here so no default style options show in the Design tab.
   builtInStyles: [],
   variables: {
+    label: {
+      displayName: 'Aria Label',
+      type: 'Text',
+      group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
+    },
     ages: {
       displayName: 'Ages',
       type: 'Array',

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
@@ -1,0 +1,50 @@
+import {render, screen, within} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import LabSnapshot, {
+  LabSnapshotProps,
+} from '@/components/snapshots/labSnapshot/LabSnapshot';
+
+describe('LabSnapshot component', () => {
+  const title = 'Lab Snapshot';
+
+  const renderSnapshot = (props: Partial<LabSnapshotProps> = {}) => {
+    render(<LabSnapshot {...props} title={title} />);
+  };
+
+  it('renders empty list placeholder', () => {
+    renderSnapshot();
+
+    const placeholder = screen.getByText(
+      (_, node) =>
+        node?.tagName === 'EM' &&
+        !!node?.textContent?.includes('Lab Snapshot placeholder'),
+    );
+
+    expect(placeholder).toBeVisible();
+  });
+
+  it('renders lab details in the correct order', () => {
+    renderSnapshot({
+      ages: ['1', '1st'],
+      level: ['2', '2nd'],
+      creation: '3, 3rd',
+      devices: ['4', '4th'],
+      browsers: ['5', '5th'],
+      accessibility: ['6', '6th'],
+      languages: ['7', '7th'],
+    });
+
+    const labSnapshot = screen.getByTitle(title);
+    expect(labSnapshot).toBeVisible();
+
+    const labDetails = within(labSnapshot).getAllByRole('listitem');
+    expect(labDetails[0]).toHaveTextContent('Ages: 1, 1st');
+    expect(labDetails[1]).toHaveTextContent('Level: 2, 2nd');
+    expect(labDetails[2]).toHaveTextContent('What you can make: 3, 3rd');
+    expect(labDetails[3]).toHaveTextContent('Devices: 4, 4th');
+    expect(labDetails[4]).toHaveTextContent('Browsers: 5, 5th');
+    expect(labDetails[5]).toHaveTextContent('Accessibility: 6, 6th');
+    expect(labDetails[6]).toHaveTextContent('Languages supported: 7, 7th');
+  });
+});

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
@@ -6,11 +6,13 @@ import LabSnapshot, {
 } from '@/components/snapshots/labSnapshot/LabSnapshot';
 
 describe('LabSnapshot component', () => {
-  const title = 'Lab Snapshot';
+  const label = 'Lab Snapshot';
 
   const renderSnapshot = (props: Partial<LabSnapshotProps> = {}) => {
-    render(<LabSnapshot {...props} title={title} />);
+    render(<LabSnapshot {...props} label={label} />);
   };
+
+  const getSnaphot = () => screen.getByLabelText(label);
 
   it('renders empty list placeholder', () => {
     renderSnapshot();
@@ -35,7 +37,7 @@ describe('LabSnapshot component', () => {
       languages: ['7', '7th'],
     });
 
-    const labSnapshot = screen.getByTitle(title);
+    const labSnapshot = getSnaphot();
 
     expect(labSnapshot).toBeVisible();
     expect(labSnapshot).toHaveTextContent(
@@ -51,7 +53,7 @@ describe('LabSnapshot component', () => {
       creation: '',
     });
 
-    const labSnapshot = screen.getByTitle(title);
+    const labSnapshot = getSnaphot();
 
     expect(labSnapshot).toBeVisible();
     expect(labSnapshot).toHaveTextContent('Ages: 1');

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, within} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import LabSnapshot, {
@@ -36,15 +36,29 @@ describe('LabSnapshot component', () => {
     });
 
     const labSnapshot = screen.getByTitle(title);
-    expect(labSnapshot).toBeVisible();
 
-    const labDetails = within(labSnapshot).getAllByRole('listitem');
-    expect(labDetails[0]).toHaveTextContent('Ages: 1, 1st');
-    expect(labDetails[1]).toHaveTextContent('Level: 2, 2nd');
-    expect(labDetails[2]).toHaveTextContent('What you can make: 3, 3rd');
-    expect(labDetails[3]).toHaveTextContent('Devices: 4, 4th');
-    expect(labDetails[4]).toHaveTextContent('Browsers: 5, 5th');
-    expect(labDetails[5]).toHaveTextContent('Accessibility: 6, 6th');
-    expect(labDetails[6]).toHaveTextContent('Languages supported: 7, 7th');
+    expect(labSnapshot).toBeVisible();
+    expect(labSnapshot).toHaveTextContent(
+      'Ages: 1, 1st' +
+        'Level: 2, 2nd' +
+        'What you can make: 3, 3rd' +
+        'Devices: 4, 4th' +
+        'Browsers: 5, 5th' +
+        'Accessibility: 6, 6th' +
+        'Languages supported: 7, 7th',
+    );
+  });
+
+  it('renders only non-empty details', () => {
+    renderSnapshot({
+      ages: ['1'],
+      level: [],
+      creation: '',
+    });
+
+    const labSnapshot = screen.getByTitle(title);
+
+    expect(labSnapshot).toBeVisible();
+    expect(labSnapshot).toHaveTextContent('Ages: 1');
   });
 });

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
@@ -26,12 +26,12 @@ describe('LabSnapshot component', () => {
 
   it('renders lab details in the correct order', () => {
     renderSnapshot({
-      ages: ['1', '1st'],
-      level: ['2', '2nd'],
-      creation: '3, 3rd',
-      devices: ['4', '4th'],
-      browsers: ['5', '5th'],
-      accessibility: ['6', '6th'],
+      ages: ['1', '1st; '],
+      level: ['2', '2nd; '],
+      creation: '3, 3rd; ',
+      devices: ['4', '4th; '],
+      browsers: ['5', '5th; '],
+      accessibility: ['6', '6th; '],
       languages: ['7', '7th'],
     });
 
@@ -39,13 +39,8 @@ describe('LabSnapshot component', () => {
 
     expect(labSnapshot).toBeVisible();
     expect(labSnapshot).toHaveTextContent(
-      'Ages: 1, 1st' +
-        'Level: 2, 2nd' +
-        'What you can make: 3, 3rd' +
-        'Devices: 4, 4th' +
-        'Browsers: 5, 5th' +
-        'Accessibility: 6, 6th' +
-        'Languages supported: 7, 7th',
+      'Ages: 1, 1st; Level: 2, 2nd; What you can make: 3, 3rd; Devices: 4, 4th; ' +
+        'Browsers: 5, 5th; Accessibility: 6, 6th; Languages supported: 7, 7th',
     );
   });
 

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/__tests__/LabSnapshot.test.tsx
@@ -12,7 +12,7 @@ describe('LabSnapshot component', () => {
     render(<LabSnapshot {...props} label={label} />);
   };
 
-  const getSnaphot = () => screen.getByLabelText(label);
+  const getSnapshot = () => screen.getByLabelText(label);
 
   it('renders empty list placeholder', () => {
     renderSnapshot();
@@ -37,7 +37,7 @@ describe('LabSnapshot component', () => {
       languages: ['7', '7th'],
     });
 
-    const labSnapshot = getSnaphot();
+    const labSnapshot = getSnapshot();
 
     expect(labSnapshot).toBeVisible();
     expect(labSnapshot).toHaveTextContent(
@@ -53,7 +53,7 @@ describe('LabSnapshot component', () => {
       creation: '',
     });
 
-    const labSnapshot = getSnaphot();
+    const labSnapshot = getSnapshot();
 
     expect(labSnapshot).toBeVisible();
     expect(labSnapshot).toHaveTextContent('Ages: 1');

--- a/frontend/apps/marketing/src/components/snapshots/labSnapshot/index.ts
+++ b/frontend/apps/marketing/src/components/snapshots/labSnapshot/index.ts
@@ -1,0 +1,3 @@
+// Export the Component Definition for use in Contentful Studio
+export {LabSnapshotContentfulComponentDefinition} from './LabSnapshotContentfulDefinition';
+export {default} from './LabSnapshot';

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -48,6 +48,9 @@ import SimpleList, {
 import CurriculumSnapshot, {
   CurriculumSnapshotContentfulComponentDefinition,
 } from '@/components/snapshots/curriculumSnapshot';
+import LabSnapshot, {
+  LabSnapshotContentfulComponentDefinition,
+} from '@/components/snapshots/labSnapshot';
 import TabGroup, {
   TabGroupContentfulComponentDefinition,
 } from '@/components/tabGroup';
@@ -107,6 +110,10 @@ defineComponents(
     {
       component: Image,
       definition: ImageContentfulComponentDefinition,
+    },
+    {
+      component: LabSnapshot,
+      definition: LabSnapshotContentfulComponentDefinition,
     },
     {
       component: Link,


### PR DESCRIPTION
## Component
<img alt="component" src="https://github.com/user-attachments/assets/87cc3548-6664-4953-b10f-5585fef0df0b" />

## Preview
<img alt="preview" src="https://github.com/user-attachments/assets/43c2c3d4-d6da-4fef-b088-44acf6e31d6a" />

## Empty list
<img alt="empty-list" src="https://github.com/user-attachments/assets/4666d6b2-333e-49f0-b8e1-b34b9337875a" />

## Links
- JIRA task: [CMS-495](https://codedotorg.atlassian.net/browse/CMS-495)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/64877