### PR TITLE
Reset scroll to top of page on dashboard links

### DIFF
--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -11,6 +11,7 @@ import {
   useLocation,
   generatePath,
   useParams,
+  ScrollRestoration,
 } from 'react-router-dom';
 
 import TutorTab from '@cdo/apps/aiTutor/views/teacherDashboard/TutorTab';
@@ -127,6 +128,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
               />
               <div>
                 <TeacherHomepage studioUrlPrefix={studioUrlPrefix} />
+                <ScrollRestoration />
               </div>
             </>
           }
@@ -140,6 +142,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
               />
               <div className={styles.pageAndSidebar}>
                 <TeacherNavigationBar showAITutorTab={showAITutorTab} />
+                <ScrollRestoration />
                 <Outlet />
               </div>
             </>


### PR DESCRIPTION
Adds a scroll restoration on the homepage and the dashboard that will scroll to the top of page when linked via react-router.

https://reactrouter.com/6.30.0/components/scroll-restoration

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
https://codedotorg.atlassian.net/browse/TEACH-1805
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
