### PR TITLE
Evaluate Student Learning: switch levels_skills to use keys instead of ids

### DIFF
--- a/dashboard/app/models/levels_skill.rb
+++ b/dashboard/app/models/levels_skill.rb
@@ -2,13 +2,17 @@
 #
 # Table name: levels_skills
 #
-#  level_id :bigint           not null
-#  skill_id :bigint           not null
+#  id         :bigint           not null, primary key
+#  skill_key  :string(255)      not null
+#  level_key  :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #
-#  index_levels_skills_on_level_id_and_skill_id  (level_id,skill_id)
-#  index_levels_skills_on_skill_id_and_level_id  (skill_id,level_id)
+#  index_levels_skills_on_level_key                (level_key)
+#  index_levels_skills_on_skill_key                (skill_key)
+#  index_levels_skills_on_skill_key_and_level_key  (skill_key,level_key) UNIQUE
 #
 class LevelsSkill < ApplicationRecord
   belongs_to :level

--- a/dashboard/app/models/skill.rb
+++ b/dashboard/app/models/skill.rb
@@ -8,6 +8,11 @@
 #  concept             :string(255)
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  key                 :string(255)      not null
+#
+# Indexes
+#
+#  index_skills_on_key  (key) UNIQUE
 #
 class Skill < ApplicationRecord
   validates :description, presence: true

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -51,12 +51,12 @@
 #  primary_contact_info_id  :integer
 #  unlock_token             :string(255)
 #  cap_status               :string(1)
-#  cap_state_date           :datetime
+#  cap_status_date          :datetime
 #
 # Indexes
 #
 #  index_users_on_birthday                             (birthday)
-#  index_users_on_cap_state_and_cap_state_date         (cap_status,cap_state_date)
+#  index_users_on_cap_status_and_cap_status_date       (cap_status,cap_status_date)
 #  index_users_on_current_sign_in_at                   (current_sign_in_at)
 #  index_users_on_deleted_at                           (deleted_at)
 #  index_users_on_email_and_deleted_at                 (email,deleted_at)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -51,12 +51,12 @@
 #  primary_contact_info_id  :integer
 #  unlock_token             :string(255)
 #  cap_status               :string(1)
-#  cap_status_date          :datetime
+#  cap_state_date           :datetime
 #
 # Indexes
 #
 #  index_users_on_birthday                             (birthday)
-#  index_users_on_cap_status_and_cap_status_date       (cap_status,cap_status_date)
+#  index_users_on_cap_state_and_cap_state_date         (cap_status,cap_state_date)
 #  index_users_on_current_sign_in_at                   (current_sign_in_at)
 #  index_users_on_deleted_at                           (deleted_at)
 #  index_users_on_email_and_deleted_at                 (email,deleted_at)

--- a/dashboard/app/serializers/user_serializer.rb
+++ b/dashboard/app/serializers/user_serializer.rb
@@ -51,12 +51,12 @@
 #  primary_contact_info_id  :integer
 #  unlock_token             :string(255)
 #  cap_status               :string(1)
-#  cap_state_date           :datetime
+#  cap_status_date          :datetime
 #
 # Indexes
 #
 #  index_users_on_birthday                             (birthday)
-#  index_users_on_cap_state_and_cap_state_date         (cap_status,cap_state_date)
+#  index_users_on_cap_status_and_cap_status_date       (cap_status,cap_status_date)
 #  index_users_on_current_sign_in_at                   (current_sign_in_at)
 #  index_users_on_deleted_at                           (deleted_at)
 #  index_users_on_email_and_deleted_at                 (email,deleted_at)

--- a/dashboard/app/serializers/user_serializer.rb
+++ b/dashboard/app/serializers/user_serializer.rb
@@ -51,12 +51,12 @@
 #  primary_contact_info_id  :integer
 #  unlock_token             :string(255)
 #  cap_status               :string(1)
