### PR TITLE
SUM - add feedback toggle + styling

### DIFF
--- a/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
@@ -12,6 +12,8 @@ import FreeResponseAiStudentResponseHeader from './FreeResponseAiStudentResponse
 import FreeResponseAiSummaryBox from './FreeResponseAiSummaryBox';
 import FreeResponseStudentResponseRow from './FreeResponseStudentResponseRow';
 
+import styles from './summary.module.scss';
+
 interface LevelData {
   levelId: number;
   unitId: number;
@@ -100,7 +102,7 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
         openDetailedAnalysis={() => setShowDetailedAnalysis(true)}
       />
       {evaluationComplete && aiSummary && showDetailedAnalysis && (
-        <div>
+        <div className={styles.detailedAnalysisContainer}>
           <FreeResponseAiStudentResponseHeader
             closeStudentResponses={() => setShowDetailedAnalysis(false)}
           />

--- a/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
@@ -102,7 +102,7 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
       {evaluationComplete && aiSummary && showDetailedAnalysis && (
         <div>
           <FreeResponseAiStudentResponseHeader
-            closeStudentResponses={() => {}}
+            closeStudentResponses={() => setShowDetailedAnalysis(false)}
           />
           {evaluations.map(evaluation => (
             <FreeResponseStudentResponseRow

--- a/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
@@ -1,7 +1,10 @@
 import Button from '@code-dot-org/component-library/button';
 import Link from '@code-dot-org/component-library/link';
 import Tags from '@code-dot-org/component-library/tags';
-import {BodyTwoText} from '@code-dot-org/component-library/typography';
+import {
+  BodyTwoText,
+  BodyThreeText,
+} from '@code-dot-org/component-library/typography';
 import React from 'react';
 
 import {StudentWorkEvaluation} from '@cdo/apps/aiEvaluation/aiEvaluationApi';
@@ -9,6 +12,7 @@ import i18n from '@cdo/locale';
 
 import aiBot from './AI-Bot-default.png';
 import {FEEDBACK_TYPE} from './AiFeedbackType';
+import FeedbackToggle from './FeedbackToggle';
 import FreeResponseSummaryDataBox from './FreeResponseSummaryDataBox';
 
 import styles from './summary.module.scss';
@@ -112,7 +116,20 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
   const aiSummaryContent = () => {
     return (
       <>
-        {aiSummaryTag(proficientStudentCount)}
+        <div className={styles.summaryBoxHeader}>
+          {aiSummaryTag(proficientStudentCount)}
+          <div>
+            <BodyThreeText className={styles.feedbackText}>
+              {i18n.aiFeedbackQuestion()}
+              <FeedbackToggle
+                onThumbsUpClick={() => {}}
+                onThumbsDownClick={() => {}}
+                size="m"
+                color="gray"
+              />
+            </BodyThreeText>
+          </div>
+        </div>
         {aiSummaryMessage(proficientStudentCount)}
         <FreeResponseSummaryDataBox
           totalStudentCount={totalNumberOfStudents}

--- a/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
@@ -107,8 +107,12 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
   const flaggedStudentCount = studentWorkEvaluations
     ? countEvaluationsByType(studentWorkEvaluations, ['Cant Evaluate'])
     : 0;
+
+  // A student can have "no response" if they have not started the level yet OR
+  // if they have submitted a response but it is empty.
   const noResponseStudentCount = studentWorkEvaluations
-    ? countEvaluationsByType(studentWorkEvaluations, ['No attempt'])
+    ? countEvaluationsByType(studentWorkEvaluations, ['No attempt']) +
+      (totalNumberOfStudents - studentWorkEvaluations.length)
     : 0;
 
   const showEvaluationSummary = studentWorkEvaluations && evaluationComplete;
@@ -118,16 +122,16 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
       <>
         <div className={styles.summaryBoxHeader}>
           {aiSummaryTag(proficientStudentCount)}
-          <div>
+          <div className={styles.feedbackQuestion}>
             <BodyThreeText className={styles.feedbackText}>
               {i18n.aiFeedbackQuestion()}
-              <FeedbackToggle
-                onThumbsUpClick={() => {}}
-                onThumbsDownClick={() => {}}
-                size="m"
-                color="gray"
-              />
             </BodyThreeText>
+            <FeedbackToggle
+              onThumbsUpClick={() => {}}
+              onThumbsDownClick={() => {}}
+              size="xs"
+              color="gray"
+            />
           </div>
         </div>
         {aiSummaryMessage(proficientStudentCount)}

--- a/apps/src/templates/levelSummary/feedback-toggle.module.scss
+++ b/apps/src/templates/levelSummary/feedback-toggle.module.scss
@@ -5,6 +5,14 @@
   align-items: center;
   gap: 6px;
   align-self: stretch;
+
+  button {
+    background-color: transparent !important;
+
+    &:hover {
+      background: var(--background-neutral-quaternary, #e4e6e9) !important;
+    }
+  }
 }
 
 .blackIcon i {

--- a/apps/src/templates/levelSummary/summary.module.scss
+++ b/apps/src/templates/levelSummary/summary.module.scss
@@ -439,18 +439,6 @@ svg text[fill] {
   border-left: 1px solid var(--borders-neutral-primary, #d1d4d8);
 }
 
-.closeButton {
-  background: transparent !important;
-
-  &:hover {
-    background: var(--background-neutral-quaternary, #e4e6e9) !important;
-  }
-
-  i {
-    font-size: 16px !important;
-  }
-}
-
 .evaluateButton {
   padding-left: 8px !important;
   padding-right: 8px !important;
@@ -458,4 +446,15 @@ svg text[fill] {
 
 .viewAnalysisLink {
   color: var(--text-neutral-primary) !important;
+}
+
+.summaryBoxHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+}
+
+.feedbackText {
+  color: var(--text-neutral-quaternary, #727a83) !important;
 }

--- a/apps/src/templates/levelSummary/summary.module.scss
+++ b/apps/src/templates/levelSummary/summary.module.scss
@@ -298,6 +298,11 @@ svg text[fill] {
   margin-bottom: 0 !important;
 }
 
+.detailedAnalysisContainer {
+  border-radius: 4px;
+  border: 1px solid var(--borders-neutral-primary);
+}
+
 .aiSummaryContainer {
   display: flex;
   padding: 16px;
@@ -306,6 +311,8 @@ svg text[fill] {
   gap: 40px;
   width: 100%;
   box-sizing: border-box;
+  margin-bottom: 20px;
+  border-radius: 4px;
 
   .leftSide {
     width: 200px;
@@ -319,6 +326,12 @@ svg text[fill] {
     display: flex;
     flex-direction: column;
     gap: 16px;
+  }
+
+  .feedbackQuestion {
+    display: flex;
+    align-items: center;
+    gap: 4px;
   }
 
   .botImage {
@@ -457,4 +470,5 @@ svg text[fill] {
 
 .feedbackText {
   color: var(--text-neutral-quaternary, #727a83) !important;
+  margin-bottom: 0 !important;
 }


### PR DESCRIPTION
This is smattering of clean-up items:

- Removes zombie styling for a "close button"
- Adds a feedback component for the summary
- Enables closing of the student AI summaries
- Fixes some style issues
- Fixes the incorrect count of "no attempt" in summary box

<img width="800" alt="image" src="https://github.com/user-attachments/assets/72ab36ab-694c-4956-98a4-88cc810761d9" />

UP NEXT: Fix "Flagged" not working...

## Links

[Figma](https://www.figma.com/design/i3smpK0bu5Tnc1JgmmMfTI/Check-For-Understanding-Summaries?node-id=2855-5224&m=dev)

## Testing story

Tested locally so far...