### PR TITLE
AI Chat: hide onboarding modal on levelbuilder

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -7,7 +7,11 @@ import {useSelector} from 'react-redux';
 import TeacherOnboardingModal from '@cdo/apps/aichat/views/TeacherOnboardingModal';
 import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarningModal';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
+import {
+  isLevelbuilderEnvironment,
+  tryGetLocalStorage,
+  trySetLocalStorage,
+} from '@cdo/apps/utils';
 
 import {ModalTypes} from '../constants';
 import aichatI18n from '../locale';
@@ -98,6 +102,11 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   );
 
   useEffect(() => {
+    // Skip showing the modal on levelbuilder
+    if (isLevelbuilderEnvironment()) {
+      return;
+    }
+
     const teacherSawAichatOnboardingModal = tryGetLocalStorage(
       'teacherSawAichatOnboarding',
       'no'

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -953,6 +953,10 @@ export function isTestEnvironment() {
   return getEnvironment() === Environments.test;
 }
 
+export function isLevelbuilderEnvironment() {
+  return getEnvironment() === Environments.levelbuilder;
+}
+
 export function isProductionEnvironment() {
   return getEnvironment() === Environments.production;
 }


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

## Summary

Hides the AI Chat warning/onboarding modal on levelbuilder. This is especially cumbersome on levelbuilder because level editors are frequently switching between the level edit page and the lab, which requires a full page reload and causes the modal to show every time.

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1424