### PR TITLE
feat(marketing): add all-the-things snapshotting

### DIFF
--- a/frontend/apps/marketing/.prettierignore
+++ b/frontend/apps/marketing/.prettierignore
@@ -1,1 +1,2 @@
 public/**
+tests/e2e/__snapshots__/**

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -28,7 +28,10 @@
     "stylelint:fix": "yarn run stylelint --fix",
     "test": "jest",
     "test:ui:ci": "playwright test",
-    "test:ui:local": "STAGE=localhost yarn test:ui:ci"
+    "test:ui:fork": "tsx ./tests/e2e/scripts/all-the-things-updater.ts fork",
+    "test:ui:local": "STAGE=localhost yarn test:ui:ci",
+    "test:ui:publish-snapshot": "tsx ./tests/e2e/scripts/all-the-things-updater.ts publish-snapshot",
+    "test:ui:update-snapshot": "tsx ./tests/e2e/scripts/all-the-things-updater.ts update-snapshot"
   },
   "prettier": "@code-dot-org/lint-config/prettier/index.mjs",
   "stylelint": {
@@ -60,10 +63,12 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
+    "@types/fs-extra": "^11.0.4",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "contentful-management": "^11.52.1",
     "cross-fetch": "^4.1.0",
     "dotenv": "^16.4.7",
     "eslint": "^9.16.0",
@@ -75,6 +80,7 @@
     "schema-dts": "^1.1.5",
     "stylelint": "^16.14.1",
     "ts-node": "^10.9.2",
+    "tsx": "^4.19.3",
     "typescript": "^5"
   },
   "engines": {

--- a/frontend/apps/marketing/tests/e2e/README.md
+++ b/frontend/apps/marketing/tests/e2e/README.md
@@ -1,0 +1,89 @@
+# End-to-End Tests for Marketing
+
+This directory contains end-to-end (E2E) tests for the Code.org marketing application.
+
+## Overview
+
+The E2E tests are designed to ensure that the marketing application behaves as expected in a real-world environment. These tests simulate user interactions with the application and verify its functionality. This test suite is intended to be used very sparingly and only tests that cannot be accomplished in unit tests or integration tests should be added to this test suite.
+
+## Prerequisites
+
+To run the full set of tests locally, an [Applitools Eyes API Key](https://applitools.com/tutorials/getting-started/retrieve-api-key) is needed. Define `APPLITOOLS_API_KEY` in `marketing/.env` to use.
+
+## Running Tests
+
+### Against a local server
+
+To execute the E2E tests against a local server running on `localhost:3001`, run the following command:
+
+**In Playwright UI Mode (recommended):**
+
+```bash
+yarn test:ui:local --ui
+```
+
+**In CLI mode:**
+
+```bash
+yarn test:ui:local
+```
+
+### Against a target stage
+
+To execute the E2E tests against a specific stage, such as the test or production stages, add the `STAGE` environment variable:
+
+```bash
+STAGE=<pr|test|production> yarn test:ui:local --ui
+```
+
+**In CLI mode:**
+
+```bash
+STAGE=<pr|test|production> yarn test:ui:local
+```
+
+## All The Things
+
+"All The Things" is a special page for the purpose of testing all UI components on a single page complete with an integration with Contentful. A special tool has been created to manage creating and updating "All The Things" tests. This page is normally updated using the source control version of the page via the Contentful management API.
+
+### Forking
+
+To update the "All The Things" page, execute the fork command which will take the `production` version of the page and create a copy on the `development` environment. Use this forked copy to manually make changes to the page on the Contentful experience builder.
+
+### Creating a fork
+
+To create a fork:
+
+```bash
+yarn test:ui:fork
+```
+
+### Updating the source control snapshot
+
+To download a copy of the "All The Things" page to source control:
+
+```bash
+yarn test:ui:update-snapshot --environment <development|test|production>
+```
+
+If working on a fork and you want to update the version control version, specify the source entry id:
+
+```bash
+yarn test:ui:update-snapshot --enviornment development --source-entry-id <fork experience entry id>
+```
+
+### Updating "All The Things" on Contentful from source control
+
+To upload the source control version of "All the Things" to Contentful:
+
+```bash
+yarn test:ui:publish-snapshot --environment <development|test|production>
+```
+
+This will save "All The Things", open up the experience in the associated environment and publish the page if it looks correct.
+
+**Note**: Normally for a merge to `test` or `production`, you will want to do this after merging your PR.
+
+## Resources
+
+- [Playwright Documentation](https://playwright.dev/docs/intro)

--- a/frontend/apps/marketing/tests/e2e/README.md
+++ b/frontend/apps/marketing/tests/e2e/README.md
@@ -46,6 +46,8 @@ STAGE=<pr|test|production> yarn test:ui:local
 
 "All The Things" is a special page for the purpose of testing all UI components on a single page complete with an integration with Contentful. A special tool has been created to manage creating and updating "All The Things" tests. This page is normally updated using the source control version of the page via the Contentful management API.
 
+All The Things can be found on all environments with the sub-path `/all-the-things`.
+
 ### Forking
 
 To update the "All The Things" page, execute the fork command which will take the `production` version of the page and create a copy on the `development` environment. Use this forked copy to manually make changes to the page on the Contentful experience builder.

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/1hQeP2bdFuIFm5kuYeefew.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/1hQeP2bdFuIFm5kuYeefew.json
@@ -1,0 +1,40 @@
+{
+  "entryContent": {
+    "fields": {
+      "seoTitle": {
+        "en-US": "⛔️ [ENGINEERING ONLY] UI Integration Testing - SEO"
+      },
+      "seoDescription": {
+        "en-US": "SEO Description"
+      },
+      "openGraphTitle": {
+        "en-US": "OpenGraph Title"
+      },
+      "openGraphDescription": {
+        "en-US": "OpenGraph Description"
+      },
+      "openGraphImage": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Asset",
+            "id": "4hXiOPiRlCXpmtypRNOZqc"
+          }
+        }
+      },
+      "keywords": {
+        "en-US": [
+          "UI Integration Test",
+          "All The Things"
+        ]
+      },
+      "hidePageFromSearchEnginesNoindex": {
+        "en-US": true
+      },
+      "hideLinksFromSearchEnginesNofollow": {
+        "en-US": true
+      }
+    }
+  },
+  "contentType": "seoMetadata"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/20rQYDvS9V3fnwtMyAW0m4.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/20rQYDvS9V3fnwtMyAW0m4.json
@@ -1,0 +1,48 @@
+{
+  "entryContent": {
+    "fields": {
+      "internalName": {
+        "en-US": "Video Carousel Test"
+      },
+      "carouselName": {
+        "en-US": "Video Carousel Test"
+      },
+      "carouselType": {
+        "en-US": "Video"
+      },
+      "slides": {
+        "en-US": [
+          {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "53hnyQQVUfylnTa7f24dDJ"
+            }
+          },
+          {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "3BLuF3jm0oTV17RPwLOgC6"
+            }
+          },
+          {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "3oxrIQkHqzpbTrXqwk0aIa"
+            }
+          },
+          {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "4xyTmh7jAVCC3glKeke0cP"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "contentType": "carousel"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
@@ -1,0 +1,10173 @@
+{
+  "entryContent": {
+    "fields": {
+      "title": {
+        "en-US": "⛔️ [ENGINEERING ONLY] UI Integration Testing"
+      },
+      "directory": {
+        "en-US": "None"
+      },
+      "slug": {
+        "en-US": "all-the-things"
+      },
+      "pageHeading": {
+        "en-US": "[Engineering] UI Integration Test"
+      },
+      "componentTree": {
+        "en-US": {
+          "breakpoints": [
+            {
+              "id": "desktop",
+              "query": "*",
+              "displayIcon": "desktop",
+              "displayName": "All Sizes",
+              "previewSize": "100%"
+            },
+            {
+              "id": "tablet",
+              "query": "<992px",
+              "displayIcon": "tablet",
+              "displayName": "Tablet",
+              "previewSize": "820px"
+            },
+            {
+              "id": "mobile",
+              "query": "<576px",
+              "displayIcon": "mobile",
+              "displayName": "Mobile",
+              "previewSize": "390px"
+            }
+          ],
+          "schemaVersion": "2023-09-28",
+          "children": [
+            {
+              "id": "4qnfpsV7",
+              "displayName": "Section",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "is6sJNT7GqG8M-aved8xI",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "m4M7qU_VBvy3rP_lT7V-J",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "Qkx4iDxSBpSpgdmwqZhqM",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "0fJNzzC8",
+                  "displayName": "Introduction",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "lgGRRfq5zcVueL3yrxoh9",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "uUa7o1jl",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "R0C45WqvjfIgrCLvhJPSB",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "UUn7E5n5",
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "204Ys74QveR6n_DzcowIB",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "AXIFq1qJ",
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "i-CBt91tEkCmZHGzb85xW",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "sYH6ME1D",
+              "displayName": "Localization",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "gyjlsYtE",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "RLcvWIOm",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "oPc8lo0F",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "YVm0InSQ",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "sQZaBqbWsJUIR6cGO4R7w",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "BkKYMhQm",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "d5NKAnwp",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "dxKxFE8C",
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "uML982xB",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "b55f9mox",
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "path": "/TDy6kSns/fields/quoteName/~locale",
+                          "type": "BoundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "VzJgPw9B",
+                      "displayName": "Heading 2",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "qQFZT2Ct",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "QKZo3i6u",
+                      "displayName": "Paragraph 1",
+                      "definitionId": "paragraph",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "path": "/OBu7LBgD/fields/longQuote/~locale",
+                          "type": "BoundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "jltL4xD9",
+                      "displayName": "Heading 3",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "bvkdCWAp",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "RydO4DZ5",
+                      "displayName": "Paragraph 1",
+                      "definitionId": "paragraph",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "M6UV6klE",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "QPXgm7xP",
+              "displayName": "Action Block",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "NspNpe6v",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "7SxgQMWi",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "d7bQZFYP",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "fCFouSL6",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "OmmiviO_PnQgExsnIQWG2",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "lBfKWG1Q",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "zB9624m9",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "NcFGUcus",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "IRGGNCsc",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "4Z9z51w4",
+                      "definitionId": "contentful-container",
+                      "patternProperties": {},
+                      "variables": {
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "row",
+                            "mobile": "column"
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px 24px",
+                            "mobile": "24px 24px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "type": "UnboundValue",
+                          "key": "36YfTgYM"
+                        },
+                        "cfOpenInNewTab": {
+                          "type": "UnboundValue",
+                          "key": "1g7RleiK"
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "type": "UnboundValue",
+                          "key": "dJNC5rnb"
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "children": [
+                        {
+                          "id": "KXc3wv4t",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "Ov2KaMlI"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "z9iS8tow"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "SGrm6TeM"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "cqVonltI",
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {},
+                              "variables": {
+                                "overline": {
+                                  "path": "/Ura63qS4/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/sOCuihY3/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "description": {
+                                  "path": "/P3w0MI3x/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "image": {
+                                  "path": "/D06vmzVo/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "primaryButton": {
+                                  "path": "/0Uc1jnt8/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/5gQSSrFE/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "GIbKtM99",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "eMXbhJJO"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "hAGyY1mh"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "Aw5CTnlT"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "cNcSAcmb",
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {},
+                              "variables": {
+                                "overline": {
+                                  "path": "/btGygYlg/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/qj8MdFqk/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "description": {
+                                  "path": "/OkAdGTNN/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "image": {
+                                  "path": "/4rTEErM8/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "primaryButton": {
+                                  "path": "/wf6Nfy0h/fields/marketingLink/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/L4ppraxB/fields/marketingLink/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "XkRIiyuw",
+                      "definitionId": "divider",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "WF9VdUgg",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "rXgI4Mvr",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "Jx09S5tI",
+                      "definitionId": "contentful-container",
+                      "patternProperties": {},
+                      "variables": {
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "24px 24px 24px 24px"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(247, 248, 250, 1)"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "row",
+                            "mobile": "column"
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px 24px",
+                            "mobile": "24px 24px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "type": "UnboundValue",
+                          "key": "xaSe4Rjf"
+                        },
+                        "cfOpenInNewTab": {
+                          "type": "UnboundValue",
+                          "key": "TnZjwBke"
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "type": "UnboundValue",
+                          "key": "gwYa67z7"
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "children": [
+                        {
+                          "id": "pSAn3QNf",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "rqSvSSLH"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "ZdTFBVAL"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "dWrBnOHy"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "HA6kV8lH",
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {},
+                              "variables": {
+                                "overline": {
+                                  "path": "/eV4HBBLe/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/eeVAmXO7/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "description": {
+                                  "path": "/1V2S6k5O/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "image": {
+                                  "path": "/3xRBhtEN/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "primaryButton": {
+                                  "path": "/iKuwF5UL/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/XC0Orztn/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "secondary"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "hAm0hXK7",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "GGSUj7T7"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "6dweZgN5"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "TC9267aF"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "NRvZhJuI",
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {},
+                              "variables": {
+                                "overline": {
+                                  "path": "/pnEVNJEY/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/289w042P/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "description": {
+                                  "path": "/8W24TK7L/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "image": {
+                                  "path": "/Gac8HyiL/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "primaryButton": {
+                                  "path": "/L1oQ0Cfn/fields/marketingLink/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/jgZPQ2f4/fields/marketingLink/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "secondary"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "HT5aw3I7",
+                      "definitionId": "divider",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "aAeOh6L6",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "Tgg1s2D2",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "kAFZ2mur",
+                      "definitionId": "contentful-container",
+                      "patternProperties": {},
+                      "variables": {
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "row",
+                            "mobile": "column"
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px 24px",
+                            "mobile": "24px 24px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "type": "UnboundValue",
+                          "key": "5rKwB2lO"
+                        },
+                        "cfOpenInNewTab": {
+                          "type": "UnboundValue",
+                          "key": "hEDkMrEi"
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "type": "UnboundValue",
+                          "key": "mp03r8eT"
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "children": [
+                        {
+                          "id": "CC1rbHZN",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "LY3fwrGF"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "vl7mGMNk"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "Mo4S1GHf"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "vKRDeLjD",
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {},
+                              "variables": {
+                                "overline": {
+                                  "path": "/S9wdCChd/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/sCyp4umt/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "description": {
+                                  "path": "/VHT0F26i/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "image": {
+                                  "path": "/hbWAEPUa/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "primaryButton": {
+                                  "path": "/NQABxHSW/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/0HkUraow/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "MFJ3yTqG",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "JjsxkEPq"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "mI3808f6"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "AKTPfVrs"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "1yfSgGaI",
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {},
+                              "variables": {
+                                "overline": {
+                                  "path": "/qUW7SuUq/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/7Gxx550Y/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "description": {
+                                  "path": "/PkMzRu3l/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "image": {
+                                  "path": "/q64yPb2d/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "primaryButton": {
+                                  "path": "/9VSvsbCf/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/o8e0EuB2/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "w6KnOUij",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "lTlx2Ck5"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "byHQXRz8"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "IuXKDn7Q"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "KtyKVhex",
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {},
+                              "variables": {
+                                "overline": {
+                                  "path": "/MKnXMzs0/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/tgGNSw4W/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "description": {
+                                  "path": "/o5ZyffFl/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "image": {
+                                  "path": "/EGqljg4x/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "primaryButton": {
+                                  "path": "/TBoKgmUE/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/tqX7SCKc/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "pD8UQKqT",
+              "displayName": "Full Width Action Block",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "BS3VZDDS",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "P8671GK5",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "VByM26Dq",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "e3oqSxBp",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "ZpinQk1s",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "mKmQjjB5",
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "0BYMXHkY",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "XQ7TfDn9",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "IAwsxK7N",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "pU9KFVeN",
+                      "definitionId": "fullWidthActionBlock",
+                      "patternProperties": {},
+                      "variables": {
+                        "image": {
+                          "path": "/FbSNI62I/fields/image/~locale/fields/file/~locale",
+                          "type": "BoundValue"
+                        },
+                        "overline": {
+                          "path": "/zibXm2hu/fields/actionBlockOverline/~locale",
+                          "type": "BoundValue"
+                        },
+                        "title": {
+                          "path": "/k5eX10Tv/fields/title/~locale",
+                          "type": "BoundValue"
+                        },
+                        "description": {
+                          "path": "/d2JuVKZQ/fields/shortDescription/~locale",
+                          "type": "BoundValue"
+                        },
+                        "primaryButton": {
+                          "path": "/NqrmKrUA/fields/primaryLinkRef/~locale",
+                          "type": "BoundValue"
+                        },
+                        "secondaryButton": {
+                          "path": "/f5guroL4/fields/secondaryLinkRef/~locale",
+                          "type": "BoundValue"
+                        },
+                        "background": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "X3HvQXNU",
+                      "definitionId": "divider",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "qPYEMk2o",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "Xsx7dtxc",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "dtvNdOmk",
+                      "definitionId": "fullWidthActionBlock",
+                      "patternProperties": {},
+                      "variables": {
+                        "image": {
+                          "path": "/DXDrLIKT/fields/image/~locale/fields/file/~locale",
+                          "type": "BoundValue"
+                        },
+                        "overline": {
+                          "path": "/XvAA9yze/fields/actionBlockOverline/~locale",
+                          "type": "BoundValue"
+                        },
+                        "title": {
+                          "path": "/lnB5pwJz/fields/title/~locale",
+                          "type": "BoundValue"
+                        },
+                        "description": {
+                          "path": "/MdJaRWGZ/fields/shortDescription/~locale",
+                          "type": "BoundValue"
+                        },
+                        "primaryButton": {
+                          "path": "/0TXnLT0j/fields/marketingLink/~locale",
+                          "type": "BoundValue"
+                        },
+                        "secondaryButton": {
+                          "path": "/uyYAAfql/fields/marketingLink/~locale",
+                          "type": "BoundValue"
+                        },
+                        "background": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "RdLeOx6U",
+                      "definitionId": "divider",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "fwnmq3Qj",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "v6A0d7WI",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "SYclWTwE",
+                      "definitionId": "contentful-container",
+                      "patternProperties": {},
+                      "variables": {
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "24px 24px 24px 24px"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(247, 248, 250, 1)"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "column"
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "type": "UnboundValue",
+                          "key": "ICrX3vs"
+                        },
+                        "cfOpenInNewTab": {
+                          "type": "UnboundValue",
+                          "key": "bAIeQt5"
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "type": "UnboundValue",
+                          "key": "fupk4k7"
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "children": [
+                        {
+                          "id": "jPGXtwTT",
+                          "definitionId": "fullWidthActionBlock",
+                          "patternProperties": {},
+                          "variables": {
+                            "image": {
+                              "path": "/w3A8mGao/fields/image/~locale/fields/file/~locale",
+                              "type": "BoundValue"
+                            },
+                            "overline": {
+                              "path": "/XXpWcD4q/fields/actionBlockOverline/~locale",
+                              "type": "BoundValue"
+                            },
+                            "title": {
+                              "path": "/x7pyjFFj/fields/title/~locale",
+                              "type": "BoundValue"
+                            },
+                            "description": {
+                              "path": "/WIYCSsvX/fields/shortDescription/~locale",
+                              "type": "BoundValue"
+                            },
+                            "primaryButton": {
+                              "path": "/xSo60zbz/fields/primaryLinkRef/~locale",
+                              "type": "BoundValue"
+                            },
+                            "secondaryButton": {
+                              "path": "/baGfsFOR/fields/secondaryLinkRef/~locale",
+                              "type": "BoundValue"
+                            },
+                            "background": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "secondary"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            }
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "8dDKrpX8",
+              "displayName": "Button",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "nM4Jx3EajfRTuaILiaRh1",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "Gs0XOO8d5eKpR2MQKAm8x",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "ZUNHb1QCXiLvRUG9taeN8",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "HjMZCQC6",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "vy3Z4qCBqa2yM79waYyZx",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "sqnBKCvr",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "lzUBFGk045vgYma7aXjur",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "ZA7w0xDd",
+                      "displayName": "Button",
+                      "definitionId": "button",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "purple"
+                          }
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "text": {
+                          "key": "hXGMAy_S9tLUATPGf5Zry",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "key": "m5B_-isX7sffstDtAWTWi",
+                          "type": "UnboundValue"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "Jr3_e_AP72m0PxsOOIzg6",
+                          "type": "UnboundValue"
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": ""
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "sMndlIZK",
+                      "displayName": "Button 1",
+                      "definitionId": "button",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "black"
+                          }
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "text": {
+                          "key": "C2eh9B38",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "key": "JwQMnloG",
+                          "type": "UnboundValue"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "Xyg0Z-kNXwLoS7tUWKWe4",
+                          "type": "UnboundValue"
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "home"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "i9TQ90r1",
+                      "displayName": "Button 2",
+                      "definitionId": "button",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "white"
+                          }
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "text": {
+                          "key": "7PWBeER6",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "key": "6ktx3JHv",
+                          "type": "UnboundValue"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "BHheSJr0-DKiQ2KV6nT9b",
+                          "type": "UnboundValue"
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "smile"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "LLoJaXAe",
+                      "definitionId": "divider",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "xs"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "fdLp3ahg",
+                      "displayName": "Left Aligned Button",
+                      "definitionId": "button",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "purple"
+                          }
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "text": {
+                          "key": "C820WrIq2MCzdJJuM4oiI",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "type": "UnboundValue",
+                          "key": "uMhUcdTnHh9zPBFXifvKq"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "Q8S_CqSaOYMVwDMKlR3jr",
+                          "type": "UnboundValue"
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": ""
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "n4kkpjAV",
+                      "displayName": "Centered Button",
+                      "definitionId": "button",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "purple"
+                          }
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "text": {
+                          "key": "WasTGlxj",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "type": "UnboundValue",
+                          "key": "NhzwQJMw"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "jjrfcFBAJ5AspsCCOO2xO",
+                          "type": "UnboundValue"
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": ""
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "UkQimeF2",
+                      "displayName": "Right Aligned Button",
+                      "definitionId": "button",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "purple"
+                          }
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "text": {
+                          "key": "B1N7IJY8",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "type": "UnboundValue",
+                          "key": "dczpwBQS"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "SHqULneHIzJfEOPmKB4fN",
+                          "type": "UnboundValue"
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": ""
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "gXGGF3fe",
+              "displayName": "Column",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "FW4Y2V_ECnApbkzqsUbE_",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "PFl39glIFt1TSFfKzC2-Z",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "08mxl1BGFzTbKwyQDG6DD",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "g3bDeJ5Q",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "LC3Zogrcyn7ko8fQM4Nqs",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "kSaqrZkL",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "7tPoQs29dgRnwZubnGEms",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "1xhHBB2q",
+                      "definitionId": "contentful-columns",
+                      "patternProperties": {},
+                      "variables": {
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "PWEyhxSkmxTGO951MgkM_",
+                          "type": "UnboundValue"
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "10px 10px 10px 10px"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1px solid rgba(0, 0, 0, 1)"
+                          }
+                        },
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "10px 10px"
+                          }
+                        },
+                        "cfColumns": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "[3,3,3,3]"
+                          }
+                        },
+                        "cfWrapColumns": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfWrapColumnsCount": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "2"
+                          }
+                        }
+                      },
+                      "children": [
+                        {
+                          "id": "4aK86X01",
+                          "definitionId": "contentful-single-column",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "-hiP47xkS8H9dfmgslbdh",
+                              "type": "UnboundValue"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "start"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfColumnSpan": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "6"
+                              }
+                            },
+                            "cfColumnSpanLock": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "zAfKojaP",
+                              "definitionId": "paragraph",
+                              "patternProperties": {},
+                              "variables": {
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "children": {
+                                  "key": "uyEiVj6ofeCIPPsOLAAcg",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "left"
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "ivBBNdu3",
+                          "definitionId": "contentful-single-column",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "h1C3gxnYgR9u4L8CDjo3D",
+                              "type": "UnboundValue"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfColumnSpan": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "6"
+                              }
+                            },
+                            "cfColumnSpanLock": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "gbRF7ltC",
+                              "definitionId": "paragraph",
+                              "patternProperties": {},
+                              "variables": {
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "children": {
+                                  "key": "fLRxfb9Ecsh1B9F3VCTCi",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "center"
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "2fCB1Xtu",
+                          "definitionId": "contentful-single-column",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "jUIXS8jmgg7N0QAzowItS",
+                              "type": "UnboundValue"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "end"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfColumnSpan": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "6"
+                              }
+                            },
+                            "cfColumnSpanLock": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "L9hvodcz",
+                              "definitionId": "paragraph",
+                              "patternProperties": {},
+                              "variables": {
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "children": {
+                                  "key": "3BFpKy2b749t3Z0j19D9a",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "right"
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "lv1SSmyU",
+                          "definitionId": "contentful-single-column",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "fP6j0_ZupHdFnUUB_Ia5H",
+                              "type": "UnboundValue"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfColumnSpan": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "6"
+                              }
+                            },
+                            "cfColumnSpanLock": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            }
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "ti6YFTJB",
+              "displayName": "Container",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "X4E1tjHt",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "6pLrv7NC",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "3kOq2u6E",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "uHUM5mzD",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "_byo2Rxu56P0ZbFndME7R",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "eDgH4prd",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "V8YHlFRp",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "uCuOdCYT",
+                      "definitionId": "contentful-container",
+                      "patternProperties": {},
+                      "variables": {
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "row"
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "key": "IsyZ4DkUsAKB5tReDxD1q",
+                          "type": "UnboundValue"
+                        },
+                        "cfOpenInNewTab": {
+                          "key": "rpWptElOUBNuPNQXKsjMo",
+                          "type": "UnboundValue"
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "mFzwT6KHtA9j1FYYT0dvh",
+                          "type": "UnboundValue"
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "children": [
+                        {
+                          "id": "a9I1ElrU",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "start"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "25%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "XeBIpyktpVkLEy45skA7l",
+                              "type": "UnboundValue"
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "2T84aGT0sd1wyPrlXpm_v",
+                              "type": "UnboundValue"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "cKcaNJOJ3vHPn3yBMhHgh",
+                              "type": "UnboundValue"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "FNbhC3Xu",
+                              "definitionId": "heading",
+                              "patternProperties": {},
+                              "variables": {
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "heading-xxl"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "children": {
+                                  "key": "op-Qp-gdr8uf9I9-WXcdr",
+                                  "type": "UnboundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "left"
+                                  }
+                                }
+                              },
+                              "children": []
+                            },
+                            {
+                              "id": "UDIwg6gf",
+                              "definitionId": "paragraph",
+                              "patternProperties": {},
+                              "variables": {
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "children": {
+                                  "key": "QcBjAcsD-IhgBz5nwADMs",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "left"
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "E07pN8W4",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "25%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "Vbrs8KDX",
+                              "type": "UnboundValue"
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "6lSOjmKa",
+                              "type": "UnboundValue"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "zkx5V9ed",
+                              "type": "UnboundValue"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "o6xpiMNG",
+                              "definitionId": "heading",
+                              "patternProperties": {},
+                              "variables": {
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "heading-xxl"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "children": {
+                                  "key": "M8tEEkEnbhdKkkzZSTBRd",
+                                  "type": "UnboundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "left"
+                                  }
+                                }
+                              },
+                              "children": []
+                            },
+                            {
+                              "id": "NcKsyTr5",
+                              "definitionId": "paragraph",
+                              "patternProperties": {},
+                              "variables": {
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "children": {
+                                  "key": "l2UKloU9",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "center"
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "1vmrSFao",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "end"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "25%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "yzVjh0Ni",
+                              "type": "UnboundValue"
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "18Loxedj",
+                              "type": "UnboundValue"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "5OJDXQCx",
+                              "type": "UnboundValue"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "48VmFOtI",
+                              "definitionId": "heading",
+                              "patternProperties": {},
+                              "variables": {
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "heading-xxl"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "children": {
+                                  "key": "sfjHI0Y3PWcC6rm8lYfap",
+                                  "type": "UnboundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "right"
+                                  }
+                                }
+                              },
+                              "children": []
+                            },
+                            {
+                              "id": "VkXRXr2S",
+                              "definitionId": "paragraph",
+                              "patternProperties": {},
+                              "variables": {
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "children": {
+                                  "key": "7Cj0SIqV",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "right"
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "Clx6dZLd",
+              "displayName": "Divider",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "FXuaWYztKfKJWXod-xTpd",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "ZClRveUvVcQjBrlrDvtm6",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "zcuX6eaiBiUs3mCXjHYq2",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "BRrxH9Ul",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "koY0ISJaPzBIDXqlznL0H",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "s5HoxC42",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "fvbdsWsT",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "pHAqHABK",
+                      "displayName": "Divider",
+                      "definitionId": "divider",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "none"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "WydkYUZS",
+                      "displayName": "Divider 1",
+                      "definitionId": "divider",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "strong"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "l"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "KpnHx64w",
+              "displayName": "Heading",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "GQ_meekKAizcWHfsUxUEe",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "JVQR-tfdKQE3G3iyEGd3d",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "k2x0YIUxjaXNGJxbL2xFl",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "DiK9VHcn",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "aTtjH3mTVn7fMVJ-xb2nG",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "QeFTqe9z",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "1O9vd7afmvcqJPb-Hst2m",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "s9BWm87K",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "ppcJTpQrNNmiFzRpoKuk7",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "g7eJTxtZ",
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-lg"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "k7cc4DWU",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "Og5azalB",
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-md"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "J8z7Qo1L",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "aqtlS0Go",
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-sm"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "mCXPy8Sk",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "B3ylIbTZ",
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xs"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "rMO0UpAm",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "emFwvLP8",
+              "displayName": "Image",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "8LDk6KB4",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "aPeti3xV",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "7954gvrQ",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "OX0joJve",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "mJJmzfsA",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "AI1IIxgR",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "ZJnqNzR6",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "pW9sYR0b",
+                      "definitionId": "contentful-container",
+                      "patternProperties": {},
+                      "variables": {
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "178px",
+                            "mobile": "fit-content"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "row",
+                            "mobile": "column"
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px 24px",
+                            "mobile": "24px 24px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "type": "UnboundValue",
+                          "key": "Fe4Bfar"
+                        },
+                        "cfOpenInNewTab": {
+                          "type": "UnboundValue",
+                          "key": "baOMaPo"
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "type": "UnboundValue",
+                          "key": "KBQ3_Cb"
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "children": [
+                        {
+                          "id": "Jk6x2y8G",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "Idr0CiO"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "JFCnn0N"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "xbPE1--"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "8oIklkai",
+                              "definitionId": "image",
+                              "patternProperties": {},
+                              "variables": {
+                                "src": {
+                                  "path": "/JtSxyKC/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "altText": {
+                                  "key": "KU5oIGN",
+                                  "type": "UnboundValue"
+                                },
+                                "decoration": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "none"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfWidth": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "100%"
+                                  }
+                                },
+                                "cfHeight": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "fit-content"
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "K3kEoR9T",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "FHSW9Y15"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "eI0ylAC7"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "uNXnh4Ev"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "fSh2sEYp",
+                              "definitionId": "image",
+                              "patternProperties": {},
+                              "variables": {
+                                "src": {
+                                  "path": "/gxYbZM71/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "altText": {
+                                  "key": "m93uQB8b",
+                                  "type": "UnboundValue"
+                                },
+                                "decoration": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "border"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfWidth": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "100%"
+                                  }
+                                },
+                                "cfHeight": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "fit-content"
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        },
+                        {
+                          "id": "N7Aakgl2",
+                          "definitionId": "contentful-container",
+                          "patternProperties": {},
+                          "variables": {
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "type": "UnboundValue",
+                              "key": "La3LNBan"
+                            },
+                            "cfOpenInNewTab": {
+                              "type": "UnboundValue",
+                              "key": "DdGHC1uP"
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "type": "UnboundValue",
+                              "key": "LlO8NttI"
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "children": [
+                            {
+                              "id": "WRfAXA8Z",
+                              "definitionId": "image",
+                              "patternProperties": {},
+                              "variables": {
+                                "src": {
+                                  "path": "/6xDlDPPs/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "altText": {
+                                  "key": "T8hhqfhy",
+                                  "type": "UnboundValue"
+                                },
+                                "decoration": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "shadow"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "cfWidth": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "100%"
+                                  }
+                                },
+                                "cfHeight": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "fit-content"
+                                  }
+                                }
+                              },
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "xHJlZCCH",
+              "displayName": "Overline",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "Ry2EmrfLWGKKxHzN2NKK2",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "MJmfC3N564sY154aazOqg",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "fbxlhQrAD8jhqeEPcb_Zc",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "85sUjnT6",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "vYKqsBQ5xXnkpbPCxrnKb",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "b2f0KDFZ",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "-KqdBQBCJexO6AUlN6Hdk",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "L9QvdEUS",
+                      "displayName": "Overline",
+                      "definitionId": "overline",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "1eCExq2WLGpJwNbRFYPCg",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "H2y2eW6g",
+                      "displayName": "Overline 1",
+                      "definitionId": "overline",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "Lu9xfUr8",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "K6qaxqTv",
+                      "displayName": "Overline 2",
+                      "definitionId": "overline",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "l"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "tgfqSQxT",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "elX9Jq6X",
+              "displayName": "Paragraph",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "REWmmbf2LKIIYFlPSLTFy",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "aDgvlZ6op1gK3MYklFgKX",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "lP2xlEiG4Ur15q_7otUZo",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "5XxdQJUA",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "L6HfuP4oVMvQ_xwZqzQc7",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "KesTZnYJ",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "4fZ-pGgFlP7R6tach397W",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "AMYwkYNk",
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-four"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "joR8i87odA3R7JLfvzfCw",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "zJvuD0HD",
+                      "displayName": "Paragraph 1",
+                      "definitionId": "paragraph",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-two"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "TSFzv7B9",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "SJd9fYto",
+                      "displayName": "Paragraph 2",
+                      "definitionId": "paragraph",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-two"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "avmUJimV",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "pl5CZVbe",
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "hRhxjrt3N9VU1NMl2QRh3",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "mmiz1hHo",
+              "displayName": "Section",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "g1GOPI4w",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "qhMtsAXw",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "Oor1uCW9",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "jIECLTTH",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "patternDark"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "TPp4t_zOnGYYUCQCHczCd",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "io9EJVj6",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "uqryIUsQ",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                },
+                {
+                  "id": "Ko7M7vnH",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "patternPrimary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "wmG6IXrB1B-h8zddto0vr",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "RSQxdVwv",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "qM57cKR3J1QPDQnHDERkX",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "ZX4djoXt",
+              "displayName": "Text Link",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "ilVAO2EaIUZ0lA5ewKtJI",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "2PSTJ_DqEZxNVxIpr_H8t",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "lgABBbaFeSQbvkWefAwA5",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "wrGEKnPn",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "7W1Qi2iLcCJo1S5FoTklH",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "WF76U7uH",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "ws1Q0E4GP0WIGLne79bIY",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "OYIhzN9w",
+                      "displayName": "Text Link 2",
+                      "definitionId": "link",
+                      "patternProperties": {},
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "xs"
+                          }
+                        },
+                        "children": {
+                          "key": "ERvTdJXH",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "key": "zQNTpdsD",
+                          "type": "UnboundValue"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "ReHgFwZk-BHm9gAcpYww7",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "bTLH9bp5",
+                      "displayName": "Text Link",
+                      "definitionId": "link",
+                      "patternProperties": {},
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "children": {
+                          "key": "EX79hiIuw8_2Ria-2tQkj",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "key": "L7sMSlH7Y_F-LSZzoglh6",
+                          "type": "UnboundValue"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "dDFAtpAu4xTWTM3cwvHX_",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "Bobqy9W3",
+                      "displayName": "Text Link 1",
+                      "definitionId": "link",
+                      "patternProperties": {},
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "children": {
+                          "key": "lIsy1GAr",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "key": "92O5l7Xr",
+                          "type": "UnboundValue"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "KGUo-pbAmZDeE_onnJmeM",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "8WDnlPms",
+                      "displayName": "Text Link 1",
+                      "definitionId": "link",
+                      "patternProperties": {},
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "l"
+                          }
+                        },
+                        "children": {
+                          "key": "nBnzzrrg",
+                          "type": "UnboundValue"
+                        },
+                        "href": {
+                          "key": "Icqsu9JA",
+                          "type": "UnboundValue"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "vNE31MABBbkMScnKL4BMU",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "bBEfl0Ck",
+                      "definitionId": "divider",
+                      "patternProperties": {},
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "xs"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "5IqQIrwI",
+                      "displayName": "Left aligned",
+                      "definitionId": "link",
+                      "patternProperties": {},
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "children": {
+                          "type": "UnboundValue",
+                          "key": "c6Xllyd"
+                        },
+                        "href": {
+                          "type": "UnboundValue",
+                          "key": "6znvK3h"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "4GGacxRsnhMslE0UcSJ97",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "MjacnNa2",
+                      "displayName": "Centered",
+                      "definitionId": "link",
+                      "patternProperties": {},
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "children": {
+                          "type": "UnboundValue",
+                          "key": "PeTivMde"
+                        },
+                        "href": {
+                          "type": "UnboundValue",
+                          "key": "5wXRsLJn"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "0v9inr8Fpqnw8F8ElhUQT",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "nLDuaCau",
+                      "displayName": "Right aligned",
+                      "definitionId": "link",
+                      "patternProperties": {},
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "children": {
+                          "type": "UnboundValue",
+                          "key": "DEtHVoSd"
+                        },
+                        "href": {
+                          "type": "UnboundValue",
+                          "key": "1VT4PEqW"
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "46SVVu7SVI_27igWB64S2",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "UXWNakDB",
+              "displayName": "Video",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "G5Iyv0YkdyGi6tu6eXCln",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "YKCODw2Gj_YPupxeh2ON7",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "5S0WDaNvwkgyaaXOaPShS",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "rtrOzYi0",
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "6AjZi52JdcRm7jrVI6Sal",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "AdqCNDR9",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "K0KxrTFkzU8KmLwowRzGo",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "CuFH5tMP",
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "Is-QBxBKRvrSLF5e6k8WM",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "e56jD7Ml",
+                      "displayName": "Video",
+                      "definitionId": "video",
+                      "patternProperties": {},
+                      "variables": {
+                        "videoTitle": {
+                          "key": "FdwpeSt6bn8LpSSV0pbtv",
+                          "type": "UnboundValue"
+                        },
+                        "videoDesc": {
+                          "key": "aL5ooU7rF-Cfhi4sEFovm",
+                          "type": "UnboundValue"
+                        },
+                        "uploadDate": {
+                          "key": "YfZC6-Hmjrj20Loaq6-FT",
+                          "type": "UnboundValue"
+                        },
+                        "youTubeId": {
+                          "key": "n0l5OgPZtTMQsbZ3GNKiR",
+                          "type": "UnboundValue"
+                        },
+                        "videoFallback": {
+                          "key": "qg0XcsQhQK20HDFZctW0_",
+                          "type": "UnboundValue"
+                        },
+                        "showCaption": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "51WBcL8X",
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "nOVfFtTI",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "WVvTAVCW",
+                      "displayName": "Video 1",
+                      "definitionId": "video",
+                      "patternProperties": {},
+                      "variables": {
+                        "videoTitle": {
+                          "key": "uTgCIxZc",
+                          "type": "UnboundValue"
+                        },
+                        "videoDesc": {
+                          "key": "7cjXZUvesiyPKoMJZUraJ",
+                          "type": "UnboundValue"
+                        },
+                        "uploadDate": {
+                          "key": "aRYsNWTbO_8er8D_crzl2",
+                          "type": "UnboundValue"
+                        },
+                        "youTubeId": {
+                          "key": "vNAYFsDQ",
+                          "type": "UnboundValue"
+                        },
+                        "videoFallback": {
+                          "key": "5OKBDu4C",
+                          "type": "UnboundValue"
+                        },
+                        "showCaption": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "jkcCZDp5",
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "8tSwOMzw",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "x1xIoh5c",
+                      "displayName": "Video",
+                      "definitionId": "video",
+                      "patternProperties": {},
+                      "variables": {
+                        "videoTitle": {
+                          "key": "jNBarAZvvExnBW0FccdXk",
+                          "type": "UnboundValue"
+                        },
+                        "videoDesc": {
+                          "key": "SQ455se7uXiseEPWsgHS4",
+                          "type": "UnboundValue"
+                        },
+                        "uploadDate": {
+                          "key": "UnsmjdqCrmrO4Trj1nuzn",
+                          "type": "UnboundValue"
+                        },
+                        "youTubeId": {
+                          "key": "HkS6sKTzMLaB2xX5evo7Z",
+                          "type": "UnboundValue"
+                        },
+                        "videoFallback": {
+                          "key": "WWIhqOfAkCpzLs6ZV3raO",
+                          "type": "UnboundValue"
+                        },
+                        "showCaption": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "HkaGv0Z3",
+              "displayName": "Video Carousel",
+              "definitionId": "contentful-section",
+              "patternProperties": {},
+              "variables": {
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "C0ZnFmnY1RLOEnDrehvP2",
+                  "type": "UnboundValue"
+                },
+                "cfOpenInNewTab": {
+                  "key": "Enm2i9xxpZNHnLD0K1fpI",
+                  "type": "UnboundValue"
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "-izis13YUPq4WCazZckUr",
+                  "type": "UnboundValue"
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "children": [
+                {
+                  "id": "nnW16yI0",
+                  "definitionId": "section",
+                  "patternProperties": {},
+                  "variables": {
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "id": {
+                      "key": "sU117GEiAbQOFMhXtxs7a",
+                      "type": "UnboundValue"
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "children": [
+                    {
+                      "id": "89PlsO6u",
+                      "definitionId": "heading",
+                      "patternProperties": {},
+                      "variables": {
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "children": {
+                          "key": "zyqjhLXToMUDWS9_Gj5le",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        }
+                      },
+                      "children": []
+                    },
+                    {
+                      "id": "CzL11C45",
+                      "definitionId": "carousel-video",
+                      "patternProperties": {},
+                      "variables": {
+                        "slides": {
+                          "path": "/9g-7kZ472XQBkhnml-mZ-/fields/slides/~locale",
+                          "type": "BoundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "dataSource": {
+        "en-US": {
+          "JtSxyKC": {
+            "sys": {
+              "id": "6fdNRFZbNXpiXQd6v7fHen",
+              "type": "Link",
+              "linkType": "Asset"
+            }
+          },
+          "0HkUraow": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "0TXnLT0j": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "0Uc1jnt8": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "1V2S6k5O": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "289w042P": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "3xRBhtEN": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "4rTEErM8": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "5gQSSrFE": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "6xDlDPPs": {
+            "sys": {
+              "id": "6fdNRFZbNXpiXQd6v7fHen",
+              "type": "Link",
+              "linkType": "Asset"
+            }
+          },
+          "7Gxx550Y": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "8W24TK7L": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "9VSvsbCf": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "D06vmzVo": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "DXDrLIKT": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "EGqljg4x": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "FbSNI62I": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "Gac8HyiL": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "L1oQ0Cfn": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "L4ppraxB": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "MKnXMzs0": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "MdJaRWGZ": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "NQABxHSW": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "NqrmKrUA": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "OBu7LBgD": {
+            "sys": {
+              "id": "4SDvKKtx0qpCDwFTizoPVx",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "OkAdGTNN": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "P3w0MI3x": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "PkMzRu3l": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "S9wdCChd": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "TBoKgmUE": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "TDy6kSns": {
+            "sys": {
+              "id": "4SDvKKtx0qpCDwFTizoPVx",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "Ura63qS4": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "VHT0F26i": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "WIYCSsvX": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "XC0Orztn": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "XXpWcD4q": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "XvAA9yze": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "baGfsFOR": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "btGygYlg": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "d2JuVKZQ": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "eV4HBBLe": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "eeVAmXO7": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "f5guroL4": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "gxYbZM71": {
+            "sys": {
+              "id": "6fdNRFZbNXpiXQd6v7fHen",
+              "type": "Link",
+              "linkType": "Asset"
+            }
+          },
+          "hbWAEPUa": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "iKuwF5UL": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "jgZPQ2f4": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "k5eX10Tv": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "lnB5pwJz": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "o5ZyffFl": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "o8e0EuB2": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "pnEVNJEY": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "q64yPb2d": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "qUW7SuUq": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "qj8MdFqk": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "sCyp4umt": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "sOCuihY3": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "tgGNSw4W": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "tqX7SCKc": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "uyYAAfql": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "w3A8mGao": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "wf6Nfy0h": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "x7pyjFFj": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "xSo60zbz": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "zibXm2hu": {
+            "sys": {
+              "id": "7Gumifs6ZTcj2G02BUoqFz",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          },
+          "9g-7kZ472XQBkhnml-mZ-": {
+            "sys": {
+              "id": "20rQYDvS9V3fnwtMyAW0m4",
+              "type": "Link",
+              "linkType": "Entry"
+            }
+          }
+        }
+      },
+      "unboundValues": {
+        "en-US": {
+          "6znvK3h": {},
+          "Fe4Bfar": {
+            "value": ""
+          },
+          "ICrX3vs": {
+            "value": ""
+          },
+          "Idr0CiO": {
+            "value": ""
+          },
+          "JFCnn0N": {
+            "value": false
+          },
+          "KBQ3_Cb": {},
+          "KU5oIGN": {
+            "value": ""
+          },
+          "bAIeQt5": {
+            "value": false
+          },
+          "baOMaPo": {
+            "value": false
+          },
+          "c6Xllyd": {
+            "value": "Link"
+          },
+          "fupk4k7": {},
+          "xbPE1--": {},
+          "0BYMXHkY": {
+            "value": "Full Width Action Block"
+          },
+          "18Loxedj": {
+            "value": false
+          },
+          "1VT4PEqW": {},
+          "1g7RleiK": {
+            "value": false
+          },
+          "36YfTgYM": {
+            "value": ""
+          },
+          "3kOq2u6E": {},
+          "5OJDXQCx": {},
+          "5OKBDu4C": {},
+          "5rKwB2lO": {
+            "value": ""
+          },
+          "5wXRsLJn": {},
+          "6dweZgN5": {
+            "value": false
+          },
+          "6ktx3JHv": {
+            "value": "about:blank"
+          },
+          "6lSOjmKa": {
+            "value": false
+          },
+          "6pLrv7NC": {
+            "value": false
+          },
+          "7954gvrQ": {},
+          "7Cj0SIqV": {
+            "value": "Right Aligned: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+          },
+          "7PWBeER6": {
+            "value": "External Button"
+          },
+          "7SxgQMWi": {
+            "value": false
+          },
+          "8LDk6KB4": {
+            "value": ""
+          },
+          "8tSwOMzw": {
+            "value": "With fallback"
+          },
+          "92O5l7Xr": {
+            "value": "/ping"
+          },
+          "AKTPfVrs": {},
+          "Aw5CTnlT": {},
+          "B1N7IJY8": {
+            "value": "Right Aligned Button"
+          },
+          "BS3VZDDS": {
+            "value": ""
+          },
+          "C2eh9B38": {
+            "value": "Secondary Black Button"
+          },
+          "DEtHVoSd": {
+            "value": "Link"
+          },
+          "DdGHC1uP": {
+            "value": false
+          },
+          "ERvTdJXH": {
+            "value": "Internal Link XS"
+          },
+          "FHSW9Y15": {
+            "value": ""
+          },
+          "GGSUj7T7": {
+            "value": ""
+          },
+          "IAwsxK7N": {
+            "value": "With all content"
+          },
+          "IRGGNCsc": {
+            "value": "With all content "
+          },
+          "Icqsu9JA": {
+            "value": "about:blank"
+          },
+          "IuXKDn7Q": {},
+          "J8z7Qo1L": {
+            "value": "Heading 4"
+          },
+          "JjsxkEPq": {
+            "value": ""
+          },
+          "JwQMnloG": {
+            "value": "/ping"
+          },
+          "LY3fwrGF": {
+            "value": ""
+          },
+          "La3LNBan": {
+            "value": ""
+          },
+          "LlO8NttI": {},
+          "Lu9xfUr8": {
+            "value": "Overline Secondary Small"
+          },
+          "M6UV6klE": {
+            "value": "Math Symbols: 1 + 2 − 2 × 5 ≠ 0"
+          },
+          "Mo4S1GHf": {},
+          "NhzwQJMw": {
+            "value": "https://code.org"
+          },
+          "NspNpe6v": {
+            "value": ""
+          },
+          "Oor1uCW9": {},
+          "Ov2KaMlI": {
+            "value": ""
+          },
+          "P8671GK5": {
+            "value": false
+          },
+          "PeTivMde": {
+            "value": "Link"
+          },
+          "RLcvWIOm": {
+            "value": false
+          },
+          "SGrm6TeM": {},
+          "T8hhqfhy": {
+            "value": "Image with shadow"
+          },
+          "TC9267aF": {},
+          "TSFzv7B9": {
+            "value": "Paragraph Secondary Medium"
+          },
+          "Tgg1s2D2": {
+            "value": "Three across"
+          },
+          "TnZjwBke": {
+            "value": false
+          },
+          "V8YHlFRp": {
+            "value": "Container"
+          },
+          "VByM26Dq": {},
+          "Vbrs8KDX": {
+            "value": ""
+          },
+          "WasTGlxj": {
+            "value": "Centered Button"
+          },
+          "X4E1tjHt": {
+            "value": ""
+          },
+          "Xsx7dtxc": {
+            "value": "With external link buttons"
+          },
+          "ZJnqNzR6": {
+            "value": "Image"
+          },
+          "ZdTFBVAL": {
+            "value": false
+          },
+          "ZpinQk1s": {},
+          "aPeti3xV": {
+            "value": false
+          },
+          "avmUJimV": {
+            "value": "Paragraph Secondary Bold"
+          },
+          "bvkdCWAp": {
+            "value": "Math"
+          },
+          "byHQXRz8": {
+            "value": false
+          },
+          "d5NKAnwp": {
+            "value": "Localization"
+          },
+          "d7bQZFYP": {},
+          "dJNC5rnb": {},
+          "dWrBnOHy": {},
+          "dczpwBQS": {
+            "value": "https://code.org"
+          },
+          "eI0ylAC7": {
+            "value": false
+          },
+          "eMXbhJJO": {
+            "value": ""
+          },
+          "fvbdsWsT": {
+            "value": "Divider"
+          },
+          "g1GOPI4w": {
+            "value": ""
+          },
+          "gwYa67z7": {},
+          "gyjlsYtE": {
+            "value": ""
+          },
+          "hAGyY1mh": {
+            "value": false
+          },
+          "hEDkMrEi": {
+            "value": false
+          },
+          "k7cc4DWU": {
+            "value": "Heading 3"
+          },
+          "l2UKloU9": {
+            "value": "Center Aligned: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+          },
+          "lIsy1GAr": {
+            "value": "Internal Link M"
+          },
+          "lTlx2Ck5": {
+            "value": ""
+          },
+          "m93uQB8b": {
+            "value": "Image with border"
+          },
+          "mCXPy8Sk": {
+            "value": "Heading 5"
+          },
+          "mI3808f6": {
+            "value": false
+          },
+          "mJJmzfsA": {},
+          "mp03r8eT": {},
+          "nBnzzrrg": {
+            "value": "External Link L"
+          },
+          "nOVfFtTI": {
+            "value": "Without fallback"
+          },
+          "oPc8lo0F": {},
+          "qQFZT2Ct": {
+            "value": "Localization - Long Text"
+          },
+          "qhMtsAXw": {
+            "value": false
+          },
+          "rMO0UpAm": {
+            "value": "Heading 6"
+          },
+          "rXgI4Mvr": {
+            "value": "With secondary background"
+          },
+          "rqSvSSLH": {
+            "value": ""
+          },
+          "tgfqSQxT": {
+            "value": "Overline Primary Large"
+          },
+          "uML982xB": {
+            "value": "Short Text"
+          },
+          "uNXnh4Ev": {},
+          "uTgCIxZc": {
+            "value": "Video without Fallback"
+          },
+          "uqryIUsQ": {
+            "value": "Section - Pattern Dark"
+          },
+          "v6A0d7WI": {
+            "value": "With secondary background"
+          },
+          "vNAYFsDQ": {
+            "value": "nKIu9yen5nc"
+          },
+          "vl7mGMNk": {
+            "value": false
+          },
+          "xaSe4Rjf": {
+            "value": ""
+          },
+          "yzVjh0Ni": {
+            "value": ""
+          },
+          "z9iS8tow": {
+            "value": false
+          },
+          "zB9624m9": {
+            "value": "Action Block"
+          },
+          "zQNTpdsD": {
+            "value": "/ping"
+          },
+          "zkx5V9ed": {},
+          "-KqdBQBCJexO6AUlN6Hdk": {
+            "value": "Overline"
+          },
+          "-hiP47xkS8H9dfmgslbdh": {},
+          "-izis13YUPq4WCazZckUr": {},
+          "08mxl1BGFzTbKwyQDG6DD": {},
+          "0v9inr8Fpqnw8F8ElhUQT": {},
+          "1O9vd7afmvcqJPb-Hst2m": {
+            "value": "Heading"
+          },
+          "1eCExq2WLGpJwNbRFYPCg": {
+            "value": "Overline Primary Medium"
+          },
+          "204Ys74QveR6n_DzcowIB": {
+            "value": "This page is for engineering to test the integration between Contentful and Code.org. Please do not modify this page unless part of the engineering group."
+          },
+          "2PSTJ_DqEZxNVxIpr_H8t": {
+            "value": false
+          },
+          "2T84aGT0sd1wyPrlXpm_v": {
+            "value": false
+          },
+          "3BFpKy2b749t3Z0j19D9a": {
+            "value": "Right aligned"
+          },
+          "46SVVu7SVI_27igWB64S2": {},
+          "4GGacxRsnhMslE0UcSJ97": {},
+          "4fZ-pGgFlP7R6tach397W": {
+            "value": "Paragraph"
+          },
+          "5S0WDaNvwkgyaaXOaPShS": {},
+          "6AjZi52JdcRm7jrVI6Sal": {},
+          "7W1Qi2iLcCJo1S5FoTklH": {},
+          "7cjXZUvesiyPKoMJZUraJ": {},
+          "7tPoQs29dgRnwZubnGEms": {
+            "value": "Column"
+          },
+          "BHheSJr0-DKiQ2KV6nT9b": {},
+          "C0ZnFmnY1RLOEnDrehvP2": {
+            "value": ""
+          },
+          "C820WrIq2MCzdJJuM4oiI": {
+            "value": "Left Aligned Button\n\n"
+          },
+          "EX79hiIuw8_2Ria-2tQkj": {
+            "value": "Internal Link S"
+          },
+          "Enm2i9xxpZNHnLD0K1fpI": {
+            "value": false
+          },
+          "FW4Y2V_ECnApbkzqsUbE_": {
+            "value": ""
+          },
+          "FXuaWYztKfKJWXod-xTpd": {
+            "value": ""
+          },
+          "FdwpeSt6bn8LpSSV0pbtv": {
+            "value": ""
+          },
+          "G5Iyv0YkdyGi6tu6eXCln": {
+            "value": ""
+          },
+          "GQ_meekKAizcWHfsUxUEe": {
+            "value": ""
+          },
+          "Gs0XOO8d5eKpR2MQKAm8x": {
+            "value": false
+          },
+          "HkS6sKTzMLaB2xX5evo7Z": {
+            "value": "nKIu9yen5nc"
+          },
+          "Is-QBxBKRvrSLF5e6k8WM": {
+            "value": "Default Drop In"
+          },
+          "IsyZ4DkUsAKB5tReDxD1q": {
+            "value": ""
+          },
+          "JVQR-tfdKQE3G3iyEGd3d": {
+            "value": false
+          },
+          "Jr3_e_AP72m0PxsOOIzg6": {},
+          "K0KxrTFkzU8KmLwowRzGo": {
+            "value": "Video"
+          },
+          "KGUo-pbAmZDeE_onnJmeM": {},
+          "L6HfuP4oVMvQ_xwZqzQc7": {},
+          "L7sMSlH7Y_F-LSZzoglh6": {
+            "value": "/ping"
+          },
+          "LC3Zogrcyn7ko8fQM4Nqs": {},
+          "M8tEEkEnbhdKkkzZSTBRd": {
+            "value": "Center"
+          },
+          "MJmfC3N564sY154aazOqg": {
+            "value": false
+          },
+          "OmmiviO_PnQgExsnIQWG2": {},
+          "PFl39glIFt1TSFfKzC2-Z": {
+            "value": false
+          },
+          "PWEyhxSkmxTGO951MgkM_": {},
+          "Q8S_CqSaOYMVwDMKlR3jr": {},
+          "QcBjAcsD-IhgBz5nwADMs": {
+            "value": "Left Aligned: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+          },
+          "Qkx4iDxSBpSpgdmwqZhqM": {},
+          "R0C45WqvjfIgrCLvhJPSB": {
+            "value": "All the things UI Integration Test"
+          },
+          "REWmmbf2LKIIYFlPSLTFy": {
+            "value": ""
+          },
+          "ReHgFwZk-BHm9gAcpYww7": {},
+          "Ry2EmrfLWGKKxHzN2NKK2": {
+            "value": ""
+          },
+          "SHqULneHIzJfEOPmKB4fN": {},
+          "SQ455se7uXiseEPWsgHS4": {},
+          "TPp4t_zOnGYYUCQCHczCd": {},
+          "UnsmjdqCrmrO4Trj1nuzn": {},
+          "WWIhqOfAkCpzLs6ZV3raO": {
+            "value": "https://videos.code.org/social/what-most-schools-dont-teach.mp4"
+          },
+          "XeBIpyktpVkLEy45skA7l": {
+            "value": ""
+          },
+          "Xyg0Z-kNXwLoS7tUWKWe4": {},
+          "YKCODw2Gj_YPupxeh2ON7": {
+            "value": false
+          },
+          "YfZC6-Hmjrj20Loaq6-FT": {},
+          "ZClRveUvVcQjBrlrDvtm6": {
+            "value": false
+          },
+          "ZUNHb1QCXiLvRUG9taeN8": {},
+          "_byo2Rxu56P0ZbFndME7R": {},
+          "aDgvlZ6op1gK3MYklFgKX": {
+            "value": false
+          },
+          "aL5ooU7rF-Cfhi4sEFovm": {},
+          "aRYsNWTbO_8er8D_crzl2": {},
+          "aTtjH3mTVn7fMVJ-xb2nG": {},
+          "cKcaNJOJ3vHPn3yBMhHgh": {},
+          "dDFAtpAu4xTWTM3cwvHX_": {},
+          "fLRxfb9Ecsh1B9F3VCTCi": {
+            "value": "Center Aligned"
+          },
+          "fP6j0_ZupHdFnUUB_Ia5H": {},
+          "fbxlhQrAD8jhqeEPcb_Zc": {},
+          "h1C3gxnYgR9u4L8CDjo3D": {},
+          "hRhxjrt3N9VU1NMl2QRh3": {
+            "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi blandit orci nec iaculis ullamcorper. Morbi blandit bibendum nibh, at auctor metus consequat sit amet. Fusce sodales nisi dolor. Nam at lorem mattis, aliquam elit ut, facilisis nunc. Donec mollis sollicitudin dolor, sed blandit diam accumsan id. Proin suscipit lacus et elit molestie dignissim. Aliquam nisi velit, lobortis ut porta volutpat, aliquam at arcu.\n\nDonec nunc sapien, mattis congue pulvinar vel, sollicitudin vel sapien. Morbi quis pulvinar nulla. Cras ac sem ante. Sed eu interdum sapien, id fermentum nunc. Donec vehicula ut erat eget vehicula. Ut euismod sem ut nisl vehicula sagittis. Suspendisse mattis justo elit, eu sagittis lorem mattis id. Sed sit amet scelerisque magna, nec dictum ex. Praesent tincidunt massa sed laoreet posuere. Sed efficitur, justo id pharetra pretium, dui turpis convallis metus, eleifend euismod risus nibh vel enim. Vestibulum molestie justo eget ligula posuere bibendum."
+          },
+          "hXGMAy_S9tLUATPGf5Zry": {
+            "value": "Primary Button"
+          },
+          "i-CBt91tEkCmZHGzb85xW": {
+            "value": "Each Section in this page is composed of a unique CMS component. Add edge case scenarios to this section that you would like tested."
+          },
+          "ilVAO2EaIUZ0lA5ewKtJI": {
+            "value": ""
+          },
+          "is6sJNT7GqG8M-aved8xI": {
+            "value": ""
+          },
+          "jNBarAZvvExnBW0FccdXk": {
+            "value": "Video with Fallback"
+          },
+          "jUIXS8jmgg7N0QAzowItS": {},
+          "jjrfcFBAJ5AspsCCOO2xO": {},
+          "joR8i87odA3R7JLfvzfCw": {
+            "value": "Paragraph Body XS"
+          },
+          "k2x0YIUxjaXNGJxbL2xFl": {},
+          "koY0ISJaPzBIDXqlznL0H": {},
+          "lP2xlEiG4Ur15q_7otUZo": {},
+          "lgABBbaFeSQbvkWefAwA5": {},
+          "lgGRRfq5zcVueL3yrxoh9": {},
+          "lzUBFGk045vgYma7aXjur": {
+            "value": "Button"
+          },
+          "m4M7qU_VBvy3rP_lT7V-J": {
+            "value": false
+          },
+          "m5B_-isX7sffstDtAWTWi": {
+            "value": "/ping"
+          },
+          "mFzwT6KHtA9j1FYYT0dvh": {},
+          "n0l5OgPZtTMQsbZ3GNKiR": {},
+          "nM4Jx3EajfRTuaILiaRh1": {
+            "value": ""
+          },
+          "op-Qp-gdr8uf9I9-WXcdr": {
+            "value": "Left"
+          },
+          "ppcJTpQrNNmiFzRpoKuk7": {
+            "value": "Heading 2"
+          },
+          "qM57cKR3J1QPDQnHDERkX": {
+            "value": "Section - Pattern Teal"
+          },
+          "qg0XcsQhQK20HDFZctW0_": {},
+          "rpWptElOUBNuPNQXKsjMo": {
+            "value": false
+          },
+          "sQZaBqbWsJUIR6cGO4R7w": {},
+          "sU117GEiAbQOFMhXtxs7a": {},
+          "sfjHI0Y3PWcC6rm8lYfap": {
+            "value": "Right"
+          },
+          "uMhUcdTnHh9zPBFXifvKq": {
+            "value": "https://code.org"
+          },
+          "uyEiVj6ofeCIPPsOLAAcg": {
+            "value": "Left Aligned"
+          },
+          "vNE31MABBbkMScnKL4BMU": {},
+          "vYKqsBQ5xXnkpbPCxrnKb": {},
+          "vy3Z4qCBqa2yM79waYyZx": {},
+          "wmG6IXrB1B-h8zddto0vr": {},
+          "ws1Q0E4GP0WIGLne79bIY": {
+            "value": "Text Link"
+          },
+          "zcuX6eaiBiUs3mCXjHYq2": {},
+          "zyqjhLXToMUDWS9_Gj5le": {
+            "value": "Video Carousel"
+          }
+        }
+      },
+      "seoMetadata": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "1hQeP2bdFuIFm5kuYeefew"
+          }
+        }
+      }
+    }
+  },
+  "contentType": "experience"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/3BLuF3jm0oTV17RPwLOgC6.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/3BLuF3jm0oTV17RPwLOgC6.json
@@ -1,0 +1,25 @@
+{
+  "entryContent": {
+    "fields": {
+      "videoTitle": {
+        "en-US": "What Most Schools Don't Teach"
+      },
+      "youTubeId": {
+        "en-US": "nKIu9yen5nc"
+      },
+      "videoFallbackFile": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Asset",
+            "id": "5Unfit2zLyqPp9HofyWU9T"
+          }
+        }
+      },
+      "videoFallbackUrl": {
+        "en-US": "https://videos.ctfassets.net/90t6bu6vlf76/5Unfit2zLyqPp9HofyWU9T/4f0a43abe3dc649dc752ca321f1945c7/what-most-schools-dont-teach.mp4"
+      }
+    }
+  },
+  "contentType": "video"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/3oxrIQkHqzpbTrXqwk0aIa.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/3oxrIQkHqzpbTrXqwk0aIa.json
@@ -1,0 +1,25 @@
+{
+  "entryContent": {
+    "fields": {
+      "videoTitle": {
+        "en-US": "Computer Science is Changing Everything"
+      },
+      "youTubeId": {
+        "en-US": "QvyTEx1wyOY"
+      },
+      "videoFallbackFile": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Asset",
+            "id": "L5PVu2K4eN5rocJTApuC5"
+          }
+        }
+      },
+      "videoFallbackUrl": {
+        "en-US": "https://videos.ctfassets.net/90t6bu6vlf76/L5PVu2K4eN5rocJTApuC5/fb69b3b7d0a0e95989feec6165725a22/cs-is-everything.mp4"
+      }
+    }
+  },
+  "contentType": "video"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/49SifjEqSHArcx1iEiSw4o.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/49SifjEqSHArcx1iEiSw4o.json
@@ -1,0 +1,22 @@
+{
+  "entryContent": {
+    "fields": {
+      "linkName": {
+        "en-US": "⛔️ [ENGINEERING ONLY] Secondary button test"
+      },
+      "label": {
+        "en-US": "Secondary button test"
+      },
+      "primaryTarget": {
+        "en-US": "/ping"
+      },
+      "isThisAnExternalLink": {
+        "en-US": false
+      },
+      "ariaLabel": {
+        "en-US": "Secondary button test"
+      }
+    }
+  },
+  "contentType": "link"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/4SDvKKtx0qpCDwFTizoPVx.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/4SDvKKtx0qpCDwFTizoPVx.json
@@ -1,0 +1,27 @@
+{
+  "entryContent": {
+    "fields": {
+      "quoteName": {
+        "ar-SA": "يدعم Code.org المعلمين على طول الطريق من خلال التعلم المهني والمناهج الشاملة والدعم عندما تحتاج إليه.",
+        "en-US": "Code.org supports teachers the whole way with professional learning, comprehensive curricula, and support when you need it.",
+        "es-ES": "Code.org apoya a los docentes en todo momento con aprendizaje profesional, programas de estudio integrales y apoyo cuando lo necesita.",
+        "uk-UA": "Code.org надає вчителям повну підтримку професійним навчанням, комплексними навчальними програмами та підтримкою, коли вона вам потрібна.",
+        "zh-CN": "Code.org 通过专业学习、全面的课程和需要时的支持为教师提供全程支持。"
+      },
+      "longQuote": {
+        "ar-SA": "انضم إلى المجتمع العالمي الذي يضم أكثر من 2 مليون معلم يعملون على تمكين الجيل القادم من المبدعين وحل المشكلات والمواطنين الرقميين! يدعم Code.org المعلمين على طول الطريق من خلال التعلم المهني والمناهج الشاملة والدعم عندما تحتاج إليه.",
+        "en-US": "Join the global community of over 2 million educators empowering the next generation of innovators, problem solvers, and digital citizens! Code.org supports teachers the whole way with professional learning, comprehensive curricula, and support when you need it.",
+        "es-ES": "¡Únase a la comunidad global de más de 2 millones de educadores que empoderan a la próxima generación de innovadores, solucionadores de problemas y ciudadanos digitales! Code.org apoya a los docentes en todo momento con aprendizaje profesional, programas de estudio integrales y apoyo cuando lo necesite.",
+        "uk-UA": "Приєднуйтесь до глобальної спільноти з понад 2 мільйонів викладачів, які підтримують наступне покоління інноваторів, тих, хто вирішує проблеми, і цифрових громадян! Code.org надає вчителям повну підтримку професійним навчанням, комплексними навчальними програмами та підтримкою, коли вона вам потрібна.",
+        "zh-CN": "加入拥有超过 200 万教育工作者的全球社区，为下一代创新者、问题解决者和数字公民赋能！Code.org 通过专业学习、综合课程和您需要时的支持为教师提供全方位支持。"
+      },
+      "name": {
+        "en-US": "Code.org Engineering Team"
+      },
+      "descriptor": {
+        "en-US": "[ENGINEERING ONLY] Content localization test"
+      }
+    }
+  },
+  "contentType": "quote"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/4xyTmh7jAVCC3glKeke0cP.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/4xyTmh7jAVCC3glKeke0cP.json
@@ -1,0 +1,25 @@
+{
+  "entryContent": {
+    "fields": {
+      "videoTitle": {
+        "en-US": "Introducing How Computers Work"
+      },
+      "youTubeId": {
+        "en-US": "OAx_6-wdslM"
+      },
+      "videoFallbackFile": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Asset",
+            "id": "2lkClZGdouHPDUTRZu8LxZ"
+          }
+        }
+      },
+      "videoFallbackUrl": {
+        "en-US": "https://videos.ctfassets.net/90t6bu6vlf76/2lkClZGdouHPDUTRZu8LxZ/271ce1df5c6909836589a34212476757/01_howcomputerswork_sm-mp4.mp4"
+      }
+    }
+  },
+  "contentType": "video"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/53hnyQQVUfylnTa7f24dDJ.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/53hnyQQVUfylnTa7f24dDJ.json
@@ -1,0 +1,28 @@
+{
+  "entryContent": {
+    "fields": {
+      "videoTitle": {
+        "en-US": "Introducing How AI Works"
+      },
+      "youTubeId": {
+        "en-US": "Ok-xpKjKp2g"
+      },
+      "videoFallbackFile": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Asset",
+            "id": "1jVlIMJ2yBmzqD1H5hHDNj"
+          }
+        }
+      },
+      "videoFallbackUrl": {
+        "en-US": "https://videos.ctfassets.net/90t6bu6vlf76/1jVlIMJ2yBmzqD1H5hHDNj/9fe6b733248373a6546b44d1bad1baf6/ai-01-intro-to-ai.mp4"
+      },
+      "publishedDate": {
+        "en-US": "2020-12-01T00:00-04:00"
+      }
+    }
+  },
+  "contentType": "video"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/5CznPyR4ZsbIkhpwSaUxoe.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/5CznPyR4ZsbIkhpwSaUxoe.json
@@ -1,0 +1,22 @@
+{
+  "entryContent": {
+    "fields": {
+      "linkName": {
+        "en-US": "⛔️ [ENGINEERING ONLY] External link button test"
+      },
+      "label": {
+        "en-US": "External link button test"
+      },
+      "primaryTarget": {
+        "en-US": "https://google.com"
+      },
+      "isThisAnExternalLink": {
+        "en-US": true
+      },
+      "ariaLabel": {
+        "en-US": "External link button test"
+      }
+    }
+  },
+  "contentType": "link"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/79dI2fR2dzbb0IN3dFQJ3t.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/79dI2fR2dzbb0IN3dFQJ3t.json
@@ -1,0 +1,19 @@
+{
+  "entryContent": {
+    "fields": {
+      "linkName": {
+        "en-US": "⛔️ [ENGINEERING ONLY] Primary button test"
+      },
+      "label": {
+        "en-US": "Primary button test"
+      },
+      "primaryTarget": {
+        "en-US": "/ping"
+      },
+      "isThisAnExternalLink": {
+        "en-US": false
+      }
+    }
+  },
+  "contentType": "link"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/7Gumifs6ZTcj2G02BUoqFz.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/7Gumifs6ZTcj2G02BUoqFz.json
@@ -1,0 +1,60 @@
+{
+  "entryContent": {
+    "fields": {
+      "title": {
+        "en-US": "TEST - Self-Paced PL"
+      },
+      "shortDescription": {
+        "en-US": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eget risus vitae massa semper aliquam quis mattis quam."
+      },
+      "image": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Asset",
+            "id": "6fdNRFZbNXpiXQd6v7fHen"
+          }
+        }
+      },
+      "primaryLinkRef": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "79dI2fR2dzbb0IN3dFQJ3t"
+          }
+        }
+      },
+      "secondaryLinkRef": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "49SifjEqSHArcx1iEiSw4o"
+          }
+        }
+      },
+      "marketingLink": {
+        "en-US": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "5CznPyR4ZsbIkhpwSaUxoe"
+          }
+        }
+      },
+      "actionBlockOverline": {
+        "en-US": "K-12 Teachers"
+      },
+      "experienceLevel": {
+        "en-US": [
+          "Beginner"
+        ]
+      },
+      "duration": {
+        "en-US": 1
+      }
+    }
+  },
+  "contentType": "selfPacedPl"
+}

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/entries.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/entries.json
@@ -1,0 +1,14 @@
+[
+  "79dI2fR2dzbb0IN3dFQJ3t",
+  "49SifjEqSHArcx1iEiSw4o",
+  "5CznPyR4ZsbIkhpwSaUxoe",
+  "7Gumifs6ZTcj2G02BUoqFz",
+  "4SDvKKtx0qpCDwFTizoPVx",
+  "53hnyQQVUfylnTa7f24dDJ",
+  "3BLuF3jm0oTV17RPwLOgC6",
+  "3oxrIQkHqzpbTrXqwk0aIa",
+  "4xyTmh7jAVCC3glKeke0cP",
+  "20rQYDvS9V3fnwtMyAW0m4",
+  "1hQeP2bdFuIFm5kuYeefew",
+  "2rnXDDT2HB8MmwM6u1L4bH"
+]

--- a/frontend/apps/marketing/tests/e2e/scripts/all-the-things-updater.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/all-the-things-updater.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env tsx
+
+import {createClient, Entry} from 'contentful-management';
+import {config} from 'dotenv';
+import yargs from 'yargs';
+import {hideBin} from 'yargs/helpers';
+
+import {fork} from './commands/fork';
+import {publishSnapshot} from './commands/publish-snapshot';
+import {updateSnapshot} from './commands/update-snapshot';
+import {ALL_THE_THINGS_ENTRY_ID, ROOT_DIR} from './config';
+import {CreateOrUpdateEntryInputProps, Environment} from './types';
+
+console.log(`Using ${ROOT_DIR}/.env`);
+config({path: `${ROOT_DIR}/.env`});
+
+const SPACE_ID = process.env.CONTENTFUL_SPACE_ID!;
+const ACCESS_TOKEN = process.env.CONTENTFUL_MANAGEMENT_TOKEN!;
+
+const client = createClient({accessToken: ACCESS_TOKEN});
+
+async function getEnvironment(environmentId: Environment) {
+  const space = await client.getSpace(SPACE_ID);
+  return space.getEnvironment(environmentId);
+}
+
+async function updateEntry({
+  entryId,
+  entryContent,
+  environment,
+  publish,
+}: {
+  entryId: string;
+  entryContent: Entry;
+  publish: boolean;
+  environment: Environment;
+}) {
+  const env = await getEnvironment(environment);
+
+  const entry = await env.getEntry(entryId);
+
+  Object.keys(entryContent.fields).forEach(field => {
+    entry.fields[field] = entryContent.fields[field];
+  });
+
+  await entry.update();
+
+  return publish ? entry.publish() : entry;
+}
+
+async function createOrUpdateEntry({
+  contentType,
+  entryId,
+  entryContent,
+  environment,
+  publish,
+  reuseId,
+}: CreateOrUpdateEntryInputProps) {
+  const env = await getEnvironment(environment);
+
+  // Check if the entry already exists
+  const existingEntry =
+    entryId && (await env.getEntry(entryId).catch(() => null));
+  if (existingEntry) {
+    // If it exists, update it
+    return updateEntry({
+      entryId,
+      entryContent,
+      publish,
+      environment,
+    });
+  } else {
+    // If it doesn't exist, create a new entry
+
+    const entry =
+      reuseId && entryId
+        ? await env.createEntryWithId(contentType, entryId, entryContent)
+        : await env.createEntry(contentType, entryContent);
+
+    return publish ? entry.publish() : entry;
+  }
+}
+
+async function main() {
+  const argv = await yargs(hideBin(process.argv))
+    .command(
+      'update-snapshot',
+      'Updates the source control version of All The Things',
+      args => {
+        args
+          .option('environment', {type: 'string', default: 'production'})
+          .option('source-entry-id', {
+            type: 'string',
+            default: ALL_THE_THINGS_ENTRY_ID,
+          });
+      },
+    )
+    .command(
+      'publish-snapshot',
+      'Publishes the source control version of All The Things to Contentful',
+      args =>
+        args.option('environment', {type: 'string', default: 'development'}),
+    )
+    .command(
+      'fork',
+      'Creates a fork of All The Things using the local snapshot',
+    )
+    .demandCommand(1)
+    .help()
+    .parse();
+
+  const command = argv._[0];
+
+  if (command === 'update-snapshot') {
+    await updateSnapshot(
+      client,
+      argv.environment as Environment,
+      argv.sourceEntryId as string,
+    );
+  } else if (command === 'publish-snapshot') {
+    await publishSnapshot(argv.environment as Environment, createOrUpdateEntry);
+  } else if (command === 'fork') {
+    await fork(createOrUpdateEntry);
+  } else {
+    console.error(`❌ Unknown command: ${command}`);
+    process.exit(1);
+  }
+}
+
+main().catch(error => {
+  console.error(`❌ Error: ${error.message}`, error);
+  process.exit(1);
+});

--- a/frontend/apps/marketing/tests/e2e/scripts/commands/fork.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/commands/fork.ts
@@ -1,0 +1,31 @@
+import {readJSON} from 'fs-extra';
+import os from 'node:os';
+
+import {SNAPSHOT_DIR, ALL_THE_THINGS_ENTRY_ID} from '../config';
+import {CreateOrUpdateEntryType, SerializedComponent} from '../types';
+
+export async function fork(createOrUpdateEntry: CreateOrUpdateEntryType) {
+  const snapshotFile = `${SNAPSHOT_DIR}/${ALL_THE_THINGS_ENTRY_ID}.json`;
+  const serializedComponent: SerializedComponent = await readJSON(snapshotFile);
+  const snapshotData = serializedComponent.entryContent;
+
+  // Change the slug and title for clarity
+  const username = os.userInfo().username;
+  const title = `[${username}] All The Things - ${new Date().toISOString()}`;
+  const slug = `all-the-things-${username}-${Date.now()}`;
+
+  snapshotData.fields.slug['en-US'] = slug;
+  snapshotData.fields.title['en-US'] = title;
+
+  const createdEntry = await createOrUpdateEntry({
+    contentType: serializedComponent.contentType,
+    entryContent: snapshotData,
+    publish: false,
+    environment: 'development',
+  });
+
+  console.log(`✅ Created fork ${title}`);
+  console.log(
+    `View on Experience Builder: https://app.contentful.com/spaces/${process.env.CONTENTFUL_SPACE_ID!}/environments/development/experiences/${createdEntry.sys.id}`,
+  );
+}

--- a/frontend/apps/marketing/tests/e2e/scripts/commands/publish-snapshot.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/commands/publish-snapshot.ts
@@ -1,0 +1,42 @@
+import {readJSON} from 'fs-extra';
+
+import {ALL_THE_THINGS_ENTRY_ID, SNAPSHOT_DIR} from '../config';
+import {
+  CreateOrUpdateEntryType,
+  Environment,
+  SerializedComponent,
+} from '../types';
+
+export async function publishSnapshot(
+  environment: Environment,
+  createOrUpdateEntry: CreateOrUpdateEntryType,
+) {
+  console.log(`Publishing snapshots to ${environment}`);
+
+  const postOrderEntryIds = await readJSON(`${SNAPSHOT_DIR}/entries.json`);
+
+  // entries.json is a post-order traversal of the component tree which means that
+  // each entry will be created from the leaf nodes of the tree up to the root node
+  for (const entryId of postOrderEntryIds) {
+    console.log(`Uploading linked entry ${entryId}`);
+    const linkedEntrySnapshotData: SerializedComponent = await readJSON(
+      `${SNAPSHOT_DIR}/${entryId}.json`,
+    );
+
+    const entry = linkedEntrySnapshotData.entryContent;
+
+    await createOrUpdateEntry({
+      contentType: linkedEntrySnapshotData.contentType,
+      entryContent: entry,
+      entryId,
+      reuseId: true,
+      publish: false,
+      environment,
+    });
+  }
+
+  console.log(`✅ Saved All The Things to ${environment} (Did not publish)`);
+  console.log(
+    `View on Experience Builder: https://app.contentful.com/spaces/${process.env.CONTENTFUL_SPACE_ID!}/environments/development/experiences/${ALL_THE_THINGS_ENTRY_ID}`,
+  );
+}

--- a/frontend/apps/marketing/tests/e2e/scripts/commands/update-snapshot.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/commands/update-snapshot.ts
@@ -1,0 +1,56 @@
+import {ClientAPI} from 'contentful-management';
+import {ensureDir, writeJSON} from 'fs-extra';
+
+import {buildComponentTree} from '../component-tree/builder';
+import {ComponentNode} from '../component-tree/component-tree';
+import {SNAPSHOT_DIR, ALL_THE_THINGS_ENTRY_ID} from '../config';
+import type {Environment} from '../types';
+
+export async function updateSnapshot(
+  client: ClientAPI,
+  environment: Environment,
+  sourceEntryId: string,
+) {
+  console.log(
+    `Updating snapshot using entry ${sourceEntryId} FORK=${sourceEntryId !== ALL_THE_THINGS_ENTRY_ID}`,
+  );
+
+  const isFork = sourceEntryId !== ALL_THE_THINGS_ENTRY_ID;
+  if (isFork) {
+    console.warn(
+      `⚠️ You are updating the snapshot using a forked version of All The Things`,
+    );
+  }
+
+  await ensureDir(SNAPSHOT_DIR);
+
+  // Fetch the target environment from where the entry is
+  const env = await client
+    .getSpace(process.env.CONTENTFUL_SPACE_ID!)
+    .then(space => space.getEnvironment(environment));
+  const rootEntry = await env.getEntry(sourceEntryId);
+
+  // Build the component tree
+  const rootNode = await buildComponentTree(env, rootEntry);
+
+  // Using DFS, serialize the component tree and track post-order traversal for bottoms-up deserialization
+  const postOrderNodes: string[] = [];
+
+  async function dfs(node: ComponentNode) {
+    await node.serialize(isFork);
+
+    for (const child of node.children) {
+      await dfs(child);
+    }
+
+    postOrderNodes.push(node.entryId);
+  }
+
+  await dfs(rootNode);
+
+  await writeJSON(`${SNAPSHOT_DIR}/entries.json`, postOrderNodes, {
+    spaces: 2,
+  });
+
+  console.log(`Post order of the component tree: ${postOrderNodes}`);
+}

--- a/frontend/apps/marketing/tests/e2e/scripts/component-tree/builder.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/component-tree/builder.ts
@@ -1,0 +1,91 @@
+import {Entry, Environment} from 'contentful-management';
+
+import {ALL_THE_THINGS_ENTRY_ID} from '../config';
+
+import {ComponentNode} from './component-tree';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getLinkedEntryIdsFromExperience(datasources: any[]) {
+  const linkedEntryIdSet = new Set<string>();
+
+  for (const datasource of datasources) {
+    if (datasource.sys?.linkType === 'Entry') {
+      linkedEntryIdSet.add(datasource.sys.id);
+    }
+  }
+
+  return linkedEntryIdSet;
+}
+
+/**
+ * The Experience JSON contains a field called "dataSource" which
+ * is a map of datasources. Each datasource references another asset or entry in a
+ * tree structure. In this case, the "All The Things" experience entry is the root node
+ * and the datasources are the direct children.
+ */
+function getRootNodeChildrenIdSet(entry: Entry) {
+  const datasources = Object.values(entry.fields.dataSource['en-US']);
+  const linkedEntryIdSet = getLinkedEntryIdsFromExperience(datasources);
+
+  // Also add the SEO entry id as a direct child of the experience entry
+  const seoEntryId = entry.fields.seoMetadata['en-US'].sys.id;
+  linkedEntryIdSet.add(seoEntryId);
+
+  return linkedEntryIdSet;
+}
+
+/**
+ * Recursively build the Component Tree, with "All The Things" experience entry as the root node
+ */
+export async function buildComponentTree(env: Environment, entry: Entry) {
+  const rootNode = new ComponentNode(ALL_THE_THINGS_ENTRY_ID, entry);
+  const rootNodeChildrenIdSet = getRootNodeChildrenIdSet(entry);
+
+  /**
+   * Reads each field (which is a 'variable' in experience) and checks if it is a linked entry.
+   * If it is, add it to the linkedEntryIdSet.
+   */
+  async function getLinkedEntriesFromEntry(entry: Entry) {
+    const linkedEntryIdSet = new Set<string>();
+
+    for (const field of Object.values(entry.fields)) {
+      const entries = Array.isArray(field['en-US'])
+        ? field['en-US']
+        : [field['en-US']];
+
+      for (const entry of entries) {
+        if (entry?.sys?.linkType === 'Entry') {
+          linkedEntryIdSet.add(entry.sys.id);
+        }
+      }
+    }
+
+    return linkedEntryIdSet;
+  }
+
+  /**
+   * Using depth-first traversal, build the component tree.
+   */
+  async function dfs(env: Environment, entryId: string) {
+    const entry = await env.getEntry(entryId);
+    const node = new ComponentNode(entryId, entry);
+
+    const linkedEntryIdSet = await getLinkedEntriesFromEntry(entry);
+
+    for (const linkedEntryId of linkedEntryIdSet) {
+      const linkedEntryNode = await dfs(env, linkedEntryId);
+      node.add(linkedEntryNode);
+    }
+
+    return node;
+  }
+
+  // Starting from the root node's children, perform dfs traversal to build the tree
+  for (const linkedEntryId of rootNodeChildrenIdSet) {
+    const linkedEntryNode = await dfs(env, linkedEntryId);
+
+    rootNode.add(linkedEntryNode);
+  }
+
+  return rootNode;
+}

