### PR TITLE
[Music] Update options block count condition

### DIFF
--- a/apps/src/music/blockly/blockTypes.ts
+++ b/apps/src/music/blockly/blockTypes.ts
@@ -36,6 +36,7 @@ export enum BlockTypes {
   REST_IN_TRACK = 'rest_in_track',
   VALUE_SAMPLE = 'value_sample',
   IF_ELSE = 'controls_if',
+  FUNCTION_CALL = 'procedures_callnoreturn',
   FUNCTION_DEFINITION = 'procedures_defnoreturn',
   FUNCTION_DEFINITION_RETURN = 'procedures_defreturn',
   CATEGORY = 'category',

--- a/apps/src/music/progress/MusicConditions.ts
+++ b/apps/src/music/progress/MusicConditions.ts
@@ -1,5 +1,5 @@
-import {defaultMaps} from '../blockly/toolbox/definitions';
-import {BlockMode} from '../constants';
+import * as simple2Blocks from '../blockly/blocks/simple2';
+import {BlockTypes} from '../blockly/blockTypes';
 
 import {ConditionNames} from './MusicValidator';
 
@@ -9,7 +9,13 @@ export const MusicConditions: ConditionNames = {
     valueType: 'string:number',
     description:
       'Counts blocks on the workspace of a given type. Blocks must be enabled on the workspace. Ex. Value: [repeatSimple2, 2]',
-    valueOptions: Object.values(defaultMaps[BlockMode.SIMPLE2]).flat(),
+    valueOptions: Array.from(
+      new Set([
+        ...Object.values(simple2Blocks).map(b => b.definition.type),
+        BlockTypes.FUNCTION_DEFINITION,
+        BlockTypes.FUNCTION_CALL,
+      ])
+    ),
   },
   PLAYED_SOUNDS_TOGETHER: {
     name: 'played_sounds_together',


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

@dancodedotorg reported an issue with validating the presence of `set effect` blocks:
> I can’t get it to recognize I’ve added 3 effect blocks using the workspace checker block (which has worked for just about every other block I’ve tried to far - just these effects ones seem tricky).
> I also kinda wondered if we needed all 3 in the type dropdown in the validation conditions editor (delay, volume, filter). That might make it harder to detect the blocks, since technically students can change any effect block into any other?

**Explanation:**
Previously, the `BLOCK_COUNT_BY_TYPE` condition's `valueOptions` were populated from `defaultMaps[BlockMode.SIMPLE2]`, which included alias block IDs for effect blocks rather than the actual Blockly type values. This led to three invalid options in the dropdown (e.g., `set_volume_effect_at_current_location_simple2`), which point to the same underlying block type.

With this change, we now derive the list of valid `valueOptions` directly from the exported Blockly block definitions. This also adds a couple other blocks, such as the experimental `play tune` block. While we were at it, I decided we should also support counting function blocks. These blocks are defined by Blockly so I added the types to the list manually.

| **Before** | **After** |
|------------|-----------|
| ![Before list](https://github.com/user-attachments/assets/7e962cbd-cfa0-4baa-a8de-aa6e0e949f96) | ![After list](https://github.com/user-attachments/assets/33787592-a428-4959-ab55-eaf5e57308de) |

## Links

https://codedotorg.slack.com/archives/C07UT279KM1/p1744169806121179?thread_ts=1744168758.845569&cid=C07UT279KM1


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
