### PR TITLE
add dashboard.learning_goals table to redshift

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -91,6 +91,7 @@ cron:
     remove_column: [other_content]
 - dashboard.rubrics
 - dashboard.rubric_ai_evaluations
+- dashboard.learning_goals
 - dashboard.level_sources_multi_types
 - dashboard.paired_user_levels
 - dashboard.parental_permission_requests:


### PR DESCRIPTION
Adds `dashboard.learning_goals` table to `dashboard_production` schema in redshift. this table is populated from data that is already visible as plaintext in our repo and does not contain PII. example contents: https://github.com/code-dot-org/code-dot-org/blob/42464175166b7c6c30cfc14abc9b5ada90ba56c5/dashboard/config/scripts_json/csd3-2024.script_json#L20415-L20419

## Testing story

- [x] validated by a `codeorg-admin`: https://github.com/code-dot-org/code-dot-org/blob/bc6cbb8acb803d381b261a2ee8b55d12e8ded76f/aws/dms/tasks.yml#L14-L17


## Deployment strategy

- [x] deployed by a `codeorg-admin`: https://github.com/code-dot-org/code-dot-org/blob/bc6cbb8acb803d381b261a2ee8b55d12e8ded76f/aws/dms/tasks.yml#L27

## Follow up work

consider merging this stale PR to update docs in this file:
* https://github.com/code-dot-org/code-dot-org/pull/62886