### PR TITLE
AI Chat: add cached tokens metrics

### DIFF
--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -40,7 +40,7 @@ module AichatOpenaiHelper
     )
 
     [
-      {role: "system", content: instructions},
+      {role: "system", content: [{type: "text", text: instructions}]},
       *stored_messages.map {|message| format_message(message, encrypted_channel_id, level_name)},
       format_message(new_message, encrypted_channel_id, level_name)
     ]
@@ -81,10 +81,15 @@ module AichatOpenaiHelper
   def self.report_usage_metrics(usage, messages, level_id, project_id, user_id)
     return unless usage
 
-    filtered = messages.reject {|message| message[:content].is_a?(String)}
-    messages_with_assets_count = filtered.count {|message| message[:content].any? {|c| c[:type] != 'text'}}
-    pdfs_count = filtered.sum {|message| message[:content].count {|c| c[:type] == 'file'}}
-    images_count = filtered.sum {|message| message[:content].count {|c| c[:type] == 'image_url'}}
+    messages_with_assets_count = messages.count do |message|
+      message[:content].any? {|c| c[:type] != 'text'}
+    end
+    pdfs_count = messages.sum do |message|
+      message[:content].count {|c| c[:type] == 'file'}
+    end
+    images_count = messages.sum do |message|
+      message[:content].count {|c| c[:type] == 'image_url'}
+    end
 
     is_multimodal = messages_with_assets_count > 0
 

--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -9,7 +9,8 @@ module AichatOpenaiHelper
   API_KEY = CDO.openai_student_learning_api_key
   MODEL = SharedConstants::AICHAT_MODEL_VERSION
 
-  def self.get_openai_assistant_response(aichat_model_customizations, stored_messages, new_message, level_id, encrypted_channel_id, user_id)
+  def self.get_openai_assistant_response(aichat_model_customizations, stored_messages, new_message, level_id, project_id, user_id)
+    encrypted_channel_id = storage_encrypt_channel_id(storage_id_for_user_id(user_id), project_id)
     messages = format_messages(
       aichat_model_customizations,
       stored_messages,
@@ -23,7 +24,7 @@ module AichatOpenaiHelper
       messages,
       aichat_model_customizations['temperature'].to_f * 2
     )
-    report_usage_metrics(usage, messages, level_id, encrypted_channel_id, user_id)
+    report_usage_metrics(usage, messages, level_id, project_id, user_id)
     response
   end
 
@@ -77,7 +78,7 @@ module AichatOpenaiHelper
   end
 
   # Reports and logs usage metrics to Cloudwatch
-  def self.report_usage_metrics(usage, messages, level_id, encrypted_channel_id, user_id)
+  def self.report_usage_metrics(usage, messages, level_id, project_id, user_id)
     return unless usage
 
     filtered = messages.reject {|message| message[:content].is_a?(String)}
@@ -87,10 +88,17 @@ module AichatOpenaiHelper
 
     is_multimodal = messages_with_assets_count > 0
 
+    # Pull out token counts and calculate costs
+    prompt_tokens = usage['prompt_tokens'] || 0
+    completion_tokens = usage['completion_tokens'] || 0
+    cached_tokens = usage.dig('prompt_tokens_details', 'cached_tokens') || 0
+
     input_rate = 0.15 / 1_000_000 # $0.15 per million tokens
+    cached_input_rate = 0.075 / 1_000_000 # $0.075 per million tokens
     output_rate = 0.60 / 1_000_000 # $0.60 per million tokens
-    input_cost = usage['prompt_tokens'] * input_rate
-    output_cost = usage['completion_tokens'] * output_rate
+
+    input_cost = (prompt_tokens * input_rate) + (cached_tokens * cached_input_rate)
+    output_cost = completion_tokens * output_rate
     total_cost = input_cost + output_cost
 
     log_payload = {
@@ -109,16 +117,18 @@ module AichatOpenaiHelper
         total: "$#{format("%.6f", total_cost)}"
       },
       levelId: level_id,
-      channelId: encrypted_channel_id,
+      projectId: project_id,
       userId: user_id
     }
 
-    CDO.log.info log_payload.to_json.to_s if DCDO.get('log_aichat_openai_usage', true)
+    CDO.log.info log_payload.to_json.to_s if DCDO.get('log_aichat_openai_usage', false)
 
