### PR TITLE
[HOME] Add drag-and-drop BE functionality

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -47,6 +47,7 @@ const {
   localeCode,
   hasSeenStandardsReportInfo,
   canViewStudentAIChatMessages,
+  sectionOrder,
 } = scriptData;
 
 $(document).ready(function () {
@@ -77,6 +78,8 @@ $(document).ready(function () {
   store.dispatch(setLocaleCode(localeCode));
 
   const showAITutorTab = canViewStudentAIChatMessages;
+
+  console.log('lfm', {sectionOrder});
 
   // When removing v1TeacherDashboard after v2 launch, remove `selectedSection` from api response.
   const getV1TeacherDashboard = () => {

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -47,7 +47,6 @@ const {
   localeCode,
   hasSeenStandardsReportInfo,
   canViewStudentAIChatMessages,
-  sectionOrder,
 } = scriptData;
 
 $(document).ready(function () {
@@ -78,8 +77,6 @@ $(document).ready(function () {
   store.dispatch(setLocaleCode(localeCode));
 
   const showAITutorTab = canViewStudentAIChatMessages;
-
-  console.log('lfm', {sectionOrder});
 
   // When removing v1TeacherDashboard after v2 launch, remove `selectedSection` from api response.
   const getV1TeacherDashboard = () => {

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
@@ -26,7 +26,6 @@ import {removeSectionOrThrow} from '@cdo/apps/templates/teacherDashboard/teacher
 import {SectionMap} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
-import i18n from '@cdo/locale';
 
 import {SectionCard} from './SectionCard';
 import {SectionDeleteModal} from './SectionDeleteModal';
@@ -141,7 +140,6 @@ export const SectionList: React.FC<SectionListProps> = ({showHiddenOnly}) => {
         setSectionToDelete(NO_SECTION_ID);
       })
       .catch((error: Error) => {
-        alert(i18n.unexpectedError());
         console.error(error);
         setSectionToDelete(NO_SECTION_ID);
       });

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
@@ -116,8 +116,14 @@ export const SectionList: React.FC<SectionListProps> = ({showHiddenOnly}) => {
   );
 
   React.useEffect(() => {
-    sortableSectionIds;
-    // TODO(lfm): Update the order of sections in the backend
+    HttpClient.put(
+      '/user_preference',
+      JSON.stringify({sectionOrder: sortableSectionIds}),
+      true,
+      {
+        'Content-Type': 'application/json; charset=UTF-8',
+      }
+    );
   }, [sortableSectionIds]);
 
   const onDeleteClickCallback = (sectionId: number) => {

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionListTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/SectionListTest.tsx
@@ -19,62 +19,70 @@ import {serverSectionFromSection} from '@cdo/apps/templates/teacherDashboard/tea
 import {TEACHER_NAVIGATION_PATHS} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
 import i18n from '@cdo/locale';
 
+jest.mock('@cdo/apps/util/HttpClient', () => ({
+  delete: jest.fn(() => Promise.resolve({})),
+  put: jest.fn(() => Promise.resolve({})),
+}));
+
+const sections = [
+  {
+    id: 11,
+    name: 'Period 1',
+    hidden: false,
+    courseVersionName: 'csd-2024',
+    unitName: null,
+    studentCount: 0,
+    participantType: 'student',
+  },
+  {
+    id: 12,
+    name: 'Period 2',
+    hidden: false,
+    courseVersionName: 'csd-2023',
+    unitName: null,
+    participantType: 'student',
+  },
+  {
+    id: 13,
+    name: 'Period 3',
+    hidden: false,
+    courseVersionName: 'csd-2022',
+    unitName: 'csd3-2022',
+    participantType: 'student',
+  },
+  {
+    id: 14,
+    name: 'Period 4',
+    hidden: false,
+    courseVersionName: 'csd-2022',
+    unitName: 'csd6-2022',
+    participantType: 'student',
+  },
+  {
+    id: 15,
+    name: 'hidden',
+    hidden: true,
+    unitName: null,
+    participantType: 'student',
+  },
+  {
+    id: 16,
+    name: 'PL Section',
+    hidden: false,
+    unitName: null,
+    participantType: 'teacher',
+  },
+];
+
 describe('SectionList', () => {
-  const sections = [
-    {
-      id: 11,
-      name: 'Period 1',
-      hidden: false,
-      courseVersionName: 'csd-2024',
-      unitName: null,
-      studentCount: 0,
-      participantType: 'student',
-    },
-    {
-      id: 12,
-      name: 'Period 2',
-      hidden: false,
-      courseVersionName: 'csd-2023',
-      unitName: null,
-      participantType: 'student',
-    },
-    {
-      id: 13,
-      name: 'Period 3',
-      hidden: false,
-      courseVersionName: 'csd-2022',
-      unitName: 'csd3-2022',
-      participantType: 'student',
-    },
-    {
-      id: 14,
-      name: 'Period 4',
-      hidden: false,
-      courseVersionName: 'csd-2022',
-      unitName: 'csd6-2022',
-      participantType: 'student',
-    },
-    {
-      id: 15,
-      name: 'hidden',
-      hidden: true,
-      unitName: null,
-      participantType: 'student',
-    },
-    {
-      id: 16,
-      name: 'PL Section',
-      hidden: false,
-      unitName: null,
-      participantType: 'teacher',
-    },
-  ];
+  let store: Store;
+  beforeEach(() => {
+    const serverSections = sections.map(serverSectionFromSection);
 
-  const serverSections = sections.map(serverSectionFromSection);
-
-  const store: Store = getStore();
-  registerReducers({teacherSections});
-  store.dispatch(setSections(serverSections));
+    store = getStore();
+    registerReducers({teacherSections});
+    store.dispatch(setSections(serverSections));
+  });
 
   function renderComponent(initialRoute = '/teacher_dashboard/home') {
     return render(

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -29,6 +29,8 @@ import HttpClient from '@cdo/apps/util/HttpClient';
 
 const INITIAL_ROUTE = '/teacher_dashboard/home';
 
+jest.mock('@cdo/apps/util/HttpClient');
+
 describe('TeacherHomepage', () => {
   const sections = [
     {

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -20,6 +20,7 @@ class TeacherDashboardController < ApplicationController
       end
       @section_summary = @section.selected_section_summarize
     end
+    @section_order = UserPreference.find_by(user_id: current_user.id)&.section_order
     @locale_code = request.locale
     view_options(full_width: true, no_padding_container: true)
   end

--- a/dashboard/app/controllers/user_preferences_controller.rb
+++ b/dashboard/app/controllers/user_preferences_controller.rb
@@ -1,0 +1,14 @@
+class UserPreferencesController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    preference = UserPreference.find_or_initialize_by(user_id: current_user.id)
+    preference.update!(section_order: update_params[:section_order])
+  end
+
+  private def update_params
+    params.transform_keys(&:underscore).permit(
+      section_order: []
+    )
+  end
+end

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -7,6 +7,7 @@
   teacher_dashboard_data = {}
   teacher_dashboard_data[:studioUrlPrefix] = CDO.studio_url('', CDO.default_scheme)
   teacher_dashboard_data[:sections] = @sections
+  teacher_dashboard_data[:sectionOrder] = @section_order
   teacher_dashboard_data[:section] = @section_summary
   teacher_dashboard_data[:currentUserId] = @current_user.id
   teacher_dashboard_data[:hasSeenStandardsReportInfo] = @current_user.has_seen_standards_report_info_dialog || false

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -48,6 +48,8 @@ Dashboard::Application.routes.draw do
       end
     end
 
+    resource :user_preference, only: [:update]
+
     resources :survey_results, only: [:create], defaults: {format: 'json'}
 
     resource :pairing, only: [:show, :update]

--- a/dashboard/test/controllers/user_preferences_controller_test.rb
+++ b/dashboard/test/controllers/user_preferences_controller_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class UserPreferencesControllerTest < ActionController::TestCase
+  setup do
+    @user = create :user
+    sign_in @user
+  end
+
+  test 'updates section_order for the current user' do
+    section_order = ['1', '2', '3']
+
+    patch :update, params: {section_order: section_order}
+
+    assert_response :success
+
+    preference = UserPreference.find_by(user_id: @user.id)
+    assert_equal section_order, preference.section_order
+  end
+
+  test 'updates existing preference without creating a new record' do
+    initial_order = ['3', '2', '1']
+    preference = UserPreference.create!(user_id: @user.id, section_order: initial_order)
+
+    new_order = ['1', '2', '3']
+
+    assert_no_difference 'UserPreference.count' do
+      patch :update, params: {section_order: new_order}
+    end
+
+    assert_response :success
+
+    preference.reload
+    assert_equal new_order, preference.section_order
+  end
+
+  test 'ignores non-permitted parameters' do
+    section_order = ['1', '2', '3']
+
+    patch :update, params: {
+      section_order: section_order,
+      unpermitted_param: 'should be ignored'
+    }
+
+    assert_response :success
+
+    preference = UserPreference.find_by(user_id: @user.id)
+    assert_equal section_order, preference.section_order
+    assert_nil preference.attributes['unpermitted_param']
+  end
+end


### PR DESCRIPTION
Adds:
* `post /user_preference` - update the user's user_preference. Currently only has the section_order.
* Sends the section_order user preference to the FE on the teacher_dashboard page
  * This order is not shown on the homepage yet. That will be a followup PR
* Call `post /user_preference` when the order on the homepage changes

## Links
https://codedotorg.atlassian.net/browse/TEACH-1760

