### PR TITLE
FIX: Restrict Load Balancer to Only Permit HTTP Requests from CloudFront

### DIFF
--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -187,10 +187,14 @@ Resources:
   FrontendSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Inbound HTTP[S] from load balancer, SSH from Gateway.
+      GroupDescription: Inbound HTTP[S] from load balancer, SSH from Gateway & Daemon.
       VpcId: {Ref: VPC}
       SecurityGroupIngress:
         # nginx listens for incoming HTTP requests forwarded by Load Balancer
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: {Ref: ALBSecurityGroup}
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
@@ -199,13 +203,25 @@ Resources:
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
+          SourceSecurityGroupId: {Ref: ALBSecurityGroup}
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
           SourceSecurityGroupId: {Ref: ELBSecurityGroup}
         # Enable Dashboard Puma to listen on a TCP port (in addition to receiving HTTP requests via a Unix socket from nginx).
         - IpProtocol: tcp
           FromPort: 9000
           ToPort: 9000
+          SourceSecurityGroupId: {Ref: ALBSecurityGroup}
+        - IpProtocol: tcp
+          FromPort: 9000
+          ToPort: 9000
           SourceSecurityGroupId: {Ref: ELBSecurityGroup}
         # Enable Pegasus Puma to listen on a TCP port (in addition to receiving HTTP requests via a Unix socket from nginx).
+        - IpProtocol: tcp
+          FromPort: 9001
+          ToPort: 9001
+          SourceSecurityGroupId: {Ref: ALBSecurityGroup}
         - IpProtocol: tcp
           FromPort: 9001
           ToPort: 9001

--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -208,7 +208,18 @@ Resources:
           FromPort: 443
           ToPort: 443
           SourceSecurityGroupId: {Ref: ELBSecurityGroup}
-        # Enable Dashboard Puma to listen on a TCP port (in addition to receiving HTTP requests via a Unix socket from nginx).
+        # nginx listens for incoming HTTP requests from daemon (for debugging with tools like curl).
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: {Ref: DaemonSecurityGroup}
+        # nginx listens for incoming HTTP requests from gateway (for debugging with tools like curl).
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: {Ref: GatewaySecurityGroup}
+        # Dashboard Puma listens for incoming HTTP requests forwarded by Load Balancer
+        # (in addition to receiving HTTP requests via a Unix socket from nginx).
         - IpProtocol: tcp
           FromPort: 9000
           ToPort: 9000
@@ -217,7 +228,8 @@ Resources:
           FromPort: 9000
           ToPort: 9000
           SourceSecurityGroupId: {Ref: ELBSecurityGroup}
-        # Enable Pegasus Puma to listen on a TCP port (in addition to receiving HTTP requests via a Unix socket from nginx).
+        # Pegasus Puma listens for incoming HTTP requests forwarded by Load Balancer
+        # (in addition to receiving HTTP requests via a Unix socket from nginx).
         - IpProtocol: tcp
           FromPort: 9001
           ToPort: 9001


### PR DESCRIPTION
Fix #63499 to unblock #64758 
https://codedotorg.atlassian.net/browse/INF-1593

Ensure that when using a load balancer that only permits incoming HTTP requests from CloudFront, that it is permitted to forward HTTP requests to web application server EC2 Instances ("Frontends").

Also permit gateway and daemon to send HTTP requests to the load balancer as well (primarily to aid in "curl" diagnostics).

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->


## Testing story

```
code-dot-org % bundle exec rake stack:vpc:validate RAILS_ENV=production

Finished stack:vpc:environment (less than a minute)
Pending update for stack `VPC`:
Modify DBSecurityGroup [AWS::EC2::SecurityGroup] Properties (SecurityGroupEgress, SecurityGroupIngress)
Modify EFSSecurityGroup [AWS::EC2::SecurityGroup] Properties (SecurityGroupIngress)
Modify FrontendSecurityGroup [AWS::EC2::SecurityGroup] Properties Replacement: True (GroupDescription, SecurityGroupIngress)
Modify MemcachedSecurityGroup [AWS::EC2::SecurityGroup] Properties (SecurityGroupIngress)
Modify RedisSecurityGroup [AWS::EC2::SecurityGroup] Properties (SecurityGroupIngress)
Finished stack:vpc:validate (less than a minute)
```

## Deployment strategy

`code-dot-org $ bundle exec rake stack:vpc:start RAILS_ENV=production`

This change will **Replace** the current SecurityGroup. How does that impact existing Resources that use this SecurityGroup? Should we, instead, implement a new "Frontend" SecurityGroup that supports traffic from load balancers that restrict inbound requests to only come from CloudFront? Would we have this problem if each Stack provisioned the SecurityGroups it needs instead of us sharing SecurityGroups across all Stacks?

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
