### PR TITLE
AI Chat: fix starter assets upload dialog overlap

### DIFF
--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -1,7 +1,6 @@
 import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
 import classNames from 'classnames';
 import React, {ChangeEvent, useState} from 'react';
-import {createPortal} from 'react-dom';
 
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import StarterAssetsDialog from '@cdo/apps/lab2/views/components/starterAssetsDialog';
@@ -154,19 +153,15 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
 
   return (
     <>
-      {levelName &&
-        showAssetManager &&
-        // Use createPortal to make sure the dialog overlay covers all elements on the page
-        createPortal(
-          <StarterAssetsDialog
-            levelName={levelName}
-            onClose={() => setShowAssetManager(false)}
-            mode="select"
-            onSelect={onSelectStarterAssets}
-            limit={numAllowedFiles}
-          />,
-          document.body
-        )}
+      {levelName && showAssetManager && (
+        <StarterAssetsDialog
+          levelName={levelName}
+          onClose={() => setShowAssetManager(false)}
+          mode="select"
+          onSelect={onSelectStarterAssets}
+          limit={numAllowedFiles}
+        />
+      )}
       <FileInput />
       <ActionDropdown
         name="uploadDropdown"

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -1,6 +1,7 @@
 import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
 import classNames from 'classnames';
 import React, {ChangeEvent, useState} from 'react';
+import {createPortal} from 'react-dom';
 
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import StarterAssetsDialog from '@cdo/apps/lab2/views/components/starterAssetsDialog';
@@ -153,15 +154,19 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
 
   return (
     <>
-      {levelName && showAssetManager && (
-        <StarterAssetsDialog
-          levelName={levelName}
-          onClose={() => setShowAssetManager(false)}
-          mode="select"
-          onSelect={onSelectStarterAssets}
-          limit={numAllowedFiles}
-        />
-      )}
+      {levelName &&
+        showAssetManager &&
+        // Use createPortal to make sure the dialog overlay covers all elements on the page
+        createPortal(
+          <StarterAssetsDialog
+            levelName={levelName}
+            onClose={() => setShowAssetManager(false)}
+            mode="select"
+            onSelect={onSelectStarterAssets}
+            limit={numAllowedFiles}
+          />,
+          document.body
+        )}
       <FileInput />
       <ActionDropdown
         name="uploadDropdown"

--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -2,7 +2,7 @@
 @import './common.scss';
 
 .labContainer {
-  position: fixed;
+  position: absolute;
   top: $top-spacing;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

## Summary

Fixes overlap issues with the starter assets dialog in AI Chat. A lot of this was already fixed by https://github.com/code-dot-org/code-dot-org/pull/65309, but there were still a few elements in the header and footer peeking through the overlay. I think there's some bigger issues here with how we handle z-indices across different stacking contexts in the page, but for now, and easy solution is to just use `createPortal` to render the modal on the document body directly. Logically, this also makes some sense as the modal backdrop is meant to cover all content on the page, and so should be at the level of top level view containers like the header and footer.

Before:

<img width="1512" alt="Screenshot 2025-04-21 at 2 14 22 PM" src="https://github.com/user-attachments/assets/597aa541-0af3-463b-8eb6-ea392504460f" />

After:

<img width="1512" alt="Screenshot 2025-04-21 at 2 14 12 PM" src="https://github.com/user-attachments/assets/41cdfe35-21ae-4a08-80fa-f75fea17d30f" />

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1422

## Testing story

Tested locally.