### PR TITLE
Ceara/aitt 975 active section curriculum context

### DIFF
--- a/dashboard/app/controllers/ai_diff_controller.rb
+++ b/dashboard/app/controllers/ai_diff_controller.rb
@@ -65,6 +65,21 @@ class AiDiffController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
+  def get_active_sections
+    # all sections updated in the last year that have curriculum assigned
+    contexts = @current_user&.sections&.where(hidden: false, updated_at: 1.year.ago..Time.now)&.select {|s| s.script_id || s.course_id}&.map do |section|
+      context_scope = SharedConstants::AI_DIFF_CONTEXT[:COURSE]
+      course_display_name = CourseOffering.find_by(id: section.course_offering_id)&.display_name
+      course_name = section.unit_group&.name
+      {
+        context: context_scope,
+        course_display_name: course_display_name,
+        course_name: course_name
+      }
+    end
+    contexts
+  end
+
   # Certain types of PII detected by Amazon Comprehend are actually allowed
   # for use in chat messages. We allow teachers to ask about lessons themed
   # on a favorite named celebrity, or how to help students at certain ages. etc.
@@ -120,6 +135,8 @@ class AiDiffController < ApplicationController
       @unit_group = @unit&.unit_groups&.first
     when SharedConstants::AI_DIFF_CONTEXT[:COURSE]
       @unit_group = UnitGroup.find_by(id: params[:contextId]) #should this be a course offering instead?
+    when SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
+      @section_contexts = get_active_sections
     end
 
     lesson_name = @lesson&.name
@@ -130,9 +147,9 @@ class AiDiffController < ApplicationController
     course_name = @unit_group.present? ? @unit_group.name : @unit&.name
 
     course_display_name = CourseOffering.find_by(id: @unit_group&.course_version&.course_offering_id)&.display_name
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(params[:context], course_display_name, params[:unitDisplayName], lesson_name, params[:isPreset])
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(params[:context], course_display_name, params[:unitDisplayName], lesson_name, params[:isPreset], @section_contexts)
 
-    bedrock_rag_response = AiDiffBedrockHelper.request_bedrock_rag_chat(params[:inputText], prompt, lesson_num, unit_num, course_name, session_id)
+    bedrock_rag_response = AiDiffBedrockHelper.request_bedrock_rag_chat(params[:inputText], prompt, lesson_num, unit_num, course_name, session_id, @section_contexts)
     #TODO: check for profanity/PII in model response
 
     {

--- a/dashboard/app/controllers/ai_diff_controller.rb
+++ b/dashboard/app/controllers/ai_diff_controller.rb
@@ -70,11 +70,12 @@ class AiDiffController < ApplicationController
     contexts = @current_user&.sections&.where(hidden: false, updated_at: 1.year.ago..Time.now)&.select {|s| s.script_id || s.course_id}&.map do |section|
       context_scope = SharedConstants::AI_DIFF_CONTEXT[:COURSE]
       course_display_name = CourseOffering.find_by(id: section.course_offering_id)&.display_name
-      course_name = section.unit_group&.name
+      course_names = [section.unit_group&.name]
+      course_names.push(section.unit_group&.family_name) unless section.unit_group&.family_name.nil?
       {
         context: context_scope,
         course_display_name: course_display_name,
-        course_name: course_name
+        course_names: course_names
       }
     end
     contexts
@@ -144,12 +145,12 @@ class AiDiffController < ApplicationController
 
     unit_num = @unit&.unit_group_units&.first&.position
 
-    course_name = @unit_group.present? ? @unit_group.name : @unit&.name
+    course_names = @unit_group.present? ? [@unit_group.name, @unit_group.family_name] : ([@unit&.name] if @unit.present?)
 
     course_display_name = CourseOffering.find_by(id: @unit_group&.course_version&.course_offering_id)&.display_name
     prompt = AiDiffBedrockHelper.get_prompt_for_context(params[:context], course_display_name, params[:unitDisplayName], lesson_name, params[:isPreset], @section_contexts)
 
-    bedrock_rag_response = AiDiffBedrockHelper.request_bedrock_rag_chat(params[:inputText], prompt, lesson_num, unit_num, course_name, session_id, @section_contexts)
+    bedrock_rag_response = AiDiffBedrockHelper.request_bedrock_rag_chat(params[:inputText], prompt, lesson_num, unit_num, course_names, session_id, @section_contexts)
     #TODO: check for profanity/PII in model response
 
     {

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -131,7 +131,7 @@ module AiDiffBedrockHelper
     }
   end
 
-  def self.filter_for_context(config, lesson_number, unit_num, course_name, section_contexts)
+  def self.filter_for_context(config, lesson_number, unit_num, course_names, section_contexts)
     and_all_filters = []
     or_all_filters = []
     unless lesson_number.nil?
@@ -150,12 +150,12 @@ module AiDiffBedrockHelper
         ]
       )
     end
