### PR TITLE
chore: increase jest timeout on long running test

### DIFF
--- a/apps/test/unit/census/CensusFormTest.js
+++ b/apps/test/unit/census/CensusFormTest.js
@@ -121,107 +121,125 @@ describe('CensusForm Component', () => {
     expect(nameInput).toHaveValue('Jane Doe');
   });
 
-  it('validates required fields on submission', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: Promise.resolve([{value: '123', label: 'Cool School'}]),
-    });
+  it(
+    'validates required fields on submission',
+    async () => {
+      mockFetch.mockResolvedValueOnce({
+        json: Promise.resolve([{value: '123', label: 'Cool School'}]),
+      });
 
-    const {user} = setup(
-      <CensusForm
-        {...{
-          ...defaultProps,
-          prefillData: {
-            ...defaultProps.prefillData,
-            userEmail: '',
-            schoolId: '123',
-          },
-        }}
-      />
-    );
+      const {user} = setup(
+        <CensusForm
+          {...{
+            ...defaultProps,
+            prefillData: {
+              ...defaultProps.prefillData,
+              userEmail: '',
+              schoolId: '123',
+            },
+          }}
+        />
+      );
 
-    // fetching school by schoolId
-    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+      // fetching school by schoolId
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
 
-    jest.clearAllMocks();
+      jest.clearAllMocks();
 
-    const emailInput = screen.getByPlaceholderText(i18n.yourEmailPlaceholder());
-    const hocInput = screen.getByRole('combobox', {
-      name: i18n.censusHowManyHoC(),
-    });
-    const afterSchoolInput = screen.getByRole('combobox', {
-      name: i18n.censusHowManyAfterSchool(),
-    });
-    const tenHoursInput = screen.getByRole('combobox', {
-      name: i18n.censusHowManyTenHours(),
-    });
-    const twentyHoursInput = screen.getByRole('combobox', {
-      name: i18n.censusHowManyTwentyHours(),
-    });
-    const shareInput = screen.getByRole('combobox', {
-      name: /Share my contact information/,
-    });
-    const optInInput = screen.getByRole('combobox', {
-      name: /Can we email you/,
-    });
-    const submitButton = screen.getByRole('button', {name: /submit/i});
+      const emailInput = screen.getByPlaceholderText(
+        i18n.yourEmailPlaceholder()
+      );
+      const hocInput = screen.getByRole('combobox', {
+        name: i18n.censusHowManyHoC(),
+      });
+      const afterSchoolInput = screen.getByRole('combobox', {
+        name: i18n.censusHowManyAfterSchool(),
+      });
+      const tenHoursInput = screen.getByRole('combobox', {
+        name: i18n.censusHowManyTenHours(),
+      });
+      const twentyHoursInput = screen.getByRole('combobox', {
+        name: i18n.censusHowManyTwentyHours(),
+      });
+      const shareInput = screen.getByRole('combobox', {
+        name: /Share my contact information/,
+      });
+      const optInInput = screen.getByRole('combobox', {
+        name: /Can we email you/,
+      });
+      const submitButton = screen.getByRole('button', {name: /submit/i});
 
-    await user.click(submitButton);
+      await user.click(submitButton);
 
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(screen.getByText(i18n.censusRequiredEmail())).toBeInTheDocument();
-    expect(screen.getByText(i18n.censusRequiredShare())).toBeInTheDocument();
-    expect(
-      screen.getByText(/required\. please let us know if we can email you\./i)
-    ).toBeInTheDocument();
-    expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(4);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(screen.getByText(i18n.censusRequiredEmail())).toBeInTheDocument();
+      expect(screen.getByText(i18n.censusRequiredShare())).toBeInTheDocument();
+      expect(
+        screen.getByText(/required\. please let us know if we can email you\./i)
+      ).toBeInTheDocument();
+      expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(
+        4
+      );
 
-    await user.type(emailInput, 'john@mail.com');
-    await user.click(submitButton);
+      await user.type(emailInput, 'john@mail.com');
+      await user.click(submitButton);
 
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(
-      screen.queryByText(i18n.censusRequiredEmail())
-    ).not.toBeInTheDocument();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(
+        screen.queryByText(i18n.censusRequiredEmail())
+      ).not.toBeInTheDocument();
 
-    await user.selectOptions(hocInput, 'SOME');
-    await user.click(submitButton);
+      await user.selectOptions(hocInput, 'SOME');
+      await user.click(submitButton);
 
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(3);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(
+        3
+      );
 
-    await user.selectOptions(afterSchoolInput, 'SOME');
-    await user.click(submitButton);
+      await user.selectOptions(afterSchoolInput, 'SOME');
+      await user.click(submitButton);
 
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(2);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(
+        2
+      );
 
-    await user.selectOptions(tenHoursInput, 'SOME');
-    await user.click(submitButton);
+      await user.selectOptions(tenHoursInput, 'SOME');
+      await user.click(submitButton);
 
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(1);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(
+        1
+      );
 
-    await user.selectOptions(twentyHoursInput, 'NONE');
-    await user.click(submitButton);
+      await user.selectOptions(twentyHoursInput, 'NONE');
+      await user.click(submitButton);
 
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(0);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(screen.queryAllByText(i18n.censusRequiredSelect())).toHaveLength(
+        0
+      );
 
-    await user.selectOptions(shareInput, 'Yes');
-    await user.click(submitButton);
+      await user.selectOptions(shareInput, 'Yes');
+      await user.click(submitButton);
 
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(
-      screen.queryByText(i18n.censusRequiredShare())
-    ).not.toBeInTheDocument();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(
+        screen.queryByText(i18n.censusRequiredShare())
+      ).not.toBeInTheDocument();
 
-    await user.selectOptions(optInInput, 'Yes');
-    await user.click(submitButton);
+      await user.selectOptions(optInInput, 'Yes');
+      await user.click(submitButton);
 
-    expect(
-      screen.queryByText(/required\. please let us know if we can email you\./i)
-    ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          /required\. please let us know if we can email you\./i
+        )
+      ).not.toBeInTheDocument();
 
-    expect(mockFetch).toHaveBeenCalled();
-  });
+      expect(mockFetch).toHaveBeenCalled();
+    },
+    1000 * 10
+  );
 });


### PR DESCRIPTION
this increases the jest timeout from 5 seconds to 10 seconds for a test that should probably be broken up into a few smaller tests. hopefully this fixes it for now, if not we'll skip it until it can be refactored.

test investigation [ticket](https://codedotorg.atlassian.net/browse/ACQ-3202)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
