### PR TITLE
Use display_name_with_latest_year for workshop topic names

### DIFF
--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -93,7 +93,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
               location_name: @workshop.location_name,
               virtual: @workshop.virtual?,
               format: @workshop.format,
-              course_offerings: @workshop.course_offerings
+              course_offerings: @workshop.course_offerings.map(&:summarize_self_paced_pl)
             }
           ),
           workshop_location_for_calendar: @workshop.location_address.presence || @workshop.location_name,

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -31,7 +31,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
   end
 
   def course_offering_names
-    object.course_offerings&.map(&:display_name)&.sort&.join(', ')
+    object.course_offerings&.map(&:display_name_with_latest_year)&.sort&.join(', ')
   end
 
   def enrolled_teacher_count


### PR DESCRIPTION
The enrollment form, workshop edit page, and workshop index weren't always consistent in the name of topics for BYOW workshops. This is because some of these places were using the `display_name` from the database and some where using the CourseOffering helper function `display_name_with_latest_year`. This PR updates the instances called out to use the latter.

![Screenshot 2025-05-06 090227](https://github.com/user-attachments/assets/2a1a5a98-50e7-4276-83bd-3d50f57ed287)
![Screenshot 2025-05-06 090236](https://github.com/user-attachments/assets/fd80cad6-0652-4ac4-87b4-4703f04d2863)
![Screenshot 2025-05-06 090255](https://github.com/user-attachments/assets/f09a240a-839b-480c-b6a6-622e9dbd06b7)
