### PR TITLE
AI Chat: fix TypeError when asset not found

### DIFF
--- a/dashboard/app/helpers/aichat_asset_helper.rb
+++ b/dashboard/app/helpers/aichat_asset_helper.rb
@@ -10,7 +10,7 @@ module AichatAssetHelper
 
     unless result && result[:status] == 'FOUND'
       raise StandardError.new(
-        "Error fetching asset #{{**asset, channel_id: channel_id, level_name: level_name, **result}}"
+        "Error fetching asset #{{asset: asset, channel_id: channel_id, level_name: level_name, result: result}}"
         )
     end
 
@@ -24,9 +24,10 @@ module AichatAssetHelper
     if source == 'level'
       level = Level.find_by(name: level_name)
       uuid_name = (level&.starter_assets || level&.project_template_level&.starter_assets || {})&.dig(filename)
-      return nil if uuid_name.nil?
+      return {status: 'NOT_FOUND'} if uuid_name.nil?
       s3_object = LevelStarterAssetsHelper.get_object(uuid_name)
       return {status: 'FOUND', body: s3_object.get.body} if s3_object
     end
+    {status: 'NOT_FOUND'}
   end
 end

--- a/dashboard/test/helpers/aichat_asset_helper_test.rb
+++ b/dashboard/test/helpers/aichat_asset_helper_test.rb
@@ -55,15 +55,20 @@ class AichatAssetHelperTest < ActionView::TestCase
       end
     end
 
-    context 'when fetch_asset returns nil' do
+    context 'when fetch_asset returns NOT_FOUND' do
       let(:asset) {missing_asset}
 
       before do
-        AichatAssetHelper.stubs(:fetch_asset).with("missing.png", "level", channel_id, level_name).returns(nil)
+        AichatAssetHelper.stubs(:fetch_asset).with("missing.png", "level", channel_id, level_name).returns({status: 'NOT_FOUND'})
       end
 
       it 'raises an error' do
-        -> {subject}.must_raise(StandardError)
+        err = -> {subject}.must_raise(StandardError)
+        err.message.must_include "Error fetching asset"
+        err.message.must_include "missing.png"
+        err.message.must_include channel_id
+        err.message.must_include level_name
+        err.message.must_include "NOT_FOUND"
       end
     end
   end
@@ -91,8 +96,8 @@ class AichatAssetHelperTest < ActionView::TestCase
         )
       end
 
-      it 'returns nil' do
-        subject.must_be_nil
+      it 'returns NOT_FOUND' do
+        subject[:status].must_equal 'NOT_FOUND'
       end
     end
 


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

## Summary

@bencodeorg noticed some [Honeybadger errors](https://app.honeybadger.io/projects/3240/faults/119675265) where we're throwing a `TypeError` when an asset is not found. An asset being missing is a legitimate error, but the `TypeError` suggests that either `asset` or `result` is `nil`, masking the actual error. This attempts to fix this by removing the double splat, and making sure we don't return `nil` from `fetch_asset`.