### PR TITLE
Wait for Font Awesome in all eyes tests

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/workshop_certificates.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/workshop_certificates.feature
@@ -6,5 +6,6 @@ Feature: Basic appearance for Workshop Certificates
 Scenario: Simple Workshop Certificate
   Given I am a teacher who has just followed a workshop certificate link
   And I open my eyes to test "workshop certificate"
-  And I see no difference for "viewing workshop certificate"
+  # This page doesn't render any icons, so we don't need to wait for Font Awesome to load.
+  And I see no difference for "viewing workshop certificate" without waiting for Font Awesome to load
   And I close my eyes

--- a/dashboard/test/ui/features/javalab/code_review_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_scenarios.feature
@@ -1,6 +1,5 @@
 @no_mobile
 @eyes
-@skip
 Feature: Code review V2
 
   # Note: this test does not cover adding comments to the review because the slate text editor

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -48,14 +48,14 @@ end
 
 # A Feature can optionally specify the stitch mode ('css' or 'scroll') for Eyes to create the full screenshot.
 And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?( without waiting for Font Awesome to load)?$/) do |identifier, stitch_mode, skip_fa_wait|
+  next if CDO.disable_all_eyes_running
+
   # Wait until the fonts are fully loaded and rendering the page
   # Hopefully fixes many of the issues with font wiggle due to lazily loading
   # alternative fonts for symbols and localized glyphs.
   wait_until do
     fonts_loaded? && (skip_fa_wait || font_awesome_loaded?)
   end
-
-  next if CDO.disable_all_eyes_running
 
   if stitch_mode == "none"
     @eyes.force_full_page_screenshot = false

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -52,8 +52,7 @@ And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?( withou
   # Hopefully fixes many of the issues with font wiggle due to lazily loading
   # alternative fonts for symbols and localized glyphs.
   wait_until do
-    fonts_loaded?
-    font_awesome_loaded? unless skip_fa_wait
+    fonts_loaded? && (skip_fa_wait || font_awesome_loaded?)
   end
 
   next if CDO.disable_all_eyes_running
@@ -108,7 +107,7 @@ def ensure_eyes_available
 end
 
 # There are several fonts we sometimes load associated with Font Awesome, but Font Awesome 6 at the "solid" weight (900) is our default,
-# so we wait for that one to load at least.
+# and used in the header (which appears across almost all pages), so we wait for that one to load at least.
 def font_awesome_loaded?
   @browser.execute_script('return [...document.fonts].find(font => font.family === "Font Awesome 6 Pro" && font.weight === "900")?.status === "loaded"') == true
 end

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -47,7 +47,7 @@ And(/^I close my eyes$/) do
 end
 
 # A Feature can optionally specify the stitch mode ('css' or 'scroll') for Eyes to create the full screenshot.
-And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?(?: without waiting for Font Awesome to load)?$/) do |identifier, stitch_mode, skip_fa_wait|
+And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?( without waiting for Font Awesome to load)?$/) do |identifier, stitch_mode, skip_fa_wait|
   # Wait until the fonts are fully loaded and rendering the page
   # Hopefully fixes many of the issues with font wiggle due to lazily loading
   # alternative fonts for symbols and localized glyphs.

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -55,6 +55,7 @@ And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?$/) do |
   # alternative fonts for symbols and localized glyphs.
   wait_until do
     fonts_loaded?
+    font_awesome_loaded?
   end
 
   if stitch_mode == "none"
@@ -104,6 +105,12 @@ def ensure_eyes_available
   @eyes = Applitools::Selenium::Eyes.new
   @eyes.api_key = CDO.applitools_eyes_api_key
   @eyes.log_handler = Logger.new('../../log/eyes.log')
+end
+
+# There are several fonts we sometimes load associated with Font Awesome, but Font Awesome 6 at the "solid" weight (900) is our default,
+# so we wait for that one to load at least.
+def font_awesome_loaded?
+  @browser.execute_script('return [...document.fonts].find(font => font.family === "Font Awesome 6" && font.weight === 900).status === "loaded"') == true
 end
 
 def fonts_loaded?

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -110,7 +110,7 @@ end
 # There are several fonts we sometimes load associated with Font Awesome, but Font Awesome 6 at the "solid" weight (900) is our default,
 # so we wait for that one to load at least.
 def font_awesome_loaded?