-    and_all_filters.push({equals: {key: "course", value: course_name}}) unless course_name.nil?
+    and_all_filters.push({in: {key: "course", value: course_names}}) unless course_names.nil?
 
-    if lesson_number.nil? && unit_num.nil? && course_name.nil?
+    if lesson_number.nil? && unit_num.nil? && course_names.nil?
       or_all_filters.push({equals: {key: "scope", value: "general"}})
       section_contexts&.each do |section_context|
-        or_all_filters.push({equals: {key: "course", value: section_context[:course_name]}})
+        or_all_filters.push({in: {key: "course", value: section_context[:course_names]}})
       end
     end
 

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -50,7 +50,16 @@ module AiDiffBedrockHelper
     end
   end
 
-  def self.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+  def self.get_prompt_supplement(section_contexts)
+    return "" unless section_contexts
+    prompt = "\nThe courses that this teacher may ask you about are:"
+    section_contexts.each do |context|
+      prompt = format("%{prompt}\n - %{course_name}", prompt: prompt, course_name: context[:course_display_name])
+    end
+    prompt
+  end
+
+  def self.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
     case context
     when SharedConstants::AI_DIFF_CONTEXT[:LESSON]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the %{course_name} course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
@@ -74,10 +83,10 @@ module AiDiffBedrockHelper
       $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
       )
     when SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
-      prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+      prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.%{section_contexts}
 
       Here are the search results in numbered order:
-      $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
+      $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name, section_contexts: get_prompt_supplement(section_contexts)
       )
     end
     unless is_preset
@@ -122,10 +131,11 @@ module AiDiffBedrockHelper
     }
   end
 
-  def self.filter_for_context(config, lesson_number, unit_num, course_name)
-    temp_filters = []
+  def self.filter_for_context(config, lesson_number, unit_num, course_name, section_contexts)
+    and_all_filters = []
+    or_all_filters = []
     unless lesson_number.nil?
