### PR TITLE
Allow removing units from original unit group

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -36,7 +36,7 @@ class UnitGroup < ApplicationRecord
   # Default units are units that are currently in this unit group
   has_many :default_units, through: :default_unit_group_units, source: :script
   # Original units are those which are owned by this unit group
-  # A unit cannot be removed from its original unit group. All original units will be in a unit group's default units, but not all default units are original units.
+  # A unit cannot be removed from its original unit group if it has resources/vocab. All original units will be in a unit group's default units, but not all default units are original units.
   # For more information, see the 'Modular Curriculum design doc' at https://docs.google.com/document/d/1e8Xs_azDTJRyJoGLSk7G2v23rpyA-ZQzgSVnle6exvg/edit?usp=sharing.
   has_many :original_units, class_name: 'Unit', foreign_key: 'original_unit_group_id'
   has_and_belongs_to_many :resources, join_table: :unit_groups_resources
@@ -228,8 +228,8 @@ class UnitGroup < ApplicationRecord
     # we want to delete existing unit group units that aren't in our new list
     units_to_remove = default_unit_group_units.map(&:script) - new_units_objects
 
-    unremovable_unit_names = units_to_remove.select {|unit| unit.original_unit_group == self}.map(&:name)
-    raise "Cannot remove units from their original course: #{unremovable_unit_names}" if unremovable_unit_names.any?
+    unremovable_unit_names = units_to_remove.select {|unit| unit.original_unit_group == self && unit.prevent_course_version_change?}.map(&:name)
+    raise "Cannot remove units from their original course if they have resources or vocab: #{unremovable_unit_names}" if unremovable_unit_names.any?
 
     new_units_objects.each_with_index do |unit, index|
       unit_group_unit = UnitGroupUnit.find_or_create_by!(unit_group: self, script: unit) do |ugu|
@@ -245,15 +245,23 @@ class UnitGroup < ApplicationRecord
     end
 
     units_to_remove.each do |unit|
-      # Units that are not in a unit group need to have these fields set in order to determine course type and visibility of course
-      unit.update!(
-        published_state: (unit.published_state ? unit.published_state : published_state),
-        instruction_type: instruction_type,
-        participant_audience: participant_audience,
-        instructor_audience: instructor_audience
-      )
-
+      if unit.unit_group_units.count == 1
+        # Units that are not in a unit group need to have these fields set in order to determine course type and visibility of course
+        # If this is the last unit group unit, then we need to set those fields and set the original_unit_group_id to nil
+        unit.update!(
+          published_state: (unit.published_state ? unit.published_state : published_state),
+          instruction_type: instruction_type,
+          participant_audience: participant_audience,
+          instructor_audience: instructor_audience
+        )
+        unit.update!(original_unit_group_id: nil, skip_name_format_validation: true)
+      end
       UnitGroupUnit.where(unit_group: self, script: unit).destroy_all
+
+      # If this is not the last unit group unit and this unit group was the original, then we should move the original unit group to the next unit group
+      if unit.original_unit_group == self && !unit.unit_group_units.nil_or_empty?
+        unit.update!(original_unit_group_id: unit.unit_group_units.first.course_id, skip_name_format_validation: true)
+      end
     end
     # Reload model so that default_unit_group_units is up to date
     transaction {reload}

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -607,6 +607,29 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_equal nil, unit2.original_unit_group
     end
 
+    test "remove UnitGroupUnits that cannot change course version from secondary unit groups" do
+      course_version = create :course_version
+      original_unit_group = create :unit_group, course_version: course_version
+      new_unit_group = create :unit_group
+
+      unit1 = create :script, name: 'unit1'
+      original_unit_group.update_scripts(['unit1'])
+      new_unit_group.update_scripts(['unit1'])
+
+      lesson = create :lesson
+      resource = create :resource, course_version: course_version
+      lesson.resources = [resource]
+      lesson_group = create :lesson_group, lessons: [lesson]
+      unit1.lesson_groups = [lesson_group]
+
+      original_unit_group.reload
+      new_unit_group.reload
+      unit1.reload
+
+      new_unit_group.update_scripts([])
+      assert_equal 0, new_unit_group.default_unit_group_units.length
+    end
+
     test "removed units have their published state instruction type participant audience and instructor audience reset" do
       unit_group = create :unit_group
       unit1 = create(:script, name: 'unit1')

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -502,26 +502,32 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_nil unit2.instruction_type
     end
 
