### PR TITLE
Summary: light background

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3133,6 +3133,13 @@ $information-desktop: "only screen and (min-width: 1024px)";
   }
 }
 
+// Summary
+#summary-content {
+  // Ensure the summary can be seen even when the lesson has a dark background.
+  background-color: $white;
+  padding: 0 20px;
+}
+
 $modal-image-width: 100px;
 $modal-image-margin-gap: 10px;
 $modal-no-icon-gap: 22px;


### PR DESCRIPTION
Ensure that a summary of student responses is visible on lessons with a dark background, by giving the summary a light background.

<img width="1481" alt="Screenshot 2025-04-07 at 4 49 53 PM" src="https://github.com/user-attachments/assets/02e84cdd-d29d-47b4-85cf-ba0e42d49df3" />

### 
This is an example URL: https://studio.code.org/s/data-science-with-python-2024/lessons/3/levels/1/summary