### PR TITLE
Revert bubble choice level

### DIFF
--- a/dashboard/config/scripts/lab2_bubblechoice_showcase.bubble_choice
+++ b/dashboard/config/scripts/lab2_bubblechoice_showcase.bubble_choice
@@ -1,7 +1,6 @@
 name 'Lab2 BubbleChoice Showcase'
 display_name 'Lab2 Bubble Choice'
 description 'This Bubble Choice level and all sublevels use Lab2.'
-uses_lab2
 
 sublevels
 level 'AI Chat Sublevel'


### PR DESCRIPTION
This reverts the bubble choice level used at `/s/allthethings/lessons/52/levels/8` to not use the Lab2 implementation.  We can switch it back once the [bubble_choice.feature](https://github.com/code-dot-org/code-dot-org/blob/ae4e4b7d5bdea7e91037518d01125640d6ea4efd/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature) UI test is updated at the same time.

The change had been made yesterday via levelbuilder which was scooped overnight, inadvertently breaking UI tests today.