-    metrics = ['prompt_tokens', 'completion_tokens'].map do |key|
+    metrics = [
+      ['PromptTokens', prompt_tokens], ['CompletionTokens', completion_tokens], ['CachedTokens', cached_tokens]
+    ].map do |key, value|
       {
-        metric_name: "AichatOpenaiRequest.#{key.camelize(:upper)}",
-        value: usage[key],
+        metric_name: "AichatOpenaiRequest.#{key}",
+        value: value,
         unit: 'Count',
         timestamp: Time.now,
         dimensions: [

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -66,7 +66,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
           request.stored_messages,
           request.new_message,
           request.level_id,
-          storage_encrypt_channel_id(storage_id_for_user_id(request.user_id), request.project_id),
+          request.project_id,
           request.user_id
         ) :
         AichatSagemakerHelper.get_sagemaker_assistant_response(

--- a/dashboard/test/helpers/aichat_openai_helper_test.rb
+++ b/dashboard/test/helpers/aichat_openai_helper_test.rb
@@ -23,7 +23,7 @@ class AichatOpenaiHelperTest < ActionView::TestCase
 
   test 'formats messages with level system prompt' do
     expected_messages = [
-      {role: 'system', content: "Be safe. test prompt test retrieval"},
+      {role: 'system', content: [{type: 'text', text: "Be safe. test prompt test retrieval"}]},
       {role: 'user', content: [{type: 'text', text: 'hello from user'}]},
       {role: 'assistant', content: [{type: 'text', text: 'assistant response'}]},
       {role: 'user', content: [{type: 'text', text: 'new message from user'}]}
@@ -42,7 +42,7 @@ class AichatOpenaiHelperTest < ActionView::TestCase
 
   test 'formats messages without level system prompt' do
     expected_messages = [
-      {role: 'system', content: "test prompt test retrieval"},
+      {role: 'system', content: [{type: 'text', text: "test prompt test retrieval"}]},
       {role: 'user', content: [{type: 'text', text: 'hello from user'}]},
       {role: 'assistant', content: [{type: 'text', text: 'assistant response'}]},
       {role: 'user', content: [{type: 'text', text: 'new message from user'}]}
@@ -73,7 +73,7 @@ class AichatOpenaiHelperTest < ActionView::TestCase
     }.deep_stringify_keys
 
     expected_messages = [
-      {role: 'system', content: "test prompt test retrieval"},
+      {role: 'system', content: [{type: 'text', text: "test prompt test retrieval"}]},
       {role: 'user', content: [{type: 'text', text: 'hello from user'}]},
       {role: 'assistant', content: [{type: 'text', text: 'assistant response'}]},
       {role: 'user', content: [

--- a/dashboard/test/jobs/aichat_request_chat_completion_job_test.rb
+++ b/dashboard/test/jobs/aichat_request_chat_completion_job_test.rb
@@ -9,7 +9,6 @@ class AichatRequestChatCompletionJobTest < ActiveJob::TestCase
     @toxic_response = {text: 'profane text', blocked_by: 'openai', details: {evaluation: 'INAPPROPRIATE'}}
     @test_env = 'unit-test-env'
     @metrics_model_id = 'metrics-test-model-id'
-    create_storage_id_for_user(@student.id)
     CDO.stubs(:rack_env).returns(@test_env)
 
     AichatSafetyHelper.stubs(:find_toxicity).returns(nil)


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Summary

We found a small but significant discrepancy between the token usage we see reflected in the OpenAI dashboard, and the token usage we see in our cloudwatch reporting. One reason for that might be that we were not including the "cached tokens" in our counts and calculations. This adds cached tokens to the cost calculation in the log payload and a new Cloudwatch metric for cached tokens.

This also includes a few misc follow-up fixes from the previous PR:
- Default DCDO flag to false (I will update the DCDO flag on prod before merging this)
- Report project ID instead of encrypted channel ID in logs
- Formatting fixes

<img width="1512" alt="Screenshot 2025-04-11 at 1 41 29 PM" src="https://github.com/user-attachments/assets/cb5dd8c1-c579-4b07-a05d-505a91b09307" />

## Links

https://codedotorg.slack.com/archives/C06FELVTV0Q/p1744392697627129

## Testing story

Tested locally with Cloudwatch and logs