### PR TITLE
from Zen desk - change text

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2736,7 +2736,7 @@
   "setUpClassClever2": "2. Hit the 'sync classroom' button above to copy your Clever students to Code.org.",
   "setUpClassCleverFinished": "You're finished! If you need to add or remove students later, do that in Clever first, and then sync your classroom again with Code.org.",
   "setUpClassGoogleIntro": "To get your class set up with Google Classroom, do the following:",
-  "setUpClassGoogle1": "1. Make sure your class is set up the way you it to be in Google Classroom.",
+  "setUpClassGoogle1": "1. Make sure your class is set up the way you want it to be in Google Classroom.",
   "setUpClassGoogle2": "2. Hit the 'sync classroom' button above to copy your Google Classroom students to Code.org.",
   "setUpClassGoogleFinished": "You're finished! If you need to add or remove students later, do that in Google Classroom first, and then sync your classroom again with Code.org.",
   "setUpClassPicIntro": "To get your class set up with picture password accounts, do the following:",


### PR DESCRIPTION
This [Zen Desk ticket ](https://codeorg.zendesk.com/agent/tickets/535453)pointed out an issue with our strings:

<img width="909" alt="image" src="https://github.com/user-attachments/assets/d2152188-d7fa-4291-a0b0-e504bb56e45b" />


Note, this may cause some eyes diffs, I will let DOTD know when merged in.

