### PR TITLE
fix(marketing): set page cache to 1 hour

### DIFF
--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -599,6 +599,31 @@ Resources:
             QueryStringBehavior: none
         Comment: Cache policy for the marketing app
 
+  ViewerResponseCloudFrontFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: MarketingAppViewerResponseFunction
+      AutoPublish: true
+      FunctionCode: |
+        function handler(event) {
+          let response = event.response;
+
+          // Set a default stale-while-revalidate cache control header if the origin does not send any cache-control header
+          // This is to workaround https://github.com/vercel/next.js/issues/73382
+          // Remove when the issue is fixed in Next.js (Cache-Control is consistently returned by the origin)
+          if (response.headers['cache-control'] === undefined) {
+              // This value should match the constant `revalidate` in `frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx`
+              response.headers['cache-control'] = {
+              value: `s-maxage=3600, stale-while-revalidate=31535400`
+            }
+          }
+
+          return response;
+        }
+      FunctionConfig:
+        Comment: Adds Cache-Control if not present
+        Runtime: cloudfront-js-2.0
+
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -657,6 +682,9 @@ Resources:
             PathPattern: /api/*
             TargetOriginId: marketing-sites-application-origin
             ViewerProtocolPolicy: redirect-to-https
+            FunctionAssociations:
+              - EventType: viewer-response
+                FunctionARN: !GetAtt ViewerResponseCloudFrontFunction.FunctionARN
 
           # Path: /_next/*
           # Description: Marketing _application_ static assets

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -656,6 +656,9 @@ Resources:
           Compress: true
           CachePolicyId: !Ref ApplicationCachingPolicy
           OriginRequestPolicyId: "216adef6-5c7f-47e4-b989-5492eafa07d3" # AllViewer
+          FunctionAssociations:
+            - EventType: viewer-response
+              FunctionARN: !GetAtt ViewerResponseCloudFrontFunction.FunctionARN
 
         ViewerCertificate:
           AcmCertificateArn:
@@ -682,9 +685,6 @@ Resources:
             PathPattern: /api/*
             TargetOriginId: marketing-sites-application-origin
             ViewerProtocolPolicy: redirect-to-https
-            FunctionAssociations:
-              - EventType: viewer-response
-                FunctionARN: !GetAtt ViewerResponseCloudFrontFunction.FunctionARN
 
           # Path: /_next/*
           # Description: Marketing _application_ static assets

--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx
@@ -14,7 +14,7 @@ import {getSeoMetadata} from '@/metadata/seo';
 import {getPageHeading} from '@/selectors/contentful/getExperienceEntryFields';
 
 export const dynamic = 'force-static'; // Ensure ISR is enabled
-export const revalidate = 600; // Cache for five minutes until on-demand revalidation works
+export const revalidate = 3600; // Cache for one hour
 
 type ExperiencePageProps = {
   params: Promise<{locale?: string; slug?: string; brand?: Brand}>;

--- a/frontend/apps/marketing/tests/e2e/cache.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/cache.spec.ts
@@ -15,7 +15,7 @@ test.describe('Caching Tests', () => {
 
     const cacheControlHeader = response?.headers()['cache-control'];
     expect(cacheControlHeader).toEqual(
-      's-maxage=600, stale-while-revalidate=31535400',
+      's-maxage=3600, stale-while-revalidate=31535400',
     );
   });
 


### PR DESCRIPTION
This PR updates the default page caching behavior to cache pages for one hour.

An additional Cloudfront viewer response function was added because Next.js has a bug[1] that appears to cause the `Cache-Control` header to be missing when operating in a distributed environment. While waiting for the bug to be fixed, the Cloudfront function will add the SWR cache control header if the origin does not supply any cache control header.

If this workaround is not in place, Cloudfront will indefinetly cache the page which is not what we intend for these pages.

[1] https://www.github.com/vercel/next.js/issues/73382