### PR TITLE
CMS-551: Add `EditorialCard` component definition for Contentful

### DIFF
--- a/frontend/apps/marketing/src/components/editorialCard/EditorialCard.tsx
+++ b/frontend/apps/marketing/src/components/editorialCard/EditorialCard.tsx
@@ -1,0 +1,95 @@
+import {EntryFields} from 'contentful';
+import {useMemo} from 'react';
+
+import EditorialCard, {
+  EDITORIAL_CARD_LAYOUTS,
+} from '@code-dot-org/component-library/cms/editorialCard';
+
+import {fontAwesomeV6BrandIconsMap} from '@/components/common/constants';
+import {LinkEntry} from '@/types/contentful/entries/Link';
+import {ExperienceAsset} from '@/types/contentful/ExperienceAsset';
+
+export enum EDITORIAL_CARD_CONTENTFUL_LAYOUTS {
+  HORIZONTAL_WITH_IMAGE = 'horizontal_with_image',
+  VERTICAL_WITH_IMAGE = 'vertical_with_image',
+  VERTICAL_WITH_ICON = 'vertical_with_icon',
+}
+
+export interface EditorialCardContentfulProps {
+  layoutOpt: EDITORIAL_CARD_CONTENTFUL_LAYOUTS;
+  heading: EntryFields.Text;
+  text: EntryFields.Text;
+  iconName?: EntryFields.Text;
+  image?: ExperienceAsset | string;
+  linkEntry?: LinkEntry;
+}
+
+const EditorialCardContentful: React.FC<EditorialCardContentfulProps> = ({
+  layoutOpt,
+  heading,
+  text,
+  image,
+  iconName,
+  linkEntry,
+}) => {
+  const layout = useMemo(() => {
+    switch (layoutOpt) {
+      case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.HORIZONTAL_WITH_IMAGE:
+        return EDITORIAL_CARD_LAYOUTS.HORIZONTAL;
+      case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_IMAGE:
+      case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_ICON:
+        return EDITORIAL_CARD_LAYOUTS.VERTICAL;
+    }
+  }, [layoutOpt]);
+
+  const media = useMemo(() => {
+    switch (layoutOpt) {
+      case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.HORIZONTAL_WITH_IMAGE:
+      case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_IMAGE:
+        return image && {src: image as string};
+      case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_ICON:
+        return (
+          iconName && {
+            iconName,
+            iconStyle: 'solid' as const,
+            iconFamily: fontAwesomeV6BrandIconsMap.has(iconName)
+              ? ('brands' as const)
+              : undefined,
+          }
+        );
+    }
+  }, [layoutOpt, iconName, image]);
+
+  const link = useMemo(
+    () =>
+      linkEntry && {
+        text: linkEntry.fields.label,
+        href: linkEntry.fields.primaryTarget,
+        external: linkEntry.fields.isThisAnExternalLink,
+        target: linkEntry.fields.isThisAnExternalLink ? '_blank' : undefined,
+        'aria-label': linkEntry.fields.ariaLabel || undefined,
+      },
+    [linkEntry],
+  );
+
+  if (!media) {
+    return (
+      <em>
+        <strong>🖼 Editorial Card placeholder.</strong> Please add an Image or
+        Icon Name in the Content sidebar, depending on the selected Layout.
+      </em>
+    );
+  }
+
+  return (
+    <EditorialCard
+      layout={layout}
+      media={media}
+      heading={heading}
+      text={text}
+      link={link}
+    />
+  );
+};
+
+export default EditorialCardContentful;

--- a/frontend/apps/marketing/src/components/editorialCard/EditorialCard.tsx
+++ b/frontend/apps/marketing/src/components/editorialCard/EditorialCard.tsx
@@ -3,11 +3,11 @@ import {useMemo} from 'react';
 
 import EditorialCard, {
   EDITORIAL_CARD_LAYOUTS,
+  EditorialCardProps,
 } from '@code-dot-org/component-library/cms/editorialCard';
 
 import {fontAwesomeV6BrandIconsMap} from '@/components/common/constants';
 import {LinkEntry} from '@/types/contentful/entries/Link';
