### PR TITLE
Evaluate Student Learning: filter nulls from returned student code samples

### DIFF
--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -48,7 +48,11 @@ const StudentCodeDatasetMaker: React.FC = () => {
     if (!codeSamples) {
       alert('No samples found for the given parameters.');
     } else {
-      setFetchedSamples(codeSamples as unknown as StudentCodeSample[]);
+      const fetchedCodeSamples = codeSamples as unknown as StudentCodeSample[];
+      const filteredCodeSamples = fetchedCodeSamples.filter(
+        item => item !== null
+      );
+      setFetchedSamples(filteredCodeSamples);
     }
     setPending(false);
   };


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/65298 and https://github.com/code-dot-org/code-dot-org/pull/65444
[TEACH-1829](https://codedotorg.atlassian.net/browse/TEACH-1829) partial

It's possible for the StudentWorkSampleApi to return null in cases where there is an issue. Now that we are logging more details about the error (which code version wasn't found) to Honeybadger I want to filter out the nulls so that we can see the rest of the successfully returned AI-evaluated code samples. 