### PR TITLE
Resize dimensions correctly in image upload

### DIFF
--- a/dashboard/legacy/middleware/helpers/asset_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/asset_bucket.rb
@@ -27,7 +27,7 @@ class AssetBucket < BucketHelper
     # in our web apps.
     if ([".jpg", ".jpeg", ".png"].include? extension.downcase) && (body.length < max_resize_size)
       image = MiniMagick::Image.read(body, extension)
-      image.resize (image.width / 4).floor.to_s + "x" + (image.height / 4).floor.to_s
+      image.resize('25%')
       return image.to_blob
     end
 

--- a/dashboard/legacy/middleware/helpers/asset_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/asset_bucket.rb
@@ -27,7 +27,7 @@ class AssetBucket < BucketHelper
     # in our web apps.
     if ([".jpg", ".jpeg", ".png"].include? extension.downcase) && (body.length < max_resize_size)
       image = MiniMagick::Image.read(body, extension)
-      image.resize (image.height / 4).floor.to_s + "x" + (image.width / 4).floor.to_s
+      image.resize (image.width / 4).floor.to_s + "x" + (image.height / 4).floor.to_s
       return image.to_blob
     end
     return body

--- a/dashboard/legacy/middleware/helpers/asset_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/asset_bucket.rb
@@ -30,7 +30,8 @@ class AssetBucket < BucketHelper
       image.resize (image.width / 4).floor.to_s + "x" + (image.height / 4).floor.to_s
       return image.to_blob
     end
-    return body
+
+    body
   end
 
   def cache_duration_seconds


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

I've been looking at putting restrictions on levelbuilder asset uploads and using this code as a starting point. I noticed that we have the dimensions reversed here (MiniMagick expects width x height, not height x width), which results in some unexpected resizing behavior.

For example, I was resizing at 6000x4000 image, and getting a 1000x667 image, which was unexpected. So I believe we were resizing the width to 1/4 of the height (4000 / 4 = 1000), and then maintaining the aspect ratio to get the height (4000/6000 * 1000 = 667).

I can wait until after the create task is over to merge this, as it would affect Applab.

## Testing story

Tested manually that with this change, a 6000x4000 image is now resized to 1500x1000 (which seems to be the expected behavior given the comments in the code).