### PR TITLE
SUM - change threshold

### DIFF
--- a/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
@@ -40,7 +40,7 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
   openDetailedAnalysis,
 }) => {
   const currentUserId = useAppSelector(state => state.currentUser.userId);
-  const proficienceyThreshold = totalNumberOfStudents * 0.8;
+  const proficienceyThreshold = totalNumberOfStudents * 0.75;
   const aiSummaryTag = (proficiencyCount: number) => {
     return (
       <Tags
@@ -76,8 +76,8 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
       <BodyTwoText>
         <strong>{`${i18n.reasoning()}: `}</strong>
         {proficiencyCount > proficienceyThreshold
-          ? 'More than 80% of the students demonstrated proficiency in their responses. '
-          : 'Less than 80% of the students demonstrated proficiency in their responses. '}
+          ? 'More than 75% of the students demonstrated proficiency in their responses. '
+          : 'Less than 75% of the students demonstrated proficiency in their responses. '}
         <Link
           type="primary"
           size="m"

--- a/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
@@ -40,21 +40,22 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
   openDetailedAnalysis,
 }) => {
   const currentUserId = useAppSelector(state => state.currentUser.userId);
-  const proficienceyThreshold = totalNumberOfStudents * 0.75;
+  const PROFICIENCY_PERCENT = 0.75;
+  const proficiencyStudentGoal = totalNumberOfStudents * PROFICIENCY_PERCENT;
   const aiSummaryTag = (proficiencyCount: number) => {
+    const sectionMeetsProficiencyThreshold =
+      proficiencyCount >= proficiencyStudentGoal;
     return (
       <Tags
         tagsList={[
           {
-            label:
-              proficiencyCount > proficienceyThreshold
-                ? FEEDBACK_TYPE.PROFICIENT.label
-                : FEEDBACK_TYPE.NEEDS_REVIEW.label,
+            label: sectionMeetsProficiencyThreshold
+              ? FEEDBACK_TYPE.PROFICIENT.label
+              : FEEDBACK_TYPE.NEEDS_REVIEW.label,
             icon: {
-              iconName:
-                proficiencyCount > proficienceyThreshold
-                  ? FEEDBACK_TYPE.PROFICIENT.icon
-                  : FEEDBACK_TYPE.NEEDS_REVIEW.icon,
+              iconName: sectionMeetsProficiencyThreshold
+                ? FEEDBACK_TYPE.PROFICIENT.icon
+                : FEEDBACK_TYPE.NEEDS_REVIEW.icon,
               iconStyle: 'solid',
               title: 'check',
               placement: 'left',
@@ -63,7 +64,7 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
         ]}
         size="l"
         className={
-          proficiencyCount > proficienceyThreshold
+          sectionMeetsProficiencyThreshold
             ? styles.proficientTag
             : styles.needsReviewTag
         }
@@ -75,7 +76,7 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
     <>
       <BodyTwoText>
         <strong>{`${i18n.reasoning()}: `}</strong>
-        {proficiencyCount >= proficienceyThreshold
+        {proficiencyCount >= proficiencyStudentGoal
           ? '75% or more of the students demonstrated proficiency in their responses. '
           : 'Less than 75% of the students demonstrated proficiency in their responses. '}
         <Link

--- a/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAiSummaryBox.tsx
@@ -75,8 +75,8 @@ const FreeResponseAiSummaryBox: React.FC<FreeResponseAiSummaryBoxProps> = ({
     <>
       <BodyTwoText>
         <strong>{`${i18n.reasoning()}: `}</strong>
-        {proficiencyCount > proficienceyThreshold
-          ? 'More than 75% of the students demonstrated proficiency in their responses. '
+        {proficiencyCount >= proficienceyThreshold
+          ? '75% or more of the students demonstrated proficiency in their responses. '
           : 'Less than 75% of the students demonstrated proficiency in their responses. '}
         <Link
           type="primary"


### PR DESCRIPTION
Based on the bug bash, we decided to make 75% the threshold for the number of students who need to be proficient in the level in order to move on. 

I modified this threshold and also made it >= so that if in a class of 4 students, 3 would need to get "proficient" to be able to get the overall tag of "proficient" 