### PR TITLE
add ui test for unnumbered lessons

### DIFF
--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -220,7 +220,7 @@ class LessonOverview extends Component {
             inLesson={true}
           />
         )}
-        <h1>{lesson.title}</h1>
+        <h1 className="uitest-lesson-title">{lesson.title}</h1>
         <h2>{i18n.minutesLabel({number: lesson.duration})}</h2>
         <div style={styles.frontPage}>
           <div style={styles.left}>

--- a/dashboard/config/levels/custom/free_response/unnumbered-lesson-level-one.level
+++ b/dashboard/config/levels/custom/free_response/unnumbered-lesson-level-one.level
@@ -1,0 +1,24 @@
+<FreeResponse>
+  <config><![CDATA[{
+  "published": true,
+  "game_id": 52,
+  "created_at": "2025-04-04T20:36:27.000Z",
+  "level_num": "custom",
+  "user_id": 1,
+  "properties": {
+    "encrypted": "false",
+    "title": "Unnumbered Lesson Level One",
+    "stay_on_level_after_submit": "false",
+    "allow_user_uploads": "false",
+    "submittable": "false",
+    "peer_reviewable": "false",
+    "optional": "false",
+    "allow_multiple_attempts": "false",
+    "skip_dialog": true,
+    "skip_sound": true
+  },
+  "audit_log": "[{\"changed_at\":\"2025-04-04 20:36:34 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"dave@code.org\"}]",
+  "level_concept_difficulty": {
+  }
+}]]></config>
+</FreeResponse>

--- a/dashboard/config/locales/courses/en.yml
+++ b/dashboard/config/locales/courses/en.yml
@@ -5374,3 +5374,9 @@ en:
           description_student: ''
           description_teacher: ''
           version_title: ''
+        ui-test-unnumbered-lessons:
+          title: ui-test-unnumbered-lessons
+          description_short: ''
+          description_student: ''
+          description_teacher: ''
+          version_title: ''

--- a/dashboard/config/locales/scripts/en.yml
+++ b/dashboard/config/locales/scripts/en.yml
@@ -23152,3 +23152,12 @@ en:
           description_short: ''
           description: ''
           student_description: ''
+        ui-test-unnumbered-lessons:
+          lessons: {}
+          lesson_groups: {}
+          name: ui-test-unnumbered-lessons
+          title: ''
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -79,6 +79,7 @@ namespace :seed do
     ui-test-facilitator-pl-course
     ui-test-single-unit-2025
     ui-test-single-unit-2026
+    ui-test-unnumbered-lessons
   ).map {|script| "test/ui/config/scripts_json/#{script}.script_json"}.freeze
   UI_TEST_SCRIPTS = SPECIAL_UI_TEST_SCRIPTS + %w(
     20-hour

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -352,15 +352,18 @@ namespace :seed do
        sports).each do |course_name|
       UnitGroup.load_from_path("config/courses/#{course_name}.course")
     end
-    %w(ui-test-course-2017
-       ui-test-course-2019
-       ui-test-single-unit-course-2025
-       ui-test-single-unit-course-2026
-       ui-test-csa-family-script
-       ui-test-facilitator-pl-course
-       ui-test-teacher-pl-course
-       ui-test-versioned-script-2017
-       ui-test-versioned-script-2019).each do |course_name|
+    %w(
+      ui-test-course-2017
+      ui-test-course-2019
+      ui-test-single-unit-course-2025
+      ui-test-single-unit-course-2026
+      ui-test-csa-family-script
+      ui-test-facilitator-pl-course
+      ui-test-teacher-pl-course
+      ui-test-versioned-script-2017
+      ui-test-versioned-script-2019
+      ui-test-unnumbered-lessons
+    ).each do |course_name|
       UnitGroup.load_from_path("test/ui/config/courses/#{course_name}.course")
     end
   end
@@ -470,7 +473,15 @@ namespace :seed do
   end
 
   timed_task_with_logging course_offerings_ui_tests: :environment do
-    %w(ui-test-course ui-test-csa-family-script ui-test-teacher-pl-course ui-test-facilitator-pl-course ui-test-single-unit-course ui-test-versioned-course).each do |course_offering_name|
+    %w(
+      ui-test-course
+      ui-test-csa-family-script
+      ui-test-teacher-pl-course
+      ui-test-facilitator-pl-course
+      ui-test-single-unit-course
+      ui-test-versioned-course
+      ui-test-unnumbered-lessons
+    ).each do |course_offering_name|
       CourseOffering.seed_record("test/ui/config/course_offerings/#{course_offering_name}.json")
     end
   end

--- a/dashboard/test/ui/config/course_offerings/ui-test-unnumbered-lessons.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-unnumbered-lessons.json
@@ -1,0 +1,20 @@
+{
+  "key": "ui-test-unnumbered-lessons",
+  "display_name": "ui-test-unnumbered-lessons",
+  "is_featured": false,
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null,
+  "image": null,
+  "cs_topic": null,
+  "school_subject": null,
+  "device_compatibility": null,
+  "description": null,
+  "professional_learning_program": null,
+  "video": null,
+  "published_date": null,
+  "self_paced_pl_course_offering_key": null,
+  "ai_teaching_assistant_available": false
+}

