### PR TITLE
Add Music Banner back onto homepage

### DIFF
--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -60,6 +60,7 @@ class DCDOBase < DynamicConfigBase
       # TODO ACQ-3074 - Remove this after the Exploring Gen AI launch
       'exploring-gen-ai-launch': DCDO.get('exploring-gen-ai-launch', false),
       'ai-tutor-teacher-nav-v2': DCDO.get('ai-tutor-teacher-nav-v2', true),
+      'music-lab-banner': DCDO.get('music-lab-banner', false),
     }
   end
 end

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -20,9 +20,9 @@
       "actions": [
         {
           "type": "music-lab-banner",
-          "text_overline": "music_lab.introducing_music_lab_strong",
-          "text_h1": "music_lab.banner.heading",
-          "text_desc": "music_lab.banner.desc",
+          "text_overline": "music_lab.banner2.overline",
+          "text_h1": "music_lab.banner2.heading",
+          "text_desc": "music_lab.banner2.desc",
           "button_label_primary": "music_lab.button.try_music_lab",
           "button_url_primary": "https://studio.code.org/s/music-intro-2024/reset",
           "button_label_secondary": "music_lab.button.learn_more",

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -4,11 +4,35 @@
       "hoc2024-soon-hoc",
       "pl-launch-superhero",
       "curriculum-launch-2024",
-      "best-of-stem-2024"
+      "best-of-stem-2024",
+      "music-lab-banner"
     ]
   },
 
   "banners": {
+    "music-lab-banner": {
+      "dcdo": "music-lab-banner",
+      "class": "music-lab-banner homepage",
+      "desktopImage": "/images/music-lab/music-lab-homepage-banner-bg.png",
+      "mobileImage": "/images/music-lab/music-lab-homepage-banner-bg.png",
+      "leftImage": "/images/music-lab/music-lab-homepage-banner-left.png",
+      "rightImage": "/images/music-lab/music-lab-homepage-banner-right.png",
+      "actions": [
+        {
+          "type": "music-lab-banner",
+          "text_overline": "music_lab.introducing_music_lab_strong",
+          "text_h1": "music_lab.banner.heading",
+          "text_desc": "music_lab.banner.desc",
+          "button_label_primary": "music_lab.button.try_music_lab",
+          "button_url_primary": "https://studio.code.org/s/music-intro-2024/reset",
+          "button_label_secondary": "music_lab.button.learn_more",
+          "button_url_secondary": "/music",
+          "text_desc_02": "music_lab.in_partnership_with",
+          "logo_list_01": "/images/avatars/amazon_future_engineer_light.png",
+          "logo_list_01_alt": "music_lab.amazon_future_engineer"
+        }
+      ]
+    },
     "hoc2024-soon-hoc": {
       "hoc_modes": ["soon-hoc"],
       "class": "hoc-banner homepage",

--- a/pegasus/sites.v3/code.org/public/css/music-lab-hero-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/music-lab-hero-banner.scss
@@ -1,0 +1,118 @@
+$width-md: 1145px;
+$width-sm: 640px;
+
+#bars {
+  max-width: 1240px;
+  height: 480px;
+  position: relative;
+  overflow: hidden;
+  align-items: center;
+  justify-content: center;
+
+  @media (max-width: $width-sm) {
+    height: 550px;
+  }
+
+  & > div.col-33 {
+    position: absolute;
+    background-position: center !important;
+
+    // Copy and buttons
+    &:nth-of-type(2) {
+      width: 560px;
+      top: unset;
+      left: unset;
+      transform: unset;
+      padding-bottom: 0 !important;
+
+      @media (max-width: $width-sm) {
+        width: 100%;
+      }
+
+      .music-lab-banner.homepage {
+        text-align: center;
+        color: var(--neutral_white);
+        padding: 0 1rem;
+
+        p.has-icon {
+          margin-bottom: 0.5rem;
+
+          strong::before {
+            font: var(--fa-font-solid);
+            content: "\f001";
+            font-size: 1rem;
+            margin-inline: 6px;
+          }
+        }
+
+        h1, p {
+          color: var(--neutral_white);
+          margin-top: 0;
+        }
+
+        .button-wrapper {
+          display: flex;
+          justify-content: center;
+          flex-wrap: wrap;
+          column-gap: 1rem;
+        }
+
+        .afe {
+          margin-top: 1.25rem;
+          display: flex;
+          justify-content: center;
+          flex-wrap: wrap;
+          gap: 0.5rem;
+
+          & > figure {
+            margin: 0;
+            width: 170px;
+
+            img {
+              width: 100%;
+            }
+          }
+          p {
+            margin: 0;
+          }
+        }
+      }
+    }
+
+    // Left & right images
+    &:nth-of-type(1),
+    &:nth-of-type(3) {
+      height: inherit;
+      width: 360px;
+      top: unset;
+      bottom: unset;
+      display: block;
+
+      @media (max-width: $width-md) {
+        width: 35%;
+      }
+
+      @media (max-width: 768px) {
+        display: none;
+      }
+    }
+
+    // Left image
+    &:nth-of-type(1) {
+      left: 0;
+
+      @media (max-width: $width-md) {
+        left: calc(-10% + -2rem);
+      }
+    }
+
+    // Right image
+    &:nth-of-type(3) {
+      right: -1rem;
+
+      @media (max-width: $width-md) {
+        right: -15%;
+      }
+    }
+  }
+}

--- a/pegasus/sites.v3/code.org/public/images/music-lab/music-lab-homepage-banner-bg.png
+++ b/pegasus/sites.v3/code.org/public/images/music-lab/music-lab-homepage-banner-bg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:885d21cc59d04af5d8d872b0a22503dbaaea9170b8dc8963152a57e8fd238e4c
+size 182169

--- a/pegasus/sites.v3/code.org/public/images/music-lab/music-lab-homepage-banner-left.png
+++ b/pegasus/sites.v3/code.org/public/images/music-lab/music-lab-homepage-banner-left.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3517902f317ef3a26e8840f83a392443809dbb50418076fa7a528584ea775d1
+size 26073

--- a/pegasus/sites.v3/code.org/public/images/music-lab/music-lab-homepage-banner-right.png
+++ b/pegasus/sites.v3/code.org/public/images/music-lab/music-lab-homepage-banner-right.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8606e1dbf3ae22f2045a7b6f5767eadbf0aa9f77e207775ec79e5ba0b9c8c804
+size 26191

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -25,6 +25,9 @@ style_min: true
 -# Apply this stylesheet when 'curriculum-launch-2024' is set to 'true'
 - if !!DCDO.get('curriculum-launch-2024', false)
   =inline_css '/generated/banners-curriculum-launch.css'
+-# Apply this stylesheet when 'music-lab-banner' is set to 'true'
+- if !!DCDO.get('music-lab-banner', false)
+  =inline_css '/generated/music-lab-hero-banner.css'
 
 - cookie_key = environment_specific_cookie_name '_user_type'
 - user_type = request.cookies[cookie_key]

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -77,6 +77,24 @@
           .button-wrapper
             %a.link-button.white.has-external-link{href: entry[:button_link], target: (entry[:external_link] ? "_blank" : nil), rel: (entry[:external_link] ? "noopener noreferrer" : nil)}
               = I18n.t(entry[:button_text])
+      - elsif entry[:type] == "music-lab-banner"
+        %div.flex-container
+          .text-wrapper
+            %p.has-icon.body-one
+              =hoc_s(:"music_lab.introducing_music_lab_strong", markdown: :inline, locals:{music_lab: "Music Lab"})
+            %h1
+              = I18n.t(entry[:text_h1])
+            %p.body-one.wrap-balance
+              = I18n.t(entry[:text_desc])
+            .button-wrapper
+              %a.link-button.white{href: entry[:button_url_primary]}
+                = I18n.t(entry[:button_label_primary])
+              %a.link-button.secondary.white{href: entry[:button_url_secondary]}
+                = I18n.t(entry[:button_label_secondary])
+            .afe
+              %p= I18n.t(entry[:text_desc_02])
+              %figure
+                %img{src: entry[:logo_list_01], alt: I18n.t(entry[:logo_list_01_alt])}
   .clear{style: "clear: both"}
 
 #hero{style: "position: relative"}

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -81,7 +81,7 @@
         %div.flex-container
           .text-wrapper
             %p.has-icon.body-one
-              =hoc_s(:"music_lab.introducing_music_lab_strong", markdown: :inline, locals:{music_lab: "Music Lab"})
+              = I18n.t(entry[:text_overline])
             %h1
               = I18n.t(entry[:text_h1])
             %p.body-one.wrap-balance

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -2536,6 +2536,10 @@
     banner:
       heading: "Create music with code"
       desc: "Get creative with your favorite artist's music and code new songs and mixes!"
+    banner2:
+      heading: "Make Music. Learn Code."
+      desc: "Get creative with your favorite artist's music by coding new songs and mixes!"
+      overline: "New artists added to Music Lab"
     featuring_songs_by: "Featuring songs by:"
     artist_list: "%{artist_list} and more!"
     artist:


### PR DESCRIPTION
Re-adds the Music Lab banner onto the homepage. This is based off the work done in https://github.com/code-dot-org/code-dot-org/pull/58403 and removed in https://github.com/code-dot-org/code-dot-org/pull/60153, with some copy changes.

Once this goes live, we'll need to flip `exploring-gen-ai-launch` to be false and `music-lab-banner` to be true.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
