### PR TITLE
Add marketing lambda association, marketing origin

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -27,10 +27,10 @@ Parameters:
     Type: String
     Default: <%=rack_env?(:production) ? '\'\'' : stack_name %>
     Description: Subdomain name for corporate web site ("Pegasus").
-  MarketingDomainName:
+  InternalMarketingDomainName:
     Type: String
-    Default: <%="code.marketing-sites.#{CDO.rack_env == 'production' ? 'code.org' : 'dev-code.org'}"%>
-    Description: Domain name for marketing site.
+    Default: <%="code.marketing-sites.#{rack_env?(:production) ? 'code.org' : 'dev-code.org'}"%>
+    Description: Interim domain name of the Contentful CMS-based marketing site. The DNS record for code.org still points to Pegasus, which dynamically routes some requests to the new Contentful site. This parameter is intended for internal routing and should not be used outside that context.
   HourOfCodeBaseDomainName:
     Type: String
     Default: hourofcode.com

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -29,9 +29,8 @@ Parameters:
     Description: Subdomain name for corporate web site ("Pegasus").
   MarketingDomainName:
     Type: String
-    # Todo: update to handle multiple envs once the app is in prod
-    Default: 'dev.marketing.dev-code.org'
-    Description: Subdomain name for marketing site.
+    Default: <%="code.marketing-sites.#{CDO.rack_env == 'production' ? 'code.org' : 'dev-code.org'}"%>
+    Description: Domain name for marketing site.
   HourOfCodeBaseDomainName:
     Type: String
     Default: hourofcode.com

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -2,7 +2,7 @@
 
 // This variable is injected via CloudFormation string substitution. This file must be used
 // in conjunction with the CloudFormation Sub function to set the value of MarketingDomainName.
-const marketingDomain = '${MarketingDomainName}'
+const marketingDomain = '${InternalMarketingDomainName}'
 
 const marketingPaths = {
   // Add key-value pairs for each path that should be served by the CMS

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -208,7 +208,7 @@ module AWS
                 OriginSSLProtocols: %w(TLSv1.2),
                 OriginReadTimeout: 30
               },
-              DomainName: "marketingsites.#{CDO.rack_env == 'production' ? 'code.org' : 'dev-code.org'}",
+              DomainName: "code.#{CDO.rack_env == 'production' ? 'marketing-sites.code.org' : 'marketing.dev-code.org'}",
               OriginPath: '',
               OriginShield: {
                 Enabled: true,

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -200,20 +200,22 @@ module AWS
               ]
             }
           end,
-          ({
-            Id: 'marketing',
-            CustomOriginConfig: {
-              OriginProtocolPolicy: 'match-viewer',
-              OriginSSLProtocols: %w(TLSv1.2),
-              OriginReadTimeout: 30
-            },
-            DomainName: "marketingsites.#{CDO.rack_env == 'production' ? 'code.org' : 'dev-code.org'}",
-            OriginPath: '',
-            OriginShield: {
-              Enabled: true,
-              OriginShieldRegion: {Ref: 'AWS::Region'}
-            },
-          } if app == :pegasus),
+          (if app == :pegasus
+             {
+               Id: 'marketing',
+              CustomOriginConfig: {
+                OriginProtocolPolicy: 'match-viewer',
+                OriginSSLProtocols: %w(TLSv1.2),
+                OriginReadTimeout: 30
+              },
+              DomainName: "marketingsites.#{CDO.rack_env == 'production' ? 'code.org' : 'dev-code.org'}",
+              OriginPath: '',
+              OriginShield: {
+                Enabled: true,
+                OriginShieldRegion: {Ref: 'AWS::Region'}
+              },
+             }
+           end),
           {
             Id: 'cdo-assets',
             DomainName: "#{CDO.assets_bucket}.s3.amazonaws.com",
@@ -276,6 +278,17 @@ module AWS
           Forward: behavior_config[:cookies]
         }
 
