### PR TITLE
SUM - add logging for summary box

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -479,6 +479,10 @@ const EVENTS = {
   AICHAT_MULTIMODAL_UPLOAD_OPENED: 'User clicks to upload multimodal assets',
   AICHAT_MULTIMODAL_UPLOAD_STAGED: 'User stages multimodal assets',
 
+  // Measures of learning
+  AI_SUMMARY_FRQ_PAGE_USER_FEEDBACK:
+    'Teacher gave feedback on AIs summary of student work',
+
   // Codebridge - File broswer-related events
   CODEBRIDGE_DELETE_FILE: 'Delete file on codebridge',
   CODEBRIDGE_DELETE_FOLDER: 'Delete folder on codebridge',

--- a/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
@@ -8,6 +8,9 @@ import {
 import React from 'react';
 
 import {StudentWorkEvaluation} from '@cdo/apps/aiEvaluation/aiEvaluationApi';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import aiBot from './AI-Bot-default.png';
@@ -36,6 +39,7 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
   totalNumberOfStudents,
   openDetailedAnalysis,
 }) => {
+  const currentUserId = useAppSelector(state => state.currentUser.userId);
   const proficienceyThreshold = totalNumberOfStudents * 0.8;
   const aiSummaryTag = (proficiencyCount: number) => {
     return (
@@ -114,6 +118,19 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
       (totalNumberOfStudents - studentWorkEvaluations.length)
     : 0;
 
+  const handleIconClick = (thumbsUp: boolean) => {
+    if (!studentWorkEvaluations) {
+      return;
+    }
+    analyticsReporter.sendEvent(EVENTS.AI_SUMMARY_FRQ_PAGE_USER_FEEDBACK, {
+      userId: currentUserId,
+      levelId: studentWorkEvaluations[0].levelId,
+      scriptId: studentWorkEvaluations[0].unitId,
+      aiInteractionType: 'ai_summary',
+      thumbsUp: thumbsUp,
+    });
+  };
+
   const showEvaluationSummary = studentWorkEvaluations && evaluationComplete;
 
   const aiSummaryContent = () => {
@@ -126,8 +143,12 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
               {i18n.aiFeedbackQuestion()}
             </BodyThreeText>
             <FeedbackToggle
-              onThumbsUpClick={() => {}}
-              onThumbsDownClick={() => {}}
+              onThumbsUpClick={() => {
+                handleIconClick(true);
+              }}
+              onThumbsDownClick={() => {
+                handleIconClick(false);
+              }}
               size="xs"
               color="gray"
             />


### PR DESCRIPTION
Adds event logging to the summary box on FRQ pages.


https://github.com/user-attachments/assets/256091fc-f6b4-4173-852a-9cd3a6e9dd4b



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1771) - Note, currently we don't use AI to really produce much in the "summary" box.  So this is intended to be a solution for our initial launch.  The feedback will be fully implemented once we use AI here
