### PR TITLE
CMS-518: Add `Rich Text` support for `FAQAccordion` component

### DIFF
--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -38,6 +38,7 @@
     "@code-dot-org/component-library": "workspace:*",
     "@code-dot-org/fonts": "workspace:*",
     "@contentful/experiences-sdk-react": "^1.37.1",
+    "@contentful/rich-text-html-renderer": "^17.0.0",
     "@next/third-parties": "^15.2.1",
     "@statsig/react-bindings": "^3.14.1",
     "@statsig/statsig-node-core": "^0.0.8",
@@ -48,6 +49,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-schemaorg": "^2.0.0",
+    "turndown": "^7.2.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
@@ -61,6 +63,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/turndown": "^5.0.5",
     "dotenv": "^16.4.7",
     "eslint": "^9.16.0",
     "eslint-plugin-jest": "^28.9.0",

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -39,6 +39,7 @@
     "@code-dot-org/fonts": "workspace:*",
     "@contentful/experiences-sdk-react": "^1.37.1",
     "@contentful/rich-text-html-renderer": "^17.0.0",
+    "@contentful/rich-text-plain-text-renderer": "^17.0.0",
     "@next/third-parties": "^15.2.1",
     "@statsig/react-bindings": "^3.14.1",
     "@statsig/statsig-node-core": "^0.0.8",
@@ -49,7 +50,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-schemaorg": "^2.0.0",
-    "turndown": "^7.2.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
@@ -63,7 +63,6 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@types/turndown": "^5.0.5",
     "dotenv": "^16.4.7",
     "eslint": "^9.16.0",
     "eslint-plugin-jest": "^28.9.0",

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
@@ -1,11 +1,17 @@
+import {documentToHtmlString} from '@contentful/rich-text-html-renderer';
 import {EntryFields, BaseEntry} from 'contentful';
 import {useMemo} from 'react';
+import TurndownService from 'turndown';
 
 import FAQAccordion, {
   FAQAccordionItem,
 } from '@code-dot-org/component-library/accordrion/faqAccordion';
 
