### PR TITLE
fix modular courses UI tests

### DIFF
--- a/dashboard/test/ui/features/step_definitions/levelbuilder_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/levelbuilder_steps.rb
@@ -262,8 +262,11 @@ Then(/^I add the temp unit to the course$/) do
 end
 
 Then(/^I add the unit "([^"]*)" to the course$/) do |unit_name|
+  steps %{
+    And I scroll the ".uitest-unit-selector" element into view
+  }
   last_dropdown = @browser.find_elements(:css, '.uitest-unit-selector').last
-  select_dropdown(last_dropdown, unit_name, nil)
+  Selenium::WebDriver::Support::Select.new(last_dropdown).select_by(:text, unit_name)
 end
 
 Given(/^I delete the temp course?$/) do

--- a/dashboard/test/ui/features/teacher_tools/modular_courses.feature
+++ b/dashboard/test/ui/features/teacher_tools/modular_courses.feature
@@ -20,11 +20,13 @@ Feature: Using Modular Courses
 
     And I click selector "a:contains(Course 2017)" once I see it to load a new page
     And I wait until element ".progress-table" is visible
+    And I wait until element "#uitest-course-dropdown" is visible
     And I select the "ui-test-shared-unit" option in dropdown "uitest-course-dropdown"
     Then I see no difference for "modular course progress - first section"
 
     Then I select the "Course 2019" option in dropdown "uitest-sidebar-section-dropdown"
     And I wait until element ".progress-table" is visible
+    And I wait until element "#uitest-course-dropdown" is visible
     And I select the "ui-test-shared-unit" option in dropdown "uitest-course-dropdown"
     Then I see no difference for "modular course progress - second section"
 


### PR DESCRIPTION
This PR fixes flakiness in `teacher_tools/modular_courses.feature` and a failure for `teacher_tools/levelbuilder/modular_courses.feature` in Firefox. 

The levelbuilder UI test was originally using `select_dropdown` which scrolls to the element before selecting an option from a dropdown.
https://github.com/code-dot-org/code-dot-org/blob/ae4e4b7d5bdea7e91037518d01125640d6ea4efd/dashboard/test/ui/features/step_definitions/steps.rb#L525-L531

Something about how Selenium was scrolling, particularly in Firefox, and the element being at the bottom of the page, meant it was being covered by the save bar. Instead of calling `select_dropdown`, it is now just scrolling to the element using a different step and calling Selenium directly. 

## Links
Levelbuilder UI test failure: [Saucelabs](https://app.saucelabs.com/tests/88520964dc494de6949369e72b869fa8)
Eyes test failure: [Saucelabs](https://app.saucelabs.com/tests/c2f09281c9b444f49e0947159ee6a09d#80)

## Testing story
Tested locally that the levelbuilder UI test passes consistently on Firefox, Safari, and Chrome. 
