### PR TITLE
[HOME] Add closing the feedback banner

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 
 import {
@@ -26,12 +27,18 @@ interface TeacherHomepageProps {
   studioUrlPrefix: string;
 }
 
+const LOCAL_STORAGE_KEY = 'teacher_homepage_feedback_closed';
+
 export const TeacherHomepage: React.FC<TeacherHomepageProps> = ({
   studioUrlPrefix,
 }) => {
   const teacherName = useAppSelector(state => state.currentUser.displayName);
 
   const dispatch = useAppDispatch();
+
+  const [isFeedbackAlertClosed, setIsFeedbackAlertClosed] = React.useState(
+    () => tryGetLocalStorage(LOCAL_STORAGE_KEY, '') === 'true'
+  );
 
   React.useEffect(() => {
     dispatch(asyncLoadTeacherHomepageSectionData());
@@ -79,22 +86,27 @@ export const TeacherHomepage: React.FC<TeacherHomepageProps> = ({
             ? i18n.welcome({teacherName: teacherName})
             : i18n.welcomeWithoutName()}
         </Heading2>
-        <Alert
-          className={styles.feedbackAlert}
-          size={'s'}
-          text={i18n.teacherHomePageFeedback()}
-          type="primary"
-          showIcon={true}
-          icon={{iconName: 'hand-wave'}}
-          isImmediateImportance={false}
-          link={{
-            text: i18n.feedbackHeader(),
-            href: 'https://usabi.li/do/a9ksz7qfbspy/iwhhup',
-            openInNewTab: true,
-            external: true,
-          }}
-          onClose={() => {}}
-        />
+        {!isFeedbackAlertClosed && (
+          <Alert
+            className={styles.feedbackAlert}
+            size={'s'}
+            text={i18n.teacherHomePageFeedback()}
+            type="primary"
+            showIcon={true}
+            icon={{iconName: 'hand-wave'}}
+            isImmediateImportance={false}
+            link={{
+              text: i18n.feedbackHeader(),
+              href: 'https://usabi.li/do/a9ksz7qfbspy/iwhhup',
+              openInNewTab: true,
+              external: true,
+            }}
+            onClose={() => {
+              setIsFeedbackAlertClosed(true);
+              trySetLocalStorage(LOCAL_STORAGE_KEY, 'true');
+            }}
+          />
+        )}
         <div className={styles.teacherHomepageContent}>
           <div className={styles.teacherHomepageLeftContent}>
             <Header


### PR DESCRIPTION
Adds implementation to close the feedback banner on the new homepage using a cookie to save it was closed.

<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 
https://codedotorg.atlassian.net/browse/TEACH-1838
