### PR TITLE
Update user_preferences_controller

### DIFF
--- a/dashboard/app/controllers/user_preferences_controller.rb
+++ b/dashboard/app/controllers/user_preferences_controller.rb
@@ -3,12 +3,48 @@ class UserPreferencesController < ApplicationController
 
   def update
     preference = UserPreference.find_or_initialize_by(user_id: current_user.id)
-    preference.update!(section_order: update_params[:section_order])
+    # Merge existing editor/console font size JSON with new values if param is present.
+    # to_h handles if current editor/console font size is nil.
+    merged_editor_font_size = update_params[:editor_font_size] ?
+      preference.editor_font_size.to_h.merge(update_params[:editor_font_size]) :
+      preference.editor_font_size
+
+    merged_console_font_size = update_params[:console_font_size] ?
+      preference.console_font_size.to_h.merge(update_params[:console_font_size]) :
+      preference.console_font_size
+
+    preference.update!(
+      section_order: update_params[:section_order] || preference.section_order,
+      editor_font_size: merged_editor_font_size,
+      console_font_size: merged_console_font_size
+    )
+  end
+
+  def console_font_size
+    preference = UserPreference.find_by(user_id: current_user.id)
+
+    if preference && preference.console_font_size.present?
+      render json: {console_font_size: preference.console_font_size}
+    else
+      render json: {}, status: :not_found
+    end
+  end
+
+  def editor_font_size
+    preference = UserPreference.find_by(user_id: current_user.id)
+
+    if preference && preference.editor_font_size.present?
+      render json: {editor_font_size: preference.editor_font_size}
+    else
+      render json: {}, status: :not_found
+    end
   end
 
   private def update_params
     params.transform_keys(&:underscore).permit(
-      section_order: []
+      section_order: [],
+      console_font_size: {},
+      editor_font_size: {}
     )
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -48,7 +48,10 @@ Dashboard::Application.routes.draw do
       end
     end
 
-    resource :user_preference, only: [:update]
+    resource :user_preference, only: [:update] do
+      get '/font_size/console', to: 'user_preferences#console_font_size'
+      get '/font_size/editor', to: 'user_preferences#editor_font_size'
+    end
 
     resources :survey_results, only: [:create], defaults: {format: 'json'}
 

--- a/dashboard/test/controllers/user_preferences_controller_test.rb
+++ b/dashboard/test/controllers/user_preferences_controller_test.rb
@@ -17,7 +17,29 @@ class UserPreferencesControllerTest < ActionController::TestCase
     assert_equal section_order, preference.section_order
   end
 
-  test 'updates existing preference without creating a new record' do
+  test 'updates console_font_size for the current user' do
+    console_font_size = {'pythonlab' => 'medium'}
+
+    patch :update, params: {console_font_size: console_font_size}
+
+    assert_response :success
+
+    preference = UserPreference.find_by(user_id: @user.id)
+    assert_equal console_font_size, preference.console_font_size
+  end
+
+  test 'updates editor_font_size for the current user' do
+    editor_font_size = {'weblab2' => 'large'}
+
+    patch :update, params: {editor_font_size: editor_font_size}
+
+    assert_response :success
+
+    preference = UserPreference.find_by(user_id: @user.id)
+    assert_equal editor_font_size, preference.editor_font_size
+  end
+
+  test 'updates existing preference for section_order without creating a new record' do
     initial_order = ['3', '2', '1']
     preference = UserPreference.create!(user_id: @user.id, section_order: initial_order)
 
@@ -33,6 +55,30 @@ class UserPreferencesControllerTest < ActionController::TestCase
     assert_equal new_order, preference.section_order
   end
 
+  test 'updates existing preference for editor_font_size without creating a new record and merges successfully' do
+    initial_editor_font_size = {
+      'pythonlab'=> 'small'
+    }
+    preference = UserPreference.create!(user_id: @user.id, editor_font_size: initial_editor_font_size)
+
+    new_editor_font_size = {
+      'weblab2'=> 'medium'
+    }
+    merged_editor_font_size = {
+      'pythonlab'=> 'small',
+      'weblab2'=> 'medium'
+    }
+
+    assert_no_difference 'UserPreference.count' do
+      patch :update, params: {editor_font_size: new_editor_font_size}
+    end
+
+    assert_response :success
+
+    preference.reload
+    assert_equal merged_editor_font_size, preference.editor_font_size
+  end
+
   test 'ignores non-permitted parameters' do
     section_order = ['1', '2', '3']
 
@@ -46,5 +92,41 @@ class UserPreferencesControllerTest < ActionController::TestCase
     preference = UserPreference.find_by(user_id: @user.id)
     assert_equal section_order, preference.section_order
     assert_nil preference.attributes['unpermitted_param']
+  end
+
+  test 'gets console_font_size for the current user' do
+    font_size = {'pythonlab' => 'large'}
+    UserPreference.create!(user_id: @user.id, console_font_size: font_size)
+
+    get :console_font_size
+
+    assert_response :success
+    assert_equal font_size, JSON.parse(response.body)['console_font_size']
+  end
+
+  test 'returns 404 if no console_font_size exists for the current user' do
+    UserPreference.create!(user_id: @user.id, console_font_size: nil)
+
+    get :console_font_size
+
+    assert_response :not_found
+  end
+
+  test 'gets editor_font_size for the current user' do
+    font_size = {'weblab2' => 'small'}
+    UserPreference.create!(user_id: @user.id, editor_font_size: font_size)
+
+    get :editor_font_size
+
+    assert_response :success
+    assert_equal font_size, JSON.parse(response.body)['editor_font_size']
+  end
+
+  test 'returns 404 if no editor_font_size exists for the current user' do
+    UserPreference.create!(user_id: @user.id, editor_font_size: nil)
+
+    get :editor_font_size
+
+    assert_response :not_found
   end
 end


### PR DESCRIPTION
Following up https://github.com/code-dot-org/code-dot-org/pull/65157 which added columns `editor_font_size` and `console_font_size` to `UserPreferences` table, this PR adds to the `update` method in `user_preferences_controller` to include updating these new JSON values if included in `params`.

I also added two `GET` paths for these two values and corresponding tests for the changes.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
