### PR TITLE
chore(marketing): clarify environment usage

### DIFF
--- a/frontend/apps/marketing/.env.example
+++ b/frontend/apps/marketing/.env.example
@@ -20,9 +20,12 @@ DRAFT_MODE_TOKEN=
 CONTENTFUL_SPACE_ID=
 
 # Contentful Environment ID
-# Note: Production must only use the master environment
+# The Contentful environment id to use. This is the environment that will be used to fetch content.
+# Valid options are: development, test, and production.
+# Normally, you would use the development environment for development and testing, and the production environment for production.
+# Note: Production must only use the production environment
 # See: https://contentful.github.io/contentful.js/contentful/latest/interfaces/CreateClientParams.html#environment
-CONTENTFUL_ENV_ID=
+CONTENTFUL_ENV_ID=development
 
 # The Contentful delivery token which only allows viewing published content.
 # Viewable in the Contentful web app under Settings > API keys


### PR DESCRIPTION
For day-to-day development, the contentful environment should be specified to use the `development` environment. The test cluster will then go to the `test` environment, and lastly the `production` environment will go to production. This eliminates showing test experiences in Production.