### PR TITLE
exclude prev / next in script level summary for lesson edit

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -414,7 +414,7 @@ class ScriptLevel < ApplicationRecord
   end
 
   def summarize_for_lesson_edit
-    summary = summarize(for_edit: true)
+    summary = summarize(false, for_edit: true)
     summary[:id] = id.to_s
     summary[:activitySectionPosition] = activity_section_position
     summary[:levels] = levels.map do |level|


### PR DESCRIPTION
Curriculum writers report that they are getting errors like this when saving a lesson:
![Screenshot 2025-04-16 at 8 58 46 PM](https://github.com/user-attachments/assets/2ecc6e41-a2c0-47b5-a216-3171ad775710)

Anecdotally it happens when someone else is editing a different lesson in the same unit. the safety checks are only supposed to prevent two people from editing the same lesson.

investigation revealed that a change to the "previous" field in the script level summary was causing the application to detect a change and reject the save (see [slack](https://codedotorg.slack.com/archives/C045UAX4WKH/p1744848539920119?thread_ts=1740432189.018989&cid=C045UAX4WKH)). 

I am able to repro the problem as follows:
1. in tab 1, open http://localhost-studio.code.org:3000/s/coursea-2025/lessons/3/edit
2. in tab 2, open http://localhost-studio.code.org:3000/s/coursea-2025/lessons/2/edit, remove a level, and save the page
3. go back to tab 1 and save lesson 3

expected: lesson 3 save succeeds
actual: lesson 3 save fails

The fix is to remove "previous" from the set of fields in which we look for changes. Here are some breadcrumbs which illustrate how the code change in this PR accomplishes this:
* https://github.com/code-dot-org/code-dot-org/blob/7a518fcd4eb3826e5dbe1e7f952ec3b15dacf98b/dashboard/app/models/script_level.rb#L317
* https://github.com/code-dot-org/code-dot-org/blob/7a518fcd4eb3826e5dbe1e7f952ec3b15dacf98b/dashboard/app/models/script_level.rb#L378-L382

## Testing story

- Verified locally that this change fixes the problem scenario listed in the repro steps above.
- because this change is scoped to the `summarize_for_lesson_edit` codepaths, it should not affect anything besides the lesson edit page.
- I did a code search for the word "previous" in our lesson edit code, and did not see this field being used anywhere.