--- a/frontend/apps/marketing/tests/e2e/scripts/component-tree/component-tree.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/component-tree/component-tree.ts
@@ -1,0 +1,54 @@
+import {Entry} from 'contentful-management';
+import {readJSON, writeJSON} from 'fs-extra';
+
+import {ALL_THE_THINGS_ENTRY_ID, SNAPSHOT_DIR} from '../config';
+import {SerializedComponent} from '../types';
+
+export class ComponentNode {
+  public children: ComponentNode[];
+  public entryId: string;
+  public entry: Entry;
+
+  constructor(entryId: string, entry: Entry) {
+    this.entryId = entryId;
+    this.entry = entry;
+    this.children = [];
+  }
+
+  add(component: ComponentNode) {
+    this.children.push(component);
+  }
+
+  async serialize(isFork: boolean) {
+    const entryPlainObject = this.entry.toPlainObject();
+
+    // If this is a fork, do not overwrite the title, slug and pageHeading
+    if (isFork && this.entryId === ALL_THE_THINGS_ENTRY_ID) {
+      const originalSerializedComponent: SerializedComponent = await readJSON(
+        `${SNAPSHOT_DIR}/${this.entryId}.json`,
+      );
+
+      const originalEntry = originalSerializedComponent.entryContent;
+
+      entryPlainObject.fields.title['en-US'] =
+        originalEntry.fields.title['en-US'];
+      entryPlainObject.fields.slug['en-US'] =
+        originalEntry.fields.slug['en-US'];
+      entryPlainObject.fields.pageHeading['en-US'] =
+        originalEntry.fields.pageHeading['en-US'];
+    }
+
+    await writeJSON(
+      `${SNAPSHOT_DIR}/${this.entryId}.json`,
+      {
+        entryContent: {fields: entryPlainObject.fields},
+        contentType: entryPlainObject.sys.contentType.sys.id,
+      },
+      {
+        spaces: 2,
+      },
+    );
+
+    console.log(`Serialized ${SNAPSHOT_DIR}/${this.entryId}.json`);
+  }
+}

