### PR TITLE
Lab2: themes fix

### DIFF
--- a/apps/src/lab2/views/ExtraLinksModal.tsx
+++ b/apps/src/lab2/views/ExtraLinksModal.tsx
@@ -152,7 +152,7 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
   };
 
   return isOpen ? (
-    <AccessibleDialog onClose={onClose}>
+    <AccessibleDialog onClose={onClose} theme="Light">
       <Heading3>Extra links</Heading3>
       {Object.entries(levelLinkData.links).map(([listTitle, links]) => (
         // Levels can be part of level groups (sublevels) and/or can be a template level

--- a/apps/src/sharedComponents/AccessibleDialog.jsx
+++ b/apps/src/sharedComponents/AccessibleDialog.jsx
@@ -21,6 +21,7 @@ function AccessibleDialog({
   closeOnClickBackdrop = false,
   onDeactivate = onClose,
   noMC = false, // exclude MineCraft button styles
+  theme,
 }) {
   // If these styles are provided by the given stylesheet, use them
   const modalStyle = styles?.modal || defaultStyle.modal;
@@ -33,7 +34,7 @@ function AccessibleDialog({
   const xIconOnClick = onDismiss ? onDismiss : onClose;
 
   return (
-    <div>
+    <div data-theme={theme}>
       <div className={backdropStyle} />
       <CloseOnEscape handleClose={onClose}>
         <FocusTrap
@@ -77,6 +78,7 @@ AccessibleDialog.propTypes = {
   closeOnClickBackdrop: PropTypes.bool,
   onDeactivate: PropTypes.func,
   noMC: PropTypes.bool,
+  theme: PropTypes.string,
 };
 
 export default AccessibleDialog;


### PR DESCRIPTION
This small follow-up to https://github.com/code-dot-org/code-dot-org/pull/65437 fixes the "Extra links" modal to use light mode even when the underlying Lab2 lab is using dark mode.

### before

<img width="674" alt="Screenshot 2025-04-28 at 3 18 44 PM" src="https://github.com/user-attachments/assets/65d62dd4-ce46-41f4-8157-16d50b1c3217" />

### after

<img width="674" alt="Screenshot 2025-04-28 at 3 19 08 PM" src="https://github.com/user-attachments/assets/d88491e4-1205-4d69-9ef6-b6954cf3133f" />