-#  cap_status_date          :datetime
+#  cap_state_date           :datetime
 #
 # Indexes
 #
 #  index_users_on_birthday                             (birthday)
-#  index_users_on_cap_status_and_cap_status_date       (cap_status,cap_status_date)
+#  index_users_on_cap_state_and_cap_state_date         (cap_status,cap_state_date)
 #  index_users_on_current_sign_in_at                   (current_sign_in_at)
 #  index_users_on_deleted_at                           (deleted_at)
 #  index_users_on_email_and_deleted_at                 (email,deleted_at)

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -4,6 +4,8 @@
   in_level_group ||= false
   left_align = local_assigns[:left_align]
   is_contained_level ||= false
+  teacher_markdown = "\n\n  <h3>Teaching Tips</h3> \n\n #{level.properties["teacher_markdown"]}" if level.properties["teacher_markdown"].present?
+  teacher_markdown += "\n\n  <h3>Example Solution</h3> \n\n #{level.solution}" if level.solution.present?
   js_data = {
     response_count: @responses&.first&.count || 0,
     is_contained_level: is_contained_level
@@ -12,7 +14,7 @@
 - if level.solution.present? && is_contained_level && Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
   %div{id: "containedLevelAnswer0"}
     .free-response{class: "contained"}
-      = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.solution}}
+      = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => teacher_markdown}}
 
 - if in_level_group || is_contained_level # The LevelGroup will collect results for each level.
   :javascript
@@ -61,7 +63,7 @@
   -# Don't render the dialog partial if we're inside a LevelGroup.
   - show_next_page_link = readonly && !level.submittable?
   = render partial: 'levels/dialog', locals: {app: 'free_response', next_level_link: @next_level_link, show_next_page_link: show_next_page_link} unless (in_level_group || is_contained_level)
-  = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.solution}} unless is_contained_level
+  = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => teacher_markdown}} unless is_contained_level
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/levels/_free_response.js'), data: {freeresponse: js_data.to_json}}

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -4,8 +4,6 @@
   in_level_group ||= false
   left_align = local_assigns[:left_align]
   is_contained_level ||= false
-  teacher_markdown = "\n\n  <h3>Teaching Tips</h3> \n\n #{level.properties["teacher_markdown"]}" if level.properties["teacher_markdown"].present?
-  teacher_markdown += "\n\n  <h3>Example Solution</h3> \n\n #{level.solution}" if level.solution.present?
   js_data = {
     response_count: @responses&.first&.count || 0,
     is_contained_level: is_contained_level
@@ -14,7 +12,7 @@
 - if level.solution.present? && is_contained_level && Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
   %div{id: "containedLevelAnswer0"}
     .free-response{class: "contained"}
-      = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => teacher_markdown}}
+      = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.solution}}
 
 - if in_level_group || is_contained_level # The LevelGroup will collect results for each level.
   :javascript
@@ -63,7 +61,7 @@
   -# Don't render the dialog partial if we're inside a LevelGroup.
   - show_next_page_link = readonly && !level.submittable?
   = render partial: 'levels/dialog', locals: {app: 'free_response', next_level_link: @next_level_link, show_next_page_link: show_next_page_link} unless (in_level_group || is_contained_level)
-  = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => teacher_markdown}} unless is_contained_level
+  = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.solution}} unless is_contained_level
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/levels/_free_response.js'), data: {freeresponse: js_data.to_json}}

