### PR TITLE
Adding four new states to CAP

### DIFF
--- a/dashboard/lib/policies/child_account/state_policies.rb
+++ b/dashboard/lib/policies/child_account/state_policies.rb
@@ -22,6 +22,34 @@ module Policies::ChildAccount::StatePolicies
         lockout_date: DateTime.parse('2025-01-06T00:00:00-05:00'),
         start_date: DateTime.parse('2025-01-06T00:00:00-05:00'),
       },
+      'NY' => {
+        name: 'NYCDPA',
+        max_age: 12,
+        grace_period_duration: 14.days.seconds,
+        lockout_date: DateTime.parse('2025-06-20T00:00:00-04:00'),
+        start_date: DateTime.parse('2025-06-20T00:00:00-04:00'),
+      },
+      'OR' => {
+        name: 'OCPA',
+        max_age: 12,
+        grace_period_duration: 14.days.seconds,
+        lockout_date: DateTime.parse('2025-07-01T00:00:00-07:00'),
+        start_date: DateTime.parse('2025-07-01T00:00:00-07:00'),
+      },
+      'MN' => {
+        name: 'MCDPA',
+        max_age: 12,
+        grace_period_duration: 14.days.seconds,
+        lockout_date: DateTime.parse('2025-07-31T00:00:00-05:00'),
+        start_date: DateTime.parse('2025-07-31T00:00:00-05:00'),
+      },
+      'MD' => {
+        name: 'MODPA',
+        max_age: 12,
+        grace_period_duration: 14.days.seconds,
+        lockout_date: DateTime.parse('2025-10-01T00:00:00-04:00'),
+        start_date: DateTime.parse('2025-10-01T00:00:00-04:00'),
+      },
     }
 
     # Override the configured dates for testing purposes

--- a/dashboard/test/lib/policies/child_account/state_policies_test.rb
+++ b/dashboard/test/lib/policies/child_account/state_policies_test.rb
@@ -9,54 +9,157 @@ class Policies::ChildAccount::StatePoliciesTest < ActiveSupport::TestCase
     end
 
     describe 'for Colorado' do
-      let(:co_state_policy) {state_policies['CO']}
-      let(:default_start_date) {DateTime.parse('2023-07-05T23:15:00+00:00')}
-      let(:default_lockout_date) {DateTime.parse('2024-07-01T00:00:00MDT')}
+      let(:state_policy) {state_policies['CO']}
+      let(:start_date) {DateTime.parse('2023-07-05T23:15:00+00:00')}
+      let(:lockout_date) {DateTime.parse('2024-07-01T00:00:00MDT')}
 
       it 'contains expected max age' do
-        _(co_state_policy[:max_age]).must_equal 12
+        _(state_policy[:max_age]).must_equal 12
       end
 
       it 'contains expected name' do
-        _(co_state_policy[:name]).must_equal 'CPA'
+        _(state_policy[:name]).must_equal 'CPA'
       end
 
       it 'contains expected grace_period_duration' do
-        _(co_state_policy[:grace_period_duration]).must_equal 14.days
+        _(state_policy[:grace_period_duration]).must_equal 14.days
       end
 
       it 'contains expected default start_date' do
-        _(co_state_policy[:start_date]).must_equal default_start_date
+        _(state_policy[:start_date]).must_equal start_date
       end
 
       it 'contains expected default lockout_date' do
-        _(co_state_policy[:lockout_date]).must_equal default_lockout_date
+        _(state_policy[:lockout_date]).must_equal lockout_date
       end
     end
 
     describe 'for Delaware' do
-      let(:co_state_policy) {state_policies['DE']}
-      let(:default_start_date) {DateTime.parse('2025-01-06T00:00:00-05:00')}
-      let(:default_lockout_date) {DateTime.parse('2025-01-06T00:00:00-05:00')}
+      let(:state_policy) {state_policies['DE']}
+      let(:start_date) {DateTime.parse('2025-01-06T00:00:00-05:00')}
+      let(:lockout_date) {DateTime.parse('2025-01-06T00:00:00-05:00')}
 
       it 'contains expected max age' do
-        _(co_state_policy[:max_age]).must_equal 12
+        _(state_policy[:max_age]).must_equal 12
       end
 
       it 'contains expected name' do
-        _(co_state_policy[:name]).must_equal 'DPDPA'
+        _(state_policy[:name]).must_equal 'DPDPA'
       end
 
       it 'contains expected grace_period_duration' do
-        _(co_state_policy[:grace_period_duration]).must_equal 14.days
+        _(state_policy[:grace_period_duration]).must_equal 14.days
       end
 
       it 'contains expected default start_date' do
