### PR TITLE
fix(marketing): set SameSite=none for dev draft mode

### DIFF
--- a/frontend/apps/marketing/src/app/api/draft/route.ts
+++ b/frontend/apps/marketing/src/app/api/draft/route.ts
@@ -1,4 +1,4 @@
-import {draftMode} from 'next/headers';
+import {cookies, draftMode} from 'next/headers';
 import {redirect} from 'next/navigation';
 
 export async function GET(request: Request) {
@@ -21,6 +21,28 @@ export async function GET(request: Request) {
   // Enable Draft Mode by setting the cookie
   const draft = await draftMode();
   draft.enable();
+
+  // Allow draft mode to use SameSite=none in development
+  if (process.env.NODE_ENV === 'development') {
+    // Get the cookie store
+    const cookieStore = await cookies();
+
+    // Get the draft mode cookie that was just set
+    const draftCookie = cookieStore.get('__prerender_bypass');
+
+    // If we have the cookie, update it with cross-origin iframe support for Contentful's Experience Builder
+    // See: https://github.com/vercel/next.js/issues/49927
+    if (draftCookie?.value) {
+      cookieStore.set({
+        name: '__prerender_bypass',
+        value: draftCookie.value,
+        httpOnly: true,
+        path: '/',
+        secure: true,
+        sameSite: 'none', // Allow cookie in cross-origin iframes
+      });
+    }
+  }
 
   redirect(
     `/${locale}/${slug}?expEditorMode=${!!searchParams.get('expEditorMode')}`,

--- a/frontend/apps/marketing/src/contentful/get-experience.ts
+++ b/frontend/apps/marketing/src/contentful/get-experience.ts
@@ -13,6 +13,12 @@ import {getContentfulClient} from './client';
  */
 export const getExperience = cache(
   async (slug: string, localeCode: string, isEditorMode = false) => {
+    // While in editor mode, the experience is passed to the ExperienceRoot
+    // component by the editor, so we don't fetch it here
+    if (isEditorMode) {
+      return {experience: undefined, error: undefined};
+    }
+
     const {isEnabled} = await draftMode();
     const client = getContentfulClient(isEnabled);
 
@@ -20,12 +26,6 @@ export const getExperience = cache(
       // The client will not be available if the environment variables for secrets are not set.
       // Rather than crashing the app, we log a warning and return undefined to allow Next.js to static
       // render the foundations of the page.
-      return {experience: undefined, error: undefined};
-    }
-
-    // While in editor mode, the experience is passed to the ExperienceRoot
-    // component by the editor, so we don't fetch it here
-    if (isEditorMode) {
       return {experience: undefined, error: undefined};
     }
 

--- a/frontend/apps/marketing/tests/e2e/cache.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/cache.spec.ts
@@ -35,6 +35,22 @@ test.describe('Caching Tests', () => {
     expect(cacheControlHeader).toEqual(
       'private, no-cache, no-store, max-age=0, must-revalidate',
     );
+
+    const cookieHeader = await allTheThingsPage.page.context().cookies();
+
+    const prerenderBypassCookie = cookieHeader.find(
+      cookie => cookie.name === '__prerender_bypass',
+    );
+
+    expect(prerenderBypassCookie).toEqual(
+      expect.objectContaining({
+        name: '__prerender_bypass',
+        path: '/',
+        httpOnly: true,
+        secure: true, // Needed for SameSite=none
+        sameSite: 'None', // Allow cookie in cross-origin iframes
+      }),
+    );
   });
 
   test('should 401 with an invalid token', async ({page, browserName}) => {


### PR DESCRIPTION
When running in localhost dev mode, the marketing app doesn't set the `SameSite` flag which then defaults to `Lax`. When the experience builder is loaded, it will bypass draft mode since the prerender bypass cookie isn't sent.

This PR sets the `SameSite=none` flag to allow for localhost usage in Contentful Experiences. This will not be needed in `NODE_ENV=production` because that uses a secure context (whereas localhost doesn't).