### PR TITLE
Evaluate Student Learning: log events for AI Analysis of FRQ clicks 

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -232,6 +232,10 @@ const EVENTS = {
   CFU_RESPONSE_UNPINNED: 'Summary Page Response Unpinned',
   CFU_RESPONSE_ALL_UNHID: 'Summary Page Response Hidden Responses Unhidden',
   CFU_RESPONSE_ALL_UNPINNED: 'Summary Page Response All Unpinned',
+  CFU_SHOW_AI_INSIGHTS_TOGGLED_OFF: 'Summary Page AI Insights Toggled Off',
+  CFU_SHOW_AI_INSIGHTS_TOGGLED_ON: 'Summary Page AI Insights Toggled On',
+  CFU_AI_ANALYSIS_BUTTON_CLICKED: 'Summary Page AI Analysis Button Clicked',
+  CFU_AI_ANALYSIS_VIEW_DETAILS: 'Summary Page AI Analysis View Details',
 
   // Maker setup
   MAKER_SETUP_PAGE_BOARD_TYPE_EVENT: 'Board Type On Maker Setup Page',

--- a/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
+++ b/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
@@ -37,7 +37,7 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
       tooHigh: aiTooHigh,
       tooLow: aiTooLow,
       profanityFalsePositive: aiProfanityFalsePositive,
-      Vague: aiVague,
+      vague: aiVague,
       feedbackOther: aiFeedbackOther,
       otherContent: aiOtherContent,
     };

--- a/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
+++ b/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
@@ -37,7 +37,7 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
       tooHigh: aiTooHigh,
       tooLow: aiTooLow,
       profanityFalsePositive: aiProfanityFalsePositive,
-      vague: aiVague,
+      Vague: aiVague,
       feedbackOther: aiFeedbackOther,
       otherContent: aiOtherContent,
     };

--- a/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
@@ -5,6 +5,8 @@ import {
   StudentWorkEvaluation,
   evaluateStudentWork,
 } from '@cdo/apps/aiEvaluation/aiEvaluationApi';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 
 import FreeResponseAiStudentResponseHeader from './FreeResponseAiStudentResponseHeader';
 import FreeResponseAiSummaryBox from './FreeResponseAiSummaryBox';
@@ -35,6 +37,14 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
     evaluationCount > 0 && responses.length === evaluationCount;
 
   const getAIEvaluations = async () => {
+    analyticsReporter.sendEvent(
+      EVENTS.CFU_AI_ANALYSIS_BUTTON_CLICKED,
+      {
+        levelId: levelData.levelId,
+        unitId: levelData.unitId,
+      },
+      PLATFORMS.BOTH
+    );
     setEvaluationsPending(true);
     const responsePromises = responses.map(async studentResponse => {
       return evaluateStudentResponse(studentResponse);
@@ -62,6 +72,18 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
     setEvaluationCount(prevCount => prevCount + 1);
   };
 
+  const openDetailedAnalysisHandler = () => {
+    analyticsReporter.sendEvent(
+      EVENTS.CFU_AI_ANALYSIS_VIEW_DETAILS,
+      {
+        levelId: levelData.levelId,
+        unitId: levelData.unitId,
+      },
+      PLATFORMS.BOTH
+    );
+    setShowDetailedAnalysis(true);
+  };
+
   useEffect(() => {
     if (evaluationComplete) {
       setEvaluationsPending(false);
@@ -77,7 +99,7 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
         studentWorkEvaluations={evaluations}
         evaluationComplete={evaluationComplete}
         totalNumberOfStudents={totalNumberOfStudents}
-        openDetailedAnalysis={() => setShowDetailedAnalysis(true)}
+        openDetailedAnalysis={openDetailedAnalysisHandler}
       />
       {evaluationComplete && showDetailedAnalysis && (
         <div className={styles.detailedAnalysisContainer}>

--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -123,6 +123,11 @@ const SummaryResponses = ({
     unitId: scriptData.reportingData.unitId,
   };
   const toggleAIAnalysis = () => {
+    if (showAIAnalysis) {
+      logEvent(EVENTS.CFU_SHOW_AI_INSIGHTS_TOGGLED_OFF);
+    } else {
+      logEvent(EVENTS.CFU_SHOW_AI_INSIGHTS_TOGGLED_ON);
+    }
     setShowAIAnalysis(prevShowAIAnalysis => !prevShowAIAnalysis);
   };
 


### PR DESCRIPTION
[TEACH-1844](https://codedotorg.atlassian.net/browse/TEACH-1844)
Adds additional logging to Statsig for interactions on the free response summary page AI analysis components. 

![Screenshot 2025-04-29 at 3 25 29 PM](https://github.com/user-attachments/assets/bdc75844-e65b-4137-aa7c-db1842964cf2)

![Screenshot 2025-04-29 at 3 25 16 PM](https://github.com/user-attachments/assets/9aecf941-ff91-4560-b79c-b03cced9ef07)

![Screenshot 2025-04-29 at 3 24 09 PM](https://github.com/user-attachments/assets/20848bf4-3e09-48b2-af82-d6e75b0ee608)

![Screenshot 2025-04-29 at 3 24 02 PM](https://github.com/user-attachments/assets/d62fdb04-ff92-412b-b556-c2b6723455fc)
