### PR TITLE
Auto-expand chat area in shared AI chat message editor component

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -19,7 +19,6 @@ export interface UserMessageEditorProps {
   /** Custom className for editor container */
   editorContainerClassName?: string;
   customPlaceholder?: string;
-  onChange?: () => void;
 }
 
 const UserMessageEditor = React.forwardRef<
@@ -33,7 +32,6 @@ const UserMessageEditor = React.forwardRef<
       editorContainerClassName,
       customPlaceholder,
       showSubmitLabel = false,
-      onChange,
     },
     ref
   ) => {
@@ -58,7 +56,18 @@ const UserMessageEditor = React.forwardRef<
       [onSubmit]
     );
 
-    useEffect(() => onChange?.(), [onChange, userMessage]);
+    useEffect(() => {
+      if (typeof ref !== 'object' || ref === null) {
+        return;
+      }
+
+      if (!ref.current) {
+        return;
+      }
+
+      ref.current.style.height = 'auto'; // Reset height
+      ref.current.style.height = ref.current.scrollHeight + 'px'; // Set to scroll height
+    }, [ref, userMessage]);
 
     const icon = {iconName: 'paper-plane'};
 

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -1,6 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import classnames from 'classnames';
-import React, {useState, useCallback, useMemo, useEffect} from 'react';
+import React, {useState, useCallback, useMemo, useEffect, useRef} from 'react';
 
 import {commonI18n} from '@cdo/apps/types/locale';
 
@@ -35,6 +35,7 @@ const UserMessageEditor = React.forwardRef<
     },
     ref
   ) => {
+    const internalInputRef = useRef<HTMLTextAreaElement | null>(null);
     const [userMessage, setUserMessage] = useState<string>('');
 
     const userMessageIsEmpty = useMemo(() => {
@@ -57,16 +58,13 @@ const UserMessageEditor = React.forwardRef<
     );
 
     useEffect(() => {
-      if (typeof ref !== 'object' || ref === null) {
+      if (!internalInputRef.current) {
         return;
       }
 
-      if (!ref.current) {
-        return;
-      }
-
-      ref.current.style.height = 'auto'; // Reset height
-      ref.current.style.height = ref.current.scrollHeight + 2 + 'px'; // Set to scroll height
+      internalInputRef.current.style.height = 'auto'; // Reset height
+      internalInputRef.current.style.height =
+        internalInputRef.current.scrollHeight + 2 + 'px'; // Set to scroll height
     }, [ref, userMessage]);
 
     const icon = {iconName: 'paper-plane'};
@@ -79,7 +77,16 @@ const UserMessageEditor = React.forwardRef<
         )}
       >
         <textarea
-          ref={ref}
+          ref={node => {
+            // need to handle this being null?
+            internalInputRef.current = node;
+
+            if (typeof ref !== 'object' || ref === null) {
+              return;
+            }
+
+            ref.current = node;
+          }}
           id="uitest-chat-textarea"
           className={moduleStyles.textArea}
           placeholder={

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -64,7 +64,7 @@ const UserMessageEditor = React.forwardRef<
 
       internalInputRef.current.style.height = 'auto'; // Need to reset height before update.
       internalInputRef.current.style.height =
-        internalInputRef.current.scrollHeight + 2 + 'px';
+        internalInputRef.current.scrollHeight + 2 + 'px'; // Add a couple of pixels to avoid scrollbars.
     }, [userMessage]);
 
     const icon = {iconName: 'paper-plane'};

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -1,6 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import classnames from 'classnames';
-import React, {useState, useCallback, useMemo} from 'react';
+import React, {useState, useCallback, useMemo, useEffect} from 'react';
 
 import {commonI18n} from '@cdo/apps/types/locale';
 
@@ -19,6 +19,7 @@ export interface UserMessageEditorProps {
   /** Custom className for editor container */
   editorContainerClassName?: string;
   customPlaceholder?: string;
+  onChange?: () => void;
 }
 
 const UserMessageEditor = React.forwardRef<
@@ -32,6 +33,7 @@ const UserMessageEditor = React.forwardRef<
       editorContainerClassName,
       customPlaceholder,
       showSubmitLabel = false,
+      onChange,
     },
     ref
   ) => {
@@ -56,7 +58,10 @@ const UserMessageEditor = React.forwardRef<
       [onSubmit]
     );
 
