### PR TITLE
[HOME] Change section options dropdown to semantic links

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionOptionsDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionOptionsDropdown.tsx
@@ -7,15 +7,15 @@ import {Link} from 'react-router-dom';
 import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-// import {toggleSectionHidden} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {toggleSectionHidden} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import {
   TEACHER_NAVIGATION_SECTIONS_URL,
   TEACHER_NAVIGATION_PATHS,
 } from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
-// import {Student} from '@cdo/apps/types/redux';
-// import HttpClient from '@cdo/apps/util/HttpClient';
-// import {useAppDispatch, AppDispatch} from '@cdo/apps/util/reduxHooks';
+import {Student} from '@cdo/apps/types/redux';
+import HttpClient from '@cdo/apps/util/HttpClient';
+import {useAppDispatch, AppDispatch} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import styles from './teacherHomepage.module.scss';
@@ -27,69 +27,41 @@ export interface SectionOptionsDropdownProps {
 
 const CERTIFICATE_URL = '/certificates/batch';
 
-// const onSectionSettingsClick = (
-//   navigate: NavigateFunction,
-//   sectionId: number
-// ) => {
-//   analyticsReporter.sendEvent(
-//     EVENTS.SECTION_CARD_SETTINGS_CLICKED,
-//     {},
-//     PLATFORMS.BOTH
-//   );
-//   navigate(
-//     `../${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${TEACHER_NAVIGATION_PATHS.settings}`
-//   );
-// };
+const onArchiveClick = (dispatch: AppDispatch, section: Section) => {
+  const hideShowEvent = section.hidden
+    ? EVENTS.SECTION_CARD_RESTORE_CLICKED
+    : EVENTS.SECTION_CARD_ARCHIVE_CLICKED;
+  analyticsReporter.sendEvent(hideShowEvent, {}, PLATFORMS.BOTH);
+  dispatch(toggleSectionHidden(section.id));
+};
 
-// const onRosterClick = (navigate: NavigateFunction, sectionId: number) => {
-//   analyticsReporter.sendEvent(
-//     EVENTS.SECTION_CARD_ROSTER_CLICKED,
-//     {},
-//     PLATFORMS.BOTH
-//   );
-//   navigate(
-//     `../${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${TEACHER_NAVIGATION_PATHS.roster}`
-//   );
-// };
-
-// const onLoginCardsClick = (navigate: NavigateFunction, sectionId: number) => {
-//   analyticsReporter.sendEvent(
-//     EVENTS.SECTION_CARD_LOGIN_CARDS_CLICKED,
-//     {},
-//     PLATFORMS.BOTH
-//   );
-//   navigate(
-//     `../${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${TEACHER_NAVIGATION_PATHS.loginInfo}`
-//   );
-// };
-
-// const onArchiveClick = (dispatch: AppDispatch, section: Section) => {
-//   const hideShowEvent = section.hidden
-//     ? EVENTS.SECTION_CARD_RESTORE_CLICKED
-//     : EVENTS.SECTION_CARD_ARCHIVE_CLICKED;
-//   analyticsReporter.sendEvent(hideShowEvent, {}, PLATFORMS.BOTH);
-//   dispatch(toggleSectionHidden(section.id));
-// };
-
-// const onDeleteClick = (
-//   onDeleteClickCallback: (sectionId: number) => void,
-//   sectionId: number
-// ) => {
-//   analyticsReporter.sendEvent(
-//     EVENTS.SECTION_CARD_DELETE_CLICKED,
-//     {},
-//     PLATFORMS.BOTH
-//   );
-//   onDeleteClickCallback(sectionId);
-// };
-
-const getLinkElement = (
-  value: string,
-  label: string,
-  iconName: string,
-  url: string,
-  eventName?: string
+const onDeleteClick = (
+  onDeleteClickCallback: (sectionId: number) => void,
+  sectionId: number
 ) => {
+  analyticsReporter.sendEvent(
+    EVENTS.SECTION_CARD_DELETE_CLICKED,
+    {},
+    PLATFORMS.BOTH
+  );
+  onDeleteClickCallback(sectionId);
+};
+
+interface LinkElementProps {
+  value: string;
+  label: string;
+  iconName: string;
+  url: string;
+  eventName?: string;
+}
+
+const LinkOption: React.FC<LinkElementProps> = ({
+  value,
+  label,
+  iconName,
+  url,
+  eventName,
+}) => {
   return (
     <li key={value}>
       <Link
@@ -100,11 +72,7 @@ const getLinkElement = (
             analyticsReporter.sendEvent(eventName, {}, PLATFORMS.BOTH);
         }}
       >
-        <FontAwesomeV6Icon
-          iconName={iconName}
-          iconStyle="solid"
-          className={styles.linkIcon}
-        />
+        <FontAwesomeV6Icon iconName={iconName} iconStyle="solid" />
         <span>{label}</span>
       </Link>
     </li>
@@ -115,87 +83,98 @@ const SectionOptionsDropdown: React.FC<SectionOptionsDropdownProps> = ({
   section,
   onDeleteClickCallback,
 }) => {
-  // const navigate = useNavigate();
-  // const dispatch = useAppDispatch();
+  const dispatch = useAppDispatch();
 
   const certFormRef = React.useRef<HTMLFormElement>(null);
 
-  const [studentNames] = React.useState<string[]>([]);
+  const [studentNames, setStudentNames] = React.useState<string[]>([]);
 
-  // const onClickPrintCerts = React.useCallback(() => {
-  //   analyticsReporter.sendEvent(
-  //     EVENTS.SECTION_TABLE_PRINT_CERTIFICATES_CLICKED,
-  //     {},
-  //     PLATFORMS.BOTH
-  //   );
-  //   HttpClient.fetchJson<Student[]>(
-  //     `/dashboardapi/sections/${section.id}/students`
-  //   )
-  //     .then(result => result.value)
-  //     .then(value => {
-  //       const names = value.map((student: {name: string}) => student.name);
-  //       setStudentNames(names);
-  //       certFormRef.current?.submit();
-  //     })
-  //     .catch(error =>
-  //       console.error('Error retrieving student names for certificates', error)
-  //     );
-  // }, [section.id]);
+  const onClickPrintCerts = React.useCallback(() => {
+    analyticsReporter.sendEvent(
+      EVENTS.SECTION_TABLE_PRINT_CERTIFICATES_CLICKED,
+      {},
+      PLATFORMS.BOTH
+    );
+    HttpClient.fetchJson<Student[]>(
+      `/dashboardapi/sections/${section.id}/students`
+    )
+      .then(result => result.value)
+      .then(value => {
+        const names = value.map((student: {name: string}) => student.name);
+        setStudentNames(names);
+        certFormRef.current?.submit();
+      })
+      .catch(error =>
+        console.error('Error retrieving student names for certificates', error)
+      );
+  }, [section.id]);
 
   const dropdownOptions = useMemo(() => {
-    //value: string,
-    // label: string,
-    // iconName: string,
-    // url: string,
-    // eventName?: string
     const options = [
-      getLinkElement(
-        'sectionSettings',
-        i18n.sectionSettings(),
-        'gear',
-        `../${TEACHER_NAVIGATION_SECTIONS_URL}/${section.id}/${TEACHER_NAVIGATION_PATHS.settings}`,
-        EVENTS.SECTION_CARD_SETTINGS_CLICKED
-      ),
-      // {
-      //   value: 'roster',
-      //   label: i18n.roster(),
-      //   icon: {iconName: 'user', iconStyle: 'solid'},
-
-      //   onClick: () => onRosterClick(navigate, section.id),
-      // },
-      // {
-      //   value: 'loginCards',
-      //   label: i18n.loginCards(),
-      //   icon: {iconName: 'id-card', iconStyle: 'solid'},
-      //   onClick: () => onLoginCardsClick(navigate, section.id),
-      // },
-      // {
-      //   value: 'certificates',
-      //   label: i18n.certificates(),
-      //   icon: {iconName: 'file-certificate', iconStyle: 'solid'},
-      //   onClick: () => onClickPrintCerts(),
-      // },
-      // {
-      //   value: section.hidden ? 'restore' : 'archive',
-      //   label: section.hidden ? i18n.restoreClassSection() : i18n.archive(),
-      //   icon: {
-      //     iconName: section.hidden ? 'window-restore' : 'box-archive',
-      //     iconStyle: 'solid',
-      //   },
-      //   onClick: () => onArchiveClick(dispatch, section),
-      // },
+      <LinkOption
+        value="sectionSettings"
+        label={i18n.sectionSettings()}
+        iconName="gear"
+        url={`../${TEACHER_NAVIGATION_SECTIONS_URL}/${section.id}/${TEACHER_NAVIGATION_PATHS.settings}`}
+        eventName={EVENTS.SECTION_CARD_SETTINGS_CLICKED}
+      />,
+      <LinkOption
+        value="roster"
+        label={i18n.roster()}
+        iconName="user"
+        url={`../${TEACHER_NAVIGATION_SECTIONS_URL}/${section.id}/${TEACHER_NAVIGATION_PATHS.roster}`}
+        eventName={EVENTS.SECTION_CARD_ROSTER_CLICKED}
+      />,
+      <LinkOption
+        value="loginCards"
+        label={i18n.loginCards()}
+        iconName="id-card"
+        url={`../${TEACHER_NAVIGATION_SECTIONS_URL}/${section.id}/${TEACHER_NAVIGATION_PATHS.loginInfo}`}
+        eventName={EVENTS.SECTION_CARD_LOGIN_CARDS_CLICKED}
+      />,
+      <li key={'certificates'}>
+        <button
+          type="button"
+          className={styles.dropdownMenuItem}
+          onClick={onClickPrintCerts}
+        >
+          <FontAwesomeV6Icon iconName="file-certificate" iconStyle="solid" />
+          <span>{i18n.certificates()}</span>
+        </button>
+      </li>,
+      <li key={'archive'}>
+        <button
+          type="button"
+          className={styles.dropdownMenuItem}
+          onClick={() => onArchiveClick(dispatch, section)}
+        >
+          <FontAwesomeV6Icon
+            iconName={section.hidden ? 'window-restore' : 'box-archive'}
+            iconStyle="solid"
+          />
+          <span>
+            {section.hidden ? i18n.restoreClassSection() : i18n.archive()}
+          </span>
+        </button>
+      </li>,
     ];
 
-    // if (section.studentCount === 0) {
-    //   options.push({
-    //     value: 'delete',
-    //     label: i18n.delete(),
-    //     icon: {iconName: 'trash', iconStyle: 'solid'},
-    //     onClick: () => onDeleteClick(onDeleteClickCallback, section.id),
-    //   });
-    // }
+    if (section.studentCount === 0) {
+      options.push(
+        <li key={'delete'}>
+          <button
+            type="button"
+            className={styles.dropdownMenuItem}
+            onClick={() => onDeleteClick(onDeleteClickCallback, section.id)}
+          >
+            <FontAwesomeV6Icon iconName="trash" iconStyle="solid" />
+            <span>{i18n.delete()}</span>
+          </button>
+        </li>
+      );
+    }
     return options;
-  }, [section]);
+  }, [section, dispatch, onDeleteClickCallback, onClickPrintCerts]);
 
   return (
     <form ref={certFormRef} action={CERTIFICATE_URL} method="POST">

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionOptionsDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionOptionsDropdown.tsx
@@ -1,20 +1,21 @@
-import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
-import {ActionDropdownOption} from '@code-dot-org/component-library/dropdown/actionDropdown';
+import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import React, {useMemo} from 'react';
-import {useNavigate, NavigateFunction} from 'react-router-dom';
+// import {useNavigate, NavigateFunction, Link} from 'react-router-dom';
+import {Link} from 'react-router-dom';
 
 import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {toggleSectionHidden} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+// import {toggleSectionHidden} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import {
   TEACHER_NAVIGATION_SECTIONS_URL,
   TEACHER_NAVIGATION_PATHS,
 } from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
-import {Student} from '@cdo/apps/types/redux';
-import HttpClient from '@cdo/apps/util/HttpClient';
-import {useAppDispatch, AppDispatch} from '@cdo/apps/util/reduxHooks';
+// import {Student} from '@cdo/apps/types/redux';
+// import HttpClient from '@cdo/apps/util/HttpClient';
+// import {useAppDispatch, AppDispatch} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import styles from './teacherHomepage.module.scss';
@@ -26,141 +27,175 @@ export interface SectionOptionsDropdownProps {
 
 const CERTIFICATE_URL = '/certificates/batch';
 
-const onSectionSettingsClick = (
-  navigate: NavigateFunction,
-  sectionId: number
+// const onSectionSettingsClick = (
+//   navigate: NavigateFunction,
+//   sectionId: number
+// ) => {
+//   analyticsReporter.sendEvent(
+//     EVENTS.SECTION_CARD_SETTINGS_CLICKED,
+//     {},
+//     PLATFORMS.BOTH
+//   );
+//   navigate(
+//     `../${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${TEACHER_NAVIGATION_PATHS.settings}`
+//   );
+// };
+
+// const onRosterClick = (navigate: NavigateFunction, sectionId: number) => {
+//   analyticsReporter.sendEvent(
+//     EVENTS.SECTION_CARD_ROSTER_CLICKED,
+//     {},
+//     PLATFORMS.BOTH
+//   );
+//   navigate(
+//     `../${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${TEACHER_NAVIGATION_PATHS.roster}`
+//   );
+// };
+
+// const onLoginCardsClick = (navigate: NavigateFunction, sectionId: number) => {
+//   analyticsReporter.sendEvent(
+//     EVENTS.SECTION_CARD_LOGIN_CARDS_CLICKED,
+//     {},
+//     PLATFORMS.BOTH
+//   );
+//   navigate(
+//     `../${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${TEACHER_NAVIGATION_PATHS.loginInfo}`
+//   );
+// };
+
+// const onArchiveClick = (dispatch: AppDispatch, section: Section) => {
+//   const hideShowEvent = section.hidden
+//     ? EVENTS.SECTION_CARD_RESTORE_CLICKED
+//     : EVENTS.SECTION_CARD_ARCHIVE_CLICKED;
+//   analyticsReporter.sendEvent(hideShowEvent, {}, PLATFORMS.BOTH);
+//   dispatch(toggleSectionHidden(section.id));
+// };
+
+// const onDeleteClick = (
+//   onDeleteClickCallback: (sectionId: number) => void,
+//   sectionId: number
+// ) => {
+//   analyticsReporter.sendEvent(
+//     EVENTS.SECTION_CARD_DELETE_CLICKED,
+//     {},
+//     PLATFORMS.BOTH
+//   );
+//   onDeleteClickCallback(sectionId);
+// };
+
+const getLinkElement = (
+  value: string,
+  label: string,
+  iconName: string,
+  url: string,
+  eventName?: string
 ) => {
-  analyticsReporter.sendEvent(
-    EVENTS.SECTION_CARD_SETTINGS_CLICKED,
-    {},
-    PLATFORMS.BOTH
+  return (
+    <li key={value}>
+      <Link
+        to={url}
+        className={styles.dropdownMenuItem}
+        onClick={() => {
+          if (eventName)
+            analyticsReporter.sendEvent(eventName, {}, PLATFORMS.BOTH);
+        }}
+      >
+        <FontAwesomeV6Icon
+          iconName={iconName}
+          iconStyle="solid"
+          className={styles.linkIcon}
+        />
+        <span>{label}</span>
+      </Link>
+    </li>
   );
-  navigate(
-    `../${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${TEACHER_NAVIGATION_PATHS.settings}`
-  );
-};
-
-const onRosterClick = (navigate: NavigateFunction, sectionId: number) => {
-  analyticsReporter.sendEvent(
-    EVENTS.SECTION_CARD_ROSTER_CLICKED,
-    {},
-    PLATFORMS.BOTH
-  );
-  navigate(
-    `../${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${TEACHER_NAVIGATION_PATHS.roster}`
-  );
-};
-
-const onLoginCardsClick = (navigate: NavigateFunction, sectionId: number) => {
-  analyticsReporter.sendEvent(
-    EVENTS.SECTION_CARD_LOGIN_CARDS_CLICKED,
-    {},
-    PLATFORMS.BOTH
-  );
-  navigate(
-    `../${TEACHER_NAVIGATION_SECTIONS_URL}/${sectionId}/${TEACHER_NAVIGATION_PATHS.loginInfo}`
-  );
-};
-
-const onArchiveClick = (dispatch: AppDispatch, section: Section) => {
-  const hideShowEvent = section.hidden
-    ? EVENTS.SECTION_CARD_RESTORE_CLICKED
-    : EVENTS.SECTION_CARD_ARCHIVE_CLICKED;
-  analyticsReporter.sendEvent(hideShowEvent, {}, PLATFORMS.BOTH);
-  dispatch(toggleSectionHidden(section.id));
-};
-
-const onDeleteClick = (
-  onDeleteClickCallback: (sectionId: number) => void,
-  sectionId: number
-) => {
-  analyticsReporter.sendEvent(
-    EVENTS.SECTION_CARD_DELETE_CLICKED,
-    {},
-    PLATFORMS.BOTH
-  );
-  onDeleteClickCallback(sectionId);
 };
 
 const SectionOptionsDropdown: React.FC<SectionOptionsDropdownProps> = ({
   section,
   onDeleteClickCallback,
 }) => {
-  const navigate = useNavigate();
-  const dispatch = useAppDispatch();
+  // const navigate = useNavigate();
+  // const dispatch = useAppDispatch();
 
   const certFormRef = React.useRef<HTMLFormElement>(null);
 
-  const [studentNames, setStudentNames] = React.useState<string[]>([]);
+  const [studentNames] = React.useState<string[]>([]);
 
-  const onClickPrintCerts = React.useCallback(() => {
-    analyticsReporter.sendEvent(
-      EVENTS.SECTION_TABLE_PRINT_CERTIFICATES_CLICKED,
-      {},
-      PLATFORMS.BOTH
-    );
-    HttpClient.fetchJson<Student[]>(
-      `/dashboardapi/sections/${section.id}/students`
-    )
-      .then(result => result.value)
-      .then(value => {
-        const names = value.map((student: {name: string}) => student.name);
-        setStudentNames(names);
-        certFormRef.current?.submit();
-      })
-      .catch(error =>
-        console.error('Error retrieving student names for certificates', error)
-      );
-  }, [section.id]);
+  // const onClickPrintCerts = React.useCallback(() => {
+  //   analyticsReporter.sendEvent(
+  //     EVENTS.SECTION_TABLE_PRINT_CERTIFICATES_CLICKED,
+  //     {},
+  //     PLATFORMS.BOTH
+  //   );
+  //   HttpClient.fetchJson<Student[]>(
+  //     `/dashboardapi/sections/${section.id}/students`
+  //   )
+  //     .then(result => result.value)
+  //     .then(value => {
+  //       const names = value.map((student: {name: string}) => student.name);
+  //       setStudentNames(names);
+  //       certFormRef.current?.submit();
+  //     })
+  //     .catch(error =>
+  //       console.error('Error retrieving student names for certificates', error)
+  //     );
+  // }, [section.id]);
 
-  const dropdownOptions: ActionDropdownOption[] = useMemo(() => {
-    const options: ActionDropdownOption[] = [
-      {
-        value: 'sectionSettings',
-        label: i18n.sectionSettings(),
-        icon: {iconName: 'gear', iconStyle: 'solid'},
-        onClick: () => onSectionSettingsClick(navigate, section.id),
-      },
-      {
-        value: 'roster',
-        label: i18n.roster(),
-        icon: {iconName: 'user', iconStyle: 'solid'},
+  const dropdownOptions = useMemo(() => {
+    //value: string,
+    // label: string,
+    // iconName: string,
+    // url: string,
+    // eventName?: string
+    const options = [
+      getLinkElement(
+        'sectionSettings',
+        i18n.sectionSettings(),
+        'gear',
+        `../${TEACHER_NAVIGATION_SECTIONS_URL}/${section.id}/${TEACHER_NAVIGATION_PATHS.settings}`,
+        EVENTS.SECTION_CARD_SETTINGS_CLICKED
+      ),
+      // {
+      //   value: 'roster',
+      //   label: i18n.roster(),
+      //   icon: {iconName: 'user', iconStyle: 'solid'},
 
-        onClick: () => onRosterClick(navigate, section.id),
-      },
-      {
-        value: 'loginCards',
-        label: i18n.loginCards(),
-        icon: {iconName: 'id-card', iconStyle: 'solid'},
-        onClick: () => onLoginCardsClick(navigate, section.id),
-      },
-      {
-        value: 'certificates',
-        label: i18n.certificates(),
-        icon: {iconName: 'file-certificate', iconStyle: 'solid'},
-        onClick: () => onClickPrintCerts(),
-      },
-      {
-        value: section.hidden ? 'restore' : 'archive',
-        label: section.hidden ? i18n.restoreClassSection() : i18n.archive(),
-        icon: {
-          iconName: section.hidden ? 'window-restore' : 'box-archive',
-          iconStyle: 'solid',
-        },
-        onClick: () => onArchiveClick(dispatch, section),
-      },
+      //   onClick: () => onRosterClick(navigate, section.id),
+      // },
+      // {
+      //   value: 'loginCards',
+      //   label: i18n.loginCards(),
+      //   icon: {iconName: 'id-card', iconStyle: 'solid'},
+      //   onClick: () => onLoginCardsClick(navigate, section.id),
+      // },
+      // {
+      //   value: 'certificates',
+      //   label: i18n.certificates(),
+      //   icon: {iconName: 'file-certificate', iconStyle: 'solid'},
+      //   onClick: () => onClickPrintCerts(),
+      // },
+      // {
+      //   value: section.hidden ? 'restore' : 'archive',
+      //   label: section.hidden ? i18n.restoreClassSection() : i18n.archive(),
+      //   icon: {
+      //     iconName: section.hidden ? 'window-restore' : 'box-archive',
+      //     iconStyle: 'solid',
+      //   },
+      //   onClick: () => onArchiveClick(dispatch, section),
+      // },
     ];
 
-    if (section.studentCount === 0) {
-      options.push({
-        value: 'delete',
-        label: i18n.delete(),
-        icon: {iconName: 'trash', iconStyle: 'solid'},
-        onClick: () => onDeleteClick(onDeleteClickCallback, section.id),
-      });
-    }
+    // if (section.studentCount === 0) {
+    //   options.push({
+    //     value: 'delete',
+    //     label: i18n.delete(),
+    //     icon: {iconName: 'trash', iconStyle: 'solid'},
+    //     onClick: () => onDeleteClick(onDeleteClickCallback, section.id),
+    //   });
+    // }
     return options;
-  }, [section, dispatch, navigate, onDeleteClickCallback, onClickPrintCerts]);
+  }, [section]);
 
   return (
     <form ref={certFormRef} action={CERTIFICATE_URL} method="POST">
@@ -175,10 +210,12 @@ const SectionOptionsDropdown: React.FC<SectionOptionsDropdownProps> = ({
       {studentNames.map((name, index) => (
         <input key={index} type="hidden" name="names[]" value={name} />
       ))}
-      <ActionDropdown
+      <CustomDropdown
         name="section-options-dropdown"
         labelText="Section Options"
         menuPlacement="right"
+        size="m"
+        useDSCOButtonAsTrigger={true}
         triggerButtonProps={{
           isIconOnly: true,
           icon: {
@@ -191,8 +228,9 @@ const SectionOptionsDropdown: React.FC<SectionOptionsDropdownProps> = ({
           className: styles.dropdownButton,
           ariaLabel: i18n.sectionOptionsDropdown(),
         }}
-        options={dropdownOptions}
-      />
+      >
+        <ul>{dropdownOptions}</ul>
+      </CustomDropdown>
     </form>
   );
 };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -1,3 +1,5 @@
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 @import 'color';
 @import 'https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap';
 
@@ -118,6 +120,45 @@
 .dropdownButton {
   width: 32px;
   height: 32px;
+}
+
+.dropdownMenuItem {
+  /* Reset's every elements apperance */
+  background: none repeat scroll 0 0 transparent;
+  border: none !important;
+  border-radius: 0;
+  border-spacing: 0;
+  list-style: none outside none;
+  margin: 0;
+  text-decoration: none;
+  text-indent: 0;
+  box-shadow: none;
+
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--neutral-base-black);
+
+  padding: 0.5rem 1rem 0.5rem 0.75rem;
+  gap: 0.75rem;
+
+  &:hover {
+    color: var(--neutral-base-black);
+    text-decoration: none;
+  }
+
+  i {
+    font-size: 1.1875rem;
+    line-height: 125%;
+    width: 1.5rem;
+    text-align: center;
+  }
+
+  span {
+    @include typography.body-two;
+    color: inherit;
+    margin-bottom: 0;
+  }
 }
 
 // SectionCardBody

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -133,6 +133,7 @@
   text-decoration: none;
   text-indent: 0;
   box-shadow: none;
+  flex-grow: 1;
 
   display: flex;
   align-items: center;
@@ -141,6 +142,10 @@
 
   padding: 0.5rem 1rem 0.5rem 0.75rem;
   gap: 0.75rem;
+
+  &:active {
+    border: 0 !important;
+  }
 
   &:hover {
     color: var(--neutral-base-black);


### PR DESCRIPTION
Uses CustomDropdown instead of ActionDropdown to use `<a>` tag links instead of `<buttons>` with on-click.

<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- Jira: 
https://codedotorg.atlassian.net/browse/TEACH-1831
