### PR TITLE
[PythonLab] Adding aria expanded status to pythonlab dropdowns

### DIFF
--- a/apps/src/codebridge/InfoPanel/InfoPanel.tsx
+++ b/apps/src/codebridge/InfoPanel/InfoPanel.tsx
@@ -107,6 +107,7 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
           isIconOnly
           onClick={() => setIsDropdownOpen(!isDropdownOpen)}
           ariaLabel={'Information panel dropdown'}
+          aria-expanded={isDropdownOpen}
           size={'xs'}
           type={'tertiary'}
           className={darkModeStyles.tertiaryButton}

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -116,6 +116,7 @@ export const PopUpButton = ({
         id={id}
         disabled={disabled}
         ariaLabel={ariaLabel}
+        aria-expanded={isOpen}
       />
       {isOpen &&
         // We use a portal so the dropdown can appear above all other elements.

--- a/apps/src/codebridge/components/ToggleFileBrowserButton.tsx
+++ b/apps/src/codebridge/components/ToggleFileBrowserButton.tsx
@@ -50,6 +50,7 @@ const ToggleFileBrowserButton: React.FunctionComponent = () => {
           size={'xs'}
           type={'tertiary'}
           className={darkModeStyles.tertiaryButton}
+          aria-expanded={config.showFileBrowser}
         />
       </WithTooltip>
     </span>


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

This PR adds aria-expanded roles to the relevant dropdowns for Pythonlab. A couple of these handed to be handled specifically, but the rest are covered by updating popupbutton to automatically include this state for all pages that utilize it.

Examples of the states in action (the voiceover now says either 'expanded' or 'collapsed' accordingly):

<img width="837" alt="Screenshot 2025-04-30 at 11 32 06 AM" src="https://github.com/user-attachments/assets/51710db7-0723-425c-ab9b-83b373713738" />

<img width="849" alt="Screenshot 2025-04-30 at 11 29 58 AM" src="https://github.com/user-attachments/assets/4661324a-f2a5-42bd-b33c-a80fed4c07ed" />

<img width="847" alt="Screenshot 2025-04-30 at 11 34 33 AM" src="https://github.com/user-attachments/assets/8529c257-76aa-467e-8a88-c51970c781fb" />

<img width="823" alt="Screenshot 2025-04-30 at 11 34 12 AM" src="https://github.com/user-attachments/assets/dcfd7ac7-41f6-4808-addb-38d6bc807a92" />


## Links

- Jira: https://codedotorg.atlassian.net/browse/CT-1093

## Testing story

Tested with voiceover

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
