### PR TITLE
AI Chat: handle file retrieval errors

### DIFF
--- a/apps/src/aichat/views/assets/FilePreview.tsx
+++ b/apps/src/aichat/views/assets/FilePreview.tsx
@@ -14,7 +14,8 @@ const FilePreview: React.FC<{
   url: string;
   isUploading?: boolean;
   onRemove?: () => void;
-}> = ({type, filename, url, isUploading, onRemove}) => {
+  onLoadError?: () => void;
+}> = ({type, filename, url, isUploading, onRemove, onLoadError}) => {
   const imageRef = useRef<HTMLImageElement>(null);
   const [imageLoaded, setImageLoaded] = useState<boolean>(false);
 
@@ -28,16 +29,23 @@ const FilePreview: React.FC<{
       setImageLoaded(true);
     };
 
+    const handleError = () => {
+      onLoadError?.();
+      setImageLoaded(true);
+    };
+
     if (imageElement.complete) {
       handleLoad();
     } else {
       imageElement.addEventListener('load', handleLoad);
+      imageElement.addEventListener('error', handleError);
     }
 
     return () => {
       imageElement.removeEventListener('load', handleLoad);
+      imageElement.removeEventListener('error', handleError);
     };
-  }, []);
+  }, [url, onLoadError]);
 
   return (
     <div className={styles[`preview-${type}`]} title={filename}>

--- a/apps/src/aichat/views/assets/FilePreview.tsx
+++ b/apps/src/aichat/views/assets/FilePreview.tsx
@@ -30,8 +30,8 @@ const FilePreview: React.FC<{
     };
 
     const handleError = () => {
-      onLoadError?.();
       setImageLoaded(true);
+      onLoadError?.();
     };
 
     if (imageElement.complete) {

--- a/apps/src/aichat/views/assets/FilePreview.tsx
+++ b/apps/src/aichat/views/assets/FilePreview.tsx
@@ -84,12 +84,14 @@ const FilePreview: React.FC<{
         <div
           className={!imageLoaded ? styles['preview-image-loading'] : undefined}
         >
-          <img
-            alt=""
-            src={url}
-            ref={imageRef}
-            className={(!imageLoaded && styles.hide) || undefined}
-          />
+          {!isUploading && (
+            <img
+              alt=""
+              src={url}
+              ref={imageRef}
+              className={(!imageLoaded && styles.hide) || undefined}
+            />
+          )}
         </div>
       ) : (
         <>

--- a/apps/src/aichat/views/assets/StagedFilesPreview.tsx
+++ b/apps/src/aichat/views/assets/StagedFilesPreview.tsx
@@ -1,11 +1,16 @@
 import Alert, {type AlertProps} from '@code-dot-org/component-library/alert';
 import React from 'react';
 
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {MAX_FILE_SIZE_MB, MAX_NUM_FILES} from '../../constants';
 import aichatI18n from '../../locale';
-import {clearStagedFilesAlert, removeStagedFile} from '../../redux';
+import {
+  clearStagedFilesAlert,
+  removeStagedFile,
+  stagedFileUploadFinished,
+} from '../../redux';
 import {getAssetUrl} from '../../utils';
 
 import FilePreview from './FilePreview';
@@ -51,10 +56,24 @@ const StagedFilesPreview: React.FC = () => {
             <FilePreview
               key={key}
               type={filename.endsWith('.pdf') ? 'pdf' : 'image'}
-              url={getAssetUrl(asset, currentChannelId, levelName)}
+              url={`${getAssetUrl(
+                asset,
+                currentChannelId,
+                levelName
+              )}?t=${key}`}
               filename={filename}
               isUploading={status === 'uploading'}
               onRemove={() => dispatch(removeStagedFile(key))}
+              onLoadError={() => {
+                dispatch(
+                  stagedFileUploadFinished({key, status: 'uploadFailed'})
+                );
+                Lab2Registry.getInstance()
+                  .getMetricsReporter()
+                  .logError('Error loading staged file', undefined, {
+                    asset,
+                  });
+              }}
             />
           );
         })}


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

## Summary

We've been seeing some intermittent errors where we fail to fetch an asset file after it's been successfully uploaded. It's not immediately clear why this is happening; my best guess is that we try to fetch too quickly after a file is uploaded to S3 and the 404 NOT FOUND response is cached somewhere or on the user's browser. This change adds a few mitigations to help prevent and diagnose these issues:

- Clear loading spinner, staged file, and display error banner if there was an error fetching the image URL
- Log an error to cloudwatch
- Add the asset `key` as a cache bust suffix to make sure we make a fresh request every time after we re-upload.

I don't think this will fix the 404s in the first place - but it means that if there a 404, 1) the staged file will be automatically removed and the error banner will be shown, and 2) when the user tries to re-upload the file, we'll fetch it with a new suffix (because we would have generated a new key) and therefore shouldn't try to load the cached 404 response.

Screencast (happen to somehow capture an actual 404). The small screen size doesn't show it, but note that the URL suffixes for the "HipHop.png" requests are different between the 404 and the successful response.

https://github.com/user-attachments/assets/0eab4b9a-d732-4583-abc7-1b846f53ce76

Error log payload:
<img width="940" alt="Screenshot 2025-04-24 at 11 58 57 AM" src="https://github.com/user-attachments/assets/9b6ca908-2149-481e-860b-135dcaf4c39f" />

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1437

## Testing story

Tested locally with intermittent (real) 404s, and manually stubbing a 404 response.