### PR TITLE
AI Chat: resize levelbuilder uploads

### DIFF
--- a/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
@@ -20,7 +20,7 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
   levelName,
   onSelect,
   limit,
-  showError,
+  currentError,
 }) => {
   const [selectedFiles, setSelectedFiles] = useState<AssetData[]>([]);
 
@@ -64,7 +64,7 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
       }}
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={loading ? <Loading /> : <ModalBody />}
-      customBottomContent={showError && <ErrorAlert />}
+      customBottomContent={currentError && <ErrorAlert />}
     />
   );
 };

--- a/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
@@ -20,7 +20,7 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
   levelName,
   onSelect,
   limit,
-  currentErrorMessage,
+  errorMessage,
 }) => {
   const [selectedFiles, setSelectedFiles] = useState<AssetData[]>([]);
 
@@ -65,9 +65,7 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={loading ? <Loading /> : <ModalBody />}
       customBottomContent={
-        currentErrorMessage && (
-          <ErrorAlert currentErrorMessage={currentErrorMessage} />
-        )
+        errorMessage && <ErrorAlert message={errorMessage} />
       }
     />
   );

--- a/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
@@ -20,7 +20,7 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
   levelName,
   onSelect,
   limit,
-  currentError,
+  currentErrorMessage,
 }) => {
   const [selectedFiles, setSelectedFiles] = useState<AssetData[]>([]);
 
@@ -64,7 +64,11 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
       }}
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={loading ? <Loading /> : <ModalBody />}
-      customBottomContent={currentError && <ErrorAlert />}
+      customBottomContent={
+        currentErrorMessage && (
+          <ErrorAlert currentErrorMessage={currentErrorMessage} />
+        )
+      }
     />
   );
 };

--- a/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
@@ -13,7 +13,6 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
   const {levelName, mode, onError} = props;
   const [assets, setAssets] = useState<AssetData[]>([]);
   const [loading, setLoading] = useState(false);
-  const [showError, setShowError] = useState(false);
   const [currentError, setCurrentError] = useState<Error | undefined>(
     undefined
   );
@@ -29,7 +28,7 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
       setAssets(assets);
     } catch (error) {
       onError?.(error as Error);
-      setShowError(true);
+      setCurrentError(error as Error);
     }
     setLoading(false);
   }, [levelName, onError]);
@@ -67,12 +66,13 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
     [assets]
   );
 
-  const setError = useCallback(
-    (error: Error) => {
-      onError?.(error);
-      setShowError(true);
+  const handleError = useCallback(
+    (error?: Error) => {
+      if (error) {
+        onError?.(error);
+      }
+
       setCurrentError(error);
-      console.log(error);
     },
     [onError]
   );
@@ -80,11 +80,10 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
   const dialogProps = {
     assets,
     loading,
-    showError,
     // Used by UploadAssetDialog
     addAsset,
     removeAsset,
-    setError,
+    handleError,
     currentError,
   };
 

--- a/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
@@ -14,6 +14,9 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
   const [assets, setAssets] = useState<AssetData[]>([]);
   const [loading, setLoading] = useState(false);
   const [showError, setShowError] = useState(false);
+  const [currentError, setCurrentError] = useState<Error | undefined>(
+    undefined
+  );
 
   const abortControllerRef = useRef(new AbortController());
 
@@ -68,6 +71,8 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
     (error: Error) => {
       onError?.(error);
       setShowError(true);
+      setCurrentError(error);
+      console.log(error);
     },
     [onError]
   );
@@ -80,6 +85,7 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
     addAsset,
     removeAsset,
     setError,
+    currentError,
   };
 
   if (mode === 'select') {

--- a/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
@@ -13,9 +13,9 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
   const {levelName, mode, onError} = props;
   const [assets, setAssets] = useState<AssetData[]>([]);
   const [loading, setLoading] = useState(false);
-  const [currentError, setCurrentError] = useState<Error | undefined>(
-    undefined
-  );
+  const [currentErrorMessage, setCurrentErrorMessage] = useState<
+    string | undefined
+  >(undefined);
 
   const abortControllerRef = useRef(new AbortController());
 
@@ -28,7 +28,7 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
       setAssets(assets);
     } catch (error) {
       onError?.(error as Error);
-      setCurrentError(error as Error);
+      setDefaultErrorMessage();
     }
     setLoading(false);
   }, [levelName, onError]);
