### PR TITLE
Mark school_info_confirmation_dialog UI test as an eyes test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -14,6 +14,7 @@ Feature: School Info Confirmation Dialog
 # 4. A year later after the user has completed school info, the user sees prompt to
 # confirm or update current school info.
 
+@eyes
 Scenario: School Info Confirmation Dialog
   # Teacher account is created with partial school info
   Given I create a teacher named "Teacher_Chuba" and go home


### PR DESCRIPTION
This test looks for screenshots but isn't marked as an eyes test. Adding the decorator to do that!