### PR TITLE
Update UI test courses with original units

### DIFF
--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -277,7 +277,8 @@ module Services
       script_to_import.is_migrated = true
       # Needed because we already have some Scripts with invalid names
       script_to_import.skip_name_format_validation = true
-      # We want to persist original_unit_group_id since it does not get set until the course is seeded
+      # We don't want to overwrite original_unit_group_id to nil if the unit exists and has an original_unit_group_id.
+      # The original_unit_group_id is set when courses are seeded.
       columns_to_update = get_columns(Unit) - [:original_unit_group_id]
       Unit.import! [script_to_import], on_duplicate_key_update: columns_to_update
 

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -277,7 +277,9 @@ module Services
       script_to_import.is_migrated = true
       # Needed because we already have some Scripts with invalid names
       script_to_import.skip_name_format_validation = true
-      Unit.import! [script_to_import], on_duplicate_key_update: get_columns(Unit)
+      # We want to persist original_unit_group_id since it does not get set until the course is seeded
+      columns_to_update = get_columns(Unit) - [:original_unit_group_id]
+      Unit.import! [script_to_import], on_duplicate_key_update: columns_to_update
 
       # activerecord-import doesn't trigger callbacks for imported models, and
       # Scripts rely on the after_save hook to invoke `generate_plc_objects`,

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -139,6 +139,7 @@ module Services
       assert_equal counts_before, get_counts
       script_after_seed = Unit.with_seed_models.find_by!(name: script.name)
       assert_script_trees_equal(script, script_after_seed)
+      assert_equal script_after_seed.original_unit_group, script.original_unit_group
     end
 
     # This tests the scenario where a script is in a unit group, but we don't
@@ -163,15 +164,17 @@ module Services
       # destroy the script and its unit group, so that no course version will
       # be available during seed.
       script_to_destroy = Unit.find(script.id)
+      unit_group_to_destroy = script_to_destroy.unit_group
       script_to_destroy.unit_group.course_version.destroy!
-      script_to_destroy.unit_group.destroy!
       script_to_destroy.destroy!
+      unit_group_to_destroy.destroy!
 
       ScriptSeed.seed_from_json(json)
 
       assert_equal expected_counts, get_counts
       script_after_seed = Unit.with_seed_models.find_by!(name: script.name)
-      assert_script_trees_equal(script, script_after_seed)
+      # original_unit_group_id is set when the unit_group is seeded, unless a script already exists with an original_unit_group_id
+      assert_script_trees_equal(script, script_after_seed, ['original_unit_group_id'])
     end
 
     test 'seed with no changes is no-op' do
@@ -1268,11 +1271,11 @@ module Services
       ].map {|c| [c.name, c.count]}.to_h
     end
 
-    def assert_script_trees_equal(s1, s2)
+    def assert_script_trees_equal(s1, s2, script_excludes = [])
       # Make sure the scripts and their associations are already in memory,
       # because fetching data from the DB could lead to false positive matches.
       assert_queries(0) do
