### PR TITLE
feat(marketing): enable request memoization

### DIFF
--- a/frontend/apps/marketing/src/contentful/__tests__/get-experience.test.ts
+++ b/frontend/apps/marketing/src/contentful/__tests__/get-experience.test.ts
@@ -4,6 +4,16 @@ import {draftMode} from 'next/headers';
 import {getContentfulClient} from '../client';
 import {getExperience} from '../get-experience';
 
+jest.mock('react', () => {
+  const testCache = <T extends (...args: Array<unknown>) => unknown>(func: T) =>
+    func;
+  const originalModule = jest.requireActual('react');
+  return {
+    ...originalModule,
+    cache: testCache,
+  };
+});
+
 jest.mock('@contentful/experiences-sdk-react', () => ({
   fetchBySlug: jest.fn(),
 }));

--- a/frontend/apps/marketing/src/contentful/get-experience.ts
+++ b/frontend/apps/marketing/src/contentful/get-experience.ts
@@ -1,5 +1,6 @@
 import {fetchBySlug} from '@contentful/experiences-sdk-react';
 import {draftMode} from 'next/headers';
+import {cache} from 'react';
 
 import {getContentfulClient} from './client';
 
@@ -10,38 +11,37 @@ import {getContentfulClient} from './client';
  * @param isEditorMode Whether the page is running in Experience Studio
  * @returns Experience content record and error if any
  */
-export const getExperience = async (
-  slug: string,
-  localeCode: string,
-  isEditorMode = false,
-) => {
-  const {isEnabled} = await draftMode();
-  const client = getContentfulClient(isEnabled);
+export const getExperience = cache(
+  async (slug: string, localeCode: string, isEditorMode = false) => {
+    const {isEnabled} = await draftMode();
+    const client = getContentfulClient(isEnabled);
 
-  if (!client) {
-    // The client will not be available if the environment variables for secrets are not set.
-    // Rather than crashing the app, we log a warning and return undefined to allow Next.js to static
-    // render the foundations of the page.
-    return {experience: undefined, error: undefined};
-  }
+    if (!client) {
+      // The client will not be available if the environment variables for secrets are not set.
+      // Rather than crashing the app, we log a warning and return undefined to allow Next.js to static
+      // render the foundations of the page.
+      return {experience: undefined, error: undefined};
+    }
 
-  // While in editor mode, the experience is passed to the ExperienceRoot
-  // component by the editor, so we don't fetch it here
-  if (isEditorMode) {
-    return {experience: undefined, error: undefined};
-  }
+    // While in editor mode, the experience is passed to the ExperienceRoot
+    // component by the editor, so we don't fetch it here
+    if (isEditorMode) {
+      return {experience: undefined, error: undefined};
+    }
 
-  let experience: Awaited<ReturnType<typeof fetchBySlug>> | undefined;
+    let experience: Awaited<ReturnType<typeof fetchBySlug>> | undefined;
 
-  try {
-    experience = await fetchBySlug({
-      client,
-      slug,
-      experienceTypeId: process.env.CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID!,
-      localeCode,
-    });
-  } catch (error) {
-    return {experience, error: error as Error};
-  }
-  return {experience, error: undefined};
-};
+    try {
+      experience = await fetchBySlug({
+        client,
+        slug,
+        experienceTypeId: process.env.CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID!,
+        localeCode,
+      });
+    } catch (error) {
+      return {experience, error: error as Error};
+    }
+
+    return {experience, error: undefined};
+  },
+);


### PR DESCRIPTION
This PR enables request memoization by leveraging React's server-side cache feature[1]. Next.js uses React's cache feature[2] to apply memoization especially between the async metadata and page rendering time to de-duplicate requests. As an experiment, I tested the slug fetcher and instrumented start/end times for it:

Before request memoization:

```
Fetch experience for slug: all-the-things took 203ms
Fetch experience for slug: all-the-things took 194ms
```

Two requests to fetch the experience were made, one for the async metadata and one for the full page despite both returning the same payload.

After request memoization:

```
Fetch experience for slug: all-the-things took 185ms
```

Only one request is made to fetch the experience.

[1] https://react.dev/reference/react/cache
[2] https://nextjs.org/docs/app/building-your-application/caching#react-cache-function