### PR TITLE
Evaluate Student Learning: update model annotations 

### DIFF
--- a/dashboard/app/models/user_level_evaluation.rb
+++ b/dashboard/app/models/user_level_evaluation.rb
@@ -12,8 +12,8 @@
 #  section_id          :integer
 #  school_year         :string(255)
 #  evaluator           :string(255)
-#  evaluation_criteria :string(255)
-#  reasoning           :string(255)
+#  evaluation_criteria :text(65535)
+#  reasoning           :text(65535)
 #  evaluation          :string(255)
 #  ai_model_version    :string(255)
 #  code_version        :string(255)

--- a/dashboard/app/models/user_level_skill_evaluation.rb
+++ b/dashboard/app/models/user_level_skill_evaluation.rb
@@ -12,8 +12,8 @@
 #  section_id          :integer
 #  school_year         :string(255)
 #  evaluator           :string(255)
-#  evaluation_criteria :string(255)
-#  reasoning           :string(255)
+#  evaluation_criteria :text(65535)
+#  reasoning           :text(65535)
 #  evaluation          :string(255)
 #  ai_model_version    :string(255)
 #  code_version        :string(255)


### PR DESCRIPTION
 I missed checking in updated annotations for UserLevelEvaluations and UserLevelSkillEvaluations when the evaluation_criteria and reasoning field were switched from string to text. This fixes that so there won't be local diffs when people run migrations. 
