### PR TITLE
Update evaluate_rubric_job.rb to use find_failure instead of find_share_failure

### DIFF
--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -240,7 +240,7 @@ class EvaluateRubricJob < ApplicationJob
     # Check for PII / sharing failures
     # Get the 2-character language code from the user's preferred locale
     locale = (user.locale || 'en')[0...2]
-    ShareFiltering.find_share_failure(code, locale, exceptions: true)
+    ShareFiltering.find_failure(code, locale, exceptions: true)
 
     openai_params = AiRubricConfig.get_openai_params(lesson_s3_name, code)
     response = get_openai_evaluations(openai_params)

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -165,7 +165,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
 
     stub_get_openai_evaluations(code: violating_code)
 
-    ShareFiltering.stubs(:find_share_failure).with(violating_code, 'en', exceptions: true).raises(
+    ShareFiltering.stubs(:find_failure).with(violating_code, 'en', exceptions: true).raises(
       ProfanityFilterException.new(
         "Profanity Failure",
         ShareFailure.new('profanity', 'damn')


### PR DESCRIPTION
The `find_share_failure` call checks for project type and only seems to work for studio-style apps. See: https://github.com/code-dot-org/code-dot-org/pull/65463#discussion_r2056956932

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
