### PR TITLE
Deflake Section Management UI Step

### DIFF
--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -292,7 +292,7 @@ Then /^the href of selector "([^"]*)" contains the section id$/ do |selector|
   href = nil
   wait_until do
     href = @browser.execute_script("return $(\"#{selector}\").attr('href');")
-    href != nil?
+    !href.nil?
   end
   expect(@section_id).to be > 0
 


### PR DESCRIPTION
One of the UI test steps we use for a few different tests (most significantly, [`teacher_homepage.feature`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature)) has a subtle bug which is causing some flakiness.

Specifically, it is attempting to use the `wait_until` helper to grab a `href` value from an asyncronously-populated UI element, but the check its using will always return true, so we will always immediately proceed with the rest of the test. This does not, however, result in a consistent failure; we have other scenarios within that UI test which will also load the relevant data and which [are already using a bug-free step](https://github.com/code-dot-org/code-dot-org/blob/0ee07a79125036a45de281affd4455c985387b88/dashboard/test/ui/features/step_definitions/section_management_steps.rb#L273) to check their own correctness. If any of those scenarios run before the scenario using this step, [this step will work fine](https://cucumber-logs.s3.amazonaws.com/circle/28247/Chrome_teacher_tools_teacher_homepage_output.html?versionId=W69x_QIv9D1_HL2_B_FcmMb1EV3Eace.#scenario_7). Otherwise, [it will fail](https://cucumber-logs.s3.amazonaws.com/circle/28036/Chrome_teacher_tools_teacher_homepage_output.html?versionId=squ0Qr6sp1xIrWEtB99GABiImDA3YXHD#scenario_1)

The simple fix is to use the same check for both steps.

## Testing story

Tested extensively locally and [in this draft PR](https://github.com/code-dot-org/code-dot-org/pull/64991). Relying on Drone to test the correctness of my fix, and relying on the repeated reruns and increased overall flakiness of [this WIP PR](https://github.com/code-dot-org/code-dot-org/pull/64432) to confirm that it improves test stability.

## Links

- https://github.com/code-dot-org/code-dot-org/pull/60708