### PR TITLE
seed courses for previously standalone units

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -312,6 +312,7 @@ namespace :seed do
        csp-2017
        csp-2019
        20-hour
+       algebra
        allthemigratedthings
        alltheselfpacedplthings
        allthettsthings
@@ -332,6 +333,7 @@ namespace :seed do
        coursec-2019
        coursee-2019
        coursea-2020
+       csp-ap
        interactive-games-animations-2023
        interactive-games-animations-2024
        customizing-llms-2024


### PR DESCRIPTION
This PR adds 2 courses that should be seeded on test builds. The units `algebra` and `csp-ap` were standalone-units prior to the standalone-unit migration. I missed adding these courses during the migration PRs. It was discovered during the data backfill of `original_unit_group_id`.