### PR TITLE
Fix start over dialog being covered by version history dropdown

### DIFF
--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -189,6 +189,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
         appName,
         {isInitialVersion: 'true'}
       );
+      closeDropdown();
       confirmStartOver();
     } else if (projectManager && selectedVersion) {
       sendCodebridgeAnalyticsEvent(

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -189,7 +189,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
         appName,
         {isInitialVersion: 'true'}
       );
-      // closeDropdown();
+      closeDropdown();
       confirmStartOver();
     } else if (projectManager && selectedVersion) {
       sendCodebridgeAnalyticsEvent(
@@ -301,7 +301,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
     );
   };
 
-  return (
+  return createPortal(
     <FocusTrap
       focusTrapOptions={{
         onDeactivate: closeDropdown,
@@ -312,7 +312,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
         className={moduleStyles.versionHistoryDropdown}
         ref={menuRef}
         role="dialog"
-        style={{top: 100, left: 300}}
+        style={dropdownStyles}
         aria-modal="true"
         aria-label={lab2I18n.versionHistoryList()}
         data-theme="Dark"
@@ -411,7 +411,8 @@ const VersionHistoryDropdown: React.FunctionComponent<
           </div>
         )}
       </div>
-    </FocusTrap>
+    </FocusTrap>,
+    document.body
   );
 };
 

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -189,7 +189,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
         appName,
         {isInitialVersion: 'true'}
       );
-      closeDropdown();
+      // closeDropdown();
       confirmStartOver();
     } else if (projectManager && selectedVersion) {
       sendCodebridgeAnalyticsEvent(
@@ -301,7 +301,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
     );
   };
 
-  return createPortal(
+  return (
     <FocusTrap
       focusTrapOptions={{
         onDeactivate: closeDropdown,
@@ -312,7 +312,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
         className={moduleStyles.versionHistoryDropdown}
         ref={menuRef}
         role="dialog"
-        style={dropdownStyles}
+        style={{top: 100, left: 300}}
         aria-modal="true"
         aria-label={lab2I18n.versionHistoryList()}
         data-theme="Dark"
@@ -411,8 +411,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
           </div>
         )}
       </div>
-    </FocusTrap>,
-    document.body
+    </FocusTrap>
   );
 };
 

--- a/apps/src/lab2/views/dialogs/generic-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/generic-dialog.module.scss
@@ -5,7 +5,6 @@
   @extend %dialog;
   display: flex;
   flex-direction: column;
-  z-index: 1100;
 }
 
 .genericDialog-dark {

--- a/apps/src/lab2/views/dialogs/generic-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/generic-dialog.module.scss
@@ -5,6 +5,7 @@
   @extend %dialog;
   display: flex;
   flex-direction: column;
+  z-index: 1100;
 }
 
 .genericDialog-dark {


### PR DESCRIPTION
This PR resolves the issue of the 'Start over' dialog being covered by the version history dropdown by closing the version history dropdown when the dialog opens.

Initially, I tried to add a z-index with a value higher than that of the `VersionHistoryDropdown` in the `StartOverDialog` (in `generic-dialog.module.scss`). But this did not solve the issue because `createPortal` is used in `VersionHistoryDropdown` but not in `StartOverDialog`. I removed `createPortal` from `VersionHistoryDropdown` and the start over dialog with the higher z-index was rendered above the dropdown  5cb1f26238edd33529ae628d54ba201d35d0b8c5. We use `createPortal` so that we can position the dropdown immediately below and to the right of the `VersionHistoryButton` which can be located in different position depending on the layout.

Thus, I took the simpler approach to close the version history dropdown when the start over dialog is displayed.
If the user clicks on 'Start over', the initial version of the project is restored. If the user clicks on 'Cancel', the 'You are viewing an older version' alert is displayed in the workspace. The user can then click on the version history button, and then click on 'Cancel' to view the current project. This is the current behavior of the 'Start over' dialog and is not changed by this PR.

## Before update
The user clicks on the version history button, selects initial version from the dropdown, then clicks on 'Restore', the 'Start over' dialog is covered by the version history dropdown.

https://github.com/user-attachments/assets/6c574944-ca58-4ae1-b46e-68cf0c0fb692



## After update
The user clicks on the version history button, selects initial version from the dropdown, then clicks on 'Restore', the 'Start over' dialog is displayed and the version history dropdown is closed.

https://github.com/user-attachments/assets/bc2ab6c7-4348-46b7-9ada-442cea48909d



<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira](https://codedotorg.atlassian.net/browse/CT-1158)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally in `pythonlab` levels.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
