### PR TITLE
[Labs] Updates Code Editor to not immediately open on Tab

### DIFF
--- a/apps/i18n/pythonlab/en_us.json
+++ b/apps/i18n/pythonlab/en_us.json
@@ -1,7 +1,7 @@
 {
   "changeConsoleVisibility": "Change Console Visibility",
   "codeEditorEditing": "Code Editor: editing",
-  "codeEditorDescription": "Code Editor: Press Enter to edit, Exc to exit.",
+  "codeEditorDescription": "Code Editor: Press Enter to edit, Escape to exit.",
   "console": "Console",
   "consoleOnly": "Console only",
   "consoleOnlyDescription": "A project that outputs to the console.",

--- a/apps/i18n/pythonlab/en_us.json
+++ b/apps/i18n/pythonlab/en_us.json
@@ -1,6 +1,7 @@
 {
   "changeConsoleVisibility": "Change Console Visibility",
-  "codeEditor": "Code Editor",
+  "codeEditorEditing": "Code Editor: editing",
+  "codeEditorDescription": "Code Editor: Press Enter to edit, Exc to exit.",
   "console": "Console",
   "consoleOnly": "Console only",
   "consoleOnlyDescription": "A project that outputs to the console.",

--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -5,7 +5,7 @@ import {Editor} from '@codebridge/Editor/Editor';
 import {FileBrowser} from '@codebridge/FileBrowser/FileBrowser';
 import {FileTabs} from '@codebridge/FileTabs/FileTabs';
 import classnames from 'classnames';
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {START_SOURCES, WARNING_BANNER_MESSAGES} from '@cdo/apps/lab2/constants';
@@ -13,6 +13,7 @@ import {isProjectTemplateLevel} from '@cdo/apps/lab2/lab2Redux';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {setRestoredOldVersion} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import i18n from '@cdo/apps/pythonlab/locale';
 import ProjectTemplateWorkspaceIconV2 from '@cdo/apps/templates/ProjectTemplateWorkspaceIconV2';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import commonI18n from '@cdo/locale';
@@ -32,6 +33,7 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
 }) => {
   const {config} = useCodebridgeContext();
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+  const containerRef = useRef<HTMLDivElement>(null);
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
   const viewingOldVersion = useAppSelector(
     state => state.lab2Project.viewingOldVersion
@@ -62,6 +64,41 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
     dispatch(setRestoredOldVersion(false));
   };
 
+  // Sets keydown event listener on the editor container to handle Escape key
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        // Move focus back to codemirror-container
+        containerRef.current?.focus();
+      }
+    };
+    const observer = new MutationObserver(() => {
+      const cmContentDiv = document.querySelector('.cm-content') as HTMLElement;
+      if (cmContentDiv) {
+        cmContentDiv.addEventListener('keydown', handleKeyDown);
+        observer.disconnect(); // Stop observing once the element is found
+      }
+    });
+
+    observer.observe(document.body, {childList: true, subtree: true});
+
+    return () => observer.disconnect(); // Cleanup observer on unmount
+  }, []);
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const cmContentDiv = document.querySelector('.cm-content');
+
+    if (cmContentDiv) {
+      cmContentDiv.setAttribute('aria-label', i18n.codeEditorEditing());
+      cmContentDiv.setAttribute('tabIndex', '-1'); // Ensure focusability
+
+      if (event.key === 'Enter') {
+        // Open the .cm-content (focus it)
+        (cmContentDiv as HTMLElement).focus();
+      }
+    }
+  };
+
   return (
     <div style={style} className={className}>
       <PanelContainer
@@ -84,14 +121,19 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
             <ToggleFileBrowserButton />
           </div>
           <FileTabs />
-
           {config.showFileBrowser && <FileBrowser />}
-
+          {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
           <div
             className={classnames(moduleStyles.workplaceEditorWrapper, {
               [moduleStyles.withFileBrowser]: config.showFileBrowser,
             })}
+            tabIndex={0}
+            onKeyDown={onKeyDown}
+            aria-label={i18n.codeEditorDescription()}
+            ref={containerRef}
+            role="application"
           >
+            {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
             <Editor
               langMapping={config.languageMapping}
               editableFileTypes={config.editableFileTypes}

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -27,6 +27,13 @@
   overflow: hidden;
   flex: 1;
   grid-column: span 2;
+
+  &:focus {
+    outline: var(--borders-brand-teal-primary) solid 2px;
+    outline-offset: 2px;
+    border-radius: 0.25rem;
+    z-index: 1;
+  }
 }
 
 .workplaceEditorWrapper.withFileBrowser {

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -11,7 +11,6 @@ import {
   setEditorFontSizeLoaded,
 } from '@cdo/apps/lab2/redux/lab2ViewRedux';
 import {AppName} from '@cdo/apps/lab2/types';
-import i18n from '@cdo/apps/pythonlab/locale';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
@@ -178,14 +177,6 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     editorReadOnlyCompartment,
     editorEditableCompartment,
   ]);
-
-  // Sets aria-label on the input div once code mirror loads
-  useEffect(() => {
-    const cmContentDiv = editorRef.current?.querySelector('.cm-content');
-    if (cmContentDiv) {
-      cmContentDiv.setAttribute('aria-label', i18n.codeEditor());
-    }
-  }, []);
 
   if (!editorFontSizeLoaded) {
     return null;


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

We made the decision to update how users interact with our CodeMirror editor based on what seems to be a bit more standard across industry. Many other editors require an extra keystroke for activation or entry, and now ours will as well. This makes the enter and exit more intuitive keystroke-wise, and also allows for easier tab navigation across the page. Slack context [here](https://codedotorg.slack.com/archives/C0532LCK125/p1744148405003269).

Before Behavior:
As a user tabs across the page, their keyboard focus moves into the editor and immediately begins editing (each tab then becomes a tab in the traditional sense, tabbing the start of the first line of code). Then they need to press either 'esc + tab' or 'esc + shift + tab' to exit the editor (forward or backward). 


After Behavior:
Now, the user can tab 'over' the editor to the other elements. To enter the editor, the user has to press the enter key. The user can then escape with the escape key. 

Skip to 15 seconds to go past the screenreader announcements and just see the keyboard interactions


https://github.com/user-attachments/assets/6d74d1d5-1d64-4a18-83cf-c5f0bb04aa1e




## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1222

## Testing story

I tested this in PythonLab and WebLab to ensure the keystrokes work. There is a current z index issue that I initially worried was related, but then I realized the same issue is happening on production so I believe this PR is safe.

## Deployment strategy

## Follow-up work

There is a followup task to add tooltips or some other messaging to let users know about the enter and exit shortcuts!
https://codedotorg.atlassian.net/browse/SL-1223

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
