### PR TITLE
Stop setting statsig_stable_id as cookie

### DIFF
--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -14,7 +14,7 @@ import {
 import {
   getUserID,
   getUserType,
-  findOrCreateStableId,
+  getStableId,
   formatUserId,
 } from './statsigHelpers';
 
@@ -27,7 +27,7 @@ class StatsigReporter {
     // stable_id is set as a cookie in application_controller.rb. However in a
     // the rare case we are running outside of the application layout,
     // set stable_id as a cookie here if it doesn't exist.
-    this.stable_id = findOrCreateStableId();
+    this.stable_id = getStableId();
     this.log(`Statsig Stable ID: ${this.stable_id}`);
     let user = {
       custom: {

--- a/apps/src/metrics/StatsigSessionReplay.js
+++ b/apps/src/metrics/StatsigSessionReplay.js
@@ -26,7 +26,7 @@ import {isProductionEnvironment} from '../utils';
 import {
   getUserID,
   getUserType,
-  findOrCreateStableId,
+  getStableId,
   formatUserId,
 } from './statsigHelpers';
 
@@ -38,7 +38,7 @@ class StatsigSessionReplay {
     // stable_id is set as a cookie in application_controller.rb. However in a
     // the rare case we are running outside of the application layout,
     // set stable_id as a cookie here if it doesn't exist.
-    this.stable_id = findOrCreateStableId();
+    this.stable_id = getStableId();
     let user = {
       customIDs: {stableID: this.stable_id},
       custom: {},

--- a/apps/src/metrics/statsigHelpers.js
+++ b/apps/src/metrics/statsigHelpers.js
@@ -1,6 +1,4 @@
-import cookies from 'js-cookie';
-
-import {getEnvironment, isProductionEnvironment, createUuid} from '../utils';
+import {getEnvironment, isProductionEnvironment} from '../utils';
 
 export function getUserID() {
   const user_id_element = document.querySelector('script[data-user-id]');
@@ -13,15 +11,10 @@ export function getUserType() {
 }
 
 export function findOrCreateStableId() {
-  const STABLE_ID_KEY = 'statsig_stable_id';
-  let stableId = cookies.get(STABLE_ID_KEY);
-  if (!stableId) {
-    stableId = createUuid();
-    cookies.set(STABLE_ID_KEY, stableId, {
-      path: '/',
-    });
-  }
-  return stableId;
+  const statsig_stable_id_element = document.querySelector(
+    'script[data-statsig-stable-id]'
+  );
+  return statsig_stable_id_element.dataset.statsigStableId;
 }
 
 export function formatUserId(userId) {

--- a/apps/src/metrics/statsigHelpers.js
+++ b/apps/src/metrics/statsigHelpers.js
@@ -10,7 +10,7 @@ export function getUserType() {
   return user_type_element ? user_type_element.dataset.userType : null;
 }
 
-export function findOrCreateStableId() {
+export function getStableId() {
   const scriptTag = document.querySelector('script[data-statsig-stable-id]');
   return scriptTag?.dataset?.statsigStableId || null;
 }

--- a/apps/src/metrics/statsigHelpers.js
+++ b/apps/src/metrics/statsigHelpers.js
@@ -11,10 +11,8 @@ export function getUserType() {
 }
 
 export function findOrCreateStableId() {
-  const statsig_stable_id_element = document.querySelector(
-    'script[data-statsig-stable-id]'
-  );
-  return statsig_stable_id_element.dataset.statsigStableId;
+  const scriptTag = document.querySelector('script[data-statsig-stable-id]');
+  return scriptTag?.dataset?.statsigStableId || null;
 }
 
 export function formatUserId(userId) {

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -135,6 +135,7 @@ class ActivitiesController < ApplicationController
           user: current_user,
           event_name: 'TA Rubric Student AI Level Submitted',
           metadata: metadata,
+          session: session,
         )
         EvaluateRubricJob.perform_later(user_id: current_user.id, requester_id: current_user.id, script_level_id: @script_level.id)
       end

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -135,7 +135,6 @@ class ActivitiesController < ApplicationController
           user: current_user,
           event_name: 'TA Rubric Student AI Level Submitted',
           metadata: metadata,
-          session: session,
         )
         EvaluateRubricJob.perform_later(user_id: current_user.id, requester_id: current_user.id, script_level_id: @script_level.id)
       end

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -86,6 +86,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
         user: current_user,
         event_name: 'lti_section_created_non_lti',
         metadata: metadata,
+        session: session,
       )
     end
     # Add all coteachers specified in params

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -86,7 +86,6 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
         user: current_user,
         event_name: 'lti_section_created_non_lti',
         metadata: metadata,
-        session: session,
       )
     end
     # Add all coteachers specified in params

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -28,7 +28,8 @@ class ApplicationController < ActionController::Base
 
   before_action :clear_sign_up_session_vars
 
-  before_action :initialize_statsig_stable_id
+  helper_method :statsig_stable_id
+  before_action :statsig_stable_id
 
   around_action :with_global_current_user
 
@@ -405,9 +406,8 @@ class ApplicationController < ActionController::Base
   end
 
   # Creates a statsig stable id for use of signed-out user tracking.
-  # This cookie is used by the Statsig SDK for both JS and Ruby.
-  protected def initialize_statsig_stable_id
-    cookies[:statsig_stable_id] ||= {value: SecureRandom.uuid, domain: :all, path: '/'}
+  protected def statsig_stable_id
+    session[:statsig_stable_id] ||= SecureRandom.uuid
   end
 
   private def pairing_still_enabled

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -17,7 +17,7 @@ class HomeController < ApplicationController
   # The terms_and_privacy page gets loaded in an iframe on the signup page, so skip
   # clearing the sign up tracking variables
   skip_before_action :clear_sign_up_session_vars, only: [:terms_and_privacy]
-  skip_before_action :initialize_statsig_stable_id, only: [:health_check]
+  skip_before_action :statsig_stable_id, only: [:health_check]
 
   def set_locale
     redirect_path = if params[:i18npath]

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -51,6 +51,7 @@ module Lti
             user: existing_user,
             event_name: 'lti_user_signin',
             metadata: metadata,
+            session: session,
           )
           target_url = session[:user_return_to] || home_path
           flash[:notice] = I18n.t('lti.account_linking.successfully_linked')

--- a/dashboard/app/controllers/lti/v1/sections_controller.rb
+++ b/dashboard/app/controllers/lti/v1/sections_controller.rb
@@ -26,7 +26,8 @@ module Lti
             Metrics::Events.log_event(
               user: current_user,
               event_name: 'lti_section_owner_changed',
-              metadata: metadata
+              metadata: metadata,
+              session: session,
             )
           end
         end

--- a/dashboard/app/controllers/lti/v1/sections_controller.rb
+++ b/dashboard/app/controllers/lti/v1/sections_controller.rb
@@ -26,8 +26,7 @@ module Lti
             Metrics::Events.log_event(
               user: current_user,
               event_name: 'lti_section_owner_changed',
-              metadata: metadata,
-              session: session,
+              metadata: metadata
             )
           end
         end

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -431,7 +431,7 @@ class LtiV1Controller < ApplicationController
         lms_name: platform_name,
       }
       Metrics::Events.log_event(
-        request: request,
+        session: session,
         event_name: 'lti_portal_registration_completed',
         metadata: metadata,
       )

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -189,6 +189,7 @@ class LtiV1Controller < ApplicationController
           user: user,
           event_name: 'lti_user_signin',
           metadata: metadata,
+          session: session,
         )
 
         # Add user's lti_user_identity to deployment if it doesn't exist
@@ -363,6 +364,7 @@ class LtiV1Controller < ApplicationController
       user: current_user,
       event_name: event_name,
       metadata: metadata,
+      session: session,
     )
 
     result[:course_name] = nrps_response.dig(:context, :title)
@@ -434,6 +436,7 @@ class LtiV1Controller < ApplicationController
         request: request,
         event_name: 'lti_portal_registration_completed',
         metadata: metadata,
+        session: session,
       )
     end
     render 'lti/v1/integration_status'
@@ -509,6 +512,7 @@ class LtiV1Controller < ApplicationController
       user: user,
       event_name: 'lti_account_linking_page_visit',
       metadata: metadata,
+      session: session,
     )
   end
 end

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -189,7 +189,6 @@ class LtiV1Controller < ApplicationController
           user: user,
           event_name: 'lti_user_signin',
           metadata: metadata,
