### PR TITLE
feat(ActionBlock): use Image component in ActionBlock and FullWidthActionBlock

### DIFF
--- a/frontend/apps/marketing/src/components/actionBlocks/defaultActionBlock/ActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/actionBlocks/defaultActionBlock/ActionBlock.tsx
@@ -1,34 +1,18 @@
-import {BaseEntry, EntryFields} from 'contentful';
+import {EntryFields} from 'contentful';
 
 import DSCOActionBlock, {
   ActionBlockProps,
 } from '@code-dot-org/component-library/actionBlock';
 
+import {ImageAssetEntry, LinkEntry} from '@/contentful/types/entries';
+
 export type ActionBlockContentfulProps = ActionBlockProps & {
   overline: EntryFields.Text;
   title: EntryFields.Text;
   description: EntryFields.Text;
-  image: BaseEntry & {
-    fields: {
-      description?: EntryFields.Text;
-      title?: EntryFields.Text;
-      file: {url: EntryFields.Text};
-    };
-  };
-  primaryButton: BaseEntry & {
-    fields: {
-      label: EntryFields.Text;
-      primaryTarget: EntryFields.Text;
-      ariaLabel: EntryFields.Text;
-    };
-  };
-  secondaryButton: BaseEntry & {
-    fields: {
-      label: EntryFields.Text;
-      primaryTarget: EntryFields.Text;
-      ariaLabel: EntryFields.Text;
-    };
-  };
+  image: ImageAssetEntry;
+  primaryButton: LinkEntry;
+  secondaryButton: LinkEntry;
   background: EntryFields.Text;
 };
 