-import {ExperienceAsset} from '@/types/contentful/ExperienceAsset';
 
 export enum EDITORIAL_CARD_CONTENTFUL_LAYOUTS {
   HORIZONTAL_WITH_IMAGE = 'horizontal_with_image',
@@ -20,7 +20,7 @@ export interface EditorialCardContentfulProps {
   heading: EntryFields.Text;
   text: EntryFields.Text;
   iconName?: EntryFields.Text;
-  image?: ExperienceAsset | string;
+  image?: EntryFields.Text;
   linkEntry?: LinkEntry;
 }
 
@@ -32,7 +32,7 @@ const EditorialCardContentful: React.FC<EditorialCardContentfulProps> = ({
   iconName,
   linkEntry,
 }) => {
-  const layout = useMemo(() => {
+  const layout: EditorialCardProps['layout'] = useMemo(() => {
     switch (layoutOpt) {
       case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.HORIZONTAL_WITH_IMAGE:
         return EDITORIAL_CARD_LAYOUTS.HORIZONTAL;
@@ -42,25 +42,25 @@ const EditorialCardContentful: React.FC<EditorialCardContentfulProps> = ({
     }
   }, [layoutOpt]);
 
-  const media = useMemo(() => {
+  const media: EditorialCardProps['media'] | undefined = useMemo(() => {
     switch (layoutOpt) {
       case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.HORIZONTAL_WITH_IMAGE:
       case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_IMAGE:
-        return image && {src: image as string};
+        return image ? {src: image} : undefined;
       case EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_ICON:
-        return (
-          iconName && {
-            iconName,
-            iconStyle: 'solid' as const,
-            iconFamily: fontAwesomeV6BrandIconsMap.has(iconName)
-              ? ('brands' as const)
-              : undefined,
-          }
-        );
+        return iconName
+          ? {
+              iconName,
+              iconStyle: 'solid',
+              iconFamily: fontAwesomeV6BrandIconsMap.has(iconName)
+                ? 'brands'
+                : undefined,
+            }
+          : undefined;
     }
   }, [layoutOpt, iconName, image]);
 
-  const link = useMemo(
+  const link: EditorialCardProps['link'] = useMemo(
     () =>
       linkEntry && {
         text: linkEntry.fields.label,

--- a/frontend/apps/marketing/src/components/editorialCard/EditorialCardContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/editorialCard/EditorialCardContentfulDefinition.ts
@@ -1,0 +1,94 @@
+// Creates a definition for the Editorial Card component to be used in Contentful Studio
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+import {EDITORIAL_CARD_CONTENTFUL_LAYOUTS} from './EditorialCard';
+
+export const EditorialCardContentfulComponentDefinition: ComponentDefinition = {
+  id: 'editorialCard',
+  name: 'Editorial Card',
+  category: '03: Basic',
+  thumbnailUrl:
+    'https://images.ctfassets.net/90t6bu6vlf76/1SptVYIyW5meSA34NcP99o/499a67854db82f98ee7717dbc9b95c6e/component_editorial_card_thumbnail.png',
+  tooltip: {
+    description:
+      'A customizable content card with an image, text, and optional link. Supports both vertical and landscape orientations.',
+    imageUrl:
+      'https://images.ctfassets.net/90t6bu6vlf76/18GIGLig36NtxqDSFegTHX/bca85090d5410f0e31c49a44bfee6b64/component_editorial_card_tooltip.png',
+  },
+  // Adding an empty array here so no default style options show in the Design tab.
+  builtInStyles: [],
+  children: false,
+  variables: {
+    layoutOpt: {
+      displayName: 'Layout',
+      type: 'Text',
+      group: 'content',
+      defaultValue: EDITORIAL_CARD_CONTENTFUL_LAYOUTS.HORIZONTAL_WITH_IMAGE,
+      validations: {
+        required: true,
+        bindingSourceType: ['manual'],
+        in: [
+          {
+            value: EDITORIAL_CARD_CONTENTFUL_LAYOUTS.HORIZONTAL_WITH_IMAGE,
+            displayName: 'Horizontal with Image',
+          },
+          {
+            value: EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_IMAGE,
+            displayName: 'Vertical with Image',
+          },
+          {
+            value: EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_ICON,
+            displayName: 'Vertical with Icon',
+          },
+        ],
+      },
+    },
+    heading: {
+      displayName: 'Heading',
+      type: 'Text',
+      group: 'content',
+      defaultValue: 'Editorial Card Heading',
+      validations: {
+        required: true,
+      },
+    },
+    text: {
+      displayName: 'Text content',
+      type: 'Text',
+      group: 'content',
+      defaultValue: 'Editorial Card\nMultiline Text',
+      validations: {
+        required: true,
+      },
+    },
+    image: {
+      displayName: 'Image',
+      type: 'Media',
+      group: 'content',
+      description:
+        'The image to display in "Horizontal/Vertical with Image" layouts',
+      defaultValue:
+        'https://images.ctfassets.net/90t6bu6vlf76/1SptVYIyW5meSA34NcP99o/499a67854db82f98ee7717dbc9b95c6e/component_editorial_card_thumbnail.png',
+      validations: {
+        bindingSourceType: ['entry', 'asset', 'manual'],
+      },
+    },
+    iconName: {
+      displayName: 'Icon name',
+      type: 'Text',
+      group: 'style',
+      description:
+        'Font Awesome icon name to display in the "Vertical with Icon" layout',
+      defaultValue: 'smile',
+    },
+    linkEntry: {
+      displayName: 'Link',
+      type: 'Link',
+      group: 'content',
+      description: 'Accepts only the "Link" content type entry',
+      validations: {
+        bindingSourceType: ['entry'],
+      },
+    },
+  },
+};

--- a/frontend/apps/marketing/src/components/editorialCard/__tests__/EditorialCard.test.tsx
+++ b/frontend/apps/marketing/src/components/editorialCard/__tests__/EditorialCard.test.tsx
@@ -1,0 +1,106 @@
+import {render, screen, within} from '@testing-library/react';
+
+import EditorialCard, {
+  EditorialCardContentfulProps,
+  EDITORIAL_CARD_CONTENTFUL_LAYOUTS,
+} from '@/components/editorialCard/EditorialCard';
+
+describe('EditorialCard component', () => {
+  const layoutOpt = EDITORIAL_CARD_CONTENTFUL_LAYOUTS.HORIZONTAL_WITH_IMAGE;
+  const heading = 'Icon Highlight Heading';
+  const text = 'Icon Highlight Text';
+  const iconName = 'smile';
+  const image =
+    'https://images.ctfassets.net/90t6bu6vlf76/1SptVYIyW5meSA34NcP99o/499a67854db82f98ee7717dbc9b95c6e/component_editorial_card_thumbnail.png';
+  const linkEntry = {
+    fields: {
+      label: 'Link',
+      primaryTarget: 'https://code.org/link',
+      ariaLabel: 'Link aria label',
+      isThisAnExternalLink: true,
+    },
+  };
+
+  const renderCard = (props: Partial<EditorialCardContentfulProps> = {}) =>
+    render(
+      <EditorialCard
+        layoutOpt={layoutOpt}
+        heading={heading}
+        text={text}
+        iconName={iconName}
+        image={image}
+        linkEntry={linkEntry}
+        {...props}
+      />,
+    );
+
+  const getCard = () => screen.getByRole('complementary');
+
+  it('renders card in "horizontal_with_image" layout with image', () => {
+    renderCard();
+
+    const img = getCard().querySelector('img');
+
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', image);
+  });
+
+  it('renders card in "vertical_with_image" layout with image', () => {
+    renderCard({
+      layoutOpt: EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_IMAGE,
+    });
+
+    const img = getCard().querySelector('img');
+
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', image);
+  });
+
+  it('renders card in "vertical_with_icon" layout with icon', () => {
+    renderCard({
+      layoutOpt: EDITORIAL_CARD_CONTENTFUL_LAYOUTS.VERTICAL_WITH_ICON,
+    });
+    expect(getCard().querySelector('i')).toBeInTheDocument();
+  });
+
+  it('renders card heading', () => {
+    renderCard();
+    expect(screen.getByRole('heading', {name: heading})).toBeVisible();
+  });
+
+  it('renders card text', () => {
+    renderCard();
+    expect(screen.getByText(text)).toBeVisible();
+  });
+
+  it('renders card link', () => {
+    renderCard();
+
+    const internalLink = screen.getByRole('link', {
+      name: linkEntry.fields.ariaLabel,
+    });
+
+    expect(internalLink).toBeVisible();
+    expect(internalLink).toHaveTextContent(linkEntry.fields.label);
+    expect(internalLink).toHaveAttribute(
+      'href',
+      linkEntry.fields.primaryTarget,
+    );
+    expect(internalLink).toHaveAttribute('target', '_blank');
+    expect(
+      within(internalLink).queryByRole('img', {name: 'external link'}),
+    ).toBeInTheDocument();
+  });
+
+  it('renders empty card placeholder when no media provided', () => {
+    renderCard({iconName: undefined, image: undefined});
+
+    const placeholder = screen.getByText(
+      (_, node) =>
+        node?.tagName === 'EM' &&
+        !!node?.textContent?.includes('Editorial Card placeholder'),
+    );
+
+    expect(placeholder).toBeVisible();
+  });
+});

--- a/frontend/apps/marketing/src/components/editorialCard/index.ts
+++ b/frontend/apps/marketing/src/components/editorialCard/index.ts
@@ -1,0 +1,3 @@
+// Export the Component Definition for use in Contentful Studio
+export {EditorialCardContentfulComponentDefinition} from './EditorialCardContentfulDefinition';
+export {default} from './EditorialCard';

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -24,6 +24,9 @@ import HeroBanner, {
 import Divider, {
   DividerContentfulComponentDefinition,
 } from '@/components/divider';
+import EditorialCard, {
+  EditorialCardContentfulComponentDefinition,
+} from '@/components/editorialCard';
 import FAQAccordion, {
   FAQAccordionContentfulComponentDefinition,
 } from '@/components/faqAccordion';
@@ -87,6 +90,10 @@ defineComponents(
       options: {
         wrapContainerWidth: '100%',
       },
+    },
+    {
+      component: EditorialCard,
+      definition: EditorialCardContentfulComponentDefinition,
     },
     {
       component: FAQAccordion,


### PR DESCRIPTION
## Component
<img width="100%" alt="component" src="https://github.com/user-attachments/assets/0cc56d78-f604-4d95-958f-5ba0582870e6" />

## Fields
| Part 1 | Part 2 |
| :----: | :-----: |
| <img width="100%" alt="fields-1" src="https://github.com/user-attachments/assets/675913bb-b7db-421e-8679-2dec858741c8" /> | <img width="100%" alt="fields-2" src="https://github.com/user-attachments/assets/4285c087-4a19-47e6-bda6-66a93b437629" /> |

## Horizontal With Image
<img width="100%" alt="horizontal-with-image" src="https://github.com/user-attachments/assets/ea792c16-ce13-4f2e-b145-ac156e82ee10" />

## Vertical With Image
<img width="100%" alt="vertical-with-image" src="https://github.com/user-attachments/assets/cacc9014-24c1-42c1-9fd8-6bf226a9b1f8" />

## Vertical With Icon
<img width="100%" alt="vetical-with-icon" src="https://github.com/user-attachments/assets/bf7e8c2a-0fe3-4bf8-9639-8346d4d1db61" />

## Links
- JIRA task: [CMS-551](https://codedotorg.atlassian.net/browse/CMS-551)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/65352