### PR TITLE
AI Chat: use built-in CSS to resize

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -78,7 +78,7 @@ const UserMessageEditor = React.forwardRef<
           maxLength={MAX_MESSAGE_LENGTH}
         />
 
-        <div className={moduleStyles.centerSingleItemContainer}>
+        <div className={moduleStyles.bottomSingleItemContainer}>
           <Button
             aria-label={commonI18n.submit()}
             id="uitest-chat-submit"

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -1,9 +1,12 @@
-$message-editor-height: 60px;
+$min-message-editor-height: 42px;
+$max-message-editor-height: 250px;
 
 .textArea {
     width: 80%;
     box-sizing: border-box;
-    resize: none;
+    resize: vertical;
+    min-height: $min-message-editor-height;
+    max-height: $max-message-editor-height;
     margin: 0;
     flex: 1;
 }
@@ -12,13 +15,12 @@ $message-editor-height: 60px;
     padding: 10px;
     display: flex;
     width: 100%;
-    height: $message-editor-height;
     box-sizing: border-box;
     gap: 5px;
 }
 
-.centerSingleItemContainer {
+.bottomSingleItemContainer {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: end;
 }


### PR DESCRIPTION
One option for resizing the chat editor woes -- allow the textbox to resize via drag, within set limits. Upside is this is dead simple -- downsides are:
- text area does not automatically grow as you add text.
- it feels a little counterintuitive (at least in it's use in AI Chat, need to check in with other folks using this component if we want to do this) that you have to drag down, but the text area then increases in size upwards.

https://github.com/user-attachments/assets/b7141875-7a40-4b0e-a433-ecbd8e82b9a1