### PR TITLE
[Music] callout for start over button

### DIFF
--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -76,9 +76,7 @@ const availableCallouts: AvailableCallouts = {
   'trigger-button-2': {selector: `#${Triggers[1].id}`},
   'trigger-button-3': {selector: `#${Triggers[2].id}`},
   'trigger-button-4': {selector: `#${Triggers[3].id}`},
-  'start-over-button': {
-    selector: 'button:has(i.fa-refresh)',
-  },
+  'start-over-button': {selector: '#start-over-button'},
   'toolbox-first-row': {selector: '.blocklyTreeRow'},
   'flyout-first-block': {
     selector: '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable',

--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -76,6 +76,9 @@ const availableCallouts: AvailableCallouts = {
   'trigger-button-2': {selector: `#${Triggers[1].id}`},
   'trigger-button-3': {selector: `#${Triggers[2].id}`},
   'trigger-button-4': {selector: `#${Triggers[3].id}`},
+  'start-over-button': {
+    selector: 'button:has(i.fa-refresh)',
+  },
   'toolbox-first-row': {selector: '.blocklyTreeRow'},
   'flyout-first-block': {
     selector: '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable',

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -176,6 +176,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
           <button
             onClick={onClickStartOver}
             type="button"
+            id="start-over-button"
             className={classNames(
               moduleStyles.button,
               allowPackSelection && packFolder && moduleStyles.buttonWide


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

@dancodedotorg asked:
> do you know if there's a way to get a callout to point to this area of the workspace where you can select a new song? I did some sleuthing and didn't see that this spot had an id, so I'm prepared for the answer to be "nope not possible".
> Asking because - I was thinking through scenarios in our more advanced levels where students can choose which song they want to use to solve a challenge, but the way this is setup in music lab: students first have to choose the song before they have a chance to read the instructions, and then only after they read the instructions can they reconsider their song and may want to pick a new one. And I'm not convinced that it's super obvious that this area lets you re-pick a song, especially after students have gone through a bunch of levels where this behavior is restricted to just "start over". So anyway - discoverability comments aside - I wanted to add a note in the instructions like "you can re-pick your song by clicking the option in the workspace header" and have a callout point to this to help students out. But maybe this isn't possible right now!
![image (290)](https://github.com/user-attachments/assets/caa434d9-d387-42fb-aedf-c1afdee3c17a)

This branch adds a callout for this. It works whether the level allows students to choose their own song or not:
![image (289)](https://github.com/user-attachments/assets/da604d02-6f7c-4cd9-953c-b0dec7a7a248)
![image (288)](https://github.com/user-attachments/assets/a53bf72b-6520-41b4-8a1d-4ae65c01a7b1)


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

https://codedotorg.slack.com/archives/C07UT279KM1/p1744043604875359

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