+    useEffect(() => onChange?.(), [onChange, userMessage]);
+
     const icon = {iconName: 'paper-plane'};
+
     return (
       <div
         className={classnames(

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -33,7 +33,7 @@ const UserMessageEditor = React.forwardRef<
       customPlaceholder,
       showSubmitLabel = false,
     },
-    ref
+    externalInputRef
   ) => {
     const internalInputRef = useRef<HTMLTextAreaElement | null>(null);
     const [userMessage, setUserMessage] = useState<string>('');
@@ -62,10 +62,10 @@ const UserMessageEditor = React.forwardRef<
         return;
       }
 
-      internalInputRef.current.style.height = 'auto'; // Reset height
+      internalInputRef.current.style.height = 'auto'; // Need to reset height before update.
       internalInputRef.current.style.height =
-        internalInputRef.current.scrollHeight + 2 + 'px'; // Set to scroll height
-    }, [ref, userMessage]);
+        internalInputRef.current.scrollHeight + 2 + 'px';
+    }, [userMessage]);
 
     const icon = {iconName: 'paper-plane'};
 
@@ -78,14 +78,14 @@ const UserMessageEditor = React.forwardRef<
       >
         <textarea
           ref={node => {
-            // need to handle this being null?
             internalInputRef.current = node;
 
-            if (typeof ref !== 'object' || ref === null) {
-              return;
+            if (
+              typeof externalInputRef === 'object' &&
+              externalInputRef !== null
+            ) {
+              externalInputRef.current = node;
             }
-
-            ref.current = node;
           }}
           id="uitest-chat-textarea"
           className={moduleStyles.textArea}
@@ -100,7 +100,7 @@ const UserMessageEditor = React.forwardRef<
           rows={1}
         />
 
-        <div className={moduleStyles.centerSingleItemContainer}>
+        <div className={moduleStyles.endSingleItemContainer}>
           <Button
             aria-label={commonI18n.submit()}
             id="uitest-chat-submit"

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -66,7 +66,7 @@ const UserMessageEditor = React.forwardRef<
       }
 
       ref.current.style.height = 'auto'; // Reset height
-      ref.current.style.height = ref.current.scrollHeight + 'px'; // Set to scroll height
+      ref.current.style.height = ref.current.scrollHeight + 2 + 'px'; // Set to scroll height
     }, [ref, userMessage]);
 
     const icon = {iconName: 'paper-plane'};
@@ -90,6 +90,7 @@ const UserMessageEditor = React.forwardRef<
           disabled={disabled}
           onKeyDown={e => handleKeyPress(e, userMessage)}
           maxLength={MAX_MESSAGE_LENGTH}
+          rows={1}
         />
 
         <div className={moduleStyles.centerSingleItemContainer}>

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -1,7 +1,8 @@
 .textArea {
+    min-height: 40px;
     max-height: 250px;
     box-sizing: border-box;
-    resize: none;
+    resize: vertical;
     margin: 0;
     flex: 1;
 }

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -15,7 +15,7 @@
     gap: 5px;
 }
 
