### PR TITLE
[Codebridge] Use hideTooltip when dropdowns close

### DIFF
--- a/apps/src/codebridge/Settings/SettingsButton.tsx
+++ b/apps/src/codebridge/Settings/SettingsButton.tsx
@@ -2,6 +2,7 @@ import {Button} from '@code-dot-org/component-library/button';
 import {
   WithTooltip,
   TooltipProps,
+  WithTooltipHandle,
 } from '@code-dot-org/component-library/tooltip';
 import React, {useCallback, useRef, useState} from 'react';
 
@@ -12,9 +13,11 @@ import SettingsDropdown from './SettingsDropdown';
 const SettingsButton: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = useState(false);
   const buttonContainerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<WithTooltipHandle>(null);
 
   const closeSettings = useCallback(() => {
     setIsOpen(false);
+    tooltipRef.current?.hideTooltip(); // Hide tooltip when dropdown closes.
   }, []);
 
   const settingsTooltipProps: TooltipProps = {
@@ -26,7 +29,7 @@ const SettingsButton: React.FunctionComponent = () => {
 
   return (
     <div ref={buttonContainerRef}>
-      <WithTooltip tooltipProps={settingsTooltipProps}>
+      <WithTooltip tooltipProps={settingsTooltipProps} ref={tooltipRef}>
         <Button
           isIconOnly
           icon={{iconStyle: 'solid', iconName: 'gear'}}

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
@@ -2,6 +2,7 @@ import {Button} from '@code-dot-org/component-library/button';
 import {
   WithTooltip,
   TooltipProps,
+  WithTooltipHandle,
 } from '@code-dot-org/component-library/tooltip';
 import React, {useCallback, useRef, useState} from 'react';
 
@@ -38,6 +39,7 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
   );
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
   const buttonContainerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<WithTooltipHandle>(null);
 
   // The version history button is generally disabled in read only mode with two exceptions:
   // if the user is viewing an old version of the project, or if this is a teacher viewing
@@ -80,6 +82,7 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
     setIsVersionListLoaded(false);
     setLoadError(false);
     setLoading(false);
+    tooltipRef.current?.hideTooltip(); // Hide tooltip when dropdown closes.
   }, []);
 
   const tooltipProps: TooltipProps = {
@@ -91,7 +94,7 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
 
   return (
     <div ref={buttonContainerRef}>
-      <WithTooltip tooltipProps={tooltipProps}>
+      <WithTooltip tooltipProps={tooltipProps} ref={tooltipRef}>
         <Button
           isIconOnly
           icon={{iconStyle: 'solid', iconName: 'history'}}

--- a/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
@@ -44,6 +44,13 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
     const hideTimeoutRef = useRef<number | null>(null);
     const suppressNextFocusRef = useRef(false);
 
+    const clearHideTimeout = () => {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+        hideTimeoutRef.current = null;
+      }
+    };
+
     // Define the additional event handlers
     const handleShowTooltip = (
       show: boolean,
@@ -55,10 +62,7 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
         return;
       }
       setShowTooltip(show);
-      if (hideTimeoutRef.current) {
-        clearTimeout(hideTimeoutRef.current);
-        hideTimeoutRef.current = null;
-      }
+      clearHideTimeout();
       if (!isTooltip) {
         setNodePosition(show ? (event.target as HTMLElement) : null);
       }
@@ -73,9 +77,7 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
 
     useImperativeHandle(ref, () => ({
       hideTooltip: () => {
-        if (hideTimeoutRef.current) {
-          clearTimeout(hideTimeoutRef.current);
-        }
+        clearHideTimeout();
         setShowTooltip(false);
         setNodePosition(null);
         suppressNextFocusRef.current = true;


### PR DESCRIPTION
This PR follows up https://github.com/code-dot-org/code-dot-org/pull/65670 and uses the now available `hideTooltip` handle to hide the tooltip when the settings/version history dropdown dialogs close.

## Before update

https://github.com/user-attachments/assets/d725f07d-19bc-4337-98d1-96bb5c8a53a6


## After update

https://github.com/user-attachments/assets/7e0a6505-0c53-4dfd-a5c3-581815c3c1dd

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
