### PR TITLE
Evaluate Student Learning: log errors when network request fails in StudentWorkSamplesApi

### DIFF
--- a/apps/src/levelbuilder/ai-iteration-tools/StudentWorkSamplesApi.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentWorkSamplesApi.tsx
@@ -20,7 +20,14 @@ export async function fetchStudentCodeSamples(
       body: JSON.stringify(studentWorkRequest),
     });
     if (!response.ok) {
-      throw new Error('Network response was not ok');
+      const errorData = await response.json();
+      const msg = `Network response was not ok fetching student code samples: ${JSON.stringify(
+        errorData,
+        null,
+        2
+      )}`;
+      console.error(msg);
+      return null;
     }
     const data = await response.json();
     return data;

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -114,7 +114,7 @@ class StudentWorkSampleController < ApplicationController
     code_samples = []
     have_enough_samples = false
     user_level_evaluations.shuffle.each do |ule|
-      unless have_enough_samples
+      unless have_enough_samples || ule.code_version.nil?
         student_code = get_student_code(ule.user_id, level, unit_id, ule.code_version)
         if student_code[:student_code]
           code_sample = {


### PR DESCRIPTION
When attempting to pull AI-evaluated student code samples on production, I'm often hitting a network request error. 
![Screenshot 2025-04-16 at 9 52 15 AM](https://github.com/user-attachments/assets/d7f484cf-3c90-46a8-8955-c02e91937619)

This doesn't happen locally. My best guess is there is something about the data on production from the various iterations of different fields being saved that's incompatible with how I'm trying to fetch it 🤷‍♀️. I'm not totally sure how to diagnose what's happening, but getting more information in the console when we hit this error seems like a good first step. 

I also added a small improvement to the `fetch_student_code_samples_with_evaluations` method in the student_work_sample controller that only tries to find student code if we have a code_version. 