-.centerSingleItemContainer {
+.endSingleItemContainer {
     display: flex;
     justify-content: center;
     align-items: end;

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -1,8 +1,8 @@
 .textArea {
-    min-height: 40px;
+    min-height: 42px;
     max-height: 250px;
     box-sizing: border-box;
-    resize: vertical;
+    resize: none;
     margin: 0;
     flex: 1;
 }

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -2,6 +2,7 @@ $message-editor-height: 60px;
 
 .textArea {
     width: 80%;
+    max-height: 250px;
     box-sizing: border-box;
     resize: none;
     margin: 0;
@@ -12,7 +13,7 @@ $message-editor-height: 60px;
     padding: 10px;
     display: flex;
     width: 100%;
-    height: $message-editor-height;
+    //height: $message-editor-height;
     box-sizing: border-box;
     gap: 5px;
 }
@@ -20,5 +21,5 @@ $message-editor-height: 60px;
 .centerSingleItemContainer {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: end;
 }

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -1,7 +1,4 @@
-$message-editor-height: 60px;
-
 .textArea {
-    width: 80%;
     max-height: 250px;
     box-sizing: border-box;
     resize: none;
@@ -13,7 +10,6 @@ $message-editor-height: 60px;
     padding: 10px;
     display: flex;
     width: 100%;
-    //height: $message-editor-height;
     box-sizing: border-box;
     gap: 5px;
 }

--- a/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
@@ -1,6 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import {PDFDownloadLink} from '@react-pdf/renderer';
-import React, {useRef} from 'react';
+import React from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -25,15 +25,12 @@ const AiDiffChatFooter: React.FC<AiDiffChatFooterProps> = ({
   waiting,
   disableEndButtons,
 }) => {
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-
   return (
     <div className={style.chatFooter}>
       <UserMessageEditor
         onSubmit={onSubmit}
         disabled={waiting}
         customPlaceholder={commonI18n.aiDifferentiation_write_message()}
-        ref={inputRef}
       />
       {!disableEndButtons && (
         <div className={style.chatFooterButtons}>

--- a/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
@@ -1,6 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import {PDFDownloadLink} from '@react-pdf/renderer';
-import React from 'react';
+import React, {useRef} from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -25,12 +25,15 @@ const AiDiffChatFooter: React.FC<AiDiffChatFooterProps> = ({
   waiting,
   disableEndButtons,
 }) => {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
   return (
     <div className={style.chatFooter}>
       <UserMessageEditor
         onSubmit={onSubmit}
         disabled={waiting}
         customPlaceholder={commonI18n.aiDifferentiation_write_message()}
+        ref={inputRef}
       />
       {!disableEndButtons && (
         <div className={style.chatFooterButtons}>

--- a/apps/src/aiTutor/views/AITutorFooter.tsx
+++ b/apps/src/aiTutor/views/AITutorFooter.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useRef} from 'react';
+import React, {useCallback} from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {askAITutor} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
@@ -19,8 +19,6 @@ interface AITutorFooterProps {
 }
 
 const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
   );
@@ -84,11 +82,7 @@ const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
 
   return (
     <div className={style.aiTutorFooter}>
-      <UserMessageEditor
-        onSubmit={handleSubmit}
-        disabled={disabled}
-        ref={inputRef}
-      />
+      <UserMessageEditor onSubmit={handleSubmit} disabled={disabled} />
     </div>
   );
 };

--- a/apps/src/aiTutor/views/AITutorFooter.tsx
+++ b/apps/src/aiTutor/views/AITutorFooter.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useRef} from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {askAITutor} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
@@ -19,6 +19,8 @@ interface AITutorFooterProps {
 }
 
 const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
   const isWaitingForChatResponse = useAppSelector(
     state => state.aiTutor.isWaitingForChatResponse
   );
@@ -82,7 +84,11 @@ const AITutorFooter: React.FC<AITutorFooterProps> = ({renderAITutor}) => {
 
   return (
     <div className={style.aiTutorFooter}>
-      <UserMessageEditor onSubmit={handleSubmit} disabled={disabled} />
+      <UserMessageEditor
+        onSubmit={handleSubmit}
+        disabled={disabled}
+        ref={inputRef}
+      />
     </div>
   );
 };

--- a/apps/src/aiTutor/views/ai-tutor.module.scss
+++ b/apps/src/aiTutor/views/ai-tutor.module.scss
@@ -14,6 +14,9 @@ $default-spacing: 16px;
   z-index: 2000;
   width: 760px;
   color: $default_text;
+  display: flex;
+  flex-direction: column;
+  height: 560px;
 }
 
 .aiTutorChatWorkspace {
@@ -86,7 +89,7 @@ button.buttonStyle {
   padding-inline-start: 0.75rem;
 
   display: flex;
-  height: 40px;
+  min-height: 40px;
   justify-content: space-between;
   align-items: center;
   align-self: stretch;
@@ -117,6 +120,7 @@ button.buttonStyle {
 .fabBackground {
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
   gap: 28px;
   padding: 1rem;
   border-right: $border-width solid $border-color;

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -45,6 +45,27 @@ const UserChatMessageEditor: React.FunctionComponent<{
     [isWaitingForChatResponse, multimodalEnabled, chatAssets, dispatch]
   );
 
+  // seems to stay big after sending a large message
+  useEffect(() => {
+    const ref = inputRef.current;
+
+    if (!ref) {
+      return;
+    }
+
+    const listener = () => {
+      ref.style.height = 'auto'; // Reset height
+      ref.style.height = ref.scrollHeight + 'px'; // Set to scroll height
+    };
+    ref.addEventListener('input', listener);
+
+    return () => {
+      if (ref) {
+        ref.removeEventListener('input', listener);
+      }
+    };
+  });
+
   const disabled = isWaitingForChatResponse || saveInProgress || uploadsPending;
 
   useEffect(() => {

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -45,18 +45,6 @@ const UserChatMessageEditor: React.FunctionComponent<{
     [isWaitingForChatResponse, multimodalEnabled, chatAssets, dispatch]
   );
 
-  // seems to stay big after sending a large message
-  const onChange = () => {
-    const ref = inputRef.current;
-
-    if (!ref) {
-      return;
-    }
-
-    ref.style.height = 'auto'; // Reset height
-    ref.style.height = ref.scrollHeight + 'px'; // Set to scroll height
-  };
-
   const disabled = isWaitingForChatResponse || saveInProgress || uploadsPending;
 
   useEffect(() => {
@@ -70,7 +58,6 @@ const UserChatMessageEditor: React.FunctionComponent<{
   return (
     <UserMessageEditor
       onSubmit={handleSubmit}
-      onChange={onChange}
       disabled={disabled}
       editorContainerClassName={editorContainerClassName}
       ref={inputRef}

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -46,25 +46,16 @@ const UserChatMessageEditor: React.FunctionComponent<{
   );
 
   // seems to stay big after sending a large message
-  useEffect(() => {
+  const onChange = () => {
     const ref = inputRef.current;
 
     if (!ref) {
       return;
     }
 
-    const listener = () => {
-      ref.style.height = 'auto'; // Reset height
-      ref.style.height = ref.scrollHeight + 'px'; // Set to scroll height
-    };
-    ref.addEventListener('input', listener);
-
-    return () => {
-      if (ref) {
-        ref.removeEventListener('input', listener);
-      }
-    };
-  });
+    ref.style.height = 'auto'; // Reset height
+    ref.style.height = ref.scrollHeight + 'px'; // Set to scroll height
+  };
 
   const disabled = isWaitingForChatResponse || saveInProgress || uploadsPending;
 
@@ -79,6 +70,7 @@ const UserChatMessageEditor: React.FunctionComponent<{
   return (
     <UserMessageEditor
       onSubmit={handleSubmit}
+      onChange={onChange}
       disabled={disabled}
       editorContainerClassName={editorContainerClassName}
       ref={inputRef}


### PR DESCRIPTION
This change auto-expands the text area in the message editing component that is shared across AI Chat, AI TA, and AI Tutor. Currently, the text area is very short and fixed height, which makes editing/composing large bits of text difficult.

| Before | After |
| - | - |
| <img width="516" alt="image" src="https://github.com/user-attachments/assets/5eaf25db-8707-4c5a-bf13-8debe4812a38" /> | <img width="519" alt="image" src="https://github.com/user-attachments/assets/b9740ac4-5be3-40f5-bd25-8f7634924879" /> |

<details><summary><b>📺 AI Chat</b></summary><video src="https://github.com/user-attachments/assets/d7dd40a0-49eb-46c5-ae2f-3500cf9438cf" /></details>
<details><summary><b>📺 AI Tutor</b></summary><video src="https://github.com/user-attachments/assets/98ef6941-642a-4a87-8a98-6de79b0af3f2" /></details>
<details><summary><b>📺 AI TA</b></summary><video src="https://github.com/user-attachments/assets/fd1fa264-7b27-4fc4-86f8-e77c4a1ba3ca" /></details>

A couple tangential notes:
- an auto-expanding text area is an [experimental CSS feature](https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing), so one day this will not be necessary.
- I wasted a bunch of time on this because [I thought the text area was jumping to a new line early for some unknown reason](https://codedotorg.slack.com/archives/C046G4TRLEN/p1743623314747409). Turned out that I believe this issue was only present when I was hooked up to an external monitor 🤦 .

## Links

- https://codedotorg.atlassian.net/browse/LABS-1323

## Testing story

I tested manually on three levels with each of the AI features, and [checked in with product managers to confirm that this is a desired change](https://codedotorg.slack.com/archives/C04VD4ZB6BT/p1744061528803729).