### PR TITLE
skip regenerating schema.rb on the test machine

### DIFF
--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -100,4 +100,9 @@ Dashboard::Application.configure do
   end
 
   config.experiment_cache_time_seconds = 0
+
+  # Prevent merge conflicts on schema.rb by skipping regeneration of schema.rb
+  # on the test machine. this is necessary because as of April 2025 the test DB
+  # schema differs from other environments due to utf8mb3 vs utf8mb4 issues.
+  config.active_record.dump_schema_after_migration = !CDO.chef_managed
 end

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -104,5 +104,5 @@ Dashboard::Application.configure do
   # Prevent merge conflicts on schema.rb by skipping regeneration of schema.rb
   # on the test machine. this is necessary because as of April 2025 the test DB
   # schema differs from other environments due to utf8mb3 vs utf8mb4 issues.
-  config.active_record.dump_schema_after_migration = !CDO.chef_managed
+  config.active_record.dump_schema_after_migration = !CDO.test_system?
 end


### PR DESCRIPTION
Last time the dashboard_test DB was reset on the test machine, we forgot to set its CHARACTER SET and COLLATE settings to match other environments. This leads to local schema.rb changes on the test machine, which cause merge conflicts which block the DTT every time a developer writes a migration. The infra team has a plan to reconcile the DB differences over the next 1-2 months (see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1744061723980879?thread_ts=1743628657.101349&cid=C0T0PNTM3)). This PR is intended to prevent the merge conflicts in the interim.

Note that this PR only changes the settings for the test machine, ensuring that developers who migrate their test DB will still see updates to schema.rb, which is helpful for developers who prefer to write migrations against their test DB. 

## Testing story

* manually verified on the test machine that schema.rb no longer gets regenerated during DTT
* manually verified on local workstation that `RAILS_ENV=test bundle exec rake db:migrate` still generates changes to schema.rb

## Follow-up work

Infra team to consider tracking the work to undo this change once staging, test and prod schemas match