--- a/frontend/apps/marketing/tests/e2e/scripts/config.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/config.ts
@@ -1,0 +1,5 @@
+import {resolve} from 'node:path';
+
+export const ALL_THE_THINGS_ENTRY_ID = '2rnXDDT2HB8MmwM6u1L4bH';
+export const ROOT_DIR = resolve('./');
+export const SNAPSHOT_DIR = resolve(`./tests/e2e/__snapshots__`);

--- a/frontend/apps/marketing/tests/e2e/scripts/types.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/types.ts
@@ -1,0 +1,25 @@
+import {Entry} from 'contentful-management';
+
+export type Environment = 'development' | 'test' | 'production';
+
+export type CreateOrUpdateEntryInputProps = {
+  contentType: string;
+  entryId?: string;
+  entryContent: Entry;
+  publish: boolean;
+  environment: Environment;
+  reuseId?: boolean;
+};
+
+export type CreateOrUpdateEntryType = ({
+  contentType,
+  entryContent,
+  environment,
+  publish,
+  reuseId,
+}: CreateOrUpdateEntryInputProps) => Promise<Entry>;
+
+export type SerializedComponent = {
+  entryContent: Entry;
+  contentType: string;
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1097,11 +1097,13 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.2.0"
+    "@types/fs-extra": "npm:^11.0.4"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^20"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
     contentful: "npm:^11.2.5"
+    contentful-management: "npm:^11.52.1"
     cookies-next: "npm:^5.1.0"
     cross-fetch: "npm:^4.1.0"
     dotenv: "npm:^16.4.7"
@@ -1119,6 +1121,7 @@ __metadata:
     schema-dts: "npm:^1.1.5"
     stylelint: "npm:^16.14.1"
     ts-node: "npm:^10.9.2"
+    tsx: "npm:^4.19.3"
     typescript: "npm:^5"
     uuid: "npm:^11.1.0"
   languageName: unknown
@@ -1388,6 +1391,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/aix-ppc64@npm:0.25.3"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/android-arm64@npm:0.23.1"
@@ -1405,6 +1415,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/android-arm64@npm:0.25.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/android-arm64@npm:0.25.3"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -1430,6 +1447,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/android-arm@npm:0.25.3"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/android-x64@npm:0.23.1"
@@ -1447,6 +1471,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/android-x64@npm:0.25.1"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/android-x64@npm:0.25.3"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -1472,6 +1503,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/darwin-arm64@npm:0.25.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/darwin-x64@npm:0.23.1"
@@ -1489,6 +1527,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/darwin-x64@npm:0.25.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/darwin-x64@npm:0.25.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -1514,6 +1559,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.3"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/freebsd-x64@npm:0.23.1"
@@ -1531,6 +1583,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/freebsd-x64@npm:0.25.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/freebsd-x64@npm:0.25.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -1556,6 +1615,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/linux-arm64@npm:0.25.3"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/linux-arm@npm:0.23.1"
@@ -1573,6 +1639,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-arm@npm:0.25.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/linux-arm@npm:0.25.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -1598,6 +1671,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/linux-ia32@npm:0.25.3"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/linux-loong64@npm:0.23.1"
@@ -1615,6 +1695,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-loong64@npm:0.25.1"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/linux-loong64@npm:0.25.3"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -1640,6 +1727,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/linux-mips64el@npm:0.25.3"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/linux-ppc64@npm:0.23.1"
@@ -1657,6 +1751,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-ppc64@npm:0.25.1"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/linux-ppc64@npm:0.25.3"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -1682,6 +1783,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/linux-riscv64@npm:0.25.3"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/linux-s390x@npm:0.23.1"
@@ -1699,6 +1807,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-s390x@npm:0.25.1"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/linux-s390x@npm:0.25.3"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -1724,9 +1839,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/linux-x64@npm:0.25.3"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-arm64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/netbsd-arm64@npm:0.25.1"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.3"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1752,6 +1881,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/netbsd-x64@npm:0.25.3"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-arm64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/openbsd-arm64@npm:0.23.1"
@@ -1769,6 +1905,13 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/openbsd-arm64@npm:0.25.1"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.3"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1794,6 +1937,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/openbsd-x64@npm:0.25.3"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/sunos-x64@npm:0.23.1"
@@ -1811,6 +1961,13 @@ __metadata:
 "@esbuild/sunos-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/sunos-x64@npm:0.25.1"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/sunos-x64@npm:0.25.3"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -1836,6 +1993,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-arm64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/win32-arm64@npm:0.25.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/win32-ia32@npm:0.23.1"
@@ -1857,6 +2021,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/win32-ia32@npm:0.25.3"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.23.1":
   version: 0.23.1
   resolution: "@esbuild/win32-x64@npm:0.23.1"
@@ -1874,6 +2045,13 @@ __metadata:
 "@esbuild/win32-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/win32-x64@npm:0.25.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.25.3":
+  version: 0.25.3
+  resolution: "@esbuild/win32-x64@npm:0.25.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5414,6 +5592,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/fs-extra@npm:^11.0.4":
+  version: 11.0.4
+  resolution: "@types/fs-extra@npm:11.0.4"
+  dependencies:
+    "@types/jsonfile": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 10c0/9e34f9b24ea464f3c0b18c3f8a82aefc36dc524cc720fc2b886e5465abc66486ff4e439ea3fb2c0acebf91f6d3f74e514f9983b1f02d4243706bdbb7511796ad
+  languageName: node
+  linkType: hard
+
 "@types/glob@npm:^8.1.0":
   version: 8.1.0
   resolution: "@types/glob@npm:8.1.0"
@@ -5514,6 +5702,15 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
+  languageName: node
+  linkType: hard
+
+"@types/jsonfile@npm:*":
+  version: 6.1.4
+  resolution: "@types/jsonfile@npm:6.1.4"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/b12d068b021e4078f6ac4441353965769be87acf15326173e2aea9f3bf8ead41bd0ad29421df5bbeb0123ec3fc02eb0a734481d52903704a1454a1845896b9eb
   languageName: node
   linkType: hard
 
@@ -6892,6 +7089,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.8.4":
+  version: 1.9.0
+  resolution: "axios@npm:1.9.0"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/9371a56886c2e43e4ff5647b5c2c3c046ed0a3d13482ef1d0135b994a628c41fbad459796f101c655e62f0c161d03883454474d2e435b2e021b1924d9f24994c
+  languageName: node
+  linkType: hard
+
 "axobject-query@npm:^4.1.0":
   version: 4.1.0
   resolution: "axobject-query@npm:4.1.0"
@@ -7980,6 +8188,19 @@ __metadata:
   version: 1.0.0
   resolution: "constants-browserify@npm:1.0.0"
   checksum: 10c0/ab49b1d59a433ed77c964d90d19e08b2f77213fb823da4729c0baead55e3c597f8f97ebccfdfc47bd896d43854a117d114c849a6f659d9986420e97da0f83ac5
+  languageName: node
+  linkType: hard
+
+"contentful-management@npm:^11.52.1":
+  version: 11.52.1
+  resolution: "contentful-management@npm:11.52.1"
+  dependencies:
+    "@contentful/rich-text-types": "npm:^16.6.1"
+    axios: "npm:^1.8.4"
+    contentful-sdk-core: "npm:^9.0.1"
+    fast-copy: "npm:^3.0.0"
+    globals: "npm:^15.15.0"
+  checksum: 10c0/7828897e30abe2605635a78a0c904d2c9161973f3541a761ea843b031e58455ab700027b5a4164c832d8428b70dd8b4645e610e7cdddfbf24df6911583ee0b3a
   languageName: node
   linkType: hard
 
@@ -9610,6 +9831,92 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:~0.25.0":
+  version: 0.25.3
+  resolution: "esbuild@npm:0.25.3"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.25.3"
+    "@esbuild/android-arm": "npm:0.25.3"
+    "@esbuild/android-arm64": "npm:0.25.3"
+    "@esbuild/android-x64": "npm:0.25.3"
+    "@esbuild/darwin-arm64": "npm:0.25.3"
+    "@esbuild/darwin-x64": "npm:0.25.3"
+    "@esbuild/freebsd-arm64": "npm:0.25.3"
+    "@esbuild/freebsd-x64": "npm:0.25.3"
+    "@esbuild/linux-arm": "npm:0.25.3"
+    "@esbuild/linux-arm64": "npm:0.25.3"
+    "@esbuild/linux-ia32": "npm:0.25.3"
+    "@esbuild/linux-loong64": "npm:0.25.3"
+    "@esbuild/linux-mips64el": "npm:0.25.3"
+    "@esbuild/linux-ppc64": "npm:0.25.3"
+    "@esbuild/linux-riscv64": "npm:0.25.3"
+    "@esbuild/linux-s390x": "npm:0.25.3"
+    "@esbuild/linux-x64": "npm:0.25.3"
+    "@esbuild/netbsd-arm64": "npm:0.25.3"
+    "@esbuild/netbsd-x64": "npm:0.25.3"
+    "@esbuild/openbsd-arm64": "npm:0.25.3"
+    "@esbuild/openbsd-x64": "npm:0.25.3"
+    "@esbuild/sunos-x64": "npm:0.25.3"
+    "@esbuild/win32-arm64": "npm:0.25.3"
+    "@esbuild/win32-ia32": "npm:0.25.3"
+    "@esbuild/win32-x64": "npm:0.25.3"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/127aff654310ede4e2eb232a7b1d8823f5b5d69222caf17aa7f172574a5b6b75f71ce78c6d8a40030421d7c75b784dc640de0fb1b87b7ea77ab2a1c832fa8df8
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -10197,7 +10504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-copy@npm:^3.0.2":
+"fast-copy@npm:^3.0.0, fast-copy@npm:^3.0.2":
   version: 3.0.2
   resolution: "fast-copy@npm:3.0.2"
   checksum: 10c0/02e8b9fd03c8c024d2987760ce126456a0e17470850b51e11a1c3254eed6832e4733ded2d93316c82bc0b36aeb991ad1ff48d1ba95effe7add7c3ab8d8eb554a
@@ -11140,6 +11447,13 @@ __metadata:
   version: 15.13.0
   resolution: "globals@npm:15.13.0"
   checksum: 10c0/640365115ca5f81d91e6a7667f4935021705e61a1a5a76a6ec5c3a5cdf6e53f165af7f9db59b7deb65cf2e1f83d03ac8d6660d0b14c569c831a9b6483eeef585
+  languageName: node
+  linkType: hard
+
+"globals@npm:^15.15.0":
+  version: 15.15.0
+  resolution: "globals@npm:15.15.0"
+  checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
   languageName: node
   linkType: hard
 
@@ -18410,6 +18724,22 @@ __metadata:
   bin:
     tsx: dist/cli.mjs
   checksum: 10c0/63164b889b1d170403e4d8753a6755dec371f220f5ce29a8e88f1f4d6085a784a12d8dc2ee669116611f2c72757ac9beaa3eea5c452796f541bdd2dc11753721
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.19.3":
+  version: 4.19.3
+  resolution: "tsx@npm:4.19.3"
+  dependencies:
+    esbuild: "npm:~0.25.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/cacfb4cf1392ae10e8e4fe032ad26ccb07cd8a3b32e5a0da270d9c48d06ee74f743e4a84686cbc9d89b48032d59bbc56cd911e076f53cebe61dc24fa525ff790
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the ability to programmatically fork the "All The Things" UI test page. When updating this page, a contributor can run the `fork` command which will create a copy of the page in the `development` environment. Contributors can then use this copy to test their changes. Once Contributors wish to merge these changes with a higher environment, they can run the `update-snapshot` command which will download the forked page and overwrite the original page.

Finally, the `publish-snapshot` command will publish the forked page to the authoritative copy of "All The Things" in the environment.

This new workflow allows for testing and validating changes to the "All The Things" in a staged manner which prevents unexpected errors from being introduced when deploying the marketing app to the various environments. Additionally, changes to the page can now be reviewed as part of the pull request process.

Longer term, the page should be automatically created from source control as part of the process of executing an e2e UI test