-    test "cannot remove UnitGroupUnits from their original course" do
+    test "cannot remove UnitGroupUnits from their original course that cannot change course version" do
       course_version = create :course_version
       unit_group = create :unit_group, course_version: course_version
 
-      create :script, name: 'unit1'
+      unit1 = create :script, name: 'unit1'
       create :script, name: 'unit2'
       unit_group.update_scripts(['unit1', 'unit2'])
+
+      lesson = create :lesson
+      resource = create :resource, course_version: course_version
+      lesson.resources = [resource]
+      lesson_group = create :lesson_group, lessons: [lesson]
+      unit1.lesson_groups = [lesson_group]
 
       unit_group.reload
       error = assert_raises RuntimeError do
         unit_group.update_scripts(['unit2'])
       end
-      assert_includes error.message, 'Cannot remove units from their original course'
+      assert_includes error.message, 'Cannot remove units from their original course if they have resources or vocab'
 
       unit_group.reload
       assert_equal 2, unit_group.default_unit_group_units.length
     end
 
     test "remove UnitGroupUnits" do
-      original_unit_group = create(
+      unit_group = create(
         :unit_group,
         published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development,
         instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led,
@@ -541,16 +547,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       )
       create(:script, name: 'unit2')
 
-      new_unit_group = create(
-        :unit_group,
-        published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development,
-        instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led,
-        instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-        participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
-      )
-
-      original_unit_group.update_scripts(['unit1'])
-      new_unit_group.update_scripts(['unit1', 'unit2'])
+      unit_group.update_scripts(['unit1', 'unit2'])
 
       unit1.reload
 
@@ -562,21 +559,21 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_nil unit1.is_course
       assert_equal unit1.version_year, '1991'
 
-      new_unit_group.update_scripts(['unit2'])
+      unit_group.update_scripts(['unit2'])
 
-      new_unit_group.reload
+      unit_group.reload
       unit1.reload
 
-      assert_equal 1, new_unit_group.default_unit_group_units.length
-      assert_equal 1, new_unit_group.default_unit_group_units[0].position
-      assert_equal 'unit2', new_unit_group.default_unit_group_units[0].script.name
+      assert_equal 1, unit_group.default_unit_group_units.length
+      assert_equal 1, unit_group.default_unit_group_units[0].position
+      assert_equal 'unit2', unit_group.default_unit_group_units[0].script.name
       assert_equal unit1.published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
       assert_equal unit1.instruction_type, Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
       assert_equal unit1.instructor_audience, Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
       assert_equal unit1.participant_audience, Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
     end
 
-    test "removed units have their published state instruction type participant audience and instructor audience reset" do
+    test "remove UnitGroupUnits from original unit group" do
       original_unit_group = create :unit_group
       new_unit_group = create :unit_group
       unit1 = create(:script, name: 'unit1')
@@ -590,6 +587,37 @@ class UnitGroupTest < ActiveSupport::TestCase
       unit1.reload
       unit2.reload
 
+      assert_equal 1, original_unit_group.original_units.length
+      assert_equal 1, new_unit_group.original_units.length
+
+      original_unit_group.update_scripts([])
+      original_unit_group.reload
+      new_unit_group.reload
+      unit1.reload
+      # unit1's original unit group moved to new_unit_group
+      assert_equal 0, original_unit_group.original_units.length
+      assert_equal new_unit_group, unit1.original_unit_group
+      assert_equal 2, new_unit_group.original_units.length
+
+      new_unit_group.update_scripts(['unit1'])
+      new_unit_group.reload
+      unit2.reload
+      # unit2's original unit group removed
+      assert_equal 1, new_unit_group.original_units.length
+      assert_equal nil, unit2.original_unit_group
+    end
+
+    test "removed units have their published state instruction type participant audience and instructor audience reset" do
+      unit_group = create :unit_group
+      unit1 = create(:script, name: 'unit1')
+      unit2 = create(:script, name: 'unit2')
+
+      unit_group.update_scripts(['unit1', 'unit2'])
+
+      unit_group.reload
+      unit1.reload
+      unit2.reload
+
       assert_nil unit1.published_state
       assert_nil unit1.instruction_type
       assert_nil unit1.instructor_audience
@@ -600,19 +628,19 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_nil unit2.instructor_audience
       assert_nil unit2.participant_audience
 
-      new_unit_group.update_scripts(['unit2'])
+      unit_group.update_scripts(['unit2'])
 
-      new_unit_group.reload
+      unit_group.reload
       unit1.reload
       unit2.reload
 
-      assert_equal new_unit_group.published_state, unit1.published_state
+      assert_equal unit_group.published_state, unit1.published_state
       refute_nil unit1.published_state
-      assert_equal new_unit_group.instruction_type, unit1.instruction_type
+      assert_equal unit_group.instruction_type, unit1.instruction_type
       refute_nil unit1.instruction_type
-      assert_equal new_unit_group.instructor_audience, unit1.instructor_audience
+      assert_equal unit_group.instructor_audience, unit1.instructor_audience
       refute_nil unit1.instructor_audience
-      assert_equal new_unit_group.participant_audience, unit1.participant_audience
+      assert_equal unit_group.participant_audience, unit1.participant_audience
       refute_nil unit1.participant_audience
 
       assert_nil unit2.published_state
@@ -622,16 +650,13 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "units with published state set independent of the unit group maintain that published state when removed" do
-      original_unit_group = create :unit_group
-      new_unit_group = create :unit_group
+      unit_group = create :unit_group
       unit1 = create(:script, name: 'unit1')
       unit2 = create(:script, name: 'unit2')
 
-      original_unit_group.update_scripts(['unit2'])
-      new_unit_group.update_scripts(['unit1', 'unit2'])
+      unit_group.update_scripts(['unit1', 'unit2'])
 
-      original_unit_group.reload
-      new_unit_group.reload
+      unit_group.reload
       unit1.reload
       unit2.reload
 
@@ -650,18 +675,18 @@ class UnitGroupTest < ActiveSupport::TestCase
 
       assert_equal Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development, unit2.published_state
 
-      new_unit_group.update_scripts(['unit1'])
+      unit_group.update_scripts(['unit1'])
 
-      new_unit_group.reload
+      unit_group.reload
       unit2.reload
 
-      refute_equal new_unit_group.published_state, unit2.published_state
+      refute_equal unit_group.published_state, unit2.published_state
       assert_equal Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development, unit2.published_state
-      assert_equal new_unit_group.instruction_type, unit2.instruction_type
+      assert_equal unit_group.instruction_type, unit2.instruction_type
       refute_nil unit2.instruction_type
-      assert_equal new_unit_group.instructor_audience, unit2.instructor_audience
+      assert_equal unit_group.instructor_audience, unit2.instructor_audience
       refute_nil unit2.instructor_audience
-      assert_equal new_unit_group.participant_audience, unit2.participant_audience
+      assert_equal unit_group.participant_audience, unit2.participant_audience
       refute_nil unit2.participant_audience
     end
   end


### PR DESCRIPTION
We recently had a case of a content editor wanting to remove a unit from its unit group and there was not a pathway for them to do so. To fix this, we will allow units to be removed from their original unit groups if the unit does not have any resources/vocab. Prior to the modularity work, units weren’t allowed to be deleted if they had resources/vocab at all, so this restores that behavior for original unit groups.

## Links
- Jira: [TEACH-1885](https://codedotorg.atlassian.net/browse/TEACH-1885)

## Testing story
Added and modified tests in `unit_group_test.rb` to cover the new behavior.
Manually verified that units can be removed from their original unit group only if the unit does not have any resources/vocab attached to it.