### PR TITLE
allow 4 byte emoji in lesson properties

### DIFF
--- a/dashboard/db/migrate/20250424231217_set_lesson_properties_to_utf8mb4.rb
+++ b/dashboard/db/migrate/20250424231217_set_lesson_properties_to_utf8mb4.rb
@@ -1,0 +1,13 @@
+class SetLessonPropertiesToUtf8mb4 < ActiveRecord::Migration[6.1]
+  def up
+    # in order to increase from 3 to 4 bytes per character without increasing
+    # the column size, we need to ensure there are no rows with observations
+    # longer than 48K characters. Spot-checking reveals the longest existing
+    # entry is only 4K.
+    execute 'alter table stages modify properties text charset utf8mb4 collate utf8mb4_unicode_ci'
+  end
+
+  def down
+    execute 'alter table stages modify properties text charset utf8 collate utf8_unicode_ci'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_04_23_171750) do
+ActiveRecord::Schema.define(version: 2025_04_24_231217) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2176,7 +2176,7 @@ ActiveRecord::Schema.define(version: 2025_04_23_171750) do
     t.datetime "updated_at"
     t.boolean "lockable", default: false, null: false
     t.integer "relative_position", null: false
-    t.text "properties"
+    t.text "properties", collation: "utf8mb4_unicode_ci"
     t.integer "lesson_group_id"
     t.string "key", null: false
     t.boolean "has_lesson_plan", null: false


### PR DESCRIPTION
See discussion in [slack](https://codedotorg.slack.com/archives/C045UAX4WKH/p1745537256233399?thread_ts=1745535278.991609&cid=C045UAX4WKH). Copies the approach from https://github.com/code-dot-org/code-dot-org/pull/63285

## Testing story

manually verified that there are no entries too long for mysql `text` fields in the production db:
```
mysql> select max(length(properties)) from stages;
+-------------------------+
| max(length(properties)) |
+-------------------------+
|                    4289 |
+-------------------------+
```
