### PR TITLE
A11Y-134 Remove __useDeprecatedTag from syncOmniAuthSectionControl

### DIFF
--- a/apps/src/accounts/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/accounts/SyncOmniAuthSectionControl.jsx
@@ -241,7 +241,7 @@ export function SyncOmniAuthSectionButton({
       disabled={[IN_PROGRESS, DISABLED].includes(buttonState)}
       onClick={onClick}
       {...iconProps(buttonState)}
-      style={{float: 'left'}}
+      style={{float: 'left', margin: '0'}}
       title={
         buttonState === DISABLED
           ? i18n.ltiSectionSyncButtonDisabledAltText()

--- a/apps/src/accounts/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/accounts/SyncOmniAuthSectionControl.jsx
@@ -199,7 +199,6 @@ class SyncOmniAuthSectionControl extends React.Component {
           </div>
           <div style={styles.closeButton}>
             <Button
-              __useDeprecatedTag
               text={i18n.closeDialog()}
               onClick={this.closeDialog}
               color={Button.ButtonColor.gray}
@@ -236,7 +235,6 @@ export function SyncOmniAuthSectionButton({
 }) {
   return (
     <Button
-      __useDeprecatedTag
       text={buttonText(buttonState, provider, providerName)}
       color={Button.ButtonColor.gray}
       size={Button.ButtonSize.default}


### PR DESCRIPTION
This PR removes the `__useDeprecatedTag` from the Button elements in the `syncOmniAuthSectionControl` component.

## Links

- Jira: [A11Y-134](https://codedotorg.atlassian.net/browse/A11Y-134)

## Testing story

| Before | After |
|-------|-------|
| <img width="1050" alt="Screenshot 2025-04-25 at 13 04 49" src="https://github.com/user-attachments/assets/196f66fc-03ea-4a4b-9a35-68b6fd9d1a1f" /> | <img width="1050" alt="Screenshot 2025-04-25 at 13 03 59" src="https://github.com/user-attachments/assets/a3e3ff8b-bcab-4756-902b-ca63522b0359" /> |

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
