### PR TITLE
[Music/Code Bridge] use start sources for predict levels except when code is editable after submitting

### DIFF
--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -122,7 +122,7 @@ export const useInitialSources = (
     }
     if (
       predictSettings?.isPredictLevel &&
-      predictSettings?.codeEditableAfterSubmit === false
+      !predictSettings?.codeEditableAfterSubmit
     ) {
       // Predict levels only use sources loaded from the server if the code is
       // editable after submit, otherwise use the start sources.

--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -120,8 +120,12 @@ export const useInitialSources = (
     if (isStartMode) {
       return startSources;
     }
-    if (predictSettings?.isPredictLevel) {
-      // Predict levels never use sources loaded from the server, only the start sources.
+    if (
+      predictSettings?.isPredictLevel &&
+      predictSettings?.codeEditableAfterSubmit === false
+    ) {
+      // Predict levels only use sources loaded from the server if the code is
+      // editable after submit, otherwise use the start sources.
       return templateSources || startSources;
     }
     if (isEditingExemplar || isViewingExemplar) {
@@ -168,6 +172,7 @@ export const useInitialSources = (
     templateStartSources,
     isStartMode,
     predictSettings?.isPredictLevel,
+    predictSettings?.codeEditableAfterSubmit,
     isEditingExemplar,
     isViewingExemplar,
     initialServerSource,

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -347,8 +347,11 @@ class UnconnectedMusicView extends React.Component {
     );
 
     const startSources = this.getStartSources();
-    const isPredictLevel =
-      this.props.levelProperties?.predictSettings?.isPredictLevel;
+    const predictSettings = this.props.levelProperties?.predictSettings;
+    const isPredictLevel = !!predictSettings?.isPredictLevel;
+    const codeEditableAfterSubmit =
+      predictSettings?.codeEditableAfterSubmit !== false;
+
     // Check if the user has already made changes to the code on the project level.
     let codeChangedOnProjectLevel = false;
     if (isToolboxMode) {
@@ -365,7 +368,12 @@ class UnconnectedMusicView extends React.Component {
       this.loadCode(this.getExemplarSources() || startSources);
     } else if (startSources || initialSources) {
       let codeToLoad = startSources;
-      if (initialSources?.source && !isPredictLevel) {
+      if (
+        initialSources?.source &&
+        // Predict levels only use sources loaded from the server if the code is editable
+        // after submit, otherwise use the start sources.
+        (isPredictLevel ? codeEditableAfterSubmit : true)
+      ) {
         codeToLoad = JSON.parse(initialSources.source);
         codeChangedOnProjectLevel =
           this.props.isProjectLevel &&

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -346,6 +346,9 @@ class UnconnectedMusicView extends React.Component {
       !!levelData?.text || !!this.props.longInstructions
     );
 
+    const startSources = this.getStartSources();
+    const isPredictLevel =
+      this.props.levelProperties?.predictSettings?.isPredictLevel;
     // Check if the user has already made changes to the code on the project level.
     let codeChangedOnProjectLevel = false;
     if (isToolboxMode) {
@@ -359,11 +362,10 @@ class UnconnectedMusicView extends React.Component {
         levelToolboxDefinition
       );
     } else if (isEditingExemplar || isViewingExemplar) {
-      this.loadCode(this.getExemplarSources() || this.getStartSources());
-    } else if (this.getStartSources() || initialSources) {
-      const startSources = this.getStartSources();
+      this.loadCode(this.getExemplarSources() || startSources);
+    } else if (startSources || initialSources) {
       let codeToLoad = startSources;
-      if (initialSources?.source) {
+      if (initialSources?.source && !isPredictLevel) {
         codeToLoad = JSON.parse(initialSources.source);
         codeChangedOnProjectLevel =
           this.props.isProjectLevel &&

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -347,10 +347,6 @@ class UnconnectedMusicView extends React.Component {
     );
 
     const startSources = this.getStartSources();
-    const predictSettings = this.props.levelProperties?.predictSettings;
-    const isPredictLevel = !!predictSettings?.isPredictLevel;
-    const codeEditableAfterSubmit =
-      predictSettings?.codeEditableAfterSubmit !== false;
 
     // Check if the user has already made changes to the code on the project level.
     let codeChangedOnProjectLevel = false;
@@ -367,12 +363,16 @@ class UnconnectedMusicView extends React.Component {
     } else if (isEditingExemplar || isViewingExemplar) {
       this.loadCode(this.getExemplarSources() || startSources);
     } else if (startSources || initialSources) {
+      const predictSettings = this.props.levelProperties?.predictSettings;
+      const isPredictLevel = !!predictSettings?.isPredictLevel;
+      const codeEditableAfterSubmit = predictSettings?.codeEditableAfterSubmit;
+      const isEditablePredictLevel = isPredictLevel && codeEditableAfterSubmit;
       let codeToLoad = startSources;
       if (
         initialSources?.source &&
         // Predict levels only use sources loaded from the server if the code is editable
         // after submit, otherwise use the start sources.
-        (isPredictLevel ? codeEditableAfterSubmit : true)
+        (!isPredictLevel || isEditablePredictLevel)
       ) {
         codeToLoad = JSON.parse(initialSources.source);
         codeChangedOnProjectLevel =

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -328,7 +328,7 @@ describe('useInitialSources', () => {
     expect(initialSources).toEqual(expectedInitialSources);
   });
 
-  it('predict levels always use start code', () => {
+  it('predict levels use start code if code is not editable after submit', () => {
     const {initialSources} = renderDefault(
       predictLevelProperties,
       sampleInitialSources
@@ -338,5 +338,23 @@ describe('useInitialSources', () => {
       labConfig: undefined,
     };
     expect(initialSources).toEqual(expectedInitialSources);
+  });
+
+  it('predict levels use initialSources if code is editable after submit', () => {
+    const editablePredictLevelProperties = {
+      ...predictLevelProperties,
+      predictSettings: {
+        ...predictLevelProperties.predictSettings,
+        isPredictLevel: true,
+        codeEditableAfterSubmit: true,
+      },
+    };
+
+    const {initialSources} = renderDefault(
+      editablePredictLevelProperties,
+      sampleInitialSources
+    );
+
+    expect(initialSources).toEqual(sampleInitialSources);
   });
 });

--- a/apps/test/unit/codebridge/test-files/predictLevelProperties.json
+++ b/apps/test/unit/codebridge/test-files/predictLevelProperties.json
@@ -23,9 +23,7 @@
   },
   "longInstructions": "##Predict and Run\r\n\r\n**What do you think this program does?**\r\n\r\nTake a look at the code in this program. Write down what you think this program will do. There are no wrong answers!",
   "hideShareAndRemix": true,
-  "referenceLinks": [
-    "/courses/csa-2023/guides/instantiating-objects"
-  ],
+  "referenceLinks": ["/courses/csa-2023/guides/instantiating-objects"],
   "mapReference": "/docs/concepts/html/",
   "teacherMarkdown": "Teachers should see this extra info.",
   "predictSettings": {
@@ -35,7 +33,7 @@
     "allowMultipleAttempts": false,
     "placeholderText": "put your answer here!",
     "freeResponseHeight": 100,
-    "codeEditableAfterSubmit": true
+    "codeEditableAfterSubmit": false
   },
   "aiTutorAvailable": true,
   "submittable": false,


### PR DESCRIPTION
Yesterday on levelbuilder, a new callout in a music level, which depended upon a custom block id, wasn't working in a predict level. This was because we were loading initial sources from the server which were saved before the level was converted to a predict level. The workaround to fix this was complicated:
> I had it marked as a predict level which took away my version history button. So I just had to uncheck that box, save, reset version history, edit, check the box for predict, rewrite answers! And…. IT WORKED!

The callout started to work because she had manually realigned her project sources to the start sources, which included the updated block id. However, it's unexpected that we'd even use project sources when loading this type of predict level.

A chat in #lab2-eng revealed that Code Bridge had a similar but opposite bug. Where Music Lab was always using initial sources in predict levels, Code Bridge never was. @molly-moen and I agreed that the correct behavior for both labs is to always use the start sources when loading a predict level _unless users can edit the code after submitting an answer._

Slack thread (report): https://codedotorg.slack.com/archives/C07UT279KM1/p1744835998356589?thread_ts=1744834806.795409&cid=C07UT279KM1

Slack thread (investigation): https://codedotorg.slack.com/archives/C044AGTKW3D/p1744919573211259

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

https://codedotorg.atlassian.net/browse/CT-1188

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manually tested in both Music Lab and Python Lab.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
