### PR TITLE
Evaluate Student Learning: write to StudentWorkEvaluationSummary join table

### DIFF
--- a/apps/src/aiEvaluation/studentWorkEvaluationsApi.ts
+++ b/apps/src/aiEvaluation/studentWorkEvaluationsApi.ts
@@ -11,7 +11,7 @@ export async function logStudentWorkEvaluations(
   levelId: number,
   unitId: number
 ) {
-  logStudentWorkEvaluation({
+  const ule = await logStudentWorkEvaluation({
     type: 'UserLevelEvaluation',
     studentId: studentWorkSample.studentId,
     codeVersion: studentWorkSample.codeVersion,
@@ -24,19 +24,24 @@ export async function logStudentWorkEvaluations(
   });
   // For each specific skill-based evaluation, log a UserLevelSkillEvaluation
   if (parsedResponse.skillEvaluations) {
-    parsedResponse.skillEvaluations.forEach((skillEvaluation: AIResponse) => {
-      logStudentWorkEvaluation({
-        type: 'UserLevelSkillEvaluation',
-        studentId: studentWorkSample.studentId,
-        levelId: levelId,
-        unitId: unitId,
-        evaluator: 'AI',
-        evaluationCriteria: skillEvaluation.evaluationCriteria,
-        evaluation: skillEvaluation.aiEvaluation,
-        reasoning: skillEvaluation.aiReasoning,
-      });
-    });
-    // TODO: Log an EvaulationSummary associating the UserLevelSkillEvaluation with the UserLevelEvaluation
+    parsedResponse.skillEvaluations.forEach(
+      async (skillEvaluation: AIResponse) => {
+        const ulse = await logStudentWorkEvaluation({
+          type: 'UserLevelSkillEvaluation',
+          studentId: studentWorkSample.studentId,
+          levelId: levelId,
+          unitId: unitId,
+          evaluator: 'AI',
+          evaluationCriteria: skillEvaluation.evaluationCriteria,
+          evaluation: skillEvaluation.aiEvaluation,
+          reasoning: skillEvaluation.aiReasoning,
+        });
+        logStudentWorkEvaluationSummary({
+          studentWorkEvaluationId: ulse.id,
+          studentWorkEvaluationSummaryId: ule.id,
+        });
+      }
+    );
   }
 }
 
@@ -67,6 +72,35 @@ export async function logStudentWorkEvaluation(
       errorMessage:
         (error as Error).message ||
         `Failed to save StudentWorkEvaluation of type ${evaluationData.type}`,
+    });
+  }
+}
+type SummaryIds = {
+  studentWorkEvaluationId: number;
+  studentWorkEvaluationSummaryId: number;
+};
+
+export async function logStudentWorkEvaluationSummary(summaryData: SummaryIds) {
+  try {
+    const response = await fetch('/student_work_evaluation_summaries', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': await getAuthenticityToken(),
+      },
+      body: JSON.stringify(summaryData),
+    });
+    if (!response.ok) {
+      throw new Error('Failed to save StudentWorkEvaluationSummary');
+    }
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    MetricsReporter.logError({
+      event: MetricEvent.STUDENT_WORK_EVALUATION_SAVE_FAIL,
+      errorMessage:
+        (error as Error).message ||
+        'Failed to save StudentWorkEvaluationSummary',
     });
   }
 }

