### PR TITLE
Codebridge/Python Lab: fix file tab overflow issue

### DIFF
--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -4,7 +4,8 @@ import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {ProjectFile} from '@codebridge/types';
 import {getFileIconNameAndStyle} from '@codebridge/utils';
 import classNames from 'classnames';
-import React, {useEffect, useRef} from 'react';
+import {throttle} from 'lodash';
+import React, {useEffect, useMemo, useRef} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
@@ -26,11 +27,24 @@ const FileTab = ({file}: FileTabProps) => {
   });
   const tabRef = useRef<HTMLDivElement>(null);
 
+  const scrollTabIntoView = () =>
+    tabRef.current?.scrollIntoView({block: 'end', inline: 'start'});
+
+  const throttledScrollTabIntoView = useMemo(
+    () => throttle(scrollTabIntoView, 30),
+    []
+  );
+
   useEffect(() => {
     if (isActive) {
-      tabRef.current?.scrollIntoView({block: 'end', inline: 'start'});
+      scrollTabIntoView();
+      window.addEventListener('resize', throttledScrollTabIntoView);
+    } else {
+      window.removeEventListener('resize', throttledScrollTabIntoView);
     }
-  }, [isActive]);
+    return () =>
+      window.removeEventListener('resize', throttledScrollTabIntoView);
+  }, [isActive, throttledScrollTabIntoView]);
 
   return (
     <div className={className} key={file.id}>

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -4,7 +4,7 @@ import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {ProjectFile} from '@codebridge/types';
 import {getFileIconNameAndStyle} from '@codebridge/utils';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
@@ -24,12 +24,20 @@ const FileTab = ({file}: FileTabProps) => {
   const className = classNames(moduleStyles.fileTab, {
     [moduleStyles.active]: isActive,
   });
+  const tabRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isActive) {
+      tabRef.current?.scrollIntoView({block: 'end', inline: 'start'});
+    }
+  }, [isActive]);
 
   return (
     <div className={className} key={file.id}>
       <div
         className={moduleStyles.label}
         onClick={() => setActiveFile(file.id)}
+        ref={tabRef}
       >
         <FontAwesomeV6Icon
           iconName={iconName}

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -13,21 +13,6 @@
   font-size: 14px;
   font-weight: 600;
   color: $light_gray_100;
-
-  scrollbar-color: $light_gray_700 $light_black;
-  // webkit-scrollbar is only used by Safari. Chrome and Firefox use scrollbar-color.
-  ::-webkit-scrollbar {
-    background: $light_black;
-    width: 10px;
-    height: 10px;
-  }
-  ::-webkit-scrollbar-thumb {
-    background: $light_gray_600;
-    border-radius: 10px;
-  }
-  ::-webkit-scrollbar-corner {
-    background: $light_black;
-  }
 }
 
 .fileTab {

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -5,14 +5,29 @@
   justify-content: flex-start;
   gap: 6px;
   align-items: flex-end;
-  overflow-x: scroll;
+  overflow-x: auto;
   max-width: 100%;
   background-color: $light_gray_900;
-  scrollbar-width: none;
-  min-height: 32px;
+  scrollbar-width: thin;
+  box-sizing: border-box;
   font-size: 14px;
   font-weight: 600;
   color: $light_gray_100;
+
+  scrollbar-color: $light_gray_600 $light_black;
+  // webkit-scrollbar is only used by Safari. Chrome and Firefox use scrollbar-color.
+  ::-webkit-scrollbar {
+    background: $light_gray_950;
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: $light_gray_600;
+    border-radius: 10px;
+  }
+  ::-webkit-scrollbar-corner {
+    background: $light_gray_950;
+  }
 }
 
 .fileTab {

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -5,7 +5,7 @@
   justify-content: flex-start;
   gap: 6px;
   align-items: flex-end;
-  overflow-x: scroll;
+  overflow-x: auto;
   max-width: 100%;
   background-color: $light_gray_900;
   scrollbar-width: thin;
@@ -14,7 +14,7 @@
   font-weight: 600;
   color: $light_gray_100;
 
-  scrollbar-color: $light_gray_600 $light_black;
+  scrollbar-color: $light_gray_700 $light_black;
   // webkit-scrollbar is only used by Safari. Chrome and Firefox use scrollbar-color.
   ::-webkit-scrollbar {
     background: $light_black;

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -5,7 +5,7 @@
   justify-content: flex-start;
   gap: 6px;
   align-items: flex-end;
-  overflow-x: auto;
+  overflow-x: scroll;
   max-width: 100%;
   background-color: $light_gray_900;
   scrollbar-width: thin;
@@ -17,7 +17,7 @@
   scrollbar-color: $light_gray_600 $light_black;
   // webkit-scrollbar is only used by Safari. Chrome and Firefox use scrollbar-color.
   ::-webkit-scrollbar {
-    background: $light_gray_950;
+    background: $light_black;
     width: 10px;
     height: 10px;
   }
@@ -26,7 +26,7 @@
     border-radius: 10px;
   }
   ::-webkit-scrollbar-corner {
-    background: $light_gray_950;
+    background: $light_black;
   }
 }
 

--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -83,9 +83,7 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
           >
             <ToggleFileBrowserButton />
           </div>
-          <div>
-            <FileTabs />
-          </div>
+          <FileTabs />
 
           {config.showFileBrowser && <FileBrowser />}
 

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -36,7 +36,7 @@
 .workspaceWorkarea {
   display: grid;
   grid-template-columns: 34px auto;
-  grid-auto-rows: 32px 1fr auto;
+  grid-auto-rows: 40px 1fr auto;
   overflow: hidden;
   flex: 1;
 }

--- a/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
+++ b/apps/test/unit/codebridge/FileTabs/FileTabsTest.tsx
@@ -40,6 +40,10 @@ const context: CodebridgeContextType = {
   closeFile: jest.fn(),
 };
 
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+});
+
 describe('FileTabs', () => {
   function renderDefault() {
     render(


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Summary

Previously, if there were more file tabs than fit in the available workspace space, the tabs would overflow with no way to access them. This also had a bad side effect of making the editor the same width as the tabs, which meant it was overflowing and not scrolling vertically. This fixes both of these issues. Now when the tabs would overflow, a scroll bar appears. In addition, if you open a new tab/click a tab that's not currently visible, we scroll the tab header so you see the tab of the file you are currently viewing. 

## Screen Recordings
### Resizing the screen
https://github.com/user-attachments/assets/c64ae0fd-cf26-4323-808d-f226fbfb3f9d

### Adding/removing tabs
Tabs can be scrolled by using the mouse on the scrollbar, tabbing through the tabs, or using arrow keys while on the tabs. In the video I use the mouse and arrow keys

https://github.com/user-attachments/assets/e871aded-193a-40a7-87d3-8cf5672f2e0d

### Switching tabs

https://github.com/user-attachments/assets/02cd5f94-4f47-4b36-93b3-8013f23a3c5f


## Links

- jira ticket: [CT-1161](https://codedotorg.atlassian.net/browse/CT-1161)


## Testing story
Tested locally on Firefox and Chrome.

## Follow-up work
@hannahbergam has a vpat ticket [CT-1110](https://codedotorg.atlassian.net/browse/CT-1110) which relates to this work. She will follow up to ensure the scrolling is fully keyboard accessible.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
