### PR TITLE
CMS-563: Align SimpleList icons to top

### DIFF
--- a/frontend/packages/component-library/src/list/simpleList/simpleList.module.scss
+++ b/frontend/packages/component-library/src/list/simpleList/simpleList.module.scss
@@ -18,8 +18,9 @@
     align-items: center;
 
     .simpleListItemIcon {
-      flex-shrink: 0;
+      align-self: start;
       text-align: center;
+      flex-shrink: 0;
     }
 
     .simpleListItemLabel {
@@ -59,9 +60,11 @@
 
     .simpleListItemIcon {
       @include mixins.icon-dimensions(var(--font-size-body-lg));
+      line-height: 1.4;
 
       &.simpleListItemBullet {
         @include mixins.icon-dimensions(0.875rem);
+        line-height: 2;
       }
     }
   }
@@ -74,9 +77,11 @@
 
     .simpleListItemIcon {
       @include mixins.icon-dimensions(var(--font-size-body-md));
+      line-height: 1.48;
 
       &.simpleListItemBullet {
         @include mixins.icon-dimensions(0.75rem);
+        line-height: 1.97;
       }
     }
   }
@@ -89,9 +94,11 @@
 
     .simpleListItemIcon {
       @include mixins.icon-dimensions(var(--font-size-body-sm));
+      line-height: 1.54;
 
       &.simpleListItemBullet {
         @include mixins.icon-dimensions(0.625rem);
+        line-height: 2.15;
       }
     }
   }
@@ -104,9 +111,11 @@
 
     .simpleListItemIcon {
       @include mixins.icon-dimensions(var(--font-size-body-xs));
+      line-height: 1.64;
 
       &.simpleListItemBullet {
         @include mixins.icon-dimensions(0.5rem);
+        line-height: 2.67;
       }
     }
   }

--- a/frontend/packages/component-library/src/list/simpleList/stories/SimpleList.story.tsx
+++ b/frontend/packages/component-library/src/list/simpleList/stories/SimpleList.story.tsx
@@ -367,6 +367,7 @@ export const Weight: Story = {
 
 export const WithMultilineItem: Story = {
   args: {
+    style: {maxWidth: '20em'},
     items: [
       {key: 'item-a', label: 'Item A'},
       {
@@ -376,8 +377,5 @@ export const WithMultilineItem: Story = {
       },
       {key: 'item-c', label: 'Item C'},
     ],
-  },
-  play: ({canvasElement}: {canvasElement: HTMLElement}) => {
-    canvasElement.style.width = '20rem';
   },
 };

--- a/frontend/packages/component-library/src/list/simpleList/stories/SimpleList.story.tsx
+++ b/frontend/packages/component-library/src/list/simpleList/stories/SimpleList.story.tsx
@@ -374,7 +374,7 @@ export const WithMultilineItem: Story = {
         label:
           'Extremely, exceptionally, extraordinarily, immensely prolonged Item B',
       },
-      {key: 'item-c', label: 'Item c'},
+      {key: 'item-c', label: 'Item C'},
     ],
   },
   play: ({canvasElement}: {canvasElement: HTMLElement}) => {

--- a/frontend/packages/component-library/src/list/simpleList/stories/SimpleList.story.tsx
+++ b/frontend/packages/component-library/src/list/simpleList/stories/SimpleList.story.tsx
@@ -364,3 +364,20 @@ export const Weight: Story = {
     });
   },
 };
+
+export const WithMultilineItem: Story = {
+  args: {
+    items: [
+      {key: 'item-a', label: 'Item A'},
+      {
+        key: 'item-b',
+        label:
+          'Extremely, exceptionally, extraordinarily, immensely prolonged Item B',
+      },
+      {key: 'item-c', label: 'Item c'},
+    ],
+  },
+  play: ({canvasElement}: {canvasElement: HTMLElement}) => {
+    canvasElement.style.width = '20rem';
+  },
+};


### PR DESCRIPTION
## Preview
<img width="100%" alt="simple-list" src="https://github.com/user-attachments/assets/55b8dca4-02b9-47e8-a3e9-08ae2af85862" />


## Links
- JIRA task: [CMS-563](https://codedotorg.atlassian.net/browse/CMS-563)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/64557