### PR TITLE
[CMS-262] Use @use instead of @import in styles to prevent styles duplication

### DIFF
--- a/frontend/packages/component-library-styles/README.md
+++ b/frontend/packages/component-library-styles/README.md
@@ -54,8 +54,9 @@ yarn link @code-dot-org/component-library-styles
 To use it in your project:
 
 ```scss
-@import '@code-dot-org/component-library-styles/colors.scss';
-@import '@code-dot-org/component-library-styles/typography.module.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 ```
 
 ## Development

--- a/frontend/packages/component-library-styles/mixins.scss
+++ b/frontend/packages/component-library-styles/mixins.scss
@@ -1,11 +1,12 @@
 @use 'primitiveColors';
 @use 'colors';
 @use 'variables' as variables;
-@import 'font.scss';
+@use 'typography.module' as typography;
+@use 'font.scss' as font;
 
 // Typography - Label styles
 @mixin label-common {
-  @include main-font-semi-bold;
+  @include font.main-font-semi-bold;
   margin-bottom: 0.5rem;
 }
 
@@ -35,7 +36,7 @@
 
 // Typography - Link styles (Link Body styles)
 @mixin link-body-common {
-  @include main-font-semi-bold;
+  @include font.main-font-semi-bold;
   text-decoration: underline;
 }
 
@@ -65,7 +66,7 @@
 
 // Typography Button text styles
 @mixin button-text-common {
-  @include main-font-semi-bold;
+  @include font.main-font-semi-bold;
   margin-bottom: 0.5rem;
 }
 
@@ -101,19 +102,19 @@
 }
 
 @mixin field-helper-section-l {
-  @include body-two;
+  @include typography.body-two;
   margin-bottom: 0;
   gap: 0.375rem;
 }
 
 @mixin field-helper-section-m {
-  @include body-three;
+  @include typography.body-three;
   margin-bottom: 0;
   gap: 0.375rem;
 }
 
 @mixin field-helper-section-s {
-  @include body-four;
+  @include typography.body-four;
   margin-bottom: 0;
   gap: 0.25rem;
 }

--- a/frontend/packages/component-library-styles/typography.module.scss
+++ b/frontend/packages/component-library-styles/typography.module.scss
@@ -1,5 +1,5 @@
 @use 'colors.scss';
-@import 'font.scss';
+@use 'font.scss' as font;
 
 // Please note (!): Mixins and variables form this file are listed in README.MD. Please keep it up to date. (any update)
 // to this files should be reflected in README.MD file.
