### PR TITLE
test(workshops): add self paced course offering ui test fixture

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -287,7 +287,10 @@ namespace :seed do
     update_scripts(incremental: true)
   end
 
-  # moved course offerings ui test seed after regular course offerings are seeded
+  # Moved course offerings ui test seed after regular course offerings are seeded
+  # because the regular course offerings seed task removes any course_offerings records
+  # left in the database that do not have a corresponding json file in config/course_offerings.
+  # The ui test course offerings must be seeded after so they are not accidentally removed.
   timed_task_with_logging scripts_ui_tests: SCRIPTS_DEPENDENCIES + [:course_offerings_ui_tests] do
     update_scripts(script_files: UI_TEST_SCRIPTS)
   end

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -287,7 +287,8 @@ namespace :seed do
     update_scripts(incremental: true)
   end
 
-  timed_task_with_logging scripts_ui_tests: SCRIPTS_DEPENDENCIES do
+  # moved course offerings ui test seed after regular course offerings are seeded
+  timed_task_with_logging scripts_ui_tests: SCRIPTS_DEPENDENCIES + [:course_offerings_ui_tests] do
     update_scripts(script_files: UI_TEST_SCRIPTS)
   end
 
@@ -654,10 +655,7 @@ namespace :seed do
   end
 
   FULL_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts, :courses, :reference_guides, :data_docs, :callouts, :school_districts, :schools, :census_summaries, :secret_words, :secret_pictures, :donors, :foorms, :import_pegasus_data, :datablock_storage].freeze
-  # The :scripts_ui_tests task must run before :course_offerings_ui_tests due to a dependency on the :course_offering task, which removes course offerings without
-  # a corresponding json file in dashboard/config/course_offerings. Running :course_offerings_ui_tests after :scripts_ui_tests ensures the test fixtures are not
-  # accidentally removed
-  UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts_ui_tests, :course_offerings_ui_tests, :courses_ui_tests, :reseed_scripts_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :import_pegasus_data, :datablock_storage].freeze
+  UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts_ui_tests, :courses_ui_tests, :reseed_scripts_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :import_pegasus_data, :datablock_storage].freeze
   ADHOC_SEED_TASKS = [:check_migrations, :videos, :concepts, :course_offerings_adhoc, :scripts_adhoc, :courses_adhoc, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :import_pegasus_data, :datablock_storage].freeze
   DEFAULT_SEED_TASKS = if rack_env == :test then UI_TEST_SEED_TASKS elsif rack_env == :adhoc then ADHOC_SEED_TASKS else FULL_SEED_TASKS end
 

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -77,6 +77,7 @@ namespace :seed do
     ui-test-versioned-script-2019
     ui-test-csa-family-script
     ui-test-teacher-pl-course
+    ui-test-self-paced-pl
     ui-test-facilitator-pl-course
     ui-test-single-unit-2025
     ui-test-single-unit-2026
@@ -365,6 +366,7 @@ namespace :seed do
       ui-test-csa-family-script
       ui-test-facilitator-pl-course
       ui-test-teacher-pl-course
+      ui-test-self-paced-pl
       ui-test-versioned-script-2017
       ui-test-versioned-script-2019
       ui-test-unnumbered-lessons
@@ -482,6 +484,7 @@ namespace :seed do
       ui-test-course
       ui-test-csa-family-script
       ui-test-teacher-pl-course
+      ui-test-self-paced-pl
       ui-test-facilitator-pl-course
       ui-test-single-unit-course
       ui-test-versioned-course

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -654,7 +654,10 @@ namespace :seed do
   end
 
   FULL_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts, :courses, :reference_guides, :data_docs, :callouts, :school_districts, :schools, :census_summaries, :secret_words, :secret_pictures, :donors, :foorms, :import_pegasus_data, :datablock_storage].freeze
-  UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :course_offerings_ui_tests, :scripts_ui_tests, :courses_ui_tests, :reseed_scripts_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :import_pegasus_data, :datablock_storage].freeze
+  # The :scripts_ui_tests task must run before :course_offerings_ui_tests due to a dependency on the :course_offering task, which removes course offerings without
+  # a corresponding json file in dashboard/config/course_offerings. Running :course_offerings_ui_tests after :scripts_ui_tests ensures the test fixtures are not
+  # accidentally removed
+  UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts_ui_tests, :course_offerings_ui_tests, :courses_ui_tests, :reseed_scripts_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :import_pegasus_data, :datablock_storage].freeze
   ADHOC_SEED_TASKS = [:check_migrations, :videos, :concepts, :course_offerings_adhoc, :scripts_adhoc, :courses_adhoc, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :import_pegasus_data, :datablock_storage].freeze
   DEFAULT_SEED_TASKS = if rack_env == :test then UI_TEST_SEED_TASKS elsif rack_env == :adhoc then ADHOC_SEED_TASKS else FULL_SEED_TASKS end
 

--- a/dashboard/test/ui/config/course_offerings/ui-test-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-course.json
@@ -2,5 +2,5 @@
   "key": "ui-test-course",
   "display_name": "ui-test-course",
   "is_featured": false,
-  "assignable": false
+  "assignable": true
 }

--- a/dashboard/test/ui/config/course_offerings/ui-test-self-paced-pl.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-self-paced-pl.json
@@ -1,0 +1,10 @@
+{
+  "key": "ui-test-self-paced-pl",
+  "display_name": "Self Paced PL Course",
+  "is_featured": false,
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": "self_paced"
+}

--- a/dashboard/test/ui/config/courses/ui-test-self-paced-pl.course
+++ b/dashboard/test/ui/config/courses/ui-test-self-paced-pl.course
@@ -1,0 +1,23 @@
+{
+  "name": "ui-test-self-paced-pl",
+  "script_names": [
+    "ui-test-self-paced-pl"
+  ],
+  "original_script_names": [
+    "ui-test-self-paced-pl"
+  ],
+  "published_state": "stable",
+  "instruction_type": "self_paced",
+  "participant_audience": "teacher",
+  "instructor_audience": "facilitator",
+  "properties": {
+    "family_name": "ui-test-self-paced-pl",
+    "version_year": "unversioned"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-self-paced-pl.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-self-paced-pl.script_json
@@ -1,0 +1,87 @@
+{
+  "script": {
+    "name": "ui-test-self-paced-pl",
+    "wrapup_video_id": null,
+    "login_required": true,
+    "properties": {
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2025-04-28 20:18:37 UTC",
+    "published_state": "stable",
+    "instruction_type": "self_paced",
+    "instructor_audience": "facilitator",
+    "participant_audience": "teacher",
+    "seeding_key": {
+      "script.name": "ui-test-self-paced-pl"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-self-paced-pl"
+      }
+    }
+  ],
+  "lessons": [
+
+  ],
+  "lesson_activities": [
+
+  ],
+  "activity_sections": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
+
+  ]
+}


### PR DESCRIPTION
This adds a `"Self Paced PL Course"` test fixture for workshop_dashboard ui tests.

While trying to add a new self paced course offering for my ui test, I noticed my new record was added, but without some of the properties I had supplied, namely `header` in [ui-test-self-paced-pl.json](https://github.com/code-dot-org/code-dot-org/pull/65531/files#diff-ea6e7afc64681f87c6e451318f629467bedc1cf290de83e0d1dbb6224e991a3aR9). It turns out the ui test fixtures were being seeded before the `:scripts_ui_tests` task, which itself depends on the `:course_offerings` seed task, which deletes any course offering records not found in the regular `dashboard/config/course_offerings` directory (the test course offerings are in the test dir). It wasn't immediately apparent why they were showing back up, but a later task, `:courses_ui_tests` will find or create a course offering for the unit group (corresponding to `ui-test-self-paced-pl.course` file, but using the `family_name` as the key. So it gave the impression the `:course_offerings_ui_tests` task completed successfully as long as the `family_name` was consistent, which it has been for all the test fixtures needed so far. 🥴 

This also required a change to an existing test fixture used in `modular_courses.feature`. The configuration file for that course offering was set to `assignable: false`, whereas the default when no config is provided is `assignable: true`. Since the seeded course offerings were being overwritten and the default was used to create new records, this course offering had been assignable before the seeding order was fixed but was no longer assignable for `modular_courses.feature`. After looking at the test it was determined the intention was for the course to be assignable, and for the student to have made some progress.

BEFORE:
- `:course_offerings_ui_tests` adds ui test course offerings
- `:scripts_ui_tests` runs `:course_offerings` task as a dependency
- `CourseOffering.seed_all` method deletes the ui test course offering records
- `:courses_ui_tests` task that seeds `UnitGroup`s does a `find_or_create_by` for course offerings by key, using `family_name`

AFTER:
- `:scripts_ui_tests` runs `:course_offerings` task and syncs course offering records with json files found in config directory, deleting orphaned records
- `:course_offerings_ui_tests` adds ui test course offerings (moved to `:scripts_ui_tests` task dependencies but after `:course_offerings`)
- `:courses_ui_tests` task that seeds `UnitGroup`s finds the existing ui test course offerings so their attributes defined in their json files are retained

<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
