### PR TITLE
feat(Header): hook up `/api/v1/users/signed_in` endpoint

### DIFF
--- a/frontend/apps/marketing/.lighthouserc.js
+++ b/frontend/apps/marketing/.lighthouserc.js
@@ -1,7 +1,7 @@
 const assertions = {
   'bf-cache': 'off',
   'color-contrast': 'off',
-  'errors-in-console': 'off',
+  'errors-in-console': ['error', {maxLength: 1}],
   'inspector-issues': 'off',
   'offscreen-images': ['error', {minScore: 0.5, maxLength: 3}],
   'total-byte-weight': ['error', {minScore: 0.5}],

--- a/frontend/apps/marketing/.lighthouserc.js
+++ b/frontend/apps/marketing/.lighthouserc.js
@@ -1,7 +1,7 @@
 const assertions = {
   'bf-cache': 'off',
   'color-contrast': 'off',
-  'errors-in-console': ['error', {maxLength: 1}],
+  'errors-in-console': ['error', {maxLength: 2}],
   'inspector-issues': 'off',
   'offscreen-images': ['error', {minScore: 0.5, maxLength: 3}],
   'total-byte-weight': ['error', {minScore: 0.5}],

--- a/frontend/apps/marketing/.lighthouserc.js
+++ b/frontend/apps/marketing/.lighthouserc.js
@@ -1,6 +1,7 @@
 const assertions = {
   'bf-cache': 'off',
   'color-contrast': 'off',
+  'errors-in-console': 'off',
   'inspector-issues': 'off',
   'offscreen-images': ['error', {minScore: 0.5, maxLength: 3}],
   'total-byte-weight': ['error', {minScore: 0.5}],

--- a/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
+++ b/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
@@ -58,7 +58,7 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
       text="Loading"
       className={classNames(
         isInHamburger ? moduleStyles.hamburger : moduleStyles.mainMenu,
-        moduleStyles.pending,
+        moduleStyles.loading,
       )}
       type="primary"
       href="#"

--- a/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
+++ b/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
@@ -55,7 +55,7 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
 
   const renderPlaceholderButton = () => (
     <LinkButton
-      text={'Loading'}
+      text="Loading"
       className={classNames(
         isInHamburger ? moduleStyles.hamburger : moduleStyles.mainMenu,
         moduleStyles.pending,

--- a/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
+++ b/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
@@ -44,7 +44,7 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
   const renderAccountButtons = () => {
     switch (signInState) {
       case 'loading':
-        return <span className={moduleStyles.loading}>Loading...</span>;
+        return renderPlaceholderButton();
       case 'signedIn':
         return renderDashboardButton();
       case 'signedOut':
@@ -52,6 +52,22 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
         return renderSignInButtons();
     }
   };
+
+  const renderPlaceholderButton = () => (
+    <LinkButton
+      text={'Loading'}
+      className={classNames(
+        isInHamburger ? moduleStyles.hamburger : moduleStyles.mainMenu,
+        moduleStyles.pending,
+      )}
+      type="primary"
+      href="#"
+      size="s"
+      color={isInHamburger ? 'purple' : 'white'}
+      isPending={signInState === 'loading'}
+      disabled
+    />
+  );
 
   const renderDashboardButton = () => (
     <LinkButton

--- a/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
+++ b/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
@@ -28,7 +28,7 @@ export interface AccountButtonsProps extends HTMLAttributes<HTMLElement> {
     href: string;
   };
   /** Is user logged in */
-  isLoggedIn: boolean;
+  isSignedIn: boolean;
   /** Is button in Hamburger Menu */
   isInHamburger: boolean;
 }
@@ -37,7 +37,7 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
   signIn,
   createAccount,
   goToDashboard,
-  isLoggedIn = false,
+  isSignedIn = false,
   isInHamburger,
 }) => {
   const renderDashboardButton = () => (
@@ -103,7 +103,7 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
 
   return (
     <div className={moduleStyles.accountLinks}>
-      {isLoggedIn ? renderDashboardButton() : renderSignInButtons()}
+      {isSignedIn ? renderDashboardButton() : renderSignInButtons()}
     </div>
   );
 };

--- a/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
+++ b/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
@@ -27,8 +27,8 @@ export interface AccountButtonsProps extends HTMLAttributes<HTMLElement> {
     /** Go to Dashboard button href */
     href: string;
   };
-  /** Is user logged in */
-  isSignedIn: boolean;
+  /** Render state for if a user is signed in */
+  signInState: 'loading' | 'signedIn' | 'signedOut' | 'error';
   /** Is button in Hamburger Menu */
   isInHamburger: boolean;
 }
@@ -37,9 +37,21 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
   signIn,
   createAccount,
   goToDashboard,
-  isSignedIn = false,
+  signInState,
   isInHamburger,
 }) => {
+  const renderAccountButtons = () => {
+    switch (signInState) {
+      case 'loading':
+        return <span className={moduleStyles.loading}>Loading...</span>;
+      case 'signedIn':
+        return renderDashboardButton();
+      case 'signedOut':
+      case 'error':
+        return renderSignInButtons();
+    }
+  };
+
   const renderDashboardButton = () => (
     <LinkButton
       text={goToDashboard.label || 'Go to Dashboard'}
@@ -101,10 +113,9 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
     );
   };
 
+  console.log(signInState);
   return (
-    <div className={moduleStyles.accountLinks}>
-      {isSignedIn ? renderDashboardButton() : renderSignInButtons()}
-    </div>
+    <div className={moduleStyles.accountLinks}>{renderAccountButtons()}</div>
   );
 };
 

--- a/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
+++ b/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
@@ -1,7 +1,9 @@
 import classNames from 'classnames';
-import {HTMLAttributes} from 'react';
+import {HTMLAttributes, useContext} from 'react';
 
 import {LinkButton, LinkButtonProps} from '@/button';
+
+import SignInContext from './context/signInContext';
 
 import moduleStyles from './header.module.scss';
 
@@ -27,8 +29,6 @@ export interface AccountButtonsProps extends HTMLAttributes<HTMLElement> {
     /** Go to Dashboard button href */
     href: string;
   };
-  /** Render state for if a user is signed in */
-  signInState: 'loading' | 'signedIn' | 'signedOut' | 'error';
   /** Is button in Hamburger Menu */
   isInHamburger: boolean;
 }
