### PR TITLE
Lab2 Bubble Choice: fixes

### DIFF
--- a/apps/src/bubbleChoice/BubbleChoice.module.scss
+++ b/apps/src/bubbleChoice/BubbleChoice.module.scss
@@ -80,6 +80,7 @@
         }
 
         .sublevelTextContainer {
+          width: 100%;
           display: flex;
           flex-direction: column;
           flex: 1;

--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -156,7 +156,10 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
             <button
               type="button"
               key={index}
-              className={styles.sublevelButton}
+              className={classNames(
+                'uitest-bubble-choice',
+                styles.sublevelButton
+              )}
               style={{
                 width: imageWidth,
                 height: imageWidth / aspectRatio,

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -85,7 +85,7 @@ class BubbleChoice < DSLDefined
 
   def summarize_for_lab2_properties(script, script_level = nil, current_user = nil)
     level_properties = super
-    summary = summarize(script_level: @script_level, user: @view_as_user, should_localize: true)
+    summary = summarize(script_level: script_level, user: @view_as_user, should_localize: true)
 
     # Remove status since this summary should not be user-specific.
     summary[:sublevels].each do |sublevel|
@@ -94,8 +94,8 @@ class BubbleChoice < DSLDefined
 
     level_properties[:levelData] = {sublevels: summary[:sublevels], displayName: summary[:display_name], description: summary[:description]}
 
-    # Overwrite the finish URL.
-    level_properties[:finishUrl] = script_level.next_level_or_redirect_path_for_user(current_user, bubble_choice_parent: true) if script_level
+    # Overwrite the incorrect finish URL with the actual next URL.
+    level_properties[:finishUrl] = summary[:redirect_url]
 
     level_properties
   end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -93,6 +93,10 @@ class BubbleChoice < DSLDefined
     end
 
     level_properties[:levelData] = {sublevels: summary[:sublevels], displayName: summary[:display_name], description: summary[:description]}
+
+    # Overwrite the finish URL.
+    level_properties[:finishUrl] = script_level.next_level_or_redirect_path_for_user(current_user, bubble_choice_parent: true) if script_level
+
     level_properties
   end
 

--- a/dashboard/config/scripts/lab2_bubblechoice_showcase.bubble_choice
+++ b/dashboard/config/scripts/lab2_bubblechoice_showcase.bubble_choice
@@ -1,6 +1,7 @@
 name 'Lab2 BubbleChoice Showcase'
 display_name 'Lab2 Bubble Choice'
 description 'This Bubble Choice level and all sublevels use Lab2.'
+uses_lab2
 
 sublevels
 level 'AI Chat Sublevel'

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -57,11 +57,10 @@ Feature: BubbleChoice
     And I wait until element "#ui-close-dialog" is not visible
 
     # Complete the level
-    And I click selector "#instructions-continue-button" to load a new page
+    And I click selector "#instructions-continue-button"
 
     # Make sure you are taken back to the Lab2 BubbleChoice activity page with progress
     And I wait until current URL contains "/lessons/52/levels/8"
-    And I wait for jquery to load
     And I wait until element ".uitest-bubble-choice:eq(0)" is visible
     And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
     And check that the url contains "/s/allthethings/lessons/52/levels/8"
@@ -86,7 +85,7 @@ Feature: BubbleChoice
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
-    When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
+    When I click selector ".teacher-panel table td:contains(Alice)" once I see it
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
     # View progress from BubbleChoice sublevel activity page


### PR DESCRIPTION
This follow-up to https://github.com/code-dot-org/code-dot-org/pull/65384 makes a few fixes to the Lab2 Bubble Choice implementation:
- When the level is the last in the current lesson, clicking the "Continue" button now takes the user to the appropriate level, which is generally the first in the next lesson, rather than to itself again.
- The sublevel description text now shows on iOS/iPadOS Safari.  Previously its width was collapsed to `0px`.
- Restores the use of a Lab2 bubble choice level in `/s/allthethings/lessons/52/levels/8` which had been reverted in https://github.com/code-dot-org/code-dot-org/pull/65611.
- Fixes the UI tests to work with the updated Lab2 bubble choice level.