### PR TITLE
[Python Lab] Unify drag & drop keyboard behavior

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowser.tsx
@@ -1,6 +1,11 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
 import {
+  dragAndDropKeyboardCodes,
+  fileBrowserCollisionDetector,
+  fileBrowserKeyboardCoordinateGetter,
+} from '@codebridge/utils/dragAndDropUtils';
+import {
   DndContext,
   DragStartEvent,
   DragOverEvent,
@@ -20,10 +25,6 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {DndDataContextProvider} from './DnDDataContextProvider';
-import {
-  fileBrowserCollisionDetector,
-  fileBrowserKeyboardCoordinateGetter,
-} from './dragAndDropUtils';
 import {Droppable} from './Droppable';
 import {FileBrowserHeaderPopUpButton} from './FileBrowserHeaderPopUpButton';
 import {useHandleDragEnd} from './hooks';
@@ -65,13 +66,7 @@ export const FileBrowser = React.memo(() => {
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: fileBrowserKeyboardCoordinateGetter(projectFolders),
-      keyboardCodes: {
-        // Start dragging on 'm', so 'enter' and 'space' can be used to open/close a folder.
-        // TODO: expose a menu to users of our keyboard options, until then this is a hidden feature.
-        start: ['KeyM'],
-        cancel: ['Escape'],
-        end: ['KeyM', 'Enter', 'Space'],
-      },
+      keyboardCodes: dragAndDropKeyboardCodes,
     })
   );
 

--- a/apps/src/codebridge/FileTabs/FileTabs.tsx
+++ b/apps/src/codebridge/FileTabs/FileTabs.tsx
@@ -1,5 +1,6 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {getOpenFiles} from '@codebridge/utils';
+import {dragAndDropKeyboardCodes} from '@codebridge/utils/dragAndDropUtils';
 import {
   DndContext,
   DragEndEvent,
@@ -41,6 +42,7 @@ export const FileTabs = React.memo(() => {
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
+      keyboardCodes: dragAndDropKeyboardCodes,
     })
   );
   const [draggingFileId, setDraggingFileId] = useState<string | null>(null);
@@ -66,6 +68,12 @@ export const FileTabs = React.memo(() => {
     }
   }
 
