### PR TITLE
[PROGRESS] Add an un-hooked button that downloads csv data on the progress page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1058,6 +1058,7 @@
   "downloadAssessmentCSV": "Download CSV of student responses",
   "downloadFeedbackCSV": "Download CSV of Feedback",
   "downloadParentLetter": "Download parent letter",
+  "downloadProgressCsv": "Download a .csv file of your students' progress in this unit.",
   "downloadReplayVideoButtonDownload": "Animation",
   "downloadReplayVideoButtonError": "Sorry, we were unable to download your animation. Please try re-running your project and trying again.",
   "downloadUnitXLessonPlans": "Download all lesson plans for Unit {unitNumber}",

--- a/apps/package.json
+++ b/apps/package.json
@@ -70,6 +70,7 @@
     "@types/js-cookie": "^3.0.6",
     "@types/mocha": "^10.0.1",
     "@types/react-bootstrap": "^0.32.36",
+    "@types/react-csv": "^1.1.10",
     "@types/react-router-dom": "^5.3.3",
     "@types/react-select": "^1.2.1",
     "@types/reactabular-table": "^8.14.6",

--- a/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
+++ b/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
@@ -1,0 +1,45 @@
+import {Button} from '@code-dot-org/component-library/button';
+import {
+  TooltipOverlay,
+  WithTooltip,
+} from '@code-dot-org/component-library/tooltip';
+import React from 'react';
+
+import i18n from '@cdo/locale';
+
+import styles from './progress-table-v2.module.scss';
+
+interface DownloadProgressCsvProps {}
+
+export const DownloadProgressCsv: React.FC<DownloadProgressCsvProps> = () => {
+  const handleDownload = () => {
+    // Does nothing as per requirements
+  };
+
+  return (
+    <TooltipOverlay>
+      <WithTooltip
+        tooltipOverlayClassName={styles.downloadCsv}
+        tooltipProps={{
+          tooltipId: 'csv-download-tooltip',
+          role: 'tooltip',
+          text: i18n.downloadProgressCsv(),
+          direction: 'onTop',
+          size: 'm',
+        }}
+      >
+        <Button
+          isIconOnly={true}
+          icon={{iconName: 'download', iconStyle: 'solid'}}
+          onClick={handleDownload}
+          size="s"
+          color="gray"
+          aria-label={i18n.downloadCSV()}
+          type="secondary"
+        />
+      </WithTooltip>
+    </TooltipOverlay>
+  );
+};
+
+export default DownloadProgressCsv;

--- a/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
+++ b/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
@@ -4,6 +4,7 @@ import {
   WithTooltip,
 } from '@code-dot-org/component-library/tooltip';
 import React from 'react';
+import {CSVLink} from 'react-csv';
 
 import i18n from '@cdo/locale';
 
@@ -11,33 +12,46 @@ import styles from './progress-table-v2.module.scss';
 
 interface DownloadProgressCsvProps {}
 
