### PR TITLE
level_group levels - fix issue with page numbers popping up in url

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -268,7 +268,7 @@ class ScriptLevel < ApplicationRecord
   end
 
   def long_assessment?
-    assessment && level.is_a?(LevelGroup)
+    assessment && level.is_a?(LevelGroup) && !activity_guide_level?
   end
 
   def anonymous?


### PR DESCRIPTION
This PR solves 2 problems with one line of code.

**Issue 1:**  For `level_group` levels that were marked as an "assessment" at a `script_level`, we were getting some weird behavior with the URL automatically adding a `page`.  This was causing issues with teachers being able to access the `summary` of student response's.   This was because the combination of being marked as an `assessment` and a `LevelGroup` triggered actions to treat this as a `long_assessment` (which included page numbers).  The `summary` button just appended `summary` to the "paginated" URL which was causing the issues for the user.

<img width="783" alt="image" src="https://github.com/user-attachments/assets/3e9f45ef-9a15-4378-9ce4-b30aeab8bcf2" />

**Action 1:** Modified how `long_assessment` is defined in the `script_level` model to avoid these `activity_guide_levels` from being included in `long_assessment`.  I confirmed with Ken that all `activity_guide_levels` are intended to be one page. 

<hr></hr> 

<img width="787" alt="image" src="https://github.com/user-attachments/assets/0866fdb6-27b9-4582-89db-a6d4a289a573" />

**Issue 2:** We also noticed an issue with how bubbles were showing up for these types of levels (`level_group` levels marked as `assessments`.  The bubble wasn't getting big and showing the number when selected.  This also stemmed from the `long_assessment` designation which caused a `puzzle_page` to be assigned to the level in redux through the [controller](https://github.com/code-dot-org/code-dot-org/blob/bf381c36af2bcd57cdc1bb3798189c42d907a35f/dashboard/app/controllers/script_levels_controller.rb#L138), some [haml](https://github.com/code-dot-org/code-dot-org/blob/bf381c36af2bcd57cdc1bb3798189c42d907a35f/dashboard/app/views/layouts/_header.html.haml#L108) - tracing this code got a little wonky (to maybe hand-wavy), but I am pretty sure this is where the problems stemmed from.

**Action 2:** Again, removing the `long_assessment` designation meant we were no longer assigning a `page` which fixed the issue where the [current page number in redux wasn't matching the level's page_number](https://github.com/code-dot-org/code-dot-org/blob/bf381c36af2bcd57cdc1bb3798189c42d907a35f/apps/src/code-studio/components/progress/LessonProgress.jsx#L175)

## Links

[Thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1744292700131889)
[Other thread](https://codedotorg.slack.com/archives/C079YTSNMM4/p1744250503017559)

## Testing story

Tested locally