-  @browser.execute_script('return [...document.fonts].find(font => font.family === "Font Awesome 6" && font.weight === 900).status === "loaded"') == true
+  @browser.execute_script('return [...document.fonts].find(font => font.family === "Font Awesome 6 Pro" && font.weight === "900")?.status === "loaded"') == true
 end
 
 def fonts_loaded?

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -47,13 +47,13 @@ And(/^I close my eyes$/) do
 end
 
 # A Feature can optionally specify the stitch mode ('css' or 'scroll') for Eyes to create the full screenshot.
-And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?$/) do |identifier, stitch_mode|
+And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?(?: without waiting for Font Awesome to load)?$/) do |identifier, stitch_mode, skip_fa_wait|
   # Wait until the fonts are fully loaded and rendering the page
   # Hopefully fixes many of the issues with font wiggle due to lazily loading
   # alternative fonts for symbols and localized glyphs.
   wait_until do
     fonts_loaded?
-    font_awesome_loaded?
+    font_awesome_loaded? unless skip_fa_wait
   end
 
   next if CDO.disable_all_eyes_running

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -48,8 +48,6 @@ end
 
 # A Feature can optionally specify the stitch mode ('css' or 'scroll') for Eyes to create the full screenshot.
 And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?$/) do |identifier, stitch_mode|
-  next if CDO.disable_all_eyes_running
-
   # Wait until the fonts are fully loaded and rendering the page
   # Hopefully fixes many of the issues with font wiggle due to lazily loading
   # alternative fonts for symbols and localized glyphs.
@@ -57,6 +55,8 @@ And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?$/) do |
     fonts_loaded?
     font_awesome_loaded?
   end
+
+  next if CDO.disable_all_eyes_running
 
   if stitch_mode == "none"
     @eyes.force_full_page_screenshot = false

--- a/dashboard/test/ui/features/teacher_tools/courses_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/courses_eyes.feature
@@ -54,7 +54,7 @@ Scenario: Signed out courses, teach
   And I wait to see "#headerlinks"
   And I see "#header-teach"
   And I press "header-teach"
-  Then I am on "https://code.org/teach"
+  Then I am on "http://code.org/teach"
   And I see no difference for "signed-out courses page, teach"
   And I close my eyes
 

--- a/dashboard/test/ui/features/teacher_tools/hour_of_code/hoc_batch_certificates.feature
+++ b/dashboard/test/ui/features/teacher_tools/hour_of_code/hoc_batch_certificates.feature
@@ -22,5 +22,6 @@ Scenario: Eyes test for oceans certificate on bulk print page
 
   When I wait until I am on "http://studio.code.org/print_certificates/batch"
   And I wait until element ".hide-print" is visible
-  And I see no difference for "bulk print page"
+  # This page doesn't render any icons, so we don't need to wait for Font Awesome to load.
+  And I see no difference for "bulk print page" without waiting for Font Awesome to load
   And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/teacher_tools/hour_of_code/hour_of_code_finish.feature
@@ -101,7 +101,8 @@ Scenario: Oceans uncustomized dashboard certificate pages
 
   When I press the first "#certificate-share img" element to load a new page
   And I wait until current URL contains "/print_certificates/"
-  And I see no difference for "oceans print certificate page"
+  # This page doesn't render any icons, so we don't need to wait for Font Awesome to load.
+  And I see no difference for "oceans print certificate page" without waiting for Font Awesome to load
 
   And I close my eyes
 
@@ -149,7 +150,8 @@ Scenario: customized dashboard certificate pages with no course name
   When I press the first "#certificate-share img" element to load a new page
   And I wait until current URL contains "/print_certificates/"
   Then I wait to see an image "/certificate_images/"
-  And I see no difference for "print certificate page"
+  # This page doesn't render any icons, so we don't need to wait for Font Awesome to load.
+  And I see no difference for "print certificate page" without waiting for Font Awesome to load
 
   And I close my eyes
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#65187

This revert is primarily aimed at restoring an "eyes" test for Javalab that was flaky because of inconsistent load timing for Font Awesome icons. To fix this, I added a wait until Font Awesome has loaded for (almost) all tests that integrate with Applitools (ie, "eyes" tests). There are a small handful of tests on pages that actually do not require Font Awesome, so I added an exception to not wait during those tests.

## Testing story

I was able to get a stubbed version of all "eyes" tests passing in Drone. Each test was able to proceed past the `font_awesome_loaded?` check.