### PR TITLE
Ceara/aitt 976 open diff chat on first load

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -1,14 +1,17 @@
 import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 
-import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
+import {
+  tryGetSessionStorage,
+  trySetSessionStorage,
+  tryGetLocalStorage,
+  trySetLocalStorage,
+} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import aiFabWithIcon from '@cdo/static/ai-bot-ta.png';
 
 import {EVENTS, PLATFORMS} from '../metrics/AnalyticsConstants';
 import analyticsReporter from '../metrics/AnalyticsReporter';
-import HttpClient from '../util/HttpClient';
-import {useAppSelector} from '../util/reduxHooks';
 
 import AiDiffContainer from './AiDiffContainer';
 
@@ -18,8 +21,6 @@ import style from './ai-differentiation.module.scss';
  * Renders an AI Bot icon button in the bottom left corner over other UI elements that controls
  * toggling an AI element open and closed.
  */
-
-const HAS_OPENED_DIFF_URL = '/api/v1/users/has_opened_ai_differentiation';
 
 interface AiDiffFloatingActionButtonProps {
   context: string;
@@ -35,11 +36,11 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
   unitDisplayName,
 }) => {
   const sessionStorageKey = 'AiDiffFabOpenStateKey';
+  const localStorageKey = 'AiDiffHasOpenedKey';
 
   // Show the pulse until the user clicks the FAB to open the chat window
-  const hasOpened = useAppSelector(
-    state => state.currentUser.hasOpenedAiDifferentiation
-  );
+  const hasOpened =
+    JSON.parse(tryGetLocalStorage(localStorageKey, false.toString())) || false;
 
   // Open the chat window if this is the first time the user has seen the FAB in this
   // session and they haven't opened the FAB yet.
@@ -72,7 +73,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
       : EVENTS.AI_DIFF_CHAT_OPENED;
     analyticsReporter.sendEvent(eventName, eventData, PLATFORMS.STATSIG);
     if (eventName === EVENTS.AI_DIFF_CHAT_OPENED) {
-      updateHasOpenedDiff();
+      trySetLocalStorage(localStorageKey, true.toString());
     }
     setIsOpen(!isOpen);
   };
@@ -80,10 +81,6 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
   useEffect(() => {
     trySetSessionStorage(sessionStorageKey, isOpen);
   }, [isOpen]);
-
-  const updateHasOpenedDiff = React.useCallback(() => {
-    HttpClient.post(HAS_OPENED_DIFF_URL, undefined, true).then(() => {});
-  }, []);
 
   return (
     <div id="fab-contained">

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -7,6 +7,8 @@ import aiFabWithIcon from '@cdo/static/ai-bot-ta.png';
 
 import {EVENTS, PLATFORMS} from '../metrics/AnalyticsConstants';
 import analyticsReporter from '../metrics/AnalyticsReporter';
+import HttpClient from '../util/HttpClient';
+import {useAppSelector} from '../util/reduxHooks';
 
 import AiDiffContainer from './AiDiffContainer';
 
@@ -16,6 +18,8 @@ import style from './ai-differentiation.module.scss';
  * Renders an AI Bot icon button in the bottom left corner over other UI elements that controls
  * toggling an AI element open and closed.
  */
+
+const HAS_OPENED_DIFF_URL = '/api/v1/users/has_opened_ai_differentiation';
 
 interface AiDiffFloatingActionButtonProps {
   context: string;
@@ -31,17 +35,27 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
   unitDisplayName,
 }) => {
   const sessionStorageKey = 'AiDiffFabOpenStateKey';
-  // Show the pulse if this is the first time the user has seen the FAB in this
-  // session. Depends on other logic which sets the open state in session storage.
-  const [isFirstSession] = useState(
-    JSON.parse(tryGetSessionStorage(sessionStorageKey, null)) === null
+
+  // Show the pulse until the user clicks the FAB to open the chat window
+  const hasOpened = useAppSelector(
+    state => state.currentUser.hasOpenedAiDifferentiation
   );
+
+  // Open the chat window if this is the first time the user has seen the FAB in this
+  // session and they haven't opened the FAB yet.
+  // Depends on other logic which sets the open state in session storage.
+  const isFirstSession =
+    JSON.parse(tryGetSessionStorage(sessionStorageKey, null)) === null &&
+    !hasOpened;
+
   const [isOpen, setIsOpen] = useState(
-    JSON.parse(tryGetSessionStorage(sessionStorageKey, false)) || false
+    JSON.parse(tryGetSessionStorage(sessionStorageKey, isFirstSession)) ||
+      isFirstSession
   );
+
   const [isFabImageLoaded, setIsFabImageLoaded] = useState(false);
 
-  const showPulse = isFirstSession && isFabImageLoaded;
+  const showPulse = !hasOpened && isFabImageLoaded;
   const classes = showPulse
     ? classNames(style.floatingActionButton, style.pulse, 'unittest-fab-pulse')
     : style.floatingActionButton;
@@ -54,15 +68,22 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
       unitName: unitDisplayName,
     };
     const eventName = isOpen
-      ? EVENTS.TA_RUBRIC_CLOSED_FROM_FAB_EVENT
-      : EVENTS.TA_RUBRIC_OPENED_FROM_FAB_EVENT;
+      ? EVENTS.AI_DIFF_CHAT_CLOSED
+      : EVENTS.AI_DIFF_CHAT_OPENED;
     analyticsReporter.sendEvent(eventName, eventData, PLATFORMS.STATSIG);
+    if (eventName === EVENTS.AI_DIFF_CHAT_OPENED) {
+      updateHasOpenedDiff();
+    }
     setIsOpen(!isOpen);
   };
 
   useEffect(() => {
     trySetSessionStorage(sessionStorageKey, isOpen);
   }, [isOpen]);
