### PR TITLE
[Pythonlab] Predict level UI polish

### DIFF
--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -257,7 +257,12 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
               />
               {predictSettings?.isPredictLevel && (
                 <InstructorsOnly>
-                  <div className={moduleStyles['message-' + theme]}>
+                  <div
+                    className={classNames(
+                      moduleStyles['message-' + theme],
+                      moduleStyles.predictSummary
+                    )}
+                  >
                     <PredictSummary />
                   </div>
                 </InstructorsOnly>

--- a/apps/src/lab2/views/components/PredictQuestion.tsx
+++ b/apps/src/lab2/views/components/PredictQuestion.tsx
@@ -46,49 +46,53 @@ const PredictQuestion: React.FunctionComponent<PredictQuestionProps> = ({
 
   return (
     <div className={className}>
-      {predictSettings.questionType === PredictQuestionType.FreeResponse ? (
-        <textarea
-          value={predictResponse}
-          placeholder={predictSettings.placeholderText}
-          onChange={e => setPredictResponse(e.target.value)}
-          style={{
-            height:
-              predictSettings.freeResponseHeight ||
-              PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT,
-          }}
-          className={moduleStyles.freeResponse}
-          readOnly={predictAnswerLocked}
-        />
-      ) : (
-        predictSettings.multipleChoiceOptions?.map((option, index) => {
-          // Add a capital letter to the beginning of each option, starting with A.
-          const letterForOption = String.fromCharCode(index + 65) + '.';
-          return (
-            <label
-              key={`multiple-choice-${index}`}
-              className={moduleStyles.multipleChoiceContainer}
-            >
-              <input
-                type={predictSettings.isMultiSelect ? 'checkbox' : 'radio'}
-                value={index.toString()}
-                checked={
-                  (predictResponse &&
-                    predictResponse.split(',').includes(index.toString())) ||
-                  false
-                }
-                onChange={handleMultiSelectChanged}
-                name={option}
-                key={index}
-                disabled={predictAnswerLocked}
-              />
-              <span className={moduleStyles.multipleChoiceLetter}>
-                {letterForOption}
-              </span>
-              <span className={moduleStyles.multipleChoiceLabel}>{option}</span>
-            </label>
-          );
-        })
-      )}
+      <div className={moduleStyles.predictQuestionContainer}>
+        {predictSettings.questionType === PredictQuestionType.FreeResponse ? (
+          <textarea
+            value={predictResponse}
+            placeholder={predictSettings.placeholderText}
+            onChange={e => setPredictResponse(e.target.value)}
+            style={{
+              height:
+                predictSettings.freeResponseHeight ||
+                PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT,
+            }}
+            className={moduleStyles.freeResponse}
+            readOnly={predictAnswerLocked}
+          />
+        ) : (
+          predictSettings.multipleChoiceOptions?.map((option, index) => {
+            // Add a capital letter to the beginning of each option, starting with A.
+            const letterForOption = String.fromCharCode(index + 65) + '.';
+            return (
+              <label
+                key={`multiple-choice-${index}`}
+                className={moduleStyles.multipleChoiceContainer}
+              >
+                <input
+                  type={predictSettings.isMultiSelect ? 'checkbox' : 'radio'}
+                  value={index.toString()}
+                  checked={
+                    (predictResponse &&
+                      predictResponse.split(',').includes(index.toString())) ||
+                    false
+                  }
+                  onChange={handleMultiSelectChanged}
+                  name={option}
+                  key={index}
+                  disabled={predictAnswerLocked}
+                />
+                <span className={moduleStyles.multipleChoiceLetter}>
+                  {letterForOption}
+                </span>
+                <span className={moduleStyles.multipleChoiceLabel}>
+                  {option}
+                </span>
+              </label>
+            );
+          })
+        )}
+      </div>
       <PredictResetButton />
     </div>
   );

--- a/apps/src/lab2/views/components/PredictResetButton.tsx
+++ b/apps/src/lab2/views/components/PredictResetButton.tsx
@@ -40,7 +40,7 @@ const PredictResetButton: React.FunctionComponent = () => {
   }
 
   return (
-    <div>
+    <div className={moduleStyles.resetButtonRow}>
       <Button
         text={i18n.deleteAnswer()}
         onClick={handleResetClick}
@@ -51,7 +51,9 @@ const PredictResetButton: React.FunctionComponent = () => {
         color={'destructive'}
         className={moduleStyles.resetButton}
       />
-      <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
+      <span className={moduleStyles.resetButtonRowSpace}>
+        <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
+      </span>
       {resetFailed && (
         <Alert
           type="danger"

--- a/apps/src/lab2/views/components/PredictResetButton.tsx
+++ b/apps/src/lab2/views/components/PredictResetButton.tsx
@@ -1,5 +1,5 @@
 import Alert from '@code-dot-org/component-library/alert';
-import {Button, buttonColors} from '@code-dot-org/component-library/button';
+import {Button} from '@code-dot-org/component-library/button';
 import React from 'react';
 
 import {resetPredictProgress} from '@cdo/apps/lab2/redux/predictLevelRedux';
@@ -48,7 +48,7 @@ const PredictResetButton: React.FunctionComponent = () => {
         disabled={!hasSubmitted}
         iconLeft={{iconStyle: 'solid', iconName: 'trash'}}
         type={'secondary'}
-        color={buttonColors.destructive}
+        color={'destructive'}
         className={moduleStyles.resetButton}
       />
       <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>

--- a/apps/src/lab2/views/components/PredictResetButton.tsx
+++ b/apps/src/lab2/views/components/PredictResetButton.tsx
@@ -40,20 +40,22 @@ const PredictResetButton: React.FunctionComponent = () => {
   }
 
   return (
-    <div className={moduleStyles.resetButtonRow}>
-      <Button
-        text={i18n.deleteAnswer()}
-        onClick={handleResetClick}
-        size={'s'}
-        disabled={!hasSubmitted}
-        iconLeft={{iconStyle: 'solid', iconName: 'trash'}}
-        type={'secondary'}
-        color={'destructive'}
-        className={moduleStyles.resetButton}
-      />
-      <span className={moduleStyles.resetButtonRowSpace}>
-        <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
-      </span>
+    <>
+      <div className={moduleStyles.resetButtonRow}>
+        <Button
+          text={i18n.deleteAnswer()}
+          onClick={handleResetClick}
+          size={'s'}
+          disabled={!hasSubmitted}
+          iconLeft={{iconStyle: 'solid', iconName: 'trash'}}
+          type={'secondary'}
+          color={'destructive'}
+          className={moduleStyles.resetButton}
+        />
+        <span className={moduleStyles.resetButtonRowSpace}>
+          <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
+        </span>
+      </div>
       {resetFailed && (
         <Alert
           type="danger"
@@ -61,7 +63,7 @@ const PredictResetButton: React.FunctionComponent = () => {
           className={moduleStyles.resetError}
         />
       )}
-    </div>
+    </>
   );
 };
 

--- a/apps/src/lab2/views/components/PredictSummary.tsx
+++ b/apps/src/lab2/views/components/PredictSummary.tsx
@@ -71,6 +71,7 @@ const PredictSummary: React.FunctionComponent = () => {
         text={commonI18n.viewStudentResponses()}
         size={'s'}
         type={'secondary'}
+        color={'black'}
         className={moduleStyles.studentResponsesButton}
       />
     </div>

--- a/apps/src/lab2/views/components/PredictSummary.tsx
+++ b/apps/src/lab2/views/components/PredictSummary.tsx
@@ -69,9 +69,8 @@ const PredictSummary: React.FunctionComponent = () => {
       <LinkButton
         href={summaryUrl}
         text={commonI18n.viewStudentResponses()}
-        size={'xs'}
+        size={'s'}
         type={'secondary'}
-        color={'black'}
         className={moduleStyles.studentResponsesButton}
       />
     </div>

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -155,6 +155,11 @@
   color: $neutral_dark;
 }
 
+.predictSummary {
+  padding: 0;
+  margin-bottom: 6px;
+}
+
 .buttonInstruction {
   width: 100%;
   height: 38px;

--- a/apps/src/lab2/views/components/predict-summary.module.scss
+++ b/apps/src/lab2/views/components/predict-summary.module.scss
@@ -5,6 +5,7 @@
   flex-wrap: wrap;
   gap: 10px;
   margin: 4px;
+  justify-content: center;
 }
 
 .responses {

--- a/apps/src/lab2/views/components/predict-summary.module.scss
+++ b/apps/src/lab2/views/components/predict-summary.module.scss
@@ -5,11 +5,11 @@
   flex-wrap: wrap;
   gap: 10px;
   margin: 4px;
-  justify-content: center;
 }
 
 .responses {
   display: flex;
+  margin-left: 2px;
 }
 
 .responseIcon {

--- a/apps/src/lab2/views/components/predict-summary.module.scss
+++ b/apps/src/lab2/views/components/predict-summary.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  margin: 4px;
 }
 
 .responses {

--- a/apps/src/lab2/views/components/predict.module.scss
+++ b/apps/src/lab2/views/components/predict.module.scss
@@ -39,8 +39,7 @@
 }
 
 .resetButton {
-  flex: 0 0 auto;
-
+  flex-grow: 1;
   // We use important here because the disabled styles used by Button
   // are more specific than a single class.
   &:disabled {
@@ -58,8 +57,8 @@
 }
 
 .resetButtonRowSpace {
+  width: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-grow: 1;
 }

--- a/apps/src/lab2/views/components/predict.module.scss
+++ b/apps/src/lab2/views/components/predict.module.scss
@@ -57,7 +57,7 @@
 }
 
 .resetButtonRowSpace {
-  width: 40px;
+  width: 32px;
   display: flex;
   align-items: center;
   justify-content: right;

--- a/apps/src/lab2/views/components/predict.module.scss
+++ b/apps/src/lab2/views/components/predict.module.scss
@@ -22,6 +22,10 @@
   box-sizing: border-box;
 }
 
+.predictQuestionContainer {
+  margin-bottom: 8px;
+}
+
 .predictSolutionContainer {
   margin: 10px;
   padding: 5px;

--- a/apps/src/lab2/views/components/predict.module.scss
+++ b/apps/src/lab2/views/components/predict.module.scss
@@ -60,5 +60,5 @@
   width: 40px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: right;
 }

--- a/apps/src/lab2/views/components/predict.module.scss
+++ b/apps/src/lab2/views/components/predict.module.scss
@@ -39,7 +39,7 @@
 }
 
 .resetButton {
-  width: 212px;
+  flex: 0 0 auto;
 
   // We use important here because the disabled styles used by Button
   // are more specific than a single class.
@@ -48,4 +48,18 @@
     color: $light_gray_800 !important;
     border: none;
   }
+}
+
+.resetButtonRow {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.resetButtonRowSpace {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 1;
 }


### PR DESCRIPTION
This PR includes UI polish updates to `PredictQuestion` and `PredictSummary` on predict levels.
Note that once https://github.com/code-dot-org/code-dot-org/pull/65537 is merged, the 'Delete Answer' background color will be black (secondary, destructive DSCO button in dark theme).

[Slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1745871849775199)

## Before update

<img width="299" alt="Screenshot 2025-04-29 at 9 19 15 AM" src="https://github.com/user-attachments/assets/4b097c24-d063-4d82-b979-3a3f9fc49810" />


## After update
Screenshot:
<img width="300" alt="Screenshot 2025-04-29 at 10 51 47 AM" src="https://github.com/user-attachments/assets/57c7d608-b09e-480f-8222-21a57dbba29e" />


Screencast video:



https://github.com/user-attachments/assets/7b266087-bbfd-4d12-8c28-036769d3b404


If there is an error in deleting the answer:

<img width="368" alt="Screenshot 2025-04-29 at 10 53 50 AM" src="https://github.com/user-attachments/assets/66629800-763c-48f8-be5e-92b8c65a6def" />


Music lab also uses predict levels so I checked in with the team at https://codedotorg.slack.com/archives/C04TH8400AU/p1745874915042849.
They let me know that there is an open task to improve the look of some predict components in Music. I made a small update so that the 'View student responses' button is not on 2 lines.

## Before update



<img width="666" alt="Screenshot 2025-04-29 at 11 25 48 AM" src="https://github.com/user-attachments/assets/9dcd74d2-2f3d-4107-99ee-76c5ab672a5d" />


## After update

<img width="699" alt="Screenshot 2025-04-29 at 11 26 00 AM" src="https://github.com/user-attachments/assets/b76d6bb1-a82f-4452-a04e-ad1a2b12b6d0" />


<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/CT-1193

## Testing story
I checked predict levels in `pythonlab` and `music` locally.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
