### PR TITLE
Evaluate Student Learning: drop UserLevelEvaluations table

### DIFF
--- a/dashboard/db/migrate/20250416140513_drop_user_level_evaluations.rb
+++ b/dashboard/db/migrate/20250416140513_drop_user_level_evaluations.rb
@@ -1,0 +1,5 @@
+class DropUserLevelEvaluations < ActiveRecord::Migration[6.1]
+  def change
+    drop_table :user_level_evaluations if ActiveRecord::Base.connection.table_exists? :user_level_evaluations
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_04_11_155821) do
+ActiveRecord::Schema.define(version: 2025_04_16_140513) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2332,22 +2332,6 @@ ActiveRecord::Schema.define(version: 2025_04_11_155821) do
     t.decimal "longitude", precision: 9, scale: 6
     t.index ["indexed_at"], name: "index_user_geos_on_indexed_at"
     t.index ["user_id"], name: "index_user_geos_on_user_id"
-  end
-
-  create_table "user_level_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "level_id", null: false
-    t.integer "script_id", null: false
-    t.string "school_year", null: false
-    t.text "evaluation_criteria"
-    t.text "ai_evaluation"
-    t.text "ai_reasoning"
-    t.string "ai_model_version"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "code_version"
-    t.index ["level_id"], name: "index_user_level_evaluations_on_level_id"
-    t.index ["user_id"], name: "index_user_level_evaluations_on_user_id"
   end
 
   create_table "user_level_interactions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
[TEACHER-1821](https://codedotorg.atlassian.net/browse/TEACH-1821)

Continuation of https://github.com/code-dot-org/code-dot-org/pull/65208

We now have a StudentWorkEvaluation table that stores UserLevelEvaluations via Single Table Inheritance. Everything has been migrated into the new StudentWorkEvaluation table and all of the references to the UserLevelEvaluationsOld model have been removed. Deleting this table is the last step in the clean up process! 
