### PR TITLE
add /_next/static/ path to the marketing function

### DIFF
--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -9,13 +9,15 @@ const marketingPaths = {
   // e.g. '/videos': true,
 }
 
+const nextJsAssetsPath = '/_next/static/';
+
 module.exports.handler = (event, context, callback) => {
   try {
     const request = event?.Records?.[0]?.cf?.request;
     const uri = request?.uri;
   
     // Set CMS origin if the requested path matches
-    if (marketingPaths[uri]) {
+    if (marketingPaths[uri] || (uri && uri.startsWith(nextJsAssetsPath))) {
       request.origin = {
         custom: {
           domainName: marketingDomain,


### PR DESCRIPTION
Using a Cloudfront cache behavior to directly route requests from the "outer" distribution to the "inner" marketing distribution doesn't work because the `Host` header needs to be modified. This isn't possible within a behavior configuration, but it can be done in the lambda@edge function. This PR adds the check for the `_next/static/*` path that we need to route to the marketing cluster. This is code that we've been adding manually in the adhocs used for testing the function.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/CMS-637)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