-type FAQAccordionContentfulProps = {
+import RichText from '@/components/richText';
+
+import moduleStyles from './faqAccordion.module.scss';
+
+export type FAQAccordionContentfulProps = {
   faqs?: (BaseEntry & {
     fields: {
       question: EntryFields.Text | EntryFields.RichText;
@@ -26,33 +32,50 @@ const checkIfEntryFieldIsRichText = (
 const FAQAccordionContentful: React.FunctionComponent<
   FAQAccordionContentfulProps
 > = ({faqs}) => {
+  const htmlToMarkdownConverter = new TurndownService();
+
+  // Converts decorated inline elements to plain text for JSON-LD
+  htmlToMarkdownConverter.addRule('plainText', {
+    filter: ['p', 'b', 'strong', 'i', 'em'],
+    replacement: (content, node) =>
+      node.parentNode && ['P', 'LI'].includes(node.parentNode.nodeName)
+        ? content
+        : content + '\n\n',
+  });
+
   const faqItems = useMemo(
     () =>
       faqs?.filter(Boolean).map(faq => {
-        let id, question, questionString, answer, answerString;
+        let question, questionString, answer, answerString;
 
         if (checkIfEntryFieldIsRichText(faq, 'question')) {
-          question =
-            'Rich Text is not supported yet. Please use Text type instead';
-          questionString = question;
-          id = 'rich-text-not-supported-yet';
+          const richTextQuestion = faq.fields.question as EntryFields.RichText;
+          question = <RichText content={richTextQuestion} />;
+          questionString = htmlToMarkdownConverter.turndown(
+            documentToHtmlString(richTextQuestion),
+          );
         } else {
           question = faq.fields.question as string;
           questionString = question;
-          id = question.replace(' ', '-').toLowerCase();
         }
 
         if (checkIfEntryFieldIsRichText(faq, 'answer')) {
-          answer =
-            'Rich Text is not supported yet. Please use Text type instead';
-          answerString = answer;
+          const richTextAnswer = faq.fields.answer as EntryFields.RichText;
+          answer = (
+            <div className={moduleStyles.faqAccordionAnswer}>
+              <RichText content={richTextAnswer} />
+            </div>
+          );
+          answerString = htmlToMarkdownConverter.turndown(
+            documentToHtmlString(richTextAnswer),
+          );
         } else {
           answer = faq.fields.answer as string;
           answerString = answer;
         }
 
         return {
-          id,
+          id: questionString,
           label: question,
           questionString,
           content: answer,
@@ -75,7 +98,9 @@ const FAQAccordionContentful: React.FunctionComponent<
     );
   }
 
-  return <FAQAccordion items={faqItems} />;
+  return (
+    <FAQAccordion className={moduleStyles.faqAccordion} items={faqItems} />
+  );
 };
 
 export default FAQAccordionContentful;

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
@@ -1,4 +1,5 @@
 import {documentToHtmlString} from '@contentful/rich-text-html-renderer';
+import {BLOCKS} from '@contentful/rich-text-types';
 import {EntryFields, BaseEntry} from 'contentful';
 import {useMemo} from 'react';
 import TurndownService from 'turndown';
@@ -20,14 +21,10 @@ export type FAQAccordionContentfulProps = {
   })[];
 };
 
-const checkIfEntryFieldIsRichText = (
-  entry: BaseEntry & {
-    fields: {[key: string]: EntryFields.Text | EntryFields.RichText};
-  },
-  fieldName: string,
-) =>
-  typeof entry.fields[fieldName] !== 'string' &&
-  'content' in entry.fields[fieldName];
+const isRichText = (
+  field: EntryFields.Text | EntryFields.RichText,
+): field is EntryFields.RichText =>
+  typeof field === 'object' && field?.nodeType === BLOCKS.DOCUMENT;
 
 const FAQAccordionContentful: React.FunctionComponent<
   FAQAccordionContentfulProps
@@ -48,26 +45,24 @@ const FAQAccordionContentful: React.FunctionComponent<
       faqs?.filter(Boolean).map(faq => {
         let question, questionString, answer, answerString;
 
-        if (checkIfEntryFieldIsRichText(faq, 'question')) {
-          const richTextQuestion = faq.fields.question as EntryFields.RichText;
-          question = <RichText content={richTextQuestion} />;
+        if (isRichText(faq.fields.question)) {
+          question = <RichText content={faq.fields.question} />;
           questionString = htmlToMarkdownConverter.turndown(
-            documentToHtmlString(richTextQuestion),
+            documentToHtmlString(faq.fields.question),
           );
         } else {
           question = faq.fields.question as string;
           questionString = question;
         }
 
-        if (checkIfEntryFieldIsRichText(faq, 'answer')) {
-          const richTextAnswer = faq.fields.answer as EntryFields.RichText;
+        if (isRichText(faq.fields.answer)) {
           answer = (
             <div className={moduleStyles.faqAccordionAnswer}>
-              <RichText content={richTextAnswer} />
+              <RichText content={faq.fields.answer} />
             </div>
           );
           answerString = htmlToMarkdownConverter.turndown(
-            documentToHtmlString(richTextAnswer),
+            documentToHtmlString(faq.fields.answer),
           );
         } else {
           answer = faq.fields.answer as string;

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
@@ -51,7 +51,7 @@ const FAQAccordionContentful: React.FunctionComponent<
             documentToHtmlString(faq.fields.question),
           );
         } else {
-          question = faq.fields.question as string;
+          question = faq.fields.question;
           questionString = question;
         }
 
@@ -65,7 +65,7 @@ const FAQAccordionContentful: React.FunctionComponent<
             documentToHtmlString(faq.fields.answer),
           );
         } else {
-          answer = faq.fields.answer as string;
+          answer = faq.fields.answer;
           answerString = answer;
         }
 

--- a/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/FAQAccordion.tsx
@@ -1,8 +1,8 @@
 import {documentToHtmlString} from '@contentful/rich-text-html-renderer';
+import {documentToPlainTextString} from '@contentful/rich-text-plain-text-renderer';
 import {BLOCKS} from '@contentful/rich-text-types';
 import {EntryFields, BaseEntry} from 'contentful';
 import {useMemo} from 'react';
-import TurndownService from 'turndown';
 
 import FAQAccordion, {
   FAQAccordionItem,
@@ -29,17 +29,6 @@ const isRichText = (
 const FAQAccordionContentful: React.FunctionComponent<
   FAQAccordionContentfulProps
 > = ({faqs}) => {
-  const htmlToMarkdownConverter = new TurndownService();
-
-  // Converts decorated inline elements to plain text for JSON-LD
-  htmlToMarkdownConverter.addRule('plainText', {
-    filter: ['p', 'b', 'strong', 'i', 'em'],
-    replacement: (content, node) =>
-      node.parentNode && ['P', 'LI'].includes(node.parentNode.nodeName)
-        ? content
-        : content + '\n\n',
-  });
-
   const faqItems = useMemo(
     () =>
       faqs?.filter(Boolean).map(faq => {
@@ -47,9 +36,8 @@ const FAQAccordionContentful: React.FunctionComponent<
 
         if (isRichText(faq.fields.question)) {
           question = <RichText content={faq.fields.question} />;
-          questionString = htmlToMarkdownConverter.turndown(
-            documentToHtmlString(faq.fields.question),
-          );
+          // See: https://developers.google.com/search/docs/appearance/structured-data/faqpage#question
+          questionString = documentToPlainTextString(faq.fields.question);
         } else {
           question = faq.fields.question;
           questionString = question;
@@ -61,9 +49,10 @@ const FAQAccordionContentful: React.FunctionComponent<
               <RichText content={faq.fields.answer} />
             </div>
           );
-          answerString = htmlToMarkdownConverter.turndown(
-            documentToHtmlString(faq.fields.answer),
-          );
+          // See: https://developers.google.com/search/docs/appearance/structured-data/faqpage#answer
+          answerString = documentToHtmlString(faq.fields.answer, {
+            preserveWhitespace: true,
+          });
         } else {
           answer = faq.fields.answer;
           answerString = answer;

--- a/frontend/apps/marketing/src/components/faqAccordion/__tests__/FAQAccordion.test.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/__tests__/FAQAccordion.test.tsx
@@ -8,6 +8,7 @@ import {
   ListItem,
 } from '@contentful/rich-text-types';
 import {render, screen} from '@testing-library/react';
+import {escape} from 'lodash';
 
 import FAQAccordion from '@/components/faqAccordion/FAQAccordion';
 
@@ -90,11 +91,11 @@ describe('FAQAccordion component', () => {
       expect(screen.getByText(questionText)).toBeVisible();
       expect(screen.getByText(answerText)).toBeInTheDocument();
       expect(queryJsonLdScript()).toHaveTextContent(
-        buildJsonLdContent(questionText, answerText),
+        buildJsonLdContent(questionText, escape(`<p>${answerText}</p>`)),
       );
     });
 
-    it('renders with bold text as plain text in JSON-LD script', () => {
+    it('renders with bold text in valid JSON-LD script format', () => {
       renderComponent({
         faqs: [
           {
@@ -115,11 +116,11 @@ describe('FAQAccordion component', () => {
       });
 
       expect(queryJsonLdScript()).toHaveTextContent(
-        buildJsonLdContent(questionText, answerText),
+        buildJsonLdContent(questionText, escape(`<p><b>${answerText}</b></p>`)),
       );
     });
 
-    it('renders with italic text as plain text in JSON-LD script', () => {
+    it('renders with italic text in valid JSON-LD script format', () => {
       renderComponent({
         faqs: [
           {
@@ -140,11 +141,11 @@ describe('FAQAccordion component', () => {
       });
 
       expect(queryJsonLdScript()).toHaveTextContent(
-        buildJsonLdContent(questionText, answerText),
+        buildJsonLdContent(questionText, escape(`<p><i>${answerText}</i></p>`)),
       );
     });
 
-    it('renders link in markdown format for JSON-LD script', () => {
+    it('renders link in valid JSON-LD script format', () => {
       const questionLinkHref = 'https://question.example';
       const answerLinkHref = 'https://answer.example';
 
@@ -187,17 +188,17 @@ describe('FAQAccordion component', () => {
 
       expect(queryJsonLdScript()).toHaveTextContent(
         buildJsonLdContent(
-          `[${questionText}](${questionLinkHref})`,
-          `[${answerText}](${answerLinkHref})`,
+          `${questionText}`,
+          escape(`<p><a href="${answerLinkHref}">${answerText}</a></p>`),
         ),
       );
     });
 
-    it('renders lists in markdown format for JSON-LD script', () => {
+    it('renders unordered list in valid JSON-LD script format', () => {
       const questionListItemA = questionText + ' A';
       const questionListItemB = questionText + ' B';
-      const answerListItem1 = answerText + ' 1';
-      const answerListItem2 = answerText + ' 2';
+      const answerListItemA = answerText + ' A';
+      const answerListItemB = answerText + ' B';
 
       renderComponent({
         faqs: [
@@ -210,6 +211,51 @@ describe('FAQAccordion component', () => {
                   content: [
                     buildRichTextListItem(questionListItemA),
                     buildRichTextListItem(questionListItemB),
+                  ],
+                },
+              ]),
+              answer: buildRichTextDocument([
+                {
+                  nodeType: BLOCKS.UL_LIST,
+                  data: {},
+                  content: [
+                    buildRichTextListItem(answerListItemA),
+                    buildRichTextListItem(answerListItemB),
+                  ],
+                },
+              ]),
+            },
+          },
+        ],
+      });
+
+      expect(queryJsonLdScript()).toHaveTextContent(
+        buildJsonLdContent(
+          `${questionListItemA} ${questionListItemB}`,
+          escape(
+            `<ul><li><p>${answerListItemA}</p></li><li><p>${answerListItemB}</p></li></ul>`,
+          ),
+        ),
+      );
+    });
+
+    it('renders ordered list in valid JSON-LD script format', () => {
+      const questionListItem1 = questionText + ' 1';
+      const questionListItem2 = questionText + ' 2';
+      const answerListItem1 = answerText + ' 1';
+      const answerListItem2 = answerText + ' 2';
+
+      renderComponent({
+        faqs: [
+          {
+            fields: {
+              question: buildRichTextDocument([
+                {
+                  nodeType: BLOCKS.OL_LIST,
+                  data: {},
+                  content: [
+                    buildRichTextListItem(questionListItem1),
+                    buildRichTextListItem(questionListItem2),
                   ],
                 },
               ]),
@@ -230,8 +276,10 @@ describe('FAQAccordion component', () => {
 
       expect(queryJsonLdScript()).toHaveTextContent(
         buildJsonLdContent(
-          `* ${questionListItemA}\n* ${questionListItemB}`,
-          `1. ${answerListItem1}\n2. ${answerListItem2}`,
+          `${questionListItem1} ${questionListItem2}`,
+          escape(
+            `<ol><li><p>${answerListItem1}</p></li><li><p>${answerListItem2}</p></li></ol>`,
+          ),
         ),
       );
     });

--- a/frontend/apps/marketing/src/components/faqAccordion/__tests__/FAQAccordion.test.tsx
+++ b/frontend/apps/marketing/src/components/faqAccordion/__tests__/FAQAccordion.test.tsx
@@ -1,0 +1,239 @@
+import {
+  BLOCKS,
+  INLINES,
+  MARKS,
+  Document,
+  TopLevelBlock,
+  Paragraph,
+  ListItem,
+} from '@contentful/rich-text-types';
+import {render, screen} from '@testing-library/react';
+
+import FAQAccordion from '@/components/faqAccordion/FAQAccordion';
+
+describe('FAQAccordion component', () => {
+  const buildJsonLdContent = (question: string, answer: string) =>
+    JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: question,
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: answer,
+          },
+        },
+      ],
+    });
+
+  const renderComponent = (props: object = {}) =>
+    render(<FAQAccordion {...props} />);
+
+  it('renders empty content placeholder', () => {
+    renderComponent({});
+
+    const placeholder = screen.getByText(
+      (_, node) =>
+        node?.tagName === 'EM' &&
+        !!node?.textContent?.includes('FAQ Accordion placeholder'),
+    );
+
+    expect(placeholder).toBeVisible();
+  });
+
+  const queryJsonLdScript = () =>
+    document.querySelector('script[type="application/ld+json"]');
+
+  describe('with Rich Text FAQ content', () => {
+    const questionText = 'Test Question';
+    const answerText = 'Test Answer';
+
+    const buildRichTextDocument = (content: TopLevelBlock[]): Document => ({
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: content,
+    });
+
+    const buildRichTextParagraph = (
+      value: string,
+      content = {},
+    ): Paragraph => ({
+      nodeType: BLOCKS.PARAGRAPH,
+      data: {},
+      content: [{nodeType: 'text', marks: [], data: {}, ...content, value}],
+    });
+
+    const buildRichTextListItem = (value: string): ListItem => ({
+      nodeType: BLOCKS.LIST_ITEM,
+      data: {},
+      content: [buildRichTextParagraph(value)],
+    });
+
+    it('renders accordion with provided content', () => {
+      renderComponent({
+        faqs: [
+          {
+            fields: {
+              question: buildRichTextDocument([
+                buildRichTextParagraph(questionText),
+              ]),
+              answer: buildRichTextDocument([
+                buildRichTextParagraph(answerText),
+              ]),
+            },
+          },
+        ],
+      });
+
+      expect(screen.getByText(questionText)).toBeVisible();
+      expect(screen.getByText(answerText)).toBeInTheDocument();
+      expect(queryJsonLdScript()).toHaveTextContent(
+        buildJsonLdContent(questionText, answerText),
+      );
+    });
+
+    it('renders with bold text as plain text in JSON-LD script', () => {
+      renderComponent({
+        faqs: [
+          {
+            fields: {
+              question: buildRichTextDocument([
+                buildRichTextParagraph(questionText, {
+                  marks: [{type: MARKS.BOLD}],
+                }),
+              ]),
+              answer: buildRichTextDocument([
+                buildRichTextParagraph(answerText, {
+                  marks: [{type: MARKS.BOLD}],
+                }),
+              ]),
+            },
+          },
+        ],
+      });
+
+      expect(queryJsonLdScript()).toHaveTextContent(
+        buildJsonLdContent(questionText, answerText),
+      );
+    });
+
+    it('renders with italic text as plain text in JSON-LD script', () => {
+      renderComponent({
+        faqs: [
+          {
+            fields: {
+              question: buildRichTextDocument([
+                buildRichTextParagraph(questionText, {
+                  marks: [{type: MARKS.ITALIC}],
+                }),
+              ]),
+              answer: buildRichTextDocument([
+                buildRichTextParagraph(answerText, {
+                  marks: [{type: MARKS.ITALIC}],
+                }),
+              ]),
+            },
+          },
+        ],
+      });
+
+      expect(queryJsonLdScript()).toHaveTextContent(
+        buildJsonLdContent(questionText, answerText),
+      );
+    });
+
+    it('renders link in markdown format for JSON-LD script', () => {
+      const questionLinkHref = 'https://question.example';
+      const answerLinkHref = 'https://answer.example';
+
+      renderComponent({
+        faqs: [
+          {
+            fields: {
+              question: buildRichTextDocument([
+                buildRichTextParagraph(questionText, {
+                  nodeType: INLINES.HYPERLINK,
+                  data: {uri: questionLinkHref},
+                  content: [
+                    {
+                      nodeType: 'text',
+                      value: questionText,
+                      marks: [],
+                      data: {},
+                    },
+                  ],
+                }),
+              ]),
+              answer: buildRichTextDocument([
+                buildRichTextParagraph(answerText, {
+                  nodeType: INLINES.HYPERLINK,
+                  data: {uri: answerLinkHref},
+                  content: [
+                    {
+                      nodeType: 'text',
+                      value: answerText,
+                      marks: [],
+                      data: {},
+                    },
+                  ],
+                }),
+              ]),
+            },
+          },
+        ],
+      });
+
+      expect(queryJsonLdScript()).toHaveTextContent(
+        buildJsonLdContent(
+          `[${questionText}](${questionLinkHref})`,
+          `[${answerText}](${answerLinkHref})`,
+        ),
+      );
+    });
+
+    it('renders lists in markdown format for JSON-LD script', () => {
+      const questionListItemA = questionText + ' A';
+      const questionListItemB = questionText + ' B';
+      const answerListItem1 = answerText + ' 1';
+      const answerListItem2 = answerText + ' 2';
+
+      renderComponent({
+        faqs: [
+          {
+            fields: {
+              question: buildRichTextDocument([
+                {
+                  nodeType: BLOCKS.UL_LIST,
+                  data: {},
+                  content: [
+                    buildRichTextListItem(questionListItemA),
+                    buildRichTextListItem(questionListItemB),
+                  ],
+                },
+              ]),
+              answer: buildRichTextDocument([
+                {
+                  nodeType: BLOCKS.OL_LIST,
+                  data: {},
+                  content: [
+                    buildRichTextListItem(answerListItem1),
+                    buildRichTextListItem(answerListItem2),
+                  ],
+                },
+              ]),
+            },
+          },
+        ],
+      });
+
+      expect(queryJsonLdScript()).toHaveTextContent(
+        buildJsonLdContent(
+          `* ${questionListItemA}\n* ${questionListItemB}`,
+          `1. ${answerListItem1}\n2. ${answerListItem2}`,
+        ),
+      );
+    });
+  });
+});

--- a/frontend/apps/marketing/src/components/faqAccordion/faqAccordion.module.scss
+++ b/frontend/apps/marketing/src/components/faqAccordion/faqAccordion.module.scss
@@ -1,0 +1,5 @@
+.faqAccordion {
+  .faqAccordionAnswer {
+    padding: 1.25rem;
+  }
+}

--- a/frontend/apps/marketing/src/components/richText/RichText.tsx
+++ b/frontend/apps/marketing/src/components/richText/RichText.tsx
@@ -22,6 +22,7 @@ import SimpleList, {
 import {
   BodyTwoText,
   StrongText,
+  EmText,
 } from '@code-dot-org/component-library/typography';
 
 import moduleStyles from './richText.module.scss';
@@ -43,20 +44,21 @@ const extractNodeContent = (node: RichTextNode): ReactNode[] => {
       ? node.content.map(extractNodeContent).flat()
       : [];
 
-  const isBold = (node: Text): boolean =>
-    node.marks.some(({type}: Mark) => type === MARKS.BOLD);
-
   switch (node.nodeType) {
-    case 'text':
-      return node.value
-        ? [
-            isBold(node) ? (
-              <StrongText key={node.value}>{node.value}</StrongText>
-            ) : (
-              node.value
-            ),
-          ]
-        : [];
+    case 'text': {
+      return [
+        node.marks.reduce((value: ReactNode, {type}: Mark) => {
+          switch (type) {
+            case MARKS.BOLD:
+              return <StrongText key={type} children={value} />;
+            case MARKS.ITALIC:
+              return <EmText key={type} children={value} />;
+            default:
+              return value;
+          }
+        }, node.value),
+      ];
+    }
     case INLINES.HYPERLINK: {
       const linkContent = getContent();
       return [
@@ -85,9 +87,8 @@ const richTextRenderOptions: Options = {
     [BLOCKS.UL_LIST]: (listNode: Block | Inline) => (
       <SimpleList
         items={listNode.content.map(
-          (itemNode: RichTextNode): SimpleListItem => {
-            const listItemContent = extractNodeContent(itemNode);
-            return {key: listItemContent.join('-'), label: listItemContent};
+          (itemNode: RichTextNode, index): SimpleListItem => {
+            return {key: index, label: extractNodeContent(itemNode)};
           },
         )}
       />

--- a/frontend/apps/marketing/src/components/richText/RichText.tsx
+++ b/frontend/apps/marketing/src/components/richText/RichText.tsx
@@ -73,6 +73,7 @@ const extractNodeContent = (node: RichTextNode): ReactNode[] => {
 };
 
 const richTextRenderOptions: Options = {
+  preserveWhitespace: true,
   renderNode: {
     [BLOCKS.PARAGRAPH]: (paragraphNode: RichTextNode) => {
       const paragraphContent = extractNodeContent(paragraphNode);

--- a/frontend/apps/marketing/src/components/richText/RichText.tsx
+++ b/frontend/apps/marketing/src/components/richText/RichText.tsx
@@ -50,9 +50,9 @@ const extractNodeContent = (node: RichTextNode): ReactNode[] => {
         node.marks.reduce((value: ReactNode, {type}: Mark) => {
           switch (type) {
             case MARKS.BOLD:
-              return <StrongText key={type} children={value} />;
+              return <StrongText key={type + value} children={value} />;
             case MARKS.ITALIC:
-              return <EmText key={type} children={value} />;
+              return <EmText key={type + value} children={value} />;
             default:
               return value;
           }

--- a/frontend/apps/marketing/src/components/richText/__tests__/RichText.test.tsx
+++ b/frontend/apps/marketing/src/components/richText/__tests__/RichText.test.tsx
@@ -1,11 +1,11 @@
 import {
   BLOCKS,
   INLINES,
+  MARKS,
   Document,
   TopLevelBlock,
 } from '@contentful/rich-text-types';
 import {render, screen} from '@testing-library/react';
-import '@testing-library/jest-dom';
 
 import RichText, {RichTextProps} from '@/components/richText/RichText';
 
@@ -68,7 +68,7 @@ describe('RichText component', () => {
             {
               nodeType: 'text',
               value: paragraphText,
-              marks: [{type: 'bold'}],
+              marks: [{type: MARKS.BOLD}],
               data: {},
             },
           ],
@@ -79,6 +79,32 @@ describe('RichText component', () => {
     const paragraph = screen.getByText(paragraphText);
     expect(paragraph).toBeVisible();
     expect(paragraph.tagName).toBe('STRONG');
+    expect(paragraph.parentElement).toHaveRole('paragraph');
+  });
+
+  it('renders paragraph with italic text', () => {
+    const paragraphText = 'Test Paragraph';
+
+    renderComponent({
+      content: buildRichTextDocument([
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: paragraphText,
+              marks: [{type: MARKS.ITALIC}],
+              data: {},
+            },
+          ],
+        },
+      ]),
+    });
+
+    const paragraph = screen.getByText(paragraphText);
+    expect(paragraph).toBeVisible();
+    expect(paragraph.tagName).toBe('EM');
     expect(paragraph.parentElement).toHaveRole('paragraph');
   });
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1086,6 +1086,7 @@ __metadata:
     "@code-dot-org/component-library": "workspace:*"
     "@code-dot-org/fonts": "workspace:*"
     "@contentful/experiences-sdk-react": "npm:^1.37.1"
+    "@contentful/rich-text-html-renderer": "npm:^17.0.0"
     "@next/eslint-plugin-next": "npm:^15.0.3"
     "@next/third-parties": "npm:^15.2.1"
     "@playwright/test": "npm:~1.49.1"
@@ -1099,6 +1100,7 @@ __metadata:
     "@types/node": "npm:^20"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
+    "@types/turndown": "npm:^5.0.5"
     contentful: "npm:^11.2.5"
     cookies-next: "npm:^5.1.0"
     dotenv: "npm:^16.4.7"
@@ -1115,6 +1117,7 @@ __metadata:
     schema-dts: "npm:^1.1.5"
     stylelint: "npm:^16.14.1"
     ts-node: "npm:^10.9.2"
+    turndown: "npm:^7.2.0"
     typescript: "npm:^5"
     uuid: "npm:^11.1.0"
   languageName: unknown
@@ -1209,6 +1212,16 @@ __metadata:
     react: ">=17.0.0"
     react-dom: ">=17.0.0"
   checksum: 10c0/d3942e08cfd06efae01463a835a168103b2a01afc85f45c6253ef48cd4331bfeb94b8f6a1e876aee8e87c688f19d06514da17b35a1ab6e90875829c98d8f8ab8
+  languageName: node
+  linkType: hard
+
+"@contentful/rich-text-html-renderer@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "@contentful/rich-text-html-renderer@npm:17.0.0"
+  dependencies:
+    "@contentful/rich-text-types": "npm:^17.0.0"
+    escape-html: "npm:^1.0.3"
+  checksum: 10c0/cbc48d53c52753e61158c099b936924cdea957323d41188320629da9396dc82ad01b40bf583d3faba9c8ce03a25e8ac699d66af6429036511d82eaf235de86d7
   languageName: node
   linkType: hard
 
@@ -3198,6 +3211,13 @@ __metadata:
     "@types/react": ">=16"
     react: ">=16"
   checksum: 10c0/381ed1211ba2b8491bf0ad9ef0d8d1badcdd114e1931d55d44019d4b827cc2752586708f9c7d2f9c3244150ed81f1f671a6ca95fae0edd5797fb47a22e06ceca
+  languageName: node
+  linkType: hard
+
+"@mixmark-io/domino@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@mixmark-io/domino@npm:2.2.0"
+  checksum: 10c0/aa468a15f9217d425220fe6a4b3f9416cbe8e566ee14efc191c6d5cc04fe39338b16a90bbac190f28d44e69465db5f2cf95f479c621ce38060ca6b2a3d346e9d
   languageName: node
   linkType: hard
 
@@ -5575,6 +5595,13 @@ __metadata:
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
+  languageName: node
+  linkType: hard
+
+"@types/turndown@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "@types/turndown@npm:5.0.5"
+  checksum: 10c0/d6b4f8451caf72399f36f810461baf5f3b5e958ff216388bb3324a9949079daad31d970a28a140b3571db8793908396e757329334f5dc8bcff414698b8c31113
   languageName: node
   linkType: hard
 
@@ -9509,6 +9536,13 @@ __metadata:
   version: 4.0.0
   resolution: "escape-goat@npm:4.0.0"
   checksum: 10c0/9d2a8314e2370f2dd9436d177f6b3b1773525df8f895c8f3e1acb716f5fd6b10b336cb1cd9862d4709b36eb207dbe33664838deca9c6d55b8371be4eebb972f6
+  languageName: node
+  linkType: hard
+
+"escape-html@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "escape-html@npm:1.0.3"
+  checksum: 10c0/524c739d776b36c3d29fa08a22e03e8824e3b2fd57500e5e44ecf3cc4707c34c60f9ca0781c0e33d191f2991161504c295e98f68c78fe7baa6e57081ec6ac0a3
   languageName: node
   linkType: hard
 
@@ -18275,6 +18309,15 @@ __metadata:
   bin:
     turbo: bin/turbo
   checksum: 10c0/cad6a7b16d2cdaa15fe75efe1938d335cb026c073dfe639aaf2dce4c4d10ecc6a63216689682c1d1f7238ceed56f6e4ba736aa1b738aec70afb66f770e7c3817
+  languageName: node
+  linkType: hard
+
+"turndown@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "turndown@npm:7.2.0"
+  dependencies:
+    "@mixmark-io/domino": "npm:^2.2.0"
+  checksum: 10c0/6abcdcdf9d35cd79d7a8100a7de1d2226b921d5bd99e73ac14a7ead39c059978f519378913375efb04c68bcfc40f7ffe2dee0ce9ae4d54dc1235b12856a78d4e
   languageName: node
   linkType: hard
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1087,6 +1087,7 @@ __metadata:
     "@code-dot-org/fonts": "workspace:*"
     "@contentful/experiences-sdk-react": "npm:^1.37.1"
     "@contentful/rich-text-html-renderer": "npm:^17.0.0"
+    "@contentful/rich-text-plain-text-renderer": "npm:^17.0.0"
     "@next/eslint-plugin-next": "npm:^15.0.3"
     "@next/third-parties": "npm:^15.2.1"
     "@playwright/test": "npm:~1.49.1"
@@ -1100,7 +1101,6 @@ __metadata:
     "@types/node": "npm:^20"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
-    "@types/turndown": "npm:^5.0.5"
     contentful: "npm:^11.2.5"
     cookies-next: "npm:^5.1.0"
     dotenv: "npm:^16.4.7"
@@ -1117,7 +1117,6 @@ __metadata:
     schema-dts: "npm:^1.1.5"
     stylelint: "npm:^16.14.1"
     ts-node: "npm:^10.9.2"
-    turndown: "npm:^7.2.0"
     typescript: "npm:^5"
     uuid: "npm:^11.1.0"
   languageName: unknown
@@ -1222,6 +1221,15 @@ __metadata:
     "@contentful/rich-text-types": "npm:^17.0.0"
     escape-html: "npm:^1.0.3"
   checksum: 10c0/cbc48d53c52753e61158c099b936924cdea957323d41188320629da9396dc82ad01b40bf583d3faba9c8ce03a25e8ac699d66af6429036511d82eaf235de86d7
+  languageName: node
+  linkType: hard
+
+"@contentful/rich-text-plain-text-renderer@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "@contentful/rich-text-plain-text-renderer@npm:17.0.0"
+  dependencies:
+    "@contentful/rich-text-types": "npm:^17.0.0"
+  checksum: 10c0/ae9fe420e6cfb82a83e5dda2d26cfa6bb9c18a365e5bee0f1e2ed4f74c69641053cf3dffc97c548c82ff08e93bbe81a470fee3bc6c651ecda3678e581955e9ed
   languageName: node
   linkType: hard
 
@@ -3211,13 +3219,6 @@ __metadata:
     "@types/react": ">=16"
     react: ">=16"
   checksum: 10c0/381ed1211ba2b8491bf0ad9ef0d8d1badcdd114e1931d55d44019d4b827cc2752586708f9c7d2f9c3244150ed81f1f671a6ca95fae0edd5797fb47a22e06ceca
-  languageName: node
-  linkType: hard
-
-"@mixmark-io/domino@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@mixmark-io/domino@npm:2.2.0"
-  checksum: 10c0/aa468a15f9217d425220fe6a4b3f9416cbe8e566ee14efc191c6d5cc04fe39338b16a90bbac190f28d44e69465db5f2cf95f479c621ce38060ca6b2a3d346e9d
   languageName: node
   linkType: hard
 
@@ -5595,13 +5596,6 @@ __metadata:
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
-  languageName: node
-  linkType: hard
-
-"@types/turndown@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "@types/turndown@npm:5.0.5"
-  checksum: 10c0/d6b4f8451caf72399f36f810461baf5f3b5e958ff216388bb3324a9949079daad31d970a28a140b3571db8793908396e757329334f5dc8bcff414698b8c31113
   languageName: node
   linkType: hard
 
@@ -18309,15 +18303,6 @@ __metadata:
   bin:
     turbo: bin/turbo
   checksum: 10c0/cad6a7b16d2cdaa15fe75efe1938d335cb026c073dfe639aaf2dce4c4d10ecc6a63216689682c1d1f7238ceed56f6e4ba736aa1b738aec70afb66f770e7c3817
-  languageName: node
-  linkType: hard
-
-"turndown@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "turndown@npm:7.2.0"
-  dependencies:
-    "@mixmark-io/domino": "npm:^2.2.0"
-  checksum: 10c0/6abcdcdf9d35cd79d7a8100a7de1d2226b921d5bd99e73ac14a7ead39c059978f519378913375efb04c68bcfc40f7ffe2dee0ce9ae4d54dc1235b12856a78d4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Preview
<img width="100%" alt="preview" src="https://github.com/user-attachments/assets/22c9aa0f-3fad-4edf-a558-cf8f9b25bbd8" />

## Rich Text
<img width="100%" alt="rich-text-answer" src="https://github.com/user-attachments/assets/c952ee72-3658-4333-a7cc-91faf2f9d444" />

## JSON-LD
<img width="100%" alt="script" src="https://github.com/user-attachments/assets/50d68f73-b15a-4257-a547-e2d7b35e4057" />
<img width="100%" alt="rich-result-test" src="https://github.com/user-attachments/assets/2ed54630-1352-4184-a2b2-b4249bf728a4" />


## Links
- JIRA task: [CMS-518](https://codedotorg.atlassian.net/browse/CMS-518)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/65246