### PR TITLE
Fix flaky test: teacher_tools/section_action_dropdown 

### DIFF
--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -1,7 +1,7 @@
 PUZZLE_SOLUTIONS = {
   "http://studio.code.org/s/allthethings/lessons/2/levels/1" => %{
     And I drag block "moveWest" to block "whenRun"
-    And I drag block "moveWest" to block "moveWest"
+    And I drag block "moveWest" to block "moveWest" plus offset 0, 10
   },
   "http://studio.code.org/s/allthethings/lessons/29/levels/1?level_name=2-3 Maze 1" => %{
     And I drag block "moveForward" to block "whenRun"

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -1,7 +1,7 @@
 PUZZLE_SOLUTIONS = {
   "http://studio.code.org/s/allthethings/lessons/2/levels/1" => %{
     And I drag block "moveWest" to block "whenRun"
-    And I drag block "moveWest" to block "moveWest" plus offset 0, 10
+    And I drag block "moveWest" to block "moveWest" plus offset 0, 20
   },
   "http://studio.code.org/s/allthethings/lessons/29/levels/1?level_name=2-3 Maze 1" => %{
     And I drag block "moveForward" to block "whenRun"


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Summary

This test was occasionally failing on iPad because the second "move west" block wasn't being dragged low enough to connect to the first one. This adds an offset to ensure it connects. 

## Links

- jira ticket: [LABS-1368](https://codedotorg.atlassian.net/browse/LABS-1368)


## Testing story
I tested via saucelabs tunnel on all browsers multiple times to ensure it passes consistently with this change.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
