### PR TITLE
Music: exemplar player inside instructions

### DIFF
--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -35,6 +35,8 @@ interface InstructionsProps {
   manageNavigation?: boolean;
   /** Optional classname for the container */
   className?: string;
+  /** Optional component to render at the bottom of the main instructions. */
+  bottomComponent?: React.ReactNode;
 }
 
 /**
@@ -50,6 +52,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   handleInstructionsTextClick,
   className,
   manageNavigation = true,
+  bottomComponent,
 }) => {
   const instructionsText = useAppSelector(
     state => state.lab.levelProperties?.longInstructions
@@ -105,6 +108,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
       hasNextLevel={hasNextLevel}
       useSecondaryFinishButton={useSecondaryFinishButton}
       onContinueOrFinish={() => dispatch(continueOrFinishLesson())}
+      bottomComponent={bottomComponent}
     />
   );
 };
@@ -135,6 +139,7 @@ interface InstructionsPanelProps {
   hasNextLevel: boolean;
   useSecondaryFinishButton: boolean;
   onContinueOrFinish: () => void;
+  bottomComponent?: React.ReactNode;
 }
 
 /**
@@ -163,6 +168,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
   hasNextLevel,
   useSecondaryFinishButton,
   onContinueOrFinish,
+  bottomComponent,
 }) => {
   const vertical = layout === 'vertical';
 
@@ -254,6 +260,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   </div>
                 </InstructorsOnly>
               )}
+              {bottomComponent && <div>{bottomComponent}</div>}
             </div>
           </div>
         )}
@@ -271,7 +278,10 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
               className={moduleStyles['message-' + theme]}
             >
               {offerBrowserTts && useMessage && !canShowNextButton && (
-                <TextToSpeech text={useMessage} />
+                <TextToSpeech
+                  text={useMessage}
+                  higherPosition={!!bottomComponent}
+                />
               )}
               {useMessage && (
                 <div ref={feedbackRef} tabIndex={-1}>

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -237,7 +237,9 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
             id="instructions-text"
             className={moduleStyles['text-' + theme]}
           >
-            {offerBrowserTts && <TextToSpeech text={text} />}
+            {offerBrowserTts && (
+              <TextToSpeech text={text} higherPosition={!!bottomComponent} />
+            )}
             <div
               id="instructions-text-content"
               className={moduleStyles.textContent}
@@ -278,10 +280,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
               className={moduleStyles['message-' + theme]}
             >
               {offerBrowserTts && useMessage && !canShowNextButton && (
-                <TextToSpeech
-                  text={useMessage}
-                  higherPosition={!!bottomComponent}
-                />
+                <TextToSpeech text={useMessage} />
               )}
               {useMessage && (
                 <div ref={feedbackRef} tabIndex={-1}>

--- a/apps/src/lab2/views/components/TextToSpeech.module.scss
+++ b/apps/src/lab2/views/components/TextToSpeech.module.scss
@@ -13,7 +13,7 @@
   color: $neutral_dark;
 
   &HigherPosition {
-    bottom: 28px;
+    bottom: 58px;
   }
 
   &Playing {

--- a/apps/src/lab2/views/components/TextToSpeech.module.scss
+++ b/apps/src/lab2/views/components/TextToSpeech.module.scss
@@ -12,6 +12,10 @@
   transition: opacity 0.2s ease;
   color: $neutral_dark;
 
+  &HigherPosition {
+    bottom: 28px;
+  }
+
   &Playing {
     opacity: 100%;
   }

--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -12,6 +12,7 @@ import moduleStyles from './TextToSpeech.module.scss';
 
 interface TextToSpeechProps {
   text: string;
+  higherPosition?: boolean;
 }
 
 const usePause = queryParams('tts-play-pause') === 'true';
@@ -28,7 +29,10 @@ const ttsButtonEnabled =
 /**
  * TextToSpeech play button.
  */
