### PR TITLE
CMS-43: Remove `EditorialCard` background color

### DIFF
--- a/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
+++ b/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
@@ -2,7 +2,6 @@
 
 // EditorialCard common styles
 .editorialCard {
-  background: var(--background-neutral-primary);
   display: flex;
   gap: 1.5rem;
   width: fit-content;


### PR DESCRIPTION
<img width="100%" alt="preview" src="https://github.com/user-attachments/assets/0049a236-4ff7-4796-83e9-f346ccb183ee" />

## Links
- JIRA task: [CMS-43](https://codedotorg.atlassian.net/browse/CMS-43)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/65352