### PR TITLE
[Blockly] Scope block selection to .blocklySvg workspace container in tests

### DIFF
--- a/dashboard/test/ui/features/step_definitions/blockly.rb
+++ b/dashboard/test/ui/features/step_definitions/blockly.rb
@@ -2,7 +2,7 @@ Given(/^block "([^"]*)" is at a ((?:blockly )?)location "([^"]*)"$/) do |block, 
   id_selector = get_id_selector
   @locations ||= {}
   block_id = get_block_id(block)
-  @block = @browser.find_element(:css, "g[#{id_selector}='#{block_id}']")
+  @block = @browser.find_element(:css, ".blocklySvg g[#{id_selector}='#{block_id}']")
   x = is_blockly ? get_block_workspace_left(block_id) : get_block_absolute_left(block_id)
   y = is_blockly ? get_block_workspace_top(block_id) : get_block_absolute_top(block_id)
   @locations[identifier] = BlocklyHelpers::Point.new(x, y)
@@ -21,7 +21,7 @@ end
 
 When(/^I click block "([^"]*)"$/) do |block|
   id_selector = get_id_selector
-  @browser.execute_script("$(\"[#{id_selector}='#{get_block_id(block)}']\").simulate( 'drag', {handle: 'corner', dx: 0, dy: 0, moves: 5});")
+  @browser.execute_script("$(\".blocklySvg [#{id_selector}='#{get_block_id(block)}']\").simulate( 'drag', {handle: 'corner', dx: 0, dy: 0, moves: 5});")
 end
 
 # This helps click on a field in Google Blockly. It always picks the first element from the list generated
@@ -43,12 +43,6 @@ end
 # Note: this is an offset relative to the current position of the block
 When /^I drag block "([^"]*)" to offset "([^"]*), ([^"]*)"$/ do |block_id, dx, dy|
   drag_block_relative(get_block_id(block_id), dx, dy)
-end
-
-# Note: this is an offset relative to the current position of the block
-When /^I begin to drag block "([^"]*)" to offset "([^"]*), ([^"]*)"$/ do |from, dx, dy|
-  id_selector = get_id_selector
-  @browser.execute_script("$(\"[#{id_selector}='#{get_block_id(from)}']\").simulate( 'drag', {skipDrop: true, handle: 'corner', dx: #{dx}, dy: #{dy}, moves: 5});")
 end
 
 When /^I drag block "([^"]*)" to block "([^"]*)"$/ do |from, to|
@@ -78,16 +72,6 @@ end
 
 When /^I drag block "([^"]*)" to block "([^"]*)" plus offset (\d+), (\d+)$/ do |from, to, dx, dy|
   code = generate_drag_code(get_block_id(from), get_block_id(to), dx, dy)
-  @browser.execute_script code
-end
-
-When /^I drag block "([^"]*)" above block "([^"]*)"$/ do |from, to|
-  id_selector = get_id_selector
-  from_id = get_block_id(from)
-  to_id = get_block_id(to)
-  height = @browser.execute_script("return $(\"[#{id_selector}='#{from_id}']\")[0].getBoundingClientRect().height;") - 10
-  destination_has_parent = @browser.execute_script("return $(\"[#{id_selector}='#{to_id}']\").parent().attr('#{id_selector}') !== undefined;")
-  code = generate_drag_code(from_id, to_id, 0, destination_has_parent ? 0 : -height)
   @browser.execute_script code
 end
 
@@ -172,7 +156,7 @@ end
 
 Then /^block "([^"]*)" is child of block "([^"]*)"$/ do |child, parent|
   id_selector = get_id_selector
-  @child_item = @browser.find_element(:css, "g[#{id_selector}='#{get_block_id(child)}']")
+  @child_item = @browser.find_element(:css, ".blocklySvg g[#{id_selector}='#{get_block_id(child)}']")
   @actual_parent_item = @child_item.find_element(:xpath, "..")
   # check for block id without relying on selenium element equality.
   actual_parent_id = @actual_parent_item.attribute(id_selector)
@@ -181,7 +165,7 @@ end
 
 Then /^block "([^"]*)" is not child of block "([^"]*)"$/ do |child, parent|
   id_selector = get_id_selector
-  @child_item = @browser.find_element(:css, "g[#{id_selector}='#{get_block_id(child)}']")
+  @child_item = @browser.find_element(:css, ".blocklySvg g[#{id_selector}='#{get_block_id(child)}']")
   @actual_parent_item = @child_item.find_element(:xpath, "..")
   # check for block id without relying on selenium element equality.
   actual_parent_id = @actual_parent_item.attribute(id_selector)
@@ -273,7 +257,7 @@ end
 
 Then /^block "([^"]*)" has class "(.*?)"$/ do |block_id, class_name|
   id_selector = get_id_selector
-  item = @browser.find_element(:css, "g[#{id_selector}='#{get_block_id(block_id)}']")
+  item = @browser.find_element(:css, ".blocklySvg g[#{id_selector}='#{get_block_id(block_id)}']")
   classes = item.attribute("class")
   expect(classes.include?(class_name)).to eq(true)
 end
@@ -281,7 +265,7 @@ end
 When /^I wait until block "([^"]*)" has class "(.*?)"$/ do |block_id, class_name|
   id_selector = get_id_selector
   wait_until do
-    item = @browser.find_element(:css, "g[#{id_selector}='#{get_block_id(block_id)}']")
+    item = @browser.find_element(:css, ".blocklySvg g[#{id_selector}='#{get_block_id(block_id)}']")
     classes = item.attribute("class")
     classes.include?(class_name)
   end