+      function_associations = {
+        accept_language: {
+          EventType: 'viewer-request',
+          FunctionARN: {'Fn::Sub': 'arn:aws:cloudfront::${AWS::AccountId}:function/AcceptLanguage'}
+        },
+        marketing_router: {
+          EventType: 'origin-request',
+          LambdaFunctionARN: {Ref: 'MarketingRouterVersion'}
+        }
+      }
+
       normalize_accept_language = headers.include?('Accept-Language')
       # Behaviors including session cookies aren't cacheable anyway, so don't bother
       # running the extra header-normalization function for these.
@@ -293,7 +306,8 @@ module AWS
           Headers: headers,
           QueryString: behavior_config[:query] != false
         },
-        FunctionAssociations: function_associations(normalize_accept_language, behavior_config[:include_marketing_router_lambda]),
+        FunctionAssociations: normalize_accept_language ? [function_associations[:accept_language]] : [],
+        LambdaFunctionAssociations: behavior_config[:include_marketing_router_lambda] ? [function_associations[:marketing_router]] : [],
         MaxTTL: 31_536_000, # =1 year,
         MinTTL: 0,
         SmoothStreaming: false,
@@ -304,26 +318,6 @@ module AWS
         behavior[:PathPattern] = path if path
         behavior[:RealtimeLogConfigArn] = {'Fn::ImportValue': 'AccessLogs-Config'}
       end
-    end
-
-    def self.function_associations(normalize_accept_language, include_marketing_router_lambda)
-      function_associations = []
-
-      if normalize_accept_language
-        function_associations << {
-          EventType: 'viewer-request',
-          FunctionARN: {'Fn::Sub': 'arn:aws:cloudfront::${AWS::AccountId}:function/AcceptLanguage'}
-        }
-      end
-
-      if include_marketing_router_lambda
-        function_associations << {
-          EventType: 'origin-request',
-          LambdaFunctionARN: {Ref: 'MarketingRouterVersion'}
-        }
-      end
-
-      function_associations
     end
 
     # Generate cookies granting access to the resource until the expiration_date.

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -208,7 +208,7 @@ module AWS
                 OriginSSLProtocols: %w(TLSv1.2),
                 OriginReadTimeout: 30
               },
-              DomainName: "code.marketing-sites.#{CDO.rack_env == 'production' ? 'code.org' : 'dev-code.org'}",
+              DomainName: {Ref: 'MarketingDomainName'},
               OriginPath: '',
               OriginShield: {
                 Enabled: true,

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -200,6 +200,20 @@ module AWS
               ]
             }
           end,
+          ({
+            Id: 'marketing',
+            CustomOriginConfig: {
+              OriginProtocolPolicy: 'match-viewer',
+              OriginSSLProtocols: %w(TLSv1.2),
+              OriginReadTimeout: 30
+            },
+            DomainName: "marketingsites.#{CDO.rack_env == 'production' ? 'code.org' : 'dev-code.org'}",
+            OriginPath: '',
+            OriginShield: {
+              Enabled: true,
+              OriginShieldRegion: {Ref: 'AWS::Region'}
+            },
+          } if app == :pegasus),
           {
             Id: 'cdo-assets',
             DomainName: "#{CDO.assets_bucket}.s3.amazonaws.com",
@@ -216,7 +230,7 @@ module AWS
               OriginAccessIdentity: 'origin-access-identity/cloudfront/E17G1PR1YAN7F4'
             },
           },
-        ],
+        ].compact,
         PriceClass: 'PriceClass_All',
         Restrictions: {
           GeoRestriction: {
@@ -262,11 +276,6 @@ module AWS
           Forward: behavior_config[:cookies]
         }
 
-      accept_language_fn =
-        {
-          EventType: 'viewer-request',
-          FunctionARN: {'Fn::Sub': 'arn:aws:cloudfront::${AWS::AccountId}:function/AcceptLanguage'}
-        }
       normalize_accept_language = headers.include?('Accept-Language')
       # Behaviors including session cookies aren't cacheable anyway, so don't bother
       # running the extra header-normalization function for these.
@@ -284,7 +293,7 @@ module AWS
           Headers: headers,
           QueryString: behavior_config[:query] != false
         },
