### PR TITLE
Evaluate Student Learning: remove the line that drops the StudentWorkEvaluations table

### DIFF
--- a/dashboard/db/migrate/20250403150349_create_student_work_evaluation_summaries.rb
+++ b/dashboard/db/migrate/20250403150349_create_student_work_evaluation_summaries.rb
@@ -1,6 +1,5 @@
 class CreateStudentWorkEvaluationSummaries < ActiveRecord::Migration[6.1]
   def change
-    drop_table :student_work_evaluation_summaries
     create_table :student_work_evaluation_summaries do |t|
       t.bigint :student_work_evaluation_id, null: false
       t.bigint :student_work_evaluation_summary_id, null: false


### PR DESCRIPTION
Ya can't drop a table you never had. 🤦‍♀️ 

Shouldn't have checked in this line. Removing to unblock folks and their migrations. 