### PR TITLE
Mini App Preview: fix button spacing

### DIFF
--- a/apps/src/codebridge/MiniAppPreview/mini-app-preview.module.scss
+++ b/apps/src/codebridge/MiniAppPreview/mini-app-preview.module.scss
@@ -6,6 +6,10 @@
 .previewHeader {
   height: 40px;
   min-height: 40px;
+
+  & > div {
+    height: 40px;
+  }
 }
 
 .miniAppContainer {


### PR DESCRIPTION
I noticed the run button wasn't centered in the header like it is when there is only a console. This applies the appropriate css to fix it.

## Before
It looks the same in horizontal and vertical
![Screenshot 2025-04-03 at 10 19 38 AM](https://github.com/user-attachments/assets/98ad7f7e-88e6-458b-af15-35e39370834c)

## After
<img width="403" alt="Screenshot 2025-04-03 at 10 19 47 AM" src="https://github.com/user-attachments/assets/1b5d8d4e-e1e1-4df2-aa03-3f9cf6383d1c" />


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
