### PR TITLE
Upgrading acme-client (update_certs was failing)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -656,6 +656,9 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     open-uri (0.1.0)
+      stringio
+      time
+      uri
     open_uri_redirections (0.2.1)
     orm_adapter (0.5.0)
     os (1.1.4)
@@ -895,6 +898,7 @@ GEM
       ip3country (~> 0.2.1)
       user_agent_parser (~> 2.15.0)
     stringex (2.5.2)
+    stringio (3.1.5)
     strscan (3.1.0)
     sysexits (1.2.0)
     syslog (0.1.2)
@@ -907,6 +911,8 @@ GEM
     thwait (0.2.0)
       e2mmap
     tilt (2.0.11)
+    time (0.4.1)
+      date
     timecop (0.8.1)
     timeout (0.3.2)
     timers (4.3.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,9 +100,10 @@ GEM
   specs:
     Ascii85 (1.1.0)
     abbrev (0.1.2)
-    acme-client (2.0.11)
+    acme-client (2.0.21)
+      base64 (~> 0.2.0)
       faraday (>= 1.0, < 3.0.0)
-      faraday-retry (~> 1.0)
+      faraday-retry (>= 1.0, < 3.0.0)
     acmesmith (2.3.1)
       acme-client (~> 2)
       aws-sdk-acm
@@ -400,7 +401,7 @@ GEM
       i18n (>= 1.8.11, < 2)
     fakeredis (0.9.2)
       redis (~> 4.8)
-    faraday (1.10.3)
+    faraday (1.10.4)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -419,8 +420,8 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -655,9 +656,6 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     open-uri (0.1.0)
-      stringio
-      time
-      uri
     open_uri_redirections (0.2.1)
     orm_adapter (0.5.0)
     os (1.1.4)
@@ -897,7 +895,6 @@ GEM
       ip3country (~> 0.2.1)
       user_agent_parser (~> 2.15.0)
     stringex (2.5.2)
-    stringio (3.1.5)
     strscan (3.1.0)
     sysexits (1.2.0)
     syslog (0.1.2)
@@ -910,8 +907,6 @@ GEM
     thwait (0.2.0)
       e2mmap
     tilt (2.0.11)
-    time (0.4.1)
-      date
     timecop (0.8.1)
     timeout (0.3.2)
     timers (4.3.5)
@@ -933,7 +928,6 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
-    uri (1.0.3)
     user_agent_parser (2.15.0)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -934,6 +934,7 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
+    uri (1.0.3)
     user_agent_parser (2.15.0)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)


### PR DESCRIPTION
The [`update_certs` process](https://docs.google.com/document/d/1sarifBawc_0gGRbSYRRsbw341ADkd5Xve0H9yLninpU/edit?tab=t.0) was failing with this error:

```
bundler: failed to load command: ./update_certs (./update_certs)
/Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/acme-client-2.0.11/lib/acme/client/certificate_request.rb:92:in `version=': X509_REQ_set_version: passed invalid argument (OpenSSL::X509::RequestError)
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/acme-client-2.0.11/lib/acme/client/certificate_request.rb:92:in `block in generate'
	from <internal:kernel>:90:in `tap'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/acme-client-2.0.11/lib/acme/client/certificate_request.rb:81:in `generate'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/acme-client-2.0.11/lib/acme/client/certificate_request.rb:40:in `csr'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/acmesmith-2.3.1/lib/acmesmith/ordering_service.rb:64:in `finalize_order'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/acmesmith-2.3.1/lib/acmesmith/ordering_service.rb:38:in `perform!'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/acmesmith-2.3.1/lib/acmesmith/client.rb:32:in `order'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/acmesmith-2.3.1/lib/acmesmith/command.rb:36:in `order'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /Users/dave/.asdf/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
	from /Users/dave/keepers/mirrors/code.org/code-dot-org/aws/cloudformation/update_certs:70:in `rescue in <top (required)>'
	from /Users/dave/keepers/mirrors/code.org/code-dot-org/aws/cloudformation/update_certs:42:in `<top (required)>'
```

Important bit:
```
`version=': X509_REQ_set_version: passed invalid argument (OpenSSL::X509::RequestError)
```

Upgrading resolved the issue.  It is a patch release, so I'm not too worried.  It did change it's dependency footprint a bit... 🤞🏻

## Testing story

I was able to successfully update the certs for the bugcrowd adhoc, following these steps: 

https://docs.google.com/document/d/1sarifBawc_0gGRbSYRRsbw341ADkd5Xve0H9yLninpU/edit?tab=t.0

## PR Checklist:

- [x] User impact is well-understood and desirable
