### PR TITLE
refactor(TextField): use InputHTMLAttributes prop

### DIFF
--- a/frontend/packages/component-library/src/textField/TextField.tsx
+++ b/frontend/packages/component-library/src/textField/TextField.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {ChangeEvent, HTMLAttributes} from 'react';
+import {ChangeEvent, InputHTMLAttributes} from 'react';
 
 import {ComponentSizeXSToL} from '@/common/types';
 import {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
@@ -7,7 +7,8 @@ import FormFieldWrapper from '@/formFieldWrapper';
 
 import moduleStyles from './textfield.module.scss';
 
-export interface TextFieldProps extends HTMLAttributes<HTMLInputElement> {
+export interface TextFieldProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
   /** TextField onChange handler*/
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   /** TextField id */
@@ -20,7 +21,7 @@ export interface TextFieldProps extends HTMLAttributes<HTMLInputElement> {
      Note: Only form elements with a name attribute will have their values passed when submitting a form. */
   name: string;
   /** The value attribute specifies the value of an input element. */
-  value?: string;
+  value?: string | number;
   /** TextField label */
   label?: string;
   /** TextField helper message */
@@ -81,6 +82,7 @@ const TextField: React.FunctionComponent<TextFieldProps> = ({
   autoComplete,
   color = 'black',
   size = 'm',
+  ['aria-describedby']: describedBy,
   ...HTMLAttributes
 }) => {
   return (
@@ -97,7 +99,7 @@ const TextField: React.FunctionComponent<TextFieldProps> = ({
         moduleStyles[`textField-size-${size}`],
         className,
       )}
-      aria-describedby={HTMLAttributes['aria-describedby']}
+      aria-describedby={describedBy}
     >
       <input
         id={id}

--- a/frontend/packages/component-library/src/textField/__tests__/TextField.test.tsx
+++ b/frontend/packages/component-library/src/textField/__tests__/TextField.test.tsx
@@ -8,7 +8,7 @@ import TextField, {TextFieldProps} from './../index';
 describe('Design System - TextField', () => {
   const renderTextField = (props: Partial<TextFieldProps>) => {
     const Wrapper: React.FC = () => {
-      const [value, setValue] = useState<string>(
+      const [value, setValue] = useState<TextFieldProps['value']>(
         props.value || 'test-textfield',
       );
       const handleChange = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
this replaces the HTMLAttributes type that extends TextFieldProps with InputHTMLAttributes, which is a superset of HTMLAttributes. this gives us all possible input props without having to explicitly define all of them. props like placeholder, maxLength, disabled etc are all on InputHTMLAttributes but not HTMLAttributes even when HTMLInputElement is passed as the generic. some of these default props we want to retain control over, like requiring each input to have a `name` prop, or we want to provide prop definitions for the developer using the component.

Unfortunately our 'size' prop on TextFieldProps conflicts with the native 'size' prop. rather than renaming our custom prop, I'm omitting it from the extended type

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