@@ -67,19 +67,25 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
   );
 
   const handleError = useCallback(
-    (error: Error) => {
+    (error: Error, userErrorMessage?: string) => {
       onError?.(error);
-      setCurrentError(error);
+      if (userErrorMessage) {
+        setCurrentErrorMessage(userErrorMessage);
+      } else {
+        setDefaultErrorMessage();
+      }
     },
     [onError]
   );
 
-  const clearError = () => setCurrentError(undefined);
+  const clearError = () => setCurrentErrorMessage(undefined);
+  const setDefaultErrorMessage = () =>
+    setCurrentErrorMessage('Something went wrong. Please try again!');
 
   const dialogProps = {
     assets,
     loading,
-    currentError,
+    currentErrorMessage,
     // Used by UploadAssetDialog
     addAsset,
     removeAsset,

--- a/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
@@ -67,24 +67,24 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
   );
 
   const handleError = useCallback(
-    (error?: Error) => {
-      if (error) {
-        onError?.(error);
-      }
-
+    (error: Error) => {
+      onError?.(error);
       setCurrentError(error);
     },
     [onError]
   );
 
+  const clearError = () => setCurrentError(undefined);
+
   const dialogProps = {
     assets,
     loading,
+    currentError,
     // Used by UploadAssetDialog
     addAsset,
     removeAsset,
     handleError,
-    currentError,
+    clearError,
   };
 
   if (mode === 'select') {

--- a/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
@@ -13,9 +13,9 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
   const {levelName, mode, onError} = props;
   const [assets, setAssets] = useState<AssetData[]>([]);
   const [loading, setLoading] = useState(false);
-  const [currentErrorMessage, setCurrentErrorMessage] = useState<
-    string | undefined
-  >(undefined);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    undefined
+  );
 
   const abortControllerRef = useRef(new AbortController());
 
@@ -70,7 +70,7 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
     (error: Error, userErrorMessage?: string) => {
       onError?.(error);
       if (userErrorMessage) {
-        setCurrentErrorMessage(userErrorMessage);
+        setErrorMessage(userErrorMessage);
       } else {
         setDefaultErrorMessage();
       }
@@ -78,14 +78,14 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
     [onError]
   );
 
-  const clearError = () => setCurrentErrorMessage(undefined);
+  const clearError = () => setErrorMessage(undefined);
   const setDefaultErrorMessage = () =>
-    setCurrentErrorMessage('Something went wrong. Please try again!');
+    setErrorMessage('Something went wrong. Please try again!');
 
   const dialogProps = {
     assets,
     loading,
-    currentErrorMessage,
+    errorMessage,
     // Used by UploadAssetDialog
     addAsset,
     removeAsset,

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -24,7 +24,7 @@ const ACCEPTED_FILE_TYPES = [
 
 export interface UploadProps extends CommonProps {
   mode: 'upload';
-  currentError?: Error;
+  clearError?: () => void;
 }
 
 const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
@@ -36,6 +36,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
   levelName,
   handleError,
   currentError,
+  clearError,
 }) => {
   const [requestInProgress, setRequestInProgress] = useState<
     'upload' | 'delete'
@@ -64,7 +65,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
   );
 
   const onDelete = async (filename: string) => {
-    handleError(undefined);
+    clearError?.();
     setRequestInProgress('delete');
     try {
       await deleteFile(filename, levelName);
@@ -108,7 +109,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       primaryButtonProps={{
         text: buttonText,
         onClick: () => {
-          handleError(undefined);
+          clearError?.();
           openFileInput();
         },
         iconLeft: {

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -36,7 +36,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
   loading,
   levelName,
   handleError,
-  currentErrorMessage,
+  errorMessage,
   clearError,
 }) => {
   const [requestInProgress, setRequestInProgress] = useState<
@@ -127,9 +127,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={loading ? <Loading /> : <ModalBody />}
       customBottomContent={
-        currentErrorMessage && (
-          <ErrorAlert currentErrorMessage={currentErrorMessage} />
-        )
+        errorMessage && <ErrorAlert message={errorMessage} />
       }
     />
   );

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -24,6 +24,7 @@ const ACCEPTED_FILE_TYPES = [
 
 export interface UploadProps extends CommonProps {
   mode: 'upload';
+  currentError?: Error;
 }
 
 const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
@@ -35,6 +36,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
   levelName,
   showError,
   setError,
+  currentError,
 }) => {
   const [requestInProgress, setRequestInProgress] = useState<
     'upload' | 'delete'
@@ -114,7 +116,9 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       }}
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={loading ? <Loading /> : <ModalBody />}
-      customBottomContent={showError && <ErrorAlert />}
+      customBottomContent={
+        showError && <ErrorAlert currentError={currentError} />
+      }
     />
   );
 };

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -2,6 +2,7 @@ import Modal from '@code-dot-org/component-library/modal';
 import React, {ChangeEvent, useState} from 'react';
 
 import useHiddenFileInput from '@cdo/apps/util/hooks/useHiddenFileInput';
+import {isNetworkError} from '@cdo/apps/util/HttpClient';
 
 import {deleteFile, uploadFile} from './api';
 import FileIcon from './FileIcon';
@@ -35,7 +36,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
   loading,
   levelName,
   handleError,
-  currentError,
+  currentErrorMessage,
   clearError,
 }) => {
   const [requestInProgress, setRequestInProgress] = useState<
@@ -54,7 +55,12 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       const asset = await uploadFile(files[0], levelName);
       addAsset(asset);
     } catch (error) {
-      handleError(error as Error);
+      let userErrorMessage;
+      if (isNetworkError(error) && error.getDetails().status === 413) {
+        userErrorMessage =
+          'Images must be less than 20 MB, and PDFs less than 5 MB. Please try a smaller asset.';
+      }
+      handleError(error as Error, userErrorMessage);
     }
     setRequestInProgress(undefined);
   };