@@ -37,9 +37,10 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
   signIn,
   createAccount,
   goToDashboard,
-  signInState,
   isInHamburger,
 }) => {
+  const signInState = useContext(SignInContext);
+
   const renderAccountButtons = () => {
     switch (signInState) {
       case 'loading':

--- a/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
+++ b/frontend/packages/component-library/src/cms/header/AccountButtons.tsx
@@ -114,7 +114,6 @@ const AccountButtons: React.FC<AccountButtonsProps> = ({
     );
   };
 
-  console.log(signInState);
   return (
     <div className={moduleStyles.accountLinks}>{renderAccountButtons()}</div>
   );

--- a/frontend/packages/component-library/src/cms/header/HamburgerMenu.tsx
+++ b/frontend/packages/component-library/src/cms/header/HamburgerMenu.tsx
@@ -31,7 +31,7 @@ export interface HamburgerMenuProps extends HTMLAttributes<HTMLElement> {
     goToDashboard: AccountButtonsProps['goToDashboard'];
   };
   /** Is user logged in */
-  isLoggedIn: AccountButtonsProps['isLoggedIn'];
+  isSignedIn: AccountButtonsProps['isSignedIn'];
   /** Project custom class name */
   className?: string;
 }
@@ -40,7 +40,7 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
   hamburgerButtonLabel,
   hamburgerLinks,
   accountLinks,
-  isLoggedIn = false,
+  isSignedIn = false,
   className,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -85,7 +85,7 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
               signIn={accountLinks.signIn}
               createAccount={accountLinks.createAccount}
               goToDashboard={accountLinks.goToDashboard}
-              isLoggedIn={isLoggedIn}
+              isSignedIn={isSignedIn}
               isInHamburger={true}
             />
           </div>

--- a/frontend/packages/component-library/src/cms/header/HamburgerMenu.tsx
+++ b/frontend/packages/component-library/src/cms/header/HamburgerMenu.tsx
@@ -30,8 +30,8 @@ export interface HamburgerMenuProps extends HTMLAttributes<HTMLElement> {
     /** Go to Dashboard button */
     goToDashboard: AccountButtonsProps['goToDashboard'];
   };
-  /** Is user logged in */
-  isSignedIn: AccountButtonsProps['isSignedIn'];
+  /** Render state for if a user is signed in */
+  signInState: 'loading' | 'signedIn' | 'signedOut' | 'error';
   /** Project custom class name */
   className?: string;
 }
@@ -40,7 +40,7 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
   hamburgerButtonLabel,
   hamburgerLinks,
   accountLinks,
-  isSignedIn = false,
+  signInState,
   className,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -85,8 +85,8 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
               signIn={accountLinks.signIn}
               createAccount={accountLinks.createAccount}
               goToDashboard={accountLinks.goToDashboard}
-              isSignedIn={isSignedIn}
               isInHamburger={true}
+              signInState={signInState}
             />
           </div>
           <ul className={moduleStyles.menu}>

--- a/frontend/packages/component-library/src/cms/header/HamburgerMenu.tsx
+++ b/frontend/packages/component-library/src/cms/header/HamburgerMenu.tsx
@@ -30,8 +30,6 @@ export interface HamburgerMenuProps extends HTMLAttributes<HTMLElement> {
     /** Go to Dashboard button */
     goToDashboard: AccountButtonsProps['goToDashboard'];
   };
-  /** Render state for if a user is signed in */
-  signInState: 'loading' | 'signedIn' | 'signedOut' | 'error';
   /** Project custom class name */
   className?: string;
 }
