### PR TITLE
fix(ci): clean up docker build artifacts

### DIFF
--- a/.github/workflows/marketing-app-ci.yml
+++ b/.github/workflows/marketing-app-ci.yml
@@ -92,6 +92,10 @@ jobs:
           # Tail the docker logs
           docker logs -f marketing &
 
+      - name: Clean unused docker build artifacts
+        run: |
+          docker system prune --all --force
+
       - name: UI Tests
         uses: ./.github/actions/frontend/marketing/ui-tests
         with:

--- a/frontend/apps/marketing/README.md
+++ b/frontend/apps/marketing/README.md
@@ -1,4 +1,4 @@
-# Code.org Marketing Application.
+# Code.org Marketing Application
 
 ## Getting Started
 


### PR DESCRIPTION
After building the Marketing app, clear the docker build artifacts to clean up disk space. Tested [here](https://github.com/code-dot-org/code-dot-org/actions/runs/14497874423/job/40670228231?pr=64575)

```
Run docker system prune --all --force
  
Deleted build cache objects:
nod6jy612so17ayhha5fvwykz
i[4](https://github.com/code-dot-org/code-dot-org/actions/runs/14497874423/job/40670228231?pr=64575#step:13:4)8[4](https://github.com/code-dot-org/code-dot-org/actions/runs/14497874423/job/40670228231?pr=64575#step:13:5)2urr132wevttd1smq9ang
yl8juf6l74iwzplb72e9zlybc
pmmlvpq6[5](https://github.com/code-dot-org/code-dot-org/actions/runs/14497874423/job/40670228231?pr=64575#step:13:6)412wzt6l5zv9rfi2
drxtahygxkb9k40x7jjdgn1dw
7wno[6](https://github.com/code-dot-org/code-dot-org/actions/runs/14497874423/job/40670228231?pr=64575#step:13:7)jfjmdv8mr53zkaekjcwh
vwg5cvkef1l1qx4m2c2kn[7](https://github.com/code-dot-org/code-dot-org/actions/runs/14497874423/job/40670228231?pr=64575#step:13:8)60k
gu7imdviz8uszokf7xlcqfykc
5hmvmjmxryfoviwp2dhhtg6cw
pnz4xmx9xrgoo7sxp27tj[8](https://github.com/code-dot-org/code-dot-org/actions/runs/14497874423/job/40670228231?pr=64575#step:13:9)j28
l4zqtw3yswp10o0fiuoksjj[9](https://github.com/code-dot-org/code-dot-org/actions/runs/14497874423/job/40670228231?pr=64575#step:13:10)6
rd41h2499gxypgxlg43r4e99m
q5ohp6hyo55f58vl3zl3kdgm8
xpwvzl1tggzji2vfbntd9zb0c
ikjx57t22jjorsam3dij4bhq4
r709734irukwgx6dhduvlb0yv
ri4w3hbgp98ywdstvwevc30bv
hizjmdh486p91s5n5rsa19zw4
q5379lz4z4ozdjjfwct6h8dv1
oxvmcdz2xyd5[13](https://github.com/code-dot-org/code-dot-org/actions/runs/14497874423/job/40670228231?pr=64575#step:13:14)7m9tqs4tuj2
dluokux8t1ppqd5z1t5rwt00d
Total reclaimed space: 16.18GB
```