### PR TITLE
Remove rogue "0"

### DIFF
--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -165,7 +165,7 @@ export class StartNewProject extends React.Component {
 
     return (
       <div>
-        {defaultProjectTypes.length && (
+        {!!defaultProjectTypes.length && (
           <>
             <h4 className="new-project-heading" style={styles.headingStartNew}>
               {i18n.projectStartNew()}
@@ -174,7 +174,7 @@ export class StartNewProject extends React.Component {
           </>
         )}
 
-        {fullListProjectButtonsData.length && (
+        {!!fullListProjectButtonsData.length && (
           <>
             <Button
               id="uitest-view-full-list"


### PR DESCRIPTION
When working on a different feature I noticed a rogue "0" in the UI. This is the result of some boolean logic accidentally getting rendered. This PR removes the "0".

## Testing story
* Manually tested on http://localhost-studio.code.org:3000/s/coursea-2019/lessons/12/extras

## Screenshots
**Before**|**After**
--|--
![Screenshot 2025-04-28 at 5 21 37 PM](https://github.com/user-attachments/assets/2142fb3c-89b0-46e1-a534-4b9d98e7f943)|![Screenshot 2025-04-28 at 5 19 35 PM](https://github.com/user-attachments/assets/81b6c3c6-06dd-4502-8525-011952ebba8e)