@@ -40,7 +38,6 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
   hamburgerButtonLabel,
   hamburgerLinks,
   accountLinks,
-  signInState,
   className,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -86,7 +83,6 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
               createAccount={accountLinks.createAccount}
               goToDashboard={accountLinks.goToDashboard}
               isInHamburger={true}
-              signInState={signInState}
             />
           </div>
           <ul className={moduleStyles.menu}>

--- a/frontend/packages/component-library/src/cms/header/Header.tsx
+++ b/frontend/packages/component-library/src/cms/header/Header.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {HTMLAttributes} from 'react';
+import {HTMLAttributes, useEffect, useState} from 'react';
 
 import {Image, ImageProps} from '@/image';
 
@@ -54,8 +54,6 @@ export interface HeaderProps extends HTMLAttributes<HTMLElement> {
     /** Go to Dashboard button */
     goToDashboard: AccountButtonsProps['goToDashboard'];
   };
-  /** Is user logged in */
-  isSignedIn: AccountButtonsProps['isSignedIn'];
   /** Help menu label */
   helpButtonLabel: HelpMenuProps['helpButtonLabel'];
   /** Help menu links */
@@ -66,6 +64,21 @@ export interface HeaderProps extends HTMLAttributes<HTMLElement> {
   hamburgerLinks: HamburgerMenuProps['hamburgerLinks'];
   /** Header custom class name */
   className?: string;
+}
+
+function getUserSignedInStatus(studioBaseUrl: string = '') {
+  return fetch(`${studioBaseUrl}/api/v1/users/signed_in`, {
+    credentials: 'include',
+  })
+    .then(response => {
+      if (response.ok) {
+        return response.json();
+      }
+      throw new Error('Network response was not ok');
+    })
+    .catch(error => {
+      console.error('There was a problem with the fetch operation:', error);
+    });
 }
 
 /**
@@ -91,57 +104,76 @@ const Header: React.FC<HeaderProps> = ({
   projectsButtonAriaLabel,
   projectsLinks,
   accountLinks,
-  isSignedIn = false,
   helpButtonLabel,
   helpLinks,
   hamburgerButtonLabel,
   hamburgerLinks,
   className,
   ...HTMLAttributes
-}) => (
-  <header
-    {...HTMLAttributes}
-    className={classNames(moduleStyles.headerNavigation, className)}
-  >
-    <nav
-      className={moduleStyles.mainLinksWrapper}
-      aria-label={navLabel.main || 'Main navigation'}
-    >
-      <a
-        href={homeLink.href}
-        className={moduleStyles.homeLink}
-        aria-label={homeLink.ariaLabel}
-      >
-        <Image src={logo.src} alt={logo.altText} loading={'eager'} />
-      </a>
-      <MainLinks mainLinksLabel={mainLinksLabel} mainLinks={mainLinks} />
-    </nav>
+}) => {
+  const [renderState, setRenderState] = useState<
+    'loading' | 'signedIn' | 'signedOut' | 'error'
+  >('loading');
 
-    <nav
-      className={moduleStyles.buttonLinks}
-      aria-label={navLabel.secondary || 'Secondary navigation'}
+  useEffect(() => {
+    getUserSignedInStatus('http://localhost-studio.code.org:3000')
+      .then(data => {
+        if (data) {
+          const renderState = data.is_signed_in ? 'signedIn' : 'signedOut';
+          setRenderState(renderState);
+        }
+      })
+      .catch(error => {
+        console.error('Error fetching user signed in status:', error);
+        setRenderState('error');
+      });
+  }, []);
+
+  return (
+    <header
+      {...HTMLAttributes}
+      className={classNames(moduleStyles.headerNavigation, className)}
     >
-      <ProjectsMenu
-        projectsLinks={projectsLinks}
-        projectsButtonLabel={projectsButtonLabel}
-        projectsButtonAriaLabel={projectsButtonAriaLabel}
-      />
-      <AccountButtons
-        signIn={accountLinks.signIn}
-        createAccount={accountLinks.createAccount}
-        goToDashboard={accountLinks.goToDashboard}
-        isSignedIn={isSignedIn}
-        isInHamburger={false}
-      />
-      <HelpMenu helpButtonLabel={helpButtonLabel} helpLinks={helpLinks} />
-      <HamburgerMenu
-        hamburgerButtonLabel={hamburgerButtonLabel}
-        hamburgerLinks={hamburgerLinks}
-        accountLinks={accountLinks}
-        isSignedIn={isSignedIn}
-      />
-    </nav>
-  </header>
-);
+      <nav
+        className={moduleStyles.mainLinksWrapper}
+        aria-label={navLabel.main || 'Main navigation'}
+      >
+        <a
+          href={homeLink.href}
+          className={moduleStyles.homeLink}
+          aria-label={homeLink.ariaLabel}
+        >
+          <Image src={logo.src} alt={logo.altText} loading={'eager'} />
+        </a>
+        <MainLinks mainLinksLabel={mainLinksLabel} mainLinks={mainLinks} />
+      </nav>
+
+      <nav
+        className={moduleStyles.buttonLinks}
+        aria-label={navLabel.secondary || 'Secondary navigation'}
+      >
+        <ProjectsMenu
+          projectsLinks={projectsLinks}
+          projectsButtonLabel={projectsButtonLabel}
+          projectsButtonAriaLabel={projectsButtonAriaLabel}
+        />
+        <AccountButtons
+          signIn={accountLinks.signIn}
+          createAccount={accountLinks.createAccount}
+          goToDashboard={accountLinks.goToDashboard}
+          isInHamburger={false}
+          signInState={renderState}
+        />
+        <HelpMenu helpButtonLabel={helpButtonLabel} helpLinks={helpLinks} />
+        <HamburgerMenu
+          hamburgerButtonLabel={hamburgerButtonLabel}
+          hamburgerLinks={hamburgerLinks}
+          accountLinks={accountLinks}
+          signInState={renderState}
+        />
+      </nav>
+    </header>
+  );
+};
 
 export default Header;

--- a/frontend/packages/component-library/src/cms/header/Header.tsx
+++ b/frontend/packages/component-library/src/cms/header/Header.tsx
@@ -79,7 +79,9 @@ const fetchUserSignedInStatus = async (studioBaseUrl: string) => {
     );
 
     if (!signedInStatus.ok) {
-      throw new Error('Network response was not ok');
+      throw new Error(
+        `Received HTTP Code ${signedInStatus.status} while fetching signed in status`,
+      );
     }
 
     return await signedInStatus.json();

--- a/frontend/packages/component-library/src/cms/header/Header.tsx
+++ b/frontend/packages/component-library/src/cms/header/Header.tsx
@@ -4,6 +4,7 @@ import {HTMLAttributes, useEffect, useState} from 'react';
 import {Image, ImageProps} from '@/image';
 
 import AccountButtons, {AccountButtonsProps} from './AccountButtons';
+import SignInContext from './context/signInContext';
 import HamburgerMenu, {HamburgerMenuProps} from './HamburgerMenu';
 import HelpMenu, {HelpMenuProps} from './HelpMenu';
 import MainLinks, {MainLinksProps} from './MainLinks';
@@ -157,20 +158,20 @@ const Header: React.FC<HeaderProps> = ({
           projectsButtonLabel={projectsButtonLabel}
           projectsButtonAriaLabel={projectsButtonAriaLabel}
         />
-        <AccountButtons
-          signIn={accountLinks.signIn}
-          createAccount={accountLinks.createAccount}
-          goToDashboard={accountLinks.goToDashboard}
-          isInHamburger={false}
-          signInState={renderState}
-        />
-        <HelpMenu helpButtonLabel={helpButtonLabel} helpLinks={helpLinks} />
-        <HamburgerMenu
-          hamburgerButtonLabel={hamburgerButtonLabel}
-          hamburgerLinks={hamburgerLinks}
-          accountLinks={accountLinks}
-          signInState={renderState}
-        />
+        <SignInContext.Provider value={renderState}>
+          <AccountButtons
+            signIn={accountLinks.signIn}
+            createAccount={accountLinks.createAccount}
+            goToDashboard={accountLinks.goToDashboard}
+            isInHamburger={false}
+          />
+          <HelpMenu helpButtonLabel={helpButtonLabel} helpLinks={helpLinks} />
+          <HamburgerMenu
+            hamburgerButtonLabel={hamburgerButtonLabel}
+            hamburgerLinks={hamburgerLinks}
+            accountLinks={accountLinks}
+          />
+        </SignInContext.Provider>
       </nav>
     </header>
   );

--- a/frontend/packages/component-library/src/cms/header/Header.tsx
+++ b/frontend/packages/component-library/src/cms/header/Header.tsx
@@ -13,6 +13,9 @@ import ProjectsMenu, {ProjectsMenuProps} from './ProjectsMenu';
 import moduleStyles from './header.module.scss';
 
 export interface HeaderProps extends HTMLAttributes<HTMLElement> {
+  /** Studio.code.org base url
+   * sets correct stage for use with user signed_in api */
+  studioBaseUrl: string;
   /** Home link */
   homeLink: {
     /** Home link url */
@@ -67,7 +70,7 @@ export interface HeaderProps extends HTMLAttributes<HTMLElement> {
   className?: string;
 }
 
-function getUserSignedInStatus(studioBaseUrl: string = '') {
+function getUserSignedInStatus(studioBaseUrl: string) {
   return fetch(`${studioBaseUrl}/api/v1/users/signed_in`, {
     credentials: 'include',
   })
@@ -96,6 +99,7 @@ function getUserSignedInStatus(studioBaseUrl: string = '') {
  * Acts as the main page header navigation.
  */
 const Header: React.FC<HeaderProps> = ({
+  studioBaseUrl,
   homeLink,
   logo,
   navLabel,
@@ -117,7 +121,7 @@ const Header: React.FC<HeaderProps> = ({
   >('loading');
 
   useEffect(() => {
-    getUserSignedInStatus('http://localhost-studio.code.org:3000')
+    getUserSignedInStatus(studioBaseUrl)
       .then(data => {
         if (data) {
           const renderState = data.is_signed_in ? 'signedIn' : 'signedOut';

--- a/frontend/packages/component-library/src/cms/header/Header.tsx
+++ b/frontend/packages/component-library/src/cms/header/Header.tsx
@@ -69,21 +69,24 @@ export interface HeaderProps extends HTMLAttributes<HTMLElement> {
   /** Header custom class name */
   className?: string;
 }
+const fetchUserSignedInStatus = async (studioBaseUrl: string) => {
+  try {
+    const signInStatus = await fetch(
+      `${studioBaseUrl}/api/v1/users/signed_in`,
+      {
+        credentials: 'include',
+      },
+    );
 
-function getUserSignedInStatus(studioBaseUrl: string) {
-  return fetch(`${studioBaseUrl}/api/v1/users/signed_in`, {
-    credentials: 'include',
-  })
-    .then(response => {
-      if (response.ok) {
-        return response.json();
-      }
+    if (!signInStatus.ok) {
       throw new Error('Network response was not ok');
-    })
-    .catch(error => {
-      console.error('There was a problem with the fetch operation:', error);
-    });
-}
+    }
+
+    return await signInStatus.json();
+  } catch (error) {
+    console.error('There was a problem with the fetch operation:', error);
+  }
+};
 
 /**
  * ## Production-ready Checklist:
@@ -121,18 +124,22 @@ const Header: React.FC<HeaderProps> = ({
   >('loading');
 
   useEffect(() => {
-    getUserSignedInStatus(studioBaseUrl)
-      .then(data => {
+    async function getUserStatus() {
+      try {
+        const data = await fetchUserSignedInStatus(studioBaseUrl);
         if (data) {
           const renderState = data.is_signed_in ? 'signedIn' : 'signedOut';
           setRenderState(renderState);
+        } else {
+          setRenderState('error');
         }
-      })
-      .catch(error => {
+      } catch (error) {
         console.error('Error fetching user signed in status:', error);
-        setRenderState('error');
-      });
-  }, []);
+      }
+    }
+
+    getUserStatus();
+  }, [studioBaseUrl]);
 
   return (
     <header

--- a/frontend/packages/component-library/src/cms/header/Header.tsx
+++ b/frontend/packages/component-library/src/cms/header/Header.tsx
@@ -55,7 +55,7 @@ export interface HeaderProps extends HTMLAttributes<HTMLElement> {
     goToDashboard: AccountButtonsProps['goToDashboard'];
   };
   /** Is user logged in */
-  isLoggedIn: AccountButtonsProps['isLoggedIn'];
+  isSignedIn: AccountButtonsProps['isSignedIn'];
   /** Help menu label */
   helpButtonLabel: HelpMenuProps['helpButtonLabel'];
   /** Help menu links */
@@ -91,7 +91,7 @@ const Header: React.FC<HeaderProps> = ({
   projectsButtonAriaLabel,
   projectsLinks,
   accountLinks,
-  isLoggedIn = false,
+  isSignedIn = false,
   helpButtonLabel,
   helpLinks,
   hamburgerButtonLabel,
@@ -130,7 +130,7 @@ const Header: React.FC<HeaderProps> = ({
         signIn={accountLinks.signIn}
         createAccount={accountLinks.createAccount}
         goToDashboard={accountLinks.goToDashboard}
-        isLoggedIn={isLoggedIn}
+        isSignedIn={isSignedIn}
         isInHamburger={false}
       />
       <HelpMenu helpButtonLabel={helpButtonLabel} helpLinks={helpLinks} />
@@ -138,7 +138,7 @@ const Header: React.FC<HeaderProps> = ({
         hamburgerButtonLabel={hamburgerButtonLabel}
         hamburgerLinks={hamburgerLinks}
         accountLinks={accountLinks}
-        isLoggedIn={isLoggedIn}
+        isSignedIn={isSignedIn}
       />
     </nav>
   </header>

--- a/frontend/packages/component-library/src/cms/header/Header.tsx
+++ b/frontend/packages/component-library/src/cms/header/Header.tsx
@@ -71,18 +71,18 @@ export interface HeaderProps extends HTMLAttributes<HTMLElement> {
 }
 const fetchUserSignedInStatus = async (studioBaseUrl: string) => {
   try {
-    const signInStatus = await fetch(
+    const signedInStatus = await fetch(
       `${studioBaseUrl}/api/v1/users/signed_in`,
       {
         credentials: 'include',
       },
     );
 
-    if (!signInStatus.ok) {
+    if (!signedInStatus.ok) {
       throw new Error('Network response was not ok');
     }
 
-    return await signInStatus.json();
+    return await signedInStatus.json();
   } catch (error) {
     console.error('There was a problem with the fetch operation:', error);
   }

--- a/frontend/packages/component-library/src/cms/header/__tests__/Header.test.tsx
+++ b/frontend/packages/component-library/src/cms/header/__tests__/Header.test.tsx
@@ -96,7 +96,7 @@ describe('Header Component', () => {
   });
 
   it('renders the account buttons correctly when user is logged in', () => {
-    render(<Header {...defaultProps} isSignedIn={true} />);
+    render(<Header {...defaultProps} />);
 
     // check that Sign In button is not rendered
     const signInButton = screen.queryByText('Sign In');

--- a/frontend/packages/component-library/src/cms/header/__tests__/Header.test.tsx
+++ b/frontend/packages/component-library/src/cms/header/__tests__/Header.test.tsx
@@ -96,7 +96,7 @@ describe('Header Component', () => {
   });
 
   it('renders the account buttons correctly when user is logged in', () => {
-    render(<Header {...defaultProps} isLoggedIn={true} />);
+    render(<Header {...defaultProps} isSignedIn={true} />);
 
     // check that Sign In button is not rendered
     const signInButton = screen.queryByText('Sign In');

--- a/frontend/packages/component-library/src/cms/header/__tests__/Header.test.tsx
+++ b/frontend/packages/component-library/src/cms/header/__tests__/Header.test.tsx
@@ -79,36 +79,112 @@ describe('Header Component', () => {
     });
   });
 
-  it('renders the account buttons correctly when user is not logged in', () => {
+  it('renders correctly when user status is loading', async () => {
+    const mockFetch = jest.fn(() => new Promise(() => {}));
+    global.fetch = mockFetch as unknown as typeof fetch;
+
     render(<Header {...defaultProps} />);
 
-    // check that Sign In button is rendered
-    const signInButton = screen.getByText('Sign In');
-    expect(signInButton).toBeInTheDocument();
+    // check that the Loading button is rendered
+    // and no other account buttons are rendered
+    await waitFor(() => {
+      const loadingButton = screen.getByText('Loading');
+      expect(loadingButton).toBeInTheDocument();
 
-    // check that Create Account button is rendered
-    const createAccountButton = screen.getByText('Create Account');
-    expect(createAccountButton).toBeInTheDocument();
+      const signInButton = screen.queryByText('Sign In');
+      expect(signInButton).not.toBeInTheDocument();
 
-    // check that Go to Dashboard button is not rendered
-    const dashboardButton = screen.queryByText('Go to Dashboard');
-    expect(dashboardButton).not.toBeInTheDocument();
+      const createAccountButton = screen.queryByText('Create Account');
+      expect(createAccountButton).not.toBeInTheDocument();
+
+      const dashboardButton = screen.queryByText('Go to Dashboard');
+      expect(dashboardButton).not.toBeInTheDocument();
+    });
+
+    jest.restoreAllMocks();
   });
 
-  it('renders the account buttons correctly when user is logged in', () => {
+  it('renders correctly when user status is signed out', async () => {
+    const mockFetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({is_signed_in: false}),
+    });
+    global.fetch = mockFetch;
+
     render(<Header {...defaultProps} />);
 
-    // check that Sign In button is not rendered
-    const signInButton = screen.queryByText('Sign In');
-    expect(signInButton).not.toBeInTheDocument();
+    // check that the Sign In and Create Account buttons are rendered
+    // and no other account buttons are rendered
+    await waitFor(() => {
+      const loadingButton = screen.queryByText('Loading');
+      expect(loadingButton).not.toBeInTheDocument();
 
-    // check that Create Account button is not rendered
-    const createAccountButton = screen.queryByText('Create Account');
-    expect(createAccountButton).not.toBeInTheDocument();
+      const signInButton = screen.getByText('Sign In');
+      expect(signInButton).toBeInTheDocument();
 
-    // check that Go to Dashboard button is rendered
-    const dashboardButton = screen.getByText('Go to Dashboard');
-    expect(dashboardButton).toBeInTheDocument();
+      const createAccountButton = screen.getByText('Create Account');
+      expect(createAccountButton).toBeInTheDocument();
+
+      const dashboardButton = screen.queryByText('Go to Dashboard');
+      expect(dashboardButton).not.toBeInTheDocument();
+    });
+
+    jest.restoreAllMocks();
+  });
+
+  it('renders correctly when user status is signed in', async () => {
+    const mockFetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({is_signed_in: true}),
+    });
+    global.fetch = mockFetch;
+
+    render(<Header {...defaultProps} />);
+
+    // check that the Go to Dashboard button is rendered
+    // and no other account buttons are rendered
+    await waitFor(() => {
+      const loadingButton = screen.queryByText('Loading');
+      expect(loadingButton).not.toBeInTheDocument();
+
+      const signInButton = screen.queryByText('Sign In');
+      expect(signInButton).not.toBeInTheDocument();
+
+      const createAccountButton = screen.queryByText('Create Account');
+      expect(createAccountButton).not.toBeInTheDocument();
+
+      const dashboardButton = screen.getByText('Go to Dashboard');
+      expect(dashboardButton).toBeInTheDocument();
+    });
+
+    jest.restoreAllMocks();
+  });
+
+  it('renders correctly when there is an error fetching user status', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Network error'));
+    global.fetch = mockFetch;
+
+    render(<Header {...defaultProps} />);
+
+    // check that the Sign In and Create account buttons are rendered
+    // and no other account buttons are rendered
+    await waitFor(() => {
+      const loadingButton = screen.queryByText('Loading');
+      expect(loadingButton).not.toBeInTheDocument();
+
+      const signInButton = screen.getByText('Sign In');
+      expect(signInButton).toBeInTheDocument();
+
+      const createAccountButton = screen.getByText('Create Account');
+      expect(createAccountButton).toBeInTheDocument();
+
+      const dashboardButton = screen.queryByText('Go to Dashboard');
+      expect(dashboardButton).not.toBeInTheDocument();
+    });
+
+    jest.restoreAllMocks();
   });
 
   it('renders the help menu with the correct links', () => {

--- a/frontend/packages/component-library/src/cms/header/config.ts
+++ b/frontend/packages/component-library/src/cms/header/config.ts
@@ -157,7 +157,7 @@ export function getDefaultHeaderProps({
         href: `${studioUrl}/home`,
       },
     },
-    isLoggedIn: false,
+    isSignedIn: false,
     helpButtonLabel: {
       open: 'Open Help menu',
       close: 'Close Help menu',

--- a/frontend/packages/component-library/src/cms/header/config.ts
+++ b/frontend/packages/component-library/src/cms/header/config.ts
@@ -26,6 +26,7 @@ export function getDefaultHeaderProps({
   studioUrl,
 }: DefaultProps): HeaderProps {
   return {
+    studioBaseUrl: studioUrl,
     homeLink: {
       href: '/',
       ariaLabel: 'Go to homepage',

--- a/frontend/packages/component-library/src/cms/header/config.ts
+++ b/frontend/packages/component-library/src/cms/header/config.ts
@@ -157,7 +157,6 @@ export function getDefaultHeaderProps({
         href: `${studioUrl}/home`,
       },
     },
-    isSignedIn: false,
     helpButtonLabel: {
       open: 'Open Help menu',
       close: 'Close Help menu',

--- a/frontend/packages/component-library/src/cms/header/context/signInContext.ts
+++ b/frontend/packages/component-library/src/cms/header/context/signInContext.ts
@@ -1,0 +1,7 @@
+import {createContext} from 'react';
+
+export type SignInState = 'loading' | 'signedIn' | 'signedOut' | 'error';
+
+const SignInContext = createContext<SignInState>('loading');
+
+export default SignInContext;

--- a/frontend/packages/component-library/src/cms/header/header.module.scss
+++ b/frontend/packages/component-library/src/cms/header/header.module.scss
@@ -92,6 +92,14 @@ header .buttonLinks {
   align-items: center;
   gap: 0.5rem;
 
+  .pending.mainMenu {
+    color: var(--text-brand-teal-primary-fixed) !important;
+    background-color: var(--background-neutral-white-fixed) !important;
+    border-color: var(--background-neutral-white-fixed) !important;
+    // Set the width to match sign in buttons to prevent layout shift
+    width: 13.713rem;
+  }
+
   .signIn.mainMenu,
   .newProject {
     background: transparent;

--- a/frontend/packages/component-library/src/cms/header/header.module.scss
+++ b/frontend/packages/component-library/src/cms/header/header.module.scss
@@ -98,6 +98,7 @@ header .buttonLinks {
     border-color: var(--background-neutral-white-fixed) !important;
     // Set the width to match sign in buttons to prevent layout shift
     width: 13.713rem;
+    opacity: 0.8;
   }
 
   .signIn.mainMenu,

--- a/frontend/packages/component-library/src/cms/header/header.module.scss
+++ b/frontend/packages/component-library/src/cms/header/header.module.scss
@@ -92,7 +92,7 @@ header .buttonLinks {
   align-items: center;
   gap: 0.5rem;
 
-  .pending.mainMenu {
+  .loading.mainMenu {
     color: var(--text-brand-teal-primary-fixed) !important;
     background-color: var(--background-neutral-white-fixed) !important;
     border-color: var(--background-neutral-white-fixed) !important;

--- a/frontend/packages/component-library/src/cms/header/stories/Header.story.tsx
+++ b/frontend/packages/component-library/src/cms/header/stories/Header.story.tsx
@@ -128,7 +128,6 @@ export const DefaultLoggedOut: Story = {
 export const LoggedIn: Story = {
   args: {
     ...defaultArgs,
-    isSignedIn: true,
   },
   parameters: {
     layout: 'fullscreen',

--- a/frontend/packages/component-library/src/cms/header/stories/Header.story.tsx
+++ b/frontend/packages/component-library/src/cms/header/stories/Header.story.tsx
@@ -125,47 +125,6 @@ export const DefaultLoggedOut: Story = {
   },
 };
 
-export const LoggedIn: Story = {
-  args: {
-    ...defaultArgs,
-  },
-  parameters: {
-    layout: 'fullscreen',
-    viewport: {
-      viewports: MINIMAL_VIEWPORTS,
-      defaultViewport: 'desktop',
-    },
-    eyes: {
-      browser: {width: 1268, height: 720, name: 'chrome'},
-    },
-    docs: {
-      description: {
-        story:
-          'The large desktop view of the header when the user is logged in. The header contains the logo, main navigation links, New Project button/menu, Go to Dashboard button, and a Help icon button/menu.',
-      },
-    },
-  },
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-
-    // check that the Go to Dashboard button is visible
-    const goToDashboardButton = await canvas.findByRole('link', {
-      name: 'Go to Dashboard',
-    });
-    await expect(goToDashboardButton).toBeVisible();
-
-    // check that the Sign In button is not visible
-    const signInButton = canvas.queryByRole('link', {name: 'Sign In'});
-    expect(signInButton).toBeNull();
-
-    // check that the Create Account button is not visible
-    const createAccountButton = canvas.queryByRole('link', {
-      name: 'Create Account',
-    });
-    expect(createAccountButton).toBeNull();
-  },
-};
-
 export const NewProjectMenu: Story = {
   args: {
     ...defaultArgs,

--- a/frontend/packages/component-library/src/cms/header/stories/Header.story.tsx
+++ b/frontend/packages/component-library/src/cms/header/stories/Header.story.tsx
@@ -128,7 +128,7 @@ export const DefaultLoggedOut: Story = {
 export const LoggedIn: Story = {
   args: {
     ...defaultArgs,
-    isLoggedIn: true,
+    isSignedIn: true,
   },
   parameters: {
     layout: 'fullscreen',


### PR DESCRIPTION
Uses the `/api/v1/users/signed_in` endpoint to show the appropriate account buttons in the Header component in Contentful based on whether a user is `signedIn` or `signedOut`. This also accounts for `loading` and `error` states.

**UX note:** I opted to have the loading state button match the width of the Sign in button group instead of the Go to Dashboard button. The likelihood of folks on the marketing site being logged out is higher than logged in, and the content jump seems less disruptive to shrink than grow. 

**Reviewer note:** hide whitespace for easier reviewing

## Links
Jira ticket: [CMS-533](https://codedotorg.atlassian.net/browse/CMS-533)
Related PR: https://github.com/code-dot-org/code-dot-org/pull/64825

## Testing story
Added unit tests to check for each state. We are unable to show the signed in state on Storybook now so I removed that story and Eyes test.

----

## Signed out and Error states

https://github.com/user-attachments/assets/de810f7f-84fa-424f-b3f7-ed429849050e

## Signed in


https://github.com/user-attachments/assets/24f5ff76-8ef7-4f73-92be-e410160061cf