@@ -289,17 +273,9 @@ end
 
 Then /^block "([^"]*)" doesn't have class "(.*?)"$/ do |block_id, class_name|
   id_selector = get_id_selector
-  item = @browser.find_element(:css, "g[#{id_selector}='#{get_block_id(block_id)}']")
+  item = @browser.find_element(:css, ".blocklySvg g[#{id_selector}='#{get_block_id(block_id)}']")
   classes = item.attribute("class")
   expect(classes.include?(class_name)).to eq(false)
-end
-
-Then /^block "([^"]*)" contains text "(.*?)"$/ do |block_id, text|
-  id_selector = get_id_selector
-  block = @browser.find_element(:css, "[#{id_selector}='#{get_block_id(block_id)}']")
-  # Replace non-breaking spaces with normal spaces
-  given_text = block.attribute('textContent').tr("\u00A0", ' ')
-  expect(given_text).to include(text)
 end
 
 Then /^the modal function editor is closed$/ do

--- a/dashboard/test/ui/features/support/blockly_helpers.rb
+++ b/dashboard/test/ui/features/support/blockly_helpers.rb
@@ -8,7 +8,7 @@ module BlocklyHelpers
 
   def generate_drag_code(from, to, target_dx, target_dy)
     id_selector = get_id_selector
-    generate_selector_drag_code "[#{id_selector}='#{from}']:last", "[#{id_selector}='#{to}']", target_dx, target_dy
+    generate_selector_drag_code "[#{id_selector}='#{from}']:last", ".blocklySvg [#{id_selector}='#{to}']", target_dx, target_dy
   end
 
   def generate_selector_drag_code(from, to, target_dx, target_dy)
@@ -17,15 +17,6 @@ module BlocklyHelpers
     "var drag_dx = #{to_offset}.left - #{from_offset}.left;" \
         "var drag_dy = #{to_offset}.top  - #{from_offset}.top;" \
         "$(\"#{from}\").simulate( 'drag', {handle: 'corner', dx: drag_dx + #{target_dx}, dy: drag_dy + #{target_dy}, moves: 5});"
-  end
-
-  def generate_begin_to_drag_code(from, to, target_dx, target_dy)
-    id_selector = get_id_selector
-    to_offset = generate_offset_code("[#{id_selector}='#{to}']")
-    from_offset = generate_offset_code("[#{id_selector}='#{from}']")
-    "var drag_dx = #{to_offset}.left - #{from_offset}.left;" \
-        "var drag_dy = #{to_offset}.top  - #{from_offset}.top;" \
-        "$(\"[#{id_selector}='#{from}']\").simulate( 'drag', {justDrag: true, handle: 'corner', dx: drag_dx + #{target_dx}, dy: drag_dy + #{target_dy}, moves: 5});"
   end
 
   def get_indexed_blockly_draggable_selector(index)
@@ -51,7 +42,7 @@ module BlocklyHelpers
     id_selector = get_id_selector
     # For IE compatability, uses the SVG DOM binding technique from:
     #   http://stackoverflow.com/questions/10349811/how-to-manipulate-translate-transforms-on-a-svg-element-with-javascript-in-chrom
-    js = "var xforms = $(\"[#{id_selector}='#{block_id}']\")[0].transform.baseVal; var firstXForm = xforms.getItem(0); if (firstXForm.type == SVGTransform.SVG_TRANSFORM_TRANSLATE){ var firstX = firstXForm.matrix.e; var firstY = firstXForm.matrix.f; }; return [firstX, firstY];"
+    js = "var xforms = $(\".blocklySvg [#{id_selector}='#{block_id}']\")[0].transform.baseVal; var firstXForm = xforms.getItem(0); if (firstXForm.type == SVGTransform.SVG_TRANSFORM_TRANSLATE){ var firstX = firstXForm.matrix.e; var firstY = firstXForm.matrix.f; }; return [firstX, firstY];"
     coordinate_pair = @browser.execute_script(js)
     Point.new(coordinate_pair[0], coordinate_pair[1])
   end
@@ -79,12 +70,12 @@ module BlocklyHelpers
 
   def get_block_absolute_left(block_id)
     id_selector = get_id_selector
-    @browser.execute_script("return $(\"[#{id_selector}='#{block_id}']\").position().left")
+    @browser.execute_script("return $(\".blocklySvg [#{id_selector}='#{block_id}']\").position().left")
   end
 
   def get_block_absolute_top(block_id)
     id_selector = get_id_selector
-    @browser.execute_script("return $(\"[#{id_selector}='#{block_id}']\").position().top")
+    @browser.execute_script("return $(\".blocklySvg [#{id_selector}='#{block_id}']\").position().top")
   end
 
   def get_block_workspace_left(block_id)


### PR DESCRIPTION
Many tests include steps where Blockly blocks on the workspace are selected by id. It is possible for blocks that are on the workspace to have the same id as blocks in the flyout. This has not been a problem so far because the workspace svgs have always shown up in the DOM earlier than the flyout (and we usually want to select the workspace block). The upcoming keyboard experiment includes a breaking change where the DOM order of the flyout and workspace are swapped. This breaks the test because we suddenly start selecting blocks in the flyout in some situations. To make this forwards compatible, we can scope the block selection to just the workspace for these steps.

This branch adds the `.blocklySvg` class to to selectors for steps that are always meant to target workspace blocks. This should ensure they continue to work as expected, even if and when the DOM order changes. While updating steps, I also found a couple that were no longer being used, so I've deleted them.


## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