@@ -121,7 +127,9 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={loading ? <Loading /> : <ModalBody />}
       customBottomContent={
-        currentError && <ErrorAlert currentError={currentError} />
+        currentErrorMessage && (
+          <ErrorAlert currentErrorMessage={currentErrorMessage} />
+        )
       }
     />
   );

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -34,8 +34,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
   removeAsset,
   loading,
   levelName,
-  showError,
-  setError,
+  handleError,
   currentError,
 }) => {
   const [requestInProgress, setRequestInProgress] = useState<
@@ -54,7 +53,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       const asset = await uploadFile(files[0], levelName);
       addAsset(asset);
     } catch (error) {
-      setError(error as Error);
+      handleError(error as Error);
     }
     setRequestInProgress(undefined);
   };
@@ -65,12 +64,13 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
   );
 
   const onDelete = async (filename: string) => {
+    handleError(undefined);
     setRequestInProgress('delete');
     try {
       await deleteFile(filename, levelName);
       removeAsset(filename);
     } catch (error) {
-      setError(error as Error);
+      handleError(error as Error);
     }
     setRequestInProgress(undefined);
   };
@@ -107,7 +107,10 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       title={'Manage Starter Assets'}
       primaryButtonProps={{
         text: buttonText,
-        onClick: openFileInput,
+        onClick: () => {
+          handleError(undefined);
+          openFileInput();
+        },
         iconLeft: {
           iconName: requestInProgress ? 'spinner' : 'upload',
           animationType: requestInProgress ? 'spin' : undefined,
@@ -117,7 +120,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={loading ? <Loading /> : <ModalBody />}
       customBottomContent={
-        showError && <ErrorAlert currentError={currentError} />
+        currentError && <ErrorAlert currentError={currentError} />
       }
     />
   );

--- a/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
@@ -4,16 +4,9 @@ import React from 'react';
 
 import styles from './starter-assets-dialog.module.scss';
 
-const ErrorAlert: React.FC<{currentErrorMessage: string}> = ({
-  currentErrorMessage,
-}) => (
+const ErrorAlert: React.FC<{message: string}> = ({message}) => (
   <div className={styles.alertContainer}>
-    <Alert
-      text={currentErrorMessage}
-      type="danger"
-      size="xs"
-      className={styles.alert}
-    />
+    <Alert text={message} type="danger" size="xs" className={styles.alert} />
   </div>
 );
 

--- a/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
@@ -2,12 +2,18 @@ import Alert from '@code-dot-org/component-library/alert';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import React from 'react';
 
+import {isNetworkError} from '@cdo/apps/util/HttpClient';
+
 import styles from './starter-assets-dialog.module.scss';
 
-const ErrorAlert: React.FC = () => (
+const ErrorAlert: React.FC<{currentError?: Error}> = ({currentError}) => (
   <div className={styles.alertContainer}>
     <Alert
-      text="Something went wrong. Please try again!"
+      text={
+        isNetworkError(currentError) && currentError.getDetails().status === 413
+          ? 'too large'
+          : 'Something went wrong. Please try again!'
+      }
       type="danger"
       size="xs"
       className={styles.alert}

--- a/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
@@ -11,7 +11,7 @@ const ErrorAlert: React.FC<{currentError?: Error}> = ({currentError}) => (
     <Alert
       text={
         isNetworkError(currentError) && currentError.getDetails().status === 413
-          ? 'too large'
+          ? 'Uploaded images must be less than 20MB. Please try a smaller image.'
           : 'Something went wrong. Please try again!'
       }
       type="danger"

--- a/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
@@ -2,18 +2,14 @@ import Alert from '@code-dot-org/component-library/alert';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import React from 'react';
 
-import {isNetworkError} from '@cdo/apps/util/HttpClient';
-
 import styles from './starter-assets-dialog.module.scss';
 
-const ErrorAlert: React.FC<{currentError?: Error}> = ({currentError}) => (
+const ErrorAlert: React.FC<{currentErrorMessage: string}> = ({
+  currentErrorMessage,
+}) => (
   <div className={styles.alertContainer}>
     <Alert
-      text={
-        isNetworkError(currentError) && currentError.getDetails().status === 413
-          ? 'Uploaded images must be less than 20MB. Please try a smaller image.'
-          : 'Something went wrong. Please try again!'
-      }
+      text={currentErrorMessage}
       type="danger"
       size="xs"
       className={styles.alert}

--- a/apps/src/lab2/views/components/starterAssetsDialog/types.ts
+++ b/apps/src/lab2/views/components/starterAssetsDialog/types.ts
@@ -20,6 +20,6 @@ export interface DialogProps {
   addAsset: (asset: AssetData) => void;
   removeAsset: (filename: string) => void;
   loading: boolean;
+  handleError: (error: Error) => void;
   currentError?: Error;
-  handleError: (error?: Error) => void;
 }

--- a/apps/src/lab2/views/components/starterAssetsDialog/types.ts
+++ b/apps/src/lab2/views/components/starterAssetsDialog/types.ts
@@ -21,5 +21,5 @@ export interface DialogProps {
   removeAsset: (filename: string) => void;
   loading: boolean;
   handleError: (error: Error, userErrorMessage?: string) => void;
-  currentErrorMessage?: string;
+  errorMessage?: string;
 }

--- a/apps/src/lab2/views/components/starterAssetsDialog/types.ts
+++ b/apps/src/lab2/views/components/starterAssetsDialog/types.ts
@@ -20,6 +20,6 @@ export interface DialogProps {
   addAsset: (asset: AssetData) => void;
   removeAsset: (filename: string) => void;
   loading: boolean;
-  showError: boolean;
-  setError: (error: Error) => void;
+  currentError?: Error;
+  handleError: (error?: Error) => void;
 }

--- a/apps/src/lab2/views/components/starterAssetsDialog/types.ts
+++ b/apps/src/lab2/views/components/starterAssetsDialog/types.ts
@@ -20,6 +20,6 @@ export interface DialogProps {
   addAsset: (asset: AssetData) => void;
   removeAsset: (filename: string) => void;
   loading: boolean;
-  handleError: (error: Error) => void;
-  currentError?: Error;
+  handleError: (error: Error, userErrorMessage?: string) => void;
+  currentErrorMessage?: string;
 }

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -5,8 +5,9 @@ class LevelStarterAssetsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:destroy]
 
   VALID_FILE_EXTENSIONS = %w(.jpg .jpeg .gif .png .mp3 .wav .pdf)
-  MAX_RESIZABLE_FILE_SIZE = 5_000_000 # 5 MB
-  MAX_FILE_SIZE = 20_000_000 # 20 MB
+
+  MAX_FILE_SIZE_AI_CHAT = 5_000_000 # 5 MB
+  MAX_DIMENSION_PIXELS_AI_CHAT = 2048
 
   # GET /level_starter_assets/:level_name
   def show
@@ -40,6 +41,7 @@ class LevelStarterAssetsController < ApplicationController
     end
 
     upload = params[:files]&.first
+    upload_tempfile = upload.tempfile
     friendly_name = upload.original_filename
     file_ext = File.extname(friendly_name)
 
@@ -47,22 +49,20 @@ class LevelStarterAssetsController < ApplicationController
       return head :unprocessable_entity
     end
 
-    # For AI Chat levels, we resize levelbuilder assets that are greater than 5 MB
+    # For AI Chat levels, we attempt to resize assets that are greater than 5 MB
     # to improve performance when used as input to OpenAI.
-    # We also set a hard limit at 20 MB (somewhat arbitrarily) to avoid performance issues resizing extremely large files.
     if @level.is_a?(Aichat)
-      if upload.size > MAX_FILE_SIZE
-        return head :payload_too_large
-      elsif upload.size > MAX_RESIZABLE_FILE_SIZE
-        resized_upload_tempfile = LevelStarterAssetsHelper.try_resize_file(upload.tempfile, file_ext)
+      if upload_tempfile.size > MAX_FILE_SIZE_AI_CHAT
+        upload_tempfile = LevelStarterAssetsHelper.try_resize_file(upload.tempfile, file_ext, MAX_DIMENSION_PIXELS_AI_CHAT)
       end
+
+      return head :payload_too_large if upload_tempfile.size > MAX_FILE_SIZE_AI_CHAT
     end
 
     # Replace the friendly file name with a UUID for storage in S3 to avoid naming conflicts.
     uuid_name = SecureRandom.uuid + file_ext
     file_obj = LevelStarterAssetsHelper.get_object(uuid_name)
-    path_to_upload = resized_upload_tempfile&.path || upload.tempfile.path
-    success = file_obj&.upload_file(path_to_upload)
+    success = file_obj&.upload_file(upload_tempfile.path)
 
     if success && @level.add_starter_asset!(friendly_name, uuid_name)
       render json: LevelStarterAssetsHelper.summarize(file_obj, friendly_name, uuid_name)

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -5,7 +5,8 @@ class LevelStarterAssetsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:destroy]
 
   VALID_FILE_EXTENSIONS = %w(.jpg .jpeg .gif .png .mp3 .wav .pdf)
-  MAX_FILE_SIZE = 5_000_000 # 5 MB
+  MAX_RESIZABLE_FILE_SIZE = 5_000_000 # 5 MB
+  MAX_FILE_SIZE = 20_000_000 # 20 MB
 
   # GET /level_starter_assets/:level_name
   def show
@@ -50,17 +51,18 @@ class LevelStarterAssetsController < ApplicationController
     # to improve performance when used as input to OpenAI.
     # We also set a hard limit at 20 MB (somewhat arbitrarily) to avoid performance issues resizing extremely large files.
     if @level.is_a?(Aichat)
-      if upload.size > 20_000_000
+      if upload.size > MAX_FILE_SIZE
         return head :payload_too_large
-      elsif upload.size > MAX_FILE_SIZE
-        resized_upload = LevelStarterAssetsHelper.try_resize_file(upload.tempfile, file_ext)
+      elsif upload.size > MAX_RESIZABLE_FILE_SIZE
+        resized_upload_tempfile = LevelStarterAssetsHelper.try_resize_file(upload.tempfile, file_ext)
       end
     end
 
     # Replace the friendly file name with a UUID for storage in S3 to avoid naming conflicts.
     uuid_name = SecureRandom.uuid + file_ext
     file_obj = LevelStarterAssetsHelper.get_object(uuid_name)
-    success = file_obj&.upload_file((resized_upload || upload).tempfile.path)
+    path_to_upload = resized_upload_tempfile&.path || upload.tempfile.path
+    success = file_obj&.upload_file(path_to_upload)
 
     if success && @level.add_starter_asset!(friendly_name, uuid_name)
       render json: LevelStarterAssetsHelper.summarize(file_obj, friendly_name, uuid_name)

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -46,22 +46,26 @@ class LevelStarterAssetsController < ApplicationController
       return head :unprocessable_entity
     end
 
-    # handle if file is not too large
-    if upload.size > MAX_FILE_SIZE
-      resized_file = LevelStarterAssetsHelper.try_resize_file(upload.tempfile.read, file_ext)
+    # For AI Chat levels, we resize levelbuilder assets that are greater than 5 MB
+    # to improve performance when used as input to OpenAI.
+    # We also set a hard limit at 20 MB (somewhat arbitrarily) to avoid performance issues resizing extremely large files.
+    if @level.is_a?(Aichat)
+      if upload.size > 20_000_000
+        return head :payload_too_large
+      elsif upload.size > MAX_FILE_SIZE
+        resized_upload = LevelStarterAssetsHelper.try_resize_file(upload.tempfile, file_ext)
+      end
     end
 
     # Replace the friendly file name with a UUID for storage in S3 to avoid naming conflicts.
     uuid_name = SecureRandom.uuid + file_ext
     file_obj = LevelStarterAssetsHelper.get_object(uuid_name)
-    # success = file_obj&.upload_file(upload.tempfile.path)
-    # success = file_obj&.upload_file(resized_file)
-    success = file_obj&.put(body: resized_file)
+    success = file_obj&.upload_file((resized_upload || upload).tempfile.path)
 
     if success && @level.add_starter_asset!(friendly_name, uuid_name)
       render json: LevelStarterAssetsHelper.summarize(file_obj, friendly_name, uuid_name)
     else
-      return head :unprocessable_entity
+      return head :request_too_large
     end
   end
 

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -65,7 +65,7 @@ class LevelStarterAssetsController < ApplicationController
     if success && @level.add_starter_asset!(friendly_name, uuid_name)
       render json: LevelStarterAssetsHelper.summarize(file_obj, friendly_name, uuid_name)
     else
-      return head :request_too_large
+      return head :unprocessable_entity
     end
   end
 

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -5,6 +5,7 @@ class LevelStarterAssetsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:destroy]
 
   VALID_FILE_EXTENSIONS = %w(.jpg .jpeg .gif .png .mp3 .wav .pdf)
+  MAX_FILE_SIZE = 5_000_000 # 5 MB
 
   # GET /level_starter_assets/:level_name
   def show
@@ -45,10 +46,17 @@ class LevelStarterAssetsController < ApplicationController
       return head :unprocessable_entity
     end
 
+    # handle if file is not too large
+    if upload.size > MAX_FILE_SIZE
+      resized_file = LevelStarterAssetsHelper.try_resize_file(upload.tempfile.read, file_ext)
+    end
+
     # Replace the friendly file name with a UUID for storage in S3 to avoid naming conflicts.
     uuid_name = SecureRandom.uuid + file_ext
     file_obj = LevelStarterAssetsHelper.get_object(uuid_name)
-    success = file_obj&.upload_file(upload.tempfile.path)
+    # success = file_obj&.upload_file(upload.tempfile.path)
+    # success = file_obj&.upload_file(resized_file)
+    success = file_obj&.put(body: resized_file)
 
     if success && @level.add_starter_asset!(friendly_name, uuid_name)
       render json: LevelStarterAssetsHelper.summarize(file_obj, friendly_name, uuid_name)

--- a/dashboard/app/helpers/level_starter_assets_helper.rb
+++ b/dashboard/app/helpers/level_starter_assets_helper.rb
@@ -1,6 +1,24 @@
 module LevelStarterAssetsHelper
   S3_BUCKET = 'cdo-v3-assets'.freeze
   S3_PREFIX = 'starter_assets/'.freeze
+  MAX_RESIZE_SIZE = 20_000_000 # 20 MB
+
+  def self.try_resize_file(body, extension)
+    # Resizing takes a lot of compute power. If we're given an image higher than 20MB, don't attempt
+    # to resize. (The upper limit we want to use may actually be much higher, but I was unable to
+    # find an image larger than 20MB to test with). Here, we resize the height and width to 1/4 of
+    # their original value because it's very quick from a compute perspective (<1s versus ~6s for
+    # 1/2). And because the resolution is still pretty good on the small visualization area used
+    # in our web apps.
+    if ([".jpg", ".jpeg", ".png"].include? extension.downcase) && (body.length < MAX_RESIZE_SIZE)
+      image = MiniMagick::Image.read(body, extension)
+      # puts (image.height / 4).floor.to_s + "x" + (image.width / 4).floor.to_s
+      # image.resize (image.height / 4).floor.to_s + "x" + (image.width / 4).floor.to_s
+      image.resize (image.width / 4).floor.to_s + "x" + (image.height / 4).floor.to_s
+      return image.to_blob
+    end
+    return body
+  end
 
   def self.summarize(file_obj, friendly_name, uuid_name)
     if file_obj.blank?

--- a/dashboard/app/helpers/level_starter_assets_helper.rb
+++ b/dashboard/app/helpers/level_starter_assets_helper.rb
@@ -2,14 +2,18 @@ module LevelStarterAssetsHelper
   S3_BUCKET = 'cdo-v3-assets'.freeze
   S3_PREFIX = 'starter_assets/'.freeze
   MAX_RESIZE_SIZE = 20_000_000 # 20 MB
+  MAX_DIMENSION_PIXELS = 2048
 
   def self.try_resize_file(file, extension)
     # Resizing takes a lot of compute power.
     # If we're given an image higher than 20MB, don't attempt to resize.
     if ([".jpg", ".jpeg", ".png"].include? extension.downcase) && (file.length < MAX_RESIZE_SIZE)
       image = MiniMagick::Image.read(file, extension)
-      image.resize '2048x2048>'
-      return image
+
+      # The '>' suffix means that the image will be resized to fit within the given dimensions,
+      # but smaller images will not be enlarged.
+      image.resize MAX_DIMENSION_PIXELS.to_s + 'x' + MAX_DIMENSION_PIXELS.to_s + '>'
+      return image.tempfile
     end
 
     file

--- a/dashboard/app/helpers/level_starter_assets_helper.rb
+++ b/dashboard/app/helpers/level_starter_assets_helper.rb
@@ -3,21 +3,16 @@ module LevelStarterAssetsHelper
   S3_PREFIX = 'starter_assets/'.freeze
   MAX_RESIZE_SIZE = 20_000_000 # 20 MB
 
-  def self.try_resize_file(body, extension)
-    # Resizing takes a lot of compute power. If we're given an image higher than 20MB, don't attempt
-    # to resize. (The upper limit we want to use may actually be much higher, but I was unable to
-    # find an image larger than 20MB to test with). Here, we resize the height and width to 1/4 of
-    # their original value because it's very quick from a compute perspective (<1s versus ~6s for
-    # 1/2). And because the resolution is still pretty good on the small visualization area used
-    # in our web apps.
-    if ([".jpg", ".jpeg", ".png"].include? extension.downcase) && (body.length < MAX_RESIZE_SIZE)
-      image = MiniMagick::Image.read(body, extension)
-      # puts (image.height / 4).floor.to_s + "x" + (image.width / 4).floor.to_s
-      # image.resize (image.height / 4).floor.to_s + "x" + (image.width / 4).floor.to_s
-      image.resize (image.width / 4).floor.to_s + "x" + (image.height / 4).floor.to_s
-      return image.to_blob
+  def self.try_resize_file(file, extension)
+    # Resizing takes a lot of compute power.
+    # If we're given an image higher than 20MB, don't attempt to resize.
+    if ([".jpg", ".jpeg", ".png"].include? extension.downcase) && (file.length < MAX_RESIZE_SIZE)
+      image = MiniMagick::Image.read(file, extension)
+      image.resize '2048x2048>'
+      return image
     end
-    return body
+
+    file
   end
 
   def self.summarize(file_obj, friendly_name, uuid_name)

--- a/dashboard/app/helpers/level_starter_assets_helper.rb
+++ b/dashboard/app/helpers/level_starter_assets_helper.rb
@@ -11,6 +11,7 @@ module LevelStarterAssetsHelper
       image.resize '2048x2048>'
       return image
     end
+
     file
   end
 

--- a/dashboard/app/helpers/level_starter_assets_helper.rb
+++ b/dashboard/app/helpers/level_starter_assets_helper.rb
@@ -11,7 +11,6 @@ module LevelStarterAssetsHelper
       image.resize '2048x2048>'
       return image
     end
-
     file
   end
 

--- a/dashboard/app/helpers/level_starter_assets_helper.rb
+++ b/dashboard/app/helpers/level_starter_assets_helper.rb
@@ -2,17 +2,17 @@ module LevelStarterAssetsHelper
   S3_BUCKET = 'cdo-v3-assets'.freeze
   S3_PREFIX = 'starter_assets/'.freeze
   MAX_RESIZE_SIZE = 20_000_000 # 20 MB
-  MAX_DIMENSION_PIXELS = 2048
 
-  def self.try_resize_file(file, extension)
+  def self.try_resize_file(file, extension, max_dimension_px)
     # Resizing takes a lot of compute power.
-    # If we're given an image higher than 20MB, don't attempt to resize.
+    # If we're given an image higher than 20MB (), don't attempt to resize.
+    # Since this is intended to be a levelbuilder-specific helper (ie, low volume/levelbuilder machine), it may be safe to increase this limit.
     if ([".jpg", ".jpeg", ".png"].include? extension.downcase) && (file.length < MAX_RESIZE_SIZE)
       image = MiniMagick::Image.read(file, extension)
 
       # The '>' suffix means that the image will be resized to fit within the given dimensions,
       # but smaller images will not be enlarged.
-      image.resize MAX_DIMENSION_PIXELS.to_s + 'x' + MAX_DIMENSION_PIXELS.to_s + '>'
+      image.resize max_dimension_px.to_s + 'x' + max_dimension_px.to_s + '>'
       return image.tempfile
     end
 

--- a/dashboard/config/levels/custom/aichat/AI Chat Test Level - 2.level
+++ b/dashboard/config/levels/custom/aichat/AI Chat Test Level - 2.level
@@ -1,8 +1,7 @@
 <Aichat>
   <config><![CDATA[{
-  "published": true,
   "game_id": 71,
-  "created_at": "2023-08-01T09:30:36.000Z",
+  "created_at": "2025-03-04T17:58:40.000Z",
   "level_num": "custom",
   "user_id": 4,
   "properties": {
@@ -33,7 +32,7 @@
         }
       },
       "visibilities": {
-        "selectedModelId": "readonly",
+        "selectedModelId": "editable",
         "temperature": "editable",
         "systemPrompt": "editable",
         "retrievalContexts": "editable",
@@ -41,10 +40,18 @@
       },
       "hidePresentationPanel": false,
       "availableModelIds": [
+        "gpt-4o-mini",
         "gen-ai-mistral-7b-inst-v01"
-      ]
+      ],
+      "multimodalEnabled": true
+    },
+    "starter_assets": {
+      "ai (bot) (1).png": "7defa204-dd10-4dc0-ac99-32e6cf226ccd.png",
+      "shrink_dragon.gif": "9d649b21-de76-41e0-b84e-4dc1a2848d1a.gif",
+      "spacious bedroom (5).jpg": "081cd803-103e-4eed-89cb-7721b81445ce.jpg"
     }
   },
-  "audit_log": "[{\"changed_at\":\"2023-07-31T21:20:20.654+00:00\",\"changed\":[\"cloned from \\\"AI Chat Test Level\\\"\"],\"cloned_from\":\"AI Chat Test Level\"},{\"changed_at\":\"2023-08-16 14:45:55 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-17 16:10:06 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-18 18:22:32 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice+levelbuilder@code.org\"},{\"changed_at\":\"2024-03-28 20:25:18 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"alice+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-18 13:37:41 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 13:41:45 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:03:36 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:05:39 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:11:46 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:13:29 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:16:39 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:56:50 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 16:11:45 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-23 14:18:24 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-24 11:07:51 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-24 11:11:17 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-30 17:55:20 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2024-09-09 19:19:42 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":14639,\"changed_by_email\":\"dan+teacher@code.org\"}]"
+  "published": true,
+  "audit_log": "[{\"changed_at\":\"2023-07-31T21:20:20.654+00:00\",\"changed\":[\"cloned from \\\"AI Chat Test Level\\\"\"],\"cloned_from\":\"AI Chat Test Level\"},{\"changed_at\":\"2023-08-16 14:45:55 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-17 16:10:06 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-18 18:22:32 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice+levelbuilder@code.org\"},{\"changed_at\":\"2024-03-28 20:25:18 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"alice+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-18 13:37:41 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 13:41:45 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:03:36 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:05:39 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:11:46 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:13:29 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:16:39 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:56:50 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 16:11:45 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-23 14:18:24 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-24 11:07:51 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-24 11:11:17 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-30 17:55:20 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2024-09-09 19:19:42 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":14639,\"changed_by_email\":\"dan+teacher@code.org\"},{\"changed_at\":\"2025-03-04 10:39:34 -0800\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"ben+levelbuilder@code.org\"},{\"changed_at\":\"2025-03-25 14:54:38 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"ben+levelbuilder@code.org\"},{\"changed_at\":\"2025-04-22 09:49:49 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"ben+levelbuilder@code.org\"},{\"changed_at\":\"2025-04-22 15:56:32 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"ben+levelbuilder@code.org\"}]"
 }]]></config>
 </Aichat>

--- a/dashboard/config/levels/custom/aichat/AI Chat Test Level - 2.level
+++ b/dashboard/config/levels/custom/aichat/AI Chat Test Level - 2.level
@@ -1,7 +1,8 @@
 <Aichat>
   <config><![CDATA[{
+  "published": true,
   "game_id": 71,
-  "created_at": "2025-03-04T17:58:40.000Z",
+  "created_at": "2023-08-01T09:30:36.000Z",
   "level_num": "custom",
   "user_id": 4,
   "properties": {
@@ -32,7 +33,7 @@
         }
       },
       "visibilities": {
-        "selectedModelId": "editable",
+        "selectedModelId": "readonly",
         "temperature": "editable",
         "systemPrompt": "editable",
         "retrievalContexts": "editable",
@@ -40,18 +41,10 @@
       },
       "hidePresentationPanel": false,
       "availableModelIds": [
-        "gpt-4o-mini",
         "gen-ai-mistral-7b-inst-v01"
-      ],
-      "multimodalEnabled": true
-    },
-    "starter_assets": {
-      "ai (bot) (1).png": "7defa204-dd10-4dc0-ac99-32e6cf226ccd.png",
-      "shrink_dragon.gif": "9d649b21-de76-41e0-b84e-4dc1a2848d1a.gif",
-      "spacious bedroom (5).jpg": "081cd803-103e-4eed-89cb-7721b81445ce.jpg"
+      ]
     }
   },