-      temp_filters.push(
+      and_all_filters.push(
         or_all: [
           {equals: {key: "lesson", value: format("L%02d", lesson_number)}},
           {equals: {key: "lesson", value: "all"}}
@@ -133,34 +143,47 @@ module AiDiffBedrockHelper
       )
     end
     unless unit_num.nil?
-      temp_filters.push(
+      and_all_filters.push(
         or_all: [
           {equals: {key: "unit", value: format("U%02d", unit_num)}},
           {equals: {key: "unit", value: "all"}}
         ]
       )
     end
-    temp_filters.push({equals: {key: "course", value: course_name}}) unless course_name.nil?
+    and_all_filters.push({equals: {key: "course", value: course_name}}) unless course_name.nil?
 
     if lesson_number.nil? && unit_num.nil? && course_name.nil?
-      temp_filters.push({equals: {key: "scope", value: "general"}})
+      or_all_filters.push({equals: {key: "scope", value: "general"}})
+      section_contexts&.each do |section_context|
+        or_all_filters.push({equals: {key: "course", value: section_context[:course_name]}})
+      end
     end
 
     #can't use "and_all" if there is only 1 expression to filter on, only 2+
-    if temp_filters.length > 1
+    curriculum_filter = if and_all_filters.length > 1
+                          {and_all: and_all_filters}
+                        elsif and_all_filters.length == 1
+                          and_all_filters[0]
+                        else
+                          nil
+                        end
+    or_all_filters.push(curriculum_filter) unless curriculum_filter.nil?
+
+    #can't use "or_all" if there is only 1 expression to filter on, only 2+
+    if or_all_filters.length > 1
       config[:retrieve_and_generate_configuration][:knowledge_base_configuration][:retrieval_configuration][:vector_search_configuration][:filter] = {
-        and_all: temp_filters
+        or_all: or_all_filters
       }
-    elsif temp_filters.length == 1
-      config[:retrieve_and_generate_configuration][:knowledge_base_configuration][:retrieval_configuration][:vector_search_configuration][:filter] = temp_filters[0]
+    elsif or_all_filters.length == 1
+      config[:retrieve_and_generate_configuration][:knowledge_base_configuration][:retrieval_configuration][:vector_search_configuration][:filter] = or_all_filters[0]
     end
     config
   end
 
-  def self.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, session_id)
+  def self.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, session_id, section_contexts)
     config = format_inputs_for_bedrock_request(input, prompt)
     config[:session_id] = session_id unless session_id.nil?
-    config = filter_for_context(config, lesson_number, unit_num, course_name)
+    config = filter_for_context(config, lesson_number, unit_num, course_name, section_contexts)
 
     response = create_bedrock_client.retrieve_and_generate(
       config

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -49,7 +49,8 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = false
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    section_contexts = nil
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the Computer Science Discoveries course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is Computer Science Discoveries CSD Unit 3, Test Lesson Name.
 
@@ -66,7 +67,8 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = false
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    section_contexts = nil
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the Computer Science Discoveries course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is Computer Science Discoveries CSD Unit 3.
 
@@ -83,7 +85,8 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = false
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    section_contexts = nil
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the Computer Science Discoveries course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is Computer Science Discoveries.
 
@@ -100,8 +103,40 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     unit_name = nil
     lesson_name = nil
     is_preset = false
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
-    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+    section_contexts = nil
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+
+      Here are the search results in numbered order:
+      $search_results$
+
+      $output_format_instructions$"
+    assert_equal prompt, expected_prompt
+  end
+
+  test 'Testing prompt formatting for general with sections, not preset' do
+    context = SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
+    course_name = nil
+    unit_name = nil
+    lesson_name = nil
+    is_preset = false
+    section_contexts = [
+      {
+        context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
+        course_display_name: "Fake Course A",
+        course_name: "fake_a"
+      },
+      {
+        context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
+        course_display_name: "Phony Class B",
+        course_name: "fake_b"
+      }
+    ]
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+The courses that this teacher may ask you about are:
+ - Fake Course A
+ - Phony Class B
 
       Here are the search results in numbered order:
       $search_results$
@@ -116,7 +151,8 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = true
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    section_contexts = nil
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the Computer Science Discoveries course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is Computer Science Discoveries CSD Unit 3, Test Lesson Name.
 
@@ -131,7 +167,8 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = true
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    section_contexts = nil
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the Computer Science Discoveries course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is Computer Science Discoveries CSD Unit 3.
 
@@ -146,7 +183,8 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = true
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
+    section_contexts = nil
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the Computer Science Discoveries course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is Computer Science Discoveries.
 
@@ -161,8 +199,38 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     unit_name = nil
     lesson_name = nil
     is_preset = true
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset)
-    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+    section_contexts = nil
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+
+      Here are the search results in numbered order:
+      $search_results$"
+    assert_equal prompt, expected_prompt
+  end
+
+  test 'Testing prompt formatting for general with sections, is preset' do
+    context = SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
+    course_name = nil
+    unit_name = nil
+    lesson_name = nil
+    is_preset = true
+    section_contexts = [
+      {
+        context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
+        course_display_name: "Fake Course A",
+        course_name: "fake_a"
+      },
+      {
+        context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
+        course_display_name: "Phony Class B",
+        course_name: "fake_b"
+      }
+    ]
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+The courses that this teacher may ask you about are:
+ - Fake Course A
+ - Phony Class B
 
       Here are the search results in numbered order:
       $search_results$"
@@ -211,6 +279,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     course_name = "test_course"
     unit_num = 2
     lesson_number = 3
+    section_contexts = nil
     formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -253,7 +322,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
         }
       }
     }
-    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name)
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
     assert_equal filtered_input, expected_input
   end
 
@@ -263,6 +332,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     course_name = "test_course"
     unit_num = 2
     lesson_number = nil
+    section_contexts = nil
     formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -301,7 +371,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
         }
       }
     }
-    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name)
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
     assert_equal filtered_input, expected_input
   end
 
@@ -311,6 +381,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     course_name = "test_course"
     unit_num = nil
     lesson_number = nil
+    section_contexts = nil
     formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -343,7 +414,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
         }
       }
     }
-    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name)
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
     assert_equal filtered_input, expected_input
   end
 
@@ -353,6 +424,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     course_name = nil
     unit_num = nil
     lesson_number = nil
+    section_contexts = nil
     formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -385,7 +457,63 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
         }
       }
     }
-    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name)
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
+    assert_equal filtered_input, expected_input
+  end
+
+  test 'Testing context filtering for general context with sections' do
+    input = "Hello there!"
+    prompt = "prompt text"
+    course_name = nil
+    unit_num = nil
+    lesson_number = nil
+    section_contexts = [
+      {
+        context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
+        course_display_name: "Fake Course A",
+        course_name: "fake_a"
+      },
+      {
+        context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
+        course_display_name: "Phony Class B",
+        course_name: "fake_b"
+      }
+    ]
+    formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
+    expected_input = {
+      input: {
+        text: "Hello there!"
+      },
+      retrieve_and_generate_configuration: {
+        type: 'KNOWLEDGE_BASE',
+        knowledge_base_configuration: {
+          knowledge_base_id: AiDiffBedrockHelper::KB_ID,
+          model_arn: 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0',
+          generation_configuration: {
+            prompt_template: {
+              text_prompt_template: "prompt text"
+            },
+            inference_config: {
+              text_inference_config: {
+                max_tokens: 1500,
+                temperature: 0.5,
+              }
+            },
+          },
+          retrieval_configuration: {
+            vector_search_configuration: {
+              filter: {or_all: [
+                {equals: {key: "scope", value: "general"}},
+                {equals: {key: "course", value: "fake_a"}},
+                {equals: {key: "course", value: "fake_b"}}
+              ]},
+              number_of_results: 10,
+            }
+          }
+        }
+      }
+    }
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
     assert_equal filtered_input, expected_input
   end
 
@@ -395,7 +523,8 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     course_name = "test_course"
     unit_num = 3
     lesson_number = 5
-    response = AiDiffBedrockHelper.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, @session_id)
+    section_contexts = nil
+    response = AiDiffBedrockHelper.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, @session_id, section_contexts)
     assert_equal response.output.text, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
     assert_equal response.session_id, "1234"
     assert_equal response.citations[0].generated_response_part.text_response_part.text, "Lorem ipsum dolor sit amet, consectetur adipiscing elit"

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -45,12 +45,12 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
 
   test 'Testing prompt formatting for lesson, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:LESSON]
-    course_name = "Computer Science Discoveries"
+    course_display_name = "Computer Science Discoveries"
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = false
     section_contexts = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the Computer Science Discoveries course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is Computer Science Discoveries CSD Unit 3, Test Lesson Name.
 
@@ -63,12 +63,12 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
 
   test 'Testing prompt formatting for unit, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:UNIT]
-    course_name = "Computer Science Discoveries"
+    course_display_name = "Computer Science Discoveries"
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = false
     section_contexts = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the Computer Science Discoveries course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is Computer Science Discoveries CSD Unit 3.
 
@@ -81,12 +81,12 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
 
   test 'Testing prompt formatting for course, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:COURSE]
-    course_name = "Computer Science Discoveries"
+    course_display_name = "Computer Science Discoveries"
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = false
     section_contexts = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the Computer Science Discoveries course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is Computer Science Discoveries.
 
@@ -99,12 +99,12 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
 
   test 'Testing prompt formatting for general, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
-    course_name = nil
+    course_display_name = nil
     unit_name = nil
     lesson_name = nil
     is_preset = false
     section_contexts = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
 
       Here are the search results in numbered order:
@@ -116,7 +116,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
 
   test 'Testing prompt formatting for general with sections, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
-    course_name = nil
+    course_display_name = nil
     unit_name = nil
     lesson_name = nil
     is_preset = false
@@ -124,15 +124,15 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
       {
         context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
         course_display_name: "Fake Course A",
-        course_name: "fake_a"
+        course_names: ["fake_a"]
       },
       {
         context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
         course_display_name: "Phony Class B",
-        course_name: "fake_b"
+        course_names: ["fake_b"]
       }
     ]
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
 The courses that this teacher may ask you about are:
  - Fake Course A
@@ -147,12 +147,12 @@ The courses that this teacher may ask you about are:
 
   test 'Testing prompt formatting for lesson, is preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:LESSON]
-    course_name = "Computer Science Discoveries"
+    course_display_name = "Computer Science Discoveries"
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = true
     section_contexts = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the Computer Science Discoveries course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is Computer Science Discoveries CSD Unit 3, Test Lesson Name.
 
@@ -163,12 +163,12 @@ The courses that this teacher may ask you about are:
 
   test 'Testing prompt formatting for unit, is preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:UNIT]
-    course_name = "Computer Science Discoveries"
+    course_display_name = "Computer Science Discoveries"
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = true
     section_contexts = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the Computer Science Discoveries course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is Computer Science Discoveries CSD Unit 3.
 
@@ -179,12 +179,12 @@ The courses that this teacher may ask you about are:
 
   test 'Testing prompt formatting for course, is preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:COURSE]
-    course_name = "Computer Science Discoveries"
+    course_display_name = "Computer Science Discoveries"
     unit_name = "CSD Unit 3"
     lesson_name = "Test Lesson Name"
     is_preset = true
     section_contexts = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the Computer Science Discoveries course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is Computer Science Discoveries.
 
@@ -195,12 +195,12 @@ The courses that this teacher may ask you about are:
 
   test 'Testing prompt formatting for general, is preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
-    course_name = nil
+    course_display_name = nil
     unit_name = nil
     lesson_name = nil
     is_preset = true
     section_contexts = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
 
       Here are the search results in numbered order:
@@ -210,7 +210,7 @@ The courses that this teacher may ask you about are:
 
   test 'Testing prompt formatting for general with sections, is preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
-    course_name = nil
+    course_display_name = nil
     unit_name = nil
     lesson_name = nil
     is_preset = true
@@ -218,15 +218,15 @@ The courses that this teacher may ask you about are:
       {
         context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
         course_display_name: "Fake Course A",
-        course_name: "fake_a"
+        course_names: ["fake_a"]
       },
       {
         context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
         course_display_name: "Phony Class B",
-        course_name: "fake_b"
+        course_names: ["fake_b"]
       }
     ]
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts)
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(context, course_display_name, unit_name, lesson_name, is_preset, section_contexts)
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
 The courses that this teacher may ask you about are:
  - Fake Course A
@@ -276,7 +276,7 @@ The courses that this teacher may ask you about are:
   test 'Testing context filtering for lesson' do
     input = "Hello there!"
     prompt = "prompt text"
-    course_name = "test_course"
+    course_names = ["test_course"]
     unit_num = 2
     lesson_number = 3
     section_contexts = nil
@@ -313,7 +313,7 @@ The courses that this teacher may ask you about are:
                     {equals: {key: "unit", value: "U02"}},
                     {equals: {key: "unit", value: "all"}}
                   ]},
-                  {equals: {key: "course", value: "test_course"}},
+                  {in: {key: "course", value: ["test_course"]}},
                 ]
               },
               number_of_results: 10,
@@ -322,14 +322,14 @@ The courses that this teacher may ask you about are:
         }
       }
     }
-    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_names, section_contexts)
     assert_equal filtered_input, expected_input
   end
 
   test 'Testing context filtering for unit' do
     input = "Hello there!"
     prompt = "prompt text"
-    course_name = "test_course"
+    course_names = ["test_course"]
     unit_num = 2
     lesson_number = nil
     section_contexts = nil
@@ -362,7 +362,7 @@ The courses that this teacher may ask you about are:
                     {equals: {key: "unit", value: "U02"}},
                     {equals: {key: "unit", value: "all"}}
                   ]},
-                  {equals: {key: "course", value: "test_course"}},
+                  {in: {key: "course", value: ["test_course"]}},
                 ]
               },
               number_of_results: 10,
@@ -371,14 +371,14 @@ The courses that this teacher may ask you about are:
         }
       }
     }
-    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_names, section_contexts)
     assert_equal filtered_input, expected_input
   end
 
   test 'Testing context filtering for course' do
     input = "Hello there!"
     prompt = "prompt text"
-    course_name = "test_course"
+    course_names = ["test_course"]
     unit_num = nil
     lesson_number = nil
     section_contexts = nil
@@ -406,7 +406,7 @@ The courses that this teacher may ask you about are:
           retrieval_configuration: {
             vector_search_configuration: {
               filter: {
-                equals: {key: "course", value: "test_course"}
+                in: {key: "course", value: ["test_course"]}
               },
               number_of_results: 10,
             }
@@ -414,14 +414,14 @@ The courses that this teacher may ask you about are:
         }
       }
     }
-    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_names, section_contexts)
     assert_equal filtered_input, expected_input
   end
 
   test 'Testing context filtering for general context' do
     input = "Hello there!"
     prompt = "prompt text"
-    course_name = nil
+    course_names = nil
     unit_num = nil
     lesson_number = nil
     section_contexts = nil
@@ -457,26 +457,26 @@ The courses that this teacher may ask you about are:
         }
       }
     }
-    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_names, section_contexts)
     assert_equal filtered_input, expected_input
   end
 
   test 'Testing context filtering for general context with sections' do
     input = "Hello there!"
     prompt = "prompt text"
-    course_name = nil
+    course_names = nil
     unit_num = nil
     lesson_number = nil
     section_contexts = [
       {
         context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
         course_display_name: "Fake Course A",
-        course_name: "fake_a"
+        course_names: ["fake_a"]
       },
       {
         context: SharedConstants::AI_DIFF_CONTEXT[:COURSE],
         course_display_name: "Phony Class B",
-        course_name: "fake_b"
+        course_names: ["fake_b"]
       }
     ]
     formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
@@ -504,8 +504,8 @@ The courses that this teacher may ask you about are:
             vector_search_configuration: {
               filter: {or_all: [
                 {equals: {key: "scope", value: "general"}},
-                {equals: {key: "course", value: "fake_a"}},
-                {equals: {key: "course", value: "fake_b"}}
+                {in: {key: "course", value: ["fake_a"]}},
+                {in: {key: "course", value: ["fake_b"]}}
               ]},
               number_of_results: 10,
             }
@@ -513,18 +513,18 @@ The courses that this teacher may ask you about are:
         }
       }
     }
-    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_name, section_contexts)
+    filtered_input = AiDiffBedrockHelper.filter_for_context(formatted_input, lesson_number, unit_num, course_names, section_contexts)
     assert_equal filtered_input, expected_input
   end
 
   test 'Testing rag generation call with session' do
     input = "Hello there!"
     prompt = "a well crafted prompt"
-    course_name = "test_course"
+    course_names = "test_course"
     unit_num = 3
     lesson_number = 5
     section_contexts = nil
-    response = AiDiffBedrockHelper.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, @session_id, section_contexts)
+    response = AiDiffBedrockHelper.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_names, @session_id, section_contexts)
     assert_equal response.output.text, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
     assert_equal response.session_id, "1234"
     assert_equal response.citations[0].generated_response_part.text_response_part.text, "Lorem ipsum dolor sit amet, consectetur adipiscing elit"


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

This adds the section courses that a teacher is currently teaching (defined here as sections that have been updated in the last year, are not hidden or deleted, and have curriculum assigned) to the prompt template and metadata filter for the `GENERAL` context. This means that the teacher can ask questions about any curriculum they have assigned to a section from the home page.

The chat on curriculum pages still has only the context for that curriculum.

Sample chat from the home page: 
[ai_differentiation_chat (6).pdf](https://github.com/user-attachments/files/19796054/ai_differentiation_chat.6.pdf)

This PR also updates the course filtering to match any document where the `course` value is in a given list that includes the course with the version year and the course family name, e.g. `["csd-2024", "csd"]`. This preserves the same behavior with the data we have now where the course includes the version year, while also allowing us to give the AP CSP info for all CSP courses if their metadata has `course: "csp"`. 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/AITT-975

## Testing story

Added dashboard unit tests for the section contexts and updated other unit tests

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
