### PR TITLE
Updates focus outline of popupButtons and resize bars

### DIFF
--- a/apps/src/codebridge/PopUpButton/PopUpButton.module.scss
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.module.scss
@@ -3,11 +3,23 @@
 .popup-button-menu {
   position: absolute;
   cursor: pointer;
-  border: 1px solid #54595E;
+  border: 1px solid #54595e;
   background-color: $light_gray_950;
   color: $white;
   min-width: 100px;
   text-align: left;
   vertical-align: top;
   z-index: 1000;
+
+  &:focus-visible {
+    outline: var(--borders-brand-teal-primary) solid 2px;
+    outline-offset: 2px;
+    border-radius: 0.375rem;
+  }
+  // Apply focus-visible styles to all child elements
+  *:focus-visible {
+    outline: var(--borders-brand-teal-primary) solid 2px;
+    outline-offset: 2px;
+    border-radius: 0.375rem;
+  }
 }

--- a/apps/src/lab2/views/components/layout/resizeBar.module.scss
+++ b/apps/src/lab2/views/components/layout/resizeBar.module.scss
@@ -8,7 +8,6 @@ $bar-width-grab-area: 7px;
 $grab-area-offset: calc(($bar-width-grab-area - $visible-area) / 2);
 $negative-grab-area-offset: calc(-1 * $grab-area-offset);
 
-
 .resizeBar {
   background-color: $light_gray_800;
   flex-shrink: 0;
@@ -53,21 +52,48 @@ $negative-grab-area-offset: calc(-1 * $grab-area-offset);
   cursor: row-resize;
 }
 
-
 .horizontalGrabbable {
-  @include horizontal-absolute-bar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
+  @include horizontal-absolute-bar(
+    $bar-width-grab-area,
+    $negative-grab-area-offset,
+    $grab-area-offset
+  );
 }
 
 .verticalGrabbable {
-  @include vertical-absolute-bar($bar-width-grab-area, $negative-grab-area-offset, $grab-area-offset);
+  @include vertical-absolute-bar(
+    $bar-width-grab-area,
+    $negative-grab-area-offset,
+    $grab-area-offset
+  );
 }
 
 .verticalResizing {
-  @include vertical-absolute-bar($visible-area, $visible-negative-area-offset, $visible-area-offset);
+  @include vertical-absolute-bar(
+    $visible-area,
+    $visible-negative-area-offset,
+    $visible-area-offset
+  );
+
+  &:focus-visible {
+    outline: var(--borders-brand-teal-primary) solid 2px;
+    outline-offset: 2px;
+    border-radius: 0.375rem;
+  }
 }
 
 .horizontalResizing {
-  @include horizontal-absolute-bar($visible-area, $visible-negative-area-offset, $visible-area-offset);
+  @include horizontal-absolute-bar(
+    $visible-area,
+    $visible-negative-area-offset,
+    $visible-area-offset
+  );
+
+  &:focus-visible {
+    outline: var(--borders-brand-teal-primary) solid 2px;
+    outline-offset: 2px;
+    border-radius: 0.375rem;
+  }
 }
 
 .visible {


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

This is an attempt to unify the focus colors to align with our new branding when it comes to visible focus while keyboard navigating. I will tackle the drag and drop elements in a followup PR, as they use a library that will make updating the styling a little more complex. 


I copied the styling on the button asset to match the existing focus-visible branding.


Before:

<img width="621" alt="Screenshot 2025-04-24 at 5 22 22 PM" src="https://github.com/user-attachments/assets/bacc7cfc-3046-41c1-860b-f70bc0629be9" />
<img width="1428" alt="Screenshot 2025-04-24 at 5 22 14 PM" src="https://github.com/user-attachments/assets/bcd64e52-accc-4cfd-bc9c-cbcf022eb824" />
<img width="255" alt="Screenshot 2025-04-24 at 5 22 00 PM" src="https://github.com/user-attachments/assets/2e842939-e11e-4e15-8d43-408980864e88" />
<img width="294" alt="Screenshot 2025-04-24 at 5 21 49 PM" src="https://github.com/user-attachments/assets/89ac2ee9-3750-417c-a46c-de5b1753f10c" />


After:

<img width="602" alt="Screenshot 2025-04-24 at 5 10 24 PM" src="https://github.com/user-attachments/assets/5949f9d7-2e5f-4130-8da5-ac6bab63d6ed" />
<img width="244" alt="Screenshot 2025-04-24 at 5 19 35 PM" src="https://github.com/user-attachments/assets/5e0ebfc4-1467-4165-b003-a8cff5d2c8d7" />
<img width="376" alt="Screenshot 2025-04-24 at 5 18 53 PM" src="https://github.com/user-attachments/assets/a5f76822-5d1b-46ba-a395-b59e158e12d5" />
<img width="373" alt="Screenshot 2025-04-24 at 5 15 53 PM" src="https://github.com/user-attachments/assets/fef34d9a-f7b8-4193-ac16-ca5a8f703a23" />
<img width="1484" alt="Screenshot 2025-04-24 at 5 10 35 PM" src="https://github.com/user-attachments/assets/933a8946-68f6-461e-a67d-6060c865a00f" />


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1226

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
