### PR TITLE
feat(marketing): invalidate cache after deployment

### DIFF
--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -159,6 +159,14 @@ jobs:
         parameter-overrides: "ContainerImageHashDigest=${{ needs.build-and-push-image.outputs.digest }},BaseHostedZoneId=${{ vars.MARKETING_BASE_HOSTED_ZONE_ID }},BaseDomainName=${{ vars.MARKETING_BASE_DOMAIN }},SubdomainName=${{ vars.MARKETING_SUBDOMAIN_NAME }},CloudFrontTLSCertificateArn=${{ vars.MARKETING_CLOUDFRONT_TLS_CERTIFICATE_ARN }}"
         capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
 
+    - name: "[Test] Invalidate CloudFront Cache"
+      env:
+        CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBIUTION_ID }}
+      run: |
+        aws cloudfront create-invalidation \
+          --distribution-id $CLOUDFRONT_DISTRIBUTION_ID \
+          --paths "/*"
+
   ui-tests:
     runs-on: ubuntu-24.04
     environment: marketing-test

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -161,7 +161,7 @@ jobs:
 
     - name: "[Test] Invalidate CloudFront Cache"
       env:
-        CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBIUTION_ID }}
+        CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
       run: |
         aws cloudfront create-invalidation \
           --distribution-id $CLOUDFRONT_DISTRIBUTION_ID \

--- a/aws/cloudformation/standalone/marketing/deployment/github.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/github.yml.erb
@@ -81,6 +81,10 @@ Resources:
                 - "${StaticAssetsBucketArn}/*"
                 - StaticAssetsBucketArn:
                     Fn::ImportValue: !Sub "${MarketingApplicationStackName}-StaticAssetsBucketArn"
+          - Effect: Allow
+            Action:
+              - "cloudfront:CreateInvalidation"
+            Resource: !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution}'
 
   GithubDeployerAccessKey:
     Type: AWS::IAM::AccessKey

--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -794,3 +794,9 @@ Outputs:
       Fn::GetAtt:
         - FargateServiceLB
         - DNSName
+  CloudFrontDistributionId:
+    Value:
+      Ref: CloudFrontDistribution
+    Export:
+      Name:
+        'Fn::Sub': '${AWS::StackName}-CloudFrontDistributionId'

--- a/aws/cloudformation/standalone/marketing/deployment/render.rb
+++ b/aws/cloudformation/standalone/marketing/deployment/render.rb
@@ -32,6 +32,9 @@ puts "\nTransforming ERB to YAML for template 'cloudfront-certificates'..."
 puts "\nTransforming ERB to YAML for template 'marketing'..."
 `erb aws_region=#{options[:region]} -T - -r ./config.rb  marketing.yml.erb > marketing.yml `
 
+puts "\nTransforming ERB to YAML for template 'github'..."
+`erb aws_region=#{options[:region]} -T - -r ./config.rb  github.yml.erb > github.yml `
+
 if $?&.exitstatus == 0
   puts "Success!"
 else


### PR DESCRIPTION
After deploying the marketing app, invalidate the cache to ensure the live content reflects the deployed application.