### PR TITLE
Expose CustomDropdown for developer use

### DIFF
--- a/frontend/packages/component-library/src/dropdown/CustomDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/CustomDropdown.tsx
@@ -26,7 +26,7 @@ export interface TriggerComponentProps extends AriaAttributes {
   'data-toggle': string;
 }
 
-export interface _CustomDropdownOption {
+export interface CustomDropdownOption {
   value: string;
   label: string;
   isOptionDisabled?: boolean;

--- a/frontend/packages/component-library/src/dropdown/CustomDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/CustomDropdown.tsx
@@ -6,11 +6,15 @@ import {
   useEffect,
   AriaAttributes,
   KeyboardEvent,
+  memo,
 } from 'react';
 
 import {Button, ButtonProps} from '@/button';
 import {dropdownColors} from '@/common/constants';
-import {useDropdownContext} from '@/common/contexts/DropdownContext';
+import {
+  DropdownProviderWrapper,
+  useDropdownContext,
+} from '@/common/contexts/DropdownContext';
 import {getAriaPropsFromProps} from '@/common/helpers';
 import {ComponentSizeXSToL, DropdownColor} from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
@@ -247,8 +251,10 @@ const CustomDropdown: React.FunctionComponent<CustomDropdownProps> = ({
           <FontAwesomeV6Icon iconStyle="solid" iconName="chevron-down" />
         </button>
       )}
-      {/** Dropdown menu content is rendered here as children props*/}
-      {children}
+      <div className={moduleStyles.dropdownMenuContainer}>
+        {/** Dropdown menu content is rendered here as children props*/}
+        {children}
+      </div>
 
       {!errorMessage && (helperMessage || helperIcon) && (
         <div className={moduleStyles.helperSection}>
@@ -271,4 +277,10 @@ const CustomDropdown: React.FunctionComponent<CustomDropdownProps> = ({
   );
 };
 
-export default CustomDropdown;
+const WrappedCustomDropdown = (props: CustomDropdownProps) => (
+  <DropdownProviderWrapper>
+    <CustomDropdown {...props} />
+  </DropdownProviderWrapper>
+);
+
+export default memo(WrappedCustomDropdown);

--- a/frontend/packages/component-library/src/dropdown/CustomDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/CustomDropdown.tsx
@@ -76,9 +76,17 @@ export interface CustomDropdownProps extends AriaAttributes {
 }
 
 /**
- * Design System: _CustomDropdown Component.
- * This is a PRIVATE component that is used to create different custom dropdowns.
- * Only used inside of Design System components. DO NOT IMPORT OR USE DIRECTLY.
+ * ### Production-ready Checklist:
+ * * (✔) implementation of component approved by design team;
+ * * (✔) has storybook, covered with stories and documentation;
+ * * (✔) has tests: test every prop, every state and every interaction that's js related;
+ * * (see ./__tests__/CustomDropdown.test.tsx)
+ * * (?) passes accessibility checks;
+ *
+ * ###  Status: ```Ready for dev```
+ *
+ * Design System: CustomDropdown Component.
+ * Renders CustomDropdown with content passed through props.
  */
 const CustomDropdown: React.FunctionComponent<CustomDropdownProps> = ({
   name,

--- a/frontend/packages/component-library/src/dropdown/README.md
+++ b/frontend/packages/component-library/src/dropdown/README.md
@@ -1,0 +1,19 @@
+# `componentLibrary/dropdown - CustomDropdown`
+
+### Status: `Ready for Dev`
+
+## Consuming This Component
+
+This package exports one styled React component: [CustomDropdown](CustomDropdown.tsx). You can import it like this:
+
+```javascript
+import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
+```
+
+CustomDropdown is a dropdown with a completely customizeable dropdown container that is shown when the button is pressed. You should only use `CustomDropdown` if all other DSCO dropdowns do not have the functionality you are looking for.
+
+For guidelines on how to use these components and the features they
+offer, [visit Storybook](https://code-dot-org.github.io/dsco_)
+(link to be updated once code-dot-org storybook will be public.).
+Or run storybook locally and go
+to [Design System / Action Dropdown](http://localhost:9001/?path=/story/designsystem-dropdown-icon-dropdown--default-icon-dropdown).

--- a/frontend/packages/component-library/src/dropdown/__tests__/CustomDropdown.test.tsx
+++ b/frontend/packages/component-library/src/dropdown/__tests__/CustomDropdown.test.tsx
@@ -8,19 +8,19 @@ describe('Design System - Custom Dropdown Component', () => {
   it('renders with correct text and children', () => {
     render(
       <CustomDropdown name="test-dropdown" labelText="Dropdown label" size="m">
-        <div data-testid="dropdown-content">Dropdown content</div>
+        <div>Dropdown content</div>
       </CustomDropdown>,
     );
 
     expect(screen.getByText('Dropdown label')).toBeInTheDocument();
-    expect(screen.getByTestId('dropdown-content')).toBeInTheDocument();
+    expect(screen.getByText('Dropdown content')).toBeInTheDocument();
   });
 
   it('opens and closes when clicked', async () => {
     const user = userEvent.setup();
     render(
       <CustomDropdown name="test-dropdown" labelText="Dropdown label" size="m">
-        <div data-testid="dropdown-content">Dropdown content</div>
+        <div>Dropdown content</div>
       </CustomDropdown>,
     );
 
@@ -30,7 +30,7 @@ describe('Design System - Custom Dropdown Component', () => {
 
     // Initially dropdown content should not be visible
     const dropdownContainer =
-      screen.getByTestId('dropdown-content').parentElement;
+      screen.getByText('Dropdown content').parentElement;
     expect(dropdownContainer).not.toHaveClass('open');
 
     // Click to open dropdown
@@ -55,7 +55,7 @@ describe('Design System - Custom Dropdown Component', () => {
         disabled
         size="m"
       >
-        <div data-testid="dropdown-content">Dropdown content</div>
+        <div>Dropdown content</div>
       </CustomDropdown>,
     );
 
@@ -78,7 +78,7 @@ describe('Design System - Custom Dropdown Component', () => {
         size="m"
         icon={{iconName: 'filter', iconStyle: 'solid', title: 'Filter Icon'}}
       >
-        <div data-testid="dropdown-content">Dropdown content</div>
+        <div>Dropdown content</div>
       </CustomDropdown>,
     );
 
@@ -99,7 +99,7 @@ describe('Design System - Custom Dropdown Component', () => {
           type: 'primary',
         }}
       >
-        <div data-testid="dropdown-content">Dropdown content</div>
+        <div>Dropdown content</div>
       </CustomDropdown>,
     );
 
@@ -120,7 +120,7 @@ describe('Design System - Custom Dropdown Component', () => {
         helperMessage="This is a helper message"
         helperIcon={{iconName: 'info-circle', iconStyle: 'solid'}}
       >
-        <div data-testid="dropdown-content">Dropdown content</div>
+        <div>Dropdown content</div>
       </CustomDropdown>,
     );
 
@@ -137,7 +137,7 @@ describe('Design System - Custom Dropdown Component', () => {
         size="m"
         errorMessage="This is an error message"
       >
-        <div data-testid="dropdown-content">Dropdown content</div>
+        <div>Dropdown content</div>
       </CustomDropdown>,
     );
 
@@ -156,7 +156,7 @@ describe('Design System - Custom Dropdown Component', () => {
         styleAsFormField={true}
         selectedValueText="Selected Option"
       >
-        <div data-testid="dropdown-content">Dropdown content</div>
+        <div>Dropdown content</div>
       </CustomDropdown>,
     );
 

--- a/frontend/packages/component-library/src/dropdown/__tests__/CustomDropdown.test.tsx
+++ b/frontend/packages/component-library/src/dropdown/__tests__/CustomDropdown.test.tsx
@@ -1,0 +1,169 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import {CustomDropdown} from './../index';
+
+describe('Design System - Custom Dropdown Component', () => {
+  it('renders with correct text and children', () => {
+    render(
+      <CustomDropdown name="test-dropdown" labelText="Dropdown label" size="m">
+        <div data-testid="dropdown-content">Dropdown content</div>
+      </CustomDropdown>,
+    );
+
+    expect(screen.getByText('Dropdown label')).toBeInTheDocument();
+    expect(screen.getByTestId('dropdown-content')).toBeInTheDocument();
+  });
+
+  it('opens and closes when clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <CustomDropdown name="test-dropdown" labelText="Dropdown label" size="m">
+        <div data-testid="dropdown-content">Dropdown content</div>
+      </CustomDropdown>,
+    );
+
+    const dropdownButton = screen.getByRole('button', {
+      name: /test-dropdown filter dropdown/i,
+    });
+
+    // Initially dropdown content should not be visible
+    const dropdownContainer =
+      screen.getByTestId('dropdown-content').parentElement;
+    expect(dropdownContainer).not.toHaveClass('open');
+
+    // Click to open dropdown
+    await user.click(dropdownButton);
+
+    // Now dropdown should be visible
+    expect(dropdownButton.parentElement).toHaveClass('open');
+
+    // Click again to close dropdown
+    await user.click(dropdownButton);
+
+    // Dropdown should be closed again
+    expect(dropdownButton.parentElement).not.toHaveClass('open');
+  });
+
+  it("doesn't open when disabled", async () => {
+    const user = userEvent.setup();
+    render(
+      <CustomDropdown
+        name="test-dropdown"
+        labelText="Dropdown label"
+        disabled
+        size="m"
+      >
+        <div data-testid="dropdown-content">Dropdown content</div>
+      </CustomDropdown>,
+    );
+
+    const dropdownButton = screen.getByRole('button', {
+      name: /test-dropdown filter dropdown/i,
+    });
+    expect(dropdownButton).toBeDisabled();
+
+    await user.click(dropdownButton);
+
+    // Dropdown should remain closed
+    expect(dropdownButton.parentElement).not.toHaveClass('open');
+  });
+
+  it('renders with a custom icon', () => {
+    render(
+      <CustomDropdown
+        name="test-dropdown"
+        labelText="Dropdown label"
+        size="m"
+        icon={{iconName: 'filter', iconStyle: 'solid', title: 'Filter Icon'}}
+      >
+        <div data-testid="dropdown-content">Dropdown content</div>
+      </CustomDropdown>,
+    );
+
+    const icon = screen.getByTitle('Filter Icon');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders with DSCO button as trigger', () => {
+    render(
+      <CustomDropdown
+        name="test-dropdown"
+        labelText="Dropdown label"
+        size="m"
+        useDSCOButtonAsTrigger={true}
+        triggerButtonProps={{
+          text: 'DSCO Button',
+          color: 'purple',
+          type: 'primary',
+        }}
+      >
+        <div data-testid="dropdown-content">Dropdown content</div>
+      </CustomDropdown>,
+    );
+
+    // The aria-label on the button is set to the CustomDropdown name prop
+    // (a unique identifier not show to users) and ` filter dropdown`.
+    const button = screen.getByRole('button', {
+      name: 'test-dropdown filter dropdown',
+    });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('renders with helper message and icon', () => {
+    render(
+      <CustomDropdown
+        name="test-dropdown"
+        labelText="Dropdown label"
+        size="m"
+        helperMessage="This is a helper message"
+        helperIcon={{iconName: 'info-circle', iconStyle: 'solid'}}
+      >
+        <div data-testid="dropdown-content">Dropdown content</div>
+      </CustomDropdown>,
+    );
+
+    expect(screen.getByText('This is a helper message')).toBeInTheDocument();
+    const helperIcon = document.querySelector('i.fa-info-circle');
+    expect(helperIcon).toBeInTheDocument();
+  });
+
+  it('renders with error message', () => {
+    render(
+      <CustomDropdown
+        name="test-dropdown"
+        labelText="Dropdown label"
+        size="m"
+        errorMessage="This is an error message"
+      >
+        <div data-testid="dropdown-content">Dropdown content</div>
+      </CustomDropdown>,
+    );
+
+    expect(screen.getByText('This is an error message')).toBeInTheDocument();
+    const errorIcon = document.querySelector('i.fa-circle-exclamation');
+    expect(errorIcon).toBeInTheDocument();
+    expect(screen.getByRole('button').parentElement).toHaveClass('hasError');
+  });
+
+  it('renders as form field with selected value', () => {
+    render(
+      <CustomDropdown
+        name="test-dropdown"
+        labelText="Dropdown label"
+        size="m"
+        styleAsFormField={true}
+        selectedValueText="Selected Option"
+      >
+        <div data-testid="dropdown-content">Dropdown content</div>
+      </CustomDropdown>,
+    );
+
+    expect(screen.getByText('Dropdown label')).toBeInTheDocument();
+    expect(screen.getByText('Selected Option')).toBeInTheDocument();
+    expect(screen.getByRole('button').parentElement).toHaveClass(
+      'styleAsFormField',
+    );
+  });
+});

--- a/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
@@ -9,11 +9,11 @@ import {
 import {ComponentSizeXSToL} from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
-import CustomDropdown, {_CustomDropdownOption} from '../CustomDropdown';
+import CustomDropdown, {CustomDropdownOption} from '../CustomDropdown';
 
 import moduleStyles from './../customDropdown.module.scss';
 
-export interface ActionDropdownOption extends _CustomDropdownOption {
+export interface ActionDropdownOption extends CustomDropdownOption {
   onClick: () => void;
   isOptionDestructive?: boolean;
   icon: FontAwesomeV6IconProps;

--- a/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
@@ -9,7 +9,7 @@ import {
 import {ComponentSizeXSToL} from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
-import CustomDropdown, {_CustomDropdownOption} from './../_CustomDropdown';
+import CustomDropdown, {_CustomDropdownOption} from '../CustomDropdown';
 
 import moduleStyles from './../customDropdown.module.scss';
 

--- a/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
@@ -1,11 +1,8 @@
 import classNames from 'classnames';
-import {useCallback, memo, AriaAttributes} from 'react';
+import {useCallback, AriaAttributes} from 'react';
 
 import {ButtonProps} from '@/button';
-import {
-  DropdownProviderWrapper,
-  useDropdownContext,
-} from '@/common/contexts/DropdownContext';
+import {useDropdownContext} from '@/common/contexts/DropdownContext';
 import {ComponentSizeXSToL} from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
@@ -40,6 +37,19 @@ export interface ActionDropdownProps extends AriaAttributes {
   triggerButtonProps?: ButtonProps;
 }
 
+/**
+ * ### Production-ready Checklist:
+ * * (✔) implementation of component approved by design team;
+ * * (✔) has storybook, covered with stories and documentation;
+ * * (✔) has tests: test every prop, every state and every interaction that's js related;
+ * * (see ./__tests__/ActionDropdown.test.tsx)
+ * * (?) passes accessibility checks;
+ *
+ * ###  Status: ```Ready for dev```
+ *
+ * Design System: Action Dropdown Component.
+ * Used to render dropdowns with a menu/list of different actions.
+ */
 const ActionDropdown: React.FunctionComponent<ActionDropdownProps> = ({
   name,
   className,
@@ -74,69 +84,48 @@ const ActionDropdown: React.FunctionComponent<ActionDropdownProps> = ({
       useDSCOButtonAsTrigger
       triggerButtonProps={triggerButtonProps}
     >
-      <div className={moduleStyles.dropdownMenuContainer}>
-        <ul>
-          {options.map(option => {
-            const {
-              value,
-              label,
-              onClick,
-              isOptionDisabled,
-              isOptionDestructive,
-              icon: {
-                iconName,
-                iconStyle,
-                title: iconTitle,
-                className: iconClassName,
-              },
-            } = option;
-            return (
-              <li key={value}>
-                <button
-                  className={classNames(
-                    moduleStyles.dropdownMenuItem,
-                    isOptionDisabled && moduleStyles.disabledDropdownMenuItem,
-                    isOptionDestructive &&
-                      moduleStyles.destructiveDropdownMenuItem,
-                  )}
-                  disabled={isOptionDisabled || disabled}
-                  type="button"
-                  onClick={() => onOptionClick(onClick)}
-                >
-                  <FontAwesomeV6Icon
-                    iconName={iconName}
-                    iconStyle={iconStyle}
-                    title={iconTitle}
-                    className={iconClassName}
-                  />
-                  <span>{label}</span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
+      <ul>
+        {options.map(option => {
+          const {
+            value,
+            label,
+            onClick,
+            isOptionDisabled,
+            isOptionDestructive,
+            icon: {
+              iconName,
+              iconStyle,
+              title: iconTitle,
+              className: iconClassName,
+            },
+          } = option;
+          return (
+            <li key={value}>
+              <button
+                className={classNames(
+                  moduleStyles.dropdownMenuItem,
+                  isOptionDisabled && moduleStyles.disabledDropdownMenuItem,
+                  isOptionDestructive &&
+                    moduleStyles.destructiveDropdownMenuItem,
+                )}
+                disabled={isOptionDisabled || disabled}
+                type="button"
+                onClick={() => onOptionClick(onClick)}
+              >
+                <FontAwesomeV6Icon
+                  iconName={iconName}
+                  iconStyle={iconStyle}
+                  title={iconTitle}
+                  className={iconClassName}
+                />
+                <span>{label}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
     </CustomDropdown>
   );
 };
 
-/**
- * ### Production-ready Checklist:
- * * (✔) implementation of component approved by design team;
- * * (✔) has storybook, covered with stories and documentation;
- * * (✔) has tests: test every prop, every state and every interaction that's js related;
- * * (see ./__tests__/ActionDropdown.test.tsx)
- * * (?) passes accessibility checks;
- *
- * ###  Status: ```Ready for dev```
- *
- * Design System: Action Dropdown Component.
- * Used to render dropdowns with a menu/list of different actions.
- */
-const WrappedActionDropdown = (props: ActionDropdownProps) => (
-  <DropdownProviderWrapper>
-    <ActionDropdown {...props} />
-  </DropdownProviderWrapper>
-);
-
-export default memo(WrappedActionDropdown);
+export default ActionDropdown;

--- a/frontend/packages/component-library/src/dropdown/actionDropdown/stories/ActionDropdown.story.tsx
+++ b/frontend/packages/component-library/src/dropdown/actionDropdown/stories/ActionDropdown.story.tsx
@@ -4,7 +4,7 @@ import ActionDropdown, {ActionDropdownProps} from '../index';
 
 export default {
   title: 'DesignSystem/Dropdown/Action Dropdown',
-  component: ActionDropdown.type,
+  component: ActionDropdown,
 } as Meta;
 
 //

--- a/frontend/packages/component-library/src/dropdown/checkboxDropdown/CheckboxDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/checkboxDropdown/CheckboxDropdown.tsx
@@ -10,7 +10,7 @@ import {
   DropdownFormFieldRelatedProps,
 } from '@/common/types';
 
-import CustomDropdown, {_CustomDropdownOption} from './../_CustomDropdown';
+import CustomDropdown, {_CustomDropdownOption} from '../CustomDropdown';
 
 import moduleStyles from './../customDropdown.module.scss';
 

--- a/frontend/packages/component-library/src/dropdown/checkboxDropdown/CheckboxDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/checkboxDropdown/CheckboxDropdown.tsx
@@ -10,11 +10,11 @@ import {
   DropdownFormFieldRelatedProps,
 } from '@/common/types';
 
-import CustomDropdown, {_CustomDropdownOption} from '../CustomDropdown';
+import CustomDropdown, {CustomDropdownOption} from '../CustomDropdown';
 
 import moduleStyles from './../customDropdown.module.scss';
 
-export type CheckboxDropdownOption = _CustomDropdownOption;
+export type CheckboxDropdownOption = CustomDropdownOption;
 
 interface BaseCheckboxDropdownProps
   extends DropdownFormFieldRelatedProps,

--- a/frontend/packages/component-library/src/dropdown/checkboxDropdown/CheckboxDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/checkboxDropdown/CheckboxDropdown.tsx
@@ -1,9 +1,8 @@
-import {AriaAttributes, memo} from 'react';
+import {AriaAttributes} from 'react';
 
 import Button, {buttonColors} from '@/button';
 import Checkbox from '@/checkbox';
 import {dropdownColors} from '@/common/constants';
-import {DropdownProviderWrapper} from '@/common/contexts/DropdownContext';
 import {
   ComponentSizeXSToL,
   DropdownColor,
@@ -70,6 +69,19 @@ export type CheckboxDropdownProps =
   | CheckboxDropdownWithoutControlProps
   | CheckboxDropdownWithControlsProps;
 
+/**
+ * ### Production-ready Checklist:
+ * * (✔) implementation of component approved by design team;
+ * * (✔) has storybook, covered with stories and documentation;
+ * * (✔) has tests: test every prop, every state and every interaction that's js related;
+ * * (see ./__tests__/CheckboxDropdown.test.jsx)
+ * * (?) passes accessibility checks;
+ *
+ * ###  Status: ```Ready for dev```
+ *
+ * Design System: Checkbox Dropdown Component.
+ * Used to render checkbox (multiple choice) dropdowns.
+ */
 const CheckboxDropdown: React.FunctionComponent<CheckboxDropdownProps> = ({
   name,
   className,
@@ -147,23 +159,4 @@ const CheckboxDropdown: React.FunctionComponent<CheckboxDropdownProps> = ({
   );
 };
 
-/**
- * ### Production-ready Checklist:
- * * (✔) implementation of component approved by design team;
- * * (✔) has storybook, covered with stories and documentation;
- * * (✔) has tests: test every prop, every state and every interaction that's js related;
- * * (see ./__tests__/CheckboxDropdown.test.jsx)
- * * (?) passes accessibility checks;
- *
- * ###  Status: ```Ready for dev```
- *
- * Design System: Checkbox Dropdown Component.
- * Used to render checkbox (multiple choice) dropdowns.
- */
-const WrappedCheckboxDropdown = (props: CheckboxDropdownProps) => (
-  <DropdownProviderWrapper>
-    <CheckboxDropdown {...props} />
-  </DropdownProviderWrapper>
-);
-
-export default memo(WrappedCheckboxDropdown);
+export default CheckboxDropdown;

--- a/frontend/packages/component-library/src/dropdown/checkboxDropdown/stories/CheckboxDropdown.story.tsx
+++ b/frontend/packages/component-library/src/dropdown/checkboxDropdown/stories/CheckboxDropdown.story.tsx
@@ -7,7 +7,7 @@ import {dropdownColors} from './../../index';
 
 export default {
   title: 'DesignSystem/Dropdown/Checkbox Dropdown',
-  component: CheckboxDropdown.type,
+  component: CheckboxDropdown,
 } as Meta;
 
 //

--- a/frontend/packages/component-library/src/dropdown/iconDropdown/IconDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/iconDropdown/IconDropdown.tsx
@@ -1,11 +1,8 @@
 import classNames from 'classnames';
-import {useCallback, memo, AriaAttributes} from 'react';
+import {useCallback, AriaAttributes} from 'react';
 
 import {dropdownColors} from '@/common/constants';
-import {
-  DropdownProviderWrapper,
-  useDropdownContext,
-} from '@/common/contexts/DropdownContext';
+import {useDropdownContext} from '@/common/contexts/DropdownContext';
 import {
   ComponentSizeXSToL,
   DropdownColor,
@@ -50,6 +47,19 @@ export interface IconDropdownProps
   onChange: (option: IconDropdownOption) => void;
 }
 
+/**
+ * ### Production-ready Checklist:
+ * * (✔) implementation of component approved by design team;
+ * * (✔) has storybook, covered with stories and documentation;
+ * * (✔) has tests: test every prop, every state and every interaction that's js related;
+ * * (see ./__tests__/IconDropdown.test.tsx)
+ * * (?) passes accessibility checks;
+ *
+ * ###  Status: ```Ready for dev```
+ *
+ * Design System: Icon Dropdown Component.
+ * Used to render dropdowns with a list of options with icons.
+ */
 const IconDropdown: React.FunctionComponent<IconDropdownProps> = ({
   name,
   className,
@@ -141,23 +151,4 @@ const IconDropdown: React.FunctionComponent<IconDropdownProps> = ({
   );
 };
 
-/**
- * ### Production-ready Checklist:
- * * (✔) implementation of component approved by design team;
- * * (✔) has storybook, covered with stories and documentation;
- * * (✔) has tests: test every prop, every state and every interaction that's js related;
- * * (see ./__tests__/IconDropdown.test.tsx)
- * * (?) passes accessibility checks;
- *
- * ###  Status: ```Ready for dev```
- *
- * Design System: Icon Dropdown Component.
- * Used to render dropdowns with a list of options with icons.
- */
-const WrappedIconDropdown = (props: IconDropdownProps) => (
-  <DropdownProviderWrapper>
-    <IconDropdown {...props} />
-  </DropdownProviderWrapper>
-);
-
-export default memo(WrappedIconDropdown);
+export default IconDropdown;

--- a/frontend/packages/component-library/src/dropdown/iconDropdown/IconDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/iconDropdown/IconDropdown.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
-import CustomDropdown, {_CustomDropdownOption} from './../_CustomDropdown';
+import CustomDropdown, {_CustomDropdownOption} from '../CustomDropdown';
 
 import moduleStyles from './../customDropdown.module.scss';
 

--- a/frontend/packages/component-library/src/dropdown/iconDropdown/IconDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/iconDropdown/IconDropdown.tsx
@@ -13,11 +13,11 @@ import {
 } from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 
-import CustomDropdown, {_CustomDropdownOption} from '../CustomDropdown';
+import CustomDropdown, {CustomDropdownOption} from '../CustomDropdown';
 
 import moduleStyles from './../customDropdown.module.scss';
 
-export interface IconDropdownOption extends _CustomDropdownOption {
+export interface IconDropdownOption extends CustomDropdownOption {
   icon: FontAwesomeV6IconProps;
 }
 

--- a/frontend/packages/component-library/src/dropdown/iconDropdown/stories/IconDropdown.story.tsx
+++ b/frontend/packages/component-library/src/dropdown/iconDropdown/stories/IconDropdown.story.tsx
@@ -7,7 +7,7 @@ import {dropdownColors} from './../../index';
 
 export default {
   title: 'DesignSystem/Dropdown/Icon Dropdown',
-  component: IconDropdown.type,
+  component: IconDropdown,
 } as Meta;
 
 //

--- a/frontend/packages/component-library/src/dropdown/index.ts
+++ b/frontend/packages/component-library/src/dropdown/index.ts
@@ -5,6 +5,7 @@ import ActionDropdown, {
   ActionDropdownProps,
 } from './actionDropdown/ActionDropdown';
 import CheckboxDropdown, {CheckboxDropdownProps} from './checkboxDropdown';
+import CustomDropdown, {CustomDropdownProps} from './CustomDropdown';
 import IconDropdown, {IconDropdownProps} from './iconDropdown';
 import SimpleDropdown, {SimpleDropdownProps} from './simpleDropdown';
 
@@ -19,4 +20,6 @@ export {
   IconDropdownProps,
   SimpleDropdown,
   SimpleDropdownProps,
+  CustomDropdown,
+  CustomDropdownProps,
 };

--- a/frontend/packages/component-library/src/dropdown/stories/CustomDropdown.story.tsx
+++ b/frontend/packages/component-library/src/dropdown/stories/CustomDropdown.story.tsx
@@ -1,0 +1,119 @@
+import {Meta, StoryFn} from '@storybook/react';
+
+import {Button} from '@/button';
+import Link from '@/link/Link';
+
+import CustomDropdown, {CustomDropdownProps} from '../CustomDropdown';
+
+export default {
+  title: 'DesignSystem/Dropdown/Custom Dropdown',
+  component: CustomDropdown,
+} as Meta;
+
+//
+// TEMPLATE
+//
+const SingleTemplate: StoryFn<CustomDropdownProps> = args => {
+  return (
+    <CustomDropdown
+      {...args}
+      name={args.name || 'custom-dropdown'}
+      labelText={args.labelText || 'Custom Dropdown'}
+    >
+      <ul>
+        <li key="1">
+          <Button
+            text="DSCO Button"
+            onClick={() => console.log('Item 1 clicked')}
+          />
+        </li>
+        <li key="2">
+          <button onClick={() => console.log('Item 2 clicked')}>
+            non-DSCO Button
+          </button>
+        </li>
+        <li key="button-3">
+          <Link text="DSCO Link" href="http://example.com" />
+        </li>
+      </ul>
+    </CustomDropdown>
+  );
+};
+
+export const DefaultCustomDropdown = SingleTemplate.bind({});
+DefaultCustomDropdown.args = {
+  name: 'default-dropdown',
+  labelText: 'Default Dropdown',
+  disabled: false,
+  size: 'm',
+  color: 'black',
+};
+
+export const DisabledCustomDropdown = SingleTemplate.bind({});
+DisabledCustomDropdown.args = {
+  name: 'disabled-dropdown',
+  labelText: 'Disabled Dropdown',
+  disabled: true,
+  size: 'm',
+};
+
+export const WithIconCustomDropdown = SingleTemplate.bind({});
+WithIconCustomDropdown.args = {
+  name: 'with-icon-dropdown',
+  labelText: 'Dropdown with Icon',
+  icon: {
+    iconName: 'filter',
+    iconStyle: 'solid',
+  },
+  size: 'm',
+};
+
+export const WithSelectedValueCustomDropdown = SingleTemplate.bind({});
+WithSelectedValueCustomDropdown.args = {
+  name: 'with-selected-value-dropdown',
+  labelText: 'Dropdown with Selected Value',
+  isSomeValueSelected: true,
+  size: 'm',
+};
+
+export const StyledAsFormFieldCustomDropdown = SingleTemplate.bind({});
+StyledAsFormFieldCustomDropdown.args = {
+  name: 'form-field-dropdown',
+  labelText: 'Form Field Dropdown',
+  styleAsFormField: true,
+  selectedValueText: 'Selected Option',
+  size: 'm',
+};
+
+export const WithHelperMessageCustomDropdown = SingleTemplate.bind({});
+WithHelperMessageCustomDropdown.args = {
+  name: 'with-helper-message-dropdown',
+  labelText: 'Dropdown with Helper',
+  helperMessage: 'This is a helper message',
+  helperIcon: {
+    iconName: 'info-circle',
+    iconStyle: 'solid',
+  },
+  size: 'm',
+};
+
+export const WithErrorMessageCustomDropdown = SingleTemplate.bind({});
+WithErrorMessageCustomDropdown.args = {
+  name: 'with-error-message-dropdown',
+  labelText: 'Dropdown with Error',
+  errorMessage: 'This is an error message',
+  size: 'm',
+};
+
+export const WithDSCOButtonTriggerCustomDropdown = SingleTemplate.bind({});
+WithDSCOButtonTriggerCustomDropdown.args = {
+  name: 'with-dsco-button-dropdown',
+  labelText: 'Dropdown with DSCO Button',
+  useDSCOButtonAsTrigger: true,
+  triggerButtonProps: {
+    text: 'Open Dropdown',
+    color: 'purple',
+    type: 'primary',
+  },
+  size: 'm',
+};


### PR DESCRIPTION
CustomDropdown was initially private to prevent it being the default dropdown by developers and reducing the utility of other dropdown types like the ActionDropdown and CheckboxDropdown. However, the other dropdown types do not cover all use cases.

In this case, the missing use case was a dropdown that allowed for react-router `<Link>` elements.

Therefore, we are exposing the CustomDropdown component for developer use. It is still highly recommend that you use other dropdown types first.

Slack thread with discussion: https://codedotorg.slack.com/archives/C0532LCK125/p1744827531717979

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
Teacher tools ticket that started this discussion: https://codedotorg.atlassian.net/browse/TEACH-1831
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
