### PR TITLE
Allow URLs in AI differentiation chat messages

### DIFF
--- a/dashboard/app/controllers/ai_diff_controller.rb
+++ b/dashboard/app/controllers/ai_diff_controller.rb
@@ -68,7 +68,7 @@ class AiDiffController < ApplicationController
   # Certain types of PII detected by Amazon Comprehend are actually allowed
   # for use in chat messages. We allow teachers to ask about lessons themed
   # on a favorite named celebrity, or how to help students at certain ages. etc.
-  ALLOWED_TYPES = %w[NAME AGE DATE_TIME USERNAME PIN].freeze
+  ALLOWED_TYPES = %w[NAME AGE DATE_TIME USERNAME PIN URL].freeze
 
   private def contains_pii?
     client =  if (Rails.application.config.respond_to?(:stub_aichat_external_services) && Rails.application.config.stub_aichat_external_services) || [:development, :test].include?(rack_env)


### PR DESCRIPTION
This change stops the PII filter from blocking messages that AWS Comprehend thinks contain URLs.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
