### PR TITLE
CMS-510: Add "Single Link" field to `IconHighlight` component

### DIFF
--- a/frontend/apps/marketing/src/components/iconHighlight/IconHighlight.tsx
+++ b/frontend/apps/marketing/src/components/iconHighlight/IconHighlight.tsx
@@ -3,47 +3,41 @@ import {useMemo} from 'react';
 
 import IconHighlight, {
   IconHighlightLinkProps,
-  IconHighlightProps,
 } from '@code-dot-org/component-library/cms/iconHighlight';
 
 import {fontAwesomeV6BrandIconsMap} from '@/components/common/constants';
+import type {LinkEntry} from '@/contentful/types/entries';
 
-export type IconHighlightContentfulLinkEntry = {
-  sys: {
-    id: EntryFields.Text;
-  };
-  fields: {
-    label: EntryFields.Text;
-    primaryTarget: EntryFields.Text;
-    ariaLabel?: EntryFields.Text;
-    isThisAnExternalLink?: EntryFields.Boolean;
-  };
-};
-
-export interface IconHighlightContentfulProps extends IconHighlightProps {
+export interface IconHighlightContentfulProps {
+  heading: EntryFields.Text;
+  text: EntryFields.Text;
   iconName: EntryFields.Text;
-  linkEntries?: IconHighlightContentfulLinkEntry[];
+  linkEntry?: LinkEntry;
+  linkEntries?: LinkEntry[];
 }
 
 const IconHighlightContentful: React.FunctionComponent<
   IconHighlightContentfulProps
-> = ({iconName, linkEntries = [], ...props}) => {
-  const links: IconHighlightLinkProps[] = useMemo(
-    () =>
-      linkEntries.filter(Boolean).map(linkEntry => ({
-        key: linkEntry.sys.id,
-        text: linkEntry.fields.label,
-        href: linkEntry.fields.primaryTarget,
-        external: linkEntry.fields.isThisAnExternalLink,
-        target: linkEntry.fields.isThisAnExternalLink ? '_blank' : undefined,
-        'aria-label': linkEntry.fields.ariaLabel || undefined,
-      })),
-    [linkEntries],
-  );
+> = ({heading, text, iconName, linkEntry, linkEntries = []}) => {
+  const links: IconHighlightLinkProps[] = useMemo(() => {
+    const links: LinkEntry[] = linkEntries.filter(Boolean);
+
+    if (!links.length && linkEntry) links.push(linkEntry);
+
+    return links.map(linkEntry => ({
+      key: linkEntry.sys.id,
+      text: linkEntry.fields.label,
+      href: linkEntry.fields.primaryTarget,
+      external: linkEntry.fields.isThisAnExternalLink,
+      target: linkEntry.fields.isThisAnExternalLink ? '_blank' : undefined,
+      'aria-label': linkEntry.fields.ariaLabel || undefined,
+    }));
+  }, [linkEntry, linkEntries]);
 
   return (
     <IconHighlight
-      {...props}
+      heading={heading}
+      text={text}
       links={links}
       icon={{
         iconName,

--- a/frontend/apps/marketing/src/components/iconHighlight/IconHighlightContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/iconHighlight/IconHighlightContentfulDefinition.ts
@@ -45,8 +45,17 @@ export const IconHighlightContentfulComponentDefinition: ComponentDefinition = {
         required: true,
       },
     },
+    linkEntry: {
+      displayName: 'Single Link',
+      type: 'Link',
+      group: 'content',
+      description: 'Accepts only the "Link" content type entry',
+      validations: {
+        bindingSourceType: ['entry'],
+      },
+    },
     linkEntries: {
-      displayName: 'Links',
+      displayName: 'Multiple Links',
       type: 'Array',
       group: 'content',
       description:

--- a/frontend/apps/marketing/src/components/iconHighlight/__tests__/IconHighlight.test.tsx
+++ b/frontend/apps/marketing/src/components/iconHighlight/__tests__/IconHighlight.test.tsx
@@ -2,7 +2,6 @@ import {render, screen, within} from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import IconHighlight, {
-  IconHighlightContentfulLinkEntry,
   IconHighlightContentfulProps,
 } from '@/components/iconHighlight/IconHighlight';
 
@@ -53,8 +52,52 @@ describe('IconHighlight component', () => {
     expect(screen.queryByRole('list')).not.toBeInTheDocument();
   });
 
-  it('renders card link list with provided link entries', () => {
-    const internalLinkEntry: IconHighlightContentfulLinkEntry = {
+  it('renders card link list with provided link entry', () => {
+    const linkEntry = {
+      sys: {
+        id: 'link',
+      },
+      fields: {
+        label: 'Link',
+        primaryTarget: 'https://code.org/link',
+        ariaLabel: 'Link aria label',
+        isThisAnExternalLink: false,
+      },
+    };
+
+    renderCardContainer({linkEntry: linkEntry});
+
+    const linkList = screen.getByRole('list');
+    expect(linkList).toBeVisible();
+
+    const internalLink = within(linkList).getByRole('link', {
+      name: linkEntry.fields.ariaLabel,
+    });
+    expect(internalLink).toBeVisible();
+    expect(internalLink).toHaveTextContent(linkEntry.fields.label);
+    expect(internalLink).toHaveAttribute(
+      'href',
+      linkEntry.fields.primaryTarget,
+    );
+    expect(internalLink).not.toHaveAttribute('target');
+    expect(
+      within(internalLink).queryByRole('img', {name: 'external link'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders card link list with only provided link entries', () => {
+    const linkEntry = {
+      sys: {
+        id: 'link',
+      },
+      fields: {
+        label: 'Link',
+        primaryTarget: 'https://code.org/link',
+        ariaLabel: 'Link aria label',
+        isThisAnExternalLink: false,
+      },
+    };
+    const internalLinkEntry = {
       sys: {
         id: 'internal-link',
       },
@@ -65,7 +108,7 @@ describe('IconHighlight component', () => {
         isThisAnExternalLink: false,
       },
     };
-    const externalLinkEntry: IconHighlightContentfulLinkEntry = {
+    const externalLinkEntry = {
       sys: {
         id: 'external-link',
       },
@@ -77,10 +120,18 @@ describe('IconHighlight component', () => {
       },
     };
 
-    renderCardContainer({linkEntries: [internalLinkEntry, externalLinkEntry]});
+    renderCardContainer({
+      linkEntry: linkEntry,
+      linkEntries: [internalLinkEntry, externalLinkEntry],
+    });
 
     const linkList = screen.getByRole('list');
     expect(linkList).toBeVisible();
+
+    const link = within(linkList).queryByRole('link', {
+      name: linkEntry.fields.ariaLabel,
+    });
+    expect(link).not.toBeInTheDocument();
 
     const internalLink = within(linkList).getByRole('link', {
       name: internalLinkEntry.fields.ariaLabel,


### PR DESCRIPTION
## With `Single Link`
<img width="100%" alt="Screenshot 2025-04-09 at 00 18 10" src="https://github.com/user-attachments/assets/4cd1bbeb-1851-4ecf-b225-cda491ac66ed" />

## With `Single Link` and `Multiple Links`
> Displays only Multiple Links
<img width="100%" alt="Screenshot 2025-04-09 at 00 18 56" src="https://github.com/user-attachments/assets/55f15b50-e7d6-44aa-93b7-0de8fe200b64" />

## Links
- JIRA task: [CMS-510](https://codedotorg.atlassian.net/browse/CMS-510)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/64714