### PR TITLE
Populate 'status' field in school_stats_by_year for 2023-2024 NCES year

### DIFF
--- a/bin/oneoff/nces_data/import_school_stats_by_years_2023_2024_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2023_2024_ccd
@@ -117,8 +117,9 @@ AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/schools_public.csv") do |fi
       student_tr_count:   row['Two or More Races Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
       title_i_status:     previous_title_1_status,
       frl_eligible_total: row['Free and Reduced Lunch Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
-      student_female: row['Female Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
-      student_male: row['Male Students [Public School] ' + SURVEY_YEAR_HEADER].to_i
+      student_female:     row['Female Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_male:       row['Male Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      status:             row['Updated Status [Public School] ' + SURVEY_YEAR_HEADER]
     }
   end
 end


### PR DESCRIPTION
Note: This is a recreation of [this PR](https://github.com/code-dot-org/code-dot-org/pull/65049) which was based on [a PR](https://github.com/code-dot-org/code-dot-org/pull/65048) that I had to close and the rebasing was getting messy so I'm just creating a new PR since it's only a couple lines changed.

This PR updates the 2023-2024 NCES oneoff data import script to populate the new `school_stats_by_year`'s `status` field added [here](https://github.com/code-dot-org/code-dot-org/pull/65212). Since we very recently imported the NCES data, I feel it's okay to just update this script and re-run it on production rather than creating a whole new script.

### Successfully ran a dryrun of the import
![dryrun](https://github.com/user-attachments/assets/8955aec7-30b9-4bb6-a2f3-5552be08e8f9)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3197)

## Testing story
Local testing.

## Deployment strategy
Once this is merged, I'll re-upload the schools_public.csv file with a slightly different name so that S3 won't see an etag it's already seen before and skip processing the file. Then, I'll re-run the oneoff script on production to populate the status field with the most recent school year's data.
