### PR TITLE
Removal of unecesssary method stubs

### DIFF
--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -337,7 +337,6 @@ class RegistrationsControllerTest < ActionController::TestCase
 
   test "create new teacher with MailJet enabled sends welcome email" do
     teacher_params = set_up_partial_registration(@default_params.update(user_type: 'teacher', email_preference_opt_in: true))
-    ActionController::TestRequest.any_instance.stubs(:country_code).returns('CA')
     MailJet.stubs(:enabled?).returns(true)
     MailJet.expects(:create_contact_and_add_to_welcome_series).once
     assert_creates(User) do
@@ -349,7 +348,6 @@ class RegistrationsControllerTest < ActionController::TestCase
 
   test "create new teacher with opt-in option as yes writes email preference as yes" do
     teacher_params = set_up_partial_registration(@default_params.update(user_type: 'teacher', email_preference_opt_in: true))
-    ActionController::TestRequest.any_instance.stubs(:country_code).returns('CA')
     assert_creates(User) do
       assert_creates(EmailPreference) do
         post :create, params: {user: teacher_params}
@@ -364,7 +362,6 @@ class RegistrationsControllerTest < ActionController::TestCase
 
   test "create new teacher with opt-in option as no writes email preference as no" do
     teacher_params = set_up_partial_registration(@default_params.update(user_type: 'teacher', email_preference_opt_in: false))
-    ActionController::TestRequest.any_instance.stubs(:country_code).returns('CA')
     assert_creates(User) do
       assert_creates(EmailPreference) do
         post :create, params: {user: teacher_params}


### PR DESCRIPTION
In the new password requirement [PR](https://github.com/code-dot-org/code-dot-org/pull/65070), 

we stubbed request calls with the following 
`ActionController::TestRequest.any_instance.stubs(:country_code)` in the setup block of `registrations_controller_test.rb`.
[Link to code](https://github.com/code-dot-org/code-dot-org/blob/7e529a250610940b84508a38062b6032dd0156e4/dashboard/test/controllers/registrations_controller_test.rb#L27)

After confirming that the stubbing which returns 'CA' was an arbitrary return value, `ActionController::TestRequest.any_instance.stubs(:country_code).returns('CA')` 
we can now confidently remove the additional stubbing taking place in `registrations_controller_test.rb`.

## Links
- jira ticket: [here](https://codedotorg.atlassian.net/browse/P20-1443)
- conversation in related PR: [here](https://github.com/code-dot-org/code-dot-org/pull/65249#discussion_r2042916638)



  