@@ -45,7 +29,7 @@ const ActionBlock: React.FC<ActionBlockContentfulProps> = ({
     overline={overline}
     title={title}
     description={description}
-    image={image}
+    image={{src: `https:${image}`}}
     primaryButton={
       primaryButton?.fields?.label
         ? {

--- a/frontend/apps/marketing/src/components/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
@@ -1,34 +1,18 @@
-import {BaseEntry, EntryFields} from 'contentful';
+import {EntryFields} from 'contentful';
 
 import DSCOFullWidthActionBlock, {
   ActionBlockProps,
 } from '@code-dot-org/component-library/actionBlock/fullWidthActionBlock';
 
+import {ImageAssetEntry, LinkEntry} from '@/contentful/types/entries';
+
 export type FullWidthActionBlockContentfulProps = ActionBlockProps & {
-  image: BaseEntry & {
-    fields: {
-      description?: EntryFields.Text;
-      title?: EntryFields.Text;
-      file: {url: EntryFields.Text};
-    };
-  };
+  image: ImageAssetEntry;
   overline: EntryFields.Text;
   title: EntryFields.Text;
   description: EntryFields.Text;
-  primaryButton: BaseEntry & {
-    fields: {
-      label: EntryFields.Text;
-      primaryTarget: EntryFields.Text;
-      ariaLabel: EntryFields.Text;
-    };
-  };
-  secondaryButton: BaseEntry & {
-    fields: {
-      label: EntryFields.Text;
-      primaryTarget: EntryFields.Text;
-      ariaLabel: EntryFields.Text;
-    };
-  };
+  primaryButton: LinkEntry;
+  secondaryButton: LinkEntry;
   background: EntryFields.Text;
 };
 
@@ -42,7 +26,7 @@ const FullWidthActionBlock: React.FC<FullWidthActionBlockContentfulProps> = ({
   background,
 }) => (
   <DSCOFullWidthActionBlock
-    image={image}
+    image={{src: `https:${image}`}}
     overline={overline}
     title={title}
     description={description}

--- a/frontend/apps/marketing/src/components/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
+++ b/frontend/apps/marketing/src/components/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
@@ -74,11 +74,12 @@ const ActionBlockCarousel: React.FC<ActionBlockCarouselProps> = ({
               }
               title={title}
               description={shortDescription}
-              image={image?.fields?.file?.url}
+              image={{src: `https:${image?.fields?.file?.url}`}}
               primaryButton={
                 primaryLinkRef?.fields?.label
                   ? {
                       text: primaryLinkRef.fields.label,
+
                       href: primaryLinkRef.fields.primaryTarget || '#',
                       ariaLabel: primaryLinkRef.fields.ariaLabel || '',
                     }

--- a/frontend/apps/marketing/src/components/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
+++ b/frontend/apps/marketing/src/components/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
@@ -79,7 +79,6 @@ const ActionBlockCarousel: React.FC<ActionBlockCarouselProps> = ({
                 primaryLinkRef?.fields?.label
                   ? {
                       text: primaryLinkRef.fields.label,
-
                       href: primaryLinkRef.fields.primaryTarget || '#',
                       ariaLabel: primaryLinkRef.fields.ariaLabel || '',
                     }

--- a/frontend/packages/component-library/src/actionBlock/ActionBlock.tsx
+++ b/frontend/packages/component-library/src/actionBlock/ActionBlock.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 
 import {LinkButton, LinkButtonProps} from '@/button';
+import Image, {ImageProps} from '@/image';
 import {
   Heading3,
   BodyThreeText,
@@ -12,13 +13,9 @@ import {ActionBlockProps} from './types';
 
 import moduleStyles from './actionBlock.module.scss';
 
-export const getImage = (image?: string) => {
+export const getImage = (image?: ImageProps) => {
   if (!image) return null;
-  return (
-    <figure>
-      <img src={image} alt="" loading={'lazy'} />
-    </figure>
-  );
+  return <Image src={image.src} loading="lazy" alt="" />;
 };
 
 export const getDetail = (details?: {label: string; description: string}) => {

--- a/frontend/packages/component-library/src/actionBlock/__tests__/ActionBlock.test.tsx
+++ b/frontend/packages/component-library/src/actionBlock/__tests__/ActionBlock.test.tsx
@@ -35,7 +35,9 @@ describe('ActionBlock', () => {
   });
 
   it('renders an image', () => {
-    render(<ActionBlock {...defaultProps} image="image.png" />);
+    render(
+      <ActionBlock {...defaultProps} image={{src: 'image.png', alt: ''}} />,
+    );
 
     expect(screen.getByAltText('')).toHaveAttribute('src', 'image.png');
   });

--- a/frontend/packages/component-library/src/actionBlock/actionBlock.module.scss
+++ b/frontend/packages/component-library/src/actionBlock/actionBlock.module.scss
@@ -11,21 +11,11 @@ $mobileBreakpoint: 900px;
   width: 100%;
 
   figure {
-    position: relative;
     width: 100%;
-    aspect-ratio: 16 / 9;
-    overflow: hidden;
+    height: unset;
+    aspect-ratio: 7 / 4;
     margin: 0 0 1rem 0;
-
-    & > img {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
+    border-radius: 0;
   }
 
   .overline {

--- a/frontend/packages/component-library/src/actionBlock/fullWidthActionBlock/FullWidthActionBlock.tsx
+++ b/frontend/packages/component-library/src/actionBlock/fullWidthActionBlock/FullWidthActionBlock.tsx
@@ -12,8 +12,20 @@ import {ActionBlockProps} from '../types';
 
 import moduleStyles from '../actionBlock.module.scss';
 
-// This component is used to render a full-width action block that's designed to be
-// used in a layout where the action block takes up the full width of its container.
+/**
+ * ### Production-ready Checklist:
+ * * (✔) implementation of component approved by design team;
+ * * (✔) has storybook, covered with stories and documentation;
+ * * (✔) has tests: test every prop, every state and every interaction that's js related;
+ * * (see ./__tests__/FullWidthActionBlock.test.tsx)
+ * * (✔) passes accessibility checks;
+ *
+ * ###  Status: ```Ready for dev```
+ *
+ * Design System: Full Width Action Block Component.
+ * This component is used to render a full-width action block that's designed to be
+ * used in a layout where the action block takes up the full width of its container.
+ */
 export const FullWidthActionBlock: React.FC<ActionBlockProps> = ({
   title,
   description,

--- a/frontend/packages/component-library/src/actionBlock/fullWidthActionBlock/__tests__/FullWidthActionBlock.test.tsx
+++ b/frontend/packages/component-library/src/actionBlock/fullWidthActionBlock/__tests__/FullWidthActionBlock.test.tsx
@@ -37,7 +37,12 @@ describe('FullWidthActionBlock', () => {
   });
 
   it('renders an image', () => {
-    render(<FullWidthActionBlock {...defaultProps} image="image.png" />);
+    render(
+      <FullWidthActionBlock
+        {...defaultProps}
+        image={{src: 'image.png', alt: ''}}
+      />,
+    );
 
     expect(screen.getByAltText('')).toHaveAttribute('src', 'image.png');
   });

--- a/frontend/packages/component-library/src/actionBlock/fullWidthActionBlock/stories/FullWidthActionBlock.story.tsx
+++ b/frontend/packages/component-library/src/actionBlock/fullWidthActionBlock/stories/FullWidthActionBlock.story.tsx
@@ -29,7 +29,7 @@ const DESCRIPTION =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eget risus vitae massa semper aliquam quis mattis quam.';
 
 const defaultArgs: ActionBlockProps = {
-  image: image,
+  image: {src: image},
   title: 'Action block title',
   description: DESCRIPTION,
   overline: 'Overline Text',

--- a/frontend/packages/component-library/src/actionBlock/stories/ActionBlock.story.tsx
+++ b/frontend/packages/component-library/src/actionBlock/stories/ActionBlock.story.tsx
@@ -37,7 +37,7 @@ const DESCRIPTION_LONG =
 const defaultArgs: ActionBlockProps = {
   title: 'Action block title',
   description: DESCRIPTION,
-  image: image1,
+  image: {src: image1},
   overline: 'Overline Text',
   background: 'primary',
   primaryButton: {
@@ -69,7 +69,7 @@ export const DefaultActionBlocks: Story = {
         }}
       >
         <ActionBlock {...args} />
-        <ActionBlock {...args} image={image2} />
+        <ActionBlock {...args} image={{src: image2}} />
       </div>
     );
   },
@@ -148,7 +148,7 @@ export const WithDetail: Story = {
         />
         <ActionBlock
           {...args}
-          image={image2}
+          image={{src: image2}}
           details={{label: 'Duration', description: '2 weeks'}}
         />
       </div>
@@ -186,7 +186,7 @@ export const WithoutSecondaryButton: Story = {
         }}
       >
         <ActionBlock {...args} />
-        <ActionBlock {...args} image={image2} />
+        <ActionBlock {...args} image={{src: image2}} />
       </div>
     );
   },
@@ -279,8 +279,16 @@ export const ThreeAcross: Story = {
         }}
       >
         <ActionBlock {...args} />
-        <ActionBlock {...args} image={image2} description={DESCRIPTION_LONG} />
-        <ActionBlock {...args} image={image3} description={DESCRIPTION_MED} />
+        <ActionBlock
+          {...args}
+          image={{src: image2}}
+          description={DESCRIPTION_LONG}
+        />
+        <ActionBlock
+          {...args}
+          image={{src: image3}}
+          description={DESCRIPTION_MED}
+        />
       </div>
     );
   },

--- a/frontend/packages/component-library/src/actionBlock/types.ts
+++ b/frontend/packages/component-library/src/actionBlock/types.ts
@@ -1,6 +1,7 @@
 import {HTMLAttributes} from 'react';
 
 import {LinkButtonProps} from '@/button';
+import {ImageProps} from '@/image';
 
 export interface ActionBlockProps extends HTMLAttributes<HTMLDivElement> {
   /** Action Block title */
@@ -8,7 +9,7 @@ export interface ActionBlockProps extends HTMLAttributes<HTMLDivElement> {
   /** Action Block description */
   description?: string;
   /** Action Block image */
-  image?: string;
+  image?: ImageProps;
   /** Action Block overline */
   overline?: string;
   /** Action Block Details */

--- a/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
+++ b/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
@@ -315,7 +315,7 @@ ActionBlockCarousel.args = {
         <ActionBlock
           title="Action Block 1"
           description={DESCRIPTION}
-          image={image1}
+          image={{src: image1}}
           overline={'Overline 1'}
           primaryButton={{
             text: 'Primary Button',
@@ -330,7 +330,7 @@ ActionBlockCarousel.args = {
         <ActionBlock
           title="Action Block 2"
           description={DESCRIPTION_MED}
-          image={image2}
+          image={{src: image2}}
           overline={'Overline 2'}
           primaryButton={{
             text: 'Primary Button',
@@ -345,7 +345,7 @@ ActionBlockCarousel.args = {
         <ActionBlock
           title="Action Block 3"
           description={DESCRIPTION}
-          image={image3}
+          image={{src: image3}}
           overline={'Overline 3'}
           primaryButton={{
             text: 'Primary Button',
@@ -360,7 +360,7 @@ ActionBlockCarousel.args = {
         <ActionBlock
           title="Action Block 4"
           description={DESCRIPTION_MED}
-          image={image4}
+          image={{src: image4}}
           overline={'Overline 4'}
           primaryButton={{
             text: 'Primary Button',
@@ -375,7 +375,7 @@ ActionBlockCarousel.args = {
         <ActionBlock
           title="Action Block 5"
           description={DESCRIPTION}
-          image={image5}
+          image={{src: image5}}
           overline={'Overline 5'}
           primaryButton={{
             text: 'Primary Button',
@@ -390,7 +390,7 @@ ActionBlockCarousel.args = {
         <ActionBlock
           title="Action Block 6"
           description={DESCRIPTION_MED}
-          image={image6}
+          image={{src: image6}}
           overline={'Overline 6'}
           primaryButton={{
             text: 'Primary Button',


### PR DESCRIPTION
Updates the `ActionBlock` and `FullWidthActionBlock` components to use the `Image` component in Storybook and Contentful.

## Links
Jira ticket: [CMS-491](https://codedotorg.atlassian.net/browse/CMS-491)

## Testing story
Tested locally in Storybook and Contentful, but should have no UI updates

----

## Storybook

https://github.com/user-attachments/assets/17294a36-cf9f-4236-9702-82f2b09e9f38



## Contentful


https://github.com/user-attachments/assets/620edc2d-aa20-4df4-b423-ed2c979f0179


