### PR TITLE
Python Lab: better text wrapping in instructions

### DIFF
--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -67,10 +67,6 @@
   display: flex;
   align-items: flex-start;
   gap: 4px;
-  height: auto;
-  overflow-x: auto;
-  overflow-y: hidden;
-  background-color: $light_gray_950;
 }
 
 %bubble {
@@ -117,6 +113,7 @@ button.validationButton {
 .markdownText {
   line-height: 0;
   user-select: text;
+  word-break: break-word;
 
   h1,
   h2,

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -134,10 +134,8 @@ button.validationButton {
 
   code {
     color: $light_primary_700;
-    // Allow code to wrap.
+    // Allow code to wrap. Single words will not wrap.
     white-space: pre-wrap;
-    word-break: break-all;
-    word-wrap: break-word;
   }
 
   p {

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -67,6 +67,10 @@
   display: flex;
   align-items: flex-start;
   gap: 4px;
+  height: auto;
+  overflow-x: auto;
+  overflow-y: hidden;
+  background-color: $light_gray_950;
 }
 
 %bubble {

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -135,7 +135,7 @@ button.validationButton {
 
   code {
     color: $light_primary_700;
-    // Allow code to wrap. Single words will not wrap.
+    // Allow code to wrap.
     white-space: pre-wrap;
   }
 


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

Follow up to #65505. I over-corrected on the code wrapping in that pr, so single words of code would be broken pretty frequently. This updates to use [word-break: break-word](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break) for the entire main instructions component, which will only break words when strictly necessary. This prevents us from needing to horizontal scrolling still, while making things much more readable.

## Before
![Screenshot 2025-05-01 at 4 07 23 PM](https://github.com/user-attachments/assets/6a961fb0-d8be-48ea-b45a-1e2d6fcd1506)

## After
![Screenshot 2025-05-01 at 4 07 26 PM](https://github.com/user-attachments/assets/054408f9-c619-4123-a788-b5490e8a6d39)

## Links

This was noted in the [bug bash](https://docs.google.com/document/d/10pwx70q0JVgztGbjPjdID00vHvrlOFXt6_56thLjSAg/edit?tab=t.0)


## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
