### PR TITLE
Revert "Summary: light background"

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3133,13 +3133,6 @@ $information-desktop: "only screen and (min-width: 1024px)";
   }
 }
 
-// Summary
-#summary-content {
-  // Ensure the summary can be seen even when the lesson has a dark background.
-  background-color: $white;
-  padding: 0 20px;
-}
-
 $modal-image-width: 100px;
 $modal-image-margin-gap: 10px;
 $modal-no-icon-gap: 22px;


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#65109.

This seemed to create a margin on the right edge of the page, at least in Eyes tests.