--- a/dashboard/test/ui/config/courses/ui-test-unnumbered-lessons.course
+++ b/dashboard/test/ui/config/courses/ui-test-unnumbered-lessons.course
@@ -1,0 +1,21 @@
+{
+  "name": "ui-test-unnumbered-lessons",
+  "script_names": [
+    "ui-test-unnumbered-lessons"
+  ],
+  "published_state": "beta",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "ui-test-unnumbered-lessons",
+    "has_numbered_units": true,
+    "version_year": "unversioned"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-unnumbered-lessons.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-unnumbered-lessons.script_json
@@ -9,7 +9,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-04-04 19:56:26 UTC",
+    "serialized_at": "2025-04-04 20:03:33 UTC",
     "published_state": "in_development",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -32,7 +32,36 @@
     }
   ],
   "lessons": [
-
+    {
+      "key": "lesson-1",
+      "name": "Lesson One",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-unnumbered-lessons"
+      }
+    },
+    {
+      "key": "lesson-2",
+      "name": "Lesson Two",
+      "absolute_position": 2,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-unnumbered-lessons"
+      }
+    }
   ],
   "lesson_activities": [
 

--- a/dashboard/test/ui/config/scripts_json/ui-test-unnumbered-lessons.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-unnumbered-lessons.script_json
@@ -1,0 +1,88 @@
+{
+  "script": {
+    "name": "ui-test-unnumbered-lessons",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "has_unnumbered_lessons": true,
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2025-04-04 19:56:26 UTC",
+    "published_state": "in_development",
+    "instruction_type": "teacher_led",
+    "instructor_audience": "teacher",
+    "participant_audience": "student",
+    "seeding_key": {
+      "script.name": "ui-test-unnumbered-lessons"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-unnumbered-lessons"
+      }
+    }
+  ],
+  "lessons": [
+
+  ],
+  "lesson_activities": [
+
+  ],
+  "activity_sections": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-unnumbered-lessons.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-unnumbered-lessons.script_json
@@ -9,11 +9,11 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-04-04 20:03:33 UTC",
-    "published_state": "in_development",
-    "instruction_type": "teacher_led",
-    "instructor_audience": "teacher",
-    "participant_audience": "student",
+    "serialized_at": "2025-04-04 20:25:39 UTC",
+    "published_state": null,
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
     "seeding_key": {
       "script.name": "ui-test-unnumbered-lessons"
     }

--- a/dashboard/test/ui/config/scripts_json/ui-test-unnumbered-lessons.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-unnumbered-lessons.script_json
@@ -9,7 +9,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-04-04 20:25:39 UTC",
+    "serialized_at": "2025-04-04 20:37:43 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -64,16 +64,67 @@
     }
   ],
   "lesson_activities": [
-
+    {
+      "key": "d99c9b7e-3210-4322-9b43-1c746cceab76",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "d99c9b7e-3210-4322-9b43-1c746cceab76",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-unnumbered-lessons"
+      }
+    }
   ],
   "activity_sections": [
-
+    {
+      "key": "572676da-a9fa-4143-a00e-d109f950efe9",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "572676da-a9fa-4143-a00e-d109f950efe9",
+        "lesson_activity.key": "d99c9b7e-3210-4322-9b43-1c746cceab76"
+      }
+    }
   ],
   "script_levels": [
-
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "unnumbered-lesson-level-one"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-unnumbered-lessons",
+        "activity_section.key": "572676da-a9fa-4143-a00e-d109f950efe9"
+      },
+      "level_keys": [
+        "unnumbered-lesson-level-one"
+      ]
+    }
   ],
   "levels_script_levels": [
-
+    {
+      "seeding_key": {
+        "level.key": "unnumbered-lesson-level-one",
+        "script_level.level_keys": [
+          "unnumbered-lesson-level-one"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-unnumbered-lessons",
+        "activity_section.key": "572676da-a9fa-4143-a00e-d109f950efe9"
+      }
+    }
   ],
   "resources": [
 

--- a/dashboard/test/ui/features/teacher_tools/unnumbered_lessons.feature
+++ b/dashboard/test/ui/features/teacher_tools/unnumbered_lessons.feature
@@ -1,0 +1,26 @@
+Feature: Unnumbered Lessons
+
+  Scenario: Units with Unnumbered Lessons
+    Given I am a teacher
+
+    When I am on "http://studio.code.org/s/ui-test-unnumbered-lessons"
+    And I wait until element ".uitest-progress-lesson" is visible
+    Then element ".uitest-progress-lesson" contains text "Lesson One"
+    And element ".uitest-progress-lesson" does not contain text "Lesson 1"
+    And element ".uitest-progress-lesson" contains text "Lesson Two"
+    And element ".uitest-progress-lesson" does not contain text "Lesson 2"
+
+    When I am on "http://studio.code.org/s/ui-test-unnumbered-lessons/lessons/1"
+    And I wait until element ".uitest-lesson-title" is visible
+    Then element ".uitest-lesson-title" contains text "Lesson One"
+    And element ".uitest-lesson-title" does not contain text "Lesson 1"
+
+    When I am on "http://studio.code.org/s/ui-test-unnumbered-lessons/lessons/1/levels/1"
+    And I wait until element "button.header_popup_link" is visible
+    And element ".uitest-progress-lesson" is not visible
+    And I click selector "button.header_popup_link"
+    And I wait until element ".uitest-progress-lesson" is visible
+    Then element ".uitest-progress-lesson" contains text "Lesson One"
+    And element ".uitest-progress-lesson" does not contain text "Lesson 1"
+    And element ".uitest-progress-lesson" contains text "Lesson Two"
+    And element ".uitest-progress-lesson" does not contain text "Lesson 2"


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/TEACH-1106. Follows https://github.com/code-dot-org/code-dot-org/pull/65008. Adds a UI test for unnumbered lessons for 3 representative cases, including the tricky way that ProgressLesson can be rendered on either the script overview page or level page (in the MiniView dropdown).

## Testing story

Adds new UI tests

