### PR TITLE
feat(efs): add distributed EFS for full page cache

### DIFF
--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -443,8 +443,6 @@ Resources:
   MarketingCacheFileSystem:
     Type: AWS::EFS::FileSystem
     Properties:
-      BackupPolicy:
-        Status: ENABLED
       Encrypted: true
       PerformanceMode: generalPurpose
       ThroughputMode: bursting

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -306,6 +306,11 @@ Resources:
           PortMappings:
             - ContainerPort: 3000
               Protocol: tcp
+          MountPoints:
+            # More details: https://nextjs.org/docs/app/building-your-application/caching#full-route-cache
+            - SourceVolume: code-dot-org-full-page-router-cache
+              ContainerPath: /app/apps/marketing/.next/server/app/code.org
+              ReadOnly: false
           Secrets:
             - Name: CONTENTFUL_TOKEN
               ValueFrom: 'arn:aws:secretsmanager:us-west-2:165336972514:secret:development/marketing/90t6bu6vlf76/contentful-fOz371:CONTENTFUL_TOKEN::'
@@ -327,6 +332,15 @@ Resources:
         Fn::GetAtt:
           - FargateServiceTaskDefTaskRole
           - Arn
+      Volumes:
+        # More details: https://nextjs.org/docs/app/building-your-application/caching#full-route-cache
+        - Name: code-dot-org-full-page-router-cache
+          EFSVolumeConfiguration:
+            FilesystemId: !Ref MarketingCacheFileSystem
+            AuthorizationConfig:
+              AccessPointId: !Ref CDOMarketingCacheAccessPoint
+              IAM: ENABLED
+            TransitEncryption: ENABLED
 
   FargateServiceTaskDefExecutionRole:
     Type: AWS::IAM::Role
@@ -420,6 +434,67 @@ Resources:
 
   ###########################
   # End AWS VPC Resources   #
+  ###########################
+
+  ###########################
+  # Start AWS EFS Resources #
+  ###########################
+
+  MarketingCacheFileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      BackupPolicy:
+        Status: ENABLED
+      Encrypted: true
+      PerformanceMode: generalPurpose
+      ThroughputMode: bursting
+      LifecyclePolicies:
+        - TransitionToIA: AFTER_30_DAYS
+      FileSystemTags:
+        - Key: Name
+          Value: Marketing-EFS-Cache
+
+<% Config::AVAILABILITY_ZONES.each_with_index do |region, index| %>
+  # Mount Target for <%= region  %>
+  MarketingCacheMountTarget<%= index %>:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref MarketingCacheFileSystem
+      SubnetId: !Ref VpcPrivateSubnet<%= index %>
+      SecurityGroups: [!Ref MarketingCacheEFSSecurityGroup]
+<% end %>
+
+  CDOMarketingCacheAccessPoint:
+    Type: AWS::EFS::AccessPoint
+    Properties:
+      FileSystemId: !Ref MarketingCacheFileSystem
+      PosixUser:
+        Uid: "1001" # Refer to the Dockerfile at frontend/apps/marketing/Dockerfile
+        Gid: "1001" # Refer to the Dockerfile at frontend/apps/marketing/Dockerfile
+      RootDirectory:
+        Path: "/cache/code.org"
+        CreationInfo:
+          OwnerUid: "1001"
+          OwnerGid: "1001"
+          Permissions: "755"
+
+  MarketingCacheEFSSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow Marketing ECS to connect to EFS
+      VpcId:
+        Ref: Vpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 2049
+          ToPort: 2049
+          SourceSecurityGroupId:         
+            Fn::GetAtt:
+              - FargateServiceSecurityGroup
+              - GroupId
+
+  ###########################
+  # End AWS EFS Resources   #
   ###########################
 
   ###########################


### PR DESCRIPTION
This PR supplements the ISR PR by adding distributed volume mounting via Amazon Elastic Filesystem (EFS). Next.js caches [full page router paths](https://nextjs.org/docs/app/building-your-application/caching#full-route-cache) via the `.next/server/app/[brand]` path in the form of local file storage. To achieve consistent caching throughout the cluster, EFS was added such that one cache update will distribute to all instances.

This is needed because the existing strategy of invalidating cache entries during a deployment no longer applies. Caching invalidation needs to occur when an entry, asset, or page is published on Contentful which necessitates the use of a page revalidation strategy. This allows for pages to be revalidated via API calls but without a distributed cache, making an API call to invalidate a particular path will only invalidate the cache on **one** instance and the other instances will not be invalidated.

Using EFS solves this problem by causing the cache update to surface across all instances in a consistent manner.

Additionally, this pattern was adopted using the [AWS Labs CDK Next.js](https://github.com/cdklabs/cdk-nextjs/tree/main?tab=readme-ov-file#nextjsglobalcontainers) implementation but ported over to raw Cloudformation. This helps to ensure our implementation of Next.js on AWS is following the same best practice princinples that are being advocated by AWS while adhering to our current team needs of using AWS Cloudformation.