### PR TITLE
Update Regional Partner Routes to Use Resourceful Routing

### DIFF
--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -605,13 +605,16 @@ Dashboard::Application.routes.draw do
     post '/milestone/:user_id/:script_level_id/:level_id', to: 'activities#milestone', as: 'milestone_script_level'
 
     get '/admin', to: 'admin_reports#directory', as: 'admin_directory'
-    resources :regional_partners
-    post 'regional_partners/:id/assign_program_manager', controller: 'regional_partners', action: 'assign_program_manager'
-    get 'regional_partners/:id/remove_program_manager/:program_manager_id', controller: 'regional_partners', action: 'remove_program_manager'
-    post 'regional_partners/:id/add_mapping', controller: 'regional_partners', action: 'add_mapping'
-    get 'regional_partners/:id/remove_mapping/:id', controller: 'regional_partners', action: 'remove_mapping'
-    post 'regional_partners/:id/replace_mappings',  controller: 'regional_partners', action: 'replace_mappings'
 
+    resources :regional_partners do
+      member do
+        post :assign_program_manager
+        get 'remove_program_manager/:program_manager_id', action: 'remove_program_manager'
+        post :add_mapping
+        get 'remove_mapping/:id', action: 'remove_mapping'
+        post :replace_mappings
+      end
+    end
     get 'regional-partner-search', to: 'regional_partners#regional_partner_search'
 
     # NPS dashboards


### PR DESCRIPTION
Part of an ongoing initiative within the engineering standards working group.

## Links

- [Tracking doc](https://docs.google.com/spreadsheets/d/1of9F1_I3Q_U1JVeceC7YRMN8U68lBOycwtUxV-97kfc/edit?gid=0#gid=0)

## Testing story

Ran `bundle exec rails routes | sort > /tmp/staging.sorted.routes` against staging latest, then with this change in place I ran `bundle exec rails routes | sort | diff /tmp/staging.sorted.routes -` and got the following:

```diff
18a19
>                                        add_mapping_regional_partner POST     /regional_partners/:id/add_mapping(.:format)                                                                                         regional_partners#add_mapping
190a192
>                             assign_program_manager_regional_partner POST     /regional_partners/:id/assign_program_manager(.:format)                                                                              regional_partners#assign_program_manager
1195,1197d1196
<                                                                     POST     /regional_partners/:id/add_mapping(.:format)                                                                                         regional_partners#add_mapping
<                                                                     POST     /regional_partners/:id/assign_program_manager(.:format)                                                                              regional_partners#assign_program_manager
<                                                                     POST     /regional_partners/:id/replace_mappings(.:format)                                                                                    regional_partners#replace_mappings
1340a1340
>                                   replace_mappings_regional_partner POST     /regional_partners/:id/replace_mappings(.:format)                                                                                    regional_partners#replace_mappings
```

The only difference in the routes before vs after is that the new ones are named.
