### PR TITLE
feat(Header): add shadow

### DIFF
--- a/frontend/packages/component-library/src/cms/header/header.module.scss
+++ b/frontend/packages/component-library/src/cms/header/header.module.scss
@@ -6,7 +6,9 @@
 $desktop-breakpoint: 1268px;
 $tablet-breakpoint: 1023px;
 $mobile-breakpoint: 425px;
-$box-shadow: 0 2px 6px 0 rgb(0 0 0 / 0.08);
+$box-shadow:
+  0px 4px 6px -1px rgb(0 0 0 / 0.1),
+  0px 2px 4px -1px rgb(0 0 0 / 0.06);
 
 // Header common styles
 .headerNavigation {
@@ -16,6 +18,7 @@ $box-shadow: 0 2px 6px 0 rgb(0 0 0 / 0.08);
   display: flex;
   justify-content: space-between;
   z-index: variables.$zindex-fixed;
+  box-shadow: $box-shadow;
 }
 
 // Main links styles


### PR DESCRIPTION
Adds a subtle shadow to the header to add depth if it's used with a similar color section. Also updates the border style on the menus to match.

## Links
Jira ticket: [CMS-604](https://codedotorg.atlassian.net/browse/CMS-604)

## Testing story
Tested locally, and this will have Eyes diffs

----

## On teal

https://github.com/user-attachments/assets/f24b70ea-ba31-41e3-bc2f-27201ac61925

## On white


https://github.com/user-attachments/assets/f5d3a321-ba0d-4962-8f08-fab6df029f1c

