### PR TITLE
feat(marketing): increase task size, task count and add autoscaling

### DIFF
--- a/aws/cloudformation/standalone/marketing/deployment/config.rb
+++ b/aws/cloudformation/standalone/marketing/deployment/config.rb
@@ -3,26 +3,35 @@ require "ostruct"
 module Config
   REGIONS = {
     'us-east-2': {
-      availability_zones: %w[us-east-2a us-east-2b],
+      availability_zones: %w[us-east-2a us-east-2b us-east-2c],
       vpc: {
         public_subnets: [
           {
             availability_zone: 'us-east-2a',
-            cidr_block: '10.0.0.0/18'
+            cidr_block: '10.0.0.0/21'
           },
           {
             availability_zone: 'us-east-2b',
-            cidr_block: '10.0.64.0/18'
-          }
+            cidr_block: '10.0.8.0/21'
+          },
+          {
+            availability_zone: 'us-east-2c',
+            cidr_block: '10.0.16.0/21'
+          },
+
         ],
         private_subnets: [
           {
             availability_zone: 'us-east-2a',
-            cidr_block: '10.0.128.0/18'
+            cidr_block: '10.0.128.0/21'
           },
           {
             availability_zone: 'us-east-2b',
-            cidr_block: '10.0.192.0/18'
+            cidr_block: '10.0.136.0/21'
+          },
+          {
+            availability_zone: 'us-east-2c',
+            cidr_block: '10.0.144.0/21'
           }
         ]
       }

--- a/aws/cloudformation/standalone/marketing/deployment/github.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/github.yml.erb
@@ -48,6 +48,11 @@ Resources:
               Fn::ImportValue: !Sub "${MarketingApplicationStackName}-FargateServiceTaskDefTaskRoleArn"
           - Effect: Allow
             Action:
+              - 'iam:GetRole'
+            Resource:
+              Fn::ImportValue: !Sub "${MarketingApplicationStackName}-ECSAutoScalingRoleArn"
+          - Effect: Allow
+            Action:
               - 'ecs:RegisterTaskDefinition'
             Resource: !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/MarketingStackStagingFargateServiceTaskDef:*"
           - Effect: Allow

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -785,6 +785,14 @@ Outputs:
     Export:
       Name:
         'Fn::Sub': '${AWS::StackName}-StaticAssetsBucketArn'
+  ECSAutoScalingRoleArn:
+    Value:
+      Fn::GetAtt:
+        - ECSAutoScalingRole
+        - Arn
+    Export:
+      Name:
+        'Fn::Sub': '${AWS::StackName}-ECSAutoScalingRoleArn'
   FargateServiceLoadBalancerDNS:
     Value:
       Fn::GetAtt:

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -343,13 +343,13 @@ Resources:
               ValueFrom: 'arn:aws:secretsmanager:us-west-2:165336972514:secret:development/marketing/90t6bu6vlf76/contentful-fOz371:STATSIG_CLIENT_KEY::'
             - Name: STATSIG_SERVER_KEY
               ValueFrom: 'arn:aws:secretsmanager:us-west-2:165336972514:secret:development/marketing/90t6bu6vlf76/contentful-fOz371:STATSIG_SERVER_KEY::'
-      Cpu: "256"
+      Cpu: "1024"
+      Memory: "2048"
       ExecutionRoleArn:
         Fn::GetAtt:
           - FargateServiceTaskDefExecutionRole
           - Arn
       Family: !Sub "${AWS::StackName}-FargateServiceTaskDef"
-      Memory: "512"
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
@@ -404,6 +404,8 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
+      DesiredCount: 3
+      AvailabilityZoneRebalancing: ENABLED
       LoadBalancers:
         - ContainerName: web
           ContainerPort: 3000
@@ -457,6 +459,47 @@ Resources:
       ToPort: 3000
     DependsOn:
       - FargateServiceTaskDefTaskRole
+
+  ECSServiceScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: 20 # Upper limit for scaling, can be increased as needed
+      MinCapacity: 3 # High availability minimum
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref EcsCluster
+          - !GetAtt FargateService.Name
+      RoleARN: !GetAtt ECSAutoScalingRole.Arn
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+
+  ECSServiceScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: CpuTargetTrackingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref ECSServiceScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 70.0
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ECSServiceAverageCPUUtilization
+        ScaleInCooldown: 60 # Wait 60 seconds before scaling up
+        ScaleOutCooldown: 300 # Wait 5 minutes before scaling down
+
+  ECSAutoScalingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: application-autoscaling.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole
 
   StaticAssetsBucket:
     Type: AWS::S3::Bucket

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -465,11 +465,7 @@ Resources:
     Properties:
       MaxCapacity: 20 # Upper limit for scaling, can be increased as needed
       MinCapacity: 3 # High availability minimum
-      ResourceId: !Join
-        - '/'
-        - - "service"
-          - !Ref EcsCluster
-          - !GetAtt FargateService.Name
+      ResourceId: !Sub "service/${EcsCluster}/${FargateService.Name}"
       RoleARN: !GetAtt ECSAutoScalingRole.Arn
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs


### PR DESCRIPTION
This PR updates the number of tasks to a minimum of three to enable high availability. Additionally, it balances these tasks across AZs to ensure the tasks are spread out for high availability. Lastly, the task size is updated to consume 1 vCPU (for the single threaded Next.js app) and 2 GB of RAM.

Lastly, an autoscaling policy is added to allow scaling if the CPU >70% as per the load test results.

Full details on the load test results are available [here](https://docs.google.com/document/d/1H3HZ_Pgzj-eT6V2ikh85Rt9eq-sJssu9HtK4al-6_5Y/edit?tab=t.0).