### PR TITLE
Python Lab: fix cancel behavior for drag and drop

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowser.tsx
@@ -52,6 +52,10 @@ export const FileBrowser = React.memo(() => {
         setDragData(undefined);
         setDropData(undefined);
       },
+      onDragCancel: () => {
+        setDragData(undefined);
+        setDropData(undefined);
+      },
     }),
     [setDragData, setDropData]
   );

--- a/apps/src/codebridge/FileTabs/FileTabs.tsx
+++ b/apps/src/codebridge/FileTabs/FileTabs.tsx
@@ -61,6 +61,11 @@ export const FileTabs = React.memo(() => {
       rearrangeFiles(arrayMove(files, oldIndex, newIndex).map(file => file.id));
     }
   }
+
+  function handleDragCancel() {
+    setDraggingFileId(null);
+  }
+
   function handleDragStart(event: DragStartEvent) {
     // Handle drag start only if the file is in the list of open files.
     // This can get called when the close button is clicked, and we want to ignore
@@ -86,6 +91,7 @@ export const FileTabs = React.memo(() => {
       <DndContext
         onDragEnd={handleDragEnd}
         onDragStart={handleDragStart}
+        onDragCancel={handleDragCancel}
         sensors={sensors}
         collisionDetection={closestCenter}
         modifiers={[restrictToParentElement, restrictToHorizontalAxis]}


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

We noticed some odd behavior when cancelling drag and drop with the keyboard. For the file tabs, when you cancelled the tab would go back to its original location but be greyed out. For the browser, it would go back to its original location but the previous location it was over would stay highlighted (see before).

The fix to this turned out to be very simple; we didn't have cancel handlers set for either the tabs or the browser. The reason the tab was greyed out was we were seeing the drag overlay. The browser just hadn't cleared the dragging data, so a folder would still be styled as if something was being dragged over it.

## Before

https://github.com/user-attachments/assets/0dc5b725-9180-4b33-aaef-b9a573346477


https://github.com/user-attachments/assets/c12279d8-4b64-4587-8c34-d32825997398


## After

https://github.com/user-attachments/assets/43793a9d-ec42-49ec-aedf-257127a6f8b6


https://github.com/user-attachments/assets/98b2134c-dfa9-40c1-8777-1bb851feaef0


## Links

- Jira: [CT-1204](https://codedotorg.atlassian.net/browse/CT-1204)

## Testing story

Tested locally



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
