### PR TITLE
[Codebridge] Save user preferences for console/editor font size in DB

### DIFF
--- a/apps/src/codebridge/Console/Console.tsx
+++ b/apps/src/codebridge/Console/Console.tsx
@@ -13,11 +13,11 @@ import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {setConsoleFontSize} from '@cdo/apps/lab2/redux/lab2ViewRedux';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import '@xterm/xterm/css/xterm.css';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {tryGetSessionStorage} from '@cdo/apps/utils';
 
 import ConsoleManager from './ConsoleManager';
 import ControlButtons from './ControlButtons';
@@ -162,21 +162,24 @@ const Console: React.FunctionComponent = () => {
     }
   }, [fontSizeKey]);
 
-  // User preference for selected font size persists within a session
-  // per signed-in user per app type (currently in pythonlab).
-  // TODO: update so that selected console font size will persist across sessions.
-  // Note that When the user selects a different font size from settings, fontSizeKey
-  // is updated alongside sessionStorage for sessionStorageKey.
+  // User preference for selected font size persists per signed-in user per app type
+  // (currently in pythonlab) because it is saved on the backend.
+  // Note that when the user selects a different font size from settings, fontSizeKey
+  // is updated and saved on the backend.
   useEffect(() => {
-    const sessionStorageKey = `${appName}ConsoleFontSizeKey`;
-    const sessionStorage = tryGetSessionStorage(sessionStorageKey, false);
-    if (
-      sessionStorage &&
-      sessionStorage !== fontSizeKey &&
-      signInState === SignInState.SignedIn
-    ) {
-      dispatch(setConsoleFontSize(sessionStorage));
+    if (signInState !== SignInState.SignedIn) {
+      return;
     }
+    const fetchFontSize = async () => {
+      const savedConsoleFontSize =
+        await new UserPreferences().getConsoleFontSize(appName);
+      if (savedConsoleFontSize !== fontSizeKey) {
+        if (savedConsoleFontSize) {
+          dispatch(setConsoleFontSize(savedConsoleFontSize));
+        }
+      }
+    };
+    fetchFontSize();
   }, [signInState, fontSizeKey, appName, dispatch]);
 
   return (

--- a/apps/src/codebridge/Console/Console.tsx
+++ b/apps/src/codebridge/Console/Console.tsx
@@ -162,25 +162,24 @@ const Console: React.FunctionComponent = () => {
     }
   }, [fontSizeKey]);
 
-  // User preference for selected font size persists per signed-in user per app type
-  // (currently in pythonlab) because it is saved on the backend.
+  // User preference for selected console font size is saved on the backend
+  // per signed-in user per app type (currently in pythonlab).
   // Note that when the user selects a different font size from settings, fontSizeKey
   // is updated and saved on the backend.
   useEffect(() => {
-    if (signInState !== SignInState.SignedIn) {
-      return;
-    }
     const fetchFontSize = async () => {
+      if (signInState !== SignInState.SignedIn) {
+        return;
+      }
       const savedConsoleFontSize =
         await new UserPreferences().getConsoleFontSize(appName);
-      if (savedConsoleFontSize !== fontSizeKey) {
-        if (savedConsoleFontSize) {
-          dispatch(setConsoleFontSize(savedConsoleFontSize));
-        }
+      if (savedConsoleFontSize) {
+        dispatch(setConsoleFontSize(savedConsoleFontSize));
       }
     };
+
     fetchFontSize();
-  }, [signInState, fontSizeKey, appName, dispatch]);
+  }, [signInState, appName, dispatch]);
 
   return (
     <PanelContainer

--- a/apps/src/codebridge/Console/Console.tsx
+++ b/apps/src/codebridge/Console/Console.tsx
@@ -160,10 +160,10 @@ const Console: React.FunctionComponent = () => {
     }
   }, [fontSizeKey]);
 
-  // User preference for selected console font size is saved on the backend
-  // per signed-in user per app type (currently in pythonlab).
-  // Note that when the user selects a different font size from settings, fontSizeKey
-  // is updated and saved on the backend.
+  // Load the user's preferred console font size from the backend which is saved
+  // per app type (currently in pythonlab) for signed-in users.
+  // When the user selects a different font size from settings, it's saved on the backend.
+  // We mark font size is loaded once the value is fetched (signed-in) or skipped (signed-out).
   useEffect(() => {
     if (signInState !== SignInState.SignedIn) {
       return;

--- a/apps/src/codebridge/Console/Console.tsx
+++ b/apps/src/codebridge/Console/Console.tsx
@@ -5,19 +5,17 @@ import {FitAddon} from '@xterm/addon-fit';
 import {ImageAddon} from '@xterm/addon-image';
 import {Terminal} from '@xterm/xterm';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {useDispatch} from 'react-redux';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {FontSize} from '@cdo/apps/lab2/constants';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
-import {setConsoleFontSize} from '@cdo/apps/lab2/redux/lab2ViewRedux';
+import {fetchAndSaveConsoleFontSize} from '@cdo/apps/lab2/redux/lab2ViewRedux';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
-import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import '@xterm/xterm/css/xterm.css';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import ConsoleManager from './ConsoleManager';
 import ControlButtons from './ControlButtons';
@@ -36,7 +34,7 @@ const Console: React.FunctionComponent = () => {
     state => state.lab2View.consoleFontSizeKey
   );
   const {signInState} = useAppSelector(state => state.currentUser);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const clearOutput = useCallback(
     (sendAnalytics: boolean) => {
@@ -167,18 +165,10 @@ const Console: React.FunctionComponent = () => {
   // Note that when the user selects a different font size from settings, fontSizeKey
   // is updated and saved on the backend.
   useEffect(() => {
-    const fetchFontSize = async () => {
-      if (signInState !== SignInState.SignedIn) {
-        return;
-      }
-      const savedConsoleFontSize =
-        await new UserPreferences().getConsoleFontSize(appName);
-      if (savedConsoleFontSize) {
-        dispatch(setConsoleFontSize(savedConsoleFontSize));
-      }
-    };
-
-    fetchFontSize();
+    if (signInState !== SignInState.SignedIn) {
+      return;
+    }
+    dispatch(fetchAndSaveConsoleFontSize({appName}));
   }, [signInState, appName, dispatch]);
 
   return (

--- a/apps/src/codebridge/Settings/SettingsDropdown.tsx
+++ b/apps/src/codebridge/Settings/SettingsDropdown.tsx
@@ -17,11 +17,11 @@ import {
   setConsoleFontSize,
   setEditorFontSize,
 } from '@cdo/apps/lab2/redux/lab2ViewRedux';
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import useOutsideClick from '@cdo/apps/util/hooks/useOutsideClick';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
-import {trySetSessionStorage} from '@cdo/apps/utils';
 import commonI18n from '@cdo/locale';
 
 import {useCodebridgeContext} from '../codebridgeContext';
@@ -97,7 +97,8 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
   ) => {
     if (selectedKey !== currentKey && FontSize[selectedKey]) {
       if (signInState === SignInState.SignedIn) {
-        trySetSessionStorage(`${appName}${type}FontSizeKey`, selectedKey);
+        const field = type === 'Console' ? 'consoleFontSize' : 'editorFontSize';
+        new UserPreferences().setFontSize(selectedKey, appName, field);
       }
       const reduxAction =
         type === 'Console' ? setConsoleFontSize : setEditorFontSize;
@@ -113,8 +114,8 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
     const selectedEditorKey = getSelectedKey(selectedEditorFontSizeValue);
     const selectedConsoleKey = getSelectedKey(selectedConsoleFontSizeValue);
 
-    // We want the user preference for selected font size to persist across a session
-    // for signed-in users per app type.
+    // We want the user preference for selected font size to persist for signed-in users
+    // per app type so we save on backend.
     handleFontSizeChange(
       'CodeEditor',
       selectedEditorKey,

--- a/apps/src/lab2/redux/lab2ViewRedux.ts
+++ b/apps/src/lab2/redux/lab2ViewRedux.ts
@@ -1,7 +1,9 @@
-import {PayloadAction, createSlice} from '@reduxjs/toolkit';
+import {PayloadAction, createSlice, createAsyncThunk} from '@reduxjs/toolkit';
 
 import {FontSize} from '@cdo/apps/lab2/constants';
-
+import {AppName} from '@cdo/apps/lab2/types';
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
+import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 export interface Lab2ViewState {
   consoleFontSizeKey: keyof typeof FontSize;
   editorFontSizeKey: keyof typeof FontSize;
@@ -11,6 +13,39 @@ const initialState: Lab2ViewState = {
   consoleFontSizeKey: 'Small',
   editorFontSizeKey: 'Small',
 };
+
+// THUNKS
+
+// This thunk fetches the user's last selected console font size from the backend, then saves
+// it in redux.
+export const fetchAndSaveConsoleFontSize = createAsyncThunk<
+  void,
+  {appName: AppName},
+  {dispatch: AppDispatch}
+>('lab2View/fetchAndSaveConsoleFontSize', async ({appName}, {dispatch}) => {
+  const savedConsoleFontSize = await new UserPreferences().getConsoleFontSize(
+    appName
+  );
+  if (savedConsoleFontSize) {
+    dispatch(setConsoleFontSize(savedConsoleFontSize));
+  }
+});
+
+// This thunk fetches the user's last selected editor font size from the backend, then saves
+// it in redux.
+export const fetchAndSaveEditorFontSize = createAsyncThunk<
+  void,
+  {appName: AppName},
+  {dispatch: AppDispatch}
+>('lab2View/fetchAndSaveEditorFontSize', async ({appName}, {dispatch}) => {
+  const savedEditorFontSize = await new UserPreferences().getEditorFontSize(
+    appName
+  );
+  console.log('savedEditorFontSize', savedEditorFontSize);
+  if (savedEditorFontSize) {
+    dispatch(setEditorFontSize(savedEditorFontSize));
+  }
+});
 
 // SLICE
 const lab2ViewSlice = createSlice({

--- a/apps/src/lab2/redux/lab2ViewRedux.ts
+++ b/apps/src/lab2/redux/lab2ViewRedux.ts
@@ -7,11 +7,13 @@ import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 export interface Lab2ViewState {
   consoleFontSizeKey: keyof typeof FontSize;
   editorFontSizeKey: keyof typeof FontSize;
+  editorFontSizeLoaded: boolean;
 }
 
 const initialState: Lab2ViewState = {
   consoleFontSizeKey: 'Small',
   editorFontSizeKey: 'Small',
+  editorFontSizeLoaded: false,
 };
 
 // THUNKS
@@ -43,6 +45,7 @@ export const fetchAndSaveEditorFontSize = createAsyncThunk<
   );
   if (savedEditorFontSize) {
     dispatch(setEditorFontSize(savedEditorFontSize));
+    dispatch(setEditorFontSizeLoaded(true));
   }
 });
 
@@ -57,9 +60,13 @@ const lab2ViewSlice = createSlice({
     setEditorFontSize(state, action: PayloadAction<keyof typeof FontSize>) {
       state.editorFontSizeKey = action.payload;
     },
+    setEditorFontSizeLoaded(state, action: PayloadAction<boolean>) {
+      state.editorFontSizeLoaded = action.payload;
+    },
   },
 });
 
-export const {setConsoleFontSize, setEditorFontSize} = lab2ViewSlice.actions;
+export const {setConsoleFontSize, setEditorFontSize, setEditorFontSizeLoaded} =
+  lab2ViewSlice.actions;
 
 export default lab2ViewSlice.reducer;

--- a/apps/src/lab2/redux/lab2ViewRedux.ts
+++ b/apps/src/lab2/redux/lab2ViewRedux.ts
@@ -41,7 +41,6 @@ export const fetchAndSaveEditorFontSize = createAsyncThunk<
   const savedEditorFontSize = await new UserPreferences().getEditorFontSize(
     appName
   );
-  console.log('savedEditorFontSize', savedEditorFontSize);
   if (savedEditorFontSize) {
     dispatch(setEditorFontSize(savedEditorFontSize));
   }

--- a/apps/src/lab2/redux/lab2ViewRedux.ts
+++ b/apps/src/lab2/redux/lab2ViewRedux.ts
@@ -45,8 +45,8 @@ export const fetchAndSaveEditorFontSize = createAsyncThunk<
   );
   if (savedEditorFontSize) {
     dispatch(setEditorFontSize(savedEditorFontSize));
-    dispatch(setEditorFontSizeLoaded(true));
   }
+  dispatch(setEditorFontSizeLoaded(true));
 });
 
 // SLICE

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -3,16 +3,14 @@ import {Compartment, EditorState, Extension} from '@codemirror/state';
 import {EditorView, ViewUpdate} from '@codemirror/view';
 import classNames from 'classnames';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
-import {useDispatch} from 'react-redux';
 
 import {FontSize} from '@cdo/apps/lab2/constants';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
-import {setEditorFontSize} from '@cdo/apps/lab2/redux/lab2ViewRedux';
+import {fetchAndSaveEditorFontSize} from '@cdo/apps/lab2/redux/lab2ViewRedux';
 import {AppName} from '@cdo/apps/lab2/types';
-import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import i18n from '@cdo/apps/pythonlab/locale';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import {editorConfig} from './editorConfig';
 import {darkMode as darkModeTheme} from './editorThemes';
@@ -35,7 +33,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   darkMode = true,
 }) => {
   const editorRef = useRef<HTMLDivElement>(null);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [didInit, setDidInit] = useState(false);
   const [fontSizeLoaded, setFontSizeLoaded] = useState(false);
   const [editorView, setEditorView] = useState<EditorView | null>(null);
@@ -49,21 +47,12 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   // Note that When the user selects a different font size from settings, fontSizeKey
   // is updated and saved on the backend.
   useEffect(() => {
-    const fetchFontSize = async () => {
-      if (signInState !== SignInState.SignedIn) {
-        setFontSizeLoaded(true);
-        return;
-      }
-      const savedEditorFontSize = await new UserPreferences().getEditorFontSize(
-        appName
-      );
-      if (savedEditorFontSize) {
-        dispatch(setEditorFontSize(savedEditorFontSize));
-      }
+    if (signInState !== SignInState.SignedIn) {
       setFontSizeLoaded(true);
-    };
-
-    fetchFontSize();
+      return;
+    }
+    dispatch(fetchAndSaveEditorFontSize({appName}));
+    setFontSizeLoaded(true);
   }, [dispatch, signInState, appName]);
 
   // These two compartments control read-only settings.

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -9,10 +9,10 @@ import {FontSize} from '@cdo/apps/lab2/constants';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {setEditorFontSize} from '@cdo/apps/lab2/redux/lab2ViewRedux';
 import {AppName} from '@cdo/apps/lab2/types';
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import i18n from '@cdo/apps/pythonlab/locale';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {tryGetSessionStorage} from '@cdo/apps/utils';
 
 import {editorConfig} from './editorConfig';
 import {darkMode as darkModeTheme} from './editorThemes';
@@ -37,28 +37,34 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   const editorRef = useRef<HTMLDivElement>(null);
   const dispatch = useDispatch();
   const [didInit, setDidInit] = useState(false);
+  const [fontSizeLoaded, setFontSizeLoaded] = useState(false);
   const [editorView, setEditorView] = useState<EditorView | null>(null);
   const channelId = useAppSelector(state => state.lab.channel?.id);
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
   const fontSizeKey = useAppSelector(state => state.lab2View.editorFontSizeKey);
   const {signInState} = useAppSelector(state => state.currentUser);
 
-  // User preference for selected font size persists within a session
+  // User preference for selected font size is saved on the backend
   // per signed-in user per app type (currently either pythonlab or weblab).
-  // TODO: update so that selected font size will persist across sessions.
   // Note that When the user selects a different font size from settings, fontSizeKey
-  // is updated alongside sessionStorage for sessionStorageKey.
+  // is updated and saved on the backend.
   useEffect(() => {
-    const sessionStorageKey = `${appName}CodeEditorFontSizeKey`;
-    const sessionStorage = tryGetSessionStorage(sessionStorageKey, false);
-    if (
-      sessionStorage &&
-      sessionStorage !== fontSizeKey &&
-      signInState === SignInState.SignedIn
-    ) {
-      dispatch(setEditorFontSize(sessionStorage));
-    }
-  }, [dispatch, signInState, fontSizeKey, appName]);
+    const fetchFontSize = async () => {
+      if (signInState !== SignInState.SignedIn) {
+        setFontSizeLoaded(true);
+        return;
+      }
+      const savedEditorFontSize = await new UserPreferences().getEditorFontSize(
+        appName
+      );
+      if (savedEditorFontSize) {
+        dispatch(setEditorFontSize(savedEditorFontSize));
+      }
+      setFontSizeLoaded(true);
+    };
+
+    fetchFontSize();
+  }, [dispatch, signInState, appName]);
 
   // These two compartments control read-only settings.
   // Controls if you can type in the editor or not.
@@ -77,7 +83,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     });
   };
   useEffect(() => {
-    if (editorRef.current === null || didInit) {
+    if (!fontSizeLoaded || editorRef.current === null || didInit) {
       return;
     }
 
@@ -131,6 +137,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     editorEditableCompartment,
     fontSizeCompartment,
     fontSizeKey,
+    fontSizeLoaded,
   ]);
 
   // When we have a new fontSizeKey, reset font size.
@@ -187,6 +194,10 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
       cmContentDiv.setAttribute('aria-label', i18n.codeEditor());
     }
   }, []);
+
+  if (!fontSizeLoaded) {
+    return null;
+  }
 
   return (
     <div

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -42,10 +42,10 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   const fontSizeKey = useAppSelector(state => state.lab2View.editorFontSizeKey);
   const {signInState} = useAppSelector(state => state.currentUser);
 
-  // User preference for selected font size is saved on the backend
-  // per signed-in user per app type (currently either pythonlab or weblab).
-  // Note that When the user selects a different font size from settings, fontSizeKey
-  // is updated and saved on the backend.
+  // Load the user's preferred editor font size from the backend which is saved
+  // per app type (currently either pythonlab or weblab) for signed-in users.
+  // When the user selects a different font size from settings, it's saved on the backend.
+  // We mark font size is loaded once the value is fetched (signed-in) or skipped (signed-out).
   useEffect(() => {
     if (signInState !== SignInState.SignedIn) {
       setFontSizeLoaded(true);

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -6,7 +6,10 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {FontSize} from '@cdo/apps/lab2/constants';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
-import {fetchAndSaveEditorFontSize} from '@cdo/apps/lab2/redux/lab2ViewRedux';
+import {
+  fetchAndSaveEditorFontSize,
+  setEditorFontSizeLoaded,
+} from '@cdo/apps/lab2/redux/lab2ViewRedux';
 import {AppName} from '@cdo/apps/lab2/types';
 import i18n from '@cdo/apps/pythonlab/locale';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
@@ -35,11 +38,12 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   const editorRef = useRef<HTMLDivElement>(null);
   const dispatch = useAppDispatch();
   const [didInit, setDidInit] = useState(false);
-  const [fontSizeLoaded, setFontSizeLoaded] = useState(false);
   const [editorView, setEditorView] = useState<EditorView | null>(null);
   const channelId = useAppSelector(state => state.lab.channel?.id);
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
-  const fontSizeKey = useAppSelector(state => state.lab2View.editorFontSizeKey);
+  const {editorFontSizeKey, editorFontSizeLoaded} = useAppSelector(
+    state => state.lab2View
+  );
   const {signInState} = useAppSelector(state => state.currentUser);
 
   // Load the user's preferred editor font size from the backend which is saved
@@ -48,11 +52,10 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   // We mark font size is loaded once the value is fetched (signed-in) or skipped (signed-out).
   useEffect(() => {
     if (signInState !== SignInState.SignedIn) {
-      setFontSizeLoaded(true);
+      dispatch(setEditorFontSizeLoaded(true));
       return;
     }
     dispatch(fetchAndSaveEditorFontSize({appName}));
-    setFontSizeLoaded(true);
   }, [dispatch, signInState, appName]);
 
   // These two compartments control read-only settings.
@@ -72,7 +75,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     });
   };
   useEffect(() => {
-    if (!fontSizeLoaded || editorRef.current === null || didInit) {
+    if (!editorFontSizeLoaded || editorRef.current === null || didInit) {
       return;
     }
 
@@ -93,7 +96,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     editorExtensions.push(
       editorReadOnlyCompartment.of(EditorState.readOnly.of(isReadOnly)),
       editorEditableCompartment.of(EditorView.editable.of(!isReadOnly)),
-      fontSizeCompartment.of(getFontSizeTheme(FontSize[fontSizeKey]))
+      fontSizeCompartment.of(getFontSizeTheme(FontSize[editorFontSizeKey]))
     );
     if (darkMode) {
       editorExtensions.push(darkModeTheme);
@@ -125,8 +128,8 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     isReadOnly,
     editorEditableCompartment,
     fontSizeCompartment,
-    fontSizeKey,
-    fontSizeLoaded,
+    editorFontSizeKey,
+    editorFontSizeLoaded,
   ]);
 
   // When we have a new fontSizeKey, reset font size.
@@ -135,12 +138,12 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
       editorView.dispatch({
         effects: [
           fontSizeCompartment.reconfigure(
-            getFontSizeTheme(FontSize[fontSizeKey])
+            getFontSizeTheme(FontSize[editorFontSizeKey])
           ),
         ],
       });
     }
-  }, [editorView, fontSizeCompartment, fontSizeKey]);
+  }, [editorView, fontSizeCompartment, editorFontSizeKey]);
 
   // When we have a new channelId and/or start code, reset the editor with the start code.
   // A new channelId means we are loading a new project, and we need to reset the editor.
@@ -184,7 +187,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     }
   }, []);
 
-  if (!fontSizeLoaded) {
+  if (!editorFontSizeLoaded) {
     return null;
   }
 

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -94,7 +94,7 @@ export default class UserPreferences extends Record({userId: 'me'}) {
   }
 
   /**
-   * Save the user's console font size selection
+   * Save the user's font size selection for the console or editor.
    * @param {string} fontSize
    * @param {string} appName
    * @param {string} field either 'consoleFontSize' or 'editorFontSize'
@@ -112,7 +112,7 @@ export default class UserPreferences extends Record({userId: 'me'}) {
   }
 
   /**
-   * Fetch the user's editor font size selection
+   * Fetch the user's console font size selection.
    * @param {string} fontSize
    * @param {string} appType
    */

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -1,8 +1,8 @@
 import {Record} from 'immutable';
 import $ from 'jquery';
 
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import HttpClient from '@cdo/apps/util/HttpClient';
-
 export default class UserPreferences extends Record({userId: 'me'}) {
   /**
    * Save the using_text_mode user preference
@@ -116,12 +116,25 @@ export default class UserPreferences extends Record({userId: 'me'}) {
    * @param {string} appName
    */
   async getConsoleFontSize(appName) {
-    const consoleFontSizeResponse = await HttpClient.fetchJson(
-      '/user_preference/font_size/console'
-    );
-    const consoleFontSize =
-      consoleFontSizeResponse.value.console_font_size[appName];
-    return consoleFontSize;
+    try {
+      const consoleFontSizeResponse = await HttpClient.fetchJson(
+        '/user_preference/font_size/console'
+      );
+      const consoleFontSize =
+        consoleFontSizeResponse.value.console_font_size[appName];
+      return consoleFontSize;
+    } catch (error) {
+      // Don't log error if console font size for 'Not found'.
+      // User did not save preferred console font size yet.
+      if (error.response.status !== 404) {
+        Lab2Registry.getInstance()
+          .getMetricsReporter()
+          .logError('Error fetching console font size', undefined, {
+            message: error.response,
+          });
+      }
+      return null;
+    }
   }
 
   /**
@@ -129,11 +142,24 @@ export default class UserPreferences extends Record({userId: 'me'}) {
    * @param {string} appName
    */
   async getEditorFontSize(appName) {
-    const editorFontSizeResponse = await HttpClient.fetchJson(
-      '/user_preference/font_size/editor'
-    );
-    const editorFontSize =
-      editorFontSizeResponse.value.editor_font_size[appName];
-    return editorFontSize;
+    try {
+      const editorFontSizeResponse = await HttpClient.fetchJson(
+        '/user_preference/font_size/editor'
+      );
+      const editorFontSize =
+        editorFontSizeResponse.value.editor_font_size[appName];
+      return editorFontSize;
+    } catch (error) {
+      // Don't log error if editor font size for 'Not found'.
+      // User did not save preferred editor font size yet.
+      if (error.response.status !== 404) {
+        Lab2Registry.getInstance()
+          .getMetricsReporter()
+          .logError('Error fetching editor font size', undefined, {
+            message: error.response,
+          });
+      }
+      return null;
+    }
   }
 }

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -113,8 +113,7 @@ export default class UserPreferences extends Record({userId: 'me'}) {
 
   /**
    * Fetch the user's console font size selection.
-   * @param {string} fontSize
-   * @param {string} appType
+   * @param {string} appName
    */
   async getConsoleFontSize(appName) {
     const consoleFontSizeResponse = await HttpClient.fetchJson(
@@ -127,8 +126,7 @@ export default class UserPreferences extends Record({userId: 'me'}) {
 
   /**
    * Fetch the user's editor font size selection.
-   * @param {string} editorFontSize
-   * @param {string} appType
+   * @param {string} appName
    */
   async getEditorFontSize(appName) {
     const editorFontSizeResponse = await HttpClient.fetchJson(

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -1,6 +1,8 @@
 import {Record} from 'immutable';
 import $ from 'jquery';
 
+import HttpClient from '@cdo/apps/util/HttpClient';
+
 export default class UserPreferences extends Record({userId: 'me'}) {
   /**
    * Save the using_text_mode user preference
@@ -89,5 +91,51 @@ export default class UserPreferences extends Record({userId: 'me'}) {
     return $.getJSON(`/api/v1/users/${this.userId}/mute_music`).then(
       response => response.mute_music
     );
+  }
+
+  /**
+   * Save the user's console font size selection
+   * @param {string} fontSize
+   * @param {string} appName
+   * @param {string} field either 'consoleFontSize' or 'editorFontSize'
+   */
+  setFontSize(fontSize, appName, field) {
+    const body = {
+      [field]: {
+        [appName]: fontSize,
+      },
+    };
+
+    HttpClient.put('/user_preference', JSON.stringify(body), true, {
+      'Content-Type': 'application/json',
+    });
+  }
+
+  /**
+   * Fetch the user's editor font size selection
+   * @param {string} fontSize
+   * @param {string} appType
+   */
+  async getConsoleFontSize(appName) {
+    const consoleFontSizeResponse = await HttpClient.fetchJson(
+      '/user_preference/font_size/console'
+    );
+    const consoleFontSize =
+      consoleFontSizeResponse.value.console_font_size[appName];
+    return consoleFontSize;
+  }
+
+  /**
+   * Fetch the user's editor font size selection
+   * @param {string} editorFontSize
+   * @param {string} appType
+   */
+  async getEditorFontSize(appName) {
+    const editorFontSizeResponse = await HttpClient.fetchJson(
+      '/user_preference/font_size/editor'
+    );
+    const editorFontSize =
+      editorFontSizeResponse.value.editor_font_size[appName];
+    return editorFontSize;
   }
 }

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -126,7 +126,7 @@ export default class UserPreferences extends Record({userId: 'me'}) {
   }
 
   /**
-   * Fetch the user's editor font size selection
+   * Fetch the user's editor font size selection.
    * @param {string} editorFontSize
    * @param {string} appType
    */

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -16,6 +16,7 @@ Scenario: Can run and see output of Python program
 
 Scenario: Continue button and progress status shows up correctly
   # Level 1 is not validated; continue button will show up after editing and running code.
+  And I wait until element ".cm-content" contains text "Hello from the start!"
   And I verify progress in the header of the current page is "not_tried" for level 1
   And I focus selector ".cm-content"
   And I press keys "print('more code')\n"

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -16,7 +16,7 @@ Scenario: Can run and see output of Python program
 
 Scenario: Continue button and progress status shows up correctly
   # Level 1 is not validated; continue button will show up after editing and running code.
-  And I wait until element ".cm-content" contains text "Hello from the start!"
+  And I wait to see ".cm-content"
   And I verify progress in the header of the current page is "not_tried" for level 1
   And I focus selector ".cm-content"
   And I press keys "print('more code')\n"

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_start_mode.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_start_mode.feature
@@ -14,6 +14,7 @@ Background:
   And I wait to see "#uitest-codebridge-run"
 
 Scenario: Correct file types are in the dropdown
+  And I wait until element ".cm-content" contains text "Hello from the start!"
   And I open the dropdown for file 0
   And element "#uitest-file-0-popup" contains text "Make validation file"
   And element "#uitest-file-0-popup" contains text "Make starter file"

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_start_mode.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_start_mode.feature
@@ -14,7 +14,7 @@ Background:
   And I wait to see "#uitest-codebridge-run"
 
 Scenario: Correct file types are in the dropdown
-  And I wait until element ".cm-content" contains text "Hello from the start!"
+  And I wait to see ".cm-content"
   And I open the dropdown for file 0
   And element "#uitest-file-0-popup" contains text "Make validation file"
   And element "#uitest-file-0-popup" contains text "Make starter file"


### PR DESCRIPTION
This PR adds the frontend implementation to save user preferences for console/editor font size in Codebridge and follows up https://github.com/code-dot-org/code-dot-org/pull/65186 which added the backend work (controller/route updates).

Currently on `prod`, the font size preference is saved across a session. This PR allows the font size user preferences to persist across multiple sessions by saving the preferences in the new `UserPreferences` table.

## Before update
User has two browser sessions open concurrently (seen with different google accounts). An editor font size update in one session does NOT update the editor font size in the other session.

https://github.com/user-attachments/assets/fdd9ac84-35e5-40f4-86aa-3d5df694a74d


## After update
User has two browser sessions open concurrently (seen with different google accounts). An editor font size update in one session DOES update the editor font size in the other session.

https://github.com/user-attachments/assets/fbea860e-48b1-412b-8abe-76141b688bcb

A console font size update in one session DOES update the console font size in the other session.


https://github.com/user-attachments/assets/da21636d-897b-43bb-bd88-16c967d7c56a




<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira](https://codedotorg.atlassian.net/browse/CT-1173)


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested on `pythonlab` and `weblab2` levels as well as `pythonlab` standalone projects.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
- Save console/editor font size preference in DB for `javalab`.

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
