### PR TITLE
Fix issue with class roster import on new homepage

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
@@ -8,6 +8,7 @@ import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import AddSectionDialog from '../../teacherDashboard/AddSectionDialog';
+import RosterDialog from '../../teacherDashboard/RosterDialog';
 import {beginEditingSection} from '../../teacherDashboard/teacherSectionsRedux';
 
 import {ArchiveAllModal} from './ArchiveAllModal';
@@ -85,6 +86,7 @@ export const Header: React.FC<HeaderProps> = ({
         </div>
       </div>
       <AddSectionDialog />
+      <RosterDialog />
     </div>
   );
 };


### PR DESCRIPTION
We did not include the RosterDialog component in the new teacher homepage which is required for creating a section with LTI integration. This update adds that component.

Roster Dialog on new homepage:
![image](https://github.com/user-attachments/assets/29f58808-d4ee-4a52-aab9-71fd4bfa9ccc)


## Links
[TEACH-1888](https://codedotorg.atlassian.net/browse/TEACH-1888)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
