### PR TITLE
Evaluate Student Learning: new STUDENT_WORK_ACCESS permission for dataset makers

### DIFF
--- a/apps/src/levelbuilder/ai-iteration-tools/AIIterationTools.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/AIIterationTools.tsx
@@ -8,14 +8,14 @@ import styles from './ai-tutor/ai-tutor-tester.module.scss';
 
 interface AIIterationToolsProps {
   aiTutorAccess: boolean;
-  datasetMaker: boolean;
+  studentWorkAccess: boolean;
 }
 
 const AIIterationTools: React.FC<AIIterationToolsProps> = ({
   aiTutorAccess,
-  datasetMaker,
+  studentWorkAccess,
 }) => {
-  const allowed = aiTutorAccess || datasetMaker;
+  const allowed = aiTutorAccess || studentWorkAccess;
   return (
     <div>
       <h1>AI Iteration Tools</h1>
@@ -28,7 +28,7 @@ const AIIterationTools: React.FC<AIIterationToolsProps> = ({
         </h3>
       )}
       <div>
-        {datasetMaker && (
+        {studentWorkAccess && (
           <div>
             <StudentCodeDatasetMaker />
             <br />

--- a/apps/src/levelbuilder/ai-iteration-tools/AIIterationTools.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/AIIterationTools.tsx
@@ -7,10 +7,15 @@ import StudentCodeDatasetMaker from './StudentCodeDatasetMaker';
 import styles from './ai-tutor/ai-tutor-tester.module.scss';
 
 interface AIIterationToolsProps {
-  allowed: boolean;
+  aiTutorAccess: boolean;
+  datasetMaker: boolean;
 }
 
-const AIIterationTools: React.FC<AIIterationToolsProps> = ({allowed}) => {
+const AIIterationTools: React.FC<AIIterationToolsProps> = ({
+  aiTutorAccess,
+  datasetMaker,
+}) => {
+  const allowed = aiTutorAccess || datasetMaker;
   return (
     <div>
       <h1>AI Iteration Tools</h1>
@@ -19,20 +24,23 @@ const AIIterationTools: React.FC<AIIterationToolsProps> = ({allowed}) => {
       </p>
       {!allowed && (
         <h3 className={styles.denied}>
-          You need to be a Levelbuilder with AI Tutor Access to use these tools.
+          You don't have the permissions needed to use these tools.
         </h3>
       )}
-      {allowed && (
-        <div>
-          <StudentCodeDatasetMaker />
-          <br />
-          <br />
-          <FreeResponseDatasetMaker />
-          <hr />
-          <br />
-          <AITutorTester />
-        </div>
-      )}
+      <div>
+        {datasetMaker && (
+          <div>
+            <StudentCodeDatasetMaker />
+            <br />
+            <hr />
+            <br />
+            <FreeResponseDatasetMaker />
+          </div>
+        )}
+        <hr />
+        <br />
+        {aiTutorAccess && <AITutorTester />}
+      </div>
     </div>
   );
 };

--- a/apps/src/sites/studio/pages/ai_iteration/tools.js
+++ b/apps/src/sites/studio/pages/ai_iteration/tools.js
@@ -9,7 +9,7 @@ $(document).ready(() => {
   ReactDOM.render(
     <AIIterationTools
       aiTutorAccess={aiIterationToolsData.aiTutorAccess}
-      datasetMaker={aiIterationToolsData.datasetMaker}
+      studentWorkAccess={aiIterationToolsData.studentWorkAccess}
     />,
     document.getElementById('ai-iteration-tools')
   );

--- a/apps/src/sites/studio/pages/ai_iteration/tools.js
+++ b/apps/src/sites/studio/pages/ai_iteration/tools.js
@@ -7,7 +7,10 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 $(document).ready(() => {
   const aiIterationToolsData = getScriptData('aiIterationToolsData');
   ReactDOM.render(
-    <AIIterationTools allowed={aiIterationToolsData.allowed} />,
+    <AIIterationTools
+      aiTutorAccess={aiIterationToolsData.aiTutorAccess}
+      datasetMaker={aiIterationToolsData.datasetMaker}
+    />,
     document.getElementById('ai-iteration-tools')
   );
 });

--- a/dashboard/app/controllers/openai_evaluate_controller.rb
+++ b/dashboard/app/controllers/openai_evaluate_controller.rb
@@ -3,8 +3,7 @@ require 'json'
 class OpenaiEvaluateController < ApplicationController
   authorize_resource class: false
 
-  #API_KEY = CDO.openai_measures_of_learning_api_key
-  API_KEY = CDO.openai_student_learning_api_key
+  API_KEY = CDO.openai_measures_of_learning_api_key
   MODEL = SharedConstants::EVALUATE_STUDENT_LEARNING_MODEL_VERSION
 
   # POST /openai/evaluate

--- a/dashboard/app/controllers/openai_evaluate_controller.rb
+++ b/dashboard/app/controllers/openai_evaluate_controller.rb
@@ -3,7 +3,8 @@ require 'json'
 class OpenaiEvaluateController < ApplicationController
   authorize_resource class: false
 
-  API_KEY = CDO.openai_measures_of_learning_api_key
+  #API_KEY = CDO.openai_measures_of_learning_api_key
+  API_KEY = CDO.openai_student_learning_api_key
   MODEL = SharedConstants::EVALUATE_STUDENT_LEARNING_MODEL_VERSION
 
   # POST /openai/evaluate

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -361,11 +361,14 @@ class Ability
       can :extra_links, ProjectsController
     end
 
-    if user.persisted? && (user.can_use_ai_iteration_tools? || user.dataset_maker?)
+    if user.persisted? && (user.can_use_ai_iteration_tools? || user.can_access_student_work?)
       can [:tools], :ai_iteration
     end
 
-    if user.persisted? && user.dataset_maker?
+    # Students can always access their own work, and teachers can access the work of students in their sections.
+    # This is specifically for the student work sample API which allows pulling student work samples to make
+    # datasets to gauge accuracy of our AI evaluation tools.
+    if user.persisted? && user.can_access_student_work?
       can [:fetch_student_code_samples], :student_work_sample
       can [:fetch_free_response_answers], :student_work_sample
     end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -361,8 +361,11 @@ class Ability
       can :extra_links, ProjectsController
     end
 
-    if user.persisted? && user.can_use_ai_iteration_tools?
+    if user.persisted? && (user.can_use_ai_iteration_tools? || user.dataset_maker?)
       can [:tools], :ai_iteration
+    end
+
+    if user.persisted? && user.dataset_maker?
       can [:fetch_student_code_samples], :student_work_sample
       can [:fetch_free_response_answers], :student_work_sample
     end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -365,9 +365,6 @@ class Ability
       can [:tools], :ai_iteration
     end
 
-    # Students can always access their own work, and teachers can access the work of students in their sections.
-    # This is specifically for the student work sample API which allows pulling student work samples to make
-    # datasets to gauge accuracy of our AI evaluation tools.
     if user.persisted? && user.can_access_student_work?
       can [:fetch_student_code_samples], :student_work_sample
       can [:fetch_free_response_answers], :student_work_sample

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1290,8 +1290,8 @@ class User < ApplicationRecord
     permission?(UserPermission::LEVELBUILDER)
   end
 
-  def dataset_maker?
-    permission?(UserPermission::DATASET_MAKER)
+  def can_access_student_work?
+    permission?(UserPermission::STUDENT_WORK_ACCESS)
   end
 
   # A user is a verified instructor if you are a universal_instructor, plc_reviewer,

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1290,6 +1290,10 @@ class User < ApplicationRecord
     permission?(UserPermission::LEVELBUILDER)
   end
 
+  # Students can always access their own work, and teachers can access the work of
+  # students in their sections. This is specifically for the student work sample API
+  # which allows pulling student work samples to make datasets to gauge accuracy of
+  # our AI evaluation tools internally.
   def can_access_student_work?
     permission?(UserPermission::STUDENT_WORK_ACCESS)
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1290,6 +1290,10 @@ class User < ApplicationRecord
     permission?(UserPermission::LEVELBUILDER)
   end
 
+  def dataset_maker?
+    permission?(UserPermission::DATASET_MAKER)
+  end
+
   # A user is a verified instructor if you are a universal_instructor, plc_reviewer,
   # facilitator, authorized_teacher, or levelbuilder. All of these permissions tell us someone
   # should be trusted with locked down instructor only content. It is important to use this

--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -46,6 +46,8 @@ class UserPermission < ApplicationRecord
     UNIVERSAL_INSTRUCTOR = 'universal_instructor'.freeze,
     # Grants access to use AI Tutor which uses AI Chat API
     AI_TUTOR_ACCESS = 'ai_tutor_access'.freeze,
+    #  Grants access to an internal tool to pull AI-evaluated samples of student work
+    DATASET_MAKER = 'dataset_maker'.freeze,
   ].freeze
 
   # Do not log the granting/removal of these permissions to slack

--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -47,7 +47,7 @@ class UserPermission < ApplicationRecord
     # Grants access to use AI Tutor which uses AI Chat API
     AI_TUTOR_ACCESS = 'ai_tutor_access'.freeze,
     #  Grants access to an internal tool to pull AI-evaluated samples of student work
-    DATASET_MAKER = 'dataset_maker'.freeze,
+    STUDENT_WORK_ACCES = 'student_work_access'.freeze,
   ].freeze
 
   # Do not log the granting/removal of these permissions to slack

--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -47,7 +47,7 @@ class UserPermission < ApplicationRecord
     # Grants access to use AI Tutor which uses AI Chat API
     AI_TUTOR_ACCESS = 'ai_tutor_access'.freeze,
     #  Grants access to an internal tool to pull AI-evaluated samples of student work
-    STUDENT_WORK_ACCES = 'student_work_access'.freeze,
+    STUDENT_WORK_ACCESS = 'student_work_access'.freeze,
   ].freeze
 
   # Do not log the granting/removal of these permissions to slack

--- a/dashboard/app/views/ai_iteration/tools.html.haml
+++ b/dashboard/app/views/ai_iteration/tools.html.haml
@@ -1,7 +1,7 @@
 :ruby
     ai_iteration_tools_data = {}
     ai_iteration_tools_data[:aiTutorAccess] = current_user.can_use_ai_iteration_tools?
-    ai_iteration_tools_data[:datasetMaker] = current_user.dataset_maker?
+    ai_iteration_tools_data[:studentWorkAccess] = current_user.can_access_student_work?
 
 %script{src: webpack_asset_path('js/ai_iteration/tools.js'), data: {aiIterationToolsData: ai_iteration_tools_data.to_json}}
 

--- a/dashboard/app/views/ai_iteration/tools.html.haml
+++ b/dashboard/app/views/ai_iteration/tools.html.haml
@@ -1,6 +1,7 @@
 :ruby
     ai_iteration_tools_data = {}
-    ai_iteration_tools_data[:allowed] = current_user.can_use_ai_iteration_tools?
+    ai_iteration_tools_data[:aiTutorAccess] = current_user.can_use_ai_iteration_tools?
+    ai_iteration_tools_data[:datasetMaker] = current_user.dataset_maker?
 
 %script{src: webpack_asset_path('js/ai_iteration/tools.js'), data: {aiIterationToolsData: ai_iteration_tools_data.to_json}}
 

--- a/dashboard/app/views/levels/_dataset_maker_level_info.html.haml
+++ b/dashboard/app/views/levels/_dataset_maker_level_info.html.haml
@@ -7,15 +7,7 @@
       %li= "level type: #{@level.type}"
       %li= "This level is in #{@level.levels_parent_levels.count} other levels"
       %li= "This level contains #{@level.child_levels.count} other levels"
-      %br
-      - if @level.levels_parent_levels.count > 0
-        %h4 Parent levels
-        %ul
-        - @level.levels_parent_levels.each do |parent_level|
-          %strong= parent_level.key
-          %li= "level id: #{parent_level.id}"
-          %li= "level type: #{parent_level.type}"
-          %br
+    
       - if @level.child_levels.count > 0
         %h4 Child levels
         %ul

--- a/dashboard/app/views/levels/_dataset_maker_level_info.html.haml
+++ b/dashboard/app/views/levels/_dataset_maker_level_info.html.haml
@@ -1,0 +1,27 @@
+- if current_user && current_user.dataset_maker?
+  = render layout: 'shared/extra_links' do
+    %strong= @level.key
+    %br
+    %ul 
+      %li= "level id: #{@level.id}"
+      %li= "level type: #{@level.type}"
+      %li= "This level is in #{@level.levels_parent_levels.count} other levels"
+      %li= "This level contains #{@level.child_levels.count} other levels"
+      %br
+      - if @level.levels_parent_levels.count > 0
+        %h4 Parent levels
+        %ul
+        - @level.levels_parent_levels.each do |parent_level|
+          %strong= parent_level.key
+          %li= "level id: #{parent_level.id}"
+          %li= "level type: #{parent_level.type}"
+          %br
+    
+      - if @level.child_levels.count > 0
+        %h4 Child levels
+        %ul 
+        - @level.child_levels.each do |child_level|
+          %strong= child_level.key
+          %li= "level id: #{child_level.id}"
+          %li= "level type: #{child_level.type}"
+          %br

--- a/dashboard/app/views/levels/_dataset_maker_level_info.html.haml
+++ b/dashboard/app/views/levels/_dataset_maker_level_info.html.haml
@@ -2,7 +2,7 @@
   = render layout: 'shared/extra_links' do
     %strong= @level.key
     %br
-    %ul 
+    %ul
       %li= "level id: #{@level.id}"
       %li= "level type: #{@level.type}"
       %li= "This level is in #{@level.levels_parent_levels.count} other levels"
@@ -16,10 +16,9 @@
           %li= "level id: #{parent_level.id}"
           %li= "level type: #{parent_level.type}"
           %br
-    
       - if @level.child_levels.count > 0
         %h4 Child levels
-        %ul 
+        %ul
         - @level.child_levels.each do |child_level|
           %strong= child_level.key
           %li= "level id: #{child_level.id}"

--- a/dashboard/app/views/levels/_student_work_dataset_maker_level_info.html.haml
+++ b/dashboard/app/views/levels/_student_work_dataset_maker_level_info.html.haml
@@ -1,4 +1,4 @@
-- if current_user && current_user.dataset_maker?
+- if current_user && current_user.can_access_student_work?
   = render layout: 'shared/extra_links' do
     %strong= @level.key
     %br
@@ -7,7 +7,6 @@
       %li= "level type: #{@level.type}"
       %li= "This level is in #{@level.levels_parent_levels.count} other levels"
       %li= "This level contains #{@level.child_levels.count} other levels"
-    
       - if @level.child_levels.count > 0
         %h4 Child levels
         %ul

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -80,6 +80,9 @@
 - if current_user && !@level.uses_lab2?
   = render partial: 'levels/admin'
 
+- if current_user && current_user.dataset_maker?
+  = render partial: 'levels/dataset_maker_level_info'
+
 - if @script && !@script.old_professional_learning_course? && !@level.is_a?(NetSim)
   = render partial: 'levels/teacher_panel'
 

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -80,8 +80,8 @@
 - if current_user && !@level.uses_lab2?
   = render partial: 'levels/admin'
 
-- if current_user && current_user.dataset_maker?
-  = render partial: 'levels/dataset_maker_level_info'
+- if current_user && current_user.can_access_student_work?
+  = render partial: 'levels/student_work_dataset_maker_level_info'
 
 - if @script && !@script.old_professional_learning_course? && !@level.is_a?(NetSim)
   = render partial: 'levels/teacher_panel'

--- a/dashboard/test/controllers/student_work_sample_controller_test.rb
+++ b/dashboard/test/controllers/student_work_sample_controller_test.rb
@@ -46,18 +46,18 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
   params: {level_id: 123, script_id: 456, num_samples: 7},
   response: :forbidden
 
-  # AI Tutor Access + Levelbuilder can fetch student code samples
+  # Dataset Maker can fetch student code samples
   # not found if bogus params
   test_user_gets_response_for :fetch_student_code_samples,
-  name: "ai_iteration_tools_user_can_access_bogus_params",
-  user: :ai_iteration_tools_user,
+  name: "dataset_maker_can_access_bogus_params",
+  user: :dataset_maker,
   method: :get,
   params: {level_id: 123, script_id: 456, num_samples: 7},
   response: :not_found
 
-  # AI Tutor Access + Levelbuilder response ok if valid params
-  test 'ai iteration tools user can access valid params",' do
-    user = create(:ai_iteration_tools_user)
+  # Dataset Maker response ok if valid params
+  test 'dataset_maker_can_access_valid_params' do
+    user = create(:dataset_maker)
     sign_in(user)
     level = create(:level)
     script = create(:script)

--- a/dashboard/test/controllers/student_work_sample_controller_test.rb
+++ b/dashboard/test/controllers/student_work_sample_controller_test.rb
@@ -46,18 +46,19 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
   params: {level_id: 123, script_id: 456, num_samples: 7},
   response: :forbidden
 
-  # Dataset Maker can fetch student code samples
+  # Can fetch student code samples with student_work_access permission
   # not found if bogus params
   test_user_gets_response_for :fetch_student_code_samples,
-  name: "dataset_maker_can_access_bogus_params",
-  user: :dataset_maker,
+  name: "student_work_dataset_maker_can_access_bogus_params",
+  user: :student_work_dataset_maker,
   method: :get,
   params: {level_id: 123, script_id: 456, num_samples: 7},
   response: :not_found
 
-  # Dataset Maker response ok if valid params
-  test 'dataset_maker_can_access_valid_params' do
-    user = create(:dataset_maker)
+  # Can fetch student code samples with student_work_access permission
+  # found if valid params
+  test 'student_work_dataset_maker_can_access_valid_params' do
+    user = create(:student_work_dataset_maker)
     sign_in(user)
     level = create(:level)
     script = create(:script)

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -204,6 +204,12 @@ FactoryBot.define do
           ai_iteration_tools_user.save
         end
       end
+      factory :dataset_maker do
+        after(:create) do |dataset_maker|
+          dataset_maker.permission = UserPermission::DATASET_MAKER
+          dataset_maker.save
+        end
+      end
       factory :facilitator do
         transient do
           course {nil}

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -204,10 +204,10 @@ FactoryBot.define do
           ai_iteration_tools_user.save
         end
       end
-      factory :dataset_maker do
-        after(:create) do |dataset_maker|
-          dataset_maker.permission = UserPermission::DATASET_MAKER
-          dataset_maker.save
+      factory :student_work_dataset_maker do
+        after(:create) do |student_work_dataset_maker|
+          student_work_dataset_maker.permission = UserPermission::STUDENT_WORK_ACCESS
+          student_work_dataset_maker.save
         end
       end
       factory :facilitator do


### PR DESCRIPTION
Background 🧵 [Slack](https://codedotorg.slack.com/archives/C045UAX4WKH/p1744044495246659?thread_ts=1744043397.802089&cid=C045UAX4WKH)
[TEACH-1795](https://codedotorg.atlassian.net/browse/TEACH-1795)

Very soon we will have contractors helping to tag student work samples. 🎉  In preparation for that work, I've created a new permission `STUDENT_WORK_ACCESS`. 

Those with `StudentWorkAccess` permissions can: 
1.) use the dataset maker tools at https://studio.code.org/ai_iteration/tools to pull samples of student code and free response answers 
![Screenshot 2025-04-08 at 3 54 49 PM](https://github.com/user-attachments/assets/91128f00-2f5e-4034-921f-26ef92aa5d1a)

2.) See level name, type and id for parents and children levels on prod in the extra links box 
![Screenshot 2025-04-08 at 3 43 56 PM](https://github.com/user-attachments/assets/de88a94d-1ae3-493c-9cfa-eb8750a6a1bf)


The motivation for this is that we want making datasets of student work samples to become more self-serve and less time-consuming for engineering. In doing so, we also want to continue to be careful about who has access to student data so it became prudent to make a new, tightly-scoped permission for this use case. For example, there are 100+ people with levelbuilder permission on production and we don't want all of them to be able to access student work samples; similarly, someone making student work datasets doesn't need access to editing all of our levels. 