-          session: session,
         )
 
         # Add user's lti_user_identity to deployment if it doesn't exist
@@ -364,7 +363,6 @@ class LtiV1Controller < ApplicationController
       user: current_user,
       event_name: event_name,
       metadata: metadata,
-      session: session,
     )
 
     result[:course_name] = nrps_response.dig(:context, :title)
@@ -436,7 +434,6 @@ class LtiV1Controller < ApplicationController
         request: request,
         event_name: 'lti_portal_registration_completed',
         metadata: metadata,
-        session: session,
       )
     end
     render 'lti/v1/integration_status'
@@ -512,7 +509,6 @@ class LtiV1Controller < ApplicationController
       user: user,
       event_name: 'lti_account_linking_page_visit',
       metadata: metadata,
-      session: session,
     )
   end
 end

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -540,7 +540,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         user: user,
         event_name: 'lti_user_signin',
         metadata: metadata,
-        session: session,
       )
       flash[:notice] = I18n.t('lti.account_linking.successfully_linked')
       sign_in_and_redirect user and return

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -540,6 +540,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         user: user,
         event_name: 'lti_user_signin',
         metadata: metadata,
+        session: session,
       )
       flash[:notice] = I18n.t('lti.account_linking.successfully_linked')
       sign_in_and_redirect user and return

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -188,6 +188,7 @@ class RegistrationsController < Devise::RegistrationsController
           user: current_user,
           event_name: 'lti_user_created',
           metadata: metadata,
+          session: session,
         )
       end
       has_school = current_user.school_info&.school_id.present?
@@ -199,6 +200,7 @@ class RegistrationsController < Devise::RegistrationsController
         event_name: 'Sign Up Finished Backend',
         metadata: event_metadata,
         get_enabled_experiments: true,
+        session: session,
       )
     end
   end

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -188,7 +188,6 @@ class RegistrationsController < Devise::RegistrationsController
           user: current_user,
           event_name: 'lti_user_created',
           metadata: metadata,
-          session: session,
         )
       end
       has_school = current_user.school_info&.school_id.present?
@@ -200,7 +199,6 @@ class RegistrationsController < Devise::RegistrationsController
         event_name: 'Sign Up Finished Backend',
         metadata: event_metadata,
         get_enabled_experiments: true,
-        session: session,
       )
     end
   end

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -203,7 +203,6 @@ class RubricsController < ApplicationController
         user: current_user,
         event_name: 'TA Rubric AI Eval started from section request',
         metadata: metadata,
-        session: session,
       )
       EvaluateRubricJob.perform_later(
         user_id: @user.id,

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -203,6 +203,7 @@ class RubricsController < ApplicationController
         user: current_user,
         event_name: 'TA Rubric AI Eval started from section request',
         metadata: metadata,
+        session: session,
       )
       EvaluateRubricJob.perform_later(
         user_id: @user.id,

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -40,6 +40,8 @@
     %script{data: {'statsig-api-client-key': CDO.safe_statsig_api_client_key}}
     -# auth key needed for statsig analytics
     %script{data: {'statsig-api-client-key-session-replay': CDO.safe_statsig_api_client_key_session_replay}}
+    -# statsig_stable_id is used to identify signed-out users in statsig
+    %script{data: {'statsig-stable-id': statsig_stable_id}}
     -# for statsig to recognized managed test server
     %script{data: {'managed-test-server': managed_test_server}}
     -# user id and type for analytics logging- may not work for cached pages

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -339,10 +339,6 @@ Devise.setup do |config|
     auth.cookies[environment_specific_cookie_name("_shortName")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_experiments")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_assumed_identity")] = {value: "", expires: Time.at(0), domain: :all, httponly: true}
-    # statsig_stable_id is set in the application controller so it's available for
-    # all users, both signed-in and signed-out. When the user logs out, we remove
-    # this cookie because it is user-specific.
-    auth.cookies[:statsig_stable_id] = {value: "", expires: Time.at(0), domain: :all}
 
     # These marketing cookies are set in the home_controller in init_homepage. When the user logs out, we
     # remove these cookies because they are user-specific. The cookies are set in init_homepage instead of after_set_user

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -349,9 +349,9 @@ Devise.setup do |config|
   end
 
   OmniAuth.config.before_request_phase do |env|
-    request = Rack::Request.new(env)
+    session = env['rack.session']
     Metrics::Events.log_event(
-      request: request,
+      session: session,
       event_name: "#{env['omniauth.strategy'].options[:name]}-begin-auth",
     )
   end

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -28,11 +28,11 @@ module Metrics
       # @metadata - a metadata hash with relevant data (optional)
       # @get_enabled_experiments - include list of experiements the user is enrolled in (optional)
       # @request - the request hash (optional)
-      def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false, request: nil)
+      def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false, session: nil)
         event_value = event_name if event_value.nil?
         enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
-        statsig_stable_id = request&.cookies&.[]('statsig_stable_id')
+        statsig_stable_id = session&[:statsig_stable_id]
 
         if CDO.rack_env?(:development)
           log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments, statsig_stable_id: statsig_stable_id)

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -32,7 +32,7 @@ module Metrics
         event_value = event_name if event_value.nil?
         enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
-        statsig_stable_id = session&[:statsig_stable_id]
+        statsig_stable_id = session&.dig(:statsig_stable_id)
 
         if CDO.rack_env?(:development)
           log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments, statsig_stable_id: statsig_stable_id)

--- a/dashboard/test/integration/global_edition_test.rb
+++ b/dashboard/test/integration/global_edition_test.rb
@@ -48,7 +48,7 @@ class GlobalEditionTest < ActionDispatch::IntegrationTest
 
           expect(Metrics::Events).to have_received(:log_event).with(
             event_name: 'Global Edition Region Selected',
-            request: anything,
+            session: anything,
             metadata: {
               region: ge_region,
               locale: ge_region_locale,
@@ -189,7 +189,7 @@ class GlobalEditionTest < ActionDispatch::IntegrationTest
 
           expect(Metrics::Events).not_to have_received(:log_event).with(
             event_name: 'Global Edition Region Selected',
-            request: anything,
+            session: anything,
             metadata: anything,
           )
 
@@ -210,7 +210,7 @@ class GlobalEditionTest < ActionDispatch::IntegrationTest
 
             expect(Metrics::Events).to have_received(:log_event).with(
               event_name: 'Global Edition Region Selected',
-              request: anything,
+              session: anything,
               metadata: {
                 region: nil,
                 locale: locale,

--- a/shared/middleware/varnish_environment.rb
+++ b/shared/middleware/varnish_environment.rb
@@ -85,10 +85,9 @@ class VarnishEnvironment < Sinatra::Base
     end
 
     def log_ge_region_select_event(ge_region)
-      session = request.session
       Metrics::Events.log_event(
         event_name: 'Global Edition Region Selected',
-        session: session,
+        session: request.session,
         metadata: {
           region: ge_region,
           locale: param_locale,

--- a/shared/middleware/varnish_environment.rb
+++ b/shared/middleware/varnish_environment.rb
@@ -85,9 +85,10 @@ class VarnishEnvironment < Sinatra::Base
     end
 
     def log_ge_region_select_event(ge_region)
+      session = request.session
       Metrics::Events.log_event(
         event_name: 'Global Edition Region Selected',
-        request: request,
+        session: session,
         metadata: {
           region: ge_region,
           locale: param_locale,


### PR DESCRIPTION
📝 PR Overview

This PR updates how we capture signed-out user metrics in order to align with our cookie policy and fix a OneTrust integration issue.

🔍 Background

Previously, we used a `statsig_stable_id` cookie to uniquely identify user sessions for Statsig. This allowed Statsig to stitch anonymous events (signed-out users) and associate them with a signed-in user later.

However:
- This broke OneTrust functionality ([Jira ticket](https://codedotorg.atlassian.net/browse/P20-1454))
- It did not comply with our cookie policy, which requires user consent for cookies we set

✅ What this PR changes

To address the above, we now:
- Store the `statsig_stable_id` in the server-side session (instead of a cookie)
- Pass the stable ID to the frontend via a <script> tag, following established conventions

This approach preserves the ability to capture anonymous user metrics without violating cookie restrictions or breaking OneTrust.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira https://codedotorg.atlassian.net/browse/P20-1505
- OneTrust Jira: https://codedotorg.atlassian.net/browse/P20-1454

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
