### PR TITLE
fix(env): inject environment to client side

### DIFF
--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -313,7 +313,7 @@ Resources:
               Value: cdn.contentful.com
             - Name: CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID
               Value: experience
-            - Name: STAGE
+            - Name: NEXT_PUBLIC_STAGE
               Value: test
           Essential: true
           Image:

--- a/frontend/apps/marketing/.env.example
+++ b/frontend/apps/marketing/.env.example
@@ -8,6 +8,10 @@ CONTENTFUL_REVALIDATE_TOKEN=
 # The secret token to enable Next.js draft mode (bypass cache)
 DRAFT_MODE_TOKEN=
 
+# The stage the application will run as
+# One of: development (default), pr, test, production
+NEXT_PUBLIC_STAGE=development
+
 ####################################
 # Contentful Environment Variables #
 ####################################

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -47,6 +47,7 @@
     "contentful": "^11.2.5",
     "cookies-next": "^5.1.0",
     "next": "^15.2.4",
+    "next-runtime-env": "^3.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-schemaorg": "^2.0.0",

--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx
@@ -5,8 +5,7 @@ import {detachExperienceStyles} from '@contentful/experiences-sdk-react';
 import {Metadata} from 'next';
 import {draftMode} from 'next/headers';
 
-import FontLoader from '@code-dot-org/fonts/FontLoader';
-
+import Bootstrap from '@/bootstrap';
 import {Brand} from '@/config/brand';
 import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
 import {getExperience} from '@/contentful/get-experience';
