### PR TITLE
AI Chat: limit student uploads to 5MB

### DIFF
--- a/apps/src/aichat/constants.ts
+++ b/apps/src/aichat/constants.ts
@@ -39,6 +39,6 @@ export const RESET_CONVERSATION_CUSTOMIZATION_UPDATES = [
 
 // Maximum number of files that can be attached to a chat message in multimodal mode.
 export const MAX_NUM_FILES = 5;
-export const MAX_FILE_SIZE_MB = 20;
+export const MAX_FILE_SIZE_MB = 5;
 // Allowed file types for upload in multimodal mode.
 export const ACCEPTED_FILE_TYPES = ['.jpg', '.jpeg', '.png', '.pdf'];

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -10,7 +10,11 @@ import useHiddenFileInput from '@cdo/apps/util/hooks/useHiddenFileInput';
 import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {ACCEPTED_FILE_TYPES, MAX_NUM_FILES} from '../../constants';
+import {
+  ACCEPTED_FILE_TYPES,
+  MAX_FILE_SIZE_MB,
+  MAX_NUM_FILES,
+} from '../../constants';
 import aichatI18n from '../../locale';
 import {
   addStagedFile,
@@ -66,6 +70,17 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
     let sizeLimitExceededCount = 0;
     let uploadFailureCount = 0;
     for (const [key, filename, file] of allowedFiles) {
+      if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+        sizeLimitExceededCount += 1;
+        dispatch(
+          stagedFileUploadFinished({
+            key,
+            status: 'sizeLimitExceeded',
+          })
+        );
+        continue; // Skip uploading this file if it exceeds the size limit
+      }
+
       try {
         await HttpClient.put(
           `/v3/assets/${currentChannelId}/${encodeURIComponent(filename)}`,


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Summary

Adds a frontend limit of 5MB to student asset uploads. Previously we had a 20MB that matched the backend, but that was only for display purposes (we relied on the server returning a 413 error code).

<img width="1512" alt="Screenshot 2025-04-22 at 3 46 36 PM" src="https://github.com/user-attachments/assets/673ae86d-3b5e-4a1e-aac6-8df203ccc310" />

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1436

## Testing story

Tested locally