### PR TITLE
Making console layout keyboard navigable

### DIFF
--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -14,6 +14,7 @@ type PopUpButtonProps = {
   id?: string;
   disabled?: boolean;
   ariaLabel?: string;
+  initialFocusId?: string;
 };
 
 const TOP_PADDING = 5;
@@ -26,6 +27,7 @@ export const PopUpButton = ({
   id,
   disabled,
   ariaLabel,
+  initialFocusId,
 }: PopUpButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [buttonRef, setButtonRef] = useState<HTMLElement | null>(null);
@@ -127,7 +129,9 @@ export const PopUpButton = ({
           <FocusTrap
             focusTrapOptions={{
               clickOutsideDeactivates: true,
-              fallbackFocus: '#fallback-element',
+              fallbackFocus: initialFocusId
+                ? `#${initialFocusId}`
+                : '#fallback-element',
             }}
           >
             <div

--- a/apps/src/codebridge/components/SwapLayoutDropdown.tsx
+++ b/apps/src/codebridge/components/SwapLayoutDropdown.tsx
@@ -1,14 +1,12 @@
-import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {PopUpButton} from '@codebridge/PopUpButton/PopUpButton';
+import {PopUpButtonOption} from '@codebridge/PopUpButton/PopUpButtonOption';
 import {sendCodebridgeAnalyticsEvent} from '@codebridge/utils/analyticsReporterHelper';
 import React, {useCallback} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-
-import dropdownStyles from '@codebridge/styles/dropdown.module.scss';
 
 /*
   Please note - this is a fairly brittle component in that it's only allowing toggling between
@@ -55,11 +53,14 @@ const SwapLayoutDropdown: React.FunctionComponent = () => {
       alignment="right"
       disabled={isRunningOrValidating}
       ariaLabel={codebridgeI18n.consoleOptions()}
+      initialFocusId="swapLayoutButton"
     >
-      <div onClick={onLayoutChange} className={dropdownStyles.dropdownItem}>
-        <FontAwesomeV6Icon iconName={iconName} iconStyle={'solid'} />
-        <div>{layoutLabel}</div>
-      </div>
+      <PopUpButtonOption
+        id="swapLayoutButton"
+        iconName={iconName}
+        labelText={layoutLabel}
+        clickHandler={onLayoutChange}
+      />
     </PopUpButton>
   );
 };


### PR DESCRIPTION
<table><tr><td>
<h2> Warning!! </h2>

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2025. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.
</td></tr></table>

This required adding a new feature to PopUpButtons: an initial focus id! 

This wasn't working for a couple reasons- the component wasn't actually using a PopUpOption, so I converted it. 

It also was a single option menu, so the user was ending up with keyboard focus on a 'menu' overall item instead of the button itself (a feature of a focus trap in a portal), which doesn't make sense with only one item. I converted the PopUpButton to have an optional focusId so that instead of focusing on the menu first we can opt to go straight to the button. 


Before (styling):

<img width="258" alt="Screenshot 2025-05-02 at 4 22 42 PM" src="https://github.com/user-attachments/assets/19d0e82a-5a6b-470a-9c4f-28355b855c24" />

A video would've been confusing because it just closed instead of actually updating the layout.

After (styling and functionality):

When it goes to vertical layout, I hit esc the first time to show that you can still close the menu. The second time I pressed enter!
<img width="238" alt="Screenshot 2025-05-02 at 4 22 53 PM" src="https://github.com/user-attachments/assets/f8470d41-e1ba-49b2-b926-a81bbf0d99bf" />

https://github.com/user-attachments/assets/17a28910-d185-4bd2-99de-9346027af61b


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1230

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