@@ -78,7 +77,7 @@ export default async function ExperiencePage({
 
   return (
     <main style={{width: '100%'}}>
-      <FontLoader locale={pageProps.locale} />
+      <Bootstrap locale={pageProps.locale} />
       {stylesheet && <style>{stylesheet}</style>}
       <ExperiencePageLoader
         experienceJSON={experienceJSON}

--- a/frontend/apps/marketing/src/bootstrap/index.tsx
+++ b/frontend/apps/marketing/src/bootstrap/index.tsx
@@ -1,0 +1,17 @@
+import {PublicEnvScript} from 'next-runtime-env';
+
+import FontLoader from '@code-dot-org/fonts/FontLoader';
+
+interface BootstrapProps {
+  locale: string;
+}
+const Bootstrap = ({locale}: BootstrapProps) => {
+  return (
+    <>
+      <PublicEnvScript disableNextScript={true} />
+      <FontLoader locale={locale} />
+    </>
+  );
+};
+
+export default Bootstrap;

--- a/frontend/apps/marketing/src/config/__tests__/studio.test.ts
+++ b/frontend/apps/marketing/src/config/__tests__/studio.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import {getStage} from '../stage';
 import {getStudioUrl} from '../studio';
 

--- a/frontend/apps/marketing/src/config/stage.ts
+++ b/frontend/apps/marketing/src/config/stage.ts
@@ -1,12 +1,16 @@
+import {env} from 'next-runtime-env';
+
 export type Stage = 'development' | 'pr' | 'test' | 'production';
 
 export function getStage(): Stage {
-  switch (process.env.STAGE) {
+  const stage = env('NEXT_PUBLIC_STAGE') as Stage;
+
+  switch (stage) {
     case 'development':
     case 'test':
     case 'production':
     case 'pr':
-      return process.env.STAGE;
+      return stage;
     default:
       return 'development';
   }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1109,6 +1109,7 @@ __metadata:
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
     next: "npm:^15.2.4"
+    next-runtime-env: "npm:^3.3.0"
     playwright-core: "npm:~1.49.1"
     prettier: "npm:3.4.2"
     react: "npm:^18.3.1"
@@ -3222,6 +3223,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/env@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/env@npm:14.2.28"
+  checksum: 10c0/edf665a7bfb14a5e74e40bad8355e4d72f2c86d5698fc541b03b42e719e57c8db1ba37fa615228954519689bed5add2c271f3e6caaa197d894471763cfbc88ee
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/env@npm:15.2.4"
@@ -3238,10 +3246,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-darwin-arm64@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/swc-darwin-arm64@npm:14.2.28"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-darwin-arm64@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/swc-darwin-arm64@npm:15.2.4"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-x64@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/swc-darwin-x64@npm:14.2.28"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3252,10 +3274,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-arm64-gnu@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/swc-linux-arm64-gnu@npm:14.2.28"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-arm64-gnu@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/swc-linux-arm64-gnu@npm:15.2.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-musl@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/swc-linux-arm64-musl@npm:14.2.28"
+  conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -3266,10 +3302,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-x64-gnu@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/swc-linux-x64-gnu@npm:14.2.28"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-x64-gnu@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/swc-linux-x64-gnu@npm:15.2.4"
   conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-musl@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/swc-linux-x64-musl@npm:14.2.28"
+  conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -3280,10 +3330,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-win32-arm64-msvc@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/swc-win32-arm64-msvc@npm:14.2.28"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-win32-arm64-msvc@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/swc-win32-arm64-msvc@npm:15.2.4"
   conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-ia32-msvc@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/swc-win32-ia32-msvc@npm:14.2.28"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-x64-msvc@npm:14.2.28":
+  version: 14.2.28
+  resolution: "@next/swc-win32-x64-msvc@npm:14.2.28"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5042,6 +5113,16 @@ __metadata:
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10c0/33002f74f6f885f04c132960835fdfc474186983ea567606db62e86acd0680ca82f34647e8e610f4e1e422d1c16fce729dde22cd3b797ab1fd9061a825dabca4
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:0.5.5":
+  version: 0.5.5
+  resolution: "@swc/helpers@npm:0.5.5"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/21a9b9cfe7e00865f9c9f3eb4c1cc5b397143464f7abee76a2c5366e591e06b0155b5aac93fe8269ef8d548df253f6fd931e9ddfc0fd12efd405f90f45506e7d
   languageName: node
   linkType: hard
 
@@ -14075,6 +14156,77 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next-runtime-env@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "next-runtime-env@npm:3.3.0"
+  dependencies:
+    next: "npm:^14"
+    react: "npm:^18"
+  peerDependencies:
+    next: ^14
+    react: ^18
+  checksum: 10c0/7e59dfd138badc7925cd3f42ff826d7121f8e53399957f61906d1e10957a855b1f21f750984431cb448c9371f400170898e5e3125beef58ac7e9d1b74e073a87
+  languageName: node
+  linkType: hard
+
+"next@npm:^14":
+  version: 14.2.28
+  resolution: "next@npm:14.2.28"
+  dependencies:
+    "@next/env": "npm:14.2.28"
+    "@next/swc-darwin-arm64": "npm:14.2.28"
+    "@next/swc-darwin-x64": "npm:14.2.28"
+    "@next/swc-linux-arm64-gnu": "npm:14.2.28"
+    "@next/swc-linux-arm64-musl": "npm:14.2.28"
+    "@next/swc-linux-x64-gnu": "npm:14.2.28"
+    "@next/swc-linux-x64-musl": "npm:14.2.28"
+    "@next/swc-win32-arm64-msvc": "npm:14.2.28"
+    "@next/swc-win32-ia32-msvc": "npm:14.2.28"
+    "@next/swc-win32-x64-msvc": "npm:14.2.28"
+    "@swc/helpers": "npm:0.5.5"
+    busboy: "npm:1.6.0"
+    caniuse-lite: "npm:^1.0.30001579"
+    graceful-fs: "npm:^4.2.11"
+    postcss: "npm:8.4.31"
+    styled-jsx: "npm:5.1.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-ia32-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 10c0/c3300970c7d633cfde371e59ef3f1b08bd5403b7f5b43bc07ec16e17d8d82b993115c61cca003cec3e8dd3fe72d1fbe2bb366f76a8e91e39c80b0f9fe7cc41df
+  languageName: node
+  linkType: hard
+
 "next@npm:^15.2.4":
   version: 15.2.4
   resolution: "next@npm:15.2.4"
@@ -15864,7 +16016,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.3.1":
+"react@npm:^18, react@npm:^18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:
@@ -17491,6 +17643,22 @@ __metadata:
   peerDependencies:
     webpack: ^5.0.0
   checksum: 10c0/8f8027fc5c6e91400cbb60066e7db3315810f8eaa0d19b2a254936eb0bec399ba8a7043b1789da9d05ab7c3ba50faf9267765ae0bf3571e48aa34ecdc774be37
+  languageName: node
+  linkType: hard
+
+"styled-jsx@npm:5.1.1":
+  version: 5.1.1
+  resolution: "styled-jsx@npm:5.1.1"
+  dependencies:
+    client-only: "npm:0.0.1"
+  peerDependencies:
+    react: ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    babel-plugin-macros:
+      optional: true
+  checksum: 10c0/42655cdadfa5388f8a48bb282d6b450df7d7b8cf066ac37038bd0499d3c9f084815ebd9ff9dfa12a218fd4441338851db79603498d7557207009c1cf4d609835
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes the injection of the public facing environment variables into the client-side. The header needs to know which stage the application is running on both on SSR and CSR modes. To do this, the environment variable is exposed publicly and injected into the `window` object using `next-runtime-env`.

This fixes the header linking to localhost-studio even in the test environment.