### PR TITLE
feat(Image): add hasRoundedCorners prop

### DIFF
--- a/frontend/apps/design-system-storybook/public/images/image-component.png
+++ b/frontend/apps/design-system-storybook/public/images/image-component.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:443d1433961cc542d983de5a3e08fdf0f8582ec6385b844cfc0c10500ec7d97b
-size 330078
+oid sha256:498a59258ca74a0a7c119af4bca5f8cde1b376a4eeda34425741753150889856
+size 310244

--- a/frontend/apps/design-system-storybook/public/images/image-component.png
+++ b/frontend/apps/design-system-storybook/public/images/image-component.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06eca89444f355cd80dbce4f774b420e94c79077043655dacbd6e8a13bd1f151
-size 295544
+oid sha256:a88502ef39482348f5bc8bcacee3b46c679c27819c1672ceb76f2c16a5c6b6ad
+size 350435

--- a/frontend/apps/design-system-storybook/public/images/image-component.png
+++ b/frontend/apps/design-system-storybook/public/images/image-component.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:498a59258ca74a0a7c119af4bca5f8cde1b376a4eeda34425741753150889856
-size 310244
+oid sha256:06eca89444f355cd80dbce4f774b420e94c79077043655dacbd6e8a13bd1f151
+size 295544

--- a/frontend/apps/marketing/src/components/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/image/Image.tsx
@@ -9,9 +9,16 @@ type ImageProps = {
   altText?: string;
   /** Image decoration */
   decoration?: 'none' | 'border' | 'shadow';
+  /** Image has rounded corners */
+  hasRoundedCorners?: boolean;
 };
 
-const Image: React.FC<ImageProps> = ({src, altText, decoration}) => {
+const Image: React.FC<ImageProps> = ({
+  src,
+  altText,
+  decoration,
+  hasRoundedCorners,
+}) => {
   // Show placeholder text until a content entry is added
   if (src == null) {
     return (
@@ -24,7 +31,14 @@ const Image: React.FC<ImageProps> = ({src, altText, decoration}) => {
     );
   }
 
-  return <DSCOImage src={src} altText={altText} decoration={decoration} />;
+  return (
+    <DSCOImage
+      src={src}
+      altText={altText}
+      decoration={decoration}
+      hasRoundedCorners={hasRoundedCorners}
+    />
+  );
 };
 
 export default Image;

--- a/frontend/apps/marketing/src/components/image/imageContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/image/imageContentfulDefinition.ts
@@ -46,5 +46,11 @@ export const ImageContentfulComponentDefinition: ComponentDefinition = {
         ],
       },
     },
+    hasRoundedCorners: {
+      displayName: 'Rounded corners',
+      type: 'Boolean',
+      defaultValue: true,
+      group: 'style',
+    },
   },
 };

--- a/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
+++ b/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
@@ -128,7 +128,7 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
         {partner && (
           <span className={moduleStyles.heroBannerPartnerContainer}>
             {partner.title}
-            <Image {...partner.logo} />
+            <Image {...partner.logo} hasRoundedCorners={false} />
           </span>
         )}
 

--- a/frontend/packages/component-library/src/cms/skinnyBanner/SkinnyBanner.tsx
+++ b/frontend/packages/component-library/src/cms/skinnyBanner/SkinnyBanner.tsx
@@ -80,7 +80,7 @@ const SkinnyBanner: React.FC<SkinnyBannerProps> = ({
         {partner && (
           <span className={moduleStyles.skinnyBannerPartnerContainer}>
             {partner.title}
-            <Image {...partner.logo} />
+            <Image {...partner.logo} hasRoundedCorners={false} />
           </span>
         )}
       </div>

--- a/frontend/packages/component-library/src/image/Image.tsx
+++ b/frontend/packages/component-library/src/image/Image.tsx
@@ -13,6 +13,8 @@ export interface ImageProps
   loading?: 'eager' | 'lazy';
   /** Image decoration */
   decoration?: 'none' | 'border' | 'shadow';
+  /** Has rounded corners */
+  hasRoundedCorners?: boolean;
   /** Custom className */
   className?: string;
   /** Image onLoad callback */
@@ -39,6 +41,7 @@ const Image: React.FC<ImageProps> = ({
   altText = '',
   loading = 'lazy',
   decoration = 'none',
+  hasRoundedCorners = true,
   style,
   className,
   onLoad,
@@ -51,6 +54,7 @@ const Image: React.FC<ImageProps> = ({
       {
         [moduleStyles['figure-hasBorder']]: decoration === 'border',
         [moduleStyles['figure-hasBoxShadow']]: decoration === 'shadow',
+        [moduleStyles['figure-hasRoundedCorners']]: hasRoundedCorners,
       },
       className,
     )}

--- a/frontend/packages/component-library/src/image/__tests__/Image.test.tsx
+++ b/frontend/packages/component-library/src/image/__tests__/Image.test.tsx
@@ -20,6 +20,18 @@ describe('Image Component', () => {
     expect(figure.className).toMatch(/figure-hasBoxShadow/);
   });
 
+  it('applies rounded corners class', () => {
+    render(
+      <Image
+        src="test.jpg"
+        altText="Has rounded corners"
+        hasRoundedCorners={true}
+      />,
+    );
+    const figure = screen.getByRole('figure');
+    expect(figure.className).toMatch(/figure-hasRoundedCorners/);
+  });
+
   it('renders Image with provided className styles', () => {
     const className = 'customClass';
     const cssSelector = `figure.${className}`;

--- a/frontend/packages/component-library/src/image/image.module.scss
+++ b/frontend/packages/component-library/src/image/image.module.scss
@@ -7,7 +7,6 @@
   height: 100%;
   overflow: hidden;
   margin: 0;
-  border-radius: variables.$regular-border-radius;
 }
 
 // Image common styles
@@ -28,4 +27,9 @@
 // Image box shadow styles
 .figure-hasBoxShadow {
   box-shadow: 0.5rem 0.5rem 0 0 var(--background-brand-teal-light);
+}
+
+// Image rounded corners styles
+.figure-hasRoundedCorners {
+  border-radius: variables.$regular-border-radius;
 }

--- a/frontend/packages/component-library/src/image/stories/Image.story.tsx
+++ b/frontend/packages/component-library/src/image/stories/Image.story.tsx
@@ -128,6 +128,33 @@ export const ImageWithShadow: Story = {
   },
 };
 
+export const ImageWithoutRoundedCorners: Story = {
+  ...SingleTemplate,
+  args: {
+    src: imageFile,
+    altText: 'Teacher helping student',
+    hasRoundedCorners: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Remove rounded corners on an image if needed, will most likely need to be set to `false` on logos.',
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const image = await canvas.findByAltText('Teacher helping student');
+    const expectedRoundedCorners = '0';
+
+    // check if image has box shadow
+    await expect(image).toHaveStyle(
+      `border-radius: ${expectedRoundedCorners};`,
+    );
+  },
+};
+
 export const ImageWithError: Story = {
   ...SingleTemplate,
   args: {


### PR DESCRIPTION
Adds a `hasRoundedCorners` prop to the Image component instead of setting it in the css automatically. It will be set to `true` by default and can be turned off in the Contentful Design sidebar. I updated the HeroBanner and SkinnyBanner Image components to `false` on the partnership section since those are logos. 

The image used for Storybook and Contentful was exported with rounded corners so I cropped them out so there might be subtle shifts in Eyes tests.

## Links
Jira ticket: [CMS-618](https://codedotorg.atlassian.net/browse/CMS-618)

## Testing story
Added Storybook story and unit test in component-library. I will add it to /all-the-things when this PR: https://github.com/code-dot-org/code-dot-org/pull/65529 is merged: [CMS-623](https://codedotorg.atlassian.net/browse/CMS-623)

----

## Storybook

<img width="1047" alt="Screenshot 2025-04-29 at 10 26 35 AM" src="https://github.com/user-attachments/assets/bc18ccf7-a472-41dd-91cf-76d6e2c4b6ad" />



## Contentful


https://github.com/user-attachments/assets/965b6a09-ffc5-40f7-a2b9-7b63b89d2154

## Updated the HeroBanner and SkinnyBanner component partnership images too

<img width="620" alt="Screenshot 2025-04-29 at 10 47 09 AM" src="https://github.com/user-attachments/assets/5039e89e-a4ee-415f-a7a7-17ed7e624237" />

<img width="443" alt="Screenshot 2025-04-29 at 10 56 45 AM" src="https://github.com/user-attachments/assets/b79d9064-3111-4659-a634-50e54428be55" />