### PR TITLE
feat(opengraph): use default og:image

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {draftMode} from 'next/headers';
 
 import FontLoader from '@code-dot-org/fonts/FontLoader';
 
+import {Brand} from '@/config/brand';
 import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
 import {getExperience} from '@/contentful/get-experience';
 import {getSeoMetadata} from '@/metadata/seo';
@@ -16,7 +17,7 @@ export const dynamic = 'force-static'; // Ensure ISR is enabled
 export const revalidate = 600; // Cache for five minutes until on-demand revalidation works
 
 type ExperiencePageProps = {
-  params: Promise<{locale?: string; slug?: string; preview?: string}>;
+  params: Promise<{locale?: string; slug?: string; brand?: Brand}>;
   searchParams: Promise<{[key: string]: string | string[] | undefined}>;
 };
 
@@ -41,6 +42,7 @@ export async function generateMetadata({
   params,
   searchParams,
 }: ExperiencePageProps): Promise<Metadata> {
+  const {brand} = (await params) || {};
   const pageProps = await getPageProps({
     params,
     searchParams,
@@ -50,7 +52,7 @@ export async function generateMetadata({
 
   return {
     title: getPageHeading(experience),
-    ...getSeoMetadata(experience, pageProps.locale),
+    ...getSeoMetadata(experience, brand, pageProps.locale),
   };
 }
 export default async function ExperiencePage({

--- a/frontend/apps/marketing/src/config/metadata/opengraph.ts
+++ b/frontend/apps/marketing/src/config/metadata/opengraph.ts
@@ -1,0 +1,9 @@
+import {Brand} from '@/config/brand';
+
+export const BRAND_OPENGRAPH_DEFAULT_IMAGE_URL: {
+  [brand in Brand]: string | undefined;
+} = {
+  [Brand.CODE_DOT_ORG]:
+    'https://images.ctfassets.net/90t6bu6vlf76/6QAykNTAjFdgHya4lBchyF/539e119f045b74395ec9aca97bacf6ed/opengraph-default.png',
+  [Brand.HOUR_OF_CODE]: undefined,
+};

--- a/frontend/apps/marketing/src/metadata/__tests__/seo.test.ts
+++ b/frontend/apps/marketing/src/metadata/__tests__/seo.test.ts
@@ -1,6 +1,7 @@
 import {Experience} from '@contentful/experiences-sdk-react';
 import {Metadata} from 'next';
 
+import {Brand} from '@/config/brand';
 import {getSeoMetadataFromExperience} from '@/selectors/contentful/getExperienceEntryFields';
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 import {SeoMetadata} from '@/types/contentful/entries/SeoMetadata';
@@ -56,7 +57,7 @@ describe('getSeoMetadata', () => {
 
   it('should return metadata when seoMetadata is defined', () => {
     const locale = 'en-US';
-    const result = getSeoMetadata(mockExperience, locale);
+    const result = getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, locale);
 
     expect(result).toEqual<Metadata>({
       title: 'Test Title',
@@ -71,13 +72,7 @@ describe('getSeoMetadata', () => {
         title: 'OG Title',
         description: 'OG Description',
         url: './',
-        images: [
-          {
-            url: 'https://example.com/test-image.jpg',
-            width: 1200,
-            height: 630,
-          },
-        ],
+        images: 'https://example.com/test-image.jpg',
       },
       robots: {
         index: true,
@@ -89,7 +84,7 @@ describe('getSeoMetadata', () => {
   it('should return undefined when seoMetadata is undefined', () => {
     (getSeoMetadataFromExperience as jest.Mock).mockReturnValue(undefined);
 
-    const result = getSeoMetadata(mockExperience, 'en-US');
+    const result = getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, 'en-US');
 
     expect(result).toBeUndefined();
   });
@@ -104,7 +99,28 @@ describe('getSeoMetadata', () => {
       seoMetadataWithoutImage,
     );
 
-    const result = getSeoMetadata(mockExperience, locale);
+    const result = getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, locale);
+
+    expect(result?.openGraph?.images).toBe(
+      'https://images.ctfassets.net/90t6bu6vlf76/6QAykNTAjFdgHya4lBchyF/539e119f045b74395ec9aca97bacf6ed/opengraph-default.png',
+    );
+  });
+
+  it('should handle missing openGraphImage default image gracefully', () => {
+    const locale = 'en-US';
+    const seoMetadataWithoutImage = {
+      ...mockSeoMetadata,
+      openGraphImage: undefined,
+    };
+    (getSeoMetadataFromExperience as jest.Mock).mockReturnValue(
+      seoMetadataWithoutImage,
+    );
+
+    const result = getSeoMetadata(
+      mockExperience,
+      'incorrect brand' as Brand,
+      locale,
+    );
 
     expect(result?.openGraph?.images).toBeUndefined();
   });
@@ -119,7 +135,7 @@ describe('getSeoMetadata', () => {
       seoMetadataWithoutRobots,
     );
 
-    const result = getSeoMetadata(mockExperience, 'en-US');
+    const result = getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, 'en-US');
 
     expect(result?.robots).toEqual({
       index: true,

--- a/frontend/apps/marketing/src/metadata/seo.ts
+++ b/frontend/apps/marketing/src/metadata/seo.ts
@@ -1,12 +1,15 @@
 import {Experience} from '@contentful/experiences-sdk-react';
 import {Metadata} from 'next';
 
+import {Brand} from '@/config/brand';
+import {BRAND_OPENGRAPH_DEFAULT_IMAGE_URL} from '@/config/metadata/opengraph';
 import {getSeoMetadataFromExperience} from '@/selectors/contentful/getExperienceEntryFields';
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 import {SeoMetadata} from '@/types/contentful/entries/SeoMetadata';
 
 export function getSeoMetadata(
   experience: Experience | undefined,
+  brand: Brand | undefined,
   locale: string,
 ): Metadata | undefined {
   const seoMetadata = getSeoMetadataFromExperience(experience);
@@ -22,15 +25,17 @@ export function getSeoMetadata(
     alternates: {
       canonical: seoMetadata.canonicalUrl,
     },
-    openGraph: getOpenGraph(seoMetadata, locale),
+    openGraph: getOpenGraph(seoMetadata, brand, locale),
     robots: getRobots(seoMetadata),
   };
 }
 
-function getOpenGraph(seoMetadata: SeoMetadata, locale: string) {
+function getOpenGraph(
+  seoMetadata: SeoMetadata,
+  brand: Brand | undefined,
+  locale: string,
+) {
   const openGraphImage = seoMetadata.openGraphImage;
-  const openGraphAssetFile = openGraphImage?.fields?.file;
-  const openGraphImageDetails = openGraphAssetFile?.details?.image;
   const openGraphImageUrl = getAbsoluteImageUrl(openGraphImage);
 
   return {
@@ -41,14 +46,10 @@ function getOpenGraph(seoMetadata: SeoMetadata, locale: string) {
     url: './',
     images:
       openGraphImage && openGraphImageUrl
-        ? [
-            {
-              url: openGraphImageUrl,
-              width: openGraphImageDetails?.width,
-              height: openGraphImageDetails?.height,
-            },
-          ]
-        : undefined,
+        ? openGraphImageUrl
+        : brand
+          ? BRAND_OPENGRAPH_DEFAULT_IMAGE_URL[brand]
+          : undefined,
   };
 }
 

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -47,8 +47,6 @@ test.describe('All the things UI e2e test', () => {
     expect(await allTheThingsPage.getOpenGraph('image')).toBe(
       'https://images.ctfassets.net/90t6bu6vlf76/4hXiOPiRlCXpmtypRNOZqc/9ebe430094c1ae1faf742e1de3f8aa8b/engineering-only-opengraph-default.png',
     );
-    expect(await allTheThingsPage.getOpenGraph('image:width')).toBe('1200');
-    expect(await allTheThingsPage.getOpenGraph('image:height')).toBe('630');
     expect(await allTheThingsPage.getOpenGraph('type')).toBe('website');
   });
 


### PR DESCRIPTION
When no opengraph image is specified in the content type, use a default open graph image.