--- a/dashboard/config/levels/custom/free_response/networks-internet-lesson5-level2_2025.level
+++ b/dashboard/config/levels/custom/free_response/networks-internet-lesson5-level2_2025.level
@@ -1,8 +1,7 @@
 <FreeResponse>
   <config><![CDATA[{
-  "published": true,
   "game_id": 52,
-  "created_at": "2025-04-02T16:35:54.000Z",
+  "created_at": "2025-03-22T01:35:34.000Z",
   "level_num": "custom",
   "user_id": 18602,
   "properties": {
@@ -17,11 +16,10 @@
     "skip_dialog": true,
     "skip_sound": true,
     "encrypted_solution": "YB6rZyrJaJe/N89yASFaXdEXdwCPc5nosEGbjaoeqTEqQbzd/PaiPsdRRiPl\nL8pxBBwh9d49AmyyF3pa06DwU97O0F7W3DA+oOy9qL8xKD6mFPmSDwgYTo1N\nlYf2yAoNTF1XvlGuKWSWpwEbj5nYD8Zxir3W9lhpB5lX5HuHEWXwatnWRteQ\nzrAofOSVVj1d8awVnawfzZcdM6/DUrla/4M1kCFjdddsfPq2y45NBUvdqNcs\nxuekjWQ+1QGtCRv9B1JA3/0TqAMEgrhrE8t9RN9NNhtJwEf3+MsivoOVGSEK\n1ozh+NLO2DnXKg/iVcdMNcbhmra07tp7hEhxRuUylQQTpF27q12yUAwpkQU4\nMfhl2RKbytwH3o3I8v64eiSQcSo7L8JBg3b2g0lile7biHWU4i0jbP12+3p8\nyhngaPt2i6KbQngC4lMRIhmbqJuro952VJlf2oURpll07BYdz0u55WjPAibT\ncqSKDRbnmDlUF0L9HwQC3a7JLEZ4uWOQrDACWPHGZZKwZVBEqPFqwFaDELbv\n7RT5sqKNXd+B+KjFT664v0R0oxGzbUtWQN/nKd02WkeQAdTnWSMBlLNUfQ==\n",
-    "name_suffix": "_2025",
-    "teacher_markdown": "This is some general advice for teachers.",
-    "stay_on_level_after_submit": "false"
+    "name_suffix": "_2025"
   },
-  "audit_log": "[{\"changed_at\":\"2025-03-22T01:35:34.920+00:00\",\"changed\":[\"cloned from \\\"networks-internet-lesson5-level2-2024\\\"\"],\"cloned_from\":\"networks-internet-lesson5-level2-2024\"},{\"changed_at\":\"2025-05-05 15:47:33 -0400\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"erin@email.com\"},{\"changed_at\":\"2025-05-05 19:03:11 -0400\",\"changed\":[\"teacher_markdown\"],\"changed_by_id\":1,\"changed_by_email\":\"erin@email.com\"}]",
+  "published": true,
+  "audit_log": "[{\"changed_at\":\"2025-03-22T01:35:34.920+00:00\",\"changed\":[\"cloned from \\\"networks-internet-lesson5-level2-2024\\\"\"],\"cloned_from\":\"networks-internet-lesson5-level2-2024\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>

--- a/dashboard/config/levels/custom/free_response/networks-internet-lesson5-level2_2025.level
+++ b/dashboard/config/levels/custom/free_response/networks-internet-lesson5-level2_2025.level
@@ -1,7 +1,8 @@
 <FreeResponse>
   <config><![CDATA[{
+  "published": true,
   "game_id": 52,
-  "created_at": "2025-03-22T01:35:34.000Z",
+  "created_at": "2025-04-02T16:35:54.000Z",
   "level_num": "custom",
   "user_id": 18602,
   "properties": {
@@ -16,10 +17,11 @@
     "skip_dialog": true,
     "skip_sound": true,
     "encrypted_solution": "YB6rZyrJaJe/N89yASFaXdEXdwCPc5nosEGbjaoeqTEqQbzd/PaiPsdRRiPl\nL8pxBBwh9d49AmyyF3pa06DwU97O0F7W3DA+oOy9qL8xKD6mFPmSDwgYTo1N\nlYf2yAoNTF1XvlGuKWSWpwEbj5nYD8Zxir3W9lhpB5lX5HuHEWXwatnWRteQ\nzrAofOSVVj1d8awVnawfzZcdM6/DUrla/4M1kCFjdddsfPq2y45NBUvdqNcs\nxuekjWQ+1QGtCRv9B1JA3/0TqAMEgrhrE8t9RN9NNhtJwEf3+MsivoOVGSEK\n1ozh+NLO2DnXKg/iVcdMNcbhmra07tp7hEhxRuUylQQTpF27q12yUAwpkQU4\nMfhl2RKbytwH3o3I8v64eiSQcSo7L8JBg3b2g0lile7biHWU4i0jbP12+3p8\nyhngaPt2i6KbQngC4lMRIhmbqJuro952VJlf2oURpll07BYdz0u55WjPAibT\ncqSKDRbnmDlUF0L9HwQC3a7JLEZ4uWOQrDACWPHGZZKwZVBEqPFqwFaDELbv\n7RT5sqKNXd+B+KjFT664v0R0oxGzbUtWQN/nKd02WkeQAdTnWSMBlLNUfQ==\n",
-    "name_suffix": "_2025"
+    "name_suffix": "_2025",
+    "teacher_markdown": "This is some general advice for teachers.",
+    "stay_on_level_after_submit": "false"
   },
-  "published": true,
-  "audit_log": "[{\"changed_at\":\"2025-03-22T01:35:34.920+00:00\",\"changed\":[\"cloned from \\\"networks-internet-lesson5-level2-2024\\\"\"],\"cloned_from\":\"networks-internet-lesson5-level2-2024\"}]",
+  "audit_log": "[{\"changed_at\":\"2025-03-22T01:35:34.920+00:00\",\"changed\":[\"cloned from \\\"networks-internet-lesson5-level2-2024\\\"\"],\"cloned_from\":\"networks-internet-lesson5-level2-2024\"},{\"changed_at\":\"2025-05-05 15:47:33 -0400\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"erin@email.com\"},{\"changed_at\":\"2025-05-05 19:03:11 -0400\",\"changed\":[\"teacher_markdown\"],\"changed_by_id\":1,\"changed_by_email\":\"erin@email.com\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>

--- a/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
+++ b/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
@@ -1,0 +1,6 @@
+class RenameCAPColumnsInUsers < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :cap_state, :cap_status
+    rename_column :users, :cap_state_date, :cap_status_date
+  end
+end

--- a/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
+++ b/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
@@ -1,6 +1,0 @@
-class RenameCAPColumnsInUsers < ActiveRecord::Migration[6.1]
-  def change
-    rename_column :users, :cap_state, :cap_status
-    rename_column :users, :cap_state_date, :cap_status_date
-  end
-end

--- a/dashboard/db/migrate/20250421191829_create_skills.rb
+++ b/dashboard/db/migrate/20250421191829_create_skills.rb
@@ -1,5 +1,6 @@
 class CreateSkills < ActiveRecord::Migration[6.1]
   def change
+    drop_table :skills if ActiveRecord::Base.connection.table_exists?(:skills)
     create_table :skills do |t|
       t.string :description, null: false
       t.text :evaluation_criteria

--- a/dashboard/db/migrate/20250423171750_create_join_table_level_skills.rb
+++ b/dashboard/db/migrate/20250423171750_create_join_table_level_skills.rb
@@ -1,5 +1,6 @@
 class CreateJoinTableLevelSkills < ActiveRecord::Migration[6.1]
   def change
+    drop_table :levels_skills if ActiveRecord::Base.connection.table_exists?(:levels_skills)
     create_join_table :levels, :skills do |t|
       t.index [:level_id, :skill_id]
       t.index [:skill_id, :level_id]

--- a/dashboard/db/migrate/20250506144135_add_key_to_skills.rb
+++ b/dashboard/db/migrate/20250506144135_add_key_to_skills.rb
@@ -1,0 +1,6 @@
+class AddKeyToSkills < ActiveRecord::Migration[6.1]
+  def change
+    add_column :skills, :key, :string, null: false
+    add_index :skills, :key, unique: true
+  end
+end

--- a/dashboard/db/migrate/20250506144736_add_keys_to_levels_skills.rb
+++ b/dashboard/db/migrate/20250506144736_add_keys_to_levels_skills.rb
@@ -1,0 +1,16 @@
+class AddKeysToLevelsSkills < ActiveRecord::Migration[6.1]
+  def change
+    drop_table :levels_skills, if_exists: true
+
+    create_table :levels_skills do |t|
+      t.string :skill_key, null: false
+      t.string :level_key, null: false
+
+      t.timestamps
+    end
+
+    add_index :levels_skills, :skill_key
+    add_index :levels_skills, :level_key
+    add_index :levels_skills, [:skill_key, :level_key], unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ai_interaction_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "ai_interaction_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id"
     t.integer "script_id"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["user_id", "level_id", "script_id"], name: "index_acs_user_level_script"
   end
 
-  create_table "aidiff_message_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "aidiff_message_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "aidiff_message_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "approval"
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["aidiff_message_id"], name: "index_aidiff_message_feedbacks_on_aidiff_message_id", unique: true
   end
 
-  create_table "aidiff_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "aidiff_messages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "aidiff_thread_id", null: false
     t.text "external_id", null: false
     t.integer "role", null: false
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["aidiff_thread_id"], name: "index_aidiff_messages_on_aidiff_thread_id"
   end
 
-  create_table "aidiff_threads", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "aidiff_threads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "external_id", null: false
     t.text "llm_version", null: false
@@ -953,7 +953,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "levels_skills", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "levels_skills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "skill_key", null: false
     t.string "level_key", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -997,7 +997,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lti_deployment_id", null: false
     t.bigint "lti_user_identity_id", null: false
     t.index ["lti_deployment_id"], name: "index_lti_deployments_user_identities_on_lti_deployment_id"
@@ -2163,7 +2163,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
   end
 
-  create_table "skills", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "skills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "description", null: false
     t.text "evaluation_criteria"
     t.string "concept"
@@ -2220,7 +2220,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
-  create_table "student_work_evaluation_summaries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "student_work_evaluation_summaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "student_work_evaluation_id", null: false
     t.bigint "student_work_evaluation_summary_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -2229,7 +2229,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["student_work_evaluation_summary_id"], name: "fk_rails_d50fa61780"
   end
 
-  create_table "student_work_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "student_work_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.integer "student_id"
     t.integer "requester_id"
@@ -2356,7 +2356,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["user_id"], name: "index_user_geos_on_user_id"
   end
 
-  create_table "user_level_interactions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_level_interactions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -2418,7 +2418,7 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.index ["user_id", "permission"], name: "index_user_permissions_on_user_id_and_permission", unique: true
   end
 
-  create_table "user_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_preferences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.json "section_order"
     t.datetime "created_at", precision: 6, null: false
@@ -2568,9 +2568,9 @@ ActiveRecord::Schema.define(version: 2025_05_06_144736) do
     t.integer "primary_contact_info_id"
     t.string "unlock_token"
     t.string "cap_status", limit: 1
-    t.datetime "cap_state_date"
+    t.datetime "cap_status_date"
     t.index ["birthday"], name: "index_users_on_birthday"
-    t.index ["cap_status", "cap_state_date"], name: "index_users_on_cap_state_and_cap_state_date"
+    t.index ["cap_status", "cap_status_date"], name: "index_users_on_cap_status_and_cap_status_date"
     t.index ["current_sign_in_at"], name: "index_users_on_current_sign_in_at"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email", "deleted_at"], name: "index_users_on_email_and_deleted_at"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_04_24_231217) do
+ActiveRecord::Schema.define(version: 2025_05_06_144736) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ai_interaction_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "ai_interaction_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id"
     t.integer "script_id"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["user_id", "level_id", "script_id"], name: "index_acs_user_level_script"
   end
 
-  create_table "aidiff_message_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aidiff_message_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "aidiff_message_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "approval"
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["aidiff_message_id"], name: "index_aidiff_message_feedbacks_on_aidiff_message_id", unique: true
   end
 
-  create_table "aidiff_messages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aidiff_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "aidiff_thread_id", null: false
     t.text "external_id", null: false
     t.integer "role", null: false
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["aidiff_thread_id"], name: "index_aidiff_messages_on_aidiff_thread_id"
   end
 
-  create_table "aidiff_threads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aidiff_threads", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "external_id", null: false
     t.text "llm_version", null: false
@@ -953,11 +953,14 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "levels_skills", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
-    t.bigint "level_id", null: false
-    t.bigint "skill_id", null: false
-    t.index ["level_id", "skill_id"], name: "index_levels_skills_on_level_id_and_skill_id"
-    t.index ["skill_id", "level_id"], name: "index_levels_skills_on_skill_id_and_level_id"
+  create_table "levels_skills", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "skill_key", null: false
+    t.string "level_key", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["level_key"], name: "index_levels_skills_on_level_key"
+    t.index ["skill_key", "level_key"], name: "index_levels_skills_on_skill_key_and_level_key", unique: true
+    t.index ["skill_key"], name: "index_levels_skills_on_skill_key"
   end
 
   create_table "libraries", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -994,7 +997,7 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "lti_deployment_id", null: false
     t.bigint "lti_user_identity_id", null: false
     t.index ["lti_deployment_id"], name: "index_lti_deployments_user_identities_on_lti_deployment_id"
@@ -2160,12 +2163,14 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
   end
 
-  create_table "skills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "skills", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "description", null: false
     t.text "evaluation_criteria"
     t.string "concept"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "key", null: false
+    t.index ["key"], name: "index_skills_on_key", unique: true
   end
 
   create_table "stages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -2215,7 +2220,7 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
-  create_table "student_work_evaluation_summaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "student_work_evaluation_summaries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "student_work_evaluation_id", null: false
     t.bigint "student_work_evaluation_summary_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -2224,7 +2229,7 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["student_work_evaluation_summary_id"], name: "fk_rails_d50fa61780"
   end
 
-  create_table "student_work_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "student_work_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.integer "student_id"
     t.integer "requester_id"
@@ -2351,7 +2356,7 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["user_id"], name: "index_user_geos_on_user_id"
   end
 
-  create_table "user_level_interactions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_level_interactions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -2413,7 +2418,7 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.index ["user_id", "permission"], name: "index_user_permissions_on_user_id_and_permission", unique: true
   end
 
-  create_table "user_preferences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.json "section_order"
     t.datetime "created_at", precision: 6, null: false
@@ -2563,9 +2568,9 @@ ActiveRecord::Schema.define(version: 2025_04_24_231217) do
     t.integer "primary_contact_info_id"
     t.string "unlock_token"
     t.string "cap_status", limit: 1
-    t.datetime "cap_status_date"
+    t.datetime "cap_state_date"
     t.index ["birthday"], name: "index_users_on_birthday"
-    t.index ["cap_status", "cap_status_date"], name: "index_users_on_cap_status_and_cap_status_date"
+    t.index ["cap_status", "cap_state_date"], name: "index_users_on_cap_state_and_cap_state_date"
     t.index ["current_sign_in_at"], name: "index_users_on_current_sign_in_at"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email", "deleted_at"], name: "index_users_on_email_and_deleted_at"


### PR DESCRIPTION
Alternate for https://codedotorg.atlassian.net/browse/TEACH-1796 and https://github.com/code-dot-org/code-dot-org/pull/65473

We need to keep levelbuilder and prod ids in sync for Skills and LevelsSkills. 

Since Levels already have unique [keys](https://github.com/code-dot-org/code-dot-org/blob/d20679084fd984484424e4822d1bcd6e40363ad0/dashboard/app/models/levels/level.rb#L380) we can accomplish this by adding keys to Skills and then joining on skill and level keys for LevelsSkills. 