### PR TITLE
[Music] Increase strictness of function validation

### DIFF
--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -138,25 +138,17 @@ export default class MusicValidator extends Validator {
             });
           }
 
-          if (eventData.functionContext) {
-            if (
-              // Exclude 'when run' and trigger contexts.
-              eventData.functionContext.name !== 'when_run' &&
-              !Triggers.map(trigger => trigger.id).includes(
-                eventData.functionContext.name
-              )
-            ) {
-              this.conditionsChecker.addSatisfiedCondition({
-                name: MusicConditions.PLAYED_SOUND_IN_ANY_FUNCTION.name,
-              });
-            }
+          if (eventHasFunctionContext(eventData)) {
             this.conditionsChecker.addSatisfiedCondition({
-              name: MusicConditions.PLAYED_SOUND_IN_FUNCTION.name,
-              value: eventData.functionContext.name,
+              name: MusicConditions.PLAYED_SOUND_IN_ANY_FUNCTION.name,
             });
             this.conditionsChecker.addSatisfiedCondition({
               name: MusicConditions.PLAYED_SOUND_IN_FUNCTION.name,
-              value: eventData.functionContext.procedureID,
+              value: eventData.functionContext!.name,
+            });
+            this.conditionsChecker.addSatisfiedCondition({
+              name: MusicConditions.PLAYED_SOUND_IN_FUNCTION.name,
+              value: eventData.functionContext!.procedureID,
             });
           }
 
@@ -180,15 +172,10 @@ export default class MusicValidator extends Validator {
           });
         }
         if (
-          eventData.functionContext &&
-          // Exclude 'when run' and trigger contexts.
-          eventData.functionContext.name !== 'when_run' &&
-          !Triggers.map(trigger => trigger.id).includes(
-            eventData.functionContext.name
-          ) &&
-          !uniqueFunctionContexts.includes(eventData.functionContext.name)
+          eventHasFunctionContext(eventData) &&
+          !uniqueFunctionContexts.includes(eventData.functionContext!.name)
         ) {
-          uniqueFunctionContexts.push(eventData.functionContext.name);
+          uniqueFunctionContexts.push(eventData.functionContext!.name);
           this.conditionsChecker.addSatisfiedCondition({
             name: MusicConditions.PLAYED_SOUNDS_IN_DIFFERENT_FUNCTIONS.name,
             value: uniqueFunctionContexts.length,
@@ -571,4 +558,19 @@ export default class MusicValidator extends Validator {
       }
     });
   }
+}
+
+// Determines whether the event has a function context that is an actual
+// invocation of a function, as opposed to a trigger or 'when run' context.
+function eventHasFunctionContext(eventData: PlaybackEvent): boolean {
+  if (!eventData.functionContext) {
+    return false;
+  }
+  // Exclude 'when run' and trigger contexts.
+  return (
+    eventData.functionContext.name !== 'when_run' &&
+    !Triggers.map(trigger => trigger.id).includes(
+      eventData.functionContext.name
+    )
+  );
 }

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -181,6 +181,11 @@ export default class MusicValidator extends Validator {
         }
         if (
           eventData.functionContext &&
+          // Exclude 'when run' and trigger contexts.
+          eventData.functionContext.name !== 'when_run' &&
+          !Triggers.map(trigger => trigger.id).includes(
+            eventData.functionContext.name
+          ) &&
           !uniqueFunctionContexts.includes(eventData.functionContext.name)
         ) {
           uniqueFunctionContexts.push(eventData.functionContext.name);


### PR DESCRIPTION
Yesterday, @dancodedotorg reported a bug with a validation condition for functions. When attempting to check that the student had used two separate functions, he observed that students could pass even if they had only used one function as shown:

![image (299)](https://github.com/user-attachments/assets/12b917d6-a7c2-4a25-bebd-71d5bbfd5860)
![image (300)](https://github.com/user-attachments/assets/9b2ae785-1347-45c1-93b2-6aedcec0da94)

This turned out to be an oversight on my part the condition was created. https://github.com/code-dot-org/code-dot-org/pull/64837

When looking at playback events, I overlooked that there is also a valid value `eventData.functionContext` for blocks under "when run" as well as triggers. Unfortunately, I didn't think to test this for either of those use cases:

![image (280)](https://github.com/user-attachments/assets/479fd8f6-8b72-492f-8990-646502f2b816)

The needed fix is the same as what was needed here:
- https://github.com/code-dot-org/code-dot-org/pull/64655

For this branch, I created a new helper that checks whether an event has a function context. For the purpose of validation, I think it's reasonable to always exclude `'when_run'` and `'trigger1'` (etc.). 

In addition to fixing `PLAYED_SOUNDS_IN_DIFFERENT_FUNCTIONS`, this also increases the strictness of `PLAYED_SOUND_IN_FUNCTION`, which checks that a sound in a function of a given name (or procedure id) was played. 

https://github.com/code-dot-org/code-dot-org/blob/mike/function-validation/apps/src/music/progress/MusicConditions.ts#L42-L47

In a [separate thread](https://codedotorg.slack.com/archives/C07UT279KM1/p1745860551584889?thread_ts=1745860216.835979&cid=C07UT279KM1) yesterday, @dancodedotorg also noticed that we were logging an unexpected success condition that included `undefined`:

![image (302)](https://github.com/user-attachments/assets/d95041a1-1393-4542-a3f4-1ceb0b84b082)
This was happening because were adding a satisfied condition for the '`when_run'` function context, both by name (which was defined) and procedure ID (which was undefined). No levels are currently using this condition to explicitly check for `'when_run'` or triggers, so I think it makes sense to make each function condition use the same level of strictness now.


This change makes Dan's level work as expected.


<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

https://codedotorg.slack.com/archives/C07UT279KM1/p1745859280034279

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
