### PR TITLE
Update CSAIF to AIF

### DIFF
--- a/apps/src/code-studio/pd/professional_learning/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning/LandingPage.jsx
@@ -35,7 +35,7 @@ import {
   COURSE_CSD,
   COURSE_CSP,
   COURSE_CSA,
-  COURSE_CSAIF,
+  COURSE_AIF,
 } from '../workshop_dashboard/workshopConstants';
 import WorkshopEnrollmentCelebrationDialog from '../workshop_enrollment/WorkshopEnrollmentCelebrationDialog';
 
@@ -499,10 +499,10 @@ function LandingPage({
         urlSlug: 'computer-science-a',
       });
     }
-    if (coursesAsFacilitator.includes(COURSE_CSAIF)) {
+    if (coursesAsFacilitator.includes(COURSE_AIF)) {
       landingPageCourses.push({
-        name: 'CSAIF',
-        urlSlug: 'computer-science-ai-fundamentals',
+        name: 'AIF',
+        urlSlug: 'ai-fundamentals',
       });
     }
     landingPageCourses.forEach(course => {

--- a/apps/src/code-studio/pd/workshop_dashboard/workshopConstants.js
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshopConstants.js
@@ -5,7 +5,7 @@ const COURSE_CSF = 'CS Fundamentals';
 const COURSE_CSD = 'CS Discoveries';
 const COURSE_CSP = 'CS Principles';
 const COURSE_CSA = 'Computer Science A';
-const COURSE_CSAIF = 'CS and AI Fundamentals';
+const COURSE_AIF = 'AI Fundamentals';
 const COURSE_BUILD_YOUR_OWN = 'Build Your Own Workshop';
 
 const MAX_SESSIONS = 10;
@@ -19,6 +19,6 @@ export {
   COURSE_CSD,
   COURSE_CSP,
   COURSE_CSA,
-  COURSE_CSAIF,
+  COURSE_AIF,
   COURSE_BUILD_YOUR_OWN,
 };

--- a/dashboard/app/controllers/pd/professional_learning_controller.rb
+++ b/dashboard/app/controllers/pd/professional_learning_controller.rb
@@ -1,7 +1,7 @@
 class Pd::ProfessionalLearningController < ApplicationController
   PLC_COURSE_ORDERING = ['CSP Support', 'ECS Support', 'CS in Algebra Support', 'CS in Science Support']
 
-  before_action :authenticate_user!, only: [:index, :workshops, :csa, :csd, :csf, :csp, :csaif]
+  before_action :authenticate_user!, only: [:index, :workshops, :csa, :csd, :csf, :csp, :aif]
 
   # GET my-professional-learning
   def index
@@ -76,11 +76,11 @@ class Pd::ProfessionalLearningController < ApplicationController
     end
   end
 
-  # GET professional-learning/facilitator/computer-science-ai-fundamentals
-  def csaif
-    @course_name = Pd::Workshop::COURSE_CSAIF
+  # GET professional-learning/facilitator/ai-fundamentals
+  def aif
+    @course_name = Pd::Workshop::COURSE_AIF
     if can_view_facilitator_page(@course_name)
-      render 'pd/professional_learning/facilitator/csaif'
+      render 'pd/professional_learning/facilitator/aif'
     else
       render 'pd/professional_learning/facilitator/not_permitted_to_view', :status => :forbidden
     end

--- a/dashboard/app/views/pd/professional_learning/facilitator/aif.html.haml
+++ b/dashboard/app/views/pd/professional_learning/facilitator/aif.html.haml
@@ -1,8 +1,8 @@
-- @page_title = 'CS & AI Fundamentals Facilitator Landing Page'
+- @page_title = 'AI Fundamentals Facilitator Landing Page'
 
 %top
 
-%h1{style: "padding: 1rem 0;"} Computer Science and AI Fundamentals Facilitator Landing Page
+%h1{style: "padding: 1rem 0;"} AI Fundamentals Facilitator Landing Page
 
 %iframe{style: "width: 800px; height: 1200px", src: "https://docs.google.com/document/d/e/2PACX-1vSgNYvNmYxujCK7jXgWepuvRsfrm40otT5YZgZun0RXchI7q3t4C1WHaJgAL4dZHrLJyOzAS4_29_hh/pub?embedded=true"}
 %br

--- a/dashboard/app/views/pd/workshop_mailer/facilitator_pre_workshop.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/facilitator_pre_workshop.html.haml
@@ -20,8 +20,8 @@
       =link_to('facilitator landing page', 'https://studio.code.org/professional-learning/facilitator/computer-science-a') + '.'
     - elsif @workshop.course == Pd::Workshop::COURSE_CSF
       =link_to('facilitator landing page', 'https://studio.code.org/professional-learning/facilitator/computer-science-fundamentals') + '.'
-    - elsif @workshop.course == Pd::Workshop::COURSE_CSAIF
-      =link_to('facilitator landing page', 'https://studio.code.org/professional-learning/facilitator/computer-science-ai-fundamentals') + '.'
+    - elsif @workshop.course == Pd::Workshop::COURSE_AIF
+      =link_to('facilitator landing page', 'https://studio.code.org/professional-learning/facilitator/ai-fundamentals') + '.'
   %li
     Have quick questions about resources, agendas, or participant requests? Post them in the facilitator
     - if @workshop.course == 'CS Fundamentals'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -871,7 +871,7 @@ Dashboard::Application.routes.draw do
     get 'professional-learning/facilitator/computer-science-discoveries', to: 'pd/professional_learning#csd'
     get 'professional-learning/facilitator/computer-science-fundamentals', to: 'pd/professional_learning#csf'
     get 'professional-learning/facilitator/computer-science-principles', to: 'pd/professional_learning#csp'
-    get 'professional-learning/facilitator/computer-science-ai-fundamentals', to: 'pd/professional_learning#csaif'
+    get 'professional-learning/facilitator/ai-fundamentals', to: 'pd/professional_learning#aif'
     get 'professional-learning/regional-partner/playbook', to: 'pd/professional_learning#rp_playbook'
     get 'professional-learning/regional_workshop_data/:zip_code', to: 'pd/professional_learning#regional_workshop_data'
 

--- a/dashboard/test/controllers/pd/professional_learning_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_controller_test.rb
@@ -373,14 +373,14 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
     get :csp
     assert_redirected_to '/users/sign_in'
 
-    get :csaif
+    get :aif
     assert_redirected_to '/users/sign_in'
   end
 
   test 'csa facilitator landing page only loads for users with one of the necessary permissions' do
     setup_facilitator_landing_users
     can_view = [@program_manager, @workshop_organizer, @workshop_admin, @csa_facilitator]
-    cannot_view = [@teacher, @csd_facilitator, @csf_facilitator, @csp_facilitator, @csaif_facilitator]
+    cannot_view = [@teacher, @csd_facilitator, @csf_facilitator, @csp_facilitator, @aif_facilitator]
 
     can_view.each do |can_view_user|
       sign_in can_view_user
@@ -400,7 +400,7 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
   test 'csd facilitator landing page only loads for users with one of the necessary permissions' do
     setup_facilitator_landing_users
     can_view = [@program_manager, @workshop_organizer, @workshop_admin, @csd_facilitator]
-    cannot_view = [@teacher, @csa_facilitator, @csf_facilitator, @csp_facilitator, @csaif_facilitator]
+    cannot_view = [@teacher, @csa_facilitator, @csf_facilitator, @csp_facilitator, @aif_facilitator]
 
     can_view.each do |can_view_user|
       sign_in can_view_user
@@ -420,7 +420,7 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
   test 'csf facilitator landing page only loads for users with one of the necessary permissions' do
     setup_facilitator_landing_users
     can_view = [@program_manager, @workshop_organizer, @workshop_admin, @csf_facilitator]
-    cannot_view = [@teacher, @csa_facilitator, @csd_facilitator, @csp_facilitator, @csaif_facilitator]
+    cannot_view = [@teacher, @csa_facilitator, @csd_facilitator, @csp_facilitator, @aif_facilitator]
 
     can_view.each do |can_view_user|
       sign_in can_view_user
@@ -440,7 +440,7 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
   test 'csp facilitator landing page only loads for users with one of the necessary permissions' do
     setup_facilitator_landing_users
     can_view = [@program_manager, @workshop_organizer, @workshop_admin, @csp_facilitator]
-    cannot_view = [@teacher, @csa_facilitator, @csd_facilitator, @csf_facilitator, @csaif_facilitator]
+    cannot_view = [@teacher, @csa_facilitator, @csd_facilitator, @csf_facilitator, @aif_facilitator]
 
     can_view.each do |can_view_user|
       sign_in can_view_user
@@ -457,21 +457,21 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
     end
   end
 
-  test 'csaif facilitator landing page only loads for users with one of the necessary permissions' do
+  test 'aif facilitator landing page only loads for users with one of the necessary permissions' do
     setup_facilitator_landing_users
-    can_view = [@program_manager, @workshop_organizer, @workshop_admin, @csaif_facilitator]
+    can_view = [@program_manager, @workshop_organizer, @workshop_admin, @aif_facilitator]
     cannot_view = [@teacher, @csa_facilitator, @csd_facilitator, @csf_facilitator, @csp_facilitator]
 
     can_view.each do |can_view_user|
       sign_in can_view_user
-      get :csaif
-      assert_template 'pd/professional_learning/facilitator/csaif'
+      get :aif
+      assert_template 'pd/professional_learning/facilitator/aif'
       sign_out can_view_user
     end
 
     cannot_view.each do |cannot_view_user|
       sign_in cannot_view_user
-      get :csaif
+      get :aif
       assert_template 'pd/professional_learning/facilitator/not_permitted_to_view'
       sign_out cannot_view_user
     end
@@ -670,7 +670,7 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
     @csf_facilitator.course_as_facilitator = Pd::Workshop::COURSE_CSF
     @csp_facilitator = create :facilitator
     @csp_facilitator.course_as_facilitator = Pd::Workshop::COURSE_CSP
-    @csaif_facilitator = create :facilitator
-    @csaif_facilitator.course_as_facilitator = Pd::Workshop::COURSE_CSAIF
+    @aif_facilitator = create :facilitator
+    @aif_facilitator.course_as_facilitator = Pd::Workshop::COURSE_AIF
   end
 end

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -8,7 +8,7 @@ module Pd
       COURSE_FACILITATOR = 'Facilitator'.freeze,
       COURSE_ADMIN_COUNSELOR = 'Admin/Counselor Workshop'.freeze,
       COURSE_BUILD_YOUR_OWN = 'Build Your Own Workshop'.freeze,
-      COURSE_CSAIF = 'CS and AI Fundamentals'.freeze,
+      COURSE_AIF = 'AI Fundamentals'.freeze,
     ].freeze
 
     ARCHIVED_COURSES = [


### PR DESCRIPTION
Renames uses of CSAIF (CS and AI Fundamentals) to just AIF (AI Fundamentals) in the workshop dashboard area of our code base.

For example, shows the new course name in the facilitator permissions dropdown:
![ai fundamentals shows right](https://github.com/user-attachments/assets/790ea346-d867-4243-bd9c-be81002b86cd)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3217)

## Testing story
Local testing and updating unit tests.
