### PR TITLE
Evaluate Student Learning: read from StudentWorkEvaluations

### DIFF
--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -11,8 +11,8 @@ interface StudentCodeSample {
   studentCode: string | undefined;
   codeVersion?: string;
   userId: number | undefined;
-  aiEvaluation?: string;
-  aiReasoning?: string;
+  evaluation?: string;
+  reasoning?: string;
   evaluationCriteria?: string;
 }
 
@@ -45,7 +45,11 @@ const StudentCodeDatasetMaker: React.FC = () => {
       levelId: Number(levelId),
     };
     const codeSamples = await fetchStudentCodeSamples(studentWorkRequest);
-    setFetchedSamples(codeSamples as unknown as StudentCodeSample[]);
+    if (!codeSamples) {
+      alert('No samples found for the given parameters.');
+    } else {
+      setFetchedSamples(codeSamples as unknown as StudentCodeSample[]);
+    }
     setPending(false);
   };
 

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -107,28 +107,39 @@ class StudentWorkSampleController < ApplicationController
   end
 
   def fetch_student_code_samples_with_evaluations(level, unit_id, num_samples)
-    evaluations = UserLevelEvaluationOld.where(level_id: level.id, script_id: unit_id)
-    if evaluations.empty?
+    user_level_evaluations = UserLevelEvaluation.where(level_id: level.id, unit_id: unit_id)
+    if user_level_evaluations.empty?
       return render status: :not_found, json: "There are no evaluations for the level with id #{level.id} in unit with id #{unit_id}"
     end
     code_samples = []
     have_enough_samples = false
-    evaluations.shuffle.each do |evaluation|
+    user_level_evaluations.shuffle.each do |ule|
       unless have_enough_samples
-        student_code = get_student_code(evaluation.user_id, level.id, unit_id, evaluation.code_version)
+        student_code = get_student_code(ule.user_id, level, unit_id, ule.code_version)
+        user_level_skill_evaluation_ids = StudentWorkEvaluationSummary.where(student_work_evaluation_summary_id: ule.id).pluck(:student_work_evaluation_id)
+        user_level_skill_evaluations = UserLevelSkillEvaluation.where(id: user_level_skill_evaluation_ids)
         if student_code[:student_code]
-          code_samples << {
+          code_sample = {
             level_id: level.id,
             unit_id: unit_id,
-            user_id: evaluation.user_id,
+            student_id: ule.student_id,
             project_id: student_code[:project_id],
             code_version: student_code[:code_version],
             student_code: student_code[:student_code],
-            ai_evaluation: evaluation.ai_evaluation,
-            ai_reasoning: evaluation.ai_reasoning,
-            evaluation_criteria: evaluation.evaluation_criteria
+            evaluation: ule.evaluation,
+            reasoning: ule.reasoning,
+            evaluation_criteria: ule.evaluation_criteria,
           }
+          # TODO: Use skill id instead of counter when we have Skills
+          counter = 1
+          user_level_skill_evaluations.each do |ulse|
+            code_sample["skill_evaluation_#{counter}"] = ulse.evaluation
+            code_sample["skill_evaluation_criteria_#{counter}"] = ulse.evaluation_criteria
+            code_sample["skill_evaluation_reasoning_#{counter}"] = ulse.reasoning
+            counter += 1
+          end
         end
+        code_samples << code_sample
         have_enough_samples = code_samples.length >= num_samples
       end
     end


### PR DESCRIPTION
### Links 
Continuation of #64948 
[Problem overview with a handy little chart ](https://docs.google.com/document/d/1pPb-LiWZuhDolIoTiKOmTFkKCDHKZOY6fB31XJPXLu4/edit?tab=t.0)of all the "types" of evaluations we'll likely need 
[FigJam with more detailed ERD](https://www.figma.com/board/S8H82OKJ3gDboYrIoQZCsu/Measures-of-Learning-ERD-brainstorms?node-id=0-1&p=f&t=V5XfUKd6IMY4xTpg-0) See ERD 2.0 Skills, Summaries & Feedback option 2 in pink 

### Summary 
Now that we are writing evaluations to the StudentWorkEvaluation table, we can read from that table instead of the old UserLevelEvaluationsOld table.

### Deployment 
This should be merged _after_ I move the current UserLevelEvaluationOlds into the StudentWorkEvaluation table. 

### Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->