-const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
+const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({
+  text,
+  higherPosition,
+}) => {
   const {isTtsAvailable, speak, cancel, pause, resume} =
     useBrowserTextToSpeech();
   const [isPlaying, setIsPlaying] = useState(false);
@@ -86,7 +90,8 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
     <button
       className={classNames(
         moduleStyles.playButton,
-        isPlaying && moduleStyles.playButtonPlaying
+        isPlaying && moduleStyles.playButtonPlaying,
+        higherPosition && moduleStyles.playButtonHigherPosition
       )}
       onClick={playText}
       onKeyDown={handleKeyDown}

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -130,9 +130,10 @@
 
 .textContent {
   height: 100%;
-  overflow-y: auto;
   padding: 15px 20px 5px 20px;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
 
 %message {
@@ -162,6 +163,7 @@
 
 .markdownText {
   line-height: 0;
+  overflow-y: auto;
 
   h1,
   h2,

--- a/apps/src/music/views/ExemplarPlayer.module.scss
+++ b/apps/src/music/views/ExemplarPlayer.module.scss
@@ -9,6 +9,11 @@
   padding-top: 0;
   user-select: none;
 
+  &InsideInstructions {
+    background-color: $neutral_light;
+    padding: 8px 0 4px 0;
+  }
+
   .entry {
     background-color: $neutral_dark80;
     color: $neutral_light;

--- a/apps/src/music/views/ExemplarPlayerView.tsx
+++ b/apps/src/music/views/ExemplarPlayerView.tsx
@@ -18,12 +18,14 @@ interface ExemplarPlayerViewProps {
   playbackEvents: PlaybackEvent[];
   title: string;
   player: MusicPlayer;
+  insideInstructions: boolean;
 }
 
 const ExemplarPlayerView: React.FunctionComponent<ExemplarPlayerViewProps> = ({
   playbackEvents,
   title,
   player,
+  insideInstructions,
 }) => {
   const dispatch = useAppDispatch();
   const isPlaying = useAppSelector(state => state.music.isPlaying);
@@ -77,7 +79,12 @@ const ExemplarPlayerView: React.FunctionComponent<ExemplarPlayerViewProps> = ({
   const packImage = MusicLibrary.getInstance()?.getPackImageUrl(DEFAULT_PACK);
 
   return (
-    <div className={moduleStyles.exemplarPlayer}>
+    <div
+      className={classNames(
+        moduleStyles.exemplarPlayer,
+        insideInstructions && moduleStyles.exemplarPlayerInsideInstructions
+      )}
+    >
       <div
         className={moduleStyles.entry}
         key={'exemplar-player'}

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -287,7 +287,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   const renderInstructions = useCallback(
     (position: InstructionsPosition) => {
       const exemplarPlayerInsideInstructions =
-        AppConfig.getValue('exemplar-player-inside-instructions') === 'true';
+        AppConfig.getValue('exemplar-player-bottom') !== 'true';
 
       const exemplarPlayer = exemplarSettings?.playerEnabled &&
         exemplarSources &&

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -286,6 +286,20 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
 
   const renderInstructions = useCallback(
     (position: InstructionsPosition) => {
+      const exemplarPlayerInsideInstructions =
+        AppConfig.getValue('exemplar-player-inside-instructions') === 'true';
+
+      const exemplarPlayer = exemplarSettings?.playerEnabled &&
+        exemplarSources &&
+        !isEditingExemplar && (
+          <ExemplarPlayerView
+            playbackEvents={exemplarPlaybackEvents}
+            title={exemplarSettings.playerTitle!}
+            player={player}
+            insideInstructions={exemplarPlayerInsideInstructions}
+          />
+        );
+
       return (
         <div
           id="instructions-area"
@@ -308,16 +322,11 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                   : 'horizontal'
               }
               handleInstructionsTextClick={onInstructionsTextClick}
+              bottomComponent={
+                exemplarPlayerInsideInstructions && exemplarPlayer
+              }
             />
-            {exemplarSettings?.playerEnabled &&
-              exemplarSources &&
-              !isEditingExemplar && (
-                <ExemplarPlayerView
-                  playbackEvents={exemplarPlaybackEvents}
-                  title={exemplarSettings.playerTitle!}
-                  player={player}
-                />
-              )}
+            {!exemplarPlayerInsideInstructions && exemplarPlayer}
           </PanelContainer>
         </div>
       );

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -258,18 +258,17 @@ const optionsList = [
     ],
   },
   {
-    name: 'exemplar-player-inside-instructions',
+    name: 'exemplar-player-bottom',
     type: 'radio',
     values: [
       {
         value: 'false',
         description:
-          'Exemplar player appears at bottom of instructions panel (default).',
+          'Exemplar player appears at bottom of main instructions text. (default).',
       },
       {
         value: 'true',
-        description:
-          'Exemplar player appears at bottom of main instructions text.',
+        description: 'Exemplar player appears at bottom of instructions panel.',
       },
     ],
   },

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -257,6 +257,22 @@ const optionsList = [
       },
     ],
   },
+  {
+    name: 'exemplar-player-inside-instructions',
+    type: 'radio',
+    values: [
+      {
+        value: 'false',
+        description:
+          'Exemplar player appears at bottom of instructions panel (default).',
+      },
+      {
+        value: 'true',
+        description:
+          'Exemplar player appears at bottom of main instructions text.',
+      },
+    ],
+  },
 ];
 
 export default class MusicMenu extends React.Component {


### PR DESCRIPTION
With this change, the exemplar player is now placed at the bottom of the main instructions text, inside its box, and pinned to the bottom in case the instructions need to be scrolled.  

The optional `?exemplar-player-bottom=true` URL parameter can be used to place it in its original position at the bottom of the instructions panel.

### Default

<img width="997" alt="Screenshot 2025-04-11 at 8 50 30 PM" src="https://github.com/user-attachments/assets/03e6b693-d30f-4b70-a82d-d109344151de" />

### With parameter

<img width="997" alt="Screenshot 2025-04-11 at 8 48 44 PM" src="https://github.com/user-attachments/assets/b524d768-3ffc-4f7d-8e1f-1dd82357ee42" />


