### PR TITLE
fix(ui-tests): use exact headings

### DIFF
--- a/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
@@ -27,7 +27,10 @@ export class AllTheThingsPage extends MarketingPage {
 
   getSectionLocator(heading: Section): Locator {
     // Find the section with the heading
-    const headingLocator = this.page.getByRole('heading', {name: heading});
+    const headingLocator = this.page.getByRole('heading', {
+      name: heading,
+      exact: true,
+    });
 
     // Go through the top-level sections, finding the one that has this heading
     return this.page.locator('section').filter({has: headingLocator});


### PR DESCRIPTION
Previously, headings were using an inexact match, so when a new component was added with "button" in its heading, it moved the button tests up. This change uses exact headings instead