### PR TITLE
Refactor the roster page join link into a separate file so we can reuse

### DIFF
--- a/apps/src/templates/manageStudents/MoveStudents.jsx
+++ b/apps/src/templates/manageStudents/MoveStudents.jsx
@@ -11,8 +11,9 @@ import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import {getVisibleSections} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import color from '@cdo/apps/util/color';
-import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
+
+import {NON_LMS_LOGIN_TYPES} from '../teacherDashboard/LoginTypeConstants';
 
 import {
   updateStudentTransfer,
@@ -105,11 +106,9 @@ class MoveStudents extends Component {
 
   isValidDestinationSection = section => {
     const isSameAsSource = section.id === this.props.currentSectionId;
-    const isExternallyRostered = ![
-      SectionLoginType.word,
-      SectionLoginType.picture,
-      SectionLoginType.email,
-    ].includes(section.loginType);
+    const isExternallyRostered = !NON_LMS_LOGIN_TYPES.includes(
+      section.loginType
+    );
 
     return !isSameAsSource && !isExternallyRostered;
   };

--- a/apps/src/templates/manageStudents/Table/index.jsx
+++ b/apps/src/templates/manageStudents/Table/index.jsx
@@ -147,7 +147,6 @@ class ManageStudentsTable extends Component {
     this.getColumns = this.getColumns.bind(this);
     this.onPrintLoginCards = this.onPrintLoginCards.bind(this);
     this.handleSaveAllClick = this.handleSaveAllClick.bind(this);
-    this.close = this.close.bind(this);
   }
 
   state = {

--- a/apps/src/templates/manageStudents/Table/index.jsx
+++ b/apps/src/templates/manageStudents/Table/index.jsx
@@ -10,7 +10,6 @@ import fontConstants from '@cdo/apps/fontConstants';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import firehoseClient from '@cdo/apps/metrics/firehose';
 import HelpTip from '@cdo/apps/sharedComponents/HelpTip';
 import Notification, {
   NotificationType,
@@ -42,18 +41,25 @@ import {
 } from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
 import ManageStudentsSharingCell from '@cdo/apps/templates/manageStudents/ManageStudentsSharingCell';
 import MoveStudents from '@cdo/apps/templates/manageStudents/MoveStudents';
-import NoSectionCodeDialog from '@cdo/apps/templates/manageStudents/NoSectionCodeDialog';
 import PasswordReset from '@cdo/apps/templates/manageStudents/PasswordReset';
 import PrintLoginCards from '@cdo/apps/templates/manageStudents/PrintLoginCards';
 import SharingControlActionsHeaderCell from '@cdo/apps/templates/manageStudents/SharingControlActionsHeaderCell';
 import ShowSecret from '@cdo/apps/templates/manageStudents/ShowSecret';
 import UsStateColumn from '@cdo/apps/templates/manageStudents/Table/UsStateColumn';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import {JoinLinkCopyButton} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton';
 import {
   tableLayoutStyles,
   sortableOptions,
 } from '@cdo/apps/templates/tables/tableConstants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
+import {
+  LOGIN_TYPES_WITH_ACTIONS_COLUMN,
+  LOGIN_TYPES_WITH_GENDER_COLUMN,
+  LOGIN_TYPES_WITH_PASSWORD_COLUMN,
+  NON_LMS_LOGIN_TYPES,
+  PICTURE_OR_WORD_LOGIN_TYPES,
+} from '@cdo/apps/templates/teacherDashboard/LoginTypeConstants';
 import {
   selectedSectionSelector,
   syncEnabled,
@@ -62,20 +68,10 @@ import {
   sectionUnitName,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
-import color from '@cdo/apps/util/color';
-import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import experiments from '@cdo/apps/util/experiments';
 import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
-import {
-  LOGIN_TYPES_WITH_ACTIONS_COLUMN,
-  LOGIN_TYPES_WITH_GENDER_COLUMN,
-  LOGIN_TYPES_WITH_NO_SECTION_CODE,
-  LOGIN_TYPES_WITH_PASSWORD_COLUMN,
-  NON_LMS_LOGIN_TYPES,
-  PICTURE_OR_WORD_LOGIN_TYPES,
-} from '../../teacherDashboard/LoginTypeConstants';
 import {showV2TeacherDashboard} from '../../teacherNavigation/TeacherNavFlagUtils';
 
 const MANAGE_STUDENTS_TABLE = 'ManageStudentsTable';
@@ -149,9 +145,7 @@ class ManageStudentsTable extends Component {
     this.getSortingColumns = this.getSortingColumns.bind(this);
     this.onSort = this.onSort.bind(this);
     this.getColumns = this.getColumns.bind(this);
-    this.copySectionCode = this.copySectionCode.bind(this);
     this.onPrintLoginCards = this.onPrintLoginCards.bind(this);
-    this.showSectionCodeDialog = this.showSectionCodeDialog.bind(this);
     this.handleSaveAllClick = this.handleSaveAllClick.bind(this);
     this.close = this.close.bind(this);
   }
@@ -163,8 +157,6 @@ class ManageStudentsTable extends Component {
         position: 0,
       },
     },
-    showCopiedMsg: false,
-    showSectionCodeDialog: false,
     showPasswordLengthFailure: false,
   };
 
@@ -755,53 +747,11 @@ class ManageStudentsTable extends Component {
     };
   }
 
-  copySectionCode() {
-    const {sectionId, sectionCode, studioUrlPrefix} = this.props;
-    const joinLink = `${studioUrlPrefix}/join/${sectionCode}`;
-    copyToClipboard(joinLink);
-    firehoseClient.putRecord(
-      {
-        study: 'teacher-dashboard',
-        study_group: 'manage-students-actions',
-        event: 'copy-section-code-join-link',
-        data_json: JSON.stringify({
-          sectionId: sectionId,
-        }),
-      },
-      {includeUserId: true}
-    );
-    this.setState({showCopiedMsg: true});
-    setTimeout(() => {
-      this.setState({showCopiedMsg: false});
-    }, 5000);
-    clearTimeout();
-  }
-
   onPrintLoginCards() {
     const {sectionId} = this.props;
     const url =
       teacherDashboardUrl(sectionId, '/login_info') + `?autoPrint=true`;
     window.open(url, '_blank', 'noopener,noreferrer');
-  }
-
-  showSectionCodeDialog() {
-    const {sectionId} = this.props;
-    firehoseClient.putRecord(
-      {
-        study: 'teacher-dashboard',
-        study_group: 'manage-students-actions',
-        event: 'no-section-code-link',
-        data_json: JSON.stringify({
-          sectionId: sectionId,
-        }),
-      },
-      {includeUserId: true}
-    );
-    this.setState({showSectionCodeDialog: true});
-  }
-
-  close() {
-    this.setState({showSectionCodeDialog: false});
   }
 
   render() {
@@ -924,45 +874,12 @@ class ManageStudentsTable extends Component {
               buttonContainerStyle={styles.button}
             />
           )}
-          {LOGIN_TYPES_WITH_PASSWORD_COLUMN.includes(loginType) && (
-            <div
-              style={styles.sectionCodeBox}
-              data-for="section-code"
-              data-tip
-              onClick={this.copySectionCode}
-            >
-              {!this.state.showCopiedMsg && (
-                <span>
-                  <span>{i18n.sectionCodeWithColon()}</span>
-                  <span style={styles.sectionCode}>{sectionCode}</span>
-                  <ReactTooltip id="section-code" role="tooltip" effect="solid">
-                    <div>{i18n.copySectionCodeTooltip()}</div>
-                  </ReactTooltip>
-                </span>
-              )}
-              {this.state.showCopiedMsg && (
-                <span>{i18n.copySectionCodeSuccess()}</span>
-              )}
-            </div>
-          )}
-          {LOGIN_TYPES_WITH_NO_SECTION_CODE.includes(loginType) && (
-            <div style={styles.sectionCodeBox}>
-              {i18n.sectionCodeWithColon()}
-              <span
-                style={styles.sectionCodeNotApplicable}
-              >{` ${i18n.notApplicable()}. `}</span>
-              <span style={styles.noSectionCode}>
-                <a onClick={() => this.showSectionCodeDialog()}>
-                  {i18n.whyWithQuestionMark()}
-                </a>
-              </span>
-              <NoSectionCodeDialog
-                typeClassroom={loginType}
-                handleClose={this.close}
-                isOpen={this.state.showSectionCodeDialog}
-              />
-            </div>
-          )}
+          <JoinLinkCopyButton
+            sectionId={sectionId}
+            sectionCode={sectionCode}
+            loginType={loginType}
+            studioUrlPrefix={this.props.studioUrlPrefix}
+          />
         </div>
         <div style={tableStyle}>
           <Table.Provider
@@ -1013,21 +930,6 @@ const styles = {
   verticalAlign: {
     display: 'flex',
     alignItems: 'center',
-  },
-  sectionCodeBox: {
-    float: 'right',
-    lineHeight: '30px',
-  },
-  sectionCode: {
-    marginLeft: 5,
-    color: color.teal,
-    ...fontConstants['main-font-bold'],
-    cursor: 'copy',
-  },
-  noSectionCode: {
-    color: color.teal,
-    textDecoration: 'none',
-    cursor: 'pointer',
   },
   sectionCodeNotApplicable: {
     ...fontConstants['main-font-bold'],

--- a/apps/src/templates/manageStudents/Table/index.jsx
+++ b/apps/src/templates/manageStudents/Table/index.jsx
@@ -68,25 +68,15 @@ import experiments from '@cdo/apps/util/experiments';
 import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
+import {
+  LOGIN_TYPES_WITH_ACTIONS_COLUMN,
+  LOGIN_TYPES_WITH_GENDER_COLUMN,
+  LOGIN_TYPES_WITH_NO_SECTION_CODE,
+  LOGIN_TYPES_WITH_PASSWORD_COLUMN,
+  NON_LMS_LOGIN_TYPES,
+  PICTURE_OR_WORD_LOGIN_TYPES,
+} from '../../teacherDashboard/LoginTypeConstants';
 import {showV2TeacherDashboard} from '../../teacherNavigation/TeacherNavFlagUtils';
-
-const LOGIN_TYPES_WITH_PASSWORD_COLUMN = [
-  SectionLoginType.word,
-  SectionLoginType.picture,
-  SectionLoginType.email,
-];
-const LOGIN_TYPES_WITH_ACTIONS_COLUMN = [
-  SectionLoginType.word,
-  SectionLoginType.picture,
-  SectionLoginType.email,
-  SectionLoginType.google_classroom,
-  SectionLoginType.clever,
-  SectionLoginType.lti_v1,
-];
-const LOGIN_TYPES_WITH_GENDER_COLUMN = [
-  SectionLoginType.word,
-  SectionLoginType.picture,
-];
 
 const MANAGE_STUDENTS_TABLE = 'ManageStudentsTable';
 
@@ -212,11 +202,7 @@ class ManageStudentsTable extends Component {
 
   isMoveStudentsEnabled() {
     const {loginType} = this.props;
-    return (
-      loginType === SectionLoginType.word ||
-      loginType === SectionLoginType.picture ||
-      loginType === SectionLoginType.email
-    );
+    return NON_LMS_LOGIN_TYPES.includes(loginType);
   }
 
   // Helper function to determine if user is a teacher
@@ -290,8 +276,7 @@ class ManageStudentsTable extends Component {
                 }
               />
             )}
-            {(rowData.loginType === SectionLoginType.word ||
-              rowData.loginType === SectionLoginType.picture) && (
+            {PICTURE_OR_WORD_LOGIN_TYPES.includes(rowData.loginType) && (
               <ShowSecret
                 initialIsShowing={false}
                 secretWord={rowData.secretWords}
@@ -852,11 +837,6 @@ class ManageStudentsTable extends Component {
       isSectionAssignedCSA,
     } = this.props;
 
-    const noSectionCode = [
-      SectionLoginType.google_classroom,
-      SectionLoginType.clever,
-    ];
-
     return (
       <div>
         {addStatus.status === AddStatus.SUCCESS && (
@@ -896,8 +876,7 @@ class ManageStudentsTable extends Component {
         {transferStatus.status === TransferStatus.SUCCESS &&
           this.renderTransferSuccessNotification()}
         <div>
-          {(loginType === SectionLoginType.word ||
-            loginType === SectionLoginType.picture) && (
+          {PICTURE_OR_WORD_LOGIN_TYPES.includes(loginType) && (
             <div style={styles.buttonWithMargin}>
               <AddMultipleStudents sectionId={this.props.sectionId} />
             </div>
@@ -911,8 +890,7 @@ class ManageStudentsTable extends Component {
               />
             </div>
           )}
-          {(loginType === SectionLoginType.word ||
-            loginType === SectionLoginType.picture) && (
+          {PICTURE_OR_WORD_LOGIN_TYPES.includes(loginType) && (
             <div style={styles.button}>
               <PrintLoginCards
                 sectionId={this.props.sectionId}
@@ -967,7 +945,7 @@ class ManageStudentsTable extends Component {
               )}
             </div>
           )}
-          {noSectionCode.includes(loginType) && (
+          {LOGIN_TYPES_WITH_NO_SECTION_CODE.includes(loginType) && (
             <div style={styles.sectionCodeBox}>
               {i18n.sectionCodeWithColon()}
               <span

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// @ts-expect-error (lfm) because old react-tooltip version is untyped. Will update soon.
 import ReactTooltip from 'react-tooltip';
 
 import firehoseClient from '@cdo/apps/metrics/firehose';
@@ -65,7 +66,7 @@ export const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
     }, 5000);
   };
 
-  return (LOGIN_TYPES_WITH_PASSWORD_COLUMN as string[]).includes(loginType) ? (
+  return LOGIN_TYPES_WITH_PASSWORD_COLUMN.includes(loginType) ? (
     <div
       className={styles.sectionCodeBox}
       data-for="section-code"

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import ReactTooltip from 'react-tooltip';
+
+import firehoseClient from '@cdo/apps/metrics/firehose';
+import NoSectionCodeDialog from '@cdo/apps/templates/manageStudents/NoSectionCodeDialog';
+import {LOGIN_TYPES_WITH_PASSWORD_COLUMN} from '@cdo/apps/templates/teacherDashboard/LoginTypeConstants';
+import copyToClipboard from '@cdo/apps/util/copyToClipboard';
+import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
+import i18n from '@cdo/locale';
+
+import styles from './joinLinkCopyButton.module.scss';
+
+interface JoinLinkCopyButtonProps {
+  loginType: keyof typeof SectionLoginType;
+  sectionCode: string;
+  sectionId: number;
+  studioUrlPrefix: string;
+}
+
+export const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
+  loginType,
+  sectionCode,
+  sectionId,
+  studioUrlPrefix,
+}) => {
+  const [shouldShowDialog, setShouldShowDialog] = React.useState(false);
+  const [showCopiedMsg, setShowCopiedMsg] = React.useState(false);
+
+  const showSectionCodeDialog = () => {
+    firehoseClient.putRecord(
+      {
+        study: 'teacher-dashboard',
+        study_group: 'manage-students-actions',
+        event: 'no-section-code-link',
+        data_json: JSON.stringify({
+          sectionId: sectionId,
+        }),
+      },
+      {includeUserId: true}
+    );
+    setShouldShowDialog(true);
+  };
+
+  const close = () => {
+    setShouldShowDialog(false);
+  };
+
+  const copySectionCode = () => {
+    const joinLink = `${studioUrlPrefix}/join/${sectionCode}`;
+    copyToClipboard(joinLink);
+    firehoseClient.putRecord(
+      {
+        study: 'teacher-dashboard',
+        study_group: 'manage-students-actions',
+        event: 'copy-section-code-join-link',
+        data_json: JSON.stringify({
+          sectionId: sectionId,
+        }),
+      },
+      {includeUserId: true}
+    );
+    setShowCopiedMsg(true);
+    setTimeout(() => {
+      setShowCopiedMsg(false);
+    }, 5000);
+  };
+
+  return (LOGIN_TYPES_WITH_PASSWORD_COLUMN as string[]).includes(loginType) ? (
+    <div
+      className={styles.sectionCodeBox}
+      data-for="section-code"
+      data-tip
+      onClick={copySectionCode}
+    >
+      {!showCopiedMsg && (
+        <span>
+          <span>{i18n.sectionCodeWithColon()}</span>
+          <span className={styles.sectionCode}>{sectionCode}</span>
+          <ReactTooltip id="section-code" role="tooltip" effect="solid">
+            <div>{i18n.copySectionCodeTooltip()}</div>
+          </ReactTooltip>
+        </span>
+      )}
+      {showCopiedMsg && <span>{i18n.copySectionCodeSuccess()}</span>}
+    </div>
+  ) : (
+    <div className={styles.sectionCodeBox}>
+      {i18n.sectionCodeWithColon()}
+      <span
+        className={styles.sectionCodeNotApplicable}
+      >{` ${i18n.notApplicable()}. `}</span>
+      <span className={styles.noSectionCode}>
+        <a onClick={() => showSectionCodeDialog()}>
+          {i18n.whyWithQuestionMark()}
+        </a>
+      </span>
+      <NoSectionCodeDialog
+        typeClassroom={loginType}
+        handleClose={close}
+        isOpen={shouldShowDialog}
+      />
+    </div>
+  );
+};

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
@@ -66,7 +66,7 @@ export const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
     }, 5000);
   };
 
-  return LOGIN_TYPES_WITH_PASSWORD_COLUMN.includes(loginType) ? (
+  return (LOGIN_TYPES_WITH_PASSWORD_COLUMN as string[]).includes(loginType) ? (
     <div
       className={styles.sectionCodeBox}
       data-for="section-code"

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
@@ -91,7 +91,7 @@ export const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
         className={styles.sectionCodeNotApplicable}
       >{` ${i18n.notApplicable()}. `}</span>
       <span className={styles.noSectionCode}>
-        <a onClick={() => showSectionCodeDialog()}>
+        <a onClick={() => showSectionCodeDialog()} id="uitest-why-link">
           {i18n.whyWithQuestionMark()}
         </a>
       </span>

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/joinLinkCopyButton.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/joinLinkCopyButton.module.scss
@@ -1,0 +1,20 @@
+@import 'color';
+@import '@code-dot-org/component-library-styles/font';
+
+.sectionCodeBox {
+  float: right;
+  line-height: 30px;
+}
+
+.sectionCode {
+  @include main-font-bold;
+  margin-left: 5px;
+  color: $teal;
+  cursor: copy;
+}
+
+.noSectionCode {
+  color: $teal;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -9,6 +9,7 @@ import i18n from '@cdo/locale';
 
 import BaseDialog from '../BaseDialog';
 
+import {NON_LMS_LOGIN_TYPES} from './LoginTypeConstants';
 import LoginTypePicker from './LoginTypePicker';
 import PadAndCenter from './PadAndCenter';
 import ParticipantTypePicker from './ParticipantTypePicker';
@@ -73,13 +74,7 @@ const AddSectionDialog = ({
 
   const onLoginTypeSelection = loginType => {
     // Oauth section types should use the roster dialog, not the section setup page
-    if (
-      [
-        SectionLoginType.picture,
-        SectionLoginType.word,
-        SectionLoginType.email,
-      ].includes(loginType)
-    ) {
+    if (NON_LMS_LOGIN_TYPES.includes(loginType)) {
       redirectToNewSectionPage(participantType, loginType);
     }
     setLoginType(loginType);

--- a/apps/src/templates/teacherDashboard/LoginTypeConstants.tsx
+++ b/apps/src/templates/teacherDashboard/LoginTypeConstants.tsx
@@ -1,0 +1,28 @@
+import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
+
+export const NON_LMS_LOGIN_TYPES = [
+  SectionLoginType.word,
+  SectionLoginType.picture,
+  SectionLoginType.email,
+];
+export const LOGIN_TYPES_WITH_PASSWORD_COLUMN = NON_LMS_LOGIN_TYPES;
+
+export const LOGIN_TYPES_WITH_ACTIONS_COLUMN = [
+  SectionLoginType.word,
+  SectionLoginType.picture,
+  SectionLoginType.email,
+  SectionLoginType.google_classroom,
+  SectionLoginType.clever,
+  SectionLoginType.lti_v1,
+];
+
+export const PICTURE_OR_WORD_LOGIN_TYPES = [
+  SectionLoginType.word,
+  SectionLoginType.picture,
+];
+export const LOGIN_TYPES_WITH_GENDER_COLUMN = PICTURE_OR_WORD_LOGIN_TYPES;
+
+export const LOGIN_TYPES_WITH_NO_SECTION_CODE = [
+  SectionLoginType.google_classroom,
+  SectionLoginType.clever,
+];

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -504,8 +504,8 @@ describe('ManageStudentsTable', () => {
         wrapper.find('NoSectionCodeDialog').props().typeClassroom
       ).to.equal(SectionLoginType.google_classroom);
       expect(wrapper.find('NoSectionCodeDialog').props().isOpen).to.be.false;
-      const mainTable = wrapper.find('ManageStudentsTable');
-      mainTable.setState({showSectionCodeDialog: true});
+
+      wrapper.find('#uitest-why-link').simulate('click');
       expect(wrapper.find('NoSectionCodeDialog').props().isOpen).to.be.true;
     });
 
@@ -527,8 +527,8 @@ describe('ManageStudentsTable', () => {
         wrapper.find('NoSectionCodeDialog').props().typeClassroom
       ).to.equal(SectionLoginType.clever);
       expect(wrapper.find('NoSectionCodeDialog').props().isOpen).to.be.false;
-      const mainTable = wrapper.find('ManageStudentsTable');
-      mainTable.setState({showSectionCodeDialog: true});
+
+      wrapper.find('#uitest-why-link').simulate('click');
       expect(wrapper.find('NoSectionCodeDialog').props().isOpen).to.equal(true);
     });
 


### PR DESCRIPTION
Should be no functional changes PR. This is a helpful refactor for the following two tickets on the homepage:
https://codedotorg.atlassian.net/browse/TEACH-1798
https://codedotorg.atlassian.net/browse/TEACH-1797

My plan is to re-use this component and update it for the homepage. Molly is OK with this roster join link styles changing to match eventually.

Before:
![image](https://github.com/user-attachments/assets/2cca9fd7-afde-4cd6-bb53-409b2e199682)

After:
![image](https://github.com/user-attachments/assets/0006491b-6adc-4700-a52d-fac77ab8af7d)


## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->
