### PR TITLE
feat(statsig): add statsig stable id to `marketing`

### DIFF
--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -43,10 +43,12 @@
     "@statsig/statsig-node-core": "^0.0.8",
     "@statsig/web-analytics": "^3.14.1",
     "contentful": "^11.2.5",
+    "cookies-next": "^5.1.0",
     "next": "^15.2.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-schemaorg": "^2.0.0"
+    "react-schemaorg": "^2.0.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@applitools/eyes-playwright": "^1.36.3",

--- a/frontend/apps/marketing/src/providers/statsig/__tests__/client.test.tsx
+++ b/frontend/apps/marketing/src/providers/statsig/__tests__/client.test.tsx
@@ -1,0 +1,179 @@
+import {useClientBootstrapInit} from '@statsig/react-bindings';
+import {render} from '@testing-library/react';
+import {setCookie, getCookie} from 'cookies-next/client';
+import {v4 as uuidv4} from 'uuid';
+
+import {Stage} from '@/config/stage';
+import OneTrustContext, {
+  OneTrustCookieGroup,
+} from '@/providers/onetrust/context/OneTrustContext';
+import plugins from '@/providers/statsig/plugins';
+
+import {getClient} from '../client';
+
+jest.mock('@statsig/react-bindings', () => ({
+  useClientBootstrapInit: jest.fn(),
+}));
+
+jest.mock('cookies-next/client', () => ({
+  getCookie: jest.fn(),
+  setCookie: jest.fn(),
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(),
+}));
+
+jest.mock('@/providers/statsig/plugins', () => ({}));
+
+const MockStatsigComponent = ({
+  clientKey,
+  stage,
+  values,
+}: {
+  clientKey: string;
+  stage: Stage;
+  values: string;
+}) => {
+  getClient(clientKey, stage, values);
+
+  return <></>;
+};
+
+describe('getClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use the statsig stable id from cookie if exists', () => {
+    (getCookie as jest.Mock).mockReturnValue('existing-stable-id');
+    const clientKey = 'test-client-key';
+    const stage = 'production';
+    const values = 'test-values';
+
+    render(
+      <OneTrustContext.Provider
+        value={{allowedCookies: new Set([OneTrustCookieGroup.Performance])}}
+      >
+        <MockStatsigComponent
+          clientKey={clientKey}
+          stage={stage}
+          values={values}
+        />
+        <div>Test Child</div>
+      </OneTrustContext.Provider>,
+    );
+
+    expect(useClientBootstrapInit).toHaveBeenCalledWith(
+      clientKey,
+      {userID: 'marketing-user', customIDs: {stableID: 'existing-stable-id'}},
+      values,
+      {
+        environment: {tier: stage},
+        plugins: plugins,
+      },
+    );
+    expect(setCookie).not.toHaveBeenCalled();
+  });
+
+  it('should generate a new stableId if none exists', () => {
+    (getCookie as jest.Mock).mockReturnValue(null);
+    (uuidv4 as jest.Mock).mockReturnValue('new-stable-id');
+    const clientKey = 'test-client-key';
+    const stage = 'development';
+    const values = 'test-values';
+
+    render(
+      <OneTrustContext.Provider
+        value={{allowedCookies: new Set([OneTrustCookieGroup.Performance])}}
+      >
+        <MockStatsigComponent
+          clientKey={clientKey}
+          stage={stage}
+          values={values}
+        />
+        <div>Test Child</div>
+      </OneTrustContext.Provider>,
+    );
+
+    expect(useClientBootstrapInit).toHaveBeenCalledWith(
+      clientKey,
+      {userID: 'marketing-user', customIDs: {stableID: 'new-stable-id'}},
+      values,
+      {
+        environment: {tier: stage},
+        plugins: plugins,
+      },
+    );
+
+    expect(setCookie).toHaveBeenCalledWith(
+      'statsig_stable_id',
+      'new-stable-id',
+      {path: '/'},
+    );
+  });
+
+  it('should use the correct environment tier based on the stage', () => {
+    (getCookie as jest.Mock).mockReturnValue('existing-stable-id');
+    const clientKey = 'test-client-key';
+    const stage = 'development';
+    const values = 'test-values';
+
+    render(
+      <OneTrustContext.Provider
+        value={{allowedCookies: new Set([OneTrustCookieGroup.Performance])}}
+      >
+        <MockStatsigComponent
+          clientKey={clientKey}
+          stage={stage}
+          values={values}
+        />
+        <div>Test Child</div>
+      </OneTrustContext.Provider>,
+    );
+
+    expect(useClientBootstrapInit).toHaveBeenCalledWith(
+      clientKey,
+      {userID: 'marketing-user', customIDs: {stableID: 'existing-stable-id'}},
+      values,
+      {
+        environment: {tier: stage},
+        plugins: plugins,
+      },
+    );
+  });
+
+  it('should NOT generate a new stableId if performance cookies are disabled', () => {
+    (getCookie as jest.Mock).mockReturnValue(null);
+    (uuidv4 as jest.Mock).mockReturnValue('new-stable-id');
+    const clientKey = 'test-client-key';
+    const stage = 'development';
+    const values = 'test-values';
+
+    render(
+      <OneTrustContext.Provider
+        value={{
+          allowedCookies: new Set([OneTrustCookieGroup.StrictlyNecessary]),
+        }}
+      >
+        <MockStatsigComponent
+          clientKey={clientKey}
+          stage={stage}
+          values={values}
+        />
+        <div>Test Child</div>
+      </OneTrustContext.Provider>,
+    );
+
+    expect(useClientBootstrapInit).toHaveBeenCalledWith(
+      clientKey,
+      {userID: 'marketing-user', customIDs: {stableID: undefined}},
+      values,
+      {
+        environment: {tier: stage},
+        plugins: plugins,
+      },
+    );
+    expect(setCookie).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/marketing/src/providers/statsig/client.ts
+++ b/frontend/apps/marketing/src/providers/statsig/client.ts
@@ -1,11 +1,43 @@
 import {useClientBootstrapInit} from '@statsig/react-bindings';
+import {setCookie} from 'cookies-next';
+import {getCookie} from 'cookies-next/client';
+import {useContext} from 'react';
+import {v4 as uuidv4} from 'uuid';
 
 import {Stage} from '@/config/stage';
+import OneTrustContext, {
+  OneTrustCookieGroup,
+} from '@/providers/onetrust/context/OneTrustContext';
 import plugins from '@/providers/statsig/plugins';
 
+function getStatsigStableId() {
+  const onetrustContext = useContext(OneTrustContext);
+
+  if (!onetrustContext?.allowedCookies.has(OneTrustCookieGroup.Performance)) {
+    // If the user has not allowed performance cookies, we do not set a stable ID
+    return undefined;
+  }
+
+  let stableId = getCookie('statsig_stable_id');
+
+  if (!stableId) {
+    stableId = uuidv4();
+    setCookie('statsig_stable_id', stableId, {
+      path: '/',
+    });
+  }
+
+  return stableId;
+}
+
 export function getClient(clientKey: string, stage: Stage, values: string) {
-  return useClientBootstrapInit(clientKey, {userID: 'marketing-user'}, values, {
-    environment: {tier: stage},
-    plugins: plugins,
-  });
+  return useClientBootstrapInit(
+    clientKey,
+    {userID: 'marketing-user', customIDs: {stableID: getStatsigStableId()}},
+    values,
+    {
+      environment: {tier: stage},
+      plugins: plugins,
+    },
+  );
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1100,6 +1100,7 @@ __metadata:
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
     contentful: "npm:^11.2.5"
+    cookies-next: "npm:^5.1.0"
     dotenv: "npm:^16.4.7"
     eslint: "npm:^9.16.0"
     eslint-plugin-jest: "npm:^28.9.0"
@@ -1115,6 +1116,7 @@ __metadata:
     stylelint: "npm:^16.14.1"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5"
+    uuid: "npm:^11.1.0"
   languageName: unknown
   linkType: soft
 
@@ -8126,6 +8128,25 @@ __metadata:
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "cookie@npm:1.0.2"
+  checksum: 10c0/fd25fe79e8fbcfcaf6aa61cd081c55d144eeeba755206c058682257cb38c4bd6795c6620de3f064c740695bb65b7949ebb1db7a95e4636efb8357a335ad3f54b
+  languageName: node
+  linkType: hard
+
+"cookies-next@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "cookies-next@npm:5.1.0"
+  dependencies:
+    cookie: "npm:^1.0.1"
+  peerDependencies:
+    next: ">=15.0.0"
+    react: ">= 16.8.0"
+  checksum: 10c0/0769e18dcaa2d9b4c51593014a8a7e360dbe809c54fdfc61310b8b53edd670ee6bdf01593067dcf81760827956cb17c07786efe22bb3d94b23e0dd388457fddb
   languageName: node
   linkType: hard
 
@@ -18742,6 +18763,15 @@ __metadata:
   version: 0.4.0
   resolution: "utila@npm:0.4.0"
   checksum: 10c0/2791604e09ca4f77ae314df83e80d1805f867eb5c7e13e7413caee01273c278cf2c9a3670d8d25c889a877f7b149d892fe61b0181a81654b425e9622ab23d42e
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds support for the Statsig stable id feature as defined in the Statsig documentation[1]. It works by reading the `statsig_stable_id` cookie and if such a cookie does not exist, setting the cookie with a v4 uuid.

Longer term, we should look into using a shared analytics package in `frontend/packages/analytics` to share the same logic between marketing and dashboard.

[1] https://docs.statsig.com/client/javascript-sdk/stable-id/