### PR TITLE
AI Chat: Longer timeout for OpenAI request

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -35,7 +35,7 @@ const paths = {
   FIND_TOXICITY_URL: `${ROOT_GENERAL_URL}/find_toxicity`,
 };
 
-const MAX_POLLING_TIME_MS = 45000;
+const MAX_POLLING_TIME_MS = 60000;
 const MIN_POLLING_INTERVAL_MS = 1000;
 const DEFAULT_BACKOFF_RATE = 1;
 

--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -26,7 +26,7 @@ class OpenaiChatController < ApplicationController
 
     messages = prepend_system_prompt(system_prompt, params[:messages])
 
-    response = client.request_chat_completion(messages)
+    response = client.request_chat_completion(messages: messages)
     response_body = JSON.parse(response.body)
     response_body = response_body['choices'][0]['message'] if response.code == 200
     chat_completion_return_message =  {status: response.code, json: response_body}

--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -60,7 +60,7 @@ module AichatOpenaiHelper
   end
 
   def self.request_chat_completion(messages, temperature)
-    http_response = client.request_chat_completion(messages, temperature)
+    http_response = client.request_chat_completion(messages: messages, temperature: temperature, timeout: 60)
     body = JSON.parse(http_response.body)
     raise StandardError.new(body['error']) if body['error']
     response = body&.dig("choices")&.first&.dig('message', 'content')

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -47,7 +47,7 @@ module AichatSafetyHelper
       attempts = 1
       Retryable.retryable(tries: 2) do
         messages = safety_check_messages(text, level_id)
-        response = client.request_chat_completion(messages, 1)
+        response = client.request_chat_completion(messages: messages, temperature: 1)
         raise "OpenAI request failed with status #{response.code}: #{response.body}" unless response.success?
 
         evaluation = JSON.parse(response.body)['choices'][0]['message']['content']

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -27,7 +27,7 @@ module OpenaiChatHelper
         headers: headers,
         body: data.to_json,
         open_timeout: DCDO.get('openai_http_open_timeout', 5),
-        read_timeout: DCDO.get('openai_http_read_timeout', 30)
+        read_timeout: DCDO.get('openai_http_read_timeout', 60)
       )
     end
   end

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -4,13 +4,14 @@ module OpenaiChatHelper
 
     OPEN_AI_URL = "https://api.openai.com/v1/chat/completions"
     DEFAULT_TEMPERATURE = 0
+    DEFAULT_TIMEOUT = 30
 
     def initialize(api_key, model)
       @api_key = api_key
       @model = model
     end
 
-    def request_chat_completion(messages, temperature = DEFAULT_TEMPERATURE)
+    def request_chat_completion(messages:, temperature: DEFAULT_TEMPERATURE, timeout: DEFAULT_TIMEOUT)
       headers = {
         "Content-Type" => "application/json",
         "Authorization" => "Bearer #{api_key}"
@@ -27,7 +28,7 @@ module OpenaiChatHelper
         headers: headers,
         body: data.to_json,
         open_timeout: DCDO.get('openai_http_open_timeout', 5),
-        read_timeout: DCDO.get('openai_http_read_timeout', 60)
+        read_timeout: DCDO.get('openai_http_read_timeout', timeout)
       )
     end
   end

--- a/dashboard/test/helpers/aichat_safety_helper_test.rb
+++ b/dashboard/test/helpers/aichat_safety_helper_test.rb
@@ -131,8 +131,8 @@ class AichatSafetyHelperTest < ActionView::TestCase
   test "Open AI safety check uses American safety prompt if not in Spanish script" do
     stub_safety_services('openai', 'user')
 
-    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).with do |messages, _|
-      assert_includes messages[0][:content], "American"
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).with do |kwargs|
+      assert_includes kwargs[:messages][0][:content], "American"
       return true
     end
 
@@ -142,8 +142,8 @@ class AichatSafetyHelperTest < ActionView::TestCase
   test "Open AI safety check uses Spanish safety prompt if in Spanish script" do
     stub_safety_services('openai', 'user')
 
-    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).with do |messages, _|
-      assert_includes messages[0][:content], "Spanish"
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).with do |kwargs|
+      assert_includes kwargs[:messages][0][:content], "Spanish"
       return true
     end
 


### PR DESCRIPTION
We have seen regular issues with timeouts when making requests to OpenAI's Chat Completions endpoint. We initially attributed these to outages on OpenAI's end, but the regularity with which we're seeing theses issues and the lack of outage reports on OpenAI's side has led us to think that the timeouts may be a result of responses just needing more than 30 seconds (current timeout limit) to complete.

~~Counterpoints to this theory are that we haven't seen timeout issues in local development, and a skim through the requests generating timeouts don't seem especially unusual. That said, we are piloting new features like a Spanish language course and support for PDFs and image support, so new timeout limits may be a reasonable change to make.~~
[edit: upon further inspection of errored requests, we did see very large assets being provided via levelbuilder in requests that were failing. We're separately looking into ways to limit the size of uploads form levelbuilder, but it does seem that size of assets and timeouts are correlated.]

We could also think of this new limit as a "ceiling", and use data collected during the pilot to fine tune it downwards.

## Links

- Alarm discussion threads: [thread 1](https://codedotorg.slack.com/archives/C03DBDN67B7/p1744206339126079), [thread 2](https://codedotorg.slack.com/archives/C03DBDN67B7/p1743589126405829)
- Honeybadger error: https://app.honeybadger.io/projects/3240/faults/112917121

## Testing story

I couldn't find great docs on HTTParty, so I tested manually that turning this timeout down to a really low value produces timeout errors, so confirmed that the setting works as expected.