### PR TITLE
Make workshop table topics show as an unordered list

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -14,6 +14,7 @@ import color from '@cdo/apps/util/color';
 
 import {workshopShape} from '../types.js';
 import {shouldShowSurveyResults} from '../workshop_summary_utils';
+import {COURSE_BUILD_YOUR_OWN} from '../workshopConstants';
 
 import FacilitatorsList from './facilitators_list';
 import SessionTimesList from './session_times_list';
@@ -248,13 +249,13 @@ export default class WorkshopTable extends React.Component {
   // Because we want Subjects and Topics to show in the same column (since they are
   // mutually exclusive for a workshop), we want to format subjects as plain text
   // and topics as an unordered list.
-  formatSubjectOrTopics = subjectsOrTopics => {
-    if (subjectsOrTopics.includes('Topics:')) {
-      const topics = subjectsOrTopics.slice(8).split(',');
+  formatSubjectOrTopics = (subjectsOrTopics, {rowData}) => {
+    if (rowData.course === COURSE_BUILD_YOUR_OWN) {
+      const topics = subjectsOrTopics.split(',');
       return (
         <ul>
           {topics.map(topic => {
-            return <li>{topic}</li>;
+            return <li key={`topic-${topic}`}>{topic}</li>;
           })}
         </ul>
       );

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -129,6 +129,9 @@ export default class WorkshopTable extends React.Component {
           label: 'Subjects/Topics',
           transforms: [sortable],
         },
+        cell: {
+          formatters: [this.formatSubjectOrTopics],
+        },
       },
       {
         property: 'virtual',
@@ -240,6 +243,24 @@ export default class WorkshopTable extends React.Component {
 
   formatSessions = (_ignored, {rowData}) => {
     return <SessionTimesList sessions={rowData.sessions} />;
+  };
+
+  // Because we want Subjects and Topics to show in the same column (since they are
+  // mutually exclusive for a workshop), we want to format subjects as plain text
+  // and topics as an unordered list.
+  formatSubjectOrTopics = subjectsOrTopics => {
+    if (subjectsOrTopics.includes('Topics:')) {
+      const topics = subjectsOrTopics.slice(8).split(',');
+      return (
+        <ul>
+          {topics.map(topic => {
+            return <li>{topic}</li>;
+          })}
+        </ul>
+      );
+    } else {
+      return subjectsOrTopics;
+    }
   };
 
   formatVirtualFormat = isVirtual => {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
@@ -22,7 +22,7 @@ function processWorkshopData(workshopData) {
     ...workshopData,
     workshops: workshopData.workshops?.map(ws => {
       if (ws.course === COURSE_BUILD_YOUR_OWN) {
-        ws.subject = `Topics: ${ws.course_offering_names}`;
+        ws.subject = ws.course_offering_names;
       }
       return ws;
     }),

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
@@ -22,7 +22,7 @@ function processWorkshopData(workshopData) {
     ...workshopData,
     workshops: workshopData.workshops?.map(ws => {
       if (ws.course === COURSE_BUILD_YOUR_OWN) {
-        ws.subject = ws.course_offering_names;
+        ws.subject = `Topics: ${ws.course_offering_names}`;
       }
       return ws;
     }),

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_table_loaderTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_table_loaderTest.js
@@ -91,7 +91,7 @@ describe('WorkshopTableLoader', () => {
       defaultFakeResponseData.workshops[0].subject
     );
     expect(returnedWorkshopSubjects[1].subject).to.eql(
-      defaultFakeResponseData.workshops[1].course_offering_names
+      `Topics: ${defaultFakeResponseData.workshops[1].course_offering_names}`
     );
   });
 

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_table_loaderTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_table_loaderTest.js
@@ -91,7 +91,7 @@ describe('WorkshopTableLoader', () => {
       defaultFakeResponseData.workshops[0].subject
     );
     expect(returnedWorkshopSubjects[1].subject).to.eql(
-      `Topics: ${defaultFakeResponseData.workshops[1].course_offering_names}`
+      defaultFakeResponseData.workshops[1].course_offering_names
     );
   });
 


### PR DESCRIPTION
Make the topics for a Build Your Own Workshop show as an unordered list instead of a comma-separated list.

### Previously using commas
![currently comma separated](https://github.com/user-attachments/assets/9ab114b2-b2bd-4d01-be0a-cdc9de5ca328)

### Now using bullet points
![bullet points](https://github.com/user-attachments/assets/a38fb044-b57e-4af3-8336-0ab5895b2fd3)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3233)

## Testing story
Local testing and updating unit test.