+
+  const updateHasOpenedDiff = React.useCallback(() => {
+    HttpClient.post(HAS_OPENED_DIFF_URL, undefined, true).then(() => {});
+  }, []);
 
   return (
     <div id="fab-contained">
@@ -80,7 +101,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
         />
       </button>
       <AiDiffContainer
-        open={isOpen}
+        open={isOpen || isFirstSession}
         context={context}
         closeTutor={handleClick}
         scriptId={scriptId}

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -35,5 +35,4 @@ export interface CurrentUserState {
   isLti: boolean;
   aiDifferentiationEnabled: boolean;
   hasCompletedAiDifferentiationWelcome: boolean;
-  hasOpenedAiDifferentiation: boolean;
 }

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -35,4 +35,5 @@ export interface CurrentUserState {
   isLti: boolean;
   aiDifferentiationEnabled: boolean;
   hasCompletedAiDifferentiationWelcome: boolean;
+  hasOpenedAiDifferentiation: boolean;
 }

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -267,7 +267,6 @@ export default function currentUser(state = initialState, action) {
       created_at,
       is_verified_instructor,
       has_completed_ai_differentiation_welcome,
-      has_opened_ai_differentiation,
       educator_role,
     } = action.serverUser;
     analyticsReport.setUserProperties(
@@ -307,7 +306,6 @@ export default function currentUser(state = initialState, action) {
       hasSeenProgressTableInvite: has_seen_progress_table_v2_invitation,
       hasCompletedAiDifferentiationWelcome:
         has_completed_ai_differentiation_welcome,
-      hasOpenedAiDifferentiation: has_opened_ai_differentiation,
       childAccountComplianceState: child_account_compliance_state,
       countryCode: country_code,
       usStateCode: us_state_code,

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -267,6 +267,7 @@ export default function currentUser(state = initialState, action) {
       created_at,
       is_verified_instructor,
       has_completed_ai_differentiation_welcome,
+      has_opened_ai_differentiation,
       educator_role,
     } = action.serverUser;
     analyticsReport.setUserProperties(
@@ -306,6 +307,7 @@ export default function currentUser(state = initialState, action) {
       hasSeenProgressTableInvite: has_seen_progress_table_v2_invitation,
       hasCompletedAiDifferentiationWelcome:
         has_completed_ai_differentiation_welcome,
+      hasOpenedAiDifferentiation: has_opened_ai_differentiation,
       childAccountComplianceState: child_account_compliance_state,
       countryCode: country_code,
       usStateCode: us_state_code,

--- a/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
@@ -1,4 +1,4 @@
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import React from 'react';
 import {Provider} from 'react-redux';
 
@@ -7,7 +7,6 @@ import {getStore, registerReducers} from '@cdo/apps/redux';
 import currentUser, {
   setInitialData,
 } from '@cdo/apps/templates/currentUserRedux';
-import HttpClient from '@cdo/apps/util/HttpClient';
 import i18n from '@cdo/locale';
 
 jest.mock('@react-pdf/renderer', () => {
@@ -26,20 +25,18 @@ const DEFAULT_PROPS = {
 };
 
 describe('AIDiffFloatingActionButton', () => {
-  let fetchStub;
-
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = () => {};
     sessionStorage.clear();
-    fetchStub = jest.spyOn(HttpClient, 'post').mockResolvedValue();
+    localStorage.clear();
   });
 
   afterEach(() => {
     sessionStorage.clear();
-    jest.restoreAllMocks();
+    localStorage.clear();
   });
 
-  function renderDefault(propOverrides = {}, hasOpenedDiff = true) {
+  function renderDefault(propOverrides = {}) {
     const store = getStore();
 
     registerReducers({
@@ -50,7 +47,6 @@ describe('AIDiffFloatingActionButton', () => {
         id: 1,
         name: 'test_user',
         has_completed_ai_differentiation_welcome: true,
-        has_opened_ai_differentiation: hasOpenedDiff,
       })
     );
 
@@ -61,13 +57,14 @@ describe('AIDiffFloatingActionButton', () => {
     );
   }
 
-  it('begins closed', () => {
+  it('begins closed if has been opened before', () => {
+    localStorage.setItem('AiDiffHasOpenedKey', 'true');
     renderDefault();
     expect(screen.getByText('AI Teaching Assistant')).not.toBeVisible();
   });
 
   it('begins open if no session storage and has not been opened before', () => {
-    renderDefault({}, false);
+    renderDefault({});
     expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
   });
 
@@ -77,25 +74,19 @@ describe('AIDiffFloatingActionButton', () => {
     expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
   });
 
-  it('opens on click', async () => {
+  it('opens on click', () => {
+    localStorage.setItem('AiDiffHasOpenedKey', 'true');
     renderDefault();
     fireEvent.click(
       screen.getByRole('button', {name: i18n.openOrCloseTeachingAssistant()})
     );
-    await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
-        '/api/v1/users/has_opened_ai_differentiation',
-        undefined,
-        true
-      );
-    });
     expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
   });
 
   describe('pulse animation', () => {
     it('renders pulse animation when hasOpenedDiff is false and window is closed', () => {
       sessionStorage.setItem('AiDiffFabOpenStateKey', 'false');
-      renderDefault({}, false);
+      renderDefault({});
       const fab = screen.getByRole('button', {
         name: i18n.openOrCloseTeachingAssistant(),
       });
@@ -108,6 +99,7 @@ describe('AIDiffFloatingActionButton', () => {
 
     it('does not render pulse animation when hasOpenedDiff is true', () => {
       sessionStorage.setItem('AiDiffFabOpenStateKey', 'false');
+      localStorage.setItem('AiDiffHasOpenedKey', 'true');
       renderDefault();
       const image = screen.getByRole('img', {name: 'AI bot'});
       fireEvent.load(image);

--- a/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
@@ -1,4 +1,4 @@
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import React from 'react';
 import {Provider} from 'react-redux';
 
@@ -7,6 +7,7 @@ import {getStore, registerReducers} from '@cdo/apps/redux';
 import currentUser, {
   setInitialData,
 } from '@cdo/apps/templates/currentUserRedux';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import i18n from '@cdo/locale';
 
 jest.mock('@react-pdf/renderer', () => {
@@ -25,16 +26,20 @@ const DEFAULT_PROPS = {
 };
 
 describe('AIDiffFloatingActionButton', () => {
+  let fetchStub;
+
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = () => {};
     sessionStorage.clear();
+    fetchStub = jest.spyOn(HttpClient, 'post').mockResolvedValue();
   });
 
   afterEach(() => {
     sessionStorage.clear();
+    jest.restoreAllMocks();
   });
 
-  function renderDefault(propOverrides = {}) {
+  function renderDefault(propOverrides = {}, hasOpenedDiff = true) {
     const store = getStore();
 
     registerReducers({
@@ -45,6 +50,7 @@ describe('AIDiffFloatingActionButton', () => {
         id: 1,
         name: 'test_user',
         has_completed_ai_differentiation_welcome: true,
+        has_opened_ai_differentiation: hasOpenedDiff,
       })
     );
 
@@ -60,23 +66,36 @@ describe('AIDiffFloatingActionButton', () => {
     expect(screen.getByText('AI Teaching Assistant')).not.toBeVisible();
   });
 
+  it('begins open if no session storage and has not been opened before', () => {
+    renderDefault({}, false);
+    expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
+  });
+
   it('begins open if open set in session storage', () => {
     sessionStorage.setItem('AiDiffFabOpenStateKey', 'true');
     renderDefault();
     expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
   });
 
-  it('opens on click', () => {
+  it('opens on click', async () => {
     renderDefault();
     fireEvent.click(
       screen.getByRole('button', {name: i18n.openOrCloseTeachingAssistant()})
     );
+    await waitFor(() => {
+      expect(fetchStub).toHaveBeenCalledWith(
+        '/api/v1/users/has_opened_ai_differentiation',
+        undefined,
+        true
+      );
+    });
     expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
   });
 
   describe('pulse animation', () => {
-    it('renders pulse animation when session storage is empty', () => {
-      renderDefault();
+    it('renders pulse animation when hasOpenedDiff is false and window is closed', () => {
+      sessionStorage.setItem('AiDiffFabOpenStateKey', 'false');
+      renderDefault({}, false);
       const fab = screen.getByRole('button', {
         name: i18n.openOrCloseTeachingAssistant(),
       });
@@ -87,7 +106,7 @@ describe('AIDiffFloatingActionButton', () => {
       expect(fab.classList.contains('unittest-fab-pulse')).toBe(true);
     });
 
-    it('does not render pulse animation when open state is present in session storage', () => {
+    it('does not render pulse animation when hasOpenedDiff is true', () => {
       sessionStorage.setItem('AiDiffFabOpenStateKey', 'false');
       renderDefault();
       const image = screen.getByRole('img', {name: 'AI bot'});

--- a/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
+++ b/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
@@ -192,10 +192,12 @@ describe('TeacherNavigationBar', () => {
 
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = () => {};
+    localStorage.clear();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    localStorage.clear();
   });
 
   test('renders correctly with visible sections', async () => {
@@ -320,6 +322,7 @@ describe('TeacherNavigationBar', () => {
 
   test('renders AiDiffFloatingActionButton component', async () => {
     // mock experiment is enabled
+    localStorage.setItem('AiDiffHasOpenedKey', 'true');
     experiments.isEnabled = jest.fn(() => true);
     renderDefault(13, `/teacher_dashboard/sections/13/unit/csd3-2022`);
 

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -73,7 +73,6 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         has_seen_ai_assessments_announcement: current_user.has_seen_ai_assessments_announcement?,
         ai_differentiation_enabled: !current_user.ai_differentiation_toggled_off?,
         has_completed_ai_differentiation_welcome: current_user.has_completed_ai_differentiation_welcome?,
-        has_opened_ai_differentiation: current_user.has_opened_ai_differentiation?,
         educator_role: current_user.educator_role,
       }
     else
@@ -329,15 +328,6 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     return head :unauthorized unless current_user
 
     current_user.update!(has_completed_ai_differentiation_welcome: true)
-
-    head :no_content
-  end
-
-  # POST /api/v1/users/has_opened_ai_differentiation
-  def post_has_opened_ai_differentiation
-    return head :unauthorized unless current_user
-
-    current_user.update!(has_opened_ai_differentiation: true)
 
     head :no_content
   end

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -73,6 +73,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         has_seen_ai_assessments_announcement: current_user.has_seen_ai_assessments_announcement?,
         ai_differentiation_enabled: !current_user.ai_differentiation_toggled_off?,
         has_completed_ai_differentiation_welcome: current_user.has_completed_ai_differentiation_welcome?,
+        has_opened_ai_differentiation: current_user.has_opened_ai_differentiation?,
         educator_role: current_user.educator_role,
       }
     else
@@ -328,6 +329,15 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     return head :unauthorized unless current_user
 
     current_user.update!(has_completed_ai_differentiation_welcome: true)
+
+    head :no_content
+  end
+
+  # POST /api/v1/users/has_opened_ai_differentiation
+  def post_has_opened_ai_differentiation
+    return head :unauthorized unless current_user
+
+    current_user.update!(has_opened_ai_differentiation: true)
 
     head :no_content
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -208,7 +208,6 @@ class User < ApplicationRecord
     educator_role
     ai_differentiation_toggled_off
     has_completed_ai_differentiation_welcome
-    has_opened_ai_differentiation
   )
 
   attr_accessor(

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -208,6 +208,7 @@ class User < ApplicationRecord
     educator_role
     ai_differentiation_toggled_off
     has_completed_ai_differentiation_welcome
+    has_opened_ai_differentiation
   )
 
   attr_accessor(

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1016,6 +1016,7 @@ Dashboard::Application.routes.draw do
         post 'users/disable_lti_roster_sync', to: 'users#post_disable_lti_roster_sync'
         post 'users/:user_id/ai_tutor_access', to: 'users#update_ai_tutor_access'
         post 'users/has_completed_ai_differentiation_welcome', to: 'users#post_has_completed_ai_differentiation_welcome'
+        post 'users/has_opened_ai_differentiation', to: 'users#post_has_opened_ai_differentiation'
 
         get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
         get 'users/:user_id/display_theme', to: 'users#get_display_theme'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1016,7 +1016,6 @@ Dashboard::Application.routes.draw do
         post 'users/disable_lti_roster_sync', to: 'users#post_disable_lti_roster_sync'
         post 'users/:user_id/ai_tutor_access', to: 'users#update_ai_tutor_access'
         post 'users/has_completed_ai_differentiation_welcome', to: 'users#post_has_completed_ai_differentiation_welcome'
-        post 'users/has_opened_ai_differentiation', to: 'users#post_has_opened_ai_differentiation'
 
         get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
         get 'users/:user_id/display_theme', to: 'users#get_display_theme'

--- a/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentitation_chat.feature
+++ b/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentitation_chat.feature
@@ -14,8 +14,16 @@ Feature: Send and receive messages in the AI differentiation chat
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And element "#sign_in_or_user" contains text "Stilgar"
+    # Close the FAB
+    And I wait until element "#ui-floatingActionButton" is visible
+    When I click selector "#ui-floatingActionButton"
+    And I wait until element "button:contains(Get Started)" is not visible
+
+    #Go to curriculum page
     And I am on "http://studio.code.org/courses/csp-2019"
     And I wait until element "#ui-floatingActionButton" is visible
+    #wait for pulse to finish
+    And I wait for 5 seconds
     And I open my eyes to test "ai diff welcome and chat"
     Then I see no difference for "ai diff floating action button icon"
 
@@ -73,7 +81,6 @@ Feature: Send and receive messages in the AI differentiation chat
     And I wait until element "#ui-floatingActionButton" is visible
 
     # Teacher sees and skips AI Diff chat welcome
-    When I click selector "#ui-floatingActionButton"
     And I wait until element "button:contains(Get Started)" is visible
     And I click selector "button:contains(Get Started)"
     And I wait until element "button:contains(Create)" is visible
@@ -110,7 +117,6 @@ Feature: Send and receive messages in the AI differentiation chat
     And element "#ui-floatingActionButton" is visible
 
     # Teacher sees and skips AI Diff chat welcome
-    When I click selector "#ui-floatingActionButton"
     And I wait until element "button:contains(Get Started)" is visible
     And I click selector "button:contains(Get Started)"
     And I click selector "a:contains('Skip the tutorial')" once I see it


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

This PR changes the logic for showing the pulse animation on the AI Differentiation FAB, and for showing the AI Diff Chat as open on the first view of the FAB.

The pulse shows:
- when the FAB is closed
- AND the user has not yet clicked the FAB to _open_ the AI Diff Chat window

The window is open:
- when there is no open state in session storage (e.g. the first time they have access to AI Diff or in a new window)
- AND the user has not yet clicked the FAB to _open_ the AI Diff Chat window

Closing the window will keep the closed state in session storage, so if the user doesn't open the window from the FAB it will remain closed (with the pulse animation) until they have a new browser session

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/AITT-976

## Testing story

Updated the apps unit test and the ui/eyes tests

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
