### PR TITLE
SUM - add experiment tag

### DIFF
--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -1,3 +1,4 @@
+import Tags from '@code-dot-org/component-library/tags';
 import Toggle from '@code-dot-org/component-library/toggle';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useState, useMemo} from 'react';
@@ -199,14 +200,21 @@ const SummaryResponses = ({
                 name={'showStudentNames'}
               />
               {aiAnalysisAvailable && (
-                <Toggle
-                  onChange={toggleAIAnalysis}
-                  checked={showAIAnalysis}
-                  label={i18n.showAiInsights()}
-                  position={'right'}
-                  size={'s'}
-                  name={'showAIAnalysis'}
-                />
+                <div className={styles.aiToggleContainer}>
+                  <Toggle
+                    onChange={toggleAIAnalysis}
+                    checked={showAIAnalysis}
+                    label={i18n.showAiInsights()}
+                    position={'right'}
+                    size={'s'}
+                    name={'showAIAnalysis'}
+                  />
+                  <Tags
+                    className={styles.headerTag}
+                    tagsList={[{label: i18n.experiment()}]}
+                    size="s"
+                  />
+                </div>
               )}
             </div>
           )}

--- a/apps/src/templates/levelSummary/summary.module.scss
+++ b/apps/src/templates/levelSummary/summary.module.scss
@@ -77,7 +77,28 @@ label.sectionSelector {
 
 .toggleGroup {
   display: flex;
+  align-items: flex-start;
   gap: 20px;
+}
+
+.aiToggleContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 4px;
+
+  .headerTag {
+    margin-left: 4px;
+
+    div {
+      background-color: var(--background-neutral-tertiary);
+
+      span {
+        color: var(--text-neutral-primary);
+      }
+    }
+  }
 }
 
 [dir='rtl'] .toggleContainer {


### PR DESCRIPTION
Adds the Experiment Tag under the "Show AI Insights toggle"

Figma:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/818ff4f4-0ad5-4b9c-9778-7b24d6f42612" />



From this PR:
<img width="708" alt="image" src="https://github.com/user-attachments/assets/52f09af7-4369-46e1-9c10-d8f1462fded2" />




## Links

[Part of this ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1719)
[Figma](https://www.figma.com/design/i3smpK0bu5Tnc1JgmmMfTI/Check-For-Understanding-Summaries?node-id=2855-5153&m=dev)
