### PR TITLE
Python Lab Info Panel: fix level switching header bug

### DIFF
--- a/apps/src/codebridge/InfoPanel/InfoPanel.tsx
+++ b/apps/src/codebridge/InfoPanel/InfoPanel.tsx
@@ -90,7 +90,9 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
     // If we change levels and were on a panel that no longer exists,
     // switch to the first panel that does exist.
     if (!panelOptions.includes(currentPanel)) {
-      setCurrentPanel(panelOptions[0]);
+      const newPanel = panelOptions[0];
+      setCurrentPanel(newPanel);
+      setCurrentPanelHeader(panelHeaderNames[newPanel]);
     }
   }, [currentPanel, panelOptions]);
 


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

If we switched levels and were on an info panel tab that doesn't exist in the next level (i.e., "For Teacher's Only"), the header would still say "For Teacher's Only" but the contents would be the instructions. This fixes this issue.

## Before
https://github.com/user-attachments/assets/1a9955e1-7c90-4597-82eb-53c9402d09ad



## After
https://github.com/user-attachments/assets/aaeab12c-4081-43dd-a6cc-932f536702c8


## Links
- Jira: [CT-1160](https://codedotorg.atlassian.net/browse/CT-1160)

## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
