### PR TITLE
chore(uglify): increase oldgen size

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -19,7 +19,7 @@
     "clean": "grunt clean",
     "build": "DEV=1 yarn grunt build",
     "build:analyze": "ANALYZE_BUNDLE=1 DEV=1 yarn grunt build",
-    "build:dist": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=7168 grunt clean build",
+    "build:dist": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=8096 grunt clean build",
     "build:dist:debug": "NODE_ENV=production DEBUG_MINIFIED=1 yarn grunt clean build",
     "build:dist:analyze": "NODE_ENV=production ANALYZE_BUNDLE=1 yarn build:dist",
     "grunt": "NODE_OPTIONS=--max-old-space-size=4096 grunt",


### PR DESCRIPTION
This PR increases the amount of oldgen space uglify can consume to prevent node out of memory errors. Tested locally with `yarn build:dist`. Longer term, we'll need to analyze why uglify is taking so much memory as we continue to increase usage.