+  function handleTabActivation(event: React.KeyboardEvent, fileId: string) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      setActiveFile(fileId);
+    }
+  }
+
   return (
     <div className={moduleStyles.fileTabs}>
       <DndContext
@@ -77,7 +85,12 @@ export const FileTabs = React.memo(() => {
       >
         <SortableContext items={files} strategy={horizontalListSortingStrategy}>
           {files.map(f => (
-            <Sortable id={f.id} key={f.id} isDragging={f.id === draggingFileId}>
+            <Sortable
+              id={f.id}
+              key={f.id}
+              isDragging={f.id === draggingFileId}
+              onKeyDown={event => handleTabActivation(event, f.id)}
+            >
               <FileTab file={f} />
             </Sortable>
           ))}

--- a/apps/src/codebridge/FileTabs/FileTabs.tsx
+++ b/apps/src/codebridge/FileTabs/FileTabs.tsx
@@ -1,6 +1,9 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {getOpenFiles} from '@codebridge/utils';
-import {dragAndDropKeyboardCodes} from '@codebridge/utils/dragAndDropUtils';
+import {
+  dragAndDropKeyboardCodes,
+  sortableKeyboardCoordinatesWithTab,
+} from '@codebridge/utils/dragAndDropUtils';
 import {
   DndContext,
   DragEndEvent,
@@ -20,7 +23,6 @@ import {
   arrayMove,
   horizontalListSortingStrategy,
   SortableContext,
-  sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable';
 import React, {useState} from 'react';
 
@@ -41,7 +43,7 @@ export const FileTabs = React.memo(() => {
       },
     }),
     useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
+      coordinateGetter: sortableKeyboardCoordinatesWithTab,
       keyboardCodes: dragAndDropKeyboardCodes,
     })
   );
@@ -70,6 +72,7 @@ export const FileTabs = React.memo(() => {
 
   function handleTabActivation(event: React.KeyboardEvent, fileId: string) {
     if (event.key === 'Enter' || event.key === ' ') {
+      // We don't stop event propagation here because we want the close button to work.
       setActiveFile(fileId);
     }
   }

--- a/apps/src/codebridge/FileTabs/Sortable.tsx
+++ b/apps/src/codebridge/FileTabs/Sortable.tsx
@@ -24,6 +24,10 @@ const Sortable: React.FunctionComponent<SortableProps> = ({
     opacity: isDragging ? 0.3 : 1.0,
   };
 
+  // Call the provided onKeyDown function if it exists,
+  // then call the listeners.onKeyDown function if it exists.
+  // This allows for custom keyboard handling while still
+  // allowing the default keyboard handling provided by dnd-kit.
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (onKeyDown) {
       onKeyDown(event);

--- a/apps/src/codebridge/FileTabs/Sortable.tsx
+++ b/apps/src/codebridge/FileTabs/Sortable.tsx
@@ -6,12 +6,14 @@ interface SortableProps {
   id: string;
   isDragging: boolean;
   children: React.ReactNode;
+  onKeyDown?: (event: React.KeyboardEvent) => void;
 }
 
 const Sortable: React.FunctionComponent<SortableProps> = ({
   id,
   isDragging,
   children,
+  onKeyDown,
 }) => {
   const {attributes, listeners, setNodeRef, transform, transition} =
     useSortable({id});
@@ -22,8 +24,23 @@ const Sortable: React.FunctionComponent<SortableProps> = ({
     opacity: isDragging ? 0.3 : 1.0,
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (onKeyDown) {
+      onKeyDown(event);
+    }
+    if (listeners?.onKeyDown) {
+      listeners?.onKeyDown(event);
+    }
+  };
+
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      onKeyDown={handleKeyDown}
+    >
       {children}
     </div>
   );

--- a/apps/src/codebridge/utils/dragAndDropUtils.ts
+++ b/apps/src/codebridge/utils/dragAndDropUtils.ts
@@ -1,4 +1,6 @@
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
+import {DragType} from '@codebridge/FileBrowser/types';
+import {getFolderChildren} from '@codebridge/utils';
 import {
   KeyboardCode,
   KeyboardCoordinateGetter,
@@ -11,10 +13,6 @@ import {
 import {RectMap} from '@dnd-kit/core/dist/store';
 
 import {ProjectFolder} from '@cdo/apps/lab2/types';
-
-import {getFolderChildren} from '../utils/getFolderChildren';
-
-import {DragType} from './types';
 
 export const FOLDER_DROP_OFFSET = 16;
 
@@ -197,4 +195,12 @@ export const getHighestPriorityCollision = (
   });
 
   return [rectangleCollisions[0]];
+};
+
+export const dragAndDropKeyboardCodes = {
+  // Start dragging on 'm', so 'enter' and 'space' can be used to open/close a file/folder.
+  // TODO: expose a menu to users of our keyboard options, until then this is a hidden feature.
+  start: ['KeyM'],
+  cancel: ['Escape'],
+  end: ['KeyM'],
 };

--- a/apps/src/codebridge/utils/dragAndDropUtils.ts
+++ b/apps/src/codebridge/utils/dragAndDropUtils.ts
@@ -11,6 +11,7 @@ import {
   ClientRect,
 } from '@dnd-kit/core';
 import {RectMap} from '@dnd-kit/core/dist/store';
+import {sortableKeyboardCoordinates} from '@dnd-kit/sortable';
 
 import {ProjectFolder} from '@cdo/apps/lab2/types';
 
@@ -195,6 +196,22 @@ export const getHighestPriorityCollision = (
   });
 
   return [rectangleCollisions[0]];
+};
+
+// Extend sortableKeyboardCoordinates to support tab and shift+tab to move items.
+export const sortableKeyboardCoordinatesWithTab: KeyboardCoordinateGetter = (
+  event,
+  args
+) => {
+  if (event.code === KeyboardCode.Tab && event.shiftKey) {
+    // Shift tab is equivalent to left arrow
+    sortableKeyboardCoordinates({...event, code: KeyboardCode.Left}, args);
+  } else if (event.code === KeyboardCode.Tab) {
+    // Tab is equivalent to right arrow
+    sortableKeyboardCoordinates({...event, code: KeyboardCode.Right}, args);
+  }
+  // Otherwise, call the original function
+  return sortableKeyboardCoordinates(event, args);
 };
 
 export const dragAndDropKeyboardCodes = {

--- a/apps/src/codebridge/utils/dragAndDropUtils.ts
+++ b/apps/src/codebridge/utils/dragAndDropUtils.ts
@@ -204,14 +204,23 @@ export const sortableKeyboardCoordinatesWithTab: KeyboardCoordinateGetter = (
   args
 ) => {
   if (event.code === KeyboardCode.Tab && event.shiftKey) {
+    event.preventDefault();
+    const newEvent = new KeyboardEvent('keydown', {
+      code: KeyboardCode.Left,
+    });
     // Shift tab is equivalent to left arrow
-    sortableKeyboardCoordinates({...event, code: KeyboardCode.Left}, args);
+    return sortableKeyboardCoordinates(newEvent, args);
   } else if (event.code === KeyboardCode.Tab) {
     // Tab is equivalent to right arrow
-    sortableKeyboardCoordinates({...event, code: KeyboardCode.Right}, args);
+    event.preventDefault();
+    const newEvent = new KeyboardEvent('keydown', {
+      code: KeyboardCode.Right,
+    });
+    return sortableKeyboardCoordinates(newEvent, args);
+  } else {
+    // Otherwise, call the original function
+    return sortableKeyboardCoordinates(event, args);
   }
-  // Otherwise, call the original function
-  return sortableKeyboardCoordinates(event, args);
 };
 
 export const dragAndDropKeyboardCodes = {

--- a/apps/src/codebridge/utils/dragAndDropUtils.ts
+++ b/apps/src/codebridge/utils/dragAndDropUtils.ts
@@ -228,5 +228,5 @@ export const dragAndDropKeyboardCodes = {
   // TODO: expose a menu to users of our keyboard options, until then this is a hidden feature.
   start: ['KeyM'],
   cancel: ['Escape'],
-  end: ['KeyM'],
+  end: ['KeyM', 'Enter', 'Space'],
 };

--- a/apps/test/unit/codebridge/utils/dragAndDropUtilsTest.ts
+++ b/apps/test/unit/codebridge/utils/dragAndDropUtilsTest.ts
@@ -4,7 +4,7 @@ import {
   fileBrowserKeyboardCoordinateGetter,
   FOLDER_DROP_OFFSET,
   getHighestPriorityCollision,
-} from '@cdo/apps/codebridge/FileBrowser/dragAndDropUtils';
+} from '@cdo/apps/codebridge/utils/dragAndDropUtils';
 
 import {
   folders,
@@ -14,7 +14,7 @@ import {
   folderActive,
   sampleDroppableRects,
   fileActive,
-} from './dragAndDropSampleData';
+} from '../FileBrowser/dragAndDropSampleData';
 
 describe('dragAndDropUtils', () => {
   describe('Keyboard coordinate getter', () => {


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

## Summary

This PR makes both the file tabs and file browser have the same keyboard behavior for drag & drop. The behavior is as follows:
- Tab to the item you want to drag
- Press 'm'
- Use the arrow keys (up/down for file browesr, left/right for tabs) or tab/shift+tab to move the item
- Press 'm' again to finish
- You can press esc to cancel the drag

As I was working on this, I also fixed the issue where you could not close a file tab with the keyboard. This was happening because it turned out activating a tab with enter was being handled by drag & drop. I added a specific keyboard handler to open a file, and had it not stop propagating events, so now you can also close a tab with the keyboard

## Screen recording
In this recording I move the tabs both with the arrow keys and tab/shift+tab


https://github.com/user-attachments/assets/36b4e3d9-c75c-4152-9fdb-16c5a1e13cea


## Links

- Jira: [CT-1201](https://codedotorg.atlassian.net/browse/CT-1201)

## Testing story
Tested locally.

## Follow-up work
We have to still customize the screen reader instructions to tell users to use the 'm' key to move files, and update the python lab docs with this information as well.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
