### PR TITLE
AI Chat: delete records 90 days old in batches

### DIFF
--- a/bin/cron/delete_old_ai_chat_data
+++ b/bin/cron/delete_old_ai_chat_data
@@ -16,11 +16,17 @@ def main
   # Pilot data collected before September 30th, 2024 is being retained for analysis.
   pilot_end_date = DateTime.new(2024, 10, 1, 0, 0, 0)
 
-  destroyed_event_count = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
-  ChatClient.message('cron-daily', "Deleted #{destroyed_event_count} AichatEvent records")
+  events_deleted = 0
+  AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).in_batches do |events|
+    events_deleted += events.delete_all
+  end
+  ChatClient.message('cron-daily', "Deleted #{events_deleted} AichatEvent records")
 
-  destroyed_request_count = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
-  ChatClient.message('cron-daily', "Deleted #{destroyed_request_count} AichatRequest records")
+  requests_deleted = 0
+  AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).in_batches do |requests|
+    requests_deleted += requests.delete_all
+  end
+  ChatClient.message('cron-daily', "Deleted #{requests_deleted} AichatRequest records")
 end
 
 main


### PR DESCRIPTION
Our AI Chat delete cronjob has been failing for a couple of months.

A couple things could be going wrong here:
- large size of rows (3 JSON columns) makes the delete slow
- no index on created_at makes query to find rows slow

A raw MySQL query on `production-console` to get the count of requests executed within a couple of seconds, so I'm theorizing the former is the problem:

```
mysql> select count(*) from aichat_requests where created_at between '2024-09-01' and '2025-02-05';
+----------+
| count(*) |
+----------+
|     5018 |
+----------+
1 row in set (1.89 sec)
```

## Links

- Slack thread with Jira and Honeybadger links: https://codedotorg.slack.com/archives/C06FELVTV0Q/p1746469158731769

## Testing story

I tested manually that this ran as expected locally.