### PR TITLE
Making withtooltip close on escape

### DIFF
--- a/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
@@ -104,11 +104,7 @@ const WithTooltip: React.FunctionComponent<WithTooltipProps> = ({
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        if (event.target instanceof HTMLElement) {
-          event.target.blur(); // Remove focus from the container
-        } else {
-          handleHideTooltip(); // Hide the tooltip if unable to remove focus natively
-        }
+        handleHideTooltip();
       }
     };
     if (showTooltip) {

--- a/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
@@ -103,7 +103,7 @@ const WithTooltip: React.FunctionComponent<WithTooltipProps> = ({
   // Effect to handle the Escape key to close the tooltip
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && !event.defaultPrevented) {
+      if (event.key === 'Escape') {
         if (event.target instanceof HTMLElement) {
           event.target.blur(); // Remove focus from the container
         } else {
@@ -112,10 +112,10 @@ const WithTooltip: React.FunctionComponent<WithTooltipProps> = ({
       }
     };
     if (showTooltip) {
-      window.addEventListener('keydown', handleKeyDown);
+      document.addEventListener('keydown', handleKeyDown);
     }
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [showTooltip]);
 


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

There were a couple tiny issues preventing this from working before- I tried with limiting these updates and none (attaching to the document instead of window, checking for preventDefault) worked on its own. 

Additionally, I decided in the case of something like codeMirror, we won't want to unfocus something if we hit escape to close a tooltip. 


https://github.com/user-attachments/assets/2a26d893-8f1e-452d-bbf4-3f8349a7139c



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1118

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
