### PR TITLE
CMS-43: DSCO - Add CMS `EditorialCard` component

### DIFF
--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -108,6 +108,14 @@
       "import": "./dist/esm/closeButton/index.mjs",
       "require": "./dist/cjs/closeButton/index.js"
     },
+    "./cms/editorialCard": {
+      "types": {
+        "import": "./dist/esm/cms/editorialCard/index.d.ts",
+        "require": "./dist/cjs/cms/editorialCard/index.d.ts"
+      },
+      "import": "./dist/esm/cms/editorialCard/index.mjs",
+      "require": "./dist/cjs/cms/editorialCard/index.js"
+    },
     "./cms/footer": {
       "types": {
         "import": "./dist/esm/cms/footer/index.d.ts",

--- a/frontend/packages/component-library/src/cms/editorialCard/EditorialCard.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/EditorialCard.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import {omit} from 'lodash';
 import {HTMLAttributes, ReactNode} from 'react';
 
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
@@ -60,7 +59,7 @@ const EditorialCard: React.FC<EditorialCardProps> = ({
     )}
   >
     <div className={moduleStyles.editorialCardMedia} aria-hidden="true">
-      {(media as ImageProps)?.src && (
+      {'src' in media && (
         <Image
           {...(media as ImageProps)}
           className={classNames(
@@ -70,7 +69,7 @@ const EditorialCard: React.FC<EditorialCardProps> = ({
         />
       )}
 
-      {(media as FontAwesomeV6IconProps)?.iconName && (
+      {'iconName' in media && (
         <FontAwesomeV6Icon
           {...(media as FontAwesomeV6IconProps)}
           className={classNames(
@@ -95,7 +94,10 @@ const EditorialCard: React.FC<EditorialCardProps> = ({
 
       {link && (
         <Link
-          {...omit(link, ['text'])}
+          {
+            // Omits text from link props
+            ...(({text, ...rest}) => rest || text)(link)
+          }
           className={classNames(moduleStyles.editorialCardLink, link.className)}
           size="s"
         >

--- a/frontend/packages/component-library/src/cms/editorialCard/EditorialCard.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/EditorialCard.tsx
@@ -23,10 +23,10 @@ export interface EditorialCardProps extends HTMLAttributes<HTMLElement> {
   text: string | ReactNode;
   /** EditorialCard link */
   link?: LinkProps;
-  /** EditorialCard class */
-  className?: string;
   /** EditorialCard layout */
   layout?: EDITORIAL_CARD_LAYOUTS;
+  /** EditorialCard class */
+  className?: string;
 }
 
 /**
@@ -34,13 +34,13 @@ export interface EditorialCardProps extends HTMLAttributes<HTMLElement> {
  *  * (✔) implementation of component approved by design team;
  *  * (✔) has storybook, covered with stories and documentation;
  *  * (✔) has tests: test every prop, every state and every interaction that's js related;
- *  * (see ./__tests__/Spacer.test.tsx)
+ *  * (see ./__tests__/EditorialCard.test.tsx)
  *  * (✔) passes accessibility checks;
  *
  * ### Status: ```Ready for dev```
  *
  * Design System: EditorialCard Component.
- * Acts as an editorial card.
+ * Acts as an editorial card that displays an image or icon over related text.
  */
 const EditorialCard: React.FC<EditorialCardProps> = ({
   media,

--- a/frontend/packages/component-library/src/cms/editorialCard/EditorialCard.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/EditorialCard.tsx
@@ -1,0 +1,117 @@
+import classNames from 'classnames';
+import {omit} from 'lodash';
+import {HTMLAttributes, ReactNode} from 'react';
+
+import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
+import Image, {ImageProps} from '@/image';
+import Link, {LinkProps} from '@/link';
+import {Heading3, BodyThreeText} from '@/typography';
+
+import moduleStyles from './editorialCard.module.scss';
+
+export enum EDITORIAL_CARD_LAYOUTS {
+  HORIZONTAL = 'horizontal',
+  VERTICAL = 'vertical',
+}
+
+export interface EditorialCardProps extends HTMLAttributes<HTMLElement> {
+  /** EditorialCard image or icon */
+  media: ImageProps | FontAwesomeV6IconProps;
+  /** EditorialCard heading */
+  heading: string | ReactNode;
+  /** EditorialCard content */
+  text: string | ReactNode;
+  /** EditorialCard link */
+  link?: LinkProps;
+  /** EditorialCard class */
+  className?: string;
+  /** EditorialCard layout */
+  layout?: EDITORIAL_CARD_LAYOUTS;
+}
+
+/**
+ * ## Production-ready Checklist:
+ *  * (✔) implementation of component approved by design team;
+ *  * (✔) has storybook, covered with stories and documentation;
+ *  * (✔) has tests: test every prop, every state and every interaction that's js related;
+ *  * (see ./__tests__/Spacer.test.tsx)
+ *  * (✔) passes accessibility checks;
+ *
+ * ### Status: ```Ready for dev```
+ *
+ * Design System: EditorialCard Component.
+ * Acts as an editorial card.
+ */
+const EditorialCard: React.FC<EditorialCardProps> = ({
+  media,
+  heading,
+  text,
+  link,
+  className,
+  layout = EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
+  ...HTMLAttributes
+}) => (
+  <aside
+    {...HTMLAttributes}
+    className={classNames(
+      moduleStyles.editorialCard,
+      moduleStyles[`editorialCard-layout-${layout}`],
+      className,
+    )}
+  >
+    <div className={moduleStyles.editorialCardMedia} aria-hidden="true">
+      {(media as ImageProps)?.src && (
+        <Image
+          {...(media as ImageProps)}
+          className={classNames(
+            moduleStyles.editorialCardImage,
+            media.className,
+          )}
+        />
+      )}
+
+      {(media as FontAwesomeV6IconProps)?.iconName && (
+        <FontAwesomeV6Icon
+          {...(media as FontAwesomeV6IconProps)}
+          className={classNames(
+            moduleStyles.editorialCardIcon,
+            media.className,
+          )}
+        />
+      )}
+    </div>
+
+    <div className={moduleStyles.editorialCardContent}>
+      <Heading3
+        visualAppearance="heading-sm"
+        className={moduleStyles.editorialCardHeading}
+      >
+        {heading}
+      </Heading3>
+
+      <BodyThreeText className={moduleStyles.editorialCardText}>
+        {text}
+      </BodyThreeText>
+
+      {link && (
+        <Link
+          {...omit(link, ['text'])}
+          className={classNames(moduleStyles.editorialCardLink, link.className)}
+          size="s"
+        >
+          {link.text}
+          {link.external && (
+            <FontAwesomeV6Icon
+              iconName="up-right-from-square"
+              iconStyle="solid"
+              role="img"
+              aria-label="external link"
+            />
+          )}
+        </Link>
+      )}
+    </div>
+  </aside>
+);
+
+export default EditorialCard;

--- a/frontend/packages/component-library/src/cms/editorialCard/EditorialCard.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/EditorialCard.tsx
@@ -96,7 +96,7 @@ const EditorialCard: React.FC<EditorialCardProps> = ({
         <Link
           {
             // Omits text from link props
-            ...(({text, ...rest}) => rest || text)(link)
+            ...(({text, ...rest}) => rest || {text})(link)
           }
           className={classNames(moduleStyles.editorialCardLink, link.className)}
           size="s"

--- a/frontend/packages/component-library/src/cms/editorialCard/README.md
+++ b/frontend/packages/component-library/src/cms/editorialCard/README.md
@@ -12,6 +12,6 @@ import EditorialCard from '@code-dot-org/component-library/cms/editorialCard';
 _Note:_ This component is used primarily for the Contentful CMS.
 
 For guidelines on how to use this component and the features it
-offers, [visit Storybook](https://code-dot-org.github.io/code-dot-org/component-library-storybook/).
+offers, [visit Storybook](https://code-dot-org.github.io/code-dot-org/component-library-storybook/?path=/docs/cms-editorialcard--docs).
 Or run storybook locally and go
 to [CMS / EditorialCard](http://localhost:6006/?path=/docs/cms-editorialcard--docs).

--- a/frontend/packages/component-library/src/cms/editorialCard/README.md
+++ b/frontend/packages/component-library/src/cms/editorialCard/README.md
@@ -1,0 +1,17 @@
+# `component-library/cms/editorialCard`
+
+## Consuming This Component
+
+This package exports one styled React component: [EditorialCard](EditorialCard.tsx).
+You can import it like this:
+
+```javascript
+import EditorialCard from '@code-dot-org/component-library/cms/editorialCard';
+```
+
+_Note:_ This component is used primarily for the Contentful CMS.
+
+For guidelines on how to use this component and the features it
+offers, [visit Storybook](https://code-dot-org.github.io/code-dot-org/component-library-storybook/).
+Or run storybook locally and go
+to [CMS / EditorialCard](http://localhost:6006/?path=/docs/cms-editorialcard--docs).

--- a/frontend/packages/component-library/src/cms/editorialCard/__tests__/EditorialCard.test.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/__tests__/EditorialCard.test.tsx
@@ -1,5 +1,4 @@
 import {render, screen, within} from '@testing-library/react';
-import '@testing-library/jest-dom';
 
 import EditorialCard, {EditorialCardProps} from './../EditorialCard';
 

--- a/frontend/packages/component-library/src/cms/editorialCard/__tests__/EditorialCard.test.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/__tests__/EditorialCard.test.tsx
@@ -1,0 +1,110 @@
+import {render, screen, within} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import EditorialCard, {EditorialCardProps} from './../EditorialCard';
+
+describe('CMS EditorialCard', () => {
+  const heading = 'EditorialCard Heading';
+  const text = 'EditorialCard Text';
+  const media = {iconName: 'smile'};
+
+  const renderCard = (props: Partial<EditorialCardProps> = {}) =>
+    render(
+      <EditorialCard
+        aria-label={heading}
+        {...{heading, text, media}}
+        {...props}
+      />,
+    );
+
+  const getCard = () => screen.getByLabelText(heading);
+
+  it('renders card', () => {
+    renderCard();
+    const card = getCard();
+    expect(card).toBeVisible();
+  });
+
+  it('renders card icon', () => {
+    renderCard();
+    const cardIcon = getCard().querySelector('i');
+    expect(cardIcon).toBeVisible();
+  });
+
+  it('renders card image', () => {
+    const image = {src: 'test.jpg'};
+
+    renderCard({media: image});
+
+    const cardImage = getCard().querySelector('img');
+    expect(cardImage).toBeVisible();
+    expect(cardImage).toHaveAttribute('src', image.src);
+  });
+
+  it('renders card heading', () => {
+    renderCard();
+    const card = getCard();
+    expect(within(card).getByRole('heading', {name: heading})).toBeVisible();
+  });
+
+  it('renders card text', () => {
+    renderCard();
+    const card = getCard();
+    expect(within(card).getByText(text)).toBeVisible();
+  });
+
+  it('renders card link list with provided internal link', () => {
+    const internalLinkProps = {
+      text: 'Internal Link',
+      href: 'https://code.org/internal-link',
+      external: false,
+    };
+
+    renderCard({link: internalLinkProps});
+
+    const internalLink = screen.getByRole('link', {
+      name: internalLinkProps.text,
+    });
+    expect(internalLink).toBeVisible();
+    expect(internalLink).toHaveAttribute('href', internalLinkProps.href);
+    expect(
+      within(internalLink).queryByRole('img', {name: 'external link'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders card link list with provided external link', () => {
+    const externalLinkProps = {
+      text: 'External Link',
+      href: 'https://code.org/external-link',
+      external: true,
+    };
+
+    renderCard({link: externalLinkProps});
+
+    const externalLink = screen.getByRole('link', {
+      name: new RegExp(externalLinkProps.text, 'i'),
+    });
+    expect(externalLink).toBeVisible();
+    expect(externalLink).toHaveAttribute('href', externalLinkProps.href);
+    expect(
+      within(externalLink).queryByRole('img', {name: 'external link'}),
+    ).toBeInTheDocument();
+  });
+
+  it('renders card with provided className styles', () => {
+    const className = 'customClass';
+    const classStyle = 'color: red;';
+
+    renderCard({className});
+    const card = getCard();
+
+    expect(card).not.toHaveStyle(classStyle);
+
+    // Add custom CSS directly in the test
+    const style = document.createElement('style');
+    style.innerHTML = `.${className} { ${classStyle} }`;
+    document.head.appendChild(style);
+
+    expect(card).toHaveStyle(classStyle);
+  });
+});

--- a/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
+++ b/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
@@ -1,0 +1,90 @@
+@use '@code-dot-org/component-library-styles/colors.scss';
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
+
+// EditorialCard common styles
+.editorialCard {
+  background: var(--background-neutral-primary);
+  display: flex;
+  gap: 1.5rem;
+  width: fit-content;
+
+  .editorialCardMedia {
+    flex-shrink: 0;
+
+    .editorialCardImage {
+      background: var(--background-neutral-tertiary);
+      border-radius: 50%;
+      overflow: hidden;
+    }
+
+    .editorialCardIcon {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      border-radius: 50%;
+      border: 3px solid var(--text-neutral-primary);
+      outline: 0.375rem solid var(--background-brand-teal-light);
+      margin: 0.375rem;
+      width: 3.5rem;
+      height: 3.5rem;
+      overflow: hidden;
+
+      &:before {
+        @include mixins.icon-dimensions(1.5rem);
+      }
+    }
+  }
+
+  .editorialCardContent {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    gap: 0.5rem;
+
+    > * {
+      margin: 0;
+    }
+
+    .editorialCardText {
+      white-space: pre-wrap;
+    }
+
+    .editorialCardLink {
+      gap: 0.375rem;
+    }
+  }
+}
+
+// EditorialCard layouts
+.editorialCard-layout {
+  &-horizontal {
+    flex-direction: row;
+    align-items: start;
+
+    .editorialCardImage {
+      width: 8rem;
+      height: 8rem;
+    }
+
+    .editorialCardContent {
+      align-items: start;
+      text-align: start;
+    }
+  }
+
+  &-vertical {
+    flex-direction: column;
+    align-items: center;
+
+    .editorialCardImage {
+      width: 12rem;
+      height: 12rem;
+    }
+
+    .editorialCardContent {
+      align-items: center;
+      text-align: center;
+    }
+  }
+}

--- a/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
+++ b/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
@@ -1,4 +1,3 @@
-@use '@code-dot-org/component-library-styles/colors.scss';
 @use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 
 // EditorialCard common styles

--- a/frontend/packages/component-library/src/cms/editorialCard/index.ts
+++ b/frontend/packages/component-library/src/cms/editorialCard/index.ts
@@ -1,0 +1,4 @@
+import './index.css';
+
+export type {EditorialCardProps} from './EditorialCard';
+export {default as default, EDITORIAL_CARD_LAYOUTS} from './EditorialCard';

--- a/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
@@ -44,6 +44,13 @@ const defaultProps: EditorialCardProps = {
   },
 };
 
+const withIconProps: EditorialCardProps = {
+  ...defaultProps,
+  media: {
+    iconName: 'smile',
+  },
+};
+
 //
 // STORIES
 //
@@ -53,7 +60,7 @@ export const Playground: Story = {
   },
 };
 
-export const VerticalLayout: Story = {
+export const VerticalWithImage: Story = {
   args: [
     {
       ...defaultProps,
@@ -70,7 +77,7 @@ export const VerticalLayout: Story = {
   ],
 };
 
-export const HorizontalLayout: Story = {
+export const HorizontalWithImage: Story = {
   args: [
     {
       ...defaultProps,
@@ -91,23 +98,40 @@ export const HorizontalLayout: Story = {
   ],
 };
 
-export const WithIcon: Story = {
+export const VerticalWithIcon: Story = {
   args: [
     {
-      ...defaultProps,
-      heading: 'Horizontal EditorialCard',
-      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
-      media: {
-        iconName: 'smile',
-      },
+      ...withIconProps,
+      layout: EDITORIAL_CARD_LAYOUTS.VERTICAL,
     },
     {
-      ...defaultProps,
-      heading: 'Vertical EditorialCard',
+      ...withIconProps,
       layout: EDITORIAL_CARD_LAYOUTS.VERTICAL,
-      media: {
-        iconName: 'smile',
-      },
+    },
+    {
+      ...withIconProps,
+      layout: EDITORIAL_CARD_LAYOUTS.VERTICAL,
+    },
+  ],
+};
+
+export const HorizontalWithIcon: Story = {
+  args: [
+    {
+      ...withIconProps,
+      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
+    },
+    {
+      ...withIconProps,
+      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
+    },
+    {
+      ...withIconProps,
+      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
+    },
+    {
+      ...withIconProps,
+      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
     },
   ],
 };

--- a/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
@@ -16,24 +16,24 @@ export default {
       ? Object.values(args)
       : [args];
     return (
-      <>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${components.length % 3 === 0 ? 3 : 2}, 1fr)`,
+          gap: '4rem',
+        }}
+      >
         {components.map((component, index) => (
-          <section key={index} style={{width: '27rem', marginBottom: '2rem'}}>
-            <EditorialCard {...defaultProps} {...component} />
-          </section>
+          <EditorialCard key={index} {...defaultProps} {...component} />
         ))}
-      </>
+      </div>
     );
   },
 } as Meta;
 
 const defaultProps: EditorialCardProps = {
   heading: 'EditorialCard Heading',
-  text:
-    'Students can explore their imagination as ' +
-    'they design unique, interactive experiences,\n' +
-    'making game design a powerful tool for ' +
-    'artistic expression.',
+  text: 'Students can explore their imagination as they design unique, interactive experiences, making game design a powerful tool for artistic expression.',
   media: {
     src: imageFile,
   },
@@ -53,17 +53,40 @@ export const Playground: Story = {
   },
 };
 
-export const Layouts: Story = {
+export const VerticalLayout: Story = {
   args: [
     {
       ...defaultProps,
-      heading: 'Horizontal EditorialCard',
+      layout: EDITORIAL_CARD_LAYOUTS.VERTICAL,
+    },
+    {
+      ...defaultProps,
+      layout: EDITORIAL_CARD_LAYOUTS.VERTICAL,
+    },
+    {
+      ...defaultProps,
+      layout: EDITORIAL_CARD_LAYOUTS.VERTICAL,
+    },
+  ],
+};
+
+export const HorizontalLayout: Story = {
+  args: [
+    {
+      ...defaultProps,
       layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
     },
     {
       ...defaultProps,
-      heading: 'Vertical EditorialCard',
-      layout: EDITORIAL_CARD_LAYOUTS.VERTICAL,
+      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
+    },
+    {
+      ...defaultProps,
+      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
+    },
+    {
+      ...defaultProps,
+      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
     },
   ],
 };

--- a/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
@@ -16,7 +16,7 @@ export default {
       ? Object.values(args)
       : [args];
     return (
-      <div
+      <section
         style={{
           display: 'grid',
           gridTemplateColumns: `repeat(${components.length % 3 === 0 ? 3 : 2}, 1fr)`,
@@ -26,7 +26,7 @@ export default {
         {components.map((component, index) => (
           <EditorialCard key={index} {...defaultProps} {...component} />
         ))}
-      </div>
+      </section>
     );
   },
 } as Meta;

--- a/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
@@ -1,0 +1,90 @@
+import imageFile from '@public/images/image-component.png';
+import type {Meta, StoryObj} from '@storybook/react';
+
+import EditorialCard, {
+  EDITORIAL_CARD_LAYOUTS,
+  EditorialCardProps,
+} from './../EditorialCard';
+
+type Story = StoryObj<EditorialCardProps | EditorialCardProps[]>;
+
+export default {
+  title: 'CMS/EditorialCard',
+  component: EditorialCard,
+  render: args => {
+    const components: EditorialCardProps[] = args[0]
+      ? Object.values(args)
+      : [args];
+    return (
+      <>
+        {components.map((component, index) => (
+          <section key={index} style={{width: '27rem', marginBottom: '2rem'}}>
+            <EditorialCard {...defaultProps} {...component} />
+          </section>
+        ))}
+      </>
+    );
+  },
+} as Meta;
+
+const defaultProps: EditorialCardProps = {
+  heading: 'EditorialCard Heading',
+  text:
+    'Students can explore their imagination as ' +
+    'they design unique, interactive experiences,\n' +
+    'making game design a powerful tool for ' +
+    'artistic expression.',
+  media: {
+    src: imageFile,
+  },
+  link: {
+    text: 'EditorialCard Link',
+    href: 'https://code.org',
+    external: true,
+  },
+};
+
+//
+// STORIES
+//
+export const Playground: Story = {
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const Layouts: Story = {
+  args: [
+    {
+      ...defaultProps,
+      heading: 'Horizontal EditorialCard',
+      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
+    },
+    {
+      ...defaultProps,
+      heading: 'Vertical EditorialCard',
+      layout: EDITORIAL_CARD_LAYOUTS.VERTICAL,
+    },
+  ],
+};
+
+export const WithIcon: Story = {
+  args: [
+    {
+      ...defaultProps,
+      heading: 'Horizontal EditorialCard',
+      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
+      media: {
+        iconName: 'smile',
+      },
+    },
+    {
+      ...defaultProps,
+      heading: 'Vertical EditorialCard',
+      layout: EDITORIAL_CARD_LAYOUTS.VERTICAL,
+      media: {
+        iconName: 'smile',
+      },
+    },
+  ],
+};

--- a/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
+++ b/frontend/packages/component-library/src/cms/editorialCard/stories/EditorialCard.story.tsx
@@ -114,24 +114,3 @@ export const VerticalWithIcon: Story = {
     },
   ],
 };
-
-export const HorizontalWithIcon: Story = {
-  args: [
-    {
-      ...withIconProps,
-      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
-    },
-    {
-      ...withIconProps,
-      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
-    },
-    {
-      ...withIconProps,
-      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
-    },
-    {
-      ...withIconProps,
-      layout: EDITORIAL_CARD_LAYOUTS.HORIZONTAL,
-    },
-  ],
-};


### PR DESCRIPTION
## Horizontal With Image
<img width="100%" alt="horizontal-layout" src="https://github.com/user-attachments/assets/3d434a62-0d56-4e5d-a94e-471d38e778a8" />

## Vertical With Image
<img width="100%" alt="vertical-layout" src="https://github.com/user-attachments/assets/583073bf-4d38-42aa-aaa8-9af85626723c" />

## Vertical With Icon
<img width="100%" alt="vertical-with-icon" src="https://github.com/user-attachments/assets/128b6076-b183-451f-8148-8a2782f0e645" />

## Links
- JIRA task: [CMS-43](https://codedotorg.atlassian.net/browse/CMS-43)
- Figma: [Editorial Card](https://www.figma.com/design/l7PsQAs2pitCNP8zUHWEuy/DSCO-CMS?node-id=2963-1164)