### PR TITLE
CMS-551: Move `EditorialCard` component `Layout` field to style group

### DIFF
--- a/frontend/apps/marketing/src/components/editorialCard/EditorialCardContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/editorialCard/EditorialCardContentfulDefinition.ts
@@ -22,7 +22,7 @@ export const EditorialCardContentfulComponentDefinition: ComponentDefinition = {
     layoutOpt: {
       displayName: 'Layout',
       type: 'Text',
-      group: 'content',
+      group: 'style',
       defaultValue: EDITORIAL_CARD_CONTENTFUL_LAYOUTS.HORIZONTAL_WITH_IMAGE,
       validations: {
         required: true,


### PR DESCRIPTION
<img width="100%" alt="design-tab" src="https://github.com/user-attachments/assets/1d0b9c1b-aafb-4511-b104-41ef8c736138" />

## Links
- JIRA task: [CMS-551](https://codedotorg.atlassian.net/browse/CMS-551)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/65413