### PR TITLE
feat(tools): add content editor tools

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {Metadata} from 'next';
 import {draftMode} from 'next/headers';
 
 import Bootstrap from '@/bootstrap';
+import ContentEditorHelper from '@/components/contentEditorHelper';
 import {Brand} from '@/config/brand';
 import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
 import {getExperience} from '@/contentful/get-experience';
@@ -58,6 +59,7 @@ export default async function ExperiencePage({
   params,
   searchParams,
 }: ExperiencePageProps) {
+  const isDraftModeEnabled = (await draftMode()).isEnabled;
   const pageProps = await getPageProps({
     params,
     searchParams,
@@ -78,6 +80,7 @@ export default async function ExperiencePage({
   return (
     <main style={{width: '100%'}}>
       <Bootstrap locale={pageProps.locale} />
+      <ContentEditorHelper isDraftModeEnabled={isDraftModeEnabled} />
       {stylesheet && <style>{stylesheet}</style>}
       <ExperiencePageLoader
         experienceJSON={experienceJSON}

--- a/frontend/apps/marketing/src/app/api/disable-draft/route.ts
+++ b/frontend/apps/marketing/src/app/api/disable-draft/route.ts
@@ -1,0 +1,9 @@
+import {draftMode} from 'next/headers';
+
+export async function POST() {
+  const draft = await draftMode();
+
+  draft.disable();
+
+  return new Response('Draft mode disabled', {status: 200});
+}

--- a/frontend/apps/marketing/src/components/contentEditorHelper/ContentEditorHelper.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/ContentEditorHelper.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import {useSearchParams} from 'next/navigation';
+import {useEffect, useState} from 'react';
+
+import Button from '@code-dot-org/component-library/button';
+import Popover from '@code-dot-org/component-library/popover';
+import {BodyTwoText} from '@code-dot-org/component-library/typography';
+
+import ContentEditorTools from '@/components/contentEditorHelper/Tools';
+
+import TokenPrompt from './TokenPrompt';
+
+import styles from './styles.module.scss';
+
+type ContentEditorToolsProps = {
+  isDraftModeEnabled: boolean;
+};
+
+const ContentEditorHelper = ({isDraftModeEnabled}: ContentEditorToolsProps) => {
+  const searchParams = useSearchParams();
+  const [popoverVisible, setPopoverVisible] = useState(false);
+  const [renderState, setRenderState] = useState<
+    'loading' | 'token-prompt' | 'tools'
+  >('loading');
+
+  useEffect(() => {
+    setRenderState(
+      localStorage.getItem('draftToken') ? 'tools' : 'token-prompt',
+    );
+  }, []);
+
+  const previewLabel = isDraftModeEnabled
+    ? 'Draft Version'
+    : 'Published Version';
+
+  const handleButtonClick = () => {
+    setPopoverVisible(true);
+  };
+
+  const handlePopoverClose = () => {
+    setPopoverVisible(false);
+  };
+
+  const handleSubmitToken = (token: string | null) => {
+    if (token) {
+      localStorage.setItem('draftToken', token);
+      setRenderState('tools');
+    }
+  };
+
+  const getRender = () => {
+    switch (renderState) {
+      case 'loading':
+        return <BodyTwoText>Loading...</BodyTwoText>;
+      case 'token-prompt':
+        return <TokenPrompt onSubmit={handleSubmitToken} />;
+      case 'tools':
+        return (
+          <ContentEditorTools
+            isDraftModeEnabled={isDraftModeEnabled}
+            onChangeDraftToken={() => setRenderState('token-prompt')}
+            previewLabel={previewLabel}
+          />
+        );
+    }
+  };
+
+  return (
+    <>
+      {popoverVisible && (
+        <Popover
+          className={styles.contentEditorPopover}
+          direction={'none'}
+          title={'Content Editor Tools'}
+          content={''}
+          onClose={handlePopoverClose}
+        >
+          <div className={styles.contentFlexContainer}>{getRender()}</div>
+        </Popover>
+      )}
+
+      {!popoverVisible &&
+        (searchParams.get('contentEditor') === 'true' ||
+          isDraftModeEnabled) && (
+          <Button
+            className={styles.floatingButton}
+            color={'destructive'}
+            text={previewLabel}
+            size={'m'}
+            onClick={handleButtonClick}
+          />
+        )}
+    </>
+  );
+};
+
+export default ContentEditorHelper;

--- a/frontend/apps/marketing/src/components/contentEditorHelper/TokenPrompt/TokenPrompt.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/TokenPrompt/TokenPrompt.tsx
@@ -1,0 +1,28 @@
+import {ChangeEvent, useState} from 'react';
+
+import Button from '@code-dot-org/component-library/button';
+import TextField from '@code-dot-org/component-library/textField';
+
+export type TokenPromptProps = {
+  onSubmit: (token: string | null) => void;
+};
+const TokenPrompt = ({onSubmit}: TokenPromptProps) => {
+  const [token, setToken] = useState<string | null>(null);
+
+  const handleTokenInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setToken(e.target.value);
+  };
+
+  return (
+    <>
+      <TextField
+        onChange={handleTokenInputChange}
+        name={'draft-token'}
+        label={'Draft Token'}
+        inputType={'password'}
+      />
+      <Button text={'Submit'} onClick={() => onSubmit(token)} size={'s'} />
+    </>
+  );
+};
+export default TokenPrompt;

--- a/frontend/apps/marketing/src/components/contentEditorHelper/TokenPrompt/__tests__/TokenPrompt.test.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/TokenPrompt/__tests__/TokenPrompt.test.tsx
@@ -1,0 +1,52 @@
+import {render, screen, fireEvent} from '@testing-library/react';
+
+import TokenPrompt, {TokenPromptProps} from '../TokenPrompt';
+
+describe('TokenPrompt', () => {
+  const mockOnSubmit = jest.fn();
+
+  const renderComponent = (props: Partial<TokenPromptProps> = {}) => {
+    return render(<TokenPrompt onSubmit={mockOnSubmit} {...props} />);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the TextField and Button components', () => {
+    renderComponent();
+
+    expect(screen.getByLabelText('Draft Token')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Submit'})).toBeInTheDocument();
+  });
+
+  it('updates the token state when input changes', () => {
+    renderComponent();
+
+    const input = screen.getByLabelText('Draft Token') as HTMLInputElement;
+    fireEvent.change(input, {target: {value: 'test-token'}});
+
+    expect(input.value).toBe('test-token');
+  });
+
+  it('calls onSubmit with the token when the button is clicked', () => {
+    renderComponent();
+
+    const input = screen.getByLabelText('Draft Token') as HTMLInputElement;
+    fireEvent.change(input, {target: {value: 'test-token'}});
+
+    const button = screen.getByRole('button', {name: 'Submit'});
+    fireEvent.click(button);
+
+    expect(mockOnSubmit).toHaveBeenCalledWith('test-token');
+  });
+
+  it('calls onSubmit with null if no token is entered', () => {
+    renderComponent();
+
+    const button = screen.getByRole('button', {name: 'Submit'});
+    fireEvent.click(button);
+
+    expect(mockOnSubmit).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/apps/marketing/src/components/contentEditorHelper/TokenPrompt/index.ts
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/TokenPrompt/index.ts
@@ -1,0 +1,3 @@
+import TokenPrompt from './TokenPrompt';
+
+export default TokenPrompt;

--- a/frontend/apps/marketing/src/components/contentEditorHelper/Tools/Tools.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/Tools/Tools.tsx
@@ -1,0 +1,98 @@
+import {redirect, useParams} from 'next/navigation';
+import {useState} from 'react';
+
+import Button from '@code-dot-org/component-library/button';
+import {BodyTwoText} from '@code-dot-org/component-library/typography';
+
+type ContentEditorToolsProps = {
+  onChangeDraftToken: () => void;
+  isDraftModeEnabled: boolean;
+  previewLabel: string;
+};
+
+const ContentEditorTools = ({
+  onChangeDraftToken,
+  isDraftModeEnabled,
+  previewLabel,
+}: ContentEditorToolsProps) => {
+  const pageParams = useParams();
+  const [shareLinkButtonText, setShareableLinkButtonText] =
+    useState('Get shareable link');
+
+  const handleCopyShareableLinkClick = () => {
+    const shareableLink = `${window.location.origin}${getEnableDraftModeUrl()}`;
+
+    navigator.clipboard.writeText(shareableLink).then(() => {
+      setShareableLinkButtonText('Copied!');
+    });
+  };
+
+  const getEnableDraftModeUrl = () => {
+    const draftModeToken = localStorage.getItem('draftToken');
+    return `/api/draft?token=${draftModeToken}&slug=${pageParams.slug}&locale=${pageParams.locale}`;
+  };
+  const handleEnterDraftMode = () => {
+    redirect(getEnableDraftModeUrl());
+  };
+
+  const handleExitDraftMode = async () => {
+    try {
+      const response = await fetch('/api/disable-draft', {
+        method: 'POST',
+      });
+
+      if (response.ok) {
+        window.location.reload();
+      } else {
+        console.error(
+          'Failed to exit draft mode with status:',
+          response.status,
+        );
+      }
+    } catch (error) {
+      console.error('Error exiting draft mode:', error);
+    }
+  };
+
+  return (
+    <>
+      <BodyTwoText>
+        <strong>Viewing {previewLabel}</strong>
+      </BodyTwoText>
+
+      <Button
+        text={shareLinkButtonText}
+        iconLeft={{iconName: 'copy'}}
+        onClick={handleCopyShareableLinkClick}
+        size={'s'}
+      />
+
+      {isDraftModeEnabled ? (
+        <Button
+          text={'Exit draft mode'}
+          color={'destructive'}
+          iconLeft={{iconName: 'right-to-bracket'}}
+          onClick={handleExitDraftMode}
+          size={'s'}
+        />
+      ) : (
+        <Button
+          text={'Enter draft mode'}
+          color={'destructive'}
+          iconLeft={{iconName: 'pencil'}}
+          onClick={handleEnterDraftMode}
+          size={'s'}
+        />
+      )}
+
+      <Button
+        text={'Change draft token'}
+        iconLeft={{iconName: 'right-left'}}
+        onClick={onChangeDraftToken}
+        size={'s'}
+      />
+    </>
+  );
+};
+
+export default ContentEditorTools;

--- a/frontend/apps/marketing/src/components/contentEditorHelper/Tools/__tests__/Tools.test.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/Tools/__tests__/Tools.test.tsx
@@ -1,0 +1,159 @@
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {useParams} from 'next/navigation';
+
+import ContentEditorTools from '../Tools';
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  redirect: jest.fn(),
+}));
+
+describe('ContentEditorTools', () => {
+  const originalLocation = window.location;
+  const mockOnChangeDraftToken = jest.fn();
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {reload: jest.fn(), origin: originalLocation.origin},
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useParams as jest.Mock).mockReturnValue({slug: 'test-slug', locale: 'en'});
+  });
+
+  it('renders the preview label', () => {
+    render(
+      <ContentEditorTools
+        onChangeDraftToken={mockOnChangeDraftToken}
+        isDraftModeEnabled={false}
+        previewLabel="Preview Mode"
+      />,
+    );
+
+    expect(screen.getByText('Viewing Preview Mode')).toBeInTheDocument();
+  });
+
+  it('copies the shareable link to the clipboard', async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValueOnce(undefined),
+      },
+    });
+
+    render(
+      <ContentEditorTools
+        onChangeDraftToken={mockOnChangeDraftToken}
+        isDraftModeEnabled={false}
+        previewLabel="Preview Mode"
+      />,
+    );
+
+    const copyButton = screen.getByText('Get shareable link');
+    fireEvent.click(copyButton);
+
+    await waitFor(async () => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `http://localhost/api/draft?token=null&slug=test-slug&locale=en`,
+      );
+
+      expect(await screen.findByText('Copied!')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onChangeDraftToken when "Change draft token" button is clicked', () => {
+    render(
+      <ContentEditorTools
+        onChangeDraftToken={mockOnChangeDraftToken}
+        isDraftModeEnabled={false}
+        previewLabel="Preview Mode"
+      />,
+    );
+
+    const changeTokenButton = screen.getByText('Change draft token');
+    fireEvent.click(changeTokenButton);
+
+    expect(mockOnChangeDraftToken).toHaveBeenCalled();
+  });
+
+  it('renders "Enter draft mode" button when draft mode is disabled', () => {
+    render(
+      <ContentEditorTools
+        onChangeDraftToken={mockOnChangeDraftToken}
+        isDraftModeEnabled={false}
+        previewLabel="Preview Mode"
+      />,
+    );
+
+    expect(screen.getByText('Enter draft mode')).toBeInTheDocument();
+  });
+
+  it('renders "Exit draft mode" button when draft mode is enabled', () => {
+    render(
+      <ContentEditorTools
+        onChangeDraftToken={mockOnChangeDraftToken}
+        isDraftModeEnabled={true}
+        previewLabel="Preview Mode"
+      />,
+    );
+
+    expect(screen.getByText('Exit draft mode')).toBeInTheDocument();
+  });
+
+  it('reloads the page when exiting draft mode succeeds', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({ok: true});
+
+    render(
+      <ContentEditorTools
+        onChangeDraftToken={mockOnChangeDraftToken}
+        isDraftModeEnabled={true}
+        previewLabel="Preview Mode"
+      />,
+    );
+
+    const exitDraftModeButton = screen.getByText('Exit draft mode');
+    fireEvent.click(exitDraftModeButton);
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/disable-draft', {
+      method: 'POST',
+    });
+
+    await screen.findByText('Exit draft mode');
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it('logs an error when exiting draft mode fails', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    global.fetch = jest.fn().mockResolvedValueOnce({ok: false, status: 500});
+
+    render(
+      <ContentEditorTools
+        onChangeDraftToken={mockOnChangeDraftToken}
+        isDraftModeEnabled={true}
+        previewLabel="Preview Mode"
+      />,
+    );
+
+    const exitDraftModeButton = screen.getByText('Exit draft mode');
+    fireEvent.click(exitDraftModeButton);
+
+    await screen.findByText('Exit draft mode');
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to exit draft mode with status:',
+      500,
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/apps/marketing/src/components/contentEditorHelper/Tools/index.ts
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/Tools/index.ts
@@ -1,0 +1,3 @@
+import Tools from './Tools';
+
+export default Tools;

--- a/frontend/apps/marketing/src/components/contentEditorHelper/__tests__/ContentEditorHelper.test.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/__tests__/ContentEditorHelper.test.tsx
@@ -1,0 +1,66 @@
+import {render, screen, fireEvent} from '@testing-library/react';
+
+import ContentEditorHelper from '../ContentEditorHelper';
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(() => ({
+    get: jest.fn(key => (key === 'contentEditor' ? 'true' : null)),
+  })),
+}));
+
+jest.mock(
+  '../TokenPrompt',
+  () =>
+    ({onSubmit}: {onSubmit: (token: string) => void}) => (
+      <button onClick={() => onSubmit('mockToken')}>Submit Token</button>
+    ),
+);
+
+jest.mock('@/components/contentEditorHelper/Tools', () =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ({onChangeDraftToken, previewLabel}: any) => (
+    <div>
+      <span>{previewLabel}</span>
+      <button onClick={onChangeDraftToken}>Change Token</button>
+    </div>
+  ),
+);
+
+describe('ContentEditorHelper', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders the floating button when contentEditor query param is true', () => {
+    render(<ContentEditorHelper isDraftModeEnabled={false} />);
+    expect(screen.getByText('Published Version')).toBeInTheDocument();
+  });
+
+  it('renders TokenPrompt when no draftToken is in localStorage', () => {
+    render(<ContentEditorHelper isDraftModeEnabled={false} />);
+    fireEvent.click(screen.getByText('Published Version'));
+    expect(screen.getByText('Submit Token')).toBeInTheDocument();
+  });
+
+  it('renders ContentEditorTools when draftToken is in localStorage', () => {
+    localStorage.setItem('draftToken', 'mockToken');
+    render(<ContentEditorHelper isDraftModeEnabled={true} />);
+    fireEvent.click(screen.getByText('Draft Version'));
+    expect(screen.getByText('Draft Version')).toBeInTheDocument();
+  });
+
+  it('updates render state to tools after submitting a token', () => {
+    render(<ContentEditorHelper isDraftModeEnabled={false} />);
+    fireEvent.click(screen.getByText('Published Version'));
+    fireEvent.click(screen.getByText('Submit Token'));
+    expect(screen.getByText('Published Version')).toBeInTheDocument();
+  });
+
+  it('updates render state to token-prompt when changing the draft token', () => {
+    localStorage.setItem('draftToken', 'mockToken');
+    render(<ContentEditorHelper isDraftModeEnabled={true} />);
+    fireEvent.click(screen.getByText('Draft Version'));
+    fireEvent.click(screen.getByText('Change Token'));
+    expect(screen.getByText('Submit Token')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/marketing/src/components/contentEditorHelper/index.ts
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/index.ts
@@ -1,0 +1,3 @@
+import ContentEditorHelper from './ContentEditorHelper';
+
+export default ContentEditorHelper;

--- a/frontend/apps/marketing/src/components/contentEditorHelper/styles.module.scss
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/styles.module.scss
@@ -1,0 +1,19 @@
+.floatingButton {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 5000; // Ensure it's above other elements
+}
+
+.contentEditorPopover {
+  z-index: 5;
+  bottom: 20px;
+  right: 20px;
+}
+
+.contentFlexContainer {
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}

--- a/frontend/packages/component-library/src/popover/Popover.tsx
+++ b/frontend/packages/component-library/src/popover/Popover.tsx
@@ -22,6 +22,7 @@ export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
   };
   /** Popover content text*/
   content: string;
+  children?: ReactNode;
   /** Popover function to close the popover */
   onClose: () => void;
   /** Custom className */
@@ -59,6 +60,7 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       className,
       size = 'm',
       style = {},
+      children,
       ...HTMLAttributes
     },
     ref,
@@ -98,6 +100,7 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
             <div className={moduleStyles.textSection}>
               <Heading5>{title}</Heading5>
               <BodyTwoText>{content}</BodyTwoText>
+              {children}
             </div>
             {buttons && (
               <div className={moduleStyles.buttonsSection}>{buttons}</div>


### PR DESCRIPTION
This pull request adds some helpful content editor tools which can be toggled on when the search parameter `contentEditor=true` is present. These tools are executed on the client-side only and requires entering the not-so-secret draft token.

The tools have the following feature:

1. Show whether the page is in draft or published state
2. Store the not-so-secret draft token in local storage
3. Create a shareable link to the content
4. Exit draft mode

---

# Published mode indicator

![image](https://github.com/user-attachments/assets/12bd6c06-3674-4d16-aa70-5b64ea12b9b6)

# Draft mode indicator

![image](https://github.com/user-attachments/assets/dd00cc90-c9c1-4bcb-bb46-859e991673ad)

# Tool menu

![image](https://github.com/user-attachments/assets/0979e086-b650-4e37-94fd-deb5724188c7)

# Changing to draft mode

![image](https://github.com/user-attachments/assets/6c1289c5-cb12-4908-8ede-79c7d48d0646)
