### PR TITLE
[Google Blockly] add support for glow highlight

### DIFF
--- a/apps/src/blockly/addons/cdoPathObjectThrasos.ts
+++ b/apps/src/blockly/addons/cdoPathObjectThrasos.ts
@@ -1,5 +1,6 @@
 import * as GoogleBlockly from 'blockly/core';
 
+import experiments from '@cdo/apps/util/experiments';
 export default class CdoPathObject extends GoogleBlockly.blockRendering
   .PathObject {
   // The built-in function also adds a cross-hatch fill pattern to disabled blocks, which we don't want.
@@ -10,7 +11,16 @@ export default class CdoPathObject extends GoogleBlockly.blockRendering
 
   // The built-in function adds a light filter over the whole block. We want to match our old
   // behavior where highlighting the block adds the same yellow outline as selecting.
+  // The built-in function can be used with the 'blockly-glow-highlight' url parameter or experiment.
   updateHighlighted(highlighted: boolean) {
-    this.setClass_('blocklySelected', highlighted);
+    if (
+      experiments.isEnabledAllowingQueryString(
+        experiments.BLOCKLY_GLOW_HIGHLIGHT
+      )
+    ) {
+      super.updateHighlighted(highlighted);
+    } else {
+      this.setClass_('blocklySelected', highlighted);
+    }
   }
 }

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -242,6 +242,21 @@ const optionsList = [
       {value: 'true', description: 'JavaScript text editor.'},
     ],
   },
+  {
+    name: 'blockly-glow-highlight',
+    type: 'radio',
+    values: [
+      {
+        value: 'false',
+        description:
+          'Show a yellow outline around highlighted blocks (default).',
+      },
+      {
+        value: 'true',
+        description: 'Add a light filter over highlighted blocks',
+      },
+    ],
+  },
 ];
 
 export default class MusicMenu extends React.Component {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -60,6 +60,8 @@ experiments.CSP_VALIDATION_VIA_AI = 'csp_validation_via_ai';
 experiments.FREE_RESPONSE_AI_ANALYSIS = 'free_response_ai_analysis';
 // Allows users to view the new version of the teacher homepage
 experiments.TEACHER_HOMEPAGE_V2 = 'teacher-homepage-v2';
+// Use glow effect for Blockly block highlighting
+experiments.BLOCKLY_GLOW_HIGHLIGHT = 'blockly-glow-highlight';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Background Context

As part of the work to migrate Flappy to Google Blockly, we began overriding Blockly's `updateHighlighted` path method, so that highlighted blocks would look like selected blocks: https://github.com/code-dot-org/code-dot-org/pull/37512

The difference between the two is that highlighted blocks (which didn't exist in CDO Blockly) have a glow fill effect while selected blocks have a yellow outline. 

This decision made it so our migrated labs worked as they always did but as far as users could tell it couples highlighting and selection. 
Music Lab highlights blocks as their associated timeline events play back, which we currently show with the yellow outline.  
While working on the Blockly v12 upgrade, I rediscovered this override and wondered if we might want to reconsider it. While Blockly's glow highlight might have some color contrast concerns, it also seems immediately more noticeable than the yellow outline.

This PR enables trying it out using a URL parameter or experiment `blockly-glow-highlight`. The difference can be seen here in these two Music Lab screen recordings:


https://github.com/user-attachments/assets/7ee67a93-8f2f-4796-8353-764d2796e1dd


https://github.com/user-attachments/assets/261ebfeb-6058-448f-b7ef-1b9f44411844

These screenshots compare the appearance in Maze when the Step button is used:

![image (291)](https://github.com/user-attachments/assets/23c26ab3-96b1-4bd9-bed2-7d790a88a6a3)

![image (292)](https://github.com/user-attachments/assets/b36fba20-3184-43a3-a395-b0b904f8f776)

Finally, this screen grab shows that it's possible to have different blocks highlighted/selected at the same time (but it's now possible to tell which is which):

![image (294)](https://github.com/user-attachments/assets/704153a6-fc15-4391-97b8-aedd7bf81637)

## Technical Details

This adjusts an existing override of `updateHighlighted` which is defined in core Blockly here:
https://github.com/google/blockly/blob/develop/core/renderers/geras/path_object.ts#L104-L115

As a follow-up, we could consider internally customizing this method's emboss filter, which is defined here:
https://github.com/google/blockly/blob/209de217d60c851052ae10c56757c7311ad8fc02/core/renderers/common/constants.ts#L936-L999

We could potentially even do this on a per-lab basis. This would allow us to do things like highlight Music Lab blocks in a way that matches how we highlight the actual timeline events.

For additional context, here is where the styles for the `blocklySelected` class (yellow outline) are defined:
https://github.com/mikeharv/blockly/blob/develop/core/comments/comment_view.ts#L878-L890

It is suspected that this overuse of the class above could actually be contributing to a bug in the current system around things staying highlighted after stopping playing. It is hoped that decoupling highlighting/selection helps solve that. 


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This branch only makes the alternate appearance possible with URL parameter or experiment, so it shouldn't impact any users or eyes tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