-        FunctionAssociations: normalize_accept_language ? [accept_language_fn] : [],
+        FunctionAssociations: function_associations(normalize_accept_language, behavior_config[:include_marketing_router_lambda]),
         MaxTTL: 31_536_000, # =1 year,
         MinTTL: 0,
         SmoothStreaming: false,
@@ -295,6 +304,26 @@ module AWS
         behavior[:PathPattern] = path if path
         behavior[:RealtimeLogConfigArn] = {'Fn::ImportValue': 'AccessLogs-Config'}
       end
+    end
+
+    def self.function_associations(normalize_accept_language, include_marketing_router_lambda)
+      function_associations = []
+
+      if normalize_accept_language
+        function_associations << {
+          EventType: 'viewer-request',
+          FunctionARN: {'Fn::Sub': 'arn:aws:cloudfront::${AWS::AccountId}:function/AcceptLanguage'}
+        }
+      end
+
+      if include_marketing_router_lambda
+        function_associations << {
+          EventType: 'origin-request',
+          LambdaFunctionARN: {Ref: 'MarketingRouterVersion'}
+        }
+      end
+
+      function_associations
     end
 
     # Generate cookies granting access to the resource until the expiration_date.

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -208,7 +208,7 @@ module AWS
                 OriginSSLProtocols: %w(TLSv1.2),
                 OriginReadTimeout: 30
               },
-              DomainName: "code.#{CDO.rack_env == 'production' ? 'marketing-sites.code.org' : 'marketing.dev-code.org'}",
+              DomainName: "code.marketing-sites.#{CDO.rack_env == 'production' ? 'code.org' : 'dev-code.org'}",
               OriginPath: '',
               OriginShield: {
                 Enabled: true,

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -230,12 +230,21 @@ class HttpCache
             query: false,
             headers: ALLOWLISTED_HEADERS,
             cookies: default_cookies
+          },
+          # NextJS assets path for the marketing app
+          {
+            path: '/_next/*',
+            proxy: 'marketing',
+            headers: ALLOWLISTED_HEADERS,
+            cookies: default_cookies,
+            include_marketing_router_lambda: true,
           }
         ],
         # Remaining Pegasus paths are cached, and vary only on language, country, and default cookies.
         default: {
           headers: LANGUAGE_HEADER + COUNTRY_HEADER,
-          cookies: default_cookies
+          cookies: default_cookies,
+          include_marketing_router_lambda: true,
         }
       },
       dashboard: {

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -172,6 +172,14 @@ class HttpCache
     {
       pegasus: {
         behaviors: [
+          # NextJS assets path for the marketing app
+          {
+            path: '/_next/*',
+            proxy: 'marketing',
+            headers: ALLOWLISTED_HEADERS,
+            cookies: default_cookies,
+            include_marketing_router_lambda: true,
+          },
           {
             # Serve Sprockets-bundled assets directly from the S3 bucket synced via `assets:precompile`.
             #
@@ -231,14 +239,6 @@ class HttpCache
             headers: ALLOWLISTED_HEADERS,
             cookies: default_cookies
           },
-          # NextJS assets path for the marketing app
-          {
-            path: '/_next/*',
-            proxy: 'marketing',
-            headers: ALLOWLISTED_HEADERS,
-            cookies: default_cookies,
-            include_marketing_router_lambda: true,
-          }
         ],
         # Remaining Pegasus paths are cached, and vary only on language, country, and default cookies.
         default: {

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -174,7 +174,7 @@ class HttpCache
         behaviors: [
           # NextJS assets path for the marketing app
           {
-            path: '/_next/*',
+            path: '/_next/static/*',
             proxy: 'marketing',
             headers: ALLOWLISTED_HEADERS,
             cookies: default_cookies,

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -176,7 +176,7 @@ class HttpCache
           {
             path: '/_next/static/*',
             proxy: 'marketing',
-            headers: ALLOWLISTED_HEADERS,
+            headers: [],
             cookies: default_cookies,
             include_marketing_router_lambda: true,
           },


### PR DESCRIPTION
Adds more Cloudformation:

- Function association for the marketing lambda@edge
- Origin for the marketing site on the Pegasus/code.org distribution
- Behavior for /_next/*

Note that the prod marketing cluster will need to be deployed first before the function will work.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
