### PR TITLE
Do not wait for FA on sign in page and a couple of other cases

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -32,8 +32,6 @@ Scenario: School Info Confirmation Dialog
   And I press keys "31513" for element "#uitest-school-zip"
   Then I wait until element "#uitest-school-dropdown" contains text "Appling County High School"
   And I select the "Appling County High School" option in dropdown "uitest-school-dropdown"
-  And I open my eyes to test "School Association"
-  And I see no difference for "School Association: all fields"
   Then I press "#save-button" using jQuery
   And I wait until element ".modal" is gone
 

--- a/dashboard/test/ui/features/initial_page_views3.feature
+++ b/dashboard/test/ui/features/initial_page_views3.feature
@@ -25,7 +25,8 @@ Feature: Looking at a few things with Applitools Eyes - Part 3
     When I open my eyes to test "<test_name>"
     And I am on "<url>"
     And I dismiss the language selector
-    Then I see no difference for "initial load"
+    # The sign in page does not use Font Awesome, so do not wait for it to load
+    Then I see no difference for "initial load" without waiting for Font Awesome to load
     And I close my eyes
     Examples:
       | url                                               | test_name                  |

--- a/dashboard/test/ui/features/javalab/javalab_demo_mode.feature
+++ b/dashboard/test/ui/features/javalab/javalab_demo_mode.feature
@@ -16,5 +16,5 @@ Feature: Javalab Demo Mode
     And I wait to see a modal containing text "Please confirm you're human"
     And I switch to the first iframe once it exists
     And I wait to see ".recaptcha-checkbox"
-    Then I see no difference for "initial modal view" using stitch mode "none"
+    Then I see no difference for "initial modal view" using stitch mode "none" without waiting for Font Awesome to load
     Then I close my eyes


### PR DESCRIPTION
A few follow-ups to https://github.com/code-dot-org/code-dot-org/pull/65461 detected in test run.

- Sign in page doesn't use FA, so don't wait for it to load.
- Javalab test is looking for fonts in an iframe, so don't wait there either
- School info interstitial is not an "eyes" test (ie, no @ eyes tag, no "and I close my eyes" step, no baselines visible in Applitools), so remove these steps.

More context in this Slack thread: https://codedotorg.slack.com/archives/C0T0PNTM3/p1746211322444399?thread_ts=1746116630.558589&cid=C0T0PNTM3