### PR TITLE
[HOME] fix error message for unique keys on promos

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/PermanentPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/PermanentPromotions.tsx
@@ -15,7 +15,7 @@ import styles from './teacherHomepage.module.scss';
 const PermanentPromotions: React.FC = () => {
   const promotions = [
     {
-      id: '1',
+      id: 'static-1',
       title: 'Grow your knowledge',
       description:
         'Empower your teaching with workshops and self-paced learning.',
@@ -30,7 +30,7 @@ const PermanentPromotions: React.FC = () => {
       ),
     },
     {
-      id: '2',
+      id: 'static-2',
       title: 'Help improve Code.org',
       description:
         'Participate in user research to help us improve our platform for everyone.',
@@ -47,9 +47,9 @@ const PermanentPromotions: React.FC = () => {
   ];
 
   return (
-    <div className={styles.staticPromotions}>
+    <>
       {promotions.map(promotion => (
-        <div key={promotion.id} className={styles.staticPromotion}>
+        <li key={promotion.id} className={styles.staticPromotion}>
           <div className={styles.staticPromotionText}>
             <BodyTwoText>
               <StrongText>{promotion.title}</StrongText>
@@ -61,9 +61,9 @@ const PermanentPromotions: React.FC = () => {
             </Link>
           </div>
           {promotion.image}
-        </div>
+        </li>
       ))}
-    </div>
+    </>
   );
 };
 

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SkeletonTeacherPromo.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SkeletonTeacherPromo.tsx
@@ -13,9 +13,10 @@ import styles from './teacherHomepage.module.scss';
 
 export const SkeletonTeacherPromo: React.FC = () => {
   return (
-    <div
+    <li
       className={classNames(styles.promotion, styles['promotion-skeleton'])}
       aria-label={i18n.loading()}
+      key="skeleton"
     >
       <OverlineTwoText className={styles.promotionType}>
         <Skeleton />
@@ -29,6 +30,6 @@ export const SkeletonTeacherPromo: React.FC = () => {
       <BodyThreeText>
         <Skeleton count={4} />
       </BodyThreeText>
-    </div>
+    </li>
   );
 };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromo.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromo.tsx
@@ -62,7 +62,7 @@ const TeacherPromo: React.FC<TeacherPromoProps> = ({
   onClose,
 }) => {
   return (
-    <div
+    <li
       className={classNames(
         styles.promotion,
         styles[`promotion-${_.lowerCase(backgroundColor)}`]
@@ -104,7 +104,7 @@ const TeacherPromo: React.FC<TeacherPromoProps> = ({
         size="s"
         className={styles.promotionButton}
       />
-    </div>
+    </li>
   );
 };
 

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
@@ -103,16 +103,20 @@ const TeacherPromotions: React.FC = () => {
   );
 
   return (
-    <div className={styles.promotions}>
+    <ul className={styles.promotions}>
       {isLoading ? (
         <SkeletonTeacherPromo />
       ) : (
-        promotions.map((promotion, ind) => (
-          <TeacherPromo {...promotion} onClose={closePromotionCallback} />
+        promotions.map(promotion => (
+          <TeacherPromo
+            {...promotion}
+            onClose={closePromotionCallback}
+            key={promotion.id}
+          />
         ))
       )}
       <PermanentPromotions />
-    </div>
+    </ul>
   );
 };
 


### PR DESCRIPTION
Fixes an error message from the teacher promos and helps accessibility by using `<ul><li>` tags instead of divs.
<img width="271" alt="image" src="https://github.com/user-attachments/assets/cc703663-290b-425e-b462-f1a692f511cc" />

No visual changes expected.

<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 
https://codedotorg.atlassian.net/browse/TEACH-1834