### PR TITLE
Remove profanity check for playlab project sources

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1969,20 +1969,6 @@ function fetchShareFailure(resolve) {
   });
 }
 
-function fetchPrivacyProfanityViolations(resolve) {
-  channels.fetch(current.id + '/privacy-profanity', (err, data) => {
-    // data.has_violation is 0 or true, coerce to a boolean
-    currentHasPrivacyProfanityViolation =
-      (data && !!data.has_violation) || currentHasPrivacyProfanityViolation;
-    resolve();
-    if (err) {
-      // Throw an error so that things like New Relic see this. This shouldn't
-      // affect anything else
-      throw err;
-    }
-  });
-}
-
 /**
  * @param project
  * @returns {Promise} A Promise which resolves when all network calls complete.
@@ -1993,9 +1979,7 @@ function fetchAbuseScoreAndPrivacyViolations(project) {
     new Promise(fetchShareFailure),
   ];
 
-  if (project.getStandaloneApp() === 'playlab') {
-    promises.push(new Promise(fetchPrivacyProfanityViolations));
-  } else if (
+  if (
     project.getStandaloneApp() === 'applab' ||
     project.getStandaloneApp() === 'gamelab' ||
     project.isWebLab()


### PR DESCRIPTION
Currently, only 'playlab' projects are checked for profanity via WebPurify. Because block ids are included in the source code, there have been a disruptive number of false positives being reported by ZenDesk users ([example ticket](https://codeorg.zendesk.com/agent/tickets/536353)) causing non-abusive projects to be blocked from sharing - [Slack thread discussion](https://codedotorg.slack.com/archives/C03DBDN67B7/p1744320221812749).

I removed this profanity check which is a [request to `/v3/channels/<channel_id>/privacy-profanity`](https://github.com/code-dot-org/code-dot-org/blob/58798cfed578bb6da7db9300c06b3fe1e8006d6f/dashboard/legacy/middleware/channels_api.rb#L272) which [calls on `channel_policy_violation`](https://github.com/code-dot-org/code-dot-org/blob/58798cfed578bb6da7db9300c06b3fe1e8006d6f/dashboard/legacy/middleware/helpers/profanity_privacy_helper.rb#L25) which uses [`ShareFiltering`](https://github.com/code-dot-org/code-dot-org/blob/58798cfed578bb6da7db9300c06b3fe1e8006d6f/lib/cdo/share_filtering.rb#L53).

This safety layer via WebPurify is performed for only 'playlab' project's source code. WebPurify is also used for [libraries](https://github.com/code-dot-org/code-dot-org/blob/58798cfed578bb6da7db9300c06b3fe1e8006d6f/dashboard/legacy/middleware/files_api.rb#L430), and we have received a handful of reports about false positives from users trying to share libraries in App Lab. But the frequency of reports of false positives have seemed to increase recently for 'playlab' projects.

## Before update


https://github.com/user-attachments/assets/8e2573aa-52af-4fd9-8525-822e224ec981


## After update


https://github.com/user-attachments/assets/a5d515c6-9f4f-48df-832e-ef2057d4f8ee


Noting that this is the same behavior for other labs including Sprite Lab which is geared for elementary students. [Example Sprite Lab project](https://studio.code.org/projects/spritelab/goKXf1LuvVqYxxd9sb49pk5m2puvsWGMVR84S48uAtE) - confirmed that the update to Play Lab to match what happens in Sprite Lab is [okay with product](https://codedotorg.slack.com/archives/C03DBDN67B7/p1745266413694169?thread_ts=1744320221.812749&cid=C03DBDN67B7).

Screencast of current behavior of Sprite Lab project which includes a word that would be blocked by WebPurify:



https://github.com/user-attachments/assets/6c58e131-cfe1-42c9-bed9-2dc15fcfcf0c




A follow-up is to remove block IDs before passing project source code to WebPurify: https://codedotorg.atlassian.net/browse/SL-1214.

<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/SL-1216

## Testing story
Checked locally on 'playlab' projects and added a word blocked by WebPurify ('poop') - can still share project.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
