### PR TITLE
SUM - add skills table

### DIFF
--- a/dashboard/app/models/skill.rb
+++ b/dashboard/app/models/skill.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: skills
+#
+#  id                  :bigint           not null, primary key
+#  description         :string(255)      not null
+#  evaluation_criteria :text(65535)
+#  concept             :string(255)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+#  Note: "concept" already exists as connected to a video "concept" and is also used in some CSF materials in our codebase
+#  the "concept" in this skill model is not the same as the "concept" in the video model.
+class Skill < ApplicationRecord
+  validates :description, presence: true
+end

--- a/dashboard/db/migrate/20250421191829_create_skills.rb
+++ b/dashboard/db/migrate/20250421191829_create_skills.rb
@@ -1,0 +1,11 @@
+class CreateSkills < ActiveRecord::Migration[6.1]
+  def change
+    create_table :skills do |t|
+      t.string :description, null: false
+      t.text :evaluation_criteria
+      t.string :concept
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_04_17_151841) do
+ActiveRecord::Schema.define(version: 2025_04_21_191829) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2151,6 +2151,14 @@ ActiveRecord::Schema.define(version: 2025_04_17_151841) do
     t.integer "sign_in_count", null: false
     t.index ["sign_in_at"], name: "index_sign_ins_on_sign_in_at"
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
+  end
+
+  create_table "skills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "description", null: false
+    t.text "evaluation_criteria"
+    t.string "concept"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "stages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
I was having a ton of trouble getting [this](https://github.com/code-dot-org/code-dot-org/pull/65117) to pass drone in this PR.  I decided to make a new PR for it as that seemed more efficient than troubleshooting the original.

Adds a `Skill` table so that we can add skills to a level that can be evaluated by AI.



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65/backlog?epics=visible&selectedIssue=TEACH-1772)

[Figjam](https://www.figma.com/board/S8H82OKJ3gDboYrIoQZCsu/Measures-of-Learning-ERD-brainstorms?t=Qwr9wEEUwIozMZKg-0) - explaining the various data used for this task 