### PR TITLE
SUM - modify strings describing logic for the summary box

### DIFF
--- a/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
@@ -72,8 +72,8 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
       <BodyTwoText>
         <strong>{`${i18n.reasoning()}:`}</strong>
         {proficiencyCount > proficienceyThreshold
-          ? 'This is proficient because more than 80% of the students demonstrated proficiency in their responses. '
-          : 'This is needs review less than 80% of students demonstrated proficiency in their responses. '}
+          ? 'More than 80% of the students demonstrated proficiency in their responses. '
+          : 'Less than 80% of the students demonstrated proficiency in their responses. '}
         <Link
           type="primary"
           size="m"


### PR DESCRIPTION
Based on [this](https://codedotorg.slack.com/archives/C067UFRDM9B/p1743189564933229) conversation, we are modifying the strings shown in the "Summary" box for the ai feedback.

OLD:
<img width="766" alt="image" src="https://github.com/user-attachments/assets/ffb63f03-a4bd-4ad0-ae75-e51ee53a3425" />


NEW:
<img width="764" alt="image" src="https://github.com/user-attachments/assets/3c041635-539b-4ae5-9676-0aaa1c1e340c" />




## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1717) <--- Erin, can you confirm that this is what this ticket is for? YES it is ✅ 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
