### PR TITLE
SUM - initial UI for student row pop-up

### DIFF
--- a/apps/src/aiEvaluation/aiInteractionFeedbackApi.ts
+++ b/apps/src/aiEvaluation/aiInteractionFeedbackApi.ts
@@ -6,6 +6,7 @@ export interface FeedbackData {
   thumbsUp?: boolean;
   levelId?: number;
   scriptId?: number;
+  metadata?: Record<string, string | boolean>;
 }
 
 export async function logUserFeedbackOnStudentEvaluation(
@@ -24,6 +25,7 @@ export async function logUserFeedbackOnStudentEvaluation(
         thumbsUp: feedbackData.thumbsUp,
         levelId: feedbackData.levelId,
         scriptId: feedbackData.scriptId,
+        metadata: feedbackData.metadata,
       }),
     });
 

--- a/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
+++ b/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
@@ -1,19 +1,25 @@
 import Button from '@code-dot-org/component-library/button';
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import {Heading4, StrongText} from '@code-dot-org/component-library/typography';
-import React, {useState} from 'react';
+import React, {useState, useRef} from 'react';
 
+import {
+  FeedbackData,
+  logUserFeedbackOnStudentEvaluation,
+} from '@cdo/apps/aiEvaluation/aiInteractionFeedbackApi';
 import AccessibleDialog from '@cdo/apps/sharedComponents/AccessibleDialog';
 import i18n from '@cdo/locale';
 
 import style from './summary.module.scss';
 
 interface AiEvaluationFeedbackModalProps {
+  feedbackData: FeedbackData;
   forStudentAiInteractionFeedback: boolean;
   closeModalHandler: () => void;
 }
 
 const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
+  feedbackData,
   forStudentAiInteractionFeedback,
   closeModalHandler,
 }) => {
@@ -24,24 +30,23 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
   const [aiFeedbackOther, setAiFeedbackOther] = useState(false);
   const [aiOtherContent, setAiOtherContent] = useState('');
 
-  const handleSendingFeedback = async () => {
-    const bodyData = {
+  const reasonGivenRef = useRef(false);
+
+  const sendFeedbackWithMetadata = async () => {
+    const metadata = {
       tooHigh: aiTooHigh,
       tooLow: aiTooLow,
       flaggedIncorrectly: aiFlagged,
-      // 'Vague' is capitalized to avoid a ForbiddenAttributes error
-      // error cause is unknown
       Vague: aiVague,
       feedbackOther: aiFeedbackOther,
       otherContent: aiOtherContent,
     };
 
-    // await updateAiFeedback(bodyData, aiFeedbackId);
-
-    // setAISubmitted(true);
-    // setAIFeedbackReceived(true);
-    console.log('Feedback prepped:', bodyData);
-    closeModalHandler();
+    const combinedFeedbackData = {
+      ...feedbackData,
+      metadata,
+    };
+    logUserFeedbackOnStudentEvaluation(combinedFeedbackData);
   };
 
   const renderOptionsForStudentAiInteractionFeedback = () => {
@@ -93,12 +98,10 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
           <div className={style.aiFeedbackOther}>
             <StrongText>{i18n.aiFeedbackOtherDetails()} </StrongText>
             <textarea
-              //   className={style.aiFeedbackTextbox}
               onChange={e => {
                 setAiOtherContent(e.target.value);
               }}
-              // eslint-disable-next-line react/forbid-dom-props
-              data-testid="ai-frq-feedback-textarea"
+              aria-label="AI feedback details"
             />
           </div>
         )}
@@ -106,13 +109,27 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
     );
   };
 
+  const handleSubmitButtonClick = () => {
+    reasonGivenRef.current = true;
+    sendFeedbackWithMetadata();
+    closeModalHandler();
+  };
+
+  const onCloseHandler = () => {
+    if (!reasonGivenRef.current) {
+      logUserFeedbackOnStudentEvaluation(feedbackData);
+      closeModalHandler();
+    }
+  };
+
   return (
-    <AccessibleDialog onClose={closeModalHandler} closeOnClickBackdrop={true}>
+    <AccessibleDialog onClose={onCloseHandler} closeOnClickBackdrop={true}>
       <div>
         <Heading4>
           Why is the AI analysis inaccurate? (Check all that apply)
         </Heading4>
         <hr />
+        {/* TODO: add options for section-level feedback - TEACH-1769 */}
         {forStudentAiInteractionFeedback &&
           renderOptionsForStudentAiInteractionFeedback()}
         <hr />
@@ -124,7 +141,7 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
             text={i18n.closeDialog()}
           />
           <Button
-            onClick={handleSendingFeedback}
+            onClick={handleSubmitButtonClick}
             type="primary"
             color="purple"
             text={i18n.aiFeedbackSubmit()}

--- a/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
+++ b/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
@@ -25,7 +25,7 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
 }) => {
   const [aiTooHigh, setAiTooHigh] = useState(false);
   const [aiTooLow, setAiTooLow] = useState(false);
-  const [aiFlagged, setAiFlagged] = useState(false);
+  const [aiProfanityFalsePositive, setAiFalsePositiveFlag] = useState(false);
   const [aiVague, setAiVague] = useState(false);
   const [aiFeedbackOther, setAiFeedbackOther] = useState(false);
   const [aiOtherContent, setAiOtherContent] = useState('');
@@ -36,7 +36,7 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
     const metadata = {
       tooHigh: aiTooHigh,
       tooLow: aiTooLow,
-      flaggedIncorrectly: aiFlagged,
+      profanityFalsePositive: aiProfanityFalsePositive,
       Vague: aiVague,
       feedbackOther: aiFeedbackOther,
       otherContent: aiOtherContent,
@@ -70,9 +70,9 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
           label={'Response was evaluated too high'}
         />
         <Checkbox
-          checked={aiFlagged}
+          checked={aiProfanityFalsePositive}
           onChange={() => {
-            setAiFlagged(!aiFlagged);
+            setAiFalsePositiveFlag(!aiProfanityFalsePositive);
           }}
           name={'flagged'}
           label={'Response was incorrectly flagged'}

--- a/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
+++ b/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
@@ -101,6 +101,7 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
               onChange={e => {
                 setAiOtherContent(e.target.value);
               }}
+              className={style.aiFeedbackOtherTextArea}
               aria-label="AI feedback details"
             />
           </div>

--- a/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
+++ b/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
@@ -1,0 +1,138 @@
+import Button from '@code-dot-org/component-library/button';
+import Checkbox from '@code-dot-org/component-library/checkbox';
+import {Heading4, StrongText} from '@code-dot-org/component-library/typography';
+import React, {useState} from 'react';
+
+import AccessibleDialog from '@cdo/apps/sharedComponents/AccessibleDialog';
+import i18n from '@cdo/locale';
+
+import style from './summary.module.scss';
+
+interface AiEvaluationFeedbackModalProps {
+  forStudentAiInteractionFeedback: boolean;
+  closeModalHandler: () => void;
+}
+
+const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
+  forStudentAiInteractionFeedback,
+  closeModalHandler,
+}) => {
+  const [aiTooHigh, setAiTooHigh] = useState(false);
+  const [aiTooLow, setAiTooLow] = useState(false);
+  const [aiFlagged, setAiFlagged] = useState(false);
+  const [aiVague, setAiVague] = useState(false);
+  const [aiFeedbackOther, setAiFeedbackOther] = useState(false);
+  const [aiOtherContent, setAiOtherContent] = useState('');
+
+  const handleSendingFeedback = async () => {
+    const bodyData = {
+      tooHigh: aiTooHigh,
+      tooLow: aiTooLow,
+      flaggedIncorrectly: aiFlagged,
+      // 'Vague' is capitalized to avoid a ForbiddenAttributes error
+      // error cause is unknown
+      Vague: aiVague,
+      feedbackOther: aiFeedbackOther,
+      otherContent: aiOtherContent,
+    };
+
+    // await updateAiFeedback(bodyData, aiFeedbackId);
+
+    // setAISubmitted(true);
+    // setAIFeedbackReceived(true);
+    console.log('Feedback prepped:', bodyData);
+    closeModalHandler();
+  };
+
+  const renderOptionsForStudentAiInteractionFeedback = () => {
+    return (
+      <>
+        <Checkbox
+          checked={aiTooLow}
+          onChange={() => {
+            setAiTooLow(!aiTooLow);
+          }}
+          name={'tooLow'}
+          label={'Response was evaluated too low'}
+        />
+
+        <Checkbox
+          checked={aiTooHigh}
+          onChange={() => {
+            setAiTooHigh(!aiTooHigh);
+          }}
+          name={'tooHigh'}
+          label={'Response was evaluated too high'}
+        />
+        <Checkbox
+          checked={aiFlagged}
+          onChange={() => {
+            setAiFlagged(!aiFlagged);
+          }}
+          name={'flagged'}
+          label={'Response was incorrectly flagged'}
+        />
+
+        <Checkbox
+          checked={aiVague}
+          onChange={() => {
+            setAiVague(!aiVague);
+          }}
+          name={'notHelpful'}
+          label={'Not specific enough to be helpful'}
+        />
+        <Checkbox
+          checked={aiFeedbackOther}
+          onChange={() => {
+            setAiFeedbackOther(!aiFeedbackOther);
+          }}
+          name={'other'}
+          label={'Other'}
+        />
+        {aiFeedbackOther && (
+          <div className={style.aiFeedbackOther}>
+            <StrongText>{i18n.aiFeedbackOtherDetails()} </StrongText>
+            <textarea
+              //   className={style.aiFeedbackTextbox}
+              onChange={e => {
+                setAiOtherContent(e.target.value);
+              }}
+              // eslint-disable-next-line react/forbid-dom-props
+              data-testid="ai-frq-feedback-textarea"
+            />
+          </div>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <AccessibleDialog onClose={closeModalHandler} closeOnClickBackdrop={true}>
+      <div>
+        <Heading4>
+          Why is the AI analysis inaccurate? (Check all that apply)
+        </Heading4>
+        <hr />
+        {forStudentAiInteractionFeedback &&
+          renderOptionsForStudentAiInteractionFeedback()}
+        <hr />
+        <div className={style.feedbackPortalButtonContainer}>
+          <Button
+            onClick={closeModalHandler}
+            type="secondary"
+            color="black"
+            text={i18n.closeDialog()}
+          />
+          <Button
+            onClick={handleSendingFeedback}
+            type="primary"
+            color="purple"
+            text={i18n.aiFeedbackSubmit()}
+          />
+        </div>
+      </div>
+    </AccessibleDialog>
+  );
+};
+
+export default AiEvaluationFeedbackModal;

--- a/apps/src/templates/levelSummary/FreeResponseStudentResponseRow.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseStudentResponseRow.tsx
@@ -22,6 +22,7 @@ const FreeResponseStudentResponseRow: React.FC<
   FreeResponseStudentResponseRowProps
 > = ({studentWorkEvaluation}) => {
   const [feedbackModalOpen, setFeedbackModalOpen] = useState<boolean>(false);
+  const [feedbackData, setFeedbackData] = useState<FeedbackData | null>(null);
 
   // used to create the tag for the response
   const analysisTag = () => {
@@ -104,17 +105,19 @@ const FreeResponseStudentResponseRow: React.FC<
   };
 
   const handleFeedbackClick = async (thumbsUp: boolean) => {
-    const feedbackData: FeedbackData = {
+    const feedbackDataGenerated = {
       aiInteractionType: 'UserLevelEvaluation',
       aiInteractionId: studentWorkEvaluation.id,
       thumbsUp,
       levelId: studentWorkEvaluation.levelId,
       scriptId: studentWorkEvaluation.unitId,
     };
+    setFeedbackData(feedbackDataGenerated);
 
-    logUserFeedbackOnStudentEvaluation(feedbackData);
     if (!thumbsUp) {
       setFeedbackModalOpen(true);
+    } else {
+      logUserFeedbackOnStudentEvaluation(feedbackDataGenerated);
     }
   };
 
@@ -138,8 +141,9 @@ const FreeResponseStudentResponseRow: React.FC<
           color="gray"
         />
       </div>
-      {feedbackModalOpen && (
+      {feedbackModalOpen && feedbackData && (
         <AiEvaluationFeedbackModal
+          feedbackData={feedbackData}
           forStudentAiInteractionFeedback={true}
           closeModalHandler={() => {
             setFeedbackModalOpen(false);

--- a/apps/src/templates/levelSummary/FreeResponseStudentResponseRow.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseStudentResponseRow.tsx
@@ -1,6 +1,6 @@
 import Tags from '@code-dot-org/component-library/tags';
 import {BodyThreeText} from '@code-dot-org/component-library/typography';
-import React from 'react';
+import React, {useState} from 'react';
 
 import {StudentWorkEvaluation} from '@cdo/apps/aiEvaluation/aiEvaluationApi';
 import {
@@ -8,6 +8,7 @@ import {
   logUserFeedbackOnStudentEvaluation,
 } from '@cdo/apps/aiEvaluation/aiInteractionFeedbackApi';
 
+import AiEvaluationFeedbackModal from './AiEvaluationFeedbackModal';
 import {FEEDBACK_TYPE} from './AiFeedbackType';
 import FeedbackToggle from './FeedbackToggle';
 
@@ -20,6 +21,8 @@ type FreeResponseStudentResponseRowProps = {
 const FreeResponseStudentResponseRow: React.FC<
   FreeResponseStudentResponseRowProps
 > = ({studentWorkEvaluation}) => {
+  const [feedbackModalOpen, setFeedbackModalOpen] = useState<boolean>(false);
+
   // used to create the tag for the response
   const analysisTag = () => {
     if (
@@ -110,6 +113,9 @@ const FreeResponseStudentResponseRow: React.FC<
     };
 
     logUserFeedbackOnStudentEvaluation(feedbackData);
+    if (!thumbsUp) {
+      setFeedbackModalOpen(true);
+    }
   };
 
   return (
@@ -132,6 +138,14 @@ const FreeResponseStudentResponseRow: React.FC<
           color="gray"
         />
       </div>
+      {feedbackModalOpen && (
+        <AiEvaluationFeedbackModal
+          forStudentAiInteractionFeedback={true}
+          closeModalHandler={() => {
+            setFeedbackModalOpen(false);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/apps/src/templates/levelSummary/summary.module.scss
+++ b/apps/src/templates/levelSummary/summary.module.scss
@@ -484,3 +484,11 @@ svg text[fill] {
   color: var(--text-neutral-quaternary, #727a83) !important;
   margin-bottom: 0 !important;
 }
+
+.feedbackPortalButtonContainer {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  align-items: flex-start;
+  align-self: stretch;
+}

--- a/apps/src/templates/levelSummary/summary.module.scss
+++ b/apps/src/templates/levelSummary/summary.module.scss
@@ -492,3 +492,16 @@ svg text[fill] {
   align-items: flex-start;
   align-self: stretch;
 }
+
+.aiFeedbackOther {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.aiFeedbackOtherTextArea {
+  width: 100%;
+  padding: 8px 12px;
+  box-sizing: border-box;
+}

--- a/dashboard/app/controllers/ai_interaction_feedback_controller.rb
+++ b/dashboard/app/controllers/ai_interaction_feedback_controller.rb
@@ -22,7 +22,7 @@ class AiInteractionFeedbackController < ApplicationController
       :scriptId,
       :thumbsUp,
       :schoolYear,
-      :metadata
+      metadata: {}
     ).transform_keys {|key| key.to_s.underscore.to_sym}
   end
 end


### PR DESCRIPTION
This adds a pop-up and logs data for when a user gives thumbs up/down feedback on a student row.  Video shows logging thumbs up feedback, thumbs down feedback with additional data on why thumbs down was selected, as well as logging thumbs down even if a user doesn't fill out the modal.


https://github.com/user-attachments/assets/e031fe2b-491c-49a8-a468-4462eb7f7115

Future work:

- In the future we might want to decide how to handle if a user clicks thumbs down multiple times - how do we send that data or modify that data.  
- Tests.
- Clean up some styles (the modal isn't perfectly aligned to the figma from a style perspective, but I wanted to get this out there before I got too much further in the work).

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1770)
[Figma](https://www.figma.com/design/i3smpK0bu5Tnc1JgmmMfTI/Check-For-Understanding-Summaries?node-id=2856-10373&m=dev)

## Testing story

Tests are coming in a future PR - this is something Erin and I have on our radar before launch.