-export const DownloadProgressCsv: React.FC<DownloadProgressCsvProps> = () => {
-  const handleDownload = () => {
-    // Does nothing as per requirements
-  };
+const CSV_HEADERS = [
+  {label: 'studentName', key: 'studentName'},
+  {label: 'level 1', key: 'level1'},
+];
 
+const testData = [
+  {studentName: 'Student 1', level1: 'Completed'},
+  {studentName: 'Student 2', level1: 'Not Completed'},
+];
+
+export const DownloadProgressCsv: React.FC<DownloadProgressCsvProps> = () => {
   return (
     <TooltipOverlay>
-      <WithTooltip
-        tooltipOverlayClassName={styles.downloadCsv}
-        tooltipProps={{
-          tooltipId: 'csv-download-tooltip',
-          role: 'tooltip',
-          text: i18n.downloadProgressCsv(),
-          direction: 'onTop',
-          size: 'm',
-        }}
+      <CSVLink
+        role="button"
+        filename="progress.csv"
+        data={testData}
+        headers={CSV_HEADERS}
       >
-        <Button
-          isIconOnly={true}
-          icon={{iconName: 'download', iconStyle: 'solid'}}
-          onClick={handleDownload}
-          size="s"
-          color="gray"
-          aria-label={i18n.downloadCSV()}
-          type="secondary"
-        />
-      </WithTooltip>
+        <WithTooltip
+          tooltipOverlayClassName={styles.downloadCsv}
+          tooltipProps={{
+            tooltipId: 'csv-download-tooltip',
+            role: 'tooltip',
+            text: i18n.downloadProgressCsv(),
+            direction: 'onTop',
+            size: 'm',
+          }}
+        >
+          <Button
+            isIconOnly={true}
+            icon={{iconName: 'download', iconStyle: 'solid'}}
+            onClick={() => {}} // Download is handled by CSVLink
+            size="s"
+            color="gray"
+            aria-label={i18n.downloadCSV()}
+            type="secondary"
+          />
+        </WithTooltip>
+      </CSVLink>
     </TooltipOverlay>
   );
 };

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -17,7 +17,6 @@ import {
 import {showV2TeacherDashboard} from '../teacherNavigation/TeacherNavFlagUtils';
 import UnitSelectorV2 from '../UnitSelectorV2';
 
-import DownloadProgressCsv from './DownloadProgressCsv';
 import IconKey from './IconKey';
 import MoreOptionsDropdown from './MoreOptionsDropdown';
 import ProgressTableV2 from './ProgressTableV2';
@@ -131,7 +130,6 @@ function SectionProgressV2({
 
           <UnitSelectorV2 className={styles.titleUnitSelectorDropdown} />
           <MoreOptionsDropdown />
-          <DownloadProgressCsv />
         </Heading6>
       </div>
       <ProgressTableV2 isSkeleton={isLoading} />

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -17,6 +17,7 @@ import {
 import {showV2TeacherDashboard} from '../teacherNavigation/TeacherNavFlagUtils';
 import UnitSelectorV2 from '../UnitSelectorV2';
 
+import DownloadProgressCsv from './DownloadProgressCsv';
 import IconKey from './IconKey';
 import MoreOptionsDropdown from './MoreOptionsDropdown';
 import ProgressTableV2 from './ProgressTableV2';
@@ -130,6 +131,7 @@ function SectionProgressV2({
 
           <UnitSelectorV2 className={styles.titleUnitSelectorDropdown} />
           <MoreOptionsDropdown />
+          <DownloadProgressCsv />
         </Heading6>
       </div>
       <ProgressTableV2 isSkeleton={isLoading} />

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -166,6 +166,14 @@ $level-cell-width: 52;
       margin-inline-start: 8px;
     }
   }
+
+  .downloadCsv {
+    display: flex;
+
+    button {
+      height: 32px;
+    }
+  }
 }
 
 .lesson {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -7834,6 +7834,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-csv@npm:^1.1.10":
+  version: 1.1.10
+  resolution: "@types/react-csv@npm:1.1.10"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10/424b3eefc565e5cc438cce3e64a1a6181be3ae2c9824570283dea7eccd4c31405e9ee88926ab1f8901817df47777fca2fab41e39dcf03c04b53817ba2353ae0d
+  languageName: node
+  linkType: hard
+
 "@types/react-dom@npm:^18.0.11":
   version: 18.0.11
   resolution: "@types/react-dom@npm:18.0.11"
@@ -10218,6 +10227,7 @@ __metadata:
     "@types/qrcode.react": "npm:^1.0.5"
     "@types/react": "npm:^18.0.28"
     "@types/react-bootstrap": "npm:^0.32.36"
+    "@types/react-csv": "npm:^1.1.10"
     "@types/react-dom": "npm:^18.0.11"
     "@types/react-router-dom": "npm:^5.3.3"
     "@types/react-select": "npm:^1.2.1"


### PR DESCRIPTION
Adds a small button to the progress page that will download CSV data. Currently, clicking on it just downloads a test file with two hard coded rows and columns.

This button is not currently called anywhere  and it will not show up without manually changing code. **NO user facing changes**

Position is not accurate in image.
![image](https://github.com/user-attachments/assets/42bbead1-c45e-4143-8f9d-185e205b47ac)

<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 
https://codedotorg.atlassian.net/browse/TEACH-1048