### PR TITLE
fix(marketing): move csr env script to root layout

### DIFF
--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -64,6 +64,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "cross-fetch": "^4.1.0",
     "dotenv": "^16.4.7",
     "eslint": "^9.16.0",
     "eslint-plugin-jest": "^28.9.0",

--- a/frontend/apps/marketing/src/app/[brand]/layout.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/layout.tsx
@@ -1,4 +1,5 @@
 import {GoogleAnalytics} from '@next/third-parties/google';
+import {PublicEnvScript} from 'next-runtime-env';
 
 import Footer from '@/components/footer';
 import Header from '@/components/header';
@@ -32,6 +33,7 @@ export default async function Layout({
 
   return (
     <>
+      <PublicEnvScript disableNextScript={true} />
       <OneTrustLoader brand={brand} />
 
       <OneTrustProvider>

--- a/frontend/apps/marketing/src/bootstrap/index.tsx
+++ b/frontend/apps/marketing/src/bootstrap/index.tsx
@@ -1,5 +1,3 @@
-import {PublicEnvScript} from 'next-runtime-env';
-
 import FontLoader from '@code-dot-org/fonts/FontLoader';
 
 interface BootstrapProps {
@@ -8,7 +6,6 @@ interface BootstrapProps {
 const Bootstrap = ({locale}: BootstrapProps) => {
   return (
     <>
-      <PublicEnvScript disableNextScript={true} />
       <FontLoader locale={locale} />
     </>
   );

--- a/frontend/apps/marketing/src/setupTests.ts
+++ b/frontend/apps/marketing/src/setupTests.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom';
+import 'cross-fetch/polyfill';
+import {TextEncoder} from 'node:util';
+
+global.TextEncoder = TextEncoder;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1103,6 +1103,7 @@ __metadata:
     "@types/react-dom": "npm:^18"
     contentful: "npm:^11.2.5"
     cookies-next: "npm:^5.1.0"
+    cross-fetch: "npm:^4.1.0"
     dotenv: "npm:^16.4.7"
     eslint: "npm:^9.16.0"
     eslint-plugin-jest: "npm:^28.9.0"
@@ -8313,6 +8314,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-fetch@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cross-fetch@npm:4.1.0"
+  dependencies:
+    node-fetch: "npm:^2.7.0"
+  checksum: 10c0/628b134ea27cfcada67025afe6ef1419813fffc5d63d175553efa75a2334522d450300a0f3f0719029700da80e96327930709d5551cf6deb39bb62f1d536642e
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -14353,7 +14363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.7, node-fetch@npm:^2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:


### PR DESCRIPTION
The CSR environment injection was previously being set on the page, but if the page threw a 404 it renders without the env script being injected. Instead, inject the environment variable on the Root Layout since this is needed for the header which is available globally.