--- a/apps/src/aiEvaluation/studentWorkEvaluationsApi.ts
+++ b/apps/src/aiEvaluation/studentWorkEvaluationsApi.ts
@@ -24,8 +24,8 @@ export async function logStudentWorkEvaluations(
   });
   // For each specific skill-based evaluation, log a UserLevelSkillEvaluation
   if (parsedResponse.skillEvaluations) {
-    parsedResponse.skillEvaluations.forEach(
-      async (skillEvaluation: AIResponse) => {
+    await Promise.all(
+      parsedResponse.skillEvaluations.map(async skillEvaluation => {
         const ulse = await logStudentWorkEvaluation({
           type: 'UserLevelSkillEvaluation',
           studentId: studentWorkSample.studentId,
@@ -40,7 +40,7 @@ export async function logStudentWorkEvaluations(
           studentWorkEvaluationId: ulse.id,
           studentWorkEvaluationSummaryId: ule.id,
         });
-      }
+      })
     );
   }
 }

--- a/dashboard/app/controllers/student_work_evaluation_summaries_controller.rb
+++ b/dashboard/app/controllers/student_work_evaluation_summaries_controller.rb
@@ -1,0 +1,24 @@
+require 'json'
+
+class StudentWorkEvaluationSummariesController < ApplicationController
+  include Rails.application.routes.url_helpers
+  before_action :authenticate_user!
+  load_and_authorize_resource :student_work_evaluation_summary
+
+  def create
+    @student_work_evaluation_summary = StudentWorkEvaluationSummary.new(student_work_evaluation_summary_params)
+    if @student_work_evaluation_summary.save
+      render(status: :created, json: {message: "Successfully created StudentWorkEvaluationSummary.", id: @student_work_evaluation_summary.id})
+    else
+      render(status: :not_acceptable, json: {error: @student_work_evaluation_summary.errors.full_messages})
+    end
+  end
+
+  def student_work_evaluation_summary_params
+    student_work_evaluation_summary_params = params.transform_keys(&:underscore).permit(
+      :student_work_evaluation_id,
+      :student_work_evaluation_summary_id,
+    )
+    student_work_evaluation_summary_params
+  end
+end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -96,6 +96,7 @@ class Ability
       can :create, UserLevel, user_id: user.id
       can :update, UserLevel, user_id: user.id
       can :create, StudentWorkEvaluation, user_id: user.id
+      can :create, StudentWorkEvaluationSummary
       can :create, UserLevelInteraction, user_id: user.id
       can :create, Follower, student_user_id: user.id
       can :destroy, Follower do |follower|

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -60,6 +60,8 @@ Dashboard::Application.routes.draw do
 
     resources :student_work_evaluations, only: [:create]
 
+    resources :student_work_evaluation_summaries, only: [:create]
+
     resources :user_level_interactions, only: [:create]
 
     patch '/api/v1/user_scripts/:script_id', to: 'api/v1/user_scripts#update'

--- a/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
+++ b/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
@@ -1,0 +1,6 @@
+class RenameCAPColumnsInUsers < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :cap_state, :cap_status
+    rename_column :users, :cap_state_date, :cap_status_date
+  end
+end

--- a/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
+++ b/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
@@ -1,6 +1,0 @@
-class RenameCAPColumnsInUsers < ActiveRecord::Migration[6.1]
-  def change
-    rename_column :users, :cap_state, :cap_status
-    rename_column :users, :cap_state_date, :cap_status_date
-  end
-end


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of altering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

### Links
Continuation of #65006
[Problem overview with a handy little chart ](https://docs.google.com/document/d/1pPb-LiWZuhDolIoTiKOmTFkKCDHKZOY6fB31XJPXLu4/edit?tab=t.0)of all the "types" of evaluations we'll likely need 
[FigJam with more detailed ERD](https://www.figma.com/board/S8H82OKJ3gDboYrIoQZCsu/Measures-of-Learning-ERD-brainstorms?node-id=0-1&p=f&t=V5XfUKd6IMY4xTpg-0) See ERD 2.0 Skills, Summaries & Feedback option 2 in pink 

### Summary 

This PR sets up writing to the StudentWorkEvaluationsSummary table when an AI-generated UserLevelEvaluation is created based on UserLevelSkillEvaluations.  With this data to associate UserSkillEvaluations with the "summary" UserLevelEvaluation we can identify and troubleshoot accuracy issues. 

### Follow up work 
- switch reads to StudentWorkEvaluations 