### PR TITLE
[Codebridge] Auto-save font size preferences in settings

### DIFF
--- a/apps/src/codebridge/Settings/SettingsDropdown.tsx
+++ b/apps/src/codebridge/Settings/SettingsDropdown.tsx
@@ -1,4 +1,3 @@
-import {Button} from '@code-dot-org/component-library/button';
 import CloseButton from '@code-dot-org/component-library/closeButton';
 import SimpleDropdown, {
   SimpleDropdownProps,
@@ -83,10 +82,27 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
   const dropdownStyles = useDropdownPosition(buttonRef, dropdownRef);
 
   const onTextEditorDropdownChange = (value: string) => {
-    setSelectedEditorFontSizeValue(getSelectedKey(value));
+    const selectedEditorKey = getSelectedKey(value);
+    setSelectedEditorFontSizeValue(selectedEditorKey);
+    // We want the user preference for selected font size to persist for signed-in users
+    // per app type so we save on backend.
+    handleFontSizeChange(
+      'CodeEditor',
+      selectedEditorKey,
+      currentEditorFontSizeKey,
+      EVENTS.CODEBRIDGE_EDITOR_FONT_SIZE_CHANGE
+    );
   };
+
   const onConsoleDropdownChange = (value: string) => {
+    const selectedConsoleKey = getSelectedKey(value);
     setSelectedConsoleFontSizeValue(getSelectedKey(value));
+    handleFontSizeChange(
+      'Console',
+      selectedConsoleKey,
+      currentConsoleFontSizeKey,
+      EVENTS.CODEBRIDGE_CONSOLE_FONT_SIZE_CHANGE
+    );
   };
 
   const handleFontSizeChange = (
@@ -108,28 +124,6 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
         fontSize: selectedKey,
       });
     }
-  };
-
-  const onSave = () => {
-    const selectedEditorKey = getSelectedKey(selectedEditorFontSizeValue);
-    const selectedConsoleKey = getSelectedKey(selectedConsoleFontSizeValue);
-
-    // We want the user preference for selected font size to persist for signed-in users
-    // per app type so we save on backend.
-    handleFontSizeChange(
-      'CodeEditor',
-      selectedEditorKey,
-      currentEditorFontSizeKey,
-      EVENTS.CODEBRIDGE_EDITOR_FONT_SIZE_CHANGE
-    );
-    handleFontSizeChange(
-      'Console',
-      selectedConsoleKey,
-      currentConsoleFontSizeKey,
-      EVENTS.CODEBRIDGE_CONSOLE_FONT_SIZE_CHANGE
-    );
-
-    closeDropdown();
   };
 
   const hasConsole = codebridgeLabsWithConsole.includes(appName);
@@ -198,23 +192,6 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
             />
           </div>
         )}
-        <div className={moduleStyles.footer}>
-          <Button
-            text={commonI18n.cancel()}
-            type="secondary"
-            size="s"
-            onClick={closeDropdown}
-            color="black"
-            className={moduleStyles.footerButton}
-          />
-          <Button
-            text={commonI18n.save()}
-            type="primary"
-            size="s"
-            onClick={onSave}
-            className={moduleStyles.footerButton}
-          />
-        </div>
       </div>
     </FocusTrap>,
     document.body

--- a/apps/src/codebridge/Settings/SettingsDropdown.tsx
+++ b/apps/src/codebridge/Settings/SettingsDropdown.tsx
@@ -94,7 +94,7 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
 
   const onConsoleDropdownChange = (value: string) => {
     const selectedConsoleKey = getSelectedKey(value);
-    setSelectedConsoleFontSizeValue(getSelectedKey(value));
+    setSelectedConsoleFontSizeValue(selectedConsoleKey);
     handleFontSizeChange(
       'Console',
       selectedConsoleKey,

--- a/apps/src/codebridge/Settings/SettingsDropdown.tsx
+++ b/apps/src/codebridge/Settings/SettingsDropdown.tsx
@@ -84,8 +84,6 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
   const onTextEditorDropdownChange = (value: string) => {
     const selectedEditorKey = getSelectedKey(value);
     setSelectedEditorFontSizeValue(selectedEditorKey);
-    // We want the user preference for selected font size to persist for signed-in users
-    // per app type so we save on backend.
     handleFontSizeChange(
       'CodeEditor',
       selectedEditorKey,
@@ -112,6 +110,8 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
     event: string
   ) => {
     if (selectedKey !== currentKey && FontSize[selectedKey]) {
+      // We want the user preference for selected font size to persist for signed-in users
+      // per app type so we save on backend.
       if (signInState === SignInState.SignedIn) {
         const field = type === 'Console' ? 'consoleFontSize' : 'editorFontSize';
         new UserPreferences().setFontSize(selectedKey, appName, field);

--- a/apps/src/codebridge/Settings/settings-dropdown.module.scss
+++ b/apps/src/codebridge/Settings/settings-dropdown.module.scss
@@ -17,7 +17,7 @@ $space-l: 8px;
   vertical-align: top;
   z-index: 1000;
   right: 0;
-  padding: $space-l;
+  padding: $space-l $space-l 16px;
 }
 
 .header {


### PR DESCRIPTION
This PR adds auto-saving in Codebridge settings. Currently in `pythonlab`, a user can select a font size preference for the code editor and console, and for `weblab2` the code editor only.
Checked with design about small tweak to UI padding [here](https://codedotorg.slack.com/archives/C06JELCAPT9/p1746211918927779).

## Before update

Screencast video:

https://github.com/user-attachments/assets/5ced1bb9-0db7-44c1-a88f-51d5aa4e33de




## After update

Screencast video:

https://github.com/user-attachments/assets/77b98b09-5ad8-450d-90e3-5461b8cf0371

Screenshot of settings dropdown in Python Lab:

![Screenshot 2025-05-02 at 2 15 07 PM](https://github.com/user-attachments/assets/48ff0b94-2285-487e-b7e9-77c71554a176)

Screenshot of settings dropdown in Web Lab 2: 

![Screenshot 2025-05-02 at 2 15 31 PM](https://github.com/user-attachments/assets/02570bf6-053f-4876-939b-fd2aa9e88108)



<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/CT-1209

## Testing story
Tested locally in `pythonlab` and `weblab2` levels and saw that font size updated after option dropdown selected.
Also logged into same account in two different browser sessions and saw that font preference was saved in backend when updated in one of the sessions.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
