### PR TITLE
Add a ProviderFlags concern

### DIFF
--- a/dashboard/app/models/concerns/user/provider_flags.rb
+++ b/dashboard/app/models/concerns/user/provider_flags.rb
@@ -1,0 +1,25 @@
+module User::ProviderFlags
+  extend ActiveSupport::Concern
+
+  included do
+    PROVIDER_MANUAL = 'manual'.freeze # "old" user created by a teacher -- logs in w/ username + password
+    PROVIDER_SPONSORED = 'sponsored'.freeze # "new" user created by a teacher -- logs in w/ name + secret picture/word
+    PROVIDER_MIGRATED = 'migrated'.freeze
+  end
+
+  def migrated?
+    provider == PROVIDER_MIGRATED
+  end
+
+  def manual?
+    provider == PROVIDER_MANUAL
+  end
+
+  def sponsored?
+    if migrated?
+      authentication_options.empty? && encrypted_password.blank?
+    else
+      provider == PROVIDER_SPONSORED
+    end
+  end
+end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -95,6 +95,7 @@ class User < ApplicationRecord
   include UserMultiAuthHelper
   include UserPermissionGrantee
   include EmailValidations
+  include ProviderFlags
   include PartialRegistration
   include Rails.application.routes.url_helpers
 
@@ -139,11 +140,6 @@ class User < ApplicationRecord
   PASSWORD_STRICT_MIN_LENGTH = 14
   # Countries that require a 14 character password minimum
   PASSWORD_STRICT_COUNTRIES = %w[AU NZ].freeze
-
-  # Provider variables
-  PROVIDER_MANUAL = 'manual'.freeze # "old" user created by a teacher -- logs in w/ username + password
-  PROVIDER_SPONSORED = 'sponsored'.freeze # "new" user created by a teacher -- logs in w/ name + secret picture/word
-  PROVIDER_MIGRATED = 'migrated'.freeze
 
   SYSTEM_DELETED_USERNAME = 'sys_deleted'
 
@@ -1624,22 +1620,6 @@ class User < ApplicationRecord
 
   def has_ever_signed_in?
     current_sign_in_at.present?
-  end
-
-  def migrated?
-    provider == PROVIDER_MIGRATED
-  end
-
-  def manual?
-    provider == PROVIDER_MANUAL
-  end
-
-  def sponsored?
-    if migrated?
-      authentication_options.empty? && encrypted_password.blank?
-    else
-      provider == PROVIDER_SPONSORED
-    end
   end
 
   def should_see_edit_email_link?

--- a/dashboard/test/models/concerns/user/provider_flags_test.rb
+++ b/dashboard/test/models/concerns/user/provider_flags_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class ProviderFlagsTest < ActiveSupport::TestCase
+  include Minitest::RSpecMocks
+  describe '#sponsored?' do
+    context 'when provider is migrated with no authentication options' do
+      let(:student) {create :student_in_picture_section}
+      before do
+        student.migrate_to_multi_auth
+        student.reload
+      end
+      it 'returns true' do
+        _(student.authentication_options.empty?).must_equal true
+        _(student.sponsored?).must_equal true
+      end
+    end
+    context 'when provider is migrated with an authentication option' do
+      let(:user) {create :user, :with_google_authentication_option}
+      it 'returns false' do
+        _(user.authentication_options.count).must_be :>, 0
+        _(user.sponsored?).must_equal false
+      end
+    end
+    context 'when student is in a picture section' do
+      let(:student) {create :student_in_picture_section}
+      it 'returns true' do
+        _(student.sponsored?).must_equal true
+      end
+    end
+    context 'when student is in a word section' do
+      let(:student) {create :student_in_word_section}
+      it 'returns true' do
+        _(student.sponsored?).must_equal true
+      end
+    end
+  end
+  describe '#migrated?' do
+    context 'when provider is migrated' do
+      let(:user) {create :user}
+      it 'returns true' do
+        _(user.migrated?).must_equal true
+      end
+    end
+    context 'when provider is not migrated' do
+      let(:user) {create :user, :demigrated}
+      it 'returns false' do
+        _(user.migrated?).must_equal false
+      end
+    end
+  end
+  describe '#manual' do
+    context 'when a provider is manual' do
+      let(:user) {create :user, :demigrated}
+      before do
+        user.provider = User::PROVIDER_MANUAL
+        user.save!
+      end
+      it 'returns true' do
+        _(user.manual?).must_equal true
+      end
+    end
+    context 'when provider is not manual' do
+      let(:user) {create :user}
+      it 'returns false' do
+        _(user.manual?).must_equal false
+      end
+    end
+  end
+end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1511,14 +1511,14 @@ class UserTest < ActiveSupport::TestCase
     )
   end
 
-  test 'sponsored? is true for migrated user with no authentication options' do
-    student = create :student_in_picture_section
-    student.migrate_to_multi_auth
-    student.reload
+  # test 'sponsored? is true for migrated user with no authentication options' do
+  #   student = create :student_in_picture_section
+  #   student.migrate_to_multi_auth
+  #   student.reload
 
-    assert_empty student.authentication_options
-    assert student.sponsored?
-  end
+  #   assert_empty student.authentication_options
+  #   assert student.sponsored?
+  # end
 
   test 'should_disable_user_type? true if user_type present and oauth_provided_user_type' do
     user = build :user, user_type: User::TYPE_TEACHER

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1511,15 +1511,6 @@ class UserTest < ActiveSupport::TestCase
     )
   end
 
-  # test 'sponsored? is true for migrated user with no authentication options' do
-  #   student = create :student_in_picture_section
-  #   student.migrate_to_multi_auth
-  #   student.reload
-
-  #   assert_empty student.authentication_options
-  #   assert student.sponsored?
-  # end
-
   test 'should_disable_user_type? true if user_type present and oauth_provided_user_type' do
     user = build :user, user_type: User::TYPE_TEACHER
     user.expects(:oauth_provided_user_type).returns(true)


### PR DESCRIPTION
This PR adds a ProviderFlags concern, and moves the following methods to it:

- `migrated?`
- `manual?`
- `sponsored?`

In addition, it moves one existing unit test to `provider_flats_test.rb`, converts it to spec style syntax, and adds additional unit test coverage for previously untested cases.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/P20-1469

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