-  "published": true,
-  "audit_log": "[{\"changed_at\":\"2023-07-31T21:20:20.654+00:00\",\"changed\":[\"cloned from \\\"AI Chat Test Level\\\"\"],\"cloned_from\":\"AI Chat Test Level\"},{\"changed_at\":\"2023-08-16 14:45:55 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-17 16:10:06 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-18 18:22:32 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice+levelbuilder@code.org\"},{\"changed_at\":\"2024-03-28 20:25:18 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"alice+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-18 13:37:41 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 13:41:45 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:03:36 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:05:39 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:11:46 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:13:29 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:16:39 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:56:50 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 16:11:45 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-23 14:18:24 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-24 11:07:51 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-24 11:11:17 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-30 17:55:20 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2024-09-09 19:19:42 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":14639,\"changed_by_email\":\"dan+teacher@code.org\"},{\"changed_at\":\"2025-03-04 10:39:34 -0800\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"ben+levelbuilder@code.org\"},{\"changed_at\":\"2025-03-25 14:54:38 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"ben+levelbuilder@code.org\"},{\"changed_at\":\"2025-04-22 09:49:49 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"ben+levelbuilder@code.org\"},{\"changed_at\":\"2025-04-22 15:56:32 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"ben+levelbuilder@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2023-07-31T21:20:20.654+00:00\",\"changed\":[\"cloned from \\\"AI Chat Test Level\\\"\"],\"cloned_from\":\"AI Chat Test Level\"},{\"changed_at\":\"2023-08-16 14:45:55 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-17 16:10:06 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-18 18:22:32 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice+levelbuilder@code.org\"},{\"changed_at\":\"2024-03-28 20:25:18 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"alice+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-18 13:37:41 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 13:41:45 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:03:36 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:05:39 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:11:46 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:13:29 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:16:39 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 14:56:50 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-18 16:11:45 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-23 14:18:24 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-24 11:07:51 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-24 11:11:17 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"cassi.brenci+local@code.org\"},{\"changed_at\":\"2024-04-30 17:55:20 -0700\",\"changed\":[\"aichat_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2024-09-09 19:19:42 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":14639,\"changed_by_email\":\"dan+teacher@code.org\"}]"
 }]]></config>
 </Aichat>


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

Resizes levelbuilder image uploads on AI Chat levels down to a maximum of 2048x2048 (while maintaining the aspect ratio). An example 13.8 MB image that is 6000x4000 I have been testing with to ~2 MB.

Also sets a maximum upload size of 20 MB somewhat arbitrarily -- there's a note in our existing resizing code that resizing is computationally expensive. This is probably not too much of a concern for this levelbuilder-only endpoint, so happy to consider a higher limit if we'd like.

Finally, there's a tweak here to the upload UI that clears the error message when another upload (or deletion of an asset) is attempted. I also set us up to handle specific errors (in this case, showing a specific error message if the file is too large).

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1435

## Testing story

I tested manually that:
- Files less than 5 MB uploaded in their native size,
- Files between 5 MB and 20 MB were resized,
- and >20MB files failed to upload.