### PR TITLE
Music: play tune updates

### DIFF
--- a/apps/src/music/blockly/FieldPattern.js
+++ b/apps/src/music/blockly/FieldPattern.js
@@ -115,7 +115,7 @@ class FieldPattern extends GoogleBlockly.Field {
       return;
     }
 
-    if (appConfig.getValue('play-tune-block') === 'true') {
+    if (appConfig.getValue('play-tune-block-drums') === 'true') {
       ReactDOM.render(
         <InstrumentGrid
           editorType="drums"

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -10,7 +10,7 @@ import {
 import {getNoteName, convertRelativeToAbsolutePitch} from '../utils/Notes';
 import {
   generateGraphDataFromTune,
-  getNoteAvailableInScaleMode,
+  isNoteAvailableInScaleMode,
   TuneGraphEvent,
 } from '../utils/Tunes';
 import InstrumentGrid from '../views/InstrumentGrid';
@@ -129,7 +129,7 @@ export default class FieldTune extends GoogleBlockly.Field {
     const notes = events
       .map(mapFn)
       .filter((event: InstrumentTickEvent) =>
-        getNoteAvailableInScaleMode(key, event.note, scaleMode)
+        isNoteAvailableInScaleMode(key, event.note, scaleMode)
       );
 
     const graphNotes: TuneGraphEvent[] = generateGraphDataFromTune({

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -7,7 +7,7 @@ import {
   InstrumentTickEvent,
   InstrumentEventValue,
 } from '../player/interfaces/InstrumentEvent';
-import {getNoteName, getNotesInKey} from '../utils/Notes';
+import {getNoteName, getNotesInKey, getTransposedNote} from '../utils/Notes';
 import {generateGraphDataFromTune, TuneGraphEvent} from '../utils/Tunes';
 import InstrumentGrid from '../views/InstrumentGrid';
 
@@ -25,11 +25,6 @@ const DISPLAY_OCTAVES = 3;
 interface FieldTuneOptions {
   currentValue: InstrumentEventValue;
 }
-
-const relativeToMidiNote = (note: number): number => {
-  const key = MusicRegistry.player.getKey();
-  return note + 60 + key;
-};
 
 /**
  * A custom field that renders the tune selection UI, used in the
@@ -135,7 +130,7 @@ export default class FieldTune extends GoogleBlockly.Field {
 
     const mapFn = (event: InstrumentTickEvent) => ({
       ...event,
-      note: relativeToMidiNote(event.note),
+      note: getTransposedNote(key, event.note),
     });
 
     const graphNotes: TuneGraphEvent[] = generateGraphDataFromTune({

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -28,7 +28,7 @@ interface FieldTuneOptions {
 
 const relativeToMidiNote = (note: number): number => {
   const key = MusicRegistry.player.getKey();
-  return note + 60 - key;
+  return note + 60 + key;
 };
 
 /**

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -26,6 +26,11 @@ interface FieldTuneOptions {
   currentValue: InstrumentEventValue;
 }
 
+const relativeToMidiNote = (note: number): number => {
+  const key = MusicRegistry.player.getKey();
+  return note + 60 - key;
+};
+
 /**
  * A custom field that renders the tune selection UI, used in the
  * "play_tune" block. The UI is rendered by {@link InstrumentGrid}.
@@ -128,8 +133,13 @@ export default class FieldTune extends GoogleBlockly.Field {
             )
         : () => true;
 
+    const mapFn = (event: InstrumentTickEvent) => ({
+      ...event,
+      note: relativeToMidiNote(event.note),
+    });
+
     const graphNotes: TuneGraphEvent[] = generateGraphDataFromTune({
-      notes: events.filter(filterFn),
+      notes: events.map(mapFn).filter(filterFn),
       width: FIELD_WIDTH,
       height: FIELD_HEIGHT,
       numOctaves: 3,

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -4,14 +4,14 @@ import ReactDOM from 'react-dom';
 
 import MusicRegistry from '../MusicRegistry';
 import {
-  InstrumentTickEvent,
   InstrumentEventValue,
+  InstrumentTickEvent,
 } from '../player/interfaces/InstrumentEvent';
 import {getNoteName, getTransposedNote} from '../utils/Notes';
 import {
   generateGraphDataFromTune,
-  TuneGraphEvent,
   getNoteAvailableInScaleMode,
+  TuneGraphEvent,
 } from '../utils/Tunes';
 import InstrumentGrid from '../views/InstrumentGrid';
 

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -121,17 +121,6 @@ export default class FieldTune extends GoogleBlockly.Field {
     const {events, scaleMode} = this.getValue();
     const key = MusicRegistry.player.getKey();
 
-    /*
-    const filterFn =
-      scaleMode === 'simple'
-        ? (event: InstrumentTickEvent) =>
-            getNotesInKey(key, START_OCTAVE, DISPLAY_OCTAVES).includes(
-              event.note
-            )
-        : () => true;
-
-    */
-
     const mapFn = (event: InstrumentTickEvent) => ({
       ...event,
       note: getTransposedNote(key, event.note),

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -7,7 +7,7 @@ import {
   InstrumentEventValue,
   InstrumentTickEvent,
 } from '../player/interfaces/InstrumentEvent';
-import {getNoteName, getTransposedNote} from '../utils/Notes';
+import {getNoteName, convertRelativeToAbsolutePitch} from '../utils/Notes';
 import {
   generateGraphDataFromTune,
   getNoteAvailableInScaleMode,
@@ -123,7 +123,7 @@ export default class FieldTune extends GoogleBlockly.Field {
 
     const mapFn = (event: InstrumentTickEvent) => ({
       ...event,
-      note: getTransposedNote(key, event.note),
+      note: convertRelativeToAbsolutePitch(key, event.note),
     });
 
     const notes = events

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -7,8 +7,12 @@ import {
   InstrumentTickEvent,
   InstrumentEventValue,
 } from '../player/interfaces/InstrumentEvent';
-import {getNoteName, getNotesInKey, getTransposedNote} from '../utils/Notes';
-import {generateGraphDataFromTune, TuneGraphEvent} from '../utils/Tunes';
+import {getNoteName, getTransposedNote} from '../utils/Notes';
+import {
+  generateGraphDataFromTune,
+  TuneGraphEvent,
+  getNoteAvailableInScaleMode,
+} from '../utils/Tunes';
 import InstrumentGrid from '../views/InstrumentGrid';
 
 const color = require('@cdo/apps/util/color');
@@ -18,9 +22,6 @@ const MAX_DISPLAY_NOTES = 3;
 const FIELD_WIDTH = 51;
 const FIELD_HEIGHT = 18;
 const FIELD_PADDING = 2;
-
-const START_OCTAVE = 4;
-const DISPLAY_OCTAVES = 3;
 
 interface FieldTuneOptions {
   currentValue: InstrumentEventValue;
@@ -120,6 +121,7 @@ export default class FieldTune extends GoogleBlockly.Field {
     const {events, scaleMode} = this.getValue();
     const key = MusicRegistry.player.getKey();
 
+    /*
     const filterFn =
       scaleMode === 'simple'
         ? (event: InstrumentTickEvent) =>
@@ -128,13 +130,21 @@ export default class FieldTune extends GoogleBlockly.Field {
             )
         : () => true;
 
+    */
+
     const mapFn = (event: InstrumentTickEvent) => ({
       ...event,
       note: getTransposedNote(key, event.note),
     });
 
+    const notes = events
+      .map(mapFn)
+      .filter((event: InstrumentTickEvent) =>
+        getNoteAvailableInScaleMode(key, event.note, scaleMode)
+      );
+
     const graphNotes: TuneGraphEvent[] = generateGraphDataFromTune({
-      notes: events.map(mapFn).filter(filterFn),
+      notes,
       width: FIELD_WIDTH,
       height: FIELD_HEIGHT,
       numOctaves: 3,

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -2,8 +2,12 @@ import * as GoogleBlockly from 'blockly/core';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import {InstrumentEventValue} from '../player/interfaces/InstrumentEvent';
-import {getNoteName} from '../utils/Notes';
+import MusicRegistry from '../MusicRegistry';
+import {
+  InstrumentTickEvent,
+  InstrumentEventValue,
+} from '../player/interfaces/InstrumentEvent';
+import {getNoteName, getNotesInKey} from '../utils/Notes';
 import {generateGraphDataFromTune, TuneGraphEvent} from '../utils/Tunes';
 import InstrumentGrid from '../views/InstrumentGrid';
 
@@ -14,6 +18,9 @@ const MAX_DISPLAY_NOTES = 3;
 const FIELD_WIDTH = 51;
 const FIELD_HEIGHT = 18;
 const FIELD_PADDING = 2;
+
+const START_OCTAVE = 4;
+const DISPLAY_OCTAVES = 3;
 
 interface FieldTuneOptions {
   currentValue: InstrumentEventValue;
@@ -110,8 +117,19 @@ export default class FieldTune extends GoogleBlockly.Field {
       this.backgroundElement
     );
 
+    const {events, scaleMode} = this.getValue();
+    const key = MusicRegistry.player.getKey();
+
+    const filterFn =
+      scaleMode === 'simple'
+        ? (event: InstrumentTickEvent) =>
+            getNotesInKey(key, START_OCTAVE, DISPLAY_OCTAVES).includes(
+              event.note
+            )
+        : () => true;
+
     const graphNotes: TuneGraphEvent[] = generateGraphDataFromTune({
-      value: this.getValue(),
+      notes: events.filter(filterFn),
       width: FIELD_WIDTH,
       height: FIELD_HEIGHT,
       numOctaves: 3,

--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -80,6 +80,8 @@ export const DEFAULT_TUNE: InstrumentEventValue = {
   instrument: 'piano',
   events: [],
   length: DEFAULT_TUNE_LENGTH,
+  relative: true,
+  scaleMode: 'simple',
 };
 
 export const LOCAL_STORAGE = 'local';

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -5,7 +5,15 @@ import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {DEFAULT_CHORD_LENGTH, MIN_BPM, MAX_BPM} from '../constants';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
 import {generateNotesFromChord, ChordNote} from '../utils/Chords';
-import {getPitchName, getTranposedNote, Key} from '../utils/Notes';
+import {
+  getPitchName,
+  getNotesInKey,
+  getTranposedNote,
+  Key,
+} from '../utils/Notes';
+
+const START_OCTAVE = 4;
+const DISPLAY_OCTAVES = 3;
 
 import {
   ChordEvent,
@@ -16,6 +24,7 @@ import {Effects} from './interfaces/Effects';
 import {
   InstrumentEvent,
   InstrumentEventValue,
+  InstrumentTickEvent,
   isInstrumentEvent,
 } from './interfaces/InstrumentEvent';
 import {PlaybackEvent} from './interfaces/PlaybackEvent';
@@ -454,11 +463,19 @@ export default class MusicPlayer {
     instrumentEvent: InstrumentEvent
   ): SamplerSequence | null {
     const {value, effects, when} = instrumentEvent;
-    const {instrument, events} = value;
+    const {instrument, events, scaleMode} = value;
+    const filterFn =
+      scaleMode === 'simple'
+        ? (event: InstrumentTickEvent) =>
+            getNotesInKey(this.key, START_OCTAVE, DISPLAY_OCTAVES).includes(
+              event.note
+            )
+        : () => true;
+
     return {
       instrument,
       effects,
-      events: events.map(event => {
+      events: events.filter(filterFn).map(event => {
         return {
           notes: [getPitchName(event.note)],
           playbackPosition: when + (event.tick - 1) / 16,

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -463,7 +463,7 @@ export default class MusicPlayer {
     instrumentEvent: InstrumentEvent
   ): SamplerSequence | null {
     const {value, effects, when} = instrumentEvent;
-    const {instrument, events, scaleMode} = value;
+    const {instrument, events, relative, scaleMode} = value;
     const filterFn =
       scaleMode === 'simple'
         ? (event: InstrumentTickEvent) =>
@@ -476,8 +476,11 @@ export default class MusicPlayer {
       instrument,
       effects,
       events: events.filter(filterFn).map(event => {
+        const note = relative
+          ? getTransposedNote(this.key, event.note)
+          : event.note;
         return {
-          notes: [getPitchName(getTransposedNote(this.key, event.note))],
+          notes: [getPitchName(note)],
           playbackPosition: when + (event.tick - 1) / 16,
         };
       }),

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -5,15 +5,8 @@ import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {DEFAULT_CHORD_LENGTH, MIN_BPM, MAX_BPM} from '../constants';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
 import {generateNotesFromChord, ChordNote} from '../utils/Chords';
-import {
-  getPitchName,
-  getNotesInKey,
-  getTransposedNote,
-  Key,
-} from '../utils/Notes';
-
-const START_OCTAVE = 4;
-const DISPLAY_OCTAVES = 3;
+import {getPitchName, getTransposedNote, Key} from '../utils/Notes';
+import {getNoteAvailableInScaleMode} from '../utils/Tunes';
 
 import {
   ChordEvent,
@@ -24,7 +17,6 @@ import {Effects} from './interfaces/Effects';
 import {
   InstrumentEvent,
   InstrumentEventValue,
-  InstrumentTickEvent,
   isInstrumentEvent,
 } from './interfaces/InstrumentEvent';
 import {PlaybackEvent} from './interfaces/PlaybackEvent';
@@ -464,26 +456,23 @@ export default class MusicPlayer {
   ): SamplerSequence | null {
     const {value, effects, when} = instrumentEvent;
     const {instrument, events, relative, scaleMode} = value;
-    const filterFn =
-      scaleMode === 'simple'
-        ? (event: InstrumentTickEvent) =>
-            getNotesInKey(this.key, START_OCTAVE, DISPLAY_OCTAVES).includes(
-              getTransposedNote(this.key, event.note)
-            )
-        : () => true;
 
     return {
       instrument,
       effects,
-      events: events.filter(filterFn).map(event => {
-        const note = relative
-          ? getTransposedNote(this.key, event.note)
-          : event.note;
-        return {
-          notes: [getPitchName(note)],
-          playbackPosition: when + (event.tick - 1) / 16,
-        };
-      }),
+      events: events
+        .filter(event =>
+          getNoteAvailableInScaleMode(this.key, event.note, scaleMode)
+        )
+        .map(event => {
+          const note = relative
+            ? getTransposedNote(this.key, event.note)
+            : event.note;
+          return {
+            notes: [getPitchName(note)],
+            playbackPosition: when + (event.tick - 1) / 16,
+          };
+        }),
     };
   }
 

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -48,7 +48,7 @@ const DEFAULT_KEY = Key.C;
 
 const relativeToMidiNote = (note: number): number => {
   const key = MusicRegistry.player.getKey();
-  return note + 60 - key;
+  return note + 60 + key;
 };
 
 /**

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -5,7 +5,11 @@ import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {DEFAULT_CHORD_LENGTH, MIN_BPM, MAX_BPM} from '../constants';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
 import {generateNotesFromChord, ChordNote} from '../utils/Chords';
-import {getPitchName, getTransposedNote, Key} from '../utils/Notes';
+import {
+  getPitchName,
+  convertRelativeToAbsolutePitch,
+  Key,
+} from '../utils/Notes';
 import {getNoteAvailableInScaleMode} from '../utils/Tunes';
 
 import {
@@ -411,7 +415,10 @@ export default class MusicPlayer {
     const samples: SampleEvent[] = [];
 
     events.forEach(event => {
-      const transposedNote = getTransposedNote(this.key, event.noteOffset);
+      const transposedNote = convertRelativeToAbsolutePitch(
+        this.key,
+        event.noteOffset
+      );
       const sampleUrl = this.getSampleForNote(transposedNote, instrument);
       if (sampleUrl !== null) {
         const eventWhen = eventStart + (event.position - 1) / 16;
@@ -456,20 +463,24 @@ export default class MusicPlayer {
   ): SamplerSequence | null {
     const {value, effects, when} = instrumentEvent;
     const {instrument, events, relative, scaleMode} = value;
+    const key = this.key;
 
     return {
       instrument,
       effects,
       events: events
+        .map(event => ({
+          ...event,
+          note: relative
+            ? convertRelativeToAbsolutePitch(key, event.note)
+            : event.note,
+        }))
         .filter(event =>
-          getNoteAvailableInScaleMode(this.key, event.note, scaleMode)
+          getNoteAvailableInScaleMode(key, event.note, scaleMode)
         )
         .map(event => {
-          const note = relative
-            ? getTransposedNote(this.key, event.note)
-            : event.note;
           return {
-            notes: [getPitchName(note)],
+            notes: [getPitchName(event.note)],
             playbackPosition: when + (event.tick - 1) / 16,
           };
         }),

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -3,13 +3,12 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 
 import {DEFAULT_CHORD_LENGTH, MIN_BPM, MAX_BPM} from '../constants';
-import MusicRegistry from '../MusicRegistry';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
 import {generateNotesFromChord, ChordNote} from '../utils/Chords';
 import {
   getPitchName,
   getNotesInKey,
-  getTranposedNote,
+  getTransposedNote,
   Key,
 } from '../utils/Notes';
 
@@ -45,11 +44,6 @@ import {
 
 const DEFAULT_BPM = 120;
 const DEFAULT_KEY = Key.C;
-
-const relativeToMidiNote = (note: number): number => {
-  const key = MusicRegistry.player.getKey();
-  return note + 60 + key;
-};
 
 /**
  * Main music player component which maintains the list of playback events and
@@ -425,8 +419,8 @@ export default class MusicPlayer {
     const samples: SampleEvent[] = [];
 
     events.forEach(event => {
-      const tranposedNote = getTranposedNote(this.key, event.noteOffset);
-      const sampleUrl = this.getSampleForNote(tranposedNote, instrument);
+      const transposedNote = getTransposedNote(this.key, event.noteOffset);
+      const sampleUrl = this.getSampleForNote(transposedNote, instrument);
       if (sampleUrl !== null) {
         const eventWhen = eventStart + (event.position - 1) / 16;
         samples.push({
@@ -474,7 +468,7 @@ export default class MusicPlayer {
       scaleMode === 'simple'
         ? (event: InstrumentTickEvent) =>
             getNotesInKey(this.key, START_OCTAVE, DISPLAY_OCTAVES).includes(
-              relativeToMidiNote(event.note)
+              getTransposedNote(this.key, event.note)
             )
         : () => true;
 
@@ -483,7 +477,7 @@ export default class MusicPlayer {
       effects,
       events: events.filter(filterFn).map(event => {
         return {
-          notes: [getPitchName(relativeToMidiNote(event.note))],
+          notes: [getPitchName(getTransposedNote(this.key, event.note))],
           playbackPosition: when + (event.tick - 1) / 16,
         };
       }),

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -10,7 +10,7 @@ import {
   convertRelativeToAbsolutePitch,
   Key,
 } from '../utils/Notes';
-import {getNoteAvailableInScaleMode} from '../utils/Tunes';
+import {isNoteAvailableInScaleMode} from '../utils/Tunes';
 
 import {
   ChordEvent,
@@ -475,9 +475,7 @@ export default class MusicPlayer {
             ? convertRelativeToAbsolutePitch(key, event.note)
             : event.note,
         }))
-        .filter(event =>
-          getNoteAvailableInScaleMode(key, event.note, scaleMode)
-        )
+        .filter(event => isNoteAvailableInScaleMode(key, event.note, scaleMode))
         .map(event => {
           return {
             notes: [getPitchName(event.note)],

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -3,6 +3,7 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 
 import {DEFAULT_CHORD_LENGTH, MIN_BPM, MAX_BPM} from '../constants';
+import MusicRegistry from '../MusicRegistry';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
 import {generateNotesFromChord, ChordNote} from '../utils/Chords';
 import {
@@ -44,6 +45,11 @@ import {
 
 const DEFAULT_BPM = 120;
 const DEFAULT_KEY = Key.C;
+
+const relativeToMidiNote = (note: number): number => {
+  const key = MusicRegistry.player.getKey();
+  return note + 60 - key;
+};
 
 /**
  * Main music player component which maintains the list of playback events and
@@ -468,7 +474,7 @@ export default class MusicPlayer {
       scaleMode === 'simple'
         ? (event: InstrumentTickEvent) =>
             getNotesInKey(this.key, START_OCTAVE, DISPLAY_OCTAVES).includes(
-              event.note
+              relativeToMidiNote(event.note)
             )
         : () => true;
 
@@ -477,7 +483,7 @@ export default class MusicPlayer {
       effects,
       events: events.filter(filterFn).map(event => {
         return {
-          notes: [getPitchName(event.note)],
+          notes: [getPitchName(relativeToMidiNote(event.note))],
           playbackPosition: when + (event.tick - 1) / 16,
         };
       }),

--- a/apps/src/music/player/interfaces/InstrumentEvent.ts
+++ b/apps/src/music/player/interfaces/InstrumentEvent.ts
@@ -18,6 +18,8 @@ export interface InstrumentEventValue {
   length: 1 | 2;
   /** If the notes were partially generated using AI */
   ai?: boolean;
+  /** If the notes are relative, e.g. 0 is the tonic for the current key. */
+  relative?: boolean;
   /** For a melodic event, the notes shown. */
   scaleMode?: ScaleMode;
 }

--- a/apps/src/music/player/interfaces/InstrumentEvent.ts
+++ b/apps/src/music/player/interfaces/InstrumentEvent.ts
@@ -10,15 +10,15 @@ export interface InstrumentEvent extends PlaybackEvent {
 export type ScaleMode = 'simple' | 'chromatic';
 
 export interface InstrumentEventValue {
-  /** Name of the instrument to play notes on */
+  /** Name of the instrument to play notes on. */
   instrument: string;
   /** Note events. */
   events: InstrumentTickEvent[];
-  /** Total length in measures (even if there are fewer notes) */
+  /** Total length in measures (even if there are fewer notes). */
   length: 1 | 2;
-  /** If the notes were partially generated using AI */
+  /** If the notes were partially generated using AI. */
   ai?: boolean;
-  /** If the notes are relative, e.g. note 0 is the tonic for the current key. */
+  /** If the notes are relative, e.g. note 0 is the tonic in the default octave for the current key. */
   relative?: boolean;
   /** For a tune, the set of notes available to be played. */
   scaleMode?: ScaleMode;

--- a/apps/src/music/player/interfaces/InstrumentEvent.ts
+++ b/apps/src/music/player/interfaces/InstrumentEvent.ts
@@ -7,6 +7,8 @@ export interface InstrumentEvent extends PlaybackEvent {
   instrumentType: 'drums' | 'melodic';
 }
 
+export type ScaleMode = 'simple' | 'chromatic';
+
 export interface InstrumentEventValue {
   /** Name of the instrument to play notes on */
   instrument: string;
@@ -16,6 +18,8 @@ export interface InstrumentEventValue {
   length: 1 | 2;
   /** If the notes were partially generated using AI */
   ai?: boolean;
+  /** For a melodic event, the notes shown. */
+  scaleMode?: ScaleMode;
 }
 
 /** A single note event. Ticks are 1-based and refer to 16th note subdivisions */

--- a/apps/src/music/player/interfaces/InstrumentEvent.ts
+++ b/apps/src/music/player/interfaces/InstrumentEvent.ts
@@ -18,9 +18,9 @@ export interface InstrumentEventValue {
   length: 1 | 2;
   /** If the notes were partially generated using AI */
   ai?: boolean;
-  /** If the notes are relative, e.g. 0 is the tonic for the current key. */
+  /** If the notes are relative, e.g. note 0 is the tonic for the current key. */
   relative?: boolean;
-  /** For a melodic event, the notes shown. */
+  /** For a tune, the set of notes available to be played. */
   scaleMode?: ScaleMode;
 }
 

--- a/apps/src/music/utils/Notes.ts
+++ b/apps/src/music/utils/Notes.ts
@@ -45,16 +45,27 @@ export const getNoteOctave = (note: number): number =>
 export const getPitchName = (note: number): string =>
   getNoteName(note) + getNoteOctave(note);
 
+// Get the appropriate offset from the root note for a given key, with
+// extra handling to pick the closest transposition.
+const getTranspositionOffsetForKey = (targetKey: Key) =>
+  targetKey > 6 ? targetKey - 12 : targetKey;
+
 // Convert a pitch from relative to absolute, by adding the note offset
 // to the target note defined by the target key.
 export const convertRelativeToAbsolutePitch = (
   targetKey: Key,
   noteOffset: number
-) => targetKey + ROOT_NOTE_START + noteOffset;
+) => {
+  return getTranspositionOffsetForKey(targetKey) + ROOT_NOTE_START + noteOffset;
+};
 
 // Convert a pitch from absolute to relative.
-export const convertAbsoluteToRelativePitch = (targetKey: Key, note: number) =>
-  note - ROOT_NOTE_START - targetKey;
+export const convertAbsoluteToRelativePitch = (
+  targetKey: Key,
+  note: number
+) => {
+  return note - ROOT_NOTE_START - getTranspositionOffsetForKey(targetKey);
+};
 
 /**
  * Returns diatonic notes in the given key and number of octaves.
@@ -67,7 +78,7 @@ export const getNotesInKey = (
   numOctaves: number
 ) => {
   // Find transposition offset
-  const offset = key > 6 ? key - 12 : key;
+  const offset = getTranspositionOffsetForKey(key);
   // Major scale intervals
   const intervals = [2, 2, 1, 2, 2, 2, 1];
 

--- a/apps/src/music/utils/Notes.ts
+++ b/apps/src/music/utils/Notes.ts
@@ -45,13 +45,15 @@ export const getNoteOctave = (note: number): number =>
 export const getPitchName = (note: number): string =>
   getNoteName(note) + getNoteOctave(note);
 
-// Transpose a note from relative to absolute, by adding the note offset
+// Convert a pitch from relative to absolute, by adding the note offset
 // to the target note defined by the target key.
-export const getTransposedNote = (targetKey: Key, noteOffset: number) =>
-  targetKey + ROOT_NOTE_START + noteOffset;
+export const convertRelativeToAbsolutePitch = (
+  targetKey: Key,
+  noteOffset: number
+) => targetKey + ROOT_NOTE_START + noteOffset;
 
-// Untranspose a note from absolute to relative.
-export const getUntransposedNote = (targetKey: Key, note: number) =>
+// Convert a pitch from absolute to relative.
+export const convertAbsoluteToRelativePitch = (targetKey: Key, note: number) =>
   note - ROOT_NOTE_START - targetKey;
 
 /**

--- a/apps/src/music/utils/Notes.ts
+++ b/apps/src/music/utils/Notes.ts
@@ -45,11 +45,12 @@ export const getNoteOctave = (note: number): number =>
 export const getPitchName = (note: number): string =>
   getNoteName(note) + getNoteOctave(note);
 
-// Transpose the note by adding the note offset to the target note defined
-// by the target key.
+// Transpose a note from relative to absolute, by adding the note offset
+// to the target note defined by the target key.
 export const getTransposedNote = (targetKey: Key, noteOffset: number) =>
   targetKey + ROOT_NOTE_START + noteOffset;
 
+// Untranspose a note from absolute to relative.
 export const getUntransposedNote = (targetKey: Key, note: number) =>
   note - ROOT_NOTE_START - targetKey;
 

--- a/apps/src/music/utils/Notes.ts
+++ b/apps/src/music/utils/Notes.ts
@@ -47,8 +47,11 @@ export const getPitchName = (note: number): string =>
 
 // Transpose the note by adding the note offset to the target note defined
 // by the target key.
-export const getTranposedNote = (targetKey: Key, noteOffset: number) =>
+export const getTransposedNote = (targetKey: Key, noteOffset: number) =>
   targetKey + ROOT_NOTE_START + noteOffset;
+
+export const getUntransposedNote = (targetKey: Key, note: number) =>
+  note - ROOT_NOTE_START - targetKey;
 
 /**
  * Returns diatonic notes in the given key and number of octaves.

--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -8,16 +8,15 @@ import {getNotesInKey} from './Notes';
 export const START_OCTAVE = 4;
 export const DISPLAY_OCTAVES = 3;
 
-export function getNoteAvailableInScaleMode(
+export const getNoteAvailableInScaleMode = (
   key: number,
   note: number,
   scaleMode?: ScaleMode
-) {
-  return scaleMode === 'simple'
+) =>
+  scaleMode === 'simple'
     ? (event: InstrumentTickEvent) =>
         getNotesInKey(key, START_OCTAVE, DISPLAY_OCTAVES).includes(note)
     : true;
-}
 
 // A single event from a tune to be rendered in a graph.
 export interface TuneGraphEvent {

--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -1,4 +1,4 @@
-import {InstrumentEventValue} from '../player/interfaces/InstrumentEvent';
+import {InstrumentTickEvent} from '../player/interfaces/InstrumentEvent';
 
 // This file contains a helper function for tunes, and is used by the
 // block's custom field.
@@ -12,7 +12,7 @@ export interface TuneGraphEvent {
 }
 
 interface GenerateGraphDataFromTuneOptions {
-  value: InstrumentEventValue;
+  notes: InstrumentTickEvent[];
   width: number;
   height: number;
   numOctaves: number;
@@ -23,7 +23,7 @@ interface GenerateGraphDataFromTuneOptions {
 
 // Given a ChordEventValue, generate a set of data for graphing it.
 export function generateGraphDataFromTune({
-  value,
+  notes,
   width,
   height,
   numOctaves,
@@ -31,8 +31,6 @@ export function generateGraphDataFromTune({
   padding,
   noteHeightScale,
 }: GenerateGraphDataFromTuneOptions): TuneGraphEvent[] {
-  const notes = value.events;
-
   // Note widths fit in the space; note heights are exaggerated.
   const noteWidth = Math.ceil((width - 2 * padding) / 16);
   const noteHeight = Math.ceil(

--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -8,7 +8,7 @@ import {getNotesInKey} from './Notes';
 export const START_OCTAVE = 4;
 export const DISPLAY_OCTAVES = 3;
 
-export const getNoteAvailableInScaleMode = (
+export const isNoteAvailableInScaleMode = (
   key: number,
   note: number,
   scaleMode?: ScaleMode

--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -1,7 +1,23 @@
-import {InstrumentTickEvent} from '../player/interfaces/InstrumentEvent';
+import {
+  InstrumentTickEvent,
+  ScaleMode,
+} from '../player/interfaces/InstrumentEvent';
 
-// This file contains a helper function for tunes, and is used by the
-// block's custom field.
+import {getNotesInKey} from './Notes';
+
+export const START_OCTAVE = 4;
+export const DISPLAY_OCTAVES = 3;
+
+export function getNoteAvailableInScaleMode(
+  key: number,
+  note: number,
+  scaleMode?: ScaleMode
+) {
+  return scaleMode === 'simple'
+    ? (event: InstrumentTickEvent) =>
+        getNotesInKey(key, START_OCTAVE, DISPLAY_OCTAVES).includes(note)
+    : true;
+}
 
 // A single event from a tune to be rendered in a graph.
 export interface TuneGraphEvent {

--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -14,8 +14,7 @@ export const getNoteAvailableInScaleMode = (
   scaleMode?: ScaleMode
 ) =>
   scaleMode === 'simple'
-    ? (event: InstrumentTickEvent) =>
-        getNotesInKey(key, START_OCTAVE, DISPLAY_OCTAVES).includes(note)
+    ? getNotesInKey(key, START_OCTAVE, DISPLAY_OCTAVES).includes(note)
     : true;
 
 // A single event from a tune to be rendered in a graph.

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -17,8 +17,8 @@ import {
 import {
   getPitchName,
   isBlackKey,
-  getTransposedNote,
-  getUntransposedNote,
+  convertRelativeToAbsolutePitch,
+  convertAbsoluteToRelativePitch,
 } from '../../utils/Notes';
 import LoadingOverlay from '../LoadingOverlay';
 import PreviewControlsV2 from '../PreviewControlsV2';
@@ -48,7 +48,20 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
   lengthMeasures,
 }) => {
   const instruments = getInstruments(editorType);
-  const [currentValue, setCurrentValue] = useState(initialValue);
+  const [currentValue, setCurrentValue] = useState(() => {
+    // Convert to absolute before saving.
+    const convertedValue = {
+      ...initialValue,
+      events: initialValue.events.map(event => ({
+        ...event,
+        note: convertRelativeToAbsolutePitch(
+          MusicRegistry.player.getKey(),
+          event.note
+        ),
+      })),
+    };
+    return convertedValue;
+  });
   const [isLoading, setIsLoading] = useState(false);
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
 
@@ -56,8 +69,16 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
   const key = MusicRegistry.player.getKey();
 
   useEffect(() => {
-    onChange(currentValue);
-  }, [onChange, currentValue]);
+    // Convert to relative before saving.
+    const convertedValue = {
+      ...currentValue,
+      events: currentValue.events.map(event => ({
+        ...event,
+        note: convertAbsoluteToRelativePitch(key, event.note),
+      })),
+    };
+    onChange(convertedValue);
+  }, [onChange, currentValue, key]);
 
   useEffect(() => {
     const instrument = currentValue.instrument;
@@ -86,32 +107,29 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
     (note: number, tick: number) => {
       const newEvents = [...currentValue.events];
       const index = newEvents.findIndex(
-        event =>
-          getTransposedNote(key, event.note) === note && event.tick === tick
+        event => event.note === note && event.tick === tick
       );
 
       if (index !== -1) {
         newEvents.splice(index, 1);
       } else {
-        const relativeNote = getUntransposedNote(key, note);
-        newEvents.push({note: relativeNote, tick});
+        newEvents.push({note, tick});
         MusicRegistry.player.previewNote(note, currentValue.instrument);
       }
       setCurrentValue({...currentValue, events: newEvents});
     },
-    [currentValue, key]
+    [currentValue]
   );
 
   const isSelected = (note: number, tick: number) => {
     return !!currentValue.events.find(
-      event =>
-        getTransposedNote(key, event.note) === note && event.tick === tick
+      event => event.note === note && event.tick === tick
     );
   };
 
   const startPreview = useCallback(() => {
     MusicRegistry.player.previewNotes(
-      currentValue,
+      {...currentValue, relative: false},
       (tick: number) => setCurrentPreviewTick(tick),
       () => setCurrentPreviewTick(0)
     );
@@ -150,10 +168,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
         type="button"
         className={styles['cell-outer']}
         onClick={() =>
-          MusicRegistry.player.previewNote(
-            getUntransposedNote(key, props.note),
-            currentValue.instrument
-          )
+          MusicRegistry.player.previewNote(props.note, currentValue.instrument)
         }
       >
         <div

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -12,10 +12,14 @@ import React, {
 import MusicRegistry from '../../MusicRegistry';
 import {
   InstrumentEventValue,
-  InstrumentTickEvent,
   ScaleMode,
 } from '../../player/interfaces/InstrumentEvent';
-import {getPitchName, isBlackKey, getNotesInKey} from '../../utils/Notes';
+import {
+  getPitchName,
+  isBlackKey,
+  getTransposedNote,
+  getUntransposedNote,
+} from '../../utils/Notes';
 import LoadingOverlay from '../LoadingOverlay';
 import PreviewControlsV2 from '../PreviewControlsV2';
 import EaseIntoView from '../util/EaseIntoView';
@@ -32,19 +36,6 @@ interface Props {
 }
 
 export type EditorType = 'drums' | 'notes';
-
-const START_OCTAVE = 4;
-const DISPLAY_OCTAVES = 3;
-
-const relativeToMidiNote = (note: number): number => {
-  const key = MusicRegistry.player.getKey();
-  return note + 60 - key;
-};
-
-const midiToRelativeNote = (midiNote: number): number => {
-  const key = MusicRegistry.player.getKey();
-  return midiNote - 60 - key;
-};
 
 /**
  * Instrument grid editor for selecting notes in a pattern.
@@ -63,6 +54,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
   //const [scaleMode, setScaleMode] = useState<ScaleMode>('simple');
 
   const scaleMode = currentValue.scaleMode;
+  const key = MusicRegistry.player.getKey();
 
   useEffect(() => {
     onChange(currentValue);
@@ -95,10 +87,11 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
     (note: number, tick: number) => {
       const newEvents = [...currentValue.events];
       const index = newEvents.findIndex(
-        event => relativeToMidiNote(event.note) === note && event.tick === tick
+        event =>
+          getTransposedNote(key, event.note) === note && event.tick === tick
       );
 
-      const relativeNote = midiToRelativeNote(note);
+      const relativeNote = getUntransposedNote(key, note);
 
       if (index !== -1) {
         newEvents.splice(index, 1);
@@ -108,23 +101,17 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
       }
       setCurrentValue({...currentValue, events: newEvents});
     },
-    [currentValue]
+    [currentValue, key]
   );
 
   const isSelected = (note: number, tick: number) => {
     return !!currentValue.events.find(
-      event => relativeToMidiNote(event.note) === note && event.tick === tick
+      event =>
+        getTransposedNote(key, event.note) === note && event.tick === tick
     );
   };
 
   const startPreview = useCallback(() => {
-    /*const currentValueRelative = JSON.parse(JSON.stringify(currentValue));
-    currentValueRelative.events = currentValueRelative.events.map(
-      (event: InstrumentTickEvent) => ({
-        ...event,
-        note: relativeToMidiNote(event.note),
-      })
-    );*/
     MusicRegistry.player.previewNotes(
       currentValue,
       (tick: number) => setCurrentPreviewTick(tick),
@@ -166,7 +153,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
         className={styles['cell-outer']}
         onClick={() =>
           MusicRegistry.player.previewNote(
-            midiToRelativeNote(props.note),
+            getUntransposedNote(key, props.note),
             currentValue.instrument
           )
         }

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -51,7 +51,6 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
   const [currentValue, setCurrentValue] = useState(initialValue);
   const [isLoading, setIsLoading] = useState(false);
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
-  //const [scaleMode, setScaleMode] = useState<ScaleMode>('simple');
 
   const scaleMode = currentValue.scaleMode;
   const key = MusicRegistry.player.getKey();
@@ -91,13 +90,12 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
           getTransposedNote(key, event.note) === note && event.tick === tick
       );
 
-      const relativeNote = getUntransposedNote(key, note);
-
       if (index !== -1) {
         newEvents.splice(index, 1);
       } else {
+        const relativeNote = getUntransposedNote(key, note);
         newEvents.push({note: relativeNote, tick});
-        MusicRegistry.player.previewNote(relativeNote, currentValue.instrument);
+        MusicRegistry.player.previewNote(note, currentValue.instrument);
       }
       setCurrentValue({...currentValue, events: newEvents});
     },

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -10,7 +10,10 @@ import React, {
 } from 'react';
 
 import MusicRegistry from '../../MusicRegistry';
-import {InstrumentEventValue} from '../../player/interfaces/InstrumentEvent';
+import {
+  InstrumentEventValue,
+  ScaleMode,
+} from '../../player/interfaces/InstrumentEvent';
 import {getPitchName, isBlackKey} from '../../utils/Notes';
 import LoadingOverlay from '../LoadingOverlay';
 import PreviewControlsV2 from '../PreviewControlsV2';
@@ -28,7 +31,6 @@ interface Props {
 }
 
 export type EditorType = 'drums' | 'notes';
-export type ScaleMode = 'simple' | 'chromatic';
 
 /**
  * Instrument grid editor for selecting notes in a pattern.
@@ -44,7 +46,9 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
   const [currentValue, setCurrentValue] = useState(initialValue);
   const [isLoading, setIsLoading] = useState(false);
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
-  const [scaleMode, setScaleMode] = useState<ScaleMode>('simple');
+  //const [scaleMode, setScaleMode] = useState<ScaleMode>('simple');
+
+  const scaleMode = currentValue.scaleMode;
 
   useEffect(() => {
     onChange(currentValue);
@@ -113,7 +117,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
     () =>
       getDisplayNotes(
         editorType,
-        scaleMode,
+        scaleMode || 'simple',
         currentValue.instrument,
         MusicRegistry.player.getKey()
       ).sort((a, b) => b.note - a.note), // Sort descending
@@ -122,12 +126,13 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
 
   const ticks = integers(lengthMeasures * 16, 1);
 
-  const interfaceMode = editorType === 'drums' ? 'drums' : scaleMode;
+  const interfaceMode =
+    editorType === 'drums' ? 'drums' : scaleMode || 'simple';
 
   const RowLabel = (props: {name: string; note: number; i: number}) => {
     const [style, label] = {
       drums: [styles.textLabel, props.name],
-      simple: [styles.label, ((displayNotes.length - props.i - 1) % 7) + 1],
+      simple: [styles.label, getPitchName(props.note)],
       chromatic: [styles.keyLabel, getPitchName(props.note)],
     }[interfaceMode];
 
@@ -146,7 +151,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
             styles.innerCell
           )}
         >
-          {label}
+          {label.replace('#', '♯')}
         </div>
       </button>
     );
@@ -163,7 +168,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
     const topVisibleRow =
       displayNotes.length - notesInOctave - parseInt(displayRows);
     // Start scrolling a few rows below
-    const scrollStartRow = topVisibleRow + 5;
+    const scrollStartRow = topVisibleRow + 3;
     const cellHeightWithGap = parseInt(cellHeight) + parseInt(rowGap);
 
     return [
@@ -209,8 +214,10 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
               {label: 'Best Notes', value: 'simple'},
               {label: 'All Notes', value: 'chromatic'},
             ]}
-            onChange={value => setScaleMode(value as ScaleMode)}
-            selectedButtonValue={scaleMode}
+            onChange={value =>
+              setCurrentValue({...currentValue, scaleMode: value as ScaleMode})
+            }
+            selectedButtonValue={scaleMode || 'simple'}
             size="xs"
           />
         )}

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -12,9 +12,10 @@ import React, {
 import MusicRegistry from '../../MusicRegistry';
 import {
   InstrumentEventValue,
+  InstrumentTickEvent,
   ScaleMode,
 } from '../../player/interfaces/InstrumentEvent';
-import {getPitchName, isBlackKey} from '../../utils/Notes';
+import {getPitchName, isBlackKey, getNotesInKey} from '../../utils/Notes';
 import LoadingOverlay from '../LoadingOverlay';
 import PreviewControlsV2 from '../PreviewControlsV2';
 import EaseIntoView from '../util/EaseIntoView';
@@ -31,6 +32,19 @@ interface Props {
 }
 
 export type EditorType = 'drums' | 'notes';
+
+const START_OCTAVE = 4;
+const DISPLAY_OCTAVES = 3;
+
+const relativeToMidiNote = (note: number): number => {
+  const key = MusicRegistry.player.getKey();
+  return note + 60 - key;
+};
+
+const midiToRelativeNote = (midiNote: number): number => {
+  const key = MusicRegistry.player.getKey();
+  return midiNote - 60 + key;
+};
 
 /**
  * Instrument grid editor for selecting notes in a pattern.
@@ -81,13 +95,16 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
     (note: number, tick: number) => {
       const newEvents = [...currentValue.events];
       const index = newEvents.findIndex(
-        event => event.note === note && event.tick === tick
+        event => relativeToMidiNote(event.note) === note && event.tick === tick
       );
+
+      const relativeNote = midiToRelativeNote(note);
+
       if (index !== -1) {
         newEvents.splice(index, 1);
       } else {
-        newEvents.push({note, tick});
-        MusicRegistry.player.previewNote(note, currentValue.instrument);
+        newEvents.push({note: relativeNote, tick});
+        MusicRegistry.player.previewNote(relativeNote, currentValue.instrument);
       }
       setCurrentValue({...currentValue, events: newEvents});
     },
@@ -96,11 +113,18 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
 
   const isSelected = (note: number, tick: number) => {
     return !!currentValue.events.find(
-      event => event.note === note && event.tick === tick
+      event => relativeToMidiNote(event.note) === note && event.tick === tick
     );
   };
 
   const startPreview = useCallback(() => {
+    /*const currentValueRelative = JSON.parse(JSON.stringify(currentValue));
+    currentValueRelative.events = currentValueRelative.events.map(
+      (event: InstrumentTickEvent) => ({
+        ...event,
+        note: relativeToMidiNote(event.note),
+      })
+    );*/
     MusicRegistry.player.previewNotes(
       currentValue,
       (tick: number) => setCurrentPreviewTick(tick),
@@ -141,7 +165,10 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
         type="button"
         className={styles['cell-outer']}
         onClick={() =>
-          MusicRegistry.player.previewNote(props.note, currentValue.instrument)
+          MusicRegistry.player.previewNote(
+            midiToRelativeNote(props.note),
+            currentValue.instrument
+          )
         }
       >
         <div

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -43,7 +43,7 @@ const relativeToMidiNote = (note: number): number => {
 
 const midiToRelativeNote = (midiNote: number): number => {
   const key = MusicRegistry.player.getKey();
-  return midiNote - 60 + key;
+  return midiNote - 60 - key;
 };
 
 /**

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -49,7 +49,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
 }) => {
   const instruments = getInstruments(editorType);
   const [currentValue, setCurrentValue] = useState(() => {
-    // Convert to absolute before saving.
+    // Convert to absolute when loading.
     const convertedValue = {
       ...initialValue,
       events: initialValue.events.map(event => ({

--- a/apps/src/music/views/InstrumentGrid/util.ts
+++ b/apps/src/music/views/InstrumentGrid/util.ts
@@ -1,7 +1,8 @@
+import {ScaleMode} from '../../player/interfaces/InstrumentEvent';
 import MusicLibrary from '../../player/MusicLibrary';
 import {getNoteName, getNotesInKey, Key} from '../../utils/Notes';
 
-import {EditorType, ScaleMode} from '.';
+import {EditorType} from '.';
 
 const START_OCTAVE = 4;
 const DISPLAY_OCTAVES = 3;

--- a/apps/src/music/views/InstrumentGrid/util.ts
+++ b/apps/src/music/views/InstrumentGrid/util.ts
@@ -1,11 +1,9 @@
 import {ScaleMode} from '../../player/interfaces/InstrumentEvent';
 import MusicLibrary from '../../player/MusicLibrary';
 import {getNoteName, getNotesInKey, Key} from '../../utils/Notes';
+import {START_OCTAVE, DISPLAY_OCTAVES} from '../../utils/Tunes';
 
 import {EditorType} from '.';
-
-const START_OCTAVE = 4;
-const DISPLAY_OCTAVES = 3;
 
 export const integers = (length: number, start: number = 0) =>
   Array.from({length}, (_, i) => i + start);

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -92,6 +92,17 @@ const optionsList = [
     ],
   },
   {
+    name: 'play-tune-block-drums',
+    type: 'radio',
+    values: [
+      {
+        value: 'false',
+        description: "Don't use shared editor UI for drums (default).",
+      },
+      {value: 'true', description: 'Use shared editor UI for drums.'},
+    ],
+  },
+  {
     name: 'play-pattern-ai-block',
     type: 'radio',
     values: [


### PR DESCRIPTION
This proposes some updates to the unreleased "play tune" block, mostly based on some first-hand observations of usage:
- When toggled to "Best Notes", only the notes that are visible are played.  Toggling back to "All Notes" reveals the remaining selected notes again.  This addresses an issue in which notes could play even when they weren't visible, while also ensuring that toggling is not destructive to work done in "All Notes".  It makes the segment button group analogous to a toggle switch in which "Best Notes" applies additional filtering to the underlying data set.
- When toggled to "Best Notes", the note names are shown.  This gives the user some more insight into what they are doing musically.
- The scroll into view is slightly more subtle. 
- Note names are rendered with ♯ instead of the regular #.
- Internally, the notes are saved as relative rather than absolute.  For example, the tonic is saved as note 0.  This should make it more flexible to reuse the same block between keys.