### PR TITLE
Python Lab: improve console output

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -86,6 +86,7 @@
   "result": "Result",
   "rootFolder": "project root",
   "run": "Run",
+  "runAt": "RUN AT {time}",
   "runToContinue": "You must run your code before continuing.",
   "runToFinish": "You must run your code before finishing.",
   "runToSubmit": "You must run your code before submitting.",
@@ -97,12 +98,14 @@
   "stop": "Stop",
   "stopValidation": "Stop validation",
   "systemCodeError": "We're sorry, we hit an issue running your program. Please refresh the page and try again.",
+  "testAt": "TEST AT {time}",
   "testName": "Test Name",
   "testsDidNotPass": "Tests did not all pass.",
   "textEditorFontSize": "Text editor font size",
   "toggleFileBrowser": "Toggle File Browser",
   "uploadFile": "Upload",
   "validate": "Validate",
+  "validateAt": "VALIDATE AT {time}",
   "validatingRunDisabledTooltip": "You cannot run code while validation is running",
   "validationNotYetPassedContinue": "You must pass tests before continuing.",
   "validationNotYetPassedFinish": "You must pass tests before finishing.",
@@ -112,3 +115,4 @@
   "viewingOldVersion": "You are viewing an older version",
   "versionRestored": "Version successfully restored"
 }
+ 

--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -115,4 +115,3 @@
   "viewingOldVersion": "You are viewing an older version",
   "versionRestored": "Version successfully restored"
 }
- 

--- a/apps/i18n/pythonlab/en_us.json
+++ b/apps/i18n/pythonlab/en_us.json
@@ -11,13 +11,9 @@
   "moduleNotSupported": "ModuleNotFoundError: The module {module} is not supported in Python Lab.",
   "neighborhood": "Neighborhood",
   "neighborhoodDescription": "A project that uses the Neighborhood.",
-  "programCompleted": "Program completed.",
   "programStopped": "Program stopped.",
   "projectPickerTitle": "Select an output type",
   "projectPickerReplaceRestoreInfo": "You can restore your old project using Version History.",
   "projectPickerReplaceWarning": "This will clear your code and start over with the new output type.",
-  "runningLevelTests": "Running level tests...",
-  "runningProgram": "Running program...",
-  "runningProjectTests": "Running your project's tests...",
   "switchProjectTypeTitle": "Switch your output type"
 }

--- a/apps/src/codebridge/Console/MessageHelpers.ts
+++ b/apps/src/codebridge/Console/MessageHelpers.ts
@@ -1,3 +1,7 @@
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+
+import {RunType} from '../types';
+
 const IMAGE_WIDTH = 600;
 const IMAGE_HEIGHT = 600;
 
@@ -21,4 +25,19 @@ export function getErrorMessage(message: string) {
 
 export function getSystemError(message: string, appName?: string) {
   return getErrorMessage(getSystemMessage(message, appName));
+}
+
+export function getTimestampMessage(runType: RunType) {
+  const currentDate = new Date();
+  const formattedTime = currentDate.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  let runString = codebridgeI18n.runAt({time: formattedTime});
+  if (runType === RunType.TEST) {
+    runString = codebridgeI18n.testAt({time: formattedTime});
+  } else if (runType === RunType.VALIDATION) {
+    runString = codebridgeI18n.validateAt({time: formattedTime});
+  }
+  return `--------${runString}--------`;
 }

--- a/apps/src/codebridge/Console/MessageHelpers.ts
+++ b/apps/src/codebridge/Console/MessageHelpers.ts
@@ -39,5 +39,5 @@ export function getTimestampMessage(runType: RunType) {
   } else if (runType === RunType.VALIDATION) {
     runString = codebridgeI18n.validateAt({time: formattedTime});
   }
-  return `--------${runString}--------`;
+  return `\x1b[38;5;249m--------${runString}--------\x1b[0m`;
 }

--- a/apps/src/codebridge/Console/MessageHelpers.ts
+++ b/apps/src/codebridge/Console/MessageHelpers.ts
@@ -39,6 +39,7 @@ export function getTimestampMessage(runType: RunType) {
   } else if (runType === RunType.VALIDATION) {
     runString = codebridgeI18n.validateAt({time: formattedTime});
   }
+  // The full message should be 32 characters long, padded with '-' on both sides
   const stringLength = runString.length;
   const paddingLeftCount = Math.max(Math.floor((32 - stringLength) / 2), 0);
   const paddingRightCount = Math.max(32 - stringLength - paddingLeftCount, 0);

--- a/apps/src/codebridge/Console/MessageHelpers.ts
+++ b/apps/src/codebridge/Console/MessageHelpers.ts
@@ -39,5 +39,10 @@ export function getTimestampMessage(runType: RunType) {
   } else if (runType === RunType.VALIDATION) {
     runString = codebridgeI18n.validateAt({time: formattedTime});
   }
-  return `\x1b[38;5;249m--------${runString}--------\x1b[0m`;
+  const stringLength = runString.length;
+  const paddingLeftCount = Math.max(Math.floor((32 - stringLength) / 2), 0);
+  const paddingRightCount = Math.max(32 - stringLength - paddingLeftCount, 0);
+  const fullMessage =
+    '-'.repeat(paddingLeftCount) + runString + '-'.repeat(paddingRightCount);
+  return `\x1b[38;5;249m${fullMessage}\x1b[0m`;
 }

--- a/apps/src/codebridge/Console/MessageHelpers.ts
+++ b/apps/src/codebridge/Console/MessageHelpers.ts
@@ -19,8 +19,7 @@ export function getImageMessage(base64Image: string) {
 
 export function getErrorMessage(message: string) {
   // This colors the message red in the terminal
-  // Reference for color codes: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
-  return `\x1b[38;5;203m${message}\x1b[0m`;
+  return getMessageWithColor(message, 203);
 }
 
 export function getSystemError(message: string, appName?: string) {
@@ -45,5 +44,13 @@ export function getTimestampMessage(runType: RunType) {
   const paddingRightCount = Math.max(32 - stringLength - paddingLeftCount, 0);
   const fullMessage =
     '-'.repeat(paddingLeftCount) + runString + '-'.repeat(paddingRightCount);
-  return `\x1b[38;5;249m${fullMessage}\x1b[0m`;
+  // Light gray color
+  return getMessageWithColor(fullMessage, 249);
+}
+
+// Return the message colored with the given ANSI color code.
+// The message will reset the color at the end so the next message will be the default color.
+// Reference for color codes: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+function getMessageWithColor(message: string, ansiColor: number) {
+  return `\x1b[38;5;${ansiColor}m${message}\x1b[0m`;
 }

--- a/apps/src/codebridge/Console/console.module.scss
+++ b/apps/src/codebridge/Console/console.module.scss
@@ -11,6 +11,7 @@
 .consoleV2 {
   flex-grow: 1;
   overflow: hidden;
+  padding-left: 4px;
 }
 
 .errorLine {

--- a/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/NeighborhoodPreview.tsx
@@ -80,7 +80,6 @@ const NeighborhoodPreview: React.FunctionComponent<
       onOutputMessage,
       onNewlineMessage,
       isRunning => dispatch(setIsRunning(isRunning)),
-      '[PYTHON LAB]',
       onPartialLineMessage
     );
     CodebridgeRegistry.getInstance().setNeighborhood(neighborhoodRef);

--- a/apps/src/codebridge/types.ts
+++ b/apps/src/codebridge/types.ts
@@ -88,3 +88,9 @@ export interface ProjectPickerSettings {
   currentType: string;
   showProjectTypePicker: () => void;
 }
+
+export enum RunType {
+  RUN,
+  TEST,
+  VALIDATION,
+}

--- a/apps/src/codebridge/types.ts
+++ b/apps/src/codebridge/types.ts
@@ -91,6 +91,6 @@ export interface ProjectPickerSettings {
 
 export enum RunType {
   RUN,
-  TEST,
-  VALIDATION,
+  TEST, // User-written tests
+  VALIDATION, // Levelbuilder-written tests
 }

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -24,12 +24,7 @@ import {
 } from '../containedLevels';
 import {initializeSubmitHelper, onSubmitComplete} from '../submitHelper';
 
-import {
-  CsaViewMode,
-  ExecutionType,
-  InputMessageType,
-  STATUS_MESSAGE_PREFIX,
-} from './constants';
+import {CsaViewMode, ExecutionType, InputMessageType} from './constants';
 import {getDisplayThemeFromString} from './DisplayTheme';
 import JavabuilderConnection from './JavabuilderConnection';
 import JavalabView from './JavalabView';
@@ -145,7 +140,6 @@ Javalab.prototype.init = function (config) {
         this.onOutputMessage,
         this.onNewlineMessage,
         this.setIsRunning,
-        STATUS_MESSAGE_PREFIX,
         // In Java Lab we don't distinguish between partial lines and full lines,
         // the provided message should have a newline at the end to be treated as
         // a full line.

--- a/apps/src/miniApps/neighborhood/Neighborhood.ts
+++ b/apps/src/miniApps/neighborhood/Neighborhood.ts
@@ -3,7 +3,6 @@ import {tiles, MazeController} from '@code-dot-org/maze';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import * as timeoutList from '@cdo/apps/lib/util/timeoutList';
 import {LOOK_ID, SVG_ID} from '@cdo/apps/maze/constants';
-import commonI18n from '@cdo/locale';
 
 import {ConsoleSignalType, NeighborhoodSignalType} from './constants';
 import NeighborhoodSpeedTracker from './NeighborhoodSpeedTracker';
@@ -23,12 +22,10 @@ type SkinType = Record<string, unknown>;
 
 export default class Neighborhood {
   private controller: typeof MazeController | null;
-  private seenFirstSignal: boolean;
   private onOutputMessage: (message: string) => void;
   private onNewlineMessage: () => void;
   private onPartialOutputMessage: (message: string) => void;
   private setIsRunning: (isRunning: boolean) => void;
-  private statusMessagePrefix: string;
   private signals: (NeighborhoodSignal | ConsoleSignal)[];
   private nextSignalIndex: number;
   private speedTracker: NeighborhoodSpeedTracker;
@@ -38,15 +35,12 @@ export default class Neighborhood {
     onOutputMessage: (message: string) => void,
     onNewlineMessage: () => void,
     setIsRunning: (isRunning: boolean) => void,
-    statusMessagePrefix: string,
     onPartialOutputMessage: (message: string) => void
   ) {
     this.controller = null;
-    this.seenFirstSignal = false;
     this.onOutputMessage = onOutputMessage;
     this.onNewlineMessage = onNewlineMessage;
     this.setIsRunning = setIsRunning;
-    this.statusMessagePrefix = statusMessagePrefix;
     this.signals = [];
     this.nextSignalIndex = -1;
     this.speedTracker = NeighborhoodSpeedTracker.getInstance();
@@ -113,14 +107,6 @@ export default class Neighborhood {
     }
     // Add next signal to our queue of signals.
     this.signals.push(signal);
-    // if this is the first non-console signal, send a starting painter message
-    if (!this.seenFirstSignal && !(signal.value in ConsoleSignalType)) {
-      this.seenFirstSignal = true;
-      this.signals.push({
-        value: ConsoleSignalType.CONSOLE_LOG,
-        detail: `${this.statusMessagePrefix} ${commonI18n.startingPainter()}\n`,
-      });
-    }
   }
 
   // Process avaiable signals recursively. We process recursively to ensure
@@ -268,7 +254,6 @@ export default class Neighborhood {
   resetSignalQueue() {
     this.signals = [];
     this.nextSignalIndex = 0;
-    this.seenFirstSignal = false;
     this.isProcessingSignals = false;
   }
 

--- a/apps/src/pythonlab/pyodideRunner.ts
+++ b/apps/src/pythonlab/pyodideRunner.ts
@@ -9,8 +9,11 @@ import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
 import pythonlabI18n from '@cdo/apps/pythonlab/locale';
 import {getStore} from '@cdo/apps/redux';
 
-import {getValidationFromSource} from '../codebridge';
-import {getSystemMessage} from '../codebridge/Console/MessageHelpers';
+import {getValidationFromSource, RunType} from '../codebridge';
+import {
+  getSystemMessage,
+  getTimestampMessage,
+} from '../codebridge/Console/MessageHelpers';
 
 import PythonValidationTracker from './progress/PythonValidationTracker';
 import {
@@ -49,9 +52,7 @@ export async function handleRunClick(
       );
       return;
     }
-    consoleManager?.writeConsoleMessage(
-      getSystemMessage(pythonlabI18n.runningProgram(), appName)
-    );
+    consoleManager?.writeConsoleMessage(getTimestampMessage(RunType.RUN));
     await runPythonCode(code, source);
     if (isNeighborhoodLevel()) {
       CodebridgeRegistry.getInstance().getNeighborhood()?.onClose();
@@ -107,7 +108,7 @@ export async function runAllTests(
   const consoleManager = CodebridgeRegistry.getInstance().getConsoleManager();
   if (validationToRun) {
     consoleManager?.writeConsoleMessage(
-      getSystemMessage(pythonlabI18n.runningLevelTests(), appName)
+      getTimestampMessage(RunType.VALIDATION)
     );
     progressManager?.resetValidation();
     // We only send the separate validation file, because otherwise the
@@ -131,7 +132,7 @@ export async function runAllTests(
     }
   } else {
     consoleManager?.writeConsoleMessage(
-      getSystemMessage(pythonlabI18n.runningProjectTests(), appName)
+      getSystemMessage(getTimestampMessage(RunType.TEST))
     );
     // Otherwise, we look for files that follow the regex 'test*.py' and run those.
     await runPythonCode(runStudentTests(), source);

--- a/apps/src/pythonlab/pyodideRunner.ts
+++ b/apps/src/pythonlab/pyodideRunner.ts
@@ -158,6 +158,9 @@ function handleRunEndedUnexpectedly(
 ) {
   consoleManager?.writeConsoleMessage(getSystemMessage(message, appName));
   if (isNeighborhoodLevel()) {
+    // We reset, run, and close the neighborhood to ensure that the neighborhood
+    // properly resets the run button back to run (from stop), and to reset the
+    // neighborhood to its original state.
     CodebridgeRegistry.getInstance().getNeighborhood()?.reset();
     CodebridgeRegistry.getInstance().getNeighborhood()?.onRun();
     CodebridgeRegistry.getInstance().getNeighborhood()?.onClose();

--- a/apps/src/pythonlab/pyodideRunner.ts
+++ b/apps/src/pythonlab/pyodideRunner.ts
@@ -1,4 +1,9 @@
 import CodebridgeRegistry from '@codebridge/CodebridgeRegistry';
+import ConsoleManager from '@codebridge/Console/ConsoleManager';
+import {
+  getSystemMessage,
+  getTimestampMessage,
+} from '@codebridge/Console/MessageHelpers';
 import {MiniApps} from '@codebridge/constants';
 import {AnyAction, Dispatch} from 'redux';
 
@@ -10,10 +15,6 @@ import pythonlabI18n from '@cdo/apps/pythonlab/locale';
 import {getStore} from '@cdo/apps/redux';
 
 import {getValidationFromSource, RunType} from '../codebridge';
-import {
-  getSystemMessage,
-  getTimestampMessage,
-} from '../codebridge/Console/MessageHelpers';
 
 import PythonValidationTracker from './progress/PythonValidationTracker';
 import {
@@ -33,26 +34,31 @@ export async function handleRunClick(
 ) {
   const consoleManager = CodebridgeRegistry.getInstance().getConsoleManager();
   if (!source) {
-    consoleManager?.writeConsoleMessage(
-      getSystemMessage(pythonlabI18n.noCode(), appName)
-    );
+    const runType = runTests
+      ? validationFile
+        ? RunType.VALIDATION
+        : RunType.TEST
+      : RunType.RUN;
+
+    consoleManager?.writeConsoleMessage(getTimestampMessage(runType));
+    handleRunEndedUnexpectedly(consoleManager, pythonlabI18n.noCode());
     return;
   }
   if (runTests) {
     await runAllTests(source, dispatch, progressManager, validationFile);
   } else {
     // Run main.py
+    consoleManager?.writeConsoleMessage(getTimestampMessage(RunType.RUN));
     const code = getFileByName(source.files, MAIN_PYTHON_FILE)?.contents;
-    if (!code) {
-      consoleManager?.writeConsoleMessage(
-        getSystemMessage(
-          pythonlabI18n.noFileToRun({fileName: MAIN_PYTHON_FILE}),
-          appName
-        )
+    if (code === undefined) {
+      handleRunEndedUnexpectedly(
+        consoleManager,
+        pythonlabI18n.noFileToRun({
+          fileName: MAIN_PYTHON_FILE,
+        })
       );
       return;
     }
-    consoleManager?.writeConsoleMessage(getTimestampMessage(RunType.RUN));
     await runPythonCode(code, source);
     if (isNeighborhoodLevel()) {
       CodebridgeRegistry.getInstance().getNeighborhood()?.onClose();
@@ -144,4 +150,18 @@ function isNeighborhoodLevel() {
     getStore().getState().lab2Project.projectSources?.labConfig?.miniApp
       ?.name === MiniApps.Neighborhood
   );
+}
+
+function handleRunEndedUnexpectedly(
+  consoleManager: ConsoleManager | null,
+  message: string
+) {
+  consoleManager?.writeConsoleMessage(getSystemMessage(message, appName));
+  if (isNeighborhoodLevel()) {
+    CodebridgeRegistry.getInstance().getNeighborhood()?.reset();
+    CodebridgeRegistry.getInstance().getNeighborhood()?.onRun();
+    CodebridgeRegistry.getInstance().getNeighborhood()?.onClose();
+  } else {
+    consoleManager?.writeConsoleMessage('');
+  }
 }

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -119,9 +119,8 @@ const setUpPyodideWorker = () => {
         writeConsoleMessage(message);
         break;
       case 'run_complete': {
-        writeConsoleMessage(
-          getSystemMessage(pythonlabI18n.programCompleted(), appName)
-        );
+        // Write a blank line to the console.
+        writeConsoleMessage('');
         delete callbacks[id];
         onSuccess(event.data);
         break;
@@ -291,6 +290,7 @@ const restartPyodideIfProgramIsRunning = () => {
     pyodideWorker.terminate();
     pyodideWorker = setUpPyodideWorker();
 
+    // TODO: decide if we want to keep this or not
     writeConsoleMessage(
       getSystemMessage(pythonlabI18n.programStopped(), appName)
     );

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -119,8 +119,11 @@ const setUpPyodideWorker = () => {
         writeConsoleMessage(message);
         break;
       case 'run_complete': {
-        // Write a blank line to the console.
-        writeConsoleMessage('');
+        // Write a blank line to the console if we are not on a neighborhood level (which handles
+        // this for us).
+        if (!outputToNeighborhood) {
+          writeConsoleMessage('');
+        }
         delete callbacks[id];
         onSuccess(event.data);
         break;

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -287,14 +287,19 @@ const asyncRun = (() => {
 })();
 
 const restartPyodideIfProgramIsRunning = () => {
-  // Only restart if there are pending callbacks, as that means the worker is currently
-  // running a program.
-
+  // Always send a stop message, as some programs will still
+  // look like they are "running" to the user even if they aren't truly running
+  // (for example, the neighborhood). We send via the console manager rather than
+  // the message handler because the neighborhood stops processing messages on stop,
+  // and we want to always show this to the user.
   const consoleManager = CodebridgeRegistry.getInstance().getConsoleManager();
   consoleManager?.writeConsoleMessage(
     getSystemMessage(pythonlabI18n.programStopped(), appName)
   );
   consoleManager?.writeConsoleMessage('');
+
+  // Only restart if there are pending callbacks, as that means the worker is currently
+  // running a program.
   if (Object.keys(callbacks).length > 0) {
     pyodideWorker.terminate();
     pyodideWorker = setUpPyodideWorker();

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -289,14 +289,15 @@ const asyncRun = (() => {
 const restartPyodideIfProgramIsRunning = () => {
   // Only restart if there are pending callbacks, as that means the worker is currently
   // running a program.
+
+  const consoleManager = CodebridgeRegistry.getInstance().getConsoleManager();
+  consoleManager?.writeConsoleMessage(
+    getSystemMessage(pythonlabI18n.programStopped(), appName)
+  );
+  consoleManager?.writeConsoleMessage('');
   if (Object.keys(callbacks).length > 0) {
     pyodideWorker.terminate();
     pyodideWorker = setUpPyodideWorker();
-
-    writeConsoleMessage(
-      getSystemMessage(pythonlabI18n.programStopped(), appName)
-    );
-    writeConsoleMessage('');
     Lab2Registry.getInstance()
       .getMetricsReporter()
       .incrementCounter('PythonLab.PyodideRestarted');

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -293,10 +293,10 @@ const restartPyodideIfProgramIsRunning = () => {
     pyodideWorker.terminate();
     pyodideWorker = setUpPyodideWorker();
 
-    // TODO: decide if we want to keep this or not
     writeConsoleMessage(
       getSystemMessage(pythonlabI18n.programStopped(), appName)
     );
+    writeConsoleMessage('');
     Lab2Registry.getInstance()
       .getMetricsReporter()
       .incrementCounter('PythonLab.PyodideRestarted');

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_neighborhood.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_neighborhood.feature
@@ -13,6 +13,6 @@ Scenario: Can run and see output of Python program
   And I open my eyes to test "run and see output of Neighborhood"
   And I see no difference for "initial load"
   And I press "uitest-codebridge-run"
-  And I wait until "#uitest-codebridge-console" contains text "[PYTHON LAB] Program completed."
+  And I wait until "#uitest-codebridge-console" contains text "10"
   And I see no difference for "completed run"
   And I close my eyes

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run_eyes.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run_eyes.feature
@@ -13,6 +13,6 @@ Scenario: Can run and see output of Python program
   And I open my eyes to test "run and see output of a Python program"
   And I see no difference for "initial load"
   And I press "uitest-codebridge-run"
-  And I wait until "#uitest-codebridge-console" contains text "[PYTHON LAB] Program completed."
+  And I wait until "#uitest-codebridge-console" contains text "Hello from the start!"
   And I see no difference for "completed run"
   And I close my eyes


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

Various improvements to the console output in python lab (with one implication for Java Lab):
- When we start a run, instead of outputting `[PYTHON LAB] Running program...` (or tests), we output a timestamp with `RUN AT`, `TEST AT`, or `VALIDATE AT` before it (see screenshots)
- We removed the neighborhood `STARTING PAINTER` message. After the work to sync the neighborhood and console this felt potentially confusing and unnecessary. This also impacts Java Lab.
- Fixed an issue where if the user's `main.py` was empty we told them they had no `main.py` to run
- Add a single blank line between runs.
- Ensure we show `Program Stopped` if a user presses stop on a neighborhood level (those were either getting swallowed by the neighborhood processor, or not shown because the program wasn't really running anymore).
- Add a little left padding to the console text

## Before
![Screenshot 2025-04-23 at 2 16 34 PM](https://github.com/user-attachments/assets/21c7b2b3-57b8-4b76-b619-0a086c519e85)

## After
### Run and validate 
![Screenshot 2025-04-23 at 2 23 01 PM](https://github.com/user-attachments/assets/2138a08a-db47-4111-a596-be3e6bc6484b)


### Neighborhood
![Screenshot 2025-04-23 at 2 23 38 PM](https://github.com/user-attachments/assets/23453666-3db0-4f95-89e2-e2d28d4dcfa6)

### No main.py followed by empty main.py
<img width="371" alt="Screenshot 2025-04-23 at 2 23 10 PM" src="https://github.com/user-attachments/assets/b41c61a2-5356-4533-b703-8eea11608c62" />

### Stopped program (still show stopped message)
![Screenshot 2025-04-23 at 2 23 58 PM](https://github.com/user-attachments/assets/6b791b09-83bf-4ae1-bfc6-e7e344ff3c47)


## Links

- Jira: [https://codedotorg.atlassian.net/browse/CT-1190](CT-1190)

## Testing story
Tested locally


## Deployment strategy
This will cause eyes diffs on Java Lab and Python Lab.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
