### PR TITLE
feat(ActionBlock): add external link logic to primary and secondary button

### DIFF
--- a/frontend/apps/marketing/src/components/actionBlocks/defaultActionBlock/ActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/actionBlocks/defaultActionBlock/ActionBlock.tsx
@@ -4,6 +4,7 @@ import DSCOActionBlock, {
   ActionBlockProps,
 } from '@code-dot-org/component-library/actionBlock';
 
+import {externalLinkIconProps} from '@/components/common/constants';
 import {ImageAssetEntry, LinkEntry} from '@/contentful/types/entries';
 
 export type ActionBlockContentfulProps = ActionBlockProps & {
@@ -36,6 +37,9 @@ const ActionBlock: React.FC<ActionBlockContentfulProps> = ({
             text: primaryButton.fields.label,
             href: primaryButton.fields.primaryTarget || '#',
             ariaLabel: primaryButton.fields.ariaLabel || '',
+            iconRight: primaryButton.fields.isThisAnExternalLink
+              ? externalLinkIconProps
+              : undefined,
           }
         : undefined
     }
@@ -45,6 +49,9 @@ const ActionBlock: React.FC<ActionBlockContentfulProps> = ({
             text: secondaryButton.fields.label,
             href: secondaryButton.fields.primaryTarget || '#',
             ariaLabel: secondaryButton.fields.ariaLabel || '',
+            iconRight: secondaryButton.fields.isThisAnExternalLink
+              ? externalLinkIconProps
+              : undefined,
           }
         : undefined
     }

--- a/frontend/apps/marketing/src/components/actionBlocks/defaultActionBlock/__tests__/ActionBlock.test.tsx
+++ b/frontend/apps/marketing/src/components/actionBlocks/defaultActionBlock/__tests__/ActionBlock.test.tsx
@@ -51,4 +51,26 @@ describe('ActionBlock', () => {
     // check for secondary button
     expect(queryByText('Test Secondary Button')).not.toBeInTheDocument();
   });
+
+  it('renders external link icon for buttons when isThisAnExternalLink is true', () => {
+    const {queryAllByTestId} = render(
+      <ActionBlock
+        {...defaultProps}
+        primaryButton={{
+          fields: {
+            ...defaultProps.primaryButton.fields,
+            isThisAnExternalLink: true,
+          },
+        }}
+        secondaryButton={{
+          fields: {
+            ...defaultProps.primaryButton.fields,
+            isThisAnExternalLink: true,
+          },
+        }}
+      />,
+    );
+
+    expect(queryAllByTestId('font-awesome-v6-icon')).toHaveLength(2);
+  });
 });

--- a/frontend/apps/marketing/src/components/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
@@ -4,6 +4,7 @@ import DSCOFullWidthActionBlock, {
   ActionBlockProps,
 } from '@code-dot-org/component-library/actionBlock/fullWidthActionBlock';
 
+import {externalLinkIconProps} from '@/components/common/constants';
 import {ImageAssetEntry, LinkEntry} from '@/contentful/types/entries';
 
 export type FullWidthActionBlockContentfulProps = ActionBlockProps & {
@@ -36,6 +37,9 @@ const FullWidthActionBlock: React.FC<FullWidthActionBlockContentfulProps> = ({
             text: primaryButton.fields.label,
             href: primaryButton.fields.primaryTarget || '#',
             ariaLabel: primaryButton.fields.ariaLabel || '',
+            iconRight: primaryButton.fields.isThisAnExternalLink
+              ? externalLinkIconProps
+              : undefined,
           }
         : undefined
     }
@@ -45,6 +49,9 @@ const FullWidthActionBlock: React.FC<FullWidthActionBlockContentfulProps> = ({
             text: secondaryButton.fields.label,
             href: secondaryButton.fields.primaryTarget || '#',
             ariaLabel: secondaryButton.fields.ariaLabel || '',
+            iconRight: secondaryButton.fields.isThisAnExternalLink
+              ? externalLinkIconProps
+              : undefined,
           }
         : undefined
     }

--- a/frontend/apps/marketing/src/components/actionBlocks/fullWidthActionBlock/__tests__/FullWidthActionBlock.test.tsx
+++ b/frontend/apps/marketing/src/components/actionBlocks/fullWidthActionBlock/__tests__/FullWidthActionBlock.test.tsx
@@ -55,4 +55,26 @@ describe('ActionBlock', () => {
     // check for secondary button
     expect(queryByText('Test Secondary Button')).not.toBeInTheDocument();
   });
+
+  it('renders external link icon for buttons when isThisAnExternalLink is true', () => {
+    const {queryAllByTestId} = render(
+      <FullWidthActionBlock
+        {...defaultProps}
+        primaryButton={{
+          fields: {
+            ...defaultProps.primaryButton.fields,
+            isThisAnExternalLink: true,
+          },
+        }}
+        secondaryButton={{
+          fields: {
+            ...defaultProps.primaryButton.fields,
+            isThisAnExternalLink: true,
+          },
+        }}
+      />,
+    );
+
+    expect(queryAllByTestId('font-awesome-v6-icon')).toHaveLength(2);
+  });
 });

--- a/frontend/apps/marketing/src/components/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
+++ b/frontend/apps/marketing/src/components/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
@@ -8,6 +8,7 @@ import ActionBlock, {
 } from '@code-dot-org/component-library/actionBlock';
 import DSCOCarousel from '@code-dot-org/component-library/carousel';
 
+import {externalLinkIconProps} from '@/components/common/constants';
 import {ImageAssetEntry, LinkEntry} from '@/contentful/types/entries';
 import {ContentfulEntry} from '@/contentful/types/entries/ContentfulEntry';
 
@@ -81,6 +82,9 @@ const ActionBlockCarousel: React.FC<ActionBlockCarouselProps> = ({
                       text: primaryLinkRef.fields.label,
                       href: primaryLinkRef.fields.primaryTarget || '#',
                       ariaLabel: primaryLinkRef.fields.ariaLabel || '',
+                      iconRight: primaryLinkRef.fields.isThisAnExternalLink
+                        ? externalLinkIconProps
+                        : undefined,
                     }
                   : undefined
               }
@@ -91,6 +95,9 @@ const ActionBlockCarousel: React.FC<ActionBlockCarouselProps> = ({
                       text: secondaryLinkRef.fields.label,
                       href: secondaryLinkRef.fields.primaryTarget || '#',
                       ariaLabel: secondaryLinkRef.fields.ariaLabel || '',
+                      iconRight: secondaryLinkRef.fields.isThisAnExternalLink
+                        ? externalLinkIconProps
+                        : undefined,
                     }
                   : undefined
               }


### PR DESCRIPTION
Adds logic to show the external link icon on the `ActionBlock`, `FullWidthActionBlock`, and `ActionBlockCarousel` components.

## Links
Jira ticket: [CMS-507](https://codedotorg.atlassian.net/browse/CMS-507)

## Testing story
Added unit tests for `ActionBlock` and `FullWidthActionBlock` and tested locally in Contentful. `ActionBlockCarousel` doesn't have unit tests so I will add one with secondary buttons on /all-the-things so we can test for Eyes diffs.

----


https://github.com/user-attachments/assets/c50620b5-481c-43cc-9600-998aa9716b82

