### PR TITLE
Python Lab: change "project type" text to "output type"

### DIFF
--- a/apps/i18n/pythonlab/en_us.json
+++ b/apps/i18n/pythonlab/en_us.json
@@ -13,11 +13,11 @@
   "neighborhoodDescription": "A project that uses the Neighborhood.",
   "programCompleted": "Program completed.",
   "programStopped": "Program stopped.",
-  "projectPickerTitle": "Select a project type",
+  "projectPickerTitle": "Select an output type",
   "projectPickerReplaceRestoreInfo": "You can restore your old project using Version History.",
-  "projectPickerReplaceWarning": "This will clear your code and start over with the new project type.",
+  "projectPickerReplaceWarning": "This will clear your code and start over with the new output type.",
   "runningLevelTests": "Running level tests...",
   "runningProgram": "Running program...",
   "runningProjectTests": "Running your project's tests...",
-  "switchProjectTypeTitle": "Switch your project type"
+  "switchProjectTypeTitle": "Switch your output type"
 }


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

We realized it could be confusing to users to use the text "project type" inside Python Lab when on the /projects page "project type" refers to Music, Python Lab, Sprite Lab, etc. This changes the text of the modal to use "output type" instead. I debated whether I should rename the component/variables, but since they live inside `/pythonlab` I think it's pretty clear that they refer to types of python projects, and it didn't seem worth the labor-intensive rename.

## Screenshots
<img width="667" alt="Screenshot 2025-04-07 at 3 10 46 PM" src="https://github.com/user-attachments/assets/5f8fd3d5-6649-45b4-a960-f794b62fec77" />
<img width="667" alt="Screenshot 2025-04-07 at 3 10 22 PM" src="https://github.com/user-attachments/assets/65606fcf-cf44-428a-8c8c-f5e203fc0615" />


## Links
- jira ticket: [CT-1174](https://codedotorg.atlassian.net/browse/CT-1174)


## Testing story
Verified the new text works locally.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