-        _(co_state_policy[:start_date]).must_equal default_start_date
+        _(state_policy[:start_date]).must_equal start_date
       end
 
       it 'contains expected default lockout_date' do
-        _(co_state_policy[:lockout_date]).must_equal default_lockout_date
+        _(state_policy[:lockout_date]).must_equal lockout_date
+      end
+    end
+
+    describe 'for New York' do
+      let(:state_policy) {state_policies['NY']}
+      let(:start_date) {DateTime.parse('2025-06-20T00:00:00-04:00')}
+      let(:lockout_date) {DateTime.parse('2025-06-20T00:00:00-04:00')}
+
+      it 'contains expected max age' do
+        _(state_policy[:max_age]).must_equal 12
+      end
+
+      it 'contains expected name' do
+        _(state_policy[:name]).must_equal 'NYCDPA'
+      end
+
+      it 'contains expected grace_period_duration' do
+        _(state_policy[:grace_period_duration]).must_equal 14.days
+      end
+
+      it 'contains expected default start_date' do
+        _(state_policy[:start_date]).must_equal start_date
+      end
+
+      it 'contains expected default lockout_date' do
+        _(state_policy[:lockout_date]).must_equal lockout_date
+      end
+    end
+
+    describe 'for Oregon' do
+      let(:state_policy) {state_policies['OR']}
+      let(:start_date) {DateTime.parse('2025-07-01T00:00:00-07:00')}
+      let(:lockout_date) {DateTime.parse('2025-07-01T00:00:00-07:00')}
+
+      it 'contains expected max age' do
+        _(state_policy[:max_age]).must_equal 12
+      end
+
+      it 'contains expected name' do
+        _(state_policy[:name]).must_equal 'OCPA'
+      end
+
+      it 'contains expected grace_period_duration' do
+        _(state_policy[:grace_period_duration]).must_equal 14.days
+      end
+
+      it 'contains expected default start_date' do
+        _(state_policy[:start_date]).must_equal start_date
+      end
+
+      it 'contains expected default lockout_date' do
+        _(state_policy[:lockout_date]).must_equal lockout_date
+      end
+    end
+
+    describe 'for Minnesota' do
+      let(:state_policy) {state_policies['MN']}
+      let(:start_date) {DateTime.parse('2025-07-31T00:00:00-05:00')}
+      let(:lockout_date) {DateTime.parse('2025-07-31T00:00:00-05:00')}
+
+      it 'contains expected max age' do
+        _(state_policy[:max_age]).must_equal 12
+      end
+
+      it 'contains expected name' do
+        _(state_policy[:name]).must_equal 'MCDPA'
+      end
+
+      it 'contains expected grace_period_duration' do
+        _(state_policy[:grace_period_duration]).must_equal 14.days
+      end
+
+      it 'contains expected default start_date' do
+        _(state_policy[:start_date]).must_equal start_date
+      end
+
+      it 'contains expected default lockout_date' do
+        _(state_policy[:lockout_date]).must_equal lockout_date
+      end
+    end
+
+    describe 'for Maryland' do
+      let(:state_policy) {state_policies['MD']}
+      let(:start_date) {DateTime.parse('2025-10-01T00:00:00-04:00')}
+      let(:lockout_date) {DateTime.parse('2025-10-01T00:00:00-04:00')}
+
+      it 'contains expected max age' do
+        _(state_policy[:max_age]).must_equal 12
+      end
+
+      it 'contains expected name' do
+        _(state_policy[:name]).must_equal 'MODPA'
+      end
+      it 'contains expected grace_period_duration' do
+        _(state_policy[:grace_period_duration]).must_equal 14.days
+      end
+
+      it 'contains expected default start_date' do
+        _(state_policy[:start_date]).must_equal start_date
+      end
+
+      it 'contains expected default lockout_date' do
+        _(state_policy[:lockout_date]).must_equal lockout_date
       end
     end
   end


### PR DESCRIPTION
Add four new states to our Child Account Policy(CAP). [Rollout Plan](https://docs.google.com/document/d/1WczMvriy1u7raeC1TfptjYh3i2NFHOd-68TvfNh07HM/edit?tab=t.0)

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1486)
* [Rollout Plan](https://docs.google.com/document/d/1WczMvriy1u7raeC1TfptjYh3i2NFHOd-68TvfNh07HM/edit?tab=t.0)
 
## Testing story
* Unit tests

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
* This will not be merged until 2025/05/01 in order to avoid impacting the AP Create Task.
* This won't be merged until I have signoff in the [Rollout Plan](https://docs.google.com/document/d/1WczMvriy1u7raeC1TfptjYh3i2NFHOd-68TvfNh07HM/edit?tab=t.0) from all stakeholders. 

