### PR TITLE
Evaluate Student Learning: add more specifics to system prompt to catch non_responses

### DIFF
--- a/dashboard/app/helpers/ai_system_prompts/evaluate_system_prompt_helper.rb
+++ b/dashboard/app/helpers/ai_system_prompts/evaluate_system_prompt_helper.rb
@@ -13,7 +13,7 @@ module AiSystemPrompts::EvaluateSystemPromptHelper
     structure_without_skills = <<~TEXT
       Please review the student's work. Respond in correctly formatted JSON.
       evaluationCriteria should be a copy of #{evaluation_criteria}.
-      aiEvaluation should be your overall assessment of the student's work. Respond with "Great", "Ok", or "Needs revision".
+      aiEvaluation should be your overall assessment of the student's work. Respond with "Great" if the student's work meets all of the requirements of the instructions. Respond "Ok" if the student's work partially meets the requirements. Otherwise, respond "Needs revision". If the student's work is not complete or is not at all related to computer science, respond with "Needs revision".
       aiReasoning should be one sentence with your reasoning.
     TEXT
     single_student_evaluation_structure = skills ? structure_with_skills : structure_without_skills


### PR DESCRIPTION
[TEACH-1868](https://codedotorg.atlassian.net/browse/TEACH-1868)

We found an example during the AI Analysis of Free Response Questions [bug bash](https://docs.google.com/document/d/1jwX9eXeRNnoy2MPjSqiYSVgU_AVoTjVt5JxdC9y_Xvo/edit?tab=t.0#bookmark=id.4x3ufufa4lrp) of a student response ("I don't want to do this") that should've been categorized as "Needs revision" was not. Because it was so glaringly not an attempt to answer the question we decided to modify the system prompt to more explicitly indicate what should "count" as "Needs revision". 

I used this [test dataset](https://docs.google.com/spreadsheets/d/1wkhZllmM0ARHKXAwZSs6LUjOVPkSZlGfNuPyKq05C9k/edit?gid=0#gid=0) that includes a handful of "non responses" generated by me and pulled real student responses. With that csv I followed the process outlined in this [How to Iterate on the System Prompt doc](https://docs.google.com/document/d/1Gd6eT_CTd6m-i5eTuv3PbjiD9VGSnj_fmcWL_FkBBv8/edit?tab=t.0).

I got 100% accuracy for the non_responses with the new system prompt, and am working to get accuracy scores for evaluation of real student responses. [Slack](https://codedotorg.slack.com/archives/C067UFRDM9B/p1745859165846249) 🧵 


With the old system prompt I got X% accuracy, in this [trace]().


With the updated system prompt I got X% accuracy, in this [trace]().
