### PR TITLE
eyes: bump dashboard test eyes to latest sdk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ group :development, :test do
 
   # For UI testing.
   gem 'cucumber'
-  gem 'eyes_selenium', '3.18.4'
+  gem 'eyes_selenium', '6.9.0'
   gem 'fakefs', '~> 2.5.0', require: false
   gem 'minitest', '~> 5.15'
   gem 'minitest-around'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,6 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     chronic (0.10.2)
-    chunky_png (1.3.6)
     cld (0.13.0)
       ffi
     cldr-plurals-runtime-rb (1.1.0)
@@ -322,7 +321,7 @@ GEM
     crowdin-api (1.10.0)
       open-uri (>= 0.1.0, < 0.2.0)
       rest-client (>= 2.0.0, < 2.2.0)
-    css_parser (1.19.0)
+    css_parser (1.21.1)
       addressable
     csv (3.3.0)
     cucumber (3.1.1)
@@ -377,20 +376,22 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     exifr (1.2.5)
-    eyes_core (3.18.4)
-      chunky_png (= 1.3.6)
+    eyes_core (6.7.0)
+      colorize
+      eyes_universal (= 4.37.0)
       faraday
       faraday-cookie_jar
       faraday_middleware
-      oily_png (~> 1.2)
       oj
-    eyes_selenium (3.18.4)
+      sorted_set
+      websocket
+    eyes_selenium (6.9.0)
       crass
       css_parser
-      eyes_core (= 3.18.4)
-      nokogiri
-      selenium-webdriver
-      state_machine
+      eyes_core (= 6.7.0)
+      selenium-webdriver (>= 3)
+      state_machines
+    eyes_universal (4.37.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -427,7 +428,7 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
+    faraday_middleware (1.2.1)
       faraday (~> 1.0)
     ffi (1.17.0)
     ffi-compiler (1.0.1)
@@ -632,8 +633,6 @@ GEM
     octokit (6.0.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    oily_png (1.2.0)
-      chunky_png (~> 1.3.1)
     oj (3.16.5)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
@@ -656,9 +655,6 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     open-uri (0.1.0)
-      stringio
-      time
-      uri
     open_uri_redirections (0.2.1)
     orm_adapter (0.5.0)
     os (1.1.4)
@@ -890,7 +886,7 @@ GEM
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    state_machine (1.2.0)
+    state_machines (0.6.0)
     statsig (1.33.2)
       concurrent-ruby (~> 1.1)
       connection_pool (~> 2.4, >= 2.4.1)
@@ -898,7 +894,6 @@ GEM
       ip3country (~> 0.2.1)
       user_agent_parser (~> 2.15.0)
     stringex (2.5.2)
-    stringio (3.1.5)
     strscan (3.1.0)
     sysexits (1.2.0)
     syslog (0.1.2)
@@ -911,8 +906,6 @@ GEM
     thwait (0.2.0)
       e2mmap
     tilt (2.0.11)
-    time (0.4.1)
-      date
     timecop (0.8.1)
     timeout (0.3.2)
     timers (4.3.5)
@@ -934,7 +927,6 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
-    uri (1.0.3)
     user_agent_parser (2.15.0)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
@@ -1025,7 +1017,7 @@ DEPENDENCIES
   dotiw
   drb
   execjs
-  eyes_selenium (= 3.18.4)
+  eyes_selenium (= 6.9.0)
   factory_bot_rails (~> 6.2)
   fakefs (~> 2.5.0)
   faker (~> 3.4)


### PR DESCRIPTION
This PR bumps the eyes selenium version to [6.9.0](https://rubygems.org/gems/eyes_selenium/versions/6.9.0)