### PR TITLE
CMS-506: Add Contentful `Rich Text` component

### DIFF
--- a/frontend/apps/marketing/src/components/richText/RichText.tsx
+++ b/frontend/apps/marketing/src/components/richText/RichText.tsx
@@ -19,7 +19,10 @@ import Link from '@code-dot-org/component-library/link';
 import SimpleList, {
   SimpleListItem,
 } from '@code-dot-org/component-library/list/simpleList';
-import {BodyTwoText} from '@code-dot-org/component-library/typography';
+import {
+  BodyTwoText,
+  StrongText,
+} from '@code-dot-org/component-library/typography';
 
 import moduleStyles from './richText.module.scss';
 
@@ -46,7 +49,13 @@ const extractNodeContent = (node: RichTextNode): ReactNode[] => {
   switch (node.nodeType) {
     case 'text':
       return node.value
-        ? [isBold(node) ? <b key={node.value}>{node.value}</b> : node.value]
+        ? [
+            isBold(node) ? (
+              <StrongText key={node.value}>{node.value}</StrongText>
+            ) : (
+              node.value
+            ),
+          ]
         : [];
     case INLINES.HYPERLINK: {
       const linkContent = getContent();

--- a/frontend/apps/marketing/src/components/richText/RichText.tsx
+++ b/frontend/apps/marketing/src/components/richText/RichText.tsx
@@ -74,6 +74,8 @@ const richTextRenderOptions: Options = {
   renderNode: {
     [BLOCKS.PARAGRAPH]: (paragraphNode: RichTextNode) => {
       const paragraphContent = extractNodeContent(paragraphNode);
+      // The Rich Text Editor wraps each line in a <p> tag, which acts as a spacer.
+      // Replaces empty paragraphs with a <br /> To comply with HTML a11y guidelines.
       return paragraphContent.length ? (
         <BodyTwoText>{paragraphContent}</BodyTwoText>
       ) : (

--- a/frontend/apps/marketing/src/components/richText/RichText.tsx
+++ b/frontend/apps/marketing/src/components/richText/RichText.tsx
@@ -1,0 +1,99 @@
+import {
+  documentToReactComponents,
+  Options,
+} from '@contentful/rich-text-react-renderer';
+import {
+  BLOCKS,
+  INLINES,
+  MARKS,
+  Document,
+  Block,
+  Inline,
+  Text,
+  Mark,
+} from '@contentful/rich-text-types';
+import {EntryFields} from 'contentful';
+import {ReactNode} from 'react';
+
+import Link from '@code-dot-org/component-library/link';
+import SimpleList, {
+  SimpleListItem,
+} from '@code-dot-org/component-library/list/simpleList';
+import {BodyTwoText} from '@code-dot-org/component-library/typography';
+
+import moduleStyles from './richText.module.scss';
+
+export interface RichTextProps {
+  content?: EntryFields.RichText | Document;
+}
+
+export type RichTextNode =
+  | Block
+  | Inline
+  | (Text & {
+      content?: RichTextNode;
+    });
+
+const extractNodeContent = (node: RichTextNode): ReactNode[] => {
+  const getContent = (): ReactNode[] =>
+    Array.isArray(node.content)
+      ? node.content.map(extractNodeContent).flat()
+      : [];
+
+  const isBold = (node: Text): boolean =>
+    node.marks.some(({type}: Mark) => type === MARKS.BOLD);
+
+  switch (node.nodeType) {
+    case 'text':
+      return node.value
+        ? [isBold(node) ? <b key={node.value}>{node.value}</b> : node.value]
+        : [];
+    case INLINES.HYPERLINK: {
+      const linkContent = getContent();
+      return [
+        <Link key={linkContent.join('-') + node.data.uri} href={node.data.uri}>
+          {linkContent}
+        </Link>,
+      ];
+    }
+    default:
+      return getContent();
+  }
+};
+
+const richTextRenderOptions: Options = {
+  renderNode: {
+    [BLOCKS.PARAGRAPH]: (paragraphNode: RichTextNode) => {
+      const paragraphContent = extractNodeContent(paragraphNode);
+      return paragraphContent.length ? (
+        <BodyTwoText>{paragraphContent}</BodyTwoText>
+      ) : (
+        <br />
+      );
+    },
+    [BLOCKS.UL_LIST]: (listNode: Block | Inline) => (
+      <SimpleList
+        items={listNode.content.map(
+          (itemNode: RichTextNode): SimpleListItem => {
+            const listItemContent = extractNodeContent(itemNode);
+            return {key: listItemContent.join('-'), label: listItemContent};
+          },
+        )}
+      />
+    ),
+  },
+};
+
+const RichText: React.FC<RichTextProps> = ({content}) =>
+  content ? (
+    <div className={moduleStyles.richText}>
+      {documentToReactComponents(content, richTextRenderOptions)}
+    </div>
+  ) : (
+    <em>
+      <strong>📄 Rich Text placeholder.</strong> Please bind a "Rich Text"
+      content type field in the Content sidebar.
+    </em>
+  );
+
+export default RichText;

--- a/frontend/apps/marketing/src/components/richText/RichTextContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/richText/RichTextContentfulDefinition.ts
@@ -1,0 +1,30 @@
+// Creates a definition for the Rich Text component to be used in Contentful Studio
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+export const RichTextContentfulComponentDefinition: ComponentDefinition = {
+  id: 'richText',
+  name: 'Rich Text',
+  category: '02: Typography',
+  thumbnailUrl:
+    'https://images.ctfassets.net/90t6bu6vlf76/2GEuq3yVKIXryX2p3cLjQC/0db314e4e19acd7a90cbdded8b348848/component_rich_text_thumbnail.png',
+  tooltip: {
+    description:
+      'An enhanced text block that binds to rich text fields. Supports inline links, selective bold styling, line breaks, and tables — ideal for structured, formatted text content.',
+    imageUrl:
+      'https://images.ctfassets.net/90t6bu6vlf76/2nDq9QyBr8reF6G31qpfS3/73a5fdd1d402ff31c9f31e17c09685db/component_rich_text_tooltip.png',
+  },
+  // Adding an empty array here so no default style options show in the Design tab.
+  builtInStyles: [],
+  children: false,
+  variables: {
+    content: {
+      displayName: 'Content',
+      type: 'RichText',
+      group: 'content',
+      validations: {
+        required: true,
+        bindingSourceType: ['entry'],
+      },
+    },
+  },
+};

--- a/frontend/apps/marketing/src/components/richText/__tests__/RichText.test.tsx
+++ b/frontend/apps/marketing/src/components/richText/__tests__/RichText.test.tsx
@@ -78,7 +78,7 @@ describe('RichText component', () => {
 
     const paragraph = screen.getByText(paragraphText);
     expect(paragraph).toBeVisible();
-    expect(paragraph.tagName).toBe('B');
+    expect(paragraph.tagName).toBe('STRONG');
     expect(paragraph.parentElement).toHaveRole('paragraph');
   });
 

--- a/frontend/apps/marketing/src/components/richText/__tests__/RichText.test.tsx
+++ b/frontend/apps/marketing/src/components/richText/__tests__/RichText.test.tsx
@@ -1,0 +1,143 @@
+import {
+  BLOCKS,
+  INLINES,
+  Document,
+  TopLevelBlock,
+} from '@contentful/rich-text-types';
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import RichText, {RichTextProps} from '@/components/richText/RichText';
+
+describe('RichText component', () => {
+  const buildRichTextDocument = (content: TopLevelBlock[]): Document => ({
+    nodeType: BLOCKS.DOCUMENT,
+    data: {},
+    content: content,
+  });
+
+  const renderComponent = ({content}: RichTextProps) =>
+    render(<RichText content={content} />);
+
+  it('renders empty content placeholder', () => {
+    renderComponent({});
+
+    const placeholder = screen.getByText(
+      (_, node) =>
+        node?.tagName === 'EM' &&
+        !!node?.textContent?.includes('Rich Text placeholder'),
+    );
+
+    expect(placeholder).toBeVisible();
+  });
+
+  it('renders paragraph with normal text', () => {
+    const paragraphText = 'Test Paragraph';
+
+    renderComponent({
+      content: buildRichTextDocument([
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: paragraphText,
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ]),
+    });
+
+    const paragraph = screen.getByText(paragraphText);
+    expect(paragraph).toBeVisible();
+    expect(paragraph).toHaveRole('paragraph');
+  });
+
+  it('renders paragraph with bold text', () => {
+    const paragraphText = 'Test Paragraph';
+
+    renderComponent({
+      content: buildRichTextDocument([
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: paragraphText,
+              marks: [{type: 'bold'}],
+              data: {},
+            },
+          ],
+        },
+      ]),
+    });
+
+    const paragraph = screen.getByText(paragraphText);
+    expect(paragraph).toBeVisible();
+    expect(paragraph.tagName).toBe('B');
+    expect(paragraph.parentElement).toHaveRole('paragraph');
+  });
+
+  it('renders paragraph with link', () => {
+    const linkText = 'Test Link';
+    const linkHref = 'https://example.com';
+
+    renderComponent({
+      content: buildRichTextDocument([
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: INLINES.HYPERLINK,
+              data: {uri: linkHref},
+              content: [
+                {
+                  nodeType: 'text',
+                  value: linkText,
+                  marks: [],
+                  data: {},
+                },
+              ],
+            },
+          ],
+        },
+      ]),
+    });
+
+    const link = screen.getByText(linkText);
+    expect(link).toBeVisible();
+    expect(link).toHaveRole('link');
+    expect(link).toHaveAttribute('href', linkHref);
+    expect(link.parentElement).toHaveRole('paragraph');
+  });
+
+  it('renders list', () => {
+    const listItemText = 'Test List Item';
+
+    renderComponent({
+      content: buildRichTextDocument([
+        {
+          nodeType: BLOCKS.UL_LIST,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: listItemText,
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ]),
+    });
+
+    const listItem = screen.getByText(listItemText);
+    expect(listItem).toBeVisible();
+    expect(listItem.parentElement).toHaveRole('listitem');
+  });
+});

--- a/frontend/apps/marketing/src/components/richText/index.ts
+++ b/frontend/apps/marketing/src/components/richText/index.ts
@@ -1,0 +1,3 @@
+// Export the Component Definition for use in Contentful Studio
+export {RichTextContentfulComponentDefinition} from './RichTextContentfulDefinition';
+export {default} from './RichText';

--- a/frontend/apps/marketing/src/components/richText/richText.module.scss
+++ b/frontend/apps/marketing/src/components/richText/richText.module.scss
@@ -1,0 +1,89 @@
+@use '@code-dot-org/component-library-styles/font.scss' as font;
+
+.richText {
+  & > * {
+    margin: 0 0 1rem;
+
+    &:last-child {
+      margin: 0;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+
+  a {
+    font-weight: font.$regular-font-weight;
+  }
+
+  b {
+    font-weight: font.$semi-bold-font-weight;
+  }
+
+  p {
+    white-space: pre-wrap;
+  }
+
+  ol {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0 0 0 1.25rem;
+
+    li {
+      @include font.main-font-regular;
+      padding-left: 0.25rem;
+    }
+  }
+
+  table {
+    border-collapse: collapse;
+    border-radius: 0.25rem;
+    box-shadow: var(--borders-neutral-primary) 0 0 0 1px;
+    overflow: hidden;
+    table-layout: fixed;
+    width: 100%;
+
+    tbody {
+      tr {
+        &:nth-child(odd) {
+          background: var(--background-neutral-secondary);
+        }
+
+        &:not(:last-child) {
+          border-bottom: 1px solid var(--borders-neutral-primary);
+        }
+
+        th,
+        td {
+          border-collapse: collapse;
+          padding: 0.75rem 1rem;
+          text-align: center;
+        }
+
+        th {
+          background: var(--background-brand-teal-primary);
+          border-bottom: 1px solid var(--borders-brand-teal-strong);
+
+          &:not(:last-child) {
+            border-right: 1px solid var(--borders-brand-teal-strong);
+          }
+
+          p {
+            color: var(--text-neutral-white-fixed);
+            text-transform: uppercase;
+            font-weight: font.$semi-bold-font-weight;
+          }
+        }
+
+        td {
+          &:not(:last-child) {
+            border-right: 1px solid var(--borders-neutral-primary);
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -39,6 +39,9 @@ import Overline, {
 import Paragraph, {
   ParagraphContentfulComponentDefinition,
 } from '@/components/paragraph';
+import RichText, {
+  RichTextContentfulComponentDefinition,
+} from '@/components/richText';
 import Section, {
   SectionContentfulComponentDefinition,
 } from '@/components/section';
@@ -123,6 +126,10 @@ defineComponents(
     {
       component: Paragraph,
       definition: ParagraphContentfulComponentDefinition,
+    },
+    {
+      component: RichText,
+      definition: RichTextContentfulComponentDefinition,
     },
     {
       component: Section,


### PR DESCRIPTION
## Component
<img width="100%" alt="component" src="https://github.com/user-attachments/assets/389b07fe-9134-4c77-8de2-48d3d2178d5d" />

## Preview
<img width="100%" alt="preview" src="https://github.com/user-attachments/assets/2a9d6b8c-8617-4b2d-8294-d12ae65afa56" />

## Empty Content
<img width="100%" alt="empty-content" src="https://github.com/user-attachments/assets/a4225250-c391-44ca-81a3-91f29943d75c" />

## Field
<img width="740" alt="with-field-example" src="https://github.com/user-attachments/assets/ff24d2c1-e5ca-42c7-b829-9e4b93f8cc30" />

## Links
- JIRA task: [CMS-506](https://codedotorg.atlassian.net/browse/CMS-506)
- Figma: [Semantic Table](https://www.figma.com/design/l7PsQAs2pitCNP8zUHWEuy/DSCO-CMS?node-id=5167-13705&t=BcP7Z0hUbwPWWwsj-0)