### PR TITLE
Export unit version history

### DIFF
--- a/bin/curriculum/export/README.md
+++ b/bin/curriculum/export/README.md
@@ -52,7 +52,9 @@ cd production
 ```bash
 SKIP_SCRIPT_PRELOAD=1 bin/curriculum/export/export_unit_progress.rb -u unit-name -o unit-name-and-date-range
 ```
-the above command runs a redshift query whose results are written to s3://cdo-data-sharing-internal via the `UNLOAD` command.
+where `unit-name-and-date-range` is something like `csd3-2024-ending-2025-04-01`.
+the above command runs a redshift query whose results are written to
+s3://cdo-data-sharing-internal via the `UNLOAD` command.
 
 5. add student source code from S3
 ```bash

--- a/bin/curriculum/export/README.md
+++ b/bin/curriculum/export/README.md
@@ -155,6 +155,34 @@ sorted in any order. Here are some of the key fields:
   student's work will be consistent for a given level.
 * `student_answer_pii_score`: see `source_pii_score` 
 * `student_answer_pii_entities`: see `source_pii_entities`
+* `source_versions`: see below
+
+#### Source Versions
+
+The `source_versions` field is a JSON array containing the source code for each
+version of the project. Here is an example:
+```
+{
+  "source_versions": [
+    {
+      "versionId": "e6vJbk8B17DM9eag36pAfsPxI_2kkJ6A",
+      "lastModified": "2024-12-05T18:34:25.000Z",
+      "isLatest": true,
+      "version_source": "...",
+      "version_source_pii_score": 0,
+      "version_source_pii_entities": []
+    }
+    ...
+  ],
+  ...
+}
+```
+
+If any versions are present, one of them will be marked as `isLatest`. This will
+contain an exact copy of the `source`, `source_pii_score` and `source_pii_entities`
+top-level fields. Non-latest versions will contain past versions of the project source
+code, each with their own pii score and pii entities. `versionId` can be
+joined against the `project_version` field in the `evals` files.
 
 ### Evaluations
 

--- a/bin/curriculum/export/README.md
+++ b/bin/curriculum/export/README.md
@@ -50,38 +50,38 @@ cd production
 
 4. export unit progress from redshift
 ```bash
-SKIP_SCRIPT_PRELOAD=1 bin/curriculum/export/export_unit_progress.rb -u unit-name -o unit-name-date-range
+SKIP_SCRIPT_PRELOAD=1 bin/curriculum/export/export_unit_progress.rb -u unit-name -o unit-name-and-date-range
 ```
 the above command runs a redshift query whose results are written to s3://cdo-data-sharing-internal via the `UNLOAD` command.
 
 5. add student source code from S3
 ```bash
-SKIP_SCRIPT_PRELOAD=1 bin/curriculum/export/add_unit_source.rb -i unit-name-date-range
+SKIP_SCRIPT_PRELOAD=1 bin/curriculum/export/add_unit_source.rb -i unit-name-and-date-range
 ```
 
 6. inspect the output for validity before performing the expensive PII filtering step
 ```bash
-ls -l /mnt/tmp-curriculum-export/sourced/<unit-name-date-range>/progress
-less /mnt/tmp-curriculum-export/sourced/<unit-name-date-range>/progress/<filename>
+ls -l /mnt/tmp-curriculum-export/sourced/<unit-name-and-date-range>/progress
+less /mnt/tmp-curriculum-export/sourced/<unit-name-and-date-range>/progress/<filename>
 ```
 
 7. filter the output to exclude PII
 ```bash
-bin/curriculum/export/filter_unit_pii.rb -i unit-name-date-range
+bin/curriculum/export/filter_unit_pii.rb -i unit-name-and-date-range
 ```
 
 8. inspect the output for validity before uploading to S3
 ```bash
-ls -l /mnt/tmp-curriculum-export/filtered/<unit-name-date-range>/progress
-less /mnt/tmp-curriculum-export/filtered/<unit-name-date-range>/progress/<filename>
+ls -l /mnt/tmp-curriculum-export/filtered/<unit-name-and-date-range>/progress
+less /mnt/tmp-curriculum-export/filtered/<unit-name-and-date-range>/progress/<filename>
 ```
 
 9. upload the filtered output to S3
 ```bash
 # s3 dir should be empty to start
-aws s3 ls s3://cdo-data-sharing/filtered-unit-progress/<unit-name-date-range>/
+aws s3 ls s3://cdo-data-sharing/filtered-unit-progress/<unit-name-and-date-range>/
 # if the dir is empty, go ahead and upload 
-aws s3 cp --recursive /mnt/tmp-curriculum-export/filtered/<unit-name-date-range> s3://cdo-data-sharing/filtered-unit-progress/<unit-name-date-range>
+aws s3 cp --recursive /mnt/tmp-curriculum-export/filtered/<unit-name-and-date-range> s3://cdo-data-sharing/filtered-unit-progress/<unit-name-and-date-range>
 ```
 
 10. add a row to the 
@@ -97,8 +97,8 @@ aws s3 cp --recursive /mnt/tmp-curriculum-export/filtered/<unit-name-date-range>
 
 Once you are happy with the data you've uploaded to S3, you should clean up the temporary files on production-daemon:
 ```bash
-rm -rf /mnt/tmp-curriculum-export/sourced/<unit-name-date-range>
-rm -rf /mnt/tmp-curriculum-export/filtered/<unit-name-date-range>
+rm -rf /mnt/tmp-curriculum-export/sourced/<unit-name-and-date-range>
+rm -rf /mnt/tmp-curriculum-export/filtered/<unit-name-and-date-range>
 ```
 ## Troubleshooting
 

--- a/bin/curriculum/export/add_unit_source.rb
+++ b/bin/curriculum/export/add_unit_source.rb
@@ -50,7 +50,7 @@ def list_s3_files(bucket, prefix)
   s3 = Aws::S3::Client.new
   response = s3.list_objects_v2(bucket: bucket, prefix: prefix)
   keys = response.contents.map(&:key)
-  raise "No files found in s3://#{bucket}/#{prefix}/" if keys.empty?
+  raise "No files found in s3://#{bucket}/#{prefix}" if keys.empty?
   keys
 end
 
@@ -78,8 +78,7 @@ def process_s3_file(bucket, key)
     channel_id = data['channel_id']
     source = get_project_source(channel_id)
     data['source'] = source
-    data['past_version_ids'] = get_past_version_ids(channel_id)
-    data['past_versions_map'] = get_past_versions_map(channel_id)
+    data['source_versions'] = get_source_versions(channel_id, latest_source: source)
     data.to_json
   rescue JSON::ParserError => exception
     puts "Error parsing JSON: #{exception}"
@@ -96,7 +95,7 @@ end
 def get_project_source(channel_id, version_id: nil)
   return nil unless channel_id
 
-  source_data = SourceBucket.new.get(channel_id, "main.json", version: version_id)
+  source_data = SourceBucket.new.get(channel_id, "main.json", nil, version_id)
   return nil unless source_data && source_data[:body] && source_data[:body].respond_to?(:string)
 
   main_json = source_data[:body].string
@@ -106,34 +105,24 @@ rescue NoMethodError => exception
   nil
 end
 
-# returns a map from each past version id to the corresponding source code
-def get_past_versions_map(channel_id)
-  past_version_ids = get_past_version_ids(channel_id)
-  past_version_ids.map do |version_id|
-    source = get_project_source(channel_id, version_id: version_id)
-    [version_id, source]
-  end.to_h
-end
-
-def get_past_version_ids(channel_id)
+# returns a list of source versions in the following format:
+# [
+#   {
+#     :versionId=>"EL24MWXWEIZOQS4OC3PAzL0hlrq.GMcA",
+#     :lastModified=>2024-09-04 05:08:09 UTC,
+#     :isLatest=>true,
+#     :source=>"...",
+#   },
+#   ...
+# ]
+def get_source_versions(channel_id, latest_source:)
   return [] unless channel_id
 
-  # sample response from SourceBucket.new.list_versions:
-  # [
-  #   {
-  #     :versionId=>"EL24MWXWEIZOQS4OC3PAzL0hlrq.GMcA",
-  #     :lastModified=>2024-09-04 05:08:09 UTC,
-  #     :isLatest=>true
-  #   },
-  #   {
-  #     :versionId=>"6SZKYyT9GZw1nmq29g9u0L3UNQmOkTsh",
-  #     :lastModified=>2024-09-04 05:06:35 UTC,
-  #     :isLatest=>false
-  #   }
-  # ]
   versions = SourceBucket.new.list_versions(channel_id, "main.json")
-  past_versions = versions.reject {|version| version[:isLatest]}
-  past_versions.map {|version| version[:versionId]}
+  versions.each do |version|
+    version[:source] = version[:isLatest] ? latest_source : get_project_source(channel_id, version_id: version[:versionId])
+  end
+  versions
 end
 
 def copy_eval_files

--- a/bin/curriculum/export/add_unit_source.rb
+++ b/bin/curriculum/export/add_unit_source.rb
@@ -79,6 +79,7 @@ def process_s3_file(bucket, key)
     source = get_project_source(channel_id)
     data['source'] = source
     data['past_version_ids'] = get_past_version_ids(channel_id)
+    data['past_versions_map'] = get_past_versions_map(channel_id)
     data.to_json
   rescue JSON::ParserError => exception
     puts "Error parsing JSON: #{exception}"
@@ -92,10 +93,10 @@ def process_s3_file(bucket, key)
   puts "Processed #{rows.size} rows in #{(Time.now - start_time).round(2)} seconds."
 end
 
-def get_project_source(channel_id)
+def get_project_source(channel_id, version_id: nil)
   return nil unless channel_id
 
-  source_data = SourceBucket.new.get(channel_id, "main.json")
+  source_data = SourceBucket.new.get(channel_id, "main.json", version: version_id)
   return nil unless source_data && source_data[:body] && source_data[:body].respond_to?(:string)
 
   main_json = source_data[:body].string
@@ -103,6 +104,15 @@ def get_project_source(channel_id)
 rescue NoMethodError => exception
   puts "Error getting source for channel id: #{channel_id}: #{exception}"
   nil
+end
+
+# returns a map from each past version id to the corresponding source code
+def get_past_versions_map(channel_id)
+  past_version_ids = get_past_version_ids(channel_id)
+  past_version_ids.map do |version_id|
+    source = get_project_source(channel_id, version_id: version_id)
+    [version_id, source]
+  end.to_h
 end
 
 def get_past_version_ids(channel_id)

--- a/bin/curriculum/export/add_unit_source.rb
+++ b/bin/curriculum/export/add_unit_source.rb
@@ -78,6 +78,7 @@ def process_s3_file(bucket, key)
     channel_id = data['channel_id']
     source = get_project_source(channel_id)
     data['source'] = source
+    data['past_version_ids'] = get_past_version_ids(channel_id)
     data.to_json
   rescue JSON::ParserError => exception
     puts "Error parsing JSON: #{exception}"
@@ -102,6 +103,27 @@ def get_project_source(channel_id)
 rescue NoMethodError => exception
   puts "Error getting source for channel id: #{channel_id}: #{exception}"
   nil
+end
+
+def get_past_version_ids(channel_id)
+  return [] unless channel_id
+
+  # sample response from SourceBucket.new.list_versions:
+  # [
+  #   {
+  #     :versionId=>"EL24MWXWEIZOQS4OC3PAzL0hlrq.GMcA",
+  #     :lastModified=>2024-09-04 05:08:09 UTC,
+  #     :isLatest=>true
+  #   },
+  #   {
+  #     :versionId=>"6SZKYyT9GZw1nmq29g9u0L3UNQmOkTsh",
+  #     :lastModified=>2024-09-04 05:06:35 UTC,
+  #     :isLatest=>false
+  #   }
+  # ]
+  versions = SourceBucket.new.list_versions(channel_id, "main.json")
+  past_versions = versions.reject {|version| version[:isLatest]}
+  past_versions.map {|version| version[:versionId]}
 end
 
 def copy_eval_files

--- a/bin/curriculum/export/add_unit_source.rb
+++ b/bin/curriculum/export/add_unit_source.rb
@@ -111,7 +111,7 @@ end
 #     :versionId=>"EL24MWXWEIZOQS4OC3PAzL0hlrq.GMcA",
 #     :lastModified=>2024-09-04 05:08:09 UTC,
 #     :isLatest=>true,
-#     :source=>"...",
+#     :version_source=>"...",
 #   },
 #   ...
 # ]
@@ -120,7 +120,7 @@ def get_source_versions(channel_id, latest_source:)
 
   versions = SourceBucket.new.list_versions(channel_id, "main.json")
   versions.each do |version|
-    version[:source] = version[:isLatest] ? latest_source : get_project_source(channel_id, version_id: version[:versionId])
+    version[:version_source] = version[:isLatest] ? latest_source : get_project_source(channel_id, version_id: version[:versionId])
   end
   versions
 end

--- a/bin/curriculum/export/add_unit_source.rb
+++ b/bin/curriculum/export/add_unit_source.rb
@@ -21,6 +21,9 @@ OptionParser.new do |opts|
   opts.on("-o", "--output-dir DIR", "Name of output directory in local filesystem under /mnt/tmp-curriculum-export/sourced/. default: INPUT_DIR") do |output_dir|
     $options[:output_dir] = output_dir
   end
+  opts.on("-v", "--source-versions", "Include source versions") do
+    $options[:source_versions] = true
+  end
 
   opts.on("-h", "--help", "Prints this help") do
     puts opts
@@ -78,7 +81,9 @@ def process_s3_file(bucket, key)
     channel_id = data['channel_id']
     source = get_project_source(channel_id)
     data['source'] = source
-    data['source_versions'] = get_source_versions(channel_id, latest_source: source)
+    if $options[:source_versions]
+      data['source_versions'] = get_source_versions(channel_id, latest_source: source)
+    end
     data.to_json
   rescue JSON::ParserError => exception
     puts "Error parsing JSON: #{exception}"

--- a/bin/curriculum/export/add_unit_source.rb
+++ b/bin/curriculum/export/add_unit_source.rb
@@ -52,9 +52,7 @@ puts "Rails environment loaded in: #{(Time.now - start_time).to_i} seconds"
 def list_s3_files(bucket, prefix)
   s3 = Aws::S3::Client.new
   response = s3.list_objects_v2(bucket: bucket, prefix: prefix)
-  keys = response.contents.map(&:key)
-  raise "No files found in s3://#{bucket}/#{prefix}" if keys.empty?
-  keys
+  response.contents.map(&:key)
 end
 
 $max_processes = 25

--- a/bin/curriculum/export/filter_file_pii.rb
+++ b/bin/curriculum/export/filter_file_pii.rb
@@ -130,20 +130,20 @@ end
 #     :versionId=>"EL24MWXWEIZOQS4OC3PAzL0hlrq.GMcA",
 #     :lastModified=>2024-09-04 05:08:09 UTC,
 #     :isLatest=>true,
-#     :source=>"...",
-#     :source_pii_score=>0.9999105930328369,
-#     :source_pii_entities=>[...]
+#     :version_source=>"...",
+#     :version_source_pii_score=>0.9999105930328369,
+#     :version_source_pii_entities=>[...]
 #   },
 #   ...
 # ]
 def process_source_versions_pii(data)
   data[:source_versions].each do |version|
     if version[:isLatest]
-      version[:source] = data[:source]
-      version[:source_pii_score] = data[:source_pii_score]
-      version[:source_pii_entities] = data[:source_pii_entities]
+      version[:version_source] = data[:source]
+      version[:version_source_pii_score] = data[:source_pii_score]
+      version[:version_source_pii_entities] = data[:source_pii_entities]
     else
-      process_field_pii(version, field: :source)
+      process_field_pii(version, field: :version_source)
     end
   end
 end

--- a/bin/curriculum/export/filter_file_pii.rb
+++ b/bin/curriculum/export/filter_file_pii.rb
@@ -121,6 +121,31 @@ end
 def process_source_pii(data)
   process_field_pii(data, field: :source, related_fields: [:link_to_project, :channel_id])
   process_field_pii(data, field: :student_answer)
+  process_source_versions_pii(data)
+end
+
+# returns a list of source versions in the following format:
+# [
+#   {
+#     :versionId=>"EL24MWXWEIZOQS4OC3PAzL0hlrq.GMcA",
+#     :lastModified=>2024-09-04 05:08:09 UTC,
+#     :isLatest=>true,
+#     :source=>"...",
+#     :source_pii_score=>0.9999105930328369,
+#     :source_pii_entities=>[...]
+#   },
+#   ...
+# ]
+def process_source_versions_pii(data)
+  data[:source_versions].each do |version|
+    if version[:isLatest]
+      version[:source] = data[:source]
+      version[:source_pii_score] = data[:source_pii_score]
+      version[:source_pii_entities] = data[:source_pii_entities]
+    else
+      process_field_pii(version, field: :source)
+    end
+  end
 end
 
 def process_ai_eval_pii(data)


### PR DESCRIPTION
Code changes for https://codedotorg.atlassian.net/browse/AITT-956 and https://codedotorg.atlassian.net/browse/AITT-990. I saw an average of 4 versions per project and used that to pick a size of 1M rows (4M project versions) per dataset in order to keep costs under control. 

## Testing story

* used this code to generate `csd3-2024-versions-1M` and `csp4-2024-versions-1M` datasets in the [gsheet](https://docs.google.com/spreadsheets/d/1BiK3a3rlEEto1x9_ITjX7l0CsbhO0WZQrdYNdISWKQA/edit?gid=0#gid=0)
* spot-checked to confirm that PII filtering is being done on version_source fields