@@ -86,53 +86,53 @@ html {
 
 @mixin heading-xxl {
   @include heading-common;
-  font-family: $barlowSemiCondensed-semibold;
-  font-weight: $semi-bold-font-weight;
+  font-family: font.$barlowSemiCondensed-semibold;
+  font-weight: font.$semi-bold-font-weight;
   font-size: 3rem;
   line-height: 1.16;
 }
 
 @mixin heading-xl {
   @include heading-common;
-  font-family: $barlowSemiCondensed-semibold;
-  font-weight: $semi-bold-font-weight;
+  font-family: font.$barlowSemiCondensed-semibold;
+  font-weight: font.$semi-bold-font-weight;
   font-size: 2.125rem;
   line-height: 1.24;
 }
 
 @mixin heading-lg {
   @include heading-common;
-  font-family: $barlowSemiCondensed-semibold;
-  font-weight: $semi-bold-font-weight;
+  font-family: font.$barlowSemiCondensed-semibold;
+  font-weight: font.$semi-bold-font-weight;
   font-size: 1.75rem;
   line-height: 1.28;
 }
 
 @mixin heading-md {
   @include heading-common;
-  font-family: $barlowSemiCondensed-semibold;
-  font-weight: $semi-bold-font-weight;
+  font-family: font.$barlowSemiCondensed-semibold;
+  font-weight: font.$semi-bold-font-weight;
   font-size: 1.5rem;
   line-height: 1.32;
 }
 
 @mixin heading-sm {
   @include heading-common;
-  @include main-font-semi-bold;
+  @include font.main-font-semi-bold;
   font-size: 1.25rem;
   line-height: 1.4;
 }
 
 @mixin heading-xs {
   @include heading-common;
-  @include main-font-semi-bold;
+  @include font.main-font-semi-bold;
   font-size: 1rem;
   line-height: 1.48;
 }
 
 // Paragraph styles
 @mixin paragraph-common {
-  @include main-font-regular;
+  @include font.main-font-regular;
   color: var(--text-neutral-primary);
   margin-bottom: 1em;
 }
@@ -164,7 +164,7 @@ html {
 // Overline styles
 @mixin overline-common {
   @include paragraph-common;
-  @include main-font-semi-bold;
+  @include font.main-font-semi-bold;
   text-transform: uppercase;
   letter-spacing: 0.04rem;
 }
@@ -189,11 +189,11 @@ html {
 
 // Strong and Em styles
 @mixin strong {
-  font-weight: $semi-bold-font-weight;
+  font-weight: font.$semi-bold-font-weight;
 }
 
 @mixin extra-strong {
-  font-weight: $bold-font-weight;
+  font-weight: font.$bold-font-weight;
 }
 
 @mixin em {
@@ -202,7 +202,7 @@ html {
 
 // Caption styles
 @mixin figcaption {
-  @include main-font-semi-bold;
+  @include font.main-font-semi-bold;
   color: var(--text-neutral-primary);
   font-size: 0.875rem;
   line-height: 1.54;

--- a/frontend/packages/component-library/src/accordion/accordion.module.scss
+++ b/frontend/packages/component-library/src/accordion/accordion.module.scss
@@ -1,6 +1,6 @@
-@import '@code-dot-org/component-library-styles/colors.scss';
-@import '@code-dot-org/component-library-styles/mixins.scss';
-@import '@code-dot-org/component-library-styles/variables.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
+@use '@code-dot-org/component-library-styles/variables.scss' as variables;
 
 // Accordion common styles
 .accordion {
@@ -17,7 +17,7 @@
     width: 100%;
     overflow: hidden;
 
-    border-radius: $regular-border-radius;
+    border-radius: variables.$regular-border-radius;
     border: 1px solid var(--borders-neutral-primary);
     background: var(--background-neutral-secondary);
 
@@ -31,7 +31,7 @@
       background: var(--background-neutral-primary);
 
       i {
-        @include transition-all;
+        @include mixins.transition-all;
         color: var(--text-neutral-placeholder);
       }
 
@@ -74,7 +74,7 @@
     }
 
     &:has(summary:focus-visible) {
-      @include focus-styles;
+      @include mixins.focus-styles;
       summary {
         outline: none;
       }

--- a/frontend/packages/component-library/src/breadcrumbs/breadcrumbs.module.scss
+++ b/frontend/packages/component-library/src/breadcrumbs/breadcrumbs.module.scss
@@ -1,6 +1,4 @@
-@import '@code-dot-org/component-library-styles/font.scss';
-@import '@code-dot-org/component-library-styles/mixins.scss';
-@import '@code-dot-org/component-library-styles/typography.module.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 
 // Breadcrumbs common styles
 .breadcrumbs {
@@ -62,7 +60,7 @@
 // Breadcrumbs sizes
 .breadcrumbs-l {
   .breadcrumb {
-    @include label-one;
+    @include mixins.label-one;
     margin: 0;
 
     .homeIcon {
@@ -80,7 +78,7 @@
 
 .breadcrumbs-m {
   .breadcrumb {
-    @include label-two;
+    @include mixins.label-two;
     margin: 0;
 
     .homeIcon {
@@ -98,7 +96,7 @@
 
 .breadcrumbs-s {
   .breadcrumb {
-    @include label-three;
+    @include mixins.label-three;
     margin: 0;
 
     .homeIcon {
@@ -116,7 +114,7 @@
 
 .breadcrumbs-xs {
   .breadcrumb {
-    @include label-four;
+    @include mixins.label-four;
     margin: 0;
 
     .homeIcon {

--- a/frontend/packages/component-library/src/button/_baseButton.module.scss
+++ b/frontend/packages/component-library/src/button/_baseButton.module.scss
@@ -1,5 +1,5 @@
 @use '@code-dot-org/component-library-styles/colors';
-@import '@code-dot-org/component-library-styles/mixins.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 
 // Button common styles
 .button,
@@ -370,7 +370,7 @@ a.button-l {
   gap: 0.5rem;
 
   span {
-    @include button-one-text;
+    @include mixins.button-one-text;
     margin: 1px 0 0;
   }
 
@@ -392,7 +392,7 @@ a.button-m {
   gap: 0.5rem;
 
   span {
-    @include button-two-text;
+    @include mixins.button-two-text;
     margin: 1px 0 0;
   }
 
@@ -414,7 +414,7 @@ a.button-s {
   gap: 0.5rem;
 
   span {
-    @include button-three-text;
+    @include mixins.button-three-text;
     margin: 1px 0 0;
   }
 
@@ -436,7 +436,7 @@ a.button-xs {
   gap: 0.25rem;
 
   span {
-    @include button-four-text;
+    @include mixins.button-four-text;
     margin: 1px 0 0;
   }
 

--- a/frontend/packages/component-library/src/checkbox/checkbox.module.scss
+++ b/frontend/packages/component-library/src/checkbox/checkbox.module.scss
@@ -1,4 +1,4 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
 
 // Checkbox common styles
 .label {

--- a/frontend/packages/component-library/src/chips/chip.module.scss
+++ b/frontend/packages/component-library/src/chips/chip.module.scss
@@ -1,7 +1,7 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
-@import '@code-dot-org/component-library-styles/font.scss';
-@import '@code-dot-org/component-library-styles/mixins.scss';
-@import '@code-dot-org/component-library-styles/typography.module.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 
 // Chips common styles
 .chips {
@@ -126,72 +126,72 @@
 // Chips sizes
 .chips-l {
   .groupLabel {
-    @include label-one;
+    @include mixins.label-one;
   }
 
   .chip {
     padding: calc(0.62rem + 2px) 1.25rem 0.62rem;
 
     &.chip-thick {
-      @include button-one-text;
+      @include mixins.button-one-text;
     }
 
     &.chip-thin {
-      @include body-one;
+      @include typography.body-one;
     }
   }
 }
 
 .chips-m {
   .groupLabel {
-    @include label-two;
+    @include mixins.label-two;
   }
 
   .chip {
     padding: calc(0.5rem + 2px) 1rem 0.5rem;
 
     &.chip-thick {
-      @include button-two-text;
+      @include mixins.button-two-text;
     }
 
     &.chip-thin {
-      @include body-two;
+      @include typography.body-two;
     }
   }
 }
 
 .chips-s {
   .groupLabel {
-    @include label-three;
+    @include mixins.label-three;
   }
 
   .chip {
     padding: calc(0.31rem + 1px) 0.75rem 0.31rem;
 
     &.chip-thick {
-      @include button-three-text;
+      @include mixins.button-three-text;
     }
 
     &.chip-thin {
-      @include body-three;
+      @include typography.body-three;
     }
   }
 }
 
 .chips-xs {
   .groupLabel {
-    @include label-four;
+    @include mixins.label-four;
   }
 
   .chip {
     padding: calc(0.12rem + 1px) 0.5rem 0.12rem;
 
     &.chip-thick {
-      @include button-four-text;
+      @include mixins.button-four-text;
     }
 
     &.chip-thin {
-      @include body-four;
+      @include typography.body-four;
     }
   }
 }

--- a/frontend/packages/component-library/src/closeButton/closeButton.module.scss
+++ b/frontend/packages/component-library/src/closeButton/closeButton.module.scss
@@ -1,5 +1,4 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
-@import '@code-dot-org/component-library-styles/mixins.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
 
 // Close Button common styles
 .closeButton {

--- a/frontend/packages/component-library/src/cms/section/section.module.scss
+++ b/frontend/packages/component-library/src/cms/section/section.module.scss
@@ -1,4 +1,4 @@
-@import '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
 
 // Section common styles
 .section {

--- a/frontend/packages/component-library/src/common/README.md
+++ b/frontend/packages/component-library/src/common/README.md
@@ -1,39 +1,11 @@
 # `dsco/common`
 
-This package contains all ComponentLibrary (DSCO) common design constants, tokens, and styles. These are made available
-as `.scss, .ts` files.
-
-**Notes:**
-
-- The [`@use`](https://sass-lang.com/documentation/at-rules/use) Sass feature is only available for Dart Sass. If you
-  are using a different Sass implementation, replace `@use` with [
-  `@import`](https://sass-lang.com/documentation/at-rules/import). Internally, this package uses `@import` to maintain
-  compatibility with all Sass implementations.
-- The import paths below use the "exports" field in `package.json`, which is a feature only available to Webpack 5+
-  consumers. If you use Webpack 4 or below, you should import this package as `@cdo/apps/componentLibrary/common` (which
-  corresponds to the "main" field in `package.json`), or point to a specific file in the package (e.g.,
-  `@code-dot-org/dsco/common/styles/mixins`).
-
-### SCSS
-
-## [mixins](styles/mixins.scss)
-
-Common mixins.
-
-Usage example:
-
-```scss
-@import '@code-dot-org/dsco/common/styles/mixins';
-
-.custom-link-text {
-  @include link-body-three; // (include mixin styles)
-  font-weight: 400; // override mixin / add custom styles
-}
-```
+This package contains all ComponentLibrary (DSCO) common helpers, types, functions, logic, etc. These are made available
+as `.ts, .tsx` files.
 
 ### TypeScript
 
-## [constants](constants.ts)
+## [constants](constants)
 
 Common constants.
 
@@ -45,18 +17,25 @@ import {componentSizeToBodyTextSizeMap} from '@code-dot-org/dsco/common/constant
 const bodyTextSize = componentSizeToBodyTextSizeMap[size];
 ```
 
-## [types](types.ts)
+## [contexts](contexts)
 
-Common types.
+Common contexts.
+
+```tsx
+import {DropdownContext} from '@code-dot-org/dsco/common/contexts';
+// ...
+
+<DropdownContext.Provider value={dropdownContextValue}>
+  {children}
+</DropdownContext.Provider>;
+```
+
+## [helpers](helpers)
+
+Common helpers.
 
 ```ts
-import {ComponentSizeXSToL} from '@code-dot-org/dsco/common/types';
-// ...
-// ...
-// ...
-type ComponentProps = {
-  size?: ComponentSizeXSToL;
-};
+import {updatePositionedElementStyles} from '@code-dot-org/dsco/common/helpers';
 ```
 
 ## [hooks](hooks)
@@ -74,15 +53,16 @@ import useBodyScrollLock from '@code-dot-org/dsco/common/hooks/useBodyScrollLock
 useBodyScrollLock();
 ```
 
-## [contexts](contexts)
+## [types](types)
 
-Common contexts.
+Common types.
 
-```tsx
-import {DropdownContext} from '@code-dot-org/dsco/common/contexts';
+```ts
+import {ComponentSizeXSToL} from '@code-dot-org/dsco/common/types';
 // ...
-
-<DropdownContext.Provider value={dropdownContextValue}>
-  {children}
-</DropdownContext.Provider>;
+// ...
+// ...
+type ComponentProps = {
+  size?: ComponentSizeXSToL;
+};
 ```

--- a/frontend/packages/component-library/src/dialog/customDialog.module.scss
+++ b/frontend/packages/component-library/src/dialog/customDialog.module.scss
@@ -1,4 +1,4 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
 
 .customDialogOverlay {
   position: fixed;

--- a/frontend/packages/component-library/src/dialog/dialog.module.scss
+++ b/frontend/packages/component-library/src/dialog/dialog.module.scss
@@ -1,4 +1,4 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
 
 // Common dialog styles
 .dialog {

--- a/frontend/packages/component-library/src/divider/divider.module.scss
+++ b/frontend/packages/component-library/src/divider/divider.module.scss
@@ -1,4 +1,4 @@
-@import '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
 
 // Divider common styles
 .divider {

--- a/frontend/packages/component-library/src/dropdown/customDropdown.module.scss
+++ b/frontend/packages/component-library/src/dropdown/customDropdown.module.scss
@@ -1,7 +1,8 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
-@import '@code-dot-org/component-library-styles/variables.scss';
-@import '@code-dot-org/component-library-styles/mixins.scss';
-@import '@code-dot-org/component-library-styles/typography.module.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/variables.scss' as variables;
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 
 // Dropdown common styles
 .dropdownContainer {
@@ -10,7 +11,7 @@
   margin: 0;
 
   &.styleAsFormField {
-    width: $form-field-width;
+    width: variables.$form-field-width;
     text-wrap: nowrap;
     text-overflow: ellipsis;
 
@@ -72,7 +73,7 @@
   }
 
   .helperSection {
-    @include field-helper-section-common;
+    @include mixins.field-helper-section-common;
     margin-top: 0.125rem;
   }
 
@@ -251,12 +252,12 @@
   }
 
   .helperSection {
-    @include field-helper-section-black;
+    @include mixins.field-helper-section-black;
   }
 
   &.hasError {
     .errorSection {
-      @include field-error-section-black;
+      @include mixins.field-error-section-black;
     }
 
     .dropdownButton {
@@ -301,22 +302,22 @@
 
     .helperSection,
     .errorSection {
-      @include field-helper-section-black-disabled;
+      @include mixins.field-helper-section-black-disabled;
     }
   }
 
   &.readOnly {
     .dropdownButton:disabled {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
 
       .dropdownLabel {
-        @include field-read-only-black-colors;
+        @include mixins.field-read-only-black-colors;
       }
     }
 
     .helperSection,
     .errorSection {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
     }
   }
 }
@@ -327,11 +328,11 @@
   }
 
   .helperSection {
-    @include field-helper-section-black;
+    @include mixins.field-helper-section-black;
   }
 
   &.hasError .errorSection {
-    @include field-error-section-black;
+    @include mixins.field-error-section-black;
   }
 
   .dropdownButton {
@@ -372,22 +373,22 @@
 
     .helperSection,
     .errorSection {
-      @include field-helper-section-black-disabled;
+      @include mixins.field-helper-section-black-disabled;
     }
   }
 
   &.readOnly {
     .dropdownButton:disabled {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
 
       .dropdownLabel {
-        @include field-read-only-black-colors;
+        @include mixins.field-read-only-black-colors;
       }
     }
 
     .helperSection,
     .errorSection {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
     }
   }
 }
@@ -398,12 +399,12 @@
   }
 
   .helperSection {
-    @include field-helper-section-white;
+    @include mixins.field-helper-section-white;
   }
 
   &.hasError {
     .errorSection {
-      @include field-error-section-black;
+      @include mixins.field-error-section-black;
     }
 
     .dropdownButton {
@@ -448,22 +449,22 @@
 
     .helperSection,
     .errorSection {
-      @include field-helper-section-white-disabled;
+      @include mixins.field-helper-section-white-disabled;
     }
   }
 
   &.readOnly {
     .dropdownButton:disabled {
-      @include field-read-only-white-colors;
+      @include mixins.field-read-only-white-colors;
 
       .dropdownLabel {
-        @include field-read-only-white-colors;
+        @include mixins.field-read-only-white-colors;
       }
     }
 
     .helperSection,
     .errorSection {
-      @include field-read-only-white-colors;
+      @include mixins.field-read-only-white-colors;
     }
   }
 }
@@ -471,22 +472,22 @@
 // Sizes
 .dropdownContainer-l {
   .dropdownFieldLabel {
-    @include label-one;
+    @include mixins.label-one;
     margin-bottom: 0.125rem;
   }
 
   .dropdownLabel-thick {
-    @include button-one-text;
+    @include mixins.button-one-text;
     margin-bottom: 0;
   }
 
   .dropdownLabel-thin {
-    @include body-one;
+    @include typography.body-one;
     margin-bottom: 0;
   }
 
   .dropdownButton {
-    @include button-one-text;
+    @include mixins.button-one-text;
     height: 3rem;
     padding: 0.625rem 1rem;
     margin-bottom: 0;
@@ -499,7 +500,7 @@
   }
 
   .helperSection {
-    @include field-helper-section-l;
+    @include mixins.field-helper-section-l;
   }
 
   .dropdownMenuContainer {
@@ -519,7 +520,7 @@
           }
 
           span {
-            @include body-one;
+            @include typography.body-one;
             color: inherit;
             margin-bottom: 0;
           }
@@ -531,22 +532,22 @@
 
 .dropdownContainer-m {
   .dropdownFieldLabel {
-    @include label-two;
+    @include mixins.label-two;
     margin-bottom: 0.125rem;
   }
 
   .dropdownLabel-thick {
-    @include button-two-text;
+    @include mixins.button-two-text;
     margin-bottom: 0;
   }
 
   .dropdownLabel-thin {
-    @include body-two;
+    @include typography.body-two;
     margin-bottom: 0;
   }
 
   .dropdownButton {
-    @include button-two-text;
+    @include mixins.button-two-text;
     height: 2.5rem;
     padding: 0.5rem 1rem;
     margin-bottom: 0;
@@ -559,7 +560,7 @@
   }
 
   .helperSection {
-    @include field-helper-section-m;
+    @include mixins.field-helper-section-m;
   }
 
   .dropdownMenuContainer {
@@ -579,7 +580,7 @@
           }
 
           span {
-            @include body-two;
+            @include typography.body-two;
             color: inherit;
             margin-bottom: 0;
           }
@@ -591,22 +592,22 @@
 
 .dropdownContainer-s {
   .dropdownFieldLabel {
-    @include label-three;
+    @include mixins.label-three;
     margin-bottom: 0.125rem;
   }
 
   .dropdownLabel-thick {
-    @include button-three-text;
+    @include mixins.button-three-text;
     margin-bottom: 0;
   }
 
   .dropdownLabel-thin {
-    @include body-three;
+    @include typography.body-three;
     margin-bottom: 0;
   }
 
   .dropdownButton {
-    @include button-three-text;
+    @include mixins.button-three-text;
     height: 2rem;
     padding: 0.3125rem 1rem;
     margin-bottom: 0;
@@ -619,7 +620,7 @@
   }
 
   .helperSection {
-    @include field-helper-section-s;
+    @include mixins.field-helper-section-s;
   }
 
   .dropdownMenuContainer {
@@ -639,7 +640,7 @@
           }
 
           span {
-            @include body-three;
+            @include typography.body-three;
             color: inherit;
             margin-bottom: 0;
           }
@@ -651,22 +652,22 @@
 
 .dropdownContainer-xs {
   .dropdownFieldLabel {
-    @include label-four;
+    @include mixins.label-four;
     margin-bottom: 0.125rem;
   }
 
   .dropdownLabel-thick {
-    @include button-four-text;
+    @include mixins.button-four-text;
     margin-bottom: 0;
   }
 
   .dropdownLabel-thin {
-    @include body-four;
+    @include typography.body-four;
     margin-bottom: 0;
   }
 
   .dropdownButton {
-    @include button-four-text;
+    @include mixins.button-four-text;
     height: 1.5rem;
     padding: 0.125rem 0.5rem;
     margin-bottom: 0;
@@ -695,7 +696,7 @@
           }
 
           span {
-            @include body-four;
+            @include typography.body-four;
             color: inherit;
             margin-bottom: 0;
           }

--- a/frontend/packages/component-library/src/dropdown/simpleDropdown/simpleDropdown.module.scss
+++ b/frontend/packages/component-library/src/dropdown/simpleDropdown/simpleDropdown.module.scss
@@ -1,7 +1,8 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
-@import '@code-dot-org/component-library-styles/variables.scss';
-@import '@code-dot-org/component-library-styles/mixins.scss';
-@import '@code-dot-org/component-library-styles/typography.module.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/variables.scss' as variables;
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 
 // Dropdown common styles
 .dropdownContainer {
@@ -13,7 +14,7 @@
   margin: 0;
 
   &.styleAsFormField {
-    width: $form-field-width;
+    width: variables.$form-field-width;
     text-wrap: nowrap;
     text-overflow: ellipsis;
 
@@ -157,16 +158,16 @@
 
   &:has(select.readOnly) {
     select {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
     }
 
     .dropdownArrowDiv:after {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
     }
 
     .helperSection,
     .errorSection {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
     }
   }
 }
@@ -237,16 +238,16 @@
 
   &:has(select.readOnly) {
     select {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
     }
 
     .dropdownArrowDiv:after {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
     }
 
     .helperSection,
     .errorSection {
-      @include field-read-only-black-colors;
+      @include mixins.field-read-only-black-colors;
     }
   }
 }
@@ -311,16 +312,16 @@
 
   &:has(select.readOnly) {
     select {
-      @include field-read-only-white-colors;
+      @include mixins.field-read-only-white-colors;
     }
 
     .dropdownArrowDiv:after {
-      @include field-read-only-white-colors;
+      @include mixins.field-read-only-white-colors;
     }
 
     .helperSection,
     .errorSection {
-      @include field-read-only-white-colors;
+      @include mixins.field-read-only-white-colors;
     }
   }
 }
@@ -329,20 +330,20 @@
 .dropdownContainer-l {
   &.dropdownContainer-thick {
     select {
-      @include button-one-text;
+      @include mixins.button-one-text;
       margin-bottom: 0;
     }
   }
 
   &.dropdownContainer-thin {
     select {
-      @include body-one;
+      @include typography.body-one;
       margin-bottom: 0;
     }
   }
 
   .dropdownLabel {
-    @include label-one;
+    @include mixins.label-one;
     margin-bottom: 0;
   }
 
@@ -377,7 +378,7 @@
   }
 
   .helperSection {
-    @include body-two;
+    @include typography.body-two;
     margin-bottom: 0;
     gap: 0.375rem;
 
@@ -390,21 +391,21 @@
 .dropdownContainer-m {
   &.dropdownContainer-thick {
     select {
-      @include button-two-text;
+      @include mixins.button-two-text;
       margin-bottom: 0;
     }
   }
 
   &.dropdownContainer-thin {
     select {
-      @include body-two;
+      @include typography.body-two;
       color: inherit;
       margin-bottom: 0;
     }
   }
 
   .dropdownLabel {
-    @include label-two;
+    @include mixins.label-two;
     margin-bottom: 0;
   }
 
@@ -439,7 +440,7 @@
   }
 
   .helperSection {
-    @include body-three;
+    @include typography.body-three;
     margin-bottom: 0;
     gap: 0.375rem;
 
@@ -452,20 +453,20 @@
 .dropdownContainer-s {
   &.dropdownContainer-thick {
     select {
-      @include button-three-text;
+      @include mixins.button-three-text;
       margin-bottom: 0;
     }
   }
 
   &.dropdownContainer-thin {
     select {
-      @include body-three;
+      @include typography.body-three;
       margin-bottom: 0;
     }
   }
 
   .dropdownLabel {
-    @include label-three;
+    @include mixins.label-three;
     margin-bottom: 0;
   }
 
@@ -500,7 +501,7 @@
   }
 
   .helperSection {
-    @include body-four;
+    @include typography.body-four;
     margin-bottom: 0;
     gap: 0.25rem;
 
@@ -513,20 +514,20 @@
 .dropdownContainer-xs {
   &.dropdownContainer-thick {
     select {
-      @include button-four-text;
+      @include mixins.button-four-text;
       margin-bottom: 0;
     }
   }
 
   &.dropdownContainer-thin {
     select {
-      @include body-four;
+      @include typography.body-four;
       margin-bottom: 0;
     }
   }
 
   .dropdownLabel {
-    @include label-four;
+    @include mixins.label-four;
     margin-bottom: 0;
   }
 
@@ -561,7 +562,7 @@
   }
 
   .helperSection {
-    @include body-four;
+    @include typography.body-four;
     margin-bottom: 0;
     gap: 0.25rem;
 

--- a/frontend/packages/component-library/src/formFieldWrapper/formFieldWrapper.module.scss
+++ b/frontend/packages/component-library/src/formFieldWrapper/formFieldWrapper.module.scss
@@ -1,7 +1,8 @@
-@import '@code-dot-org/component-library-styles/mixins.scss';
-@import '@code-dot-org/component-library-styles/colors.scss';
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
-@import '@code-dot-org/component-library-styles/typography.module.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 
 // FromFieldWrapper common styles
 .formFieldWrapper {
@@ -76,12 +77,12 @@
 .formFieldWrapper-size {
   &-l {
     .formFieldWrapperLabel {
-      @include label-one;
+      @include mixins.label-one;
       margin-bottom: 0;
     }
 
     .formFieldWrapperHelper {
-      @include body-two;
+      @include typography.body-two;
       margin-bottom: 0;
       gap: 0.375rem;
     }
@@ -89,12 +90,12 @@
 
   &-m {
     .formFieldWrapperLabel {
-      @include label-two;
+      @include mixins.label-two;
       margin-bottom: 0;
     }
 
     .formFieldWrapperHelper {
-      @include body-three;
+      @include typography.body-three;
       margin-bottom: 0;
       gap: 0.375rem;
     }
@@ -102,12 +103,12 @@
 
   &-s {
     .formFieldWrapperLabel {
-      @include label-three;
+      @include mixins.label-three;
       margin-bottom: 0;
     }
 
     .formFieldWrapperHelper {
-      @include body-four;
+      @include typography.body-four;
       margin-bottom: 0;
       gap: 0.25rem;
     }

--- a/frontend/packages/component-library/src/image/image.module.scss
+++ b/frontend/packages/component-library/src/image/image.module.scss
@@ -1,5 +1,5 @@
-@import '@code-dot-org/component-library-styles/colors.scss';
-@import '@code-dot-org/component-library-styles/variables.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/variables.scss' as variables;
 
 .figureContainer {
   position: relative;
@@ -7,7 +7,7 @@
   height: 100%;
   overflow: hidden;
   margin: 0;
-  border-radius: $regular-border-radius;
+  border-radius: variables.$regular-border-radius;
 }
 
 // Image common styles

--- a/frontend/packages/component-library/src/link/link.module.scss
+++ b/frontend/packages/component-library/src/link/link.module.scss
@@ -1,5 +1,5 @@
 @use '@code-dot-org/component-library-styles/colors';
-@import '@code-dot-org/component-library-styles/mixins.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 
 // Link common styles
 .link {
@@ -55,17 +55,17 @@
 
 // Sizes
 .link-l {
-  @include link-body-one;
+  @include mixins.link-body-one;
 }
 
 .link-m {
-  @include link-body-two;
+  @include mixins.link-body-two;
 }
 
 .link-s {
-  @include link-body-three;
+  @include mixins.link-body-three;
 }
 
 .link-xs {
-  @include link-body-four;
+  @include mixins.link-body-four;
 }

--- a/frontend/packages/component-library/src/modal/modal.module.scss
+++ b/frontend/packages/component-library/src/modal/modal.module.scss
@@ -1,4 +1,4 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
 
 // Common Modal styles
 .modal {

--- a/frontend/packages/component-library/src/popover/popover.module.scss
+++ b/frontend/packages/component-library/src/popover/popover.module.scss
@@ -1,6 +1,4 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
-@import '@code-dot-org/component-library-styles/font.scss';
-@import '@code-dot-org/component-library-styles/mixins.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
 
 /*
 Popover classNames structure:

--- a/frontend/packages/component-library/src/radioButton/radioButton.module.scss
+++ b/frontend/packages/component-library/src/radioButton/radioButton.module.scss
@@ -1,4 +1,4 @@
-@import '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
 
 .radioButton {
   display: flex;

--- a/frontend/packages/component-library/src/segmentedButtons/segmentedButtons.module.scss
+++ b/frontend/packages/component-library/src/segmentedButtons/segmentedButtons.module.scss
@@ -1,5 +1,5 @@
-@import '@code-dot-org/component-library-styles/mixins.scss';
-@import '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 
 .segmentedButtons {
   display: flex;
@@ -159,7 +159,7 @@
 
   .segmentedButton {
     span {
-      @include button-one-text;
+      @include mixins.button-one-text;
       margin-bottom: 0;
       // Margin-top for correct vertical alignment of the metropolis font
       margin-top: 1px;
@@ -190,7 +190,7 @@
 
   .segmentedButton {
     span {
-      @include button-two-text;
+      @include mixins.button-two-text;
       margin-bottom: 0;
       // Margin-top for correct vertical alignment of the metropolis font
       margin-top: 1px;
@@ -221,7 +221,7 @@
 
   .segmentedButton {
     span {
-      @include button-three-text;
+      @include mixins.button-three-text;
       margin-bottom: 0;
       // Margin-top for correct vertical alignment of the metropolis font
       margin-top: 1px;
@@ -252,7 +252,7 @@
 
   .segmentedButton {
     span {
-      @include button-four-text;
+      @include mixins.button-four-text;
       margin-bottom: 0;
 
       // Margin-top for correct vertical alignment of the metropolis font

--- a/frontend/packages/component-library/src/slider/slider.module.scss
+++ b/frontend/packages/component-library/src/slider/slider.module.scss
@@ -1,6 +1,6 @@
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
-@import '@code-dot-org/component-library-styles/colors.scss';
-@import '@code-dot-org/component-library-styles/mixins.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 
 //Slider colors for use in JSX/TSX
 $slider-black-track-fill-color: var(--background-neutral-primary-inverse);
@@ -51,7 +51,7 @@ $slider-aqua-track-disabled-color: var(--background-neutral-disabled);
   align-self: stretch;
 
   .sliderLabel {
-    @include label-two;
+    @include mixins.label-two;
     flex: 1;
     margin-bottom: 0;
   }

--- a/frontend/packages/component-library/src/tabs/tabs.module.scss
+++ b/frontend/packages/component-library/src/tabs/tabs.module.scss
@@ -2,8 +2,7 @@
 @use '@code-dot-org/component-library-styles/primitiveColors.scss';
 @use '@code-dot-org/component-library-styles/colors.scss';
 @use '@code-dot-org/component-library-styles/variables' as variables;
-@import '@code-dot-org/component-library-styles/font.scss';
-@import '@code-dot-org/component-library-styles/mixins.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 
 .tabs {
   ul {
@@ -307,7 +306,7 @@
     }
 
     &:focus-visible {
-      @include focus-styles;
+      @include mixins.focus-styles;
     }
 
     &:active:not(:disabled, .selectedTab) {
@@ -343,7 +342,7 @@
       gap: 1rem;
 
       li button[role='tab'] {
-        @include button-one-text;
+        @include mixins.button-one-text;
         margin: 0;
         padding: 0.625rem 0;
         gap: 0.5rem;
@@ -367,7 +366,7 @@
       gap: 0.25rem;
 
       li button[role='tab'] {
-        @include label-one;
+        @include mixins.label-one;
         margin: 0;
         padding: 0 0.75rem;
         gap: 0.375rem;
@@ -431,7 +430,7 @@
       gap: 1rem;
 
       li button[role='tab'] {
-        @include button-two-text;
+        @include mixins.button-two-text;
         margin: 0;
         padding: 0.5rem 0;
         gap: 0.5rem;
@@ -455,7 +454,7 @@
       gap: 0.25rem;
 
       li button[role='tab'] {
-        @include label-two;
+        @include mixins.label-two;
         margin: 0;
         padding: 0 0.75rem;
         gap: 0.375rem;
@@ -518,7 +517,7 @@
       gap: 1rem;
 
       li button[role='tab'] {
-        @include button-three-text;
+        @include mixins.button-three-text;
         margin: 0;
         padding: 0.3125rem 0;
         gap: 0.375rem;
@@ -542,7 +541,7 @@
       gap: 0.125rem;
 
       li button[role='tab'] {
-        @include label-three;
+        @include mixins.label-three;
         margin: 0;
         padding: 0 0.625rem;
         gap: 0.25rem;
@@ -608,7 +607,7 @@
       gap: 0.5rem;
 
       li button[role='tab'] {
-        @include button-four-text;
+        @include mixins.button-four-text;
         margin: 0;
         padding: 0.0625rem 0;
         gap: 0.375rem;
@@ -632,7 +631,7 @@
       gap: 0.125rem;
 
       li button[role='tab'] {
-        @include label-four;
+        @include mixins.label-four;
         margin: 0;
         padding: 0 0.5rem;
         gap: 0.25rem;

--- a/frontend/packages/component-library/src/textField/textfield.module.scss
+++ b/frontend/packages/component-library/src/textField/textfield.module.scss
@@ -1,7 +1,8 @@
-@import '@code-dot-org/component-library-styles/mixins.scss';
-@import '@code-dot-org/component-library-styles/colors.scss';
-@import '@code-dot-org/component-library-styles/primitiveColors.scss';
-@import '@code-dot-org/component-library-styles/typography.module.scss';
+@use '@code-dot-org/component-library-styles/primitiveColors.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 
 // TextField common styles
 .textField {
@@ -20,7 +21,7 @@
     }
 
     &:focus-visible {
-      @include focus-styles;
+      @include mixins.focus-styles;
     }
   }
 }
@@ -106,7 +107,7 @@
 .textField-size {
   &-l {
     input {
-      @include body-one;
+      @include typography.body-one;
       padding: 0.625rem 0.875rem;
       margin-bottom: 0;
     }
@@ -114,7 +115,7 @@
 
   &-m {
     input {
-      @include body-two;
+      @include typography.body-two;
       padding: 0.5rem 0.75rem;
       margin-bottom: 0;
 
@@ -126,7 +127,7 @@
 
   &-s {
     input {
-      @include body-three;
+      @include typography.body-three;
       padding: 0.3125rem 0.625rem;
       margin-bottom: 0;
 

--- a/frontend/packages/component-library/src/toggle/toggle.module.scss
+++ b/frontend/packages/component-library/src/toggle/toggle.module.scss
@@ -1,4 +1,4 @@
-@import '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
 
 .toggle {
   display: flex;

--- a/frontend/packages/component-library/src/tooltip/tooltip.module.scss
+++ b/frontend/packages/component-library/src/tooltip/tooltip.module.scss
@@ -1,5 +1,6 @@
-@import '@code-dot-org/component-library-styles/colors.scss';
-@import '@code-dot-org/component-library-styles/typography.module.scss';
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 
 $tooltip-background-color: var(--background-neutral-primary-inverse);
 $tail-offset: 4px;
@@ -134,7 +135,7 @@ $tooltip-span-vertical-top-spacing: 2px;
   gap: 0.375rem;
 
   span {
-    @include body-one;
+    @include typography.body-one;
     margin-top: $tooltip-span-vertical-top-spacing;
     margin-bottom: 0;
   }
@@ -153,7 +154,7 @@ $tooltip-span-vertical-top-spacing: 2px;
   gap: 0.25rem;
 
   span {
-    @include body-two;
+    @include typography.body-two;
     margin-top: $tooltip-span-vertical-top-spacing;
     margin-bottom: 0;
   }
@@ -172,7 +173,7 @@ $tooltip-span-vertical-top-spacing: 2px;
   gap: 0.25rem;
 
   span {
-    @include body-three;
+    @include typography.body-three;
     margin-top: $tooltip-span-vertical-top-spacing;
     margin-bottom: 0;
   }
@@ -191,7 +192,7 @@ $tooltip-span-vertical-top-spacing: 2px;
   gap: 0.25rem;
 
   span {
-    @include body-four;
+    @include typography.body-four;
     margin-top: $tooltip-span-vertical-top-spacing;
     margin-bottom: 0;
   }


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

### [CMS-262] Use @use instead of @import in styles to prevent styles duplication

This PR simply replace uses of deprecated `@import` statements with modern `@use` statement which prevents duplicates. Keep in mind, for some reason, might be related to how we build styles in package, some duplicates of styles are still present, but there're significantly less duplicates then before.

This PR results in more then 4 time less duplicates of common styles. Which should give significant boost to all our consumers.

I've tested this on [Hero Banner story](https://code-dot-org.github.io/code-dot-org/component-library-storybook/?path=/story/cms-herobanner--with-partner-and-cta), before this update there were 35(!) copies of primitiveColors.scss, after this update there are only(lol) 8 copies of primitiveColors.scss.

It should be possible to get rid of duplicates completely, but that would probably be more complicated then this quick update.

* [feat(common/Readme): update common folder documentation](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/de527a17507132d8528a432d50511f49daacdac3)

feat: use `@use` instead of `@import` in scss to prevent styles duplication:
* [feat(toggle): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/9ca6f850b7d218c7b9a09052082dcca33176134e)
* [feat(tooltip): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/f81536f221eaec078c6053109404fd17d7b1ab63)
* [feat(textField): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/9d5d8fd19f84f8c2b202557451f2c75d61633182)
* [feat(tabs): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/33753dabe2c044ad94731298907a723043d8c794)
* [feat(slider): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/af3128ef87492699c09d99fecef9006139ee01a9)
* [feat(segmentedButton): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/7ca23c5e796a95a1c39a4ca71c7b995949cf9958)
* [feat(radioButton): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/c3728556fe4a2892bfeb66fc6a557c964225cb2f)
* [feat(popover): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/8c34833fc5552a729f6cc3be0d9b8d90ac9d794b)
* [feat(modal): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/d85f6a3da3498879c31abca046c75b4fddf5316f)
* [feat(link): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/64f8493868b6840c0eadbe2c573d1db15ceb02b2)
* [feat(image): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/d23d2dc3cabc53e62528bbff068fbcfe189b7fa4)
* [feat(formFieldWrapper): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/8e285ee27d0f0ea9ac44d787ae1a599b84b11fec)
* [feat(dropdown): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/7f7adc3050f1374ff8bd0ecdb7539e04f71e7efa)
* [feat(divider): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/1338cd1048d14690c61dafd4dc018c0fa8e5b0f8)
* [feat(dialog): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/d8b9ac7ec7b44362bef5a36272f5ba5737c827e0)
* [feat(cms/section): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/8aa8b6c5e0e255d381548d4c3669baedc3fb82f0)
* [feat(closeButton): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/f332fda67ccc1e2357f8a87da4bf4d7a3a490cc8)
* [feat(chips): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/c89580db246a0fb65c88ad5fb4428f73ab78718f)
* [feat(checkbox): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/615fea20ea19182cc09d52723ba4b9de2b796265)
* [feat(button): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/5ab89f5e789e878658ae744c2768fd9f82ef6b06)
* [feat(breadcrumbs): use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/52603509c73a355b8c0b93091384ce1df18236bb)
* [feat: use `@use` instead of `@import` in scss](https://github.com/code-dot-org/code-dot-org/pull/65292/commits/98f336b945cbc2ac8706f88ffa7514cd346f7772)

Before (see scroll length in styles inspect section):
<img width="2555" alt="Знімок екрана 2025-04-16 о 12 12 49" src="https://github.com/user-attachments/assets/b9c384ec-3539-456d-b5cc-de6d0076e8ad" />


After (see scroll length in styles inspect section):
<img width="2555" alt="Знімок екрана 2025-04-16 о 12 13 03" src="https://github.com/user-attachments/assets/800597b8-64db-4925-bbf9-3808ebd3aa5c" />

## Links
- jira ticket: [CMS-262](https://codedotorg.atlassian.net/browse/CMS-262)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
