### PR TITLE
feat(marketing): add bindingSourceType to content fields on existing components

### DIFF
--- a/frontend/apps/marketing/src/components/button/ButtonContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/button/ButtonContentfulDefinition.ts
@@ -44,12 +44,18 @@ export const ButtonContentfulComponentDefinition: ComponentDefinition = {
       type: 'Text',
       defaultValue: 'Button',
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     href: {
       displayName: 'Link URL',
       type: 'Text',
       defaultValue: 'https://code.org',
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     isLinkExternal: {
       displayName:
@@ -59,11 +65,17 @@ export const ButtonContentfulComponentDefinition: ComponentDefinition = {
       type: 'Boolean',
       defaultValue: false,
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     ariaLabel: {
       displayName: 'Aria Label',
       type: 'Text',
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     iconLeftName: {
       displayName: 'Left Icon Name',

--- a/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
@@ -102,6 +102,9 @@ export const HeroBannerContentfulComponentDefinition: ComponentDefinition = {
       group: 'content',
       description:
         'The title of the video. This will double as the caption under the video player.',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     sectionVideoYouTubeId: {
       displayName: 'Video YouTube ID',
@@ -109,6 +112,9 @@ export const HeroBannerContentfulComponentDefinition: ComponentDefinition = {
       group: 'content',
       description:
         'The YouTube ID of the video. This is the unique identifier for the video on YouTube.',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     sectionVideoFallback: {
       displayName: 'Video fallback',
@@ -116,6 +122,9 @@ export const HeroBannerContentfulComponentDefinition: ComponentDefinition = {
       group: 'content',
       description:
         'This is the URL of the video that will be used in place of the YouTube video if YouTube is blocked.',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     buttonLink: {
       displayName: 'Button Link',

--- a/frontend/apps/marketing/src/components/editorialCard/EditorialCardContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/editorialCard/EditorialCardContentfulDefinition.ts
@@ -50,6 +50,7 @@ export const EditorialCardContentfulComponentDefinition: ComponentDefinition = {
       defaultValue: 'Editorial Card Heading',
       validations: {
         required: true,
+        bindingSourceType: ['entry', 'manual'],
       },
     },
     text: {
@@ -59,6 +60,7 @@ export const EditorialCardContentfulComponentDefinition: ComponentDefinition = {
       defaultValue: 'Editorial Card\nMultiline Text',
       validations: {
         required: true,
+        bindingSourceType: ['entry', 'manual'],
       },
     },
     image: {

--- a/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
@@ -39,6 +39,9 @@ export const HeadingContentfulComponentDefinition: ComponentDefinition = {
       type: 'Text',
       defaultValue: 'Heading',
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
   },
 };

--- a/frontend/apps/marketing/src/components/iconHighlight/IconHighlightContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/iconHighlight/IconHighlightContentfulDefinition.ts
@@ -24,6 +24,7 @@ export const IconHighlightContentfulComponentDefinition: ComponentDefinition = {
       defaultValue: 'Icon Highlight Heading',
       validations: {
         required: true,
+        bindingSourceType: ['entry', 'manual'],
       },
     },
     text: {
@@ -33,6 +34,7 @@ export const IconHighlightContentfulComponentDefinition: ComponentDefinition = {
       defaultValue: 'Icon Highlight\nMultiline Text',
       validations: {
         required: true,
+        bindingSourceType: ['entry', 'manual'],
       },
     },
     iconName: {

--- a/frontend/apps/marketing/src/components/iframe/iframeContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/iframe/iframeContentfulDefinition.ts
@@ -22,6 +22,7 @@ export const IframeContentfulComponentDefinition: ComponentDefinition = {
       group: 'content',
       validations: {
         required: true,
+        bindingSourceType: ['entry', 'manual'],
       },
     },
     title: {
@@ -30,6 +31,7 @@ export const IframeContentfulComponentDefinition: ComponentDefinition = {
       group: 'content',
       validations: {
         required: true,
+        bindingSourceType: ['entry', 'manual'],
       },
     },
     height: {

--- a/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/link/LinkContentfulDefinition.ts
@@ -36,11 +36,17 @@ export const LinkContentfulComponentDefinition: ComponentDefinition = {
       type: 'Text',
       defaultValue: 'Link',
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     href: {
       displayName: 'Link URL',
       type: 'Text',
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     isLinkExternal: {
       displayName:
@@ -50,12 +56,18 @@ export const LinkContentfulComponentDefinition: ComponentDefinition = {
       type: 'Boolean',
       defaultValue: false,
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     removeMarginBottom: {...removeMarginBottomDefinition},
     ariaLabel: {
       displayName: 'Aria Label',
       type: 'Text',
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
   },
 };

--- a/frontend/apps/marketing/src/components/overline/OverlineContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/overline/OverlineContentfulDefinition.ts
@@ -48,6 +48,9 @@ export const OverlineContentfulComponentDefinition: ComponentDefinition = {
       type: 'Text',
       defaultValue: 'Overline',
       group: 'content',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
   },
 };

--- a/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
@@ -50,6 +50,9 @@ export const ParagraphContentfulComponentDefinition: ComponentDefinition = {
       defaultValue: 'Paragraph',
       group: 'content',
       description: 'The text or other elements to display inside the paragraph',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     isStrong: {
       displayName: 'Make this paragraph bold',

--- a/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/section/sectionContentfulDefinition.ts
@@ -65,6 +65,9 @@ export const SectionContentfulComponentDefinition: ComponentDefinition = {
       type: 'Text',
       group: 'content',
       description: 'Adds a custom ID to a section; can be used for skip links.',
+      validations: {
+        bindingSourceType: ['manual'],
+      },
     },
   },
 };

--- a/frontend/apps/marketing/src/components/video/videoContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/video/videoContentfulDefinition.ts
@@ -22,18 +22,27 @@ export const VideoContentfulComponentDefinition: ComponentDefinition = {
       group: 'content',
       description:
         'The title of the video. This will double as the caption under the video player.',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     videoDesc: {
       displayName: 'Description',
       type: 'Text',
       group: 'content',
       description: 'The description of the video. Helpful for SEO.',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     uploadDate: {
       displayName: 'Published Date',
       type: 'Date',
       group: 'content',
       description: 'The upload date of the video. Required for SEO.',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     youTubeId: {
       displayName: 'YouTube ID',
@@ -41,6 +50,9 @@ export const VideoContentfulComponentDefinition: ComponentDefinition = {
       group: 'content',
       description:
         'The YouTube ID of the video. This is the unique identifier for the video on YouTube.',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     videoFallback: {
       displayName: 'Video fallback',
@@ -48,6 +60,9 @@ export const VideoContentfulComponentDefinition: ComponentDefinition = {
       group: 'content',
       description:
         'This is the URL of the video that will be used in place of the YouTube video if YouTube is blocked.',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     showCaption: {
       displayName: 'Show video caption',


### PR DESCRIPTION
Sets the `bindingSourceType` on existing component definition content fields. This will remove options editors can’t use when selecting entries for content fields. 

**See screenshot below for example of what's being updated:**

![Screenshot 2025-04-30 at 11 56 08 AM](https://github.com/user-attachments/assets/a189af2b-e0a2-42c0-abc9-931c616e58f5)



## Links
Jira ticket: [CMS-624](https://codedotorg.atlassian.net/browse/CMS-624)

## Testing story
Tested locally on Contentful