### PR TITLE
Evaluate Student Learning: add db tables to Redshift export 

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -29,199 +29,200 @@
 # All tables in this section are exported to the Redshift `dashboard_production_pii` schema. Sensitive data may be
 # exported to this schema, but should be limited to only columns that have an identified analytics purpose.
 cron-pii:
-  - dashboard.census_submissions
-  - pegasus.contacts
-  - pegasus.forms
-  - pegasus.form_geos
-  - pegasus.hoc_activity:
-      remove_column:
+- dashboard.census_submissions
+- pegasus.contacts
+- pegasus.forms
+- pegasus.form_geos
+- pegasus.hoc_activity:
+    remove_column:
         - started_ip
         - pixel_finished_ip
         - pixel_started_ip
         - finished_ip
         - name
         - session
-  - pegasus.poste_deliveries
-  - dashboard.regional_partners
-  - dashboard.regional_partners_school_districts
-  - dashboard.pd_%
-  - dashboard.course_offerings_pd_workshops
-  - dashboard.email_preferences
-  - dashboard.teacher_feedbacks
-  - dashboard.authentication_options:
-      remove_column: [data]
-  - dashboard.peer_reviews
-  - dashboard.projects
-  - dashboard.foorm_%
-  - dashboard.potential_teachers
-  - dashboard.learning_goal_ai_evaluations
-  - dashboard.learning_goal_teacher_evaluations
-  - dashboard.learning_goal_ai_evaluation_feedbacks
-  - dashboard.ai_tutor_interactions
-  - dashboard.ai_tutor_interaction_feedbacks
-  - dashboard.aichat_requests
-  - dashboard.aichat_events
-  - dashboard.aidiff_messages
-  - dashboard.aidiff_threads
-  - dashboard.lti_deployments_user_identities
-  - dashboard.student_work_evaluations
-  - dashboard.ai_interaction_feedbacks
+- pegasus.poste_deliveries
+- dashboard.regional_partners
+- dashboard.regional_partners_school_districts
+- dashboard.pd_%
+- dashboard.course_offerings_pd_workshops
+- dashboard.email_preferences
+- dashboard.teacher_feedbacks
+- dashboard.authentication_options:
+    remove_column: [data]
+- dashboard.peer_reviews
+- dashboard.projects
+- dashboard.foorm_%
+- dashboard.potential_teachers
+- dashboard.learning_goal_ai_evaluations
+- dashboard.learning_goal_teacher_evaluations
+- dashboard.learning_goal_ai_evaluation_feedbacks
+- dashboard.ai_tutor_interactions
+- dashboard.ai_tutor_interaction_feedbacks
+- dashboard.aichat_requests
+- dashboard.aichat_events
+- dashboard.aidiff_messages
+- dashboard.aidiff_threads
+- dashboard.lti_deployments_user_identities
+- dashboard.student_work_evaluations
+- dashboard.ai_interaction_feedbacks
+
 
 # All tables in this section are exported to the Redshift `dashboard_production` schema. Do NOT export columns containing
 # sensitive data to this schema.
 cron:
-  - dashboard.ai_tutor_interactions:
-      remove_column:
-        - prompt
-        - ai_response
-  - dashboard.experiments
-  - dashboard.authored_hint_view_requests
-  - dashboard.hint_view_requests
-  - dashboard.puzzle_ratings
-  - dashboard.metrics
-  - dashboard.contained_level_answers
-  - dashboard.contained_levels
-  - dashboard.learning_goal_ai_evaluations:
-      remove_column:
-        - observations
-        - evidence
-  - dashboard.learning_goal_teacher_evaluations:
-      remove_column: [feedback]
-  - dashboard.learning_goal_ai_evaluation_feedbacks:
-      remove_column: [other_content]
-  - dashboard.rubrics
-  - dashboard.rubric_ai_evaluations
-  - dashboard.learning_goals
-  - dashboard.level_sources_multi_types
-  - dashboard.paired_user_levels
-  - dashboard.parental_permission_requests:
-      remove_column: [parent_email]
-  - dashboard.plc_course_units
-  - dashboard.plc_courses
-  - dashboard.plc_enrollment_module_assignments
-  - dashboard.plc_enrollment_unit_assignments
-  - dashboard.plc_learning_modules
-  - dashboard.plc_learning_module_tasks
-  - dashboard.plc_tasks
-  - dashboard.plc_user_course_enrollments
-  - dashboard.channel_tokens
-  - dashboard.schools
-  - dashboard.school_infos
-  - dashboard.school_districts
-  - dashboard.school_stats_by_years
-  - dashboard.scripts
-  - dashboard.stages
-  - dashboard.levels
-  - dashboard.script_levels
-  - dashboard.levels_script_levels
-  - dashboard.parent_levels_child_levels
-  - dashboard.courses
-  - dashboard.course_offerings
-  - dashboard.course_scripts
-  - dashboard.unit_groups
-  - dashboard.survey_results
-  - dashboard.sections
-  - dashboard.section_instructors
-  - dashboard.followers
-  - dashboard.section_hidden_stages
-  - dashboard.user_proficiencies
-  - dashboard.user_permissions
-  - dashboard.user_level_interactions
-  - dashboard.level_concept_difficulties
-  - dashboard.user_scripts
-  - dashboard.census_submissions:
-      remove_column:
-        - submitter_email_address
-        - submitter_name
-        - tell_us_more
-        - inaccuracy_comment
-  - dashboard.census_submissions_school_infos
-  - dashboard.census_summaries
-  - dashboard.standards
-  - dashboard.stages_standards
-  - dashboard.standard_categories
-  - dashboard.frameworks
-  - dashboard.user_project_storage_ids
-  - dashboard.lti_integrations:
-      remove_column: [admin_email]
-  - dashboard.lti_deployments
-  - dashboard.lti_courses
-  - dashboard.lti_feedbacks
-  - dashboard.lti_sections
-  - dashboard.lti_user_identities
-  - dashboard.lti_deployments_user_identities
-  - dashboard.new_feature_feedbacks
-  - dashboard.cap_user_events
-  - dashboard.ai_tutor_interaction_feedbacks
-  - dashboard.aichat_sessions
-  - dashboard.aidiff_message_feedbacks
+- dashboard.ai_tutor_interactions:
+    remove_column:
+      - prompt
+      - ai_response
+- dashboard.experiments
+- dashboard.authored_hint_view_requests
+- dashboard.hint_view_requests
+- dashboard.puzzle_ratings
+- dashboard.metrics
+- dashboard.contained_level_answers
+- dashboard.contained_levels
+- dashboard.learning_goal_ai_evaluations:
+    remove_column:
+      - observations
+      - evidence
+- dashboard.learning_goal_teacher_evaluations:
+    remove_column: [feedback]
+- dashboard.learning_goal_ai_evaluation_feedbacks:
+    remove_column: [other_content]
+- dashboard.rubrics
+- dashboard.rubric_ai_evaluations
+- dashboard.learning_goals
+- dashboard.level_sources_multi_types
+- dashboard.paired_user_levels
+- dashboard.parental_permission_requests:
+    remove_column: [parent_email]
+- dashboard.plc_course_units
+- dashboard.plc_courses
+- dashboard.plc_enrollment_module_assignments
+- dashboard.plc_enrollment_unit_assignments
+- dashboard.plc_learning_modules
+- dashboard.plc_learning_module_tasks
+- dashboard.plc_tasks
+- dashboard.plc_user_course_enrollments
+- dashboard.channel_tokens
+- dashboard.schools
+- dashboard.school_infos
+- dashboard.school_districts
+- dashboard.school_stats_by_years
+- dashboard.scripts
+- dashboard.stages
+- dashboard.levels
+- dashboard.script_levels
+- dashboard.levels_script_levels
+- dashboard.parent_levels_child_levels
+- dashboard.courses
+- dashboard.course_offerings
+- dashboard.course_scripts
+- dashboard.unit_groups
+- dashboard.survey_results
+- dashboard.sections
+- dashboard.section_instructors
+- dashboard.followers
+- dashboard.section_hidden_stages
+- dashboard.user_proficiencies
+- dashboard.user_permissions
+- dashboard.user_level_interactions
+- dashboard.level_concept_difficulties
+- dashboard.user_scripts
+- dashboard.census_submissions:
+    remove_column:
+    - submitter_email_address
+    - submitter_name
+    - tell_us_more
+    - inaccuracy_comment
+- dashboard.census_submissions_school_infos
+- dashboard.census_summaries
+- dashboard.standards
+- dashboard.stages_standards
+- dashboard.standard_categories
+- dashboard.frameworks
+- dashboard.user_project_storage_ids
+- dashboard.lti_integrations:
+    remove_column: [admin_email]
+- dashboard.lti_deployments
+- dashboard.lti_courses
+- dashboard.lti_feedbacks
+- dashboard.lti_sections
+- dashboard.lti_user_identities
+- dashboard.lti_deployments_user_identities
+- dashboard.new_feature_feedbacks
+- dashboard.cap_user_events
+- dashboard.ai_tutor_interaction_feedbacks
+- dashboard.aichat_sessions
+- dashboard.aidiff_message_feedbacks
 
 # All tables in this section are exported to the Redshift `dashboard_production` schema. Do NOT export columns containing
 # sensitive data to this schema.
 cron-user-hierarchy:
-  - dashboard.users:
-      remove_column:
-        - email
-        - encrypted_password
-        - reset_password_token
-        - reset_password_sent_at
-        - remember_created_at
-        - current_sign_in_ip
-        - last_sign_in_ip
-        - username
-        - uid
-        - name
-        - school
-        - full_address
-        - confirmation_token
-        - confirmed_at
-        - confirmation_sent_at
-        - unconfirmed_email
-        - secret_picture_id
-        - hashed_email
-        - secret_words
-        - properties
-        - invitation_token
-        - invitation_created_at
-        - invitation_sent_at
-        - invitation_accepted_at
-        - invitation_limit
-        - invitation_by_id
-        - invitations_count
-        - parent_email
-        - unlock_token
-  - dashboard.user_geos:
-      remove_column:
-        - ip_address
-        - latitude
-        - longitude
-  - dashboard.teacher_profiles
-  - dashboard.studio_people:
-      remove_column: [emails]
-  - dashboard.sign_ins
+- dashboard.users:
+    remove_column:
+    - email
+    - encrypted_password
+    - reset_password_token
+    - reset_password_sent_at
+    - remember_created_at
+    - current_sign_in_ip
+    - last_sign_in_ip
+    - username
+    - uid
+    - name
+    - school
+    - full_address
+    - confirmation_token
+    - confirmed_at
+    - confirmation_sent_at
+    - unconfirmed_email
+    - secret_picture_id
+    - hashed_email
+    - secret_words
+    - properties
+    - invitation_token
+    - invitation_created_at
+    - invitation_sent_at
+    - invitation_accepted_at
+    - invitation_limit
+    - invitation_by_id
+    - invitations_count
+    - parent_email
+    - unlock_token
+- dashboard.user_geos:
+    remove_column:
+    - ip_address
+    - latitude
+    - longitude
+- dashboard.teacher_profiles
+- dashboard.studio_people:
+    remove_column: [emails]
+- dashboard.sign_ins
 
 # All tables in this section are exported to the Redshift `dashboard_production_pii` schema. Sensitive data may be
 # exported to this schema, but should be limited to only columns that have an identified analytics purpose.
 cron-user-hierarchy-pii:
-  - dashboard.studio_people
-  - dashboard.teacher_profiles
-  - dashboard.users:
-      remove_column:
+- dashboard.studio_people
+- dashboard.teacher_profiles
+- dashboard.users:
+    remove_column:
         - encrypted_password
         - reset_password_token
         - secret_picture_id
         - secret_words
-  - dashboard.user_geos
-  - dashboard.user_school_infos
+- dashboard.user_geos
+- dashboard.user_school_infos
 
 # All tables in this section are exported to the Redshift `dashboard_production` schema. Do NOT export columns containing
 # sensitive data to this schema.
 cron-user-levels:
-  - dashboard.user_levels
+- dashboard.user_levels
 
 # All tables in this section are exported to the Redshift `dashboard_production_pii` schema. Sensitive data may be
 # exported to this schema, but should be limited to only columns that have an identified analytics purpose.
 cron-level-sources-pii:
-  - dashboard.level_sources:
-      skip_staging_table: true
-      schedule: "weekly"
+- dashboard.level_sources:
+    skip_staging_table: true
+    schedule: 'weekly'

--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -29,199 +29,199 @@
 # All tables in this section are exported to the Redshift `dashboard_production_pii` schema. Sensitive data may be
 # exported to this schema, but should be limited to only columns that have an identified analytics purpose.
 cron-pii:
-- dashboard.census_submissions
-- pegasus.contacts
-- pegasus.forms
-- pegasus.form_geos
-- pegasus.hoc_activity:
-    remove_column:
+  - dashboard.census_submissions
+  - pegasus.contacts
+  - pegasus.forms
+  - pegasus.form_geos
+  - pegasus.hoc_activity:
+      remove_column:
         - started_ip
         - pixel_finished_ip
         - pixel_started_ip
         - finished_ip
         - name
         - session
-- pegasus.poste_deliveries
-- dashboard.regional_partners
-- dashboard.regional_partners_school_districts
-- dashboard.pd_%
-- dashboard.course_offerings_pd_workshops
-- dashboard.email_preferences
-- dashboard.teacher_feedbacks
-- dashboard.authentication_options:
-    remove_column: [data]
-- dashboard.peer_reviews
-- dashboard.projects
-- dashboard.foorm_%
-- dashboard.potential_teachers
-- dashboard.learning_goal_ai_evaluations
-- dashboard.learning_goal_teacher_evaluations
-- dashboard.learning_goal_ai_evaluation_feedbacks
-- dashboard.ai_tutor_interactions
-- dashboard.ai_tutor_interaction_feedbacks
-- dashboard.aichat_requests
-- dashboard.aichat_events
-- dashboard.aidiff_messages
-- dashboard.aidiff_threads
-- dashboard.lti_deployments_user_identities
-- dashboard.user_level_evaluations
-
+  - pegasus.poste_deliveries
+  - dashboard.regional_partners
+  - dashboard.regional_partners_school_districts
+  - dashboard.pd_%
+  - dashboard.course_offerings_pd_workshops
+  - dashboard.email_preferences
+  - dashboard.teacher_feedbacks
+  - dashboard.authentication_options:
+      remove_column: [data]
+  - dashboard.peer_reviews
+  - dashboard.projects
+  - dashboard.foorm_%
+  - dashboard.potential_teachers
+  - dashboard.learning_goal_ai_evaluations
+  - dashboard.learning_goal_teacher_evaluations
+  - dashboard.learning_goal_ai_evaluation_feedbacks
+  - dashboard.ai_tutor_interactions
+  - dashboard.ai_tutor_interaction_feedbacks
+  - dashboard.aichat_requests
+  - dashboard.aichat_events
+  - dashboard.aidiff_messages
+  - dashboard.aidiff_threads
+  - dashboard.lti_deployments_user_identities
+  - dashboard.student_work_evaluations
+  - dashboard.ai_interaction_feedbacks
 
 # All tables in this section are exported to the Redshift `dashboard_production` schema. Do NOT export columns containing
 # sensitive data to this schema.
 cron:
-- dashboard.ai_tutor_interactions:
-    remove_column:
-      - prompt
-      - ai_response
-- dashboard.experiments
-- dashboard.authored_hint_view_requests
-- dashboard.hint_view_requests
-- dashboard.puzzle_ratings
-- dashboard.metrics
-- dashboard.contained_level_answers
-- dashboard.contained_levels
-- dashboard.learning_goal_ai_evaluations:
-    remove_column:
-      - observations
-      - evidence
-- dashboard.learning_goal_teacher_evaluations:
-    remove_column: [feedback]
-- dashboard.learning_goal_ai_evaluation_feedbacks:
-    remove_column: [other_content]
-- dashboard.rubrics
-- dashboard.rubric_ai_evaluations
-- dashboard.learning_goals
-- dashboard.level_sources_multi_types
-- dashboard.paired_user_levels
-- dashboard.parental_permission_requests:
-    remove_column: [parent_email]
-- dashboard.plc_course_units
-- dashboard.plc_courses
-- dashboard.plc_enrollment_module_assignments
-- dashboard.plc_enrollment_unit_assignments
-- dashboard.plc_learning_modules
-- dashboard.plc_learning_module_tasks
-- dashboard.plc_tasks
-- dashboard.plc_user_course_enrollments
-- dashboard.channel_tokens
-- dashboard.schools
-- dashboard.school_infos
-- dashboard.school_districts
-- dashboard.school_stats_by_years
-- dashboard.scripts
-- dashboard.stages
-- dashboard.levels
-- dashboard.script_levels
-- dashboard.levels_script_levels
-- dashboard.parent_levels_child_levels
-- dashboard.courses
-- dashboard.course_offerings
-- dashboard.course_scripts
-- dashboard.unit_groups
-- dashboard.survey_results
-- dashboard.sections
-- dashboard.section_instructors
-- dashboard.followers
-- dashboard.section_hidden_stages
-- dashboard.user_proficiencies
-- dashboard.user_permissions
-- dashboard.user_level_interactions
-- dashboard.level_concept_difficulties
-- dashboard.user_scripts
-- dashboard.census_submissions:
-    remove_column:
-    - submitter_email_address
-    - submitter_name
-    - tell_us_more
-    - inaccuracy_comment
-- dashboard.census_submissions_school_infos
-- dashboard.census_summaries
-- dashboard.standards
-- dashboard.stages_standards
-- dashboard.standard_categories
-- dashboard.frameworks
-- dashboard.user_project_storage_ids
-- dashboard.lti_integrations:
-    remove_column: [admin_email]
-- dashboard.lti_deployments
-- dashboard.lti_courses
-- dashboard.lti_feedbacks
-- dashboard.lti_sections
-- dashboard.lti_user_identities
-- dashboard.lti_deployments_user_identities
-- dashboard.new_feature_feedbacks
-- dashboard.cap_user_events
-- dashboard.ai_tutor_interaction_feedbacks
-- dashboard.aichat_sessions
-- dashboard.aidiff_message_feedbacks
+  - dashboard.ai_tutor_interactions:
+      remove_column:
+        - prompt
+        - ai_response
+  - dashboard.experiments
+  - dashboard.authored_hint_view_requests
+  - dashboard.hint_view_requests
+  - dashboard.puzzle_ratings
+  - dashboard.metrics
+  - dashboard.contained_level_answers
+  - dashboard.contained_levels
+  - dashboard.learning_goal_ai_evaluations:
+      remove_column:
+        - observations
+        - evidence
+  - dashboard.learning_goal_teacher_evaluations:
+      remove_column: [feedback]
+  - dashboard.learning_goal_ai_evaluation_feedbacks:
+      remove_column: [other_content]
+  - dashboard.rubrics
+  - dashboard.rubric_ai_evaluations
+  - dashboard.learning_goals
+  - dashboard.level_sources_multi_types
+  - dashboard.paired_user_levels
+  - dashboard.parental_permission_requests:
+      remove_column: [parent_email]
+  - dashboard.plc_course_units
+  - dashboard.plc_courses
+  - dashboard.plc_enrollment_module_assignments
+  - dashboard.plc_enrollment_unit_assignments
+  - dashboard.plc_learning_modules
+  - dashboard.plc_learning_module_tasks
+  - dashboard.plc_tasks
+  - dashboard.plc_user_course_enrollments
+  - dashboard.channel_tokens
+  - dashboard.schools
+  - dashboard.school_infos
+  - dashboard.school_districts
+  - dashboard.school_stats_by_years
+  - dashboard.scripts
+  - dashboard.stages
+  - dashboard.levels
+  - dashboard.script_levels
+  - dashboard.levels_script_levels
+  - dashboard.parent_levels_child_levels
+  - dashboard.courses
+  - dashboard.course_offerings
+  - dashboard.course_scripts
+  - dashboard.unit_groups
+  - dashboard.survey_results
+  - dashboard.sections
+  - dashboard.section_instructors
+  - dashboard.followers
+  - dashboard.section_hidden_stages
+  - dashboard.user_proficiencies
+  - dashboard.user_permissions
+  - dashboard.user_level_interactions
+  - dashboard.level_concept_difficulties
+  - dashboard.user_scripts
+  - dashboard.census_submissions:
+      remove_column:
+        - submitter_email_address
+        - submitter_name
+        - tell_us_more
+        - inaccuracy_comment
+  - dashboard.census_submissions_school_infos
+  - dashboard.census_summaries
+  - dashboard.standards
+  - dashboard.stages_standards
+  - dashboard.standard_categories
+  - dashboard.frameworks
+  - dashboard.user_project_storage_ids
+  - dashboard.lti_integrations:
+      remove_column: [admin_email]
+  - dashboard.lti_deployments
+  - dashboard.lti_courses
+  - dashboard.lti_feedbacks
+  - dashboard.lti_sections
+  - dashboard.lti_user_identities
+  - dashboard.lti_deployments_user_identities
+  - dashboard.new_feature_feedbacks
+  - dashboard.cap_user_events
+  - dashboard.ai_tutor_interaction_feedbacks
+  - dashboard.aichat_sessions
+  - dashboard.aidiff_message_feedbacks
 
 # All tables in this section are exported to the Redshift `dashboard_production` schema. Do NOT export columns containing
 # sensitive data to this schema.
 cron-user-hierarchy:
-- dashboard.users:
-    remove_column:
-    - email
-    - encrypted_password
-    - reset_password_token
-    - reset_password_sent_at
-    - remember_created_at
-    - current_sign_in_ip
-    - last_sign_in_ip
-    - username
-    - uid
-    - name
-    - school
-    - full_address
-    - confirmation_token
-    - confirmed_at
-    - confirmation_sent_at
-    - unconfirmed_email
-    - secret_picture_id
-    - hashed_email
-    - secret_words
-    - properties
-    - invitation_token
-    - invitation_created_at
-    - invitation_sent_at
-    - invitation_accepted_at
-    - invitation_limit
-    - invitation_by_id
-    - invitations_count
-    - parent_email
-    - unlock_token
-- dashboard.user_geos:
-    remove_column:
-    - ip_address
-    - latitude
-    - longitude
-- dashboard.teacher_profiles
-- dashboard.studio_people:
-    remove_column: [emails]
-- dashboard.sign_ins
+  - dashboard.users:
+      remove_column:
+        - email
+        - encrypted_password
+        - reset_password_token
+        - reset_password_sent_at
+        - remember_created_at
+        - current_sign_in_ip
+        - last_sign_in_ip
+        - username
+        - uid
+        - name
+        - school
+        - full_address
+        - confirmation_token
+        - confirmed_at
+        - confirmation_sent_at
+        - unconfirmed_email
+        - secret_picture_id
+        - hashed_email
+        - secret_words
+        - properties
+        - invitation_token
+        - invitation_created_at
+        - invitation_sent_at
+        - invitation_accepted_at
+        - invitation_limit
+        - invitation_by_id
+        - invitations_count
+        - parent_email
+        - unlock_token
+  - dashboard.user_geos:
+      remove_column:
+        - ip_address
+        - latitude
+        - longitude
+  - dashboard.teacher_profiles
+  - dashboard.studio_people:
+      remove_column: [emails]
+  - dashboard.sign_ins
 
 # All tables in this section are exported to the Redshift `dashboard_production_pii` schema. Sensitive data may be
 # exported to this schema, but should be limited to only columns that have an identified analytics purpose.
 cron-user-hierarchy-pii:
-- dashboard.studio_people
-- dashboard.teacher_profiles
-- dashboard.users:
-    remove_column:
+  - dashboard.studio_people
+  - dashboard.teacher_profiles
+  - dashboard.users:
+      remove_column:
         - encrypted_password
         - reset_password_token
         - secret_picture_id
         - secret_words
-- dashboard.user_geos
-- dashboard.user_school_infos
+  - dashboard.user_geos
+  - dashboard.user_school_infos
 
 # All tables in this section are exported to the Redshift `dashboard_production` schema. Do NOT export columns containing
 # sensitive data to this schema.
 cron-user-levels:
-- dashboard.user_levels
+  - dashboard.user_levels
 
 # All tables in this section are exported to the Redshift `dashboard_production_pii` schema. Sensitive data may be
 # exported to this schema, but should be limited to only columns that have an identified analytics purpose.
 cron-level-sources-pii:
-- dashboard.level_sources:
-    skip_staging_table: true
-    schedule: 'weekly'
+  - dashboard.level_sources:
+      skip_staging_table: true
+      schedule: "weekly"


### PR DESCRIPTION
We're deprecating the `user_level_evaluations` table in favor of a more flexible and comprehensive `student_work_evaluations` table. See https://github.com/code-dot-org/code-dot-org/pull/64942 

And we've added a new more generic feedbacks table, `ai_interactions_feedbacks`. See https://github.com/code-dot-org/code-dot-org/pull/64882

This PR adds both of those tables to the Redshift export so they will be available in Trevor and removes the old `user_level_evaluations` table. 
