### PR TITLE
Adds a simple neighborhood pythonlab eyes test

### DIFF
--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_neighborhood.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_neighborhood.feature
@@ -1,0 +1,18 @@
+@no_mobile
+# Our minimum version of Safari does not support web workers
+@no_safari
+@eyes
+Feature: Python Lab Neighborhood eyes
+
+Background:
+  Given I am on "http://studio.code.org/s/allthethings/lessons/50/levels/10"
+  And I wait to see "#uitest-codebridge-run"
+  And I wait until "#uitest-codebridge-run" is not disabled
+
+Scenario: Can run and see output of Python program
+  And I open my eyes to test "run and see output of Neighborhood"
+  And I see no difference for "initial load"
+  And I press "uitest-codebridge-run"
+  And I wait until "#uitest-codebridge-console" contains text "[PYTHON LAB] Program completed."
+  And I see no difference for "completed run"
+  And I close my eyes


### PR DESCRIPTION
We've been making updates to pythonlab and want to make sure we have eyes coverage for neighborhood in pythonlab. This adds a fairly simple test modeled off of pythonlab_run_eyes.feature. The test hits the run button and takes a screenshot after running. 

Screenshot from the first [saucelabs run](https://app.saucelabs.com/tests/9ad7bd65116646f39682c4764fbb1cf2#72):

<img width="1435" alt="Screenshot 2025-04-03 at 5 24 03 PM" src="https://github.com/user-attachments/assets/fe351b13-1229-4234-be7d-294e272893d1" />

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1171

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
