### PR TITLE
CMS-43: Add background to EditorialCard icon

### DIFF
--- a/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
+++ b/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
@@ -21,6 +21,7 @@
       align-items: center;
       text-align: center;
       border-radius: 50%;
+      background: var(--background-neutral-primary);
       border: 3px solid var(--text-neutral-primary);
       outline: 0.375rem solid var(--background-brand-teal-light);
       margin: 0.375rem;


### PR DESCRIPTION
<img width="100%" alt="preview" src="https://github.com/user-attachments/assets/2b06395f-aacf-4643-90a4-3cc1a44d9f62" />

## Links
- JIRA task: [CMS-43](https://codedotorg.atlassian.net/browse/CMS-43)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/65352