### PR TITLE
fix course link on levelbuilder unit page

### DIFF
--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -59,8 +59,10 @@
         = "This script is in #{@script.unit_groups.length} course#{'s' unless @script.unit_groups.length == 1}:"
         %ul
           - @script.unit_groups.each do |course|
-            - course_url = course.single_unit_course? ? edit_course_path(course) : course_path(course)
-            %li= link_to course_path(course), course_url
+            - if course.single_unit_course?
+              %li= link_to edit_course_path(course), edit_course_path(course)
+            - else
+              %li= link_to course_path(course), course_path(course)
       - lesson_plans = @script.is_migrated && @script.use_legacy_lesson_plans && @script.lessons.select(&:has_lesson_plan).map {|lesson| {name: lesson.name, url: lesson.get_uncached_show_path}}
       -if lesson_plans && lesson_plans.count > 0
         ="There are #{lesson_plans.count} unlaunched code studio lesson plans in this unit:"

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -59,7 +59,8 @@
         = "This script is in #{@script.unit_groups.length} course#{'s' unless @script.unit_groups.length == 1}:"
         %ul
           - @script.unit_groups.each do |course|
-            %li= link_to course_path(course)
+            - course_url = course.single_unit_course? ? edit_course_path(course) : course_path(course)
+            %li= link_to course_path(course), course_url
       - lesson_plans = @script.is_migrated && @script.use_legacy_lesson_plans && @script.lessons.select(&:has_lesson_plan).map {|lesson| {name: lesson.name, url: lesson.get_uncached_show_path}}
       -if lesson_plans && lesson_plans.count > 0
         ="There are #{lesson_plans.count} unlaunched code studio lesson plans in this unit:"


### PR DESCRIPTION
This small PR fixes the course link when a levelbuilder is on a unit overview page. 

Before this change, the course link in the levelbuilder "Extra Links" box displayed the course url, but just loaded the current script page when pressed.
![Screenshot 2025-04-09 at 10 16 10 AM](https://github.com/user-attachments/assets/0330801a-8a39-4186-b910-4a96ed630104)


After this change, the course url actually goes to the course overview page when the current unit is within a "normal" course:
<img width="302" alt="Screenshot 2025-04-09 at 10 11 39 AM" src="https://github.com/user-attachments/assets/fd58171f-fe63-49fe-a846-e9023696e653" />

In single-unit courses, the course url links to the course edit page:
<img width="311" alt="Screenshot 2025-04-09 at 1 37 07 PM" src="https://github.com/user-attachments/assets/8c21bb25-cb87-4b2c-83a2-875e7c4701d3" />

## Testing story
Manually verified that the course url takes you to the course overview page when the course is "normal" and the course edit page when the course is a single-unit course. 

## Follow-up work
We should still add a `/courses` page to allow content editors to view all courses, but this should help ease the frustration they are currently feeling.