-        assert_scripts_equal s1, s2
+        assert_scripts_equal s1, s2, script_excludes
         assert_lesson_groups_equal s1.lesson_groups, s2.lesson_groups
         assert_lessons_equal s1.lessons, s2.lessons
         assert_lesson_activities_equal(
@@ -1327,8 +1330,8 @@ module Services
       end
     end
 
-    def assert_scripts_equal(script1, script2)
-      assert_attributes_equal(script1, script2, ['properties'])
+    def assert_scripts_equal(script1, script2, additional_excludes = [])
+      assert_attributes_equal(script1, script2, additional_excludes + ['properties'])
       assert_equal script1.properties.except('seeded_from'),
         script2.properties.except('seeded_from')
     end
@@ -1457,6 +1460,7 @@ module Services
         unit_group = create :unit_group, family_name: family_name, version_year: version_year
         create :unit_group_unit, unit_group: unit_group, script: script, position: 1
         CourseOffering.add_course_offering(unit_group)
+        script.update!(original_unit_group_id: unit_group.id)
       else
         script.update!(
           is_course: true,

--- a/dashboard/test/ui/config/courses/ui-test-course-2017.course
+++ b/dashboard/test/ui/config/courses/ui-test-course-2017.course
@@ -4,6 +4,10 @@
     "ui-test-script-in-course-2017",
     "ui-test-script-2-in-course-2017"
   ],
+  "original_script_names": [
+    "ui-test-script-in-course-2017",
+    "ui-test-script-2-in-course-2017"
+  ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
   "participant_audience": "student",

--- a/dashboard/test/ui/config/courses/ui-test-course-2019.course
+++ b/dashboard/test/ui/config/courses/ui-test-course-2019.course
@@ -4,6 +4,10 @@
     "ui-test-script-in-course-2019",
     "ui-test-script-2-in-course-2019"
   ],
+  "original_script_names": [
+    "ui-test-script-in-course-2019",
+    "ui-test-script-2-in-course-2019"
+  ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
   "participant_audience": "student",

--- a/dashboard/test/ui/config/courses/ui-test-csa-family-script.course
+++ b/dashboard/test/ui/config/courses/ui-test-csa-family-script.course
@@ -3,6 +3,9 @@
   "script_names": [
     "ui-test-csa-family-script"
   ],
+  "original_script_names": [
+    "ui-test-csa-family-script"
+  ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
   "participant_audience": "student",

--- a/dashboard/test/ui/config/courses/ui-test-facilitator-pl-course.course
+++ b/dashboard/test/ui/config/courses/ui-test-facilitator-pl-course.course
@@ -3,6 +3,9 @@
   "script_names": [
     "ui-test-facilitator-pl-course"
   ],
+  "original_script_names": [
+    "ui-test-facilitator-pl-course"
+  ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
   "participant_audience": "facilitator",

--- a/dashboard/test/ui/config/courses/ui-test-single-unit-course-2025.course
+++ b/dashboard/test/ui/config/courses/ui-test-single-unit-course-2025.course
@@ -3,6 +3,9 @@
   "script_names": [
     "ui-test-single-unit-2025"
   ],
+  "original_script_names": [
+    "ui-test-single-unit-2025"
+  ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
   "participant_audience": "student",

--- a/dashboard/test/ui/config/courses/ui-test-single-unit-course-2026.course
+++ b/dashboard/test/ui/config/courses/ui-test-single-unit-course-2026.course
@@ -3,6 +3,9 @@
   "script_names": [
     "ui-test-single-unit-2026"
   ],
+  "original_script_names": [
+    "ui-test-single-unit-2026"
+  ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
   "participant_audience": "student",

--- a/dashboard/test/ui/config/courses/ui-test-teacher-pl-course.course
+++ b/dashboard/test/ui/config/courses/ui-test-teacher-pl-course.course
@@ -3,6 +3,9 @@
   "script_names": [
     "ui-test-teacher-pl-course"
   ],
+  "original_script_names": [
+    "ui-test-teacher-pl-course"
+  ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
   "participant_audience": "teacher",

--- a/dashboard/test/ui/config/courses/ui-test-unnumbered-lessons.course
+++ b/dashboard/test/ui/config/courses/ui-test-unnumbered-lessons.course
@@ -3,6 +3,9 @@
   "script_names": [
     "ui-test-unnumbered-lessons"
   ],
+  "original_script_names": [
+    "ui-test-unnumbered-lessons"
+  ],
   "published_state": "beta",
   "instruction_type": "teacher_led",
   "participant_audience": "student",

--- a/dashboard/test/ui/config/courses/ui-test-versioned-script-2017.course
+++ b/dashboard/test/ui/config/courses/ui-test-versioned-script-2017.course
@@ -3,6 +3,9 @@
   "script_names": [
     "ui-test-versioned-script-2017"
   ],
+  "original_script_names": [
+    "ui-test-versioned-script-2017"
+  ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
   "participant_audience": "student",

--- a/dashboard/test/ui/config/courses/ui-test-versioned-script-2019.course
+++ b/dashboard/test/ui/config/courses/ui-test-versioned-script-2019.course
@@ -3,6 +3,9 @@
   "script_names": [
     "ui-test-versioned-script-2019"
   ],
+  "original_script_names": [
+    "ui-test-versioned-script-2019"
+  ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
   "participant_audience": "student",


### PR DESCRIPTION
This PR adds `original_units` to the UI test courses' `.course` files. An additional change was needed in `script_seed.rb` to make sure that the `original_unit_group_id` is not overwritten when a Unit exists and has an `original_unit_group_id`. 

## Links
- Jira: [TEACH-1596](https://codedotorg.atlassian.net/browse/TEACH-1596)
- PR to add `original_unit_group_id` to the Unit model: #65274 

## Testing story
Verified that running `bundle exec rake seed:ui_test` seeds the UI test courses with their appropriate `original_units`. 
