### PR TITLE
fix(e2e): use engineering only asset

### DIFF
--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -47,7 +47,7 @@ test.describe('All the things UI e2e test', () => {
     expect(await allTheThingsPage.getOpenGraph('image')).toBe(
       'https://images.ctfassets.net/90t6bu6vlf76/4hXiOPiRlCXpmtypRNOZqc/9ebe430094c1ae1faf742e1de3f8aa8b/engineering-only-opengraph-default.png',
     );
-    expect(await allTheThingsPage.getOpenGraph('image:width')).toBe('1600');
+    expect(await allTheThingsPage.getOpenGraph('image:width')).toBe('1200');
     expect(await allTheThingsPage.getOpenGraph('image:height')).toBe('900');
     expect(await allTheThingsPage.getOpenGraph('type')).toBe('website');
   });

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -48,7 +48,7 @@ test.describe('All the things UI e2e test', () => {
       'https://images.ctfassets.net/90t6bu6vlf76/4hXiOPiRlCXpmtypRNOZqc/9ebe430094c1ae1faf742e1de3f8aa8b/engineering-only-opengraph-default.png',
     );
     expect(await allTheThingsPage.getOpenGraph('image:width')).toBe('1200');
-    expect(await allTheThingsPage.getOpenGraph('image:height')).toBe('900');
+    expect(await allTheThingsPage.getOpenGraph('image:height')).toBe('630');
     expect(await allTheThingsPage.getOpenGraph('type')).toBe('website');
   });
 

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -45,7 +45,7 @@ test.describe('All the things UI e2e test', () => {
       'OpenGraph Description',
     );
     expect(await allTheThingsPage.getOpenGraph('image')).toBe(
-      'https://images.ctfassets.net/90t6bu6vlf76/4mNRGSevP1JdG2th62NXfs/9ac89df80ecfc67309b06003f74864ba/ai-and-oceans-cover.png',
+      'https://images.ctfassets.net/90t6bu6vlf76/4hXiOPiRlCXpmtypRNOZqc/9ebe430094c1ae1faf742e1de3f8aa8b/engineering-only-opengraph-default.png',
     );
     expect(await allTheThingsPage.getOpenGraph('image:width')).toBe('1600');
     expect(await allTheThingsPage.getOpenGraph('image:height')).toBe('900');


### PR DESCRIPTION
Updates the asset defined in the all the things e2e test to an engineering only asset