### PR TITLE
[HOME] Add a loading state to settings

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -59,7 +59,9 @@ export default function CurriculumQuickAssign({
   const [courseOfferings, setCourseOfferings] = useState(null);
   const [filteredCourseOfferings, setFilteredCourseOfferings] = useState(null);
   const [decideLater, setDecideLater] = useState(false);
-  const [marketingAudience, setMarketingAudience] = useState('');
+  const [marketingAudience, setMarketingAudience] = useState(
+    MARKETING_AUDIENCE.ELEMENTARY
+  );
   const [selectedCourseOffering, setSelectedCourseOffering] = useState();
   const [isLoading, setIsLoading] = useState(true);
 
@@ -289,7 +291,9 @@ export default function CurriculumQuickAssign({
       {isLoading && !isNewSection ? (
         <>
           <Heading3>{i18n.assignCurriculum()}</Heading3>
-          <Spinner />
+          <div className={moduleStyles.loadingSpinner}>
+            <Spinner />
+          </div>
         </>
       ) : (
         <>

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -59,9 +59,7 @@ export default function CurriculumQuickAssign({
   const [courseOfferings, setCourseOfferings] = useState(null);
   const [filteredCourseOfferings, setFilteredCourseOfferings] = useState(null);
   const [decideLater, setDecideLater] = useState(false);
-  const [marketingAudience, setMarketingAudience] = useState(
-    MARKETING_AUDIENCE.ELEMENTARY
-  );
+  const [marketingAudience, setMarketingAudience] = useState('');
   const [selectedCourseOffering, setSelectedCourseOffering] = useState();
   const [isLoading, setIsLoading] = useState(true);
 

--- a/apps/src/templates/sectionsRefresh/LoadingSectionsSetUpContainer.tsx
+++ b/apps/src/templates/sectionsRefresh/LoadingSectionsSetUpContainer.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import SectionsSetUpContainer from './SectionsSetUpContainer';
+
+interface LoadingSectionsSetUpContainerProps {
+  defaultRedirectUrl: string;
+}
+
+const LoadingSectionsSetUpContainer: React.FC<
+  LoadingSectionsSetUpContainerProps
+> = ({defaultRedirectUrl}) => {
+  const defaultSection = {
+    id: -1,
+    name: '',
+    code: '',
+    grade: [],
+    hidden: false,
+    loginType: 'email',
+    participantType: 'student',
+    pairingAllowed: true,
+    restrictSection: false,
+    ttsAutoplayEnabled: false,
+    lessonExtras: true,
+    aiTutorEnabled: false,
+    sharing_disabled: false,
+    sharingDisabled: false,
+    primaryInstructor: {
+      id: -1,
+      email: '',
+      userId: -1,
+      isCurrentUser: true,
+      ltiRosterSyncEnabled: false,
+    },
+    sectionInstructors: [],
+    course: {
+      textToSpeechEnabled: false,
+      lessonExtrasAvailable: false,
+    },
+  };
+
+  return (
+    <SectionsSetUpContainer
+      isUsersFirstSection={false}
+      sectionToBeEdited={defaultSection}
+      canEnableAITutor={false}
+      defaultRedirectUrl={defaultRedirectUrl}
+      setIsEditInProgress={() => {}}
+      isLoading={true}
+    />
+  );
+};
+
+export default LoadingSectionsSetUpContainer;

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -17,6 +17,7 @@ import InfoHelpTip from '@cdo/apps/sharedComponents/InfoHelpTip';
 import Notification, {
   NotificationType,
 } from '@cdo/apps/sharedComponents/Notification';
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
 import CoteacherSettings from '@cdo/apps/templates/sectionsRefresh/coteacherSettings/CoteacherSettings';
 import {navigateToHref} from '@cdo/apps/utils';
@@ -79,6 +80,7 @@ export default function SectionsSetUpContainer({
   userCountry,
   defaultRedirectUrl,
   setIsEditInProgress = value => {},
+  isLoading = false,
 }) {
   const [sections, updateSection] = useSections(sectionToBeEdited);
   const updateSectionAndSetEditInProgress = (sectionIdx, keyToUpdate, val) => {
@@ -434,68 +436,80 @@ export default function SectionsSetUpContainer({
           updateSectionAndSetEditInProgress(0, key, val)
         }
         isNewSection={isNewSection}
+        isLoading={isLoading}
       />
 
-      {/* Allow the curriculum quick assign region to be configured per-region */}
-      <GlobalEditionWrapper
-        component={CurriculumQuickAssign}
-        componentId="CurriculumQuickAssign"
-        props={{
-          id: 'uitest-curriculum-quick-assign',
-          isNewSection: isNewSection,
-          updateSection: (key, val) => updateSection(0, key, val),
-          setIsEditInProgress: setIsEditInProgress,
-          sectionCourse: sections[0].course || consolidatedCourseData(),
-          initialParticipantType: sections[0].participantType,
-        }}
-      />
-
-      <div
-        className={classnames(
-          moduleStyles.containerWithMarginTop,
-          moduleStyles.withBorderTop
-        )}
-      >
-        {renderCoteacherSection()}
-        {renderAdvancedSettings()}
-      </div>
-      <div
-        className={classnames(
-          moduleStyles.splitButtonsContainer,
-          moduleStyles.containerWithMarginTop
-        )}
-      >
-        {isNewSection && ( // Only show 'save and add another' button when creating a new section
-          <Button
-            className={moduleStyles.buttonLeft}
-            icon="plus"
-            text={i18n.addAnotherClassSection()}
-            color={Button.ButtonColor.neutralDark}
-            onClick={e => {
-              e.preventDefault();
-              saveSection(sections[0], true, coteachersToAdd);
+      {isLoading ? (
+        <>
+          <Heading3>{i18n.assignCurriculum()}</Heading3>
+          <div className={moduleStyles.loadingSpinner}>
+            <Spinner />
+          </div>
+        </>
+      ) : (
+        <>
+          {/* Allow the curriculum quick assign region to be configured per-region */}
+          <GlobalEditionWrapper
+            component={CurriculumQuickAssign}
+            componentId="CurriculumQuickAssign"
+            props={{
+              id: 'uitest-curriculum-quick-assign',
+              isNewSection: isNewSection,
+              updateSection: (key, val) => updateSection(0, key, val),
+              setIsEditInProgress: setIsEditInProgress,
+              sectionCourse: sections[0].course || consolidatedCourseData(),
+              initialParticipantType: sections[0].participantType,
             }}
           />
-        )}
-        <Button
-          className={moduleStyles.buttonRight}
-          id="uitest-save-section-changes"
-          text={
-            isSaveInProgress
-              ? i18n.saving()
-              : isNewSection
-              ? i18n.finishCreatingSections()
-              : i18n.save()
-          }
-          color={Button.ButtonColor.brandSecondaryDefault}
-          disabled={isSaveInProgress}
-          onClick={e => {
-            e.preventDefault();
-            setIsSaveInProgress(true);
-            saveSection(sections[0], false, coteachersToAdd);
-          }}
-        />
-      </div>
+
+          <div
+            className={classnames(
+              moduleStyles.containerWithMarginTop,
+              moduleStyles.withBorderTop
+            )}
+          >
+            {renderCoteacherSection()}
+            {renderAdvancedSettings()}
+          </div>
+          <div
+            className={classnames(
+              moduleStyles.splitButtonsContainer,
+              moduleStyles.containerWithMarginTop
+            )}
+          >
+            {isNewSection && ( // Only show 'save and add another' button when creating a new section
+              <Button
+                className={moduleStyles.buttonLeft}
+                icon="plus"
+                text={i18n.addAnotherClassSection()}
+                color={Button.ButtonColor.neutralDark}
+                onClick={e => {
+                  e.preventDefault();
+                  saveSection(sections[0], true, coteachersToAdd);
+                }}
+              />
+            )}
+            <Button
+              className={moduleStyles.buttonRight}
+              id="uitest-save-section-changes"
+              text={
+                isSaveInProgress
+                  ? i18n.saving()
+                  : isNewSection
+                  ? i18n.finishCreatingSections()
+                  : i18n.save()
+              }
+              color={Button.ButtonColor.brandSecondaryDefault}
+              disabled={isSaveInProgress}
+              onClick={e => {
+                e.preventDefault();
+                setIsSaveInProgress(true);
+                saveSection(sections[0], false, coteachersToAdd);
+              }}
+            />
+          </div>
+        </>
+      )}
     </form>
   );
 }
@@ -507,4 +521,5 @@ SectionsSetUpContainer.propTypes = {
   userCountry: PropTypes.string,
   defaultRedirectUrl: PropTypes.string.isRequired,
   setIsEditInProgress: PropTypes.func,
+  isLoading: PropTypes.bool,
 };

--- a/apps/src/templates/sectionsRefresh/SingleSectionSetUp.jsx
+++ b/apps/src/templates/sectionsRefresh/SingleSectionSetUp.jsx
@@ -1,5 +1,6 @@
 import Chips from '@code-dot-org/component-library/chips';
 import {Heading2} from '@code-dot-org/component-library/typography';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -11,17 +12,21 @@ import {StudentGradeLevels} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import moduleStyles from './sections-refresh.module.scss';
+import skeletonizeContent from '@cdo/apps/sharedComponents/skeletonize-content.module.scss';
 
 export default function SingleSectionSetUp({
   sectionNum,
   section,
   updateSection,
   isNewSection,
+  isLoading = false,
 }) {
   const gradeOptions = StudentGradeLevels.map(g => ({label: g, value: g}));
   const participantType = isNewSection
     ? queryParams('participantType')
     : section.participantType;
+
+  console.log('lfm', {section});
 
   return (
     <div>
@@ -29,14 +34,25 @@ export default function SingleSectionSetUp({
         <Heading2>{i18n.classSection()}</Heading2>
         <label className={moduleStyles.typographyLabelTwo}>
           {i18n.className()}
-          <input
-            required
-            type="text"
-            id="uitest-section-name-setup"
-            className={moduleStyles.classNameTextField}
-            value={section.name}
-            onChange={e => updateSection('name', e.target.value)}
-          />
+
+          {isLoading ? (
+            <div
+              className={classNames(
+                moduleStyles.skeletonTextField,
+                skeletonizeContent.skeletonizeContent
+              )}
+            />
+          ) : (
+            <input
+              required
+              type="text"
+              id="uitest-section-name-setup"
+              className={moduleStyles.classNameTextField}
+              value={section.name}
+              onChange={e => updateSection('name', e.target.value)}
+              disabled={isLoading}
+            />
+          )}
         </label>
       </div>
       {experiments.isEnabled('teacher-homepage-v2') &&
@@ -63,6 +79,7 @@ export default function SingleSectionSetUp({
             options={gradeOptions}
             values={section.grades || []}
             setValues={g => updateSection('grades', g)}
+            disabled={isLoading}
           />
         </div>
       )}
@@ -75,4 +92,5 @@ SingleSectionSetUp.propTypes = {
   section: PropTypes.object.isRequired,
   updateSection: PropTypes.func.isRequired,
   isNewSection: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
 };

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -31,6 +31,14 @@ input.classNameTextField {
   }
 }
 
+.skeletonTextField {
+  width: 100%;
+  box-sizing: border-box;
+  height: 31px;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}
+
 label.typographyLabelTwo {
   @include label-two;
 }
@@ -231,4 +239,8 @@ button.advancedSettingsButton {
 
 .avatarContainer {
   margin-bottom: 20px;
+}
+
+.loadingSpinner {
+  margin-bottom: 16px;
 }

--- a/apps/src/templates/teacherNavigation/DashboardSectionSettings.tsx
+++ b/apps/src/templates/teacherNavigation/DashboardSectionSettings.tsx
@@ -1,10 +1,12 @@
 import Modal from '@code-dot-org/component-library/modal';
+import _ from 'lodash';
 import React from 'react';
-import {useBlocker} from 'react-router-dom';
+import {useBlocker, useParams} from 'react-router-dom';
 
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
+import LoadingSectionsSetUpContainer from '../sectionsRefresh/LoadingSectionsSetUpContainer';
 import SectionsSetUpContainer from '../sectionsRefresh/SectionsSetUpContainer';
 import {selectedSectionSelector} from '../teacherDashboard/teacherSectionsReduxSelectors';
 
@@ -22,6 +24,17 @@ const DashboardSectionSettings: React.FunctionComponent<
 > = ({redirectUrl}) => {
   const selectedSection = useAppSelector(selectedSectionSelector);
   const [isEditInProgress, setIsEditInProgress] = React.useState(false);
+  const {isLoadingSectionData, needsReload} = useAppSelector(
+    state => state.teacherSections
+  );
+  const urlSectionId = useParams().sectionId;
+  const isLoading = React.useMemo(
+    () =>
+      isLoadingSectionData ||
+      needsReload ||
+      _.toNumber(urlSectionId) !== selectedSection.id,
+    [isLoadingSectionData, needsReload, urlSectionId, selectedSection.id]
+  );
 
   const blocker = useBlocker(
     ({currentLocation, nextLocation}) =>
@@ -41,12 +54,16 @@ const DashboardSectionSettings: React.FunctionComponent<
 
   return (
     <div>
-      <SectionsSetUpContainer
-        isUsersFirstSection={false}
-        sectionToBeEdited={selectedSection}
-        defaultRedirectUrl={redirectUrl}
-        setIsEditInProgress={setIsEditInProgress}
-      />
+      {isLoading ? (
+        <LoadingSectionsSetUpContainer defaultRedirectUrl={redirectUrl} />
+      ) : (
+        <SectionsSetUpContainer
+          isUsersFirstSection={false}
+          sectionToBeEdited={selectedSection}
+          defaultRedirectUrl={redirectUrl}
+          setIsEditInProgress={setIsEditInProgress}
+        />
+      )}
       {blocker.state === 'blocked' && (
         <Modal
           title={i18n.saveBlockerModalTitle()}

--- a/apps/src/templates/teacherNavigation/PageHeader.tsx
+++ b/apps/src/templates/teacherNavigation/PageHeader.tsx
@@ -20,14 +20,16 @@ import styles from './teacher-navigation.module.scss';
 import skeletonizeContent from '@cdo/apps/sharedComponents/skeletonize-content.module.scss';
 
 const skeletonSectionName = (
-  <span
+  <Typography
+    semanticTag={'h2'}
+    visualAppearance={'overline-two'}
     className={classNames(
       skeletonizeContent.skeletonizeContent,
       styles.skeletonHeaderSectionName
     )}
   >
     SKELETON SECTION NAME
-  </span>
+  </Typography>
 );
 
 const PageHeader: React.FC = () => {

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -173,9 +173,6 @@ const TeacherNavigationBar: React.FC<{
             unitName: sections[sectionId]?.unitName,
           })
         );
-        if (currentPathObject.url === TEACHER_NAVIGATION_PATHS.settings) {
-          window.location.reload();
-        }
       }
 
       analyticsReporter.sendEvent(EVENTS.NAVIGATE_TO_SECTION, {

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -53,7 +53,7 @@
   margin-bottom: 2px;
 }
 
-.sidebarNewTags{
+.sidebarNewTags {
   margin-inline-start: 10px;
 }
 
@@ -62,7 +62,7 @@
 }
 
 .sidebarSectionHeader .sidebarNewTags div span {
-  color: white
+  color: white;
 }
 
 .sectionDropdown {
@@ -160,8 +160,12 @@
   }
 }
 
-.skeletonHeaderSectionName {
+h2.skeletonHeaderSectionName {
   width: fit-content;
+  height: 21px;
+  margin-bottom: 0;
+  margin-top: 0;
+  border-radius: 4px;
 }
 
 .calendarContentContainer {

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -55,12 +55,12 @@ describe('CurriculumQuickAssign', () => {
       />
     );
 
-    expect(wrapper.find('Button').at(0).props().icon).toBe('caret-down');
+    expect(wrapper.find('Button').at(0).props().icon).toBe('caret-right');
     wrapper
       .find('Button')
       .at(0)
       .simulate('click', {preventDefault: () => {}});
-    expect(wrapper.find('Button').at(0).props().icon).toBe('caret-right');
+    expect(wrapper.find('Button').at(0).props().icon).toBe('caret-down');
   });
 
   it('opens and closes version dropdowns with table open and collapse', () => {
@@ -72,17 +72,17 @@ describe('CurriculumQuickAssign', () => {
       />
     );
 
-    expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(1);
-    wrapper
-      .find('Button')
-      .at(0)
-      .simulate('click', {preventDefault: () => {}});
     expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(0);
     wrapper
       .find('Button')
       .at(0)
       .simulate('click', {preventDefault: () => {}});
     expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(1);
+    wrapper
+      .find('Button')
+      .at(0)
+      .simulate('click', {preventDefault: () => {}});
+    expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(0);
   });
 
   it('leaves dropdowns alone when decide later clicked', () => {
@@ -94,14 +94,8 @@ describe('CurriculumQuickAssign', () => {
       />
     );
 
-    // Dropdown starts open
-    expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(1);
-
-    // Close dropdown first
-    wrapper
-      .find('Button')
-      .at(0)
-      .simulate('click', {preventDefault: () => {}});
+    // No dropdowns active at beginning
+    expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(0);
 
     // Toggle decide later, verify its state changes.
     expect(wrapper.find('input').props().checked).toBe(false);

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -55,12 +55,12 @@ describe('CurriculumQuickAssign', () => {
       />
     );
 
-    expect(wrapper.find('Button').at(0).props().icon).toBe('caret-right');
+    expect(wrapper.find('Button').at(0).props().icon).toBe('caret-down');
     wrapper
       .find('Button')
       .at(0)
       .simulate('click', {preventDefault: () => {}});
-    expect(wrapper.find('Button').at(0).props().icon).toBe('caret-down');
+    expect(wrapper.find('Button').at(0).props().icon).toBe('caret-right');
   });
 
   it('opens and closes version dropdowns with table open and collapse', () => {
@@ -72,17 +72,17 @@ describe('CurriculumQuickAssign', () => {
       />
     );
 
-    expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(0);
-    wrapper
-      .find('Button')
-      .at(0)
-      .simulate('click', {preventDefault: () => {}});
     expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(1);
     wrapper
       .find('Button')
       .at(0)
       .simulate('click', {preventDefault: () => {}});
     expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(0);
+    wrapper
+      .find('Button')
+      .at(0)
+      .simulate('click', {preventDefault: () => {}});
+    expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(1);
   });
 
   it('leaves dropdowns alone when decide later clicked', () => {
@@ -94,8 +94,14 @@ describe('CurriculumQuickAssign', () => {
       />
     );
 
-    // No dropdowns active at beginning
-    expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(0);
+    // Dropdown starts open
+    expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(1);
+
+    // Close dropdown first
+    wrapper
+      .find('Button')
+      .at(0)
+      .simulate('click', {preventDefault: () => {}});
 
     // Toggle decide later, verify its state changes.
     expect(wrapper.find('input').props().checked).toBe(false);


### PR DESCRIPTION
Fixes two issues:
* Needing a hard reload whenever a new section is selected
* Showing the incorrect section when linked from the homepage


## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
