### PR TITLE
condition value not resetting when condition name changes

### DIFF
--- a/apps/src/lab2/levelEditors/validations/EditCondition.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditCondition.tsx
@@ -96,6 +96,7 @@ const EditCondition: React.FunctionComponent<EditConditionProps> = ({
         value={condition.name}
         onChange={e => {
           condition.name = e.target.value;
+          condition.value = undefined;
           if (!hasValueType) {
             condition.value = undefined;
           }
@@ -120,11 +121,10 @@ const EditCondition: React.FunctionComponent<EditConditionProps> = ({
 
               const isNumber = type === 'number';
               const isString = type === 'string';
-
               if (isNumber || (isString && !useDropdown)) {
                 return (
                   <input
-                    key={i}
+                    key={`${condition.name}-${i}`}
                     type={isNumber ? 'number' : 'text'}
                     className={
                       isNumber


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->


This PR fixes an issue where changing the condition name in the exemplar validation editor didn't reset the associated condition value. This could result in mismatched values like '1:2' being saved for a condition that only expects a single number input, causing validation to break.

### Context:
The bug was discovered while editing new validations on several levels (e.g., [76714](https://levelbuilder-studio.code.org/levels/76714)). If a user initially selected a condition with a multi-part value (like played_sounds:2) and then switched to a single-input condition, the second value (2) would persist even though it was no longer valid. This led to broken validation logic.

### Fix:
We now explicitly reset condition.value to undefined when the condition name changes, ensuring that any inputs get properly reinitialized. To force re-rendering of the inputs and avoid stale values, each input is keyed by the condition name and its index.

### Related levels that were fixed manually:

https://levelbuilder-studio.code.org/levels/76714

https://levelbuilder-studio.code.org/levels/76715

https://levelbuilder-studio.code.org/levels/76716
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
