### PR TITLE
Evaluate Student Learning: log code version when the project isn't found in s3

### DIFF
--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -116,7 +116,7 @@ class StudentWorkSampleController < ApplicationController
     user_level_evaluations.shuffle.each do |ule|
       unless have_enough_samples || ule.code_version.nil?
         student_code = get_student_code(ule.user_id, level, unit_id, ule.code_version)
-        if student_code[:student_code]
+        if student_code && student_code[:student_code]
           code_sample = {
             level_id: level.id,
             unit_id: unit_id,
@@ -164,9 +164,12 @@ class StudentWorkSampleController < ApplicationController
       s3_filename = "#{base_dir}/#{storage_id}/#{storage_app_id}/main.json"
       s3_args = {bucket: bucket, key: s3_filename}
       s3_args[:version_id] = code_version if code_version
-      Rails.logger.info("Erin is trying to fetch student code from S3: #{s3_args}")
-      body = s3.get_object(s3_args)[:body].read
-      student_code = JSON.parse(body)['source'] if body
+      begin
+        body = s3.get_object(s3_args)[:body].read
+      rescue
+        Rails.logger.info("No code sample found in S3 with with args: #{s3_args}")
+      end
+      student_code = body ? JSON.parse(body)['source'] : nil
     end
     {
       project_id: channel_id,

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -167,7 +167,7 @@ class StudentWorkSampleController < ApplicationController
       begin
         body = s3.get_object(s3_args)[:body].read
       rescue
-        Rails.logger.info("No code sample found in S3 with with args: #{s3_args}")
+        CDO.log("No code sample found in S3 with with args: #{s3_args}")
       end
       student_code = body ? JSON.parse(body)['source'] : nil
     end

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -164,6 +164,7 @@ class StudentWorkSampleController < ApplicationController
       s3_filename = "#{base_dir}/#{storage_id}/#{storage_app_id}/main.json"
       s3_args = {bucket: bucket, key: s3_filename}
       s3_args[:version_id] = code_version if code_version
+      Rails.logger.info("Erin is trying to fetch student code from S3: #{s3_args}")
       body = s3.get_object(s3_args)[:body].read
       student_code = JSON.parse(body)['source'] if body
     end

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -167,7 +167,7 @@ class StudentWorkSampleController < ApplicationController
       begin
         body = s3.get_object(s3_args)[:body].read
       rescue
-        CDO.log("No code sample found in S3 with with args: #{s3_args}")
+        CDO.log.info("No code sample found in S3 with with args: #{s3_args}")
       end
       student_code = body ? JSON.parse(body)['source'] : nil
     end

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -166,8 +166,9 @@ class StudentWorkSampleController < ApplicationController
       s3_args[:version_id] = code_version if code_version
       begin
         body = s3.get_object(s3_args)[:body].read
-      rescue
-        CDO.log.info("No code sample found in S3 with with args: #{s3_args}")
+      rescue => exception
+        Honeybadger.notify(exception, context: {message: "No code sample found in S3 with with args: #{s3_args}"})
+        return
       end
       student_code = body ? JSON.parse(body)['source'] : nil
     end


### PR DESCRIPTION
Continuation of https://github.com/code-dot-org/code-dot-org/pull/65298
[TEACH-1829](https://codedotorg.atlassian.net/browse/TEACH-1829) partial

In the Dataset Maker pulling AI evaluated student code implodes. Based on this 
[HoneyBadger Error](https://app.honeybadger.io/projects/3240/faults/119456364#notice-breadcrumbs) I know that the error is occurring when the specified version does not exist, but it's hard to diagnose which sample(s) are causing the issue. 

This PR makes 2 modifications: 1.) I rescue when the S3 error occurs so we can still continue through the list of possible code sample without killing the whole request and 2.) I log the args for the S3 get so that we can see which code versions are problematic.
