### PR TITLE
Fix long section name extending past section card

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -69,6 +69,8 @@
 
 .sectionCardHeaderLeft {
   display: flex;
+  flex: 1;
+  min-width: 0;
 
   button {
     margin-inline-end: 6px;
@@ -83,16 +85,14 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  max-width: calc(100% - 32px);
+  min-width: 0;
+  flex: 1;
 
   h5 {
-    height: 28px;
     margin-bottom: 0;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    max-width: 720px;
-    width: 100%;
   }
 
   p {
@@ -111,6 +111,7 @@
 
 .sectionCardHeaderRight {
   display: flex;
+  margin-left: 8px;
 }
 
 // SectionOptionsDropdown

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -89,6 +89,7 @@
   flex: 1;
 
   h5 {
+    height: 28px;
     margin-bottom: 0;
     overflow: hidden;
     white-space: nowrap;
@@ -111,7 +112,7 @@
 
 .sectionCardHeaderRight {
   display: flex;
-  margin-left: 8px;
+  margin-inline-start: 6px;
 }
 
 // SectionOptionsDropdown


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/baeaa561-82cc-4d13-909f-275bca23d06b)


After:
![image](https://github.com/user-attachments/assets/ca027c41-9fd0-46c9-8814-6a75429468ff)


I did fix this already, but adding the drag and drop and the avatar messed it up. This should hopefully be more robust.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
https://codedotorg.atlassian.net/browse/TEACH-1794
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
