### PR TITLE
Fix gamelab_loading_animations test

### DIFF
--- a/dashboard/test/ui/features/step_definitions/gamelab.rb
+++ b/dashboard/test/ui/features/step_definitions/gamelab.rb
@@ -31,7 +31,10 @@ When /^I (?:reset the game|press reset)$/ do
 end
 
 When /^I switch to(?: the)? animation (?:mode|tab)$/ do
-  steps 'When I press "animationMode"'
+  steps <<-STEPS
+    When I press "animationMode"
+    And I wait to see "#newListItem"
+  STEPS
 end
 
 When /^I switch to(?: the)? code (?:mode|tab) in Game Lab$/ do


### PR DESCRIPTION
The test `Chrome_star_labs_gamelab_loading_animations` has been failing on Drone a lot in the last few days ([example failure](https://app.saucelabs.com/tests/e94c540b21d64d57ab3611853f3d7461#23)). The issue seems to be trying to click a button before it exists. I updated the step to switch to the animation tab to wait for it to load, and it fixed the issue for me.

## Testing story
Tested via saucelabs. I could repro the issue against localhost, not against test. I also verified that other tests that use this step still pass.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
