### PR TITLE
feat(Video): remove bottom margin on caption

### DIFF
--- a/frontend/packages/component-library/src/video/video.module.scss
+++ b/frontend/packages/component-library/src/video/video.module.scss
@@ -74,6 +74,10 @@
   align-items: start;
   gap: 1rem;
 
+  figcaption {
+    margin-bottom: 0;
+  }
+
   .download {
     margin-top: 0.25rem;
   }


### PR DESCRIPTION
Removes bottom margin on caption in Video component.

## Links
Jira ticket: [CMS-608](https://codedotorg.atlassian.net/browse/CMS-608)

## Testing story
Tested locally in Storybook and Contentful, might result in Eyes diffs since spacing changed

----

<img width="280" alt="Screenshot 2025-04-30 at 12 22 01 PM" src="https://github.com/user-attachments/assets/167c8a30-38e9-4cd8-afea-abf2658dcbe7" />
