### PR TITLE
AIChat Asset Helper Unit Tests

### DIFF
--- a/dashboard/app/helpers/aichat_asset_helper.rb
+++ b/dashboard/app/helpers/aichat_asset_helper.rb
@@ -25,7 +25,7 @@ module AichatAssetHelper
       level = Level.find_by(name: level_name)
       uuid_name = (level&.starter_assets || level&.project_template_level&.starter_assets || {})&.dig(filename)
       return nil if uuid_name.nil?
-      s3_object = ::LevelStarterAssetsHelper.get_object(uuid_name)
+      s3_object = LevelStarterAssetsHelper.get_object(uuid_name)
       return {status: 'FOUND', body: s3_object.get.body} if s3_object
     end
   end

--- a/dashboard/app/helpers/aichat_asset_helper.rb
+++ b/dashboard/app/helpers/aichat_asset_helper.rb
@@ -25,7 +25,7 @@ module AichatAssetHelper
       level = Level.find_by(name: level_name)
       uuid_name = (level&.starter_assets || level&.project_template_level&.starter_assets || {})&.dig(filename)
       return nil if uuid_name.nil?
-      s3_object = LevelStarterAssetsHelper.get_object(uuid_name)
+      s3_object = ::LevelStarterAssetsHelper.get_object(uuid_name)
       return {status: 'FOUND', body: s3_object.get.body} if s3_object
     end
   end

--- a/dashboard/test/helpers/aichat_asset_helper_test.rb
+++ b/dashboard/test/helpers/aichat_asset_helper_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+Object.send(:remove_const, :LevelStarterAssetsHelper) if Object.const_defined?(:LevelStarterAssetsHelper)
+LevelStarterAssetsHelper = Module.new do
+  def self.get_object(uuid)
+    OpenStruct.new(get: OpenStruct.new(body: StringIO.new("level content for #{uuid}")))
+  end
+end
+
+class AichatAssetHelperTest < ActionView::TestCase
+  FAKE_BUCKET = Object.new
+  def FAKE_BUCKET.get(channel_id, filename)
+    if filename == 'project.png'
+      {status: 'FOUND', body: StringIO.new('project content')}
+    else
+      {status: 'NOT_FOUND'}
+    end
+  end
+
+  if AichatAssetHelper.const_defined?(:ASSET_BUCKET)
+    AichatAssetHelper.send(:remove_const, :ASSET_BUCKET)
+  end
+
+  AichatAssetHelper.const_set(:ASSET_BUCKET, FAKE_BUCKET)
+
+  def setup
+    @channel_id = 'abc123'
+    @level_name = 'level-one'
+
+    @project_asset = {"filename" => "project.png", "source" => "project"}
+    @level_asset   = {"filename" => "level.png", "source" => "level"}
+
+    # Stub Level
+    Level.stubs(:find_by).with(name: @level_name).returns(
+      OpenStruct.new(
+        starter_assets: {'level.png' => 'uuid-123'},
+        project_template_level: nil
+      )
+    )
+  end
+
+  puts "::LevelStarterAssetsHelper defined? #{Object.const_defined?(:LevelStarterAssetsHelper)}"
+
+  test 'returns base64 data URI for project asset' do
+    result = AichatAssetHelper.get_asset_data_uri(@project_asset, @channel_id, @level_name)
+    assert_match(/^data:image\/png;base64,/, result)
+    decoded = Base64.decode64(result.split(',').last)
+    assert_equal 'project content', decoded
+  end
+
+  test 'returns base64 data URI for level asset' do
+    result = AichatAssetHelper.get_asset_data_uri(@level_asset, @channel_id, @level_name)
+    assert_match(/^data:image\/png;base64,/, result)
+    decoded = Base64.decode64(result.split(',').last)
+    assert_equal 'level content for uuid-123', decoded
+  end
+
+  test 'raises error if asset is not found' do
+    missing_asset = {"filename" => "nonexistent.png", "source" => "level"}
+    Level.stubs(:find_by).with(name: @level_name).returns(
+      OpenStruct.new(starter_assets: {}, project_template_level: nil)
+    )
+
+    assert_raises(StandardError) do
+      AichatAssetHelper.get_asset_data_uri(missing_asset, @channel_id, @level_name)
+    end
+  end
+end

--- a/dashboard/test/helpers/aichat_asset_helper_test.rb
+++ b/dashboard/test/helpers/aichat_asset_helper_test.rb
@@ -1,17 +1,6 @@
 require 'test_helper'
-
-# Top-level override of LevelStarterAssetsHelper (real one is restored in teardown)
-REAL_LSA_HELPER = Object.const_get(:LevelStarterAssetsHelper) if Object.const_defined?(:LevelStarterAssetsHelper)
-
-Object.send(:remove_const, :LevelStarterAssetsHelper) if Object.const_defined?(:LevelStarterAssetsHelper)
-LevelStarterAssetsHelper = Module.new do
-  def self.get_object(uuid)
-    OpenStruct.new(get: OpenStruct.new(body: StringIO.new("level content for #{uuid}")))
-  end
-end
-
 class AichatAssetHelperTest < ActionView::TestCase
-  # Setup mock asset bucket at class level
+  # Set up a fake bucket object with a .get method
   FAKE_BUCKET = Object.new
   def FAKE_BUCKET.get(channel_id, filename)
     if filename == 'project.png'
@@ -21,6 +10,7 @@ class AichatAssetHelperTest < ActionView::TestCase
     end
   end
 
+  # Replace ASSET_BUCKET constant safely
   if AichatAssetHelper.const_defined?(:ASSET_BUCKET)
     AichatAssetHelper.send(:remove_const, :ASSET_BUCKET)
   end
@@ -33,18 +23,17 @@ class AichatAssetHelperTest < ActionView::TestCase
     @project_asset = {"filename" => "project.png", "source" => "project"}
     @level_asset   = {"filename" => "level.png", "source" => "level"}
 
+    LevelStarterAssetsHelper.stubs(:get_object).returns(
+      OpenStruct.new(get: OpenStruct.new(body: StringIO.new("level content for uuid-123")))
+    )
+
+    # ✅ Stub Level return object
     Level.stubs(:find_by).with(name: @level_name).returns(
       OpenStruct.new(
         starter_assets: {'level.png' => 'uuid-123'},
         project_template_level: nil
       )
     )
-  end
-
-  def teardown
-    # Restore the real LevelStarterAssetsHelper
-    Object.send(:remove_const, :LevelStarterAssetsHelper)
-    Object.const_set(:LevelStarterAssetsHelper, REAL_LSA_HELPER)
   end
 
   test 'returns base64 data URI for project asset' do
@@ -63,7 +52,6 @@ class AichatAssetHelperTest < ActionView::TestCase
 
   test 'raises error if asset is not found' do
     missing_asset = {"filename" => "nonexistent.png", "source" => "level"}
-
     Level.stubs(:find_by).with(name: @level_name).returns(
       OpenStruct.new(starter_assets: {}, project_template_level: nil)
     )

--- a/dashboard/test/helpers/aichat_asset_helper_test.rb
+++ b/dashboard/test/helpers/aichat_asset_helper_test.rb
@@ -1,4 +1,8 @@
 require 'test_helper'
+
+# Top-level override of LevelStarterAssetsHelper (real one is restored in teardown)
+REAL_LSA_HELPER = Object.const_get(:LevelStarterAssetsHelper) if Object.const_defined?(:LevelStarterAssetsHelper)
+
 Object.send(:remove_const, :LevelStarterAssetsHelper) if Object.const_defined?(:LevelStarterAssetsHelper)
 LevelStarterAssetsHelper = Module.new do
   def self.get_object(uuid)
@@ -7,6 +11,7 @@ LevelStarterAssetsHelper = Module.new do
 end
 
 class AichatAssetHelperTest < ActionView::TestCase
+  # Setup mock asset bucket at class level
   FAKE_BUCKET = Object.new
   def FAKE_BUCKET.get(channel_id, filename)
     if filename == 'project.png'
@@ -19,7 +24,6 @@ class AichatAssetHelperTest < ActionView::TestCase
   if AichatAssetHelper.const_defined?(:ASSET_BUCKET)
     AichatAssetHelper.send(:remove_const, :ASSET_BUCKET)
   end
-
   AichatAssetHelper.const_set(:ASSET_BUCKET, FAKE_BUCKET)
 
   def setup
@@ -29,7 +33,6 @@ class AichatAssetHelperTest < ActionView::TestCase
     @project_asset = {"filename" => "project.png", "source" => "project"}
     @level_asset   = {"filename" => "level.png", "source" => "level"}
 
-    # Stub Level
     Level.stubs(:find_by).with(name: @level_name).returns(
       OpenStruct.new(
         starter_assets: {'level.png' => 'uuid-123'},
@@ -38,7 +41,11 @@ class AichatAssetHelperTest < ActionView::TestCase
     )
   end
 
-  puts "::LevelStarterAssetsHelper defined? #{Object.const_defined?(:LevelStarterAssetsHelper)}"
+  def teardown
+    # Restore the real LevelStarterAssetsHelper
+    Object.send(:remove_const, :LevelStarterAssetsHelper)
+    Object.const_set(:LevelStarterAssetsHelper, REAL_LSA_HELPER)
+  end
 
   test 'returns base64 data URI for project asset' do
     result = AichatAssetHelper.get_asset_data_uri(@project_asset, @channel_id, @level_name)
@@ -56,6 +63,7 @@ class AichatAssetHelperTest < ActionView::TestCase
 
   test 'raises error if asset is not found' do
     missing_asset = {"filename" => "nonexistent.png", "source" => "level"}
+
     Level.stubs(:find_by).with(name: @level_name).returns(
       OpenStruct.new(starter_assets: {}, project_template_level: nil)
     )

--- a/dashboard/test/helpers/aichat_asset_helper_test.rb
+++ b/dashboard/test/helpers/aichat_asset_helper_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
+
 class AichatAssetHelperTest < ActionView::TestCase
-  # Set up a fake bucket object with a .get method
+  # Override ASSET_BUCKET with a test double since it's already instantiated in the helper
+  # and cannot be easily stubbed. This avoids triggering real S3 calls during tests.
   FAKE_BUCKET = Object.new
   def FAKE_BUCKET.get(channel_id, filename)
     if filename == 'project.png'
@@ -10,25 +12,24 @@ class AichatAssetHelperTest < ActionView::TestCase
     end
   end
 
-  # Replace ASSET_BUCKET constant safely
   if AichatAssetHelper.const_defined?(:ASSET_BUCKET)
     AichatAssetHelper.send(:remove_const, :ASSET_BUCKET)
   end
   AichatAssetHelper.const_set(:ASSET_BUCKET, FAKE_BUCKET)
 
-  def setup
-    @channel_id = 'abc123'
-    @level_name = 'level-one'
+  let(:channel_id) {'abc123'}
+  let(:level_name) {'level-one'}
 
-    @project_asset = {"filename" => "project.png", "source" => "project"}
-    @level_asset   = {"filename" => "level.png", "source" => "level"}
+  let(:project_asset) {{"filename" => "project.png", "source" => "project"}}
+  let(:level_asset)   {{"filename" => "level.png", "source" => "level"}}
+  let(:missing_asset) {{"filename" => "missing.png", "source" => "level"}}
 
+  before do
     LevelStarterAssetsHelper.stubs(:get_object).returns(
       OpenStruct.new(get: OpenStruct.new(body: StringIO.new("level content for uuid-123")))
     )
 
-    # ✅ Stub Level return object
-    Level.stubs(:find_by).with(name: @level_name).returns(
+    Level.stubs(:find_by).with(name: level_name).returns(
       OpenStruct.new(
         starter_assets: {'level.png' => 'uuid-123'},
         project_template_level: nil
@@ -36,28 +37,119 @@ class AichatAssetHelperTest < ActionView::TestCase
     )
   end
 
-  test 'returns base64 data URI for project asset' do
-    result = AichatAssetHelper.get_asset_data_uri(@project_asset, @channel_id, @level_name)
-    assert_match(/^data:image\/png;base64,/, result)
-    decoded = Base64.decode64(result.split(',').last)
-    assert_equal 'project content', decoded
+  describe '.get_asset_data_uri (unit)' do
+    subject {AichatAssetHelper.get_asset_data_uri(asset, channel_id, level_name)}
+
+    context 'when fetch_asset returns FOUND' do
+      let(:asset) {project_asset}
+
+      before do
+        AichatAssetHelper.stubs(:fetch_asset).with("project.png", "project", channel_id, level_name).returns(
+          {status: 'FOUND', body: StringIO.new("stubbed content")}
+        )
+      end
+
+      it 'returns a base64-encoded data URI' do
+        subject.must_match(/^data:image\/png;base64,/)
+        Base64.decode64(subject.split(',').last).must_equal "stubbed content"
+      end
+    end
+
+    context 'when fetch_asset returns nil' do
+      let(:asset) {missing_asset}
+
+      before do
+        AichatAssetHelper.stubs(:fetch_asset).with("missing.png", "level", channel_id, level_name).returns(nil)
+      end
+
+      it 'raises an error' do
+        -> {subject}.must_raise(StandardError)
+      end
+    end
   end
 
-  test 'returns base64 data URI for level asset' do
-    result = AichatAssetHelper.get_asset_data_uri(@level_asset, @channel_id, @level_name)
-    assert_match(/^data:image\/png;base64,/, result)
-    decoded = Base64.decode64(result.split(',').last)
-    assert_equal 'level content for uuid-123', decoded
+  describe '.fetch_asset (unit)' do
+    subject {AichatAssetHelper.fetch_asset(filename, source, channel_id, level_name)}
+
+    context 'when source is level and asset exists' do
+      let(:filename) {level_asset["filename"]}
+      let(:source)   {level_asset["source"]}
+
+      it 'returns FOUND with content' do
+        subject[:status].must_equal 'FOUND'
+        subject[:body].read.must_equal 'level content for uuid-123'
+      end
+    end
+
+    context 'when source is level and asset is missing' do
+      let(:filename) {missing_asset["filename"]}
+      let(:source)   {missing_asset["source"]}
+
+      before do
+        Level.stubs(:find_by).with(name: level_name).returns(
+          OpenStruct.new(starter_assets: {}, project_template_level: nil)
+        )
+      end
+
+      it 'returns nil' do
+        subject.must_be_nil
+      end
+    end
+
+    context 'when source is project and asset exists' do
+      let(:filename) {project_asset["filename"]}
+      let(:source)   {project_asset["source"]}
+
+      it 'returns FOUND with content' do
+        subject[:status].must_equal 'FOUND'
+        subject[:body].read.must_equal 'project content'
+      end
+    end
+
+    context 'when source is project and asset is missing' do
+      let(:filename) {'nonexistent.png'}
+      let(:source)   {'project'}
+
+      it 'returns NOT_FOUND response' do
+        result = AichatAssetHelper.fetch_asset(filename, source, channel_id, level_name)
+        result[:status].must_equal 'NOT_FOUND'
+      end
+    end
   end
 
-  test 'raises error if asset is not found' do
-    missing_asset = {"filename" => "nonexistent.png", "source" => "level"}
-    Level.stubs(:find_by).with(name: @level_name).returns(
-      OpenStruct.new(starter_assets: {}, project_template_level: nil)
-    )
+  describe '.get_asset_data_uri (integration)' do
+    subject {AichatAssetHelper.get_asset_data_uri(asset, channel_id, level_name)}
 
-    assert_raises(StandardError) do
-      AichatAssetHelper.get_asset_data_uri(missing_asset, @channel_id, @level_name)
+    context 'with a valid project asset' do
+      let(:asset) {project_asset}
+
+      it 'returns a base64-encoded data URI' do
+        subject.must_match(/^data:image\/png;base64,/)
+        Base64.decode64(subject.split(',').last).must_equal 'project content'
+      end
+    end
+
+    context 'with a valid level asset' do
+      let(:asset) {level_asset}
+
+      it 'returns a base64-encoded data URI' do
+        subject.must_match(/^data:image\/png;base64,/)
+        Base64.decode64(subject.split(',').last).must_equal 'level content for uuid-123'
+      end
+    end
+
+    context 'with a missing asset' do
+      let(:asset) {missing_asset}
+
+      before do
+        Level.stubs(:find_by).with(name: level_name).returns(
+          OpenStruct.new(starter_assets: {}, project_template_level: nil)
+        )
+      end
+
+      it 'raises a StandardError' do
+        -> {subject}.must_raise(StandardError)
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Adds unit tests for `AichatAssetHelper`, which supports multimodal AI chat features by retrieving and encoding asset files as Base64 URIs.

### What’s Covered

These tests validate:

1. Project assets provided by the student
2. Starter assets provided by the level
3. Error handling when an asset cannot be found

### Tests

- `test_returns_base64_data_URI_for_project_asset`
- `test_returns_base64_data_URI_for_level_asset`
- `test_raises_error_if_asset_is_not_found`

All pass under `bundle exec rails test test/helpers/aichat_asset_helper_test.rb`

### Risks

- I had to use global constant overrides (`const_set`), which worked inside single-threaded Minitest but should be watched if tests are parallelized.

### Follow-up

- If we refactor the helper to use dependency injection (e.g., `def self.asset_bucket`) instead of instantiating it as a constant, we can simplify test setup and avoid constant overrides entirely. 
- Will be discussing with others if this desirable or if having it immutably instantiating at the start is important for functionality 