### PR TITLE
AI Chat: report separate errors separately

### DIFF
--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -13,6 +13,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
   end
 
   before_perform do |job|
+    puts job
     request = job.arguments.first[:request]
     request.update!(execution_status: SharedConstants::AI_REQUEST_EXECUTION_STATUS[:RUNNING])
     report_job_start(request)
@@ -24,7 +25,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
   end
 
   # Catch any exceptions that occur during the job and update the request status accordingly
-  rescue_from Exception do |exception|
+  rescue_from StandardError do |exception|
     if rack_env?(:development)
       puts "AichatRequestChatCompletionJob Error: #{exception.full_message}"
     end
@@ -41,8 +42,8 @@ class AichatRequestChatCompletionJob < ApplicationJob
     # Report metrics for the failed job (after_perform doesn't run on failure)
     report_job_finish(request)
 
-    # Raise an exception to notify our system of the failed job. Make sure not to exceed the delayed_jobs.last_error column size.
-    raise "AichatRequestChatCompletionJob failed with unexpected error: #{exception.message}. Context: #{request.to_json[0..MAX_REQUEST_LOG_LENGTH]}"
+    # Re-raise error to notify our system of the failed job.
+    raise
   end
 
   def perform(request:, locale:)

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -13,7 +13,6 @@ class AichatRequestChatCompletionJob < ApplicationJob
   end
 
   before_perform do |job|
-    puts job
     request = job.arguments.first[:request]
     request.update!(execution_status: SharedConstants::AI_REQUEST_EXECUTION_STATUS[:RUNNING])
     report_job_start(request)
@@ -43,7 +42,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
     report_job_finish(request)
 
     # Re-raise error to notify our system of the failed job.
-    raise
+    raise exception
   end
 
   def perform(request:, locale:)

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -5,7 +5,6 @@ class AichatRequestChatCompletionJob < ApplicationJob
 
   DEFAULT_TOXICITY_THRESHOLD_USER_INPUT = 0.2
   DEFAULT_TOXICITY_THRESHOLD_MODEL_OUTPUT = 0.6
-  MAX_REQUEST_LOG_LENGTH = 4 * 1024 * 1024
 
   before_enqueue do |job|
     request = job.arguments.first[:request]

--- a/dashboard/test/jobs/aichat_request_chat_completion_job_test.rb
+++ b/dashboard/test/jobs/aichat_request_chat_completion_job_test.rb
@@ -88,7 +88,6 @@ class AichatRequestChatCompletionJobTest < ActiveJob::TestCase
     assert_equal SharedConstants::AI_REQUEST_EXECUTION_STATUS[:FAILURE], request.reload.execution_status
     assert request.response.include?(error_message)
     assert exception.message.include?(error_message)
-    assert exception.message.include?(request.to_json)
   end
 
   test 'execution status is set to USER_INPUT_TOO_LARGE and an exception is raised if the input validation error occurs' do


### PR DESCRIPTION
When an error occurs in AI Chat (any type of error), we currently raise a new RuntimeError that contains all of the error details:

https://github.com/code-dot-org/code-dot-org/blob/c35de3e2ffd60254be6ed3b486f7b627560dfd17/dashboard/app/jobs/aichat_request_chat_completion_job.rb#L45

This is confusing in Honeybadger because these are all reported under the same error type, even though they may all be of different types. For example, [this timeout error](https://app.honeybadger.io/projects/3240/faults/112917121/01JRG98AR8XG7M76S16DEHKP3J?page=3) and [this invalid response from OpenAI](https://app.honeybadger.io/projects/3240/faults/112917121/01JRG98AR8XG7M76S16DEHKP3J?page=3) are reported under the same error.

This change will (I think) split out error reporting into each error type, which should help us track the frequency independently. It is [aligned with what happens in our rubric job](https://github.com/code-dot-org/code-dot-org/blob/c35de3e2ffd60254be6ed3b486f7b627560dfd17/dashboard/app/jobs/evaluate_rubric_job.rb#L96-L112), which I believe we modeled off of for this work.

A separate thing that I'm not sure if it's a problem or not is that we sort of "double report" to Honeybadger -- ie, [this error](https://app.honeybadger.io/projects/3240/faults/112917120) is also reported to Honeybadger when we see an error. This error does contain details that are useful and included as "context", which seems more appropriate than what we were doing before this change (ie, put all context in the error message itself). So, I think having both errors reported to Honeybadger are useful for different situations.

## Testing story

I tested this manually with ActiveJob enabled, although I'm not 100% sure how to test the Honeybadger bit.

There was a problem in the past with error logging being too long, and I do see some quite long stack traces being logged to the `delayed_jobs` table locally, but this seems no different than what we're doing in EvaluateRubricJob?
