### PR TITLE
UI tests for level_group_levels

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
@@ -45,8 +45,8 @@ Scenario: Teacher can view student summary of responses on level marked as asses
 Scenario: Student can see level numbers for level group levels in header.
   Given I create a teacher-associated student named "Lilian"
   Given I am on "http://studio.code.org/s/allthethings/lessons/53/levels/1"
-  And I wait until element "span:contains(1)" is visible
+  And I wait until element ".progress-bubble.enabled span:contains(1)" is visible
 
   # Check that the student can see this numbering on an "assessment" level too.
   Given I am on "http://studio.code.org/s/allthethings/lessons/53/levels/2"
-  And I wait until element "span:contains(2)" is visible
+  And I wait until element ".progress-bubble.enabled span:contains(2)" is visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
@@ -34,7 +34,7 @@ Scenario: Teacher can view student summary of responses on level marked as asses
   And I type "sample response" into ".free-response > textarea"
   And I press ".submitButton" using jQuery to load a new page
 
-  # Teacher can view summary
+  # Teacher can view summary, specifically on a level marked as an assessment in levelbuilder
   When I sign in as "Teacher_Lilian"
   And I am on "http://studio.code.org/s/allthethings/lessons/53/levels/2"
   And I wait until element "a:contains(View student responses)" is visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
@@ -9,3 +9,33 @@ Scenario: Submit activity guide and go to next level.
 
   And I press ".submitButton:first" using jQuery
   Then I wait until I am on a different page than I noted before
+
+Scenario: Teacher can view student summary of responses.
+  Given I create a teacher-associated student named "Lilian"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/53/levels/1"
+  Then I press "unchecked_0"
+  And I type "sample response" into ".free-response > textarea"
+  And I press ".submitButton" using jQuery to load a new page
+
+  # Teacher can view summary
+  When I sign in as "Teacher_Lilian"
+  And I am on "http://studio.code.org/s/allthethings/lessons/53/levels/1"
+  And I wait until element "a:contains(View student responses)" is visible
+  And I click selector "a:contains(View student responses)"
+  And I wait until current URL contains "/summary"
+  And I wait until element "#summary-container" is visible
+
+Scenario: Teacher can view student summary of responses on level marked as assessment
+  Given I create a teacher-associated student named "Lilian"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/53/levels/2"
+  Then I press "unchecked_0"
+  And I type "sample response" into ".free-response > textarea"
+  And I press ".submitButton" using jQuery to load a new page
+
+  # Teacher can view summary
+  When I sign in as "Teacher_Lilian"
+  And I am on "http://studio.code.org/s/allthethings/lessons/53/levels/2"
+  And I wait until element "a:contains(View student responses)" is visible
+  And I click selector "a:contains(View student responses)"
+  And I wait until current URL contains "/summary"
+  And I wait until element "#summary-container" is visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
@@ -13,6 +13,8 @@ Scenario: Submit activity guide and go to next level.
 Scenario: Teacher can view student summary of responses.
   Given I create a teacher-associated student named "Lilian"
   Given I am on "http://studio.code.org/s/allthethings/lessons/53/levels/1"
+  And I wait until element "span:contains(1)" is visible
+
   Then I press "unchecked_0"
   And I type "sample response" into ".free-response > textarea"
   And I press ".submitButton" using jQuery to load a new page
@@ -39,3 +41,12 @@ Scenario: Teacher can view student summary of responses on level marked as asses
   And I click selector "a:contains(View student responses)"
   And I wait until current URL contains "/summary"
   And I wait until element "#summary-container" is visible
+
+Scenario: Student can see level numbers for level group levels in header.
+  Given I create a teacher-associated student named "Lilian"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/53/levels/1"
+  And I wait until element "span:contains(1)" is visible
+
+  # Check that the student can see this numbering on an "assessment" level too.
+  Given I am on "http://studio.code.org/s/allthethings/lessons/53/levels/2"
+  And I wait until element "span:contains(2)" is visible


### PR DESCRIPTION
Continuation of [this PR](https://github.com/code-dot-org/code-dot-org/pull/65192) - adds UI tests that check for the following:

1. can see the current level number in the progress bar
2. can click summary button and the page renders at least one student response
3. testing the above with and without the level being marked as an assessment

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
