### PR TITLE
Create a lesson summary csv

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1056,6 +1056,8 @@
   "doSomething": "do something",
   "download": "Download",
   "downloadCSV": "Download CSV",
+  "downloadLevelProgressCSV": "Download level progress CSV",
+  "downloadLessonProgressCSV": "Download lesson summary CSV",
   "downloadAssessmentCSV": "Download CSV of student responses",
   "downloadFeedbackCSV": "Download CSV of Feedback",
   "downloadParentLetter": "Download parent letter",

--- a/apps/src/templates/manageStudents/utils.ts
+++ b/apps/src/templates/manageStudents/utils.ts
@@ -1,11 +1,11 @@
 export function getFullName(student: {
   name: string;
-  familyName: string | null;
+  familyName?: string | null;
 }): string;
 export function getFullName(name: string, familyName?: string): string;
 
 export function getFullName(
-  studentOrName: {name: string; familyName: string | null} | string,
+  studentOrName: {name: string; familyName?: string | null} | string,
   familyName?: string
 ): string {
   if (typeof studentOrName === 'string') {

--- a/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
+++ b/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
@@ -1,8 +1,4 @@
-import {LinkButton} from '@code-dot-org/component-library/button';
-import {
-  TooltipOverlay,
-  WithTooltip,
-} from '@code-dot-org/component-library/tooltip';
+import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
 import React from 'react';
 import {useSelector} from 'react-redux';
 
@@ -20,31 +16,61 @@ export const DownloadProgressCsv: React.FC = () => {
     state => state.teacherSections.selectedSectionId
   );
 
+  const getDownloadUrl = React.useCallback(
+    (type: string) =>
+      `/teacher_dashboard/sections/${sectionId}/download_progress_csv?unit_id=${unitId}&type=${type}`,
+    [sectionId, unitId]
+  );
+
   return (
-    <TooltipOverlay>
-      <WithTooltip
-        tooltipOverlayClassName={styles.downloadCsv}
-        tooltipProps={{
-          tooltipId: 'csv-download-tooltip',
-          role: 'tooltip',
-          text: i18n.downloadProgressCsv(),
-          direction: 'onTop',
-          size: 'm',
-        }}
-      >
-        <LinkButton
-          href={`/teacher_dashboard/sections/${sectionId}/download_progress_csv?unit_id=${unitId}&type=level`}
-          download={true}
-          isIconOnly={true}
-          icon={{iconName: 'download', iconStyle: 'solid'}}
-          size="s"
-          color="gray"
-          aria-label={i18n.downloadCSV()}
-          type="secondary"
-          target="_blank"
-        />
-      </WithTooltip>
-    </TooltipOverlay>
+    <CustomDropdown
+      name="download-progress-csv"
+      labelText={i18n.downloadProgressCsv()}
+      size="s"
+      useDSCOButtonAsTrigger={true}
+      menuPlacement="right"
+      triggerButtonProps={{
+        isIconOnly: true,
+        icon: {
+          iconName: 'download',
+          iconStyle: 'solid',
+        },
+        color: 'gray',
+        type: 'secondary',
+        size: 's',
+        ariaLabel: i18n.sectionOptionsDropdown(),
+        className: styles.downloadCsvDropdown,
+      }}
+    >
+      <ul>
+        <li key="level">
+          <a
+            href={getDownloadUrl('level')}
+            aria-label={i18n.downloadCSV()}
+            type="secondary"
+            target="_blank"
+            rel="noreferrer"
+            download={true}
+            className={styles.dropdownMenuItem}
+          >
+            {i18n.downloadLevelProgressCSV()}
+          </a>
+        </li>
+        <li key="lesson">
+          <a
+            href={getDownloadUrl('lesson')}
+            aria-label={i18n.downloadCSV()}
+            type="secondary"
+            target="_blank"
+            rel="noreferrer"
+            download={true}
+            className={styles.dropdownMenuItem}
+          >
+            {i18n.downloadLessonProgressCSV()}
+          </a>
+        </li>
+      </ul>
+    </CustomDropdown>
   );
 };
 

--- a/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
+++ b/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
@@ -1,8 +1,10 @@
-import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
+import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
 import React from 'react';
 import {useSelector} from 'react-redux';
 
 import {getStore} from '@cdo/apps/redux';
+import {getFullName} from '@cdo/apps/templates/manageStudents/utils';
+import {Student} from '@cdo/apps/types/redux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
@@ -12,25 +14,47 @@ import styles from './progress-table-v2.module.scss';
 
 const downloadLessonProgressCSV = () => {
   const store = getStore();
-  const unitData = getCurrentUnitData(store.getState());
+  const unitData = getCurrentUnitData(store.getState()) as {
+    lessons: {title: string; name: string; id: number}[];
+  };
+
   const unitId = store.getState().unitSelection.scriptId;
 
   const lessonProgressByStudent =
     store.getState().sectionProgress.studentLessonProgressByUnit[unitId];
 
-  const students = store.getState().teacherSections.selectedStudents;
+  const students = store.getState().teacherSections
+    .selectedStudents as Student[];
 
-  const columnNames = ['Student_Name'];
+  const columnNames = [
+    'Student_Name',
+    ...unitData.lessons.map(lesson => lesson.title),
+  ];
 
-  console.log('lfm', {unitData, lessonProgressByStudent, students});
-  const table = students.map((student: {name: string}) => ({
-    Student_Name: student.name,
-  }));
+  const table = students.map(student => {
+    const lessonProgress = lessonProgressByStudent[student.id];
+
+    let lessonData = {};
+
+    unitData.lessons.forEach(lesson => {
+      const progress = lessonProgress[lesson.id];
+      const percent = progress ? Math.round(progress.completedPercent) : '0';
+
+      lessonData = {...lessonData, [lesson.title]: percent + '%'};
+    });
+
+    return {
+      Student_Name: getFullName(student),
+      ...lessonData,
+    };
+  });
 
   downloadCSV(`lesson_progress_${unitId}.csv`, columnNames, table);
-  console.log('lfm', {unitData, lessonProgressByStudent});
 };
 
+// A custom CSV download function that sets up a fake URL with the CSV and triggers a download
+// We are using this instead of `react-csv` because we want to create the CSV when the user clicks the button
+// and not when the component mounts.
 const downloadCSV = (
   fileName: string,
   columnNames: string[],
@@ -71,11 +95,28 @@ export const DownloadProgressCsv: React.FC = () => {
   );
 
   return (
-    <CustomDropdown
+    <ActionDropdown
       name="download-progress-csv"
       labelText={i18n.downloadProgressCsv()}
       size="s"
-      useDSCOButtonAsTrigger={true}
+      options={[
+        {
+          label: i18n.downloadLessonProgressCSV(),
+          icon: {iconName: 'download', iconStyle: 'solid'},
+          value: 'lesson',
+          onClick: () => {
+            downloadLessonProgressCSV();
+          },
+        },
+        {
+          label: i18n.downloadLevelProgressCSV(),
+          icon: {iconName: 'download', iconStyle: 'solid'},
+          value: 'level',
+          onClick: () => {
+            window.open(getDownloadUrl('level'), '_blank');
+          },
+        },
+      ]}
       menuPlacement="right"
       triggerButtonProps={{
         isIconOnly: true,
@@ -89,41 +130,7 @@ export const DownloadProgressCsv: React.FC = () => {
         ariaLabel: i18n.sectionOptionsDropdown(),
         className: styles.downloadCsvDropdown,
       }}
-    >
-      <ul>
-        <li key="lesson test">
-          <button onClick={downloadLessonProgressCSV} type="button">
-            test download lesson
-          </button>
-        </li>
-        <li key="level">
-          <a
-            href={getDownloadUrl('level')}
-            aria-label={i18n.downloadCSV()}
-            type="secondary"
-            target="_blank"
-            rel="noreferrer"
-            download={true}
-            className={styles.dropdownMenuItem}
-          >
-            {i18n.downloadLevelProgressCSV()}
-          </a>
-        </li>
-        <li key="lesson">
-          <a
-            href={getDownloadUrl('lesson')}
-            aria-label={i18n.downloadCSV()}
-            type="secondary"
-            target="_blank"
-            rel="noreferrer"
-            download={true}
-            className={styles.dropdownMenuItem}
-          >
-            {i18n.downloadLessonProgressCSV()}
-          </a>
-        </li>
-      </ul>
-    </CustomDropdown>
+    />
   );
 };
 

--- a/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
+++ b/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
@@ -4,7 +4,6 @@ import {useSelector} from 'react-redux';
 
 import {getStore} from '@cdo/apps/redux';
 import {getFullName} from '@cdo/apps/templates/manageStudents/utils';
-import {Student} from '@cdo/apps/types/redux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
@@ -12,20 +11,18 @@ import {getCurrentUnitData} from '../sectionProgress/sectionProgressRedux';
 
 import styles from './progress-table-v2.module.scss';
 
-const downloadLessonProgressCSV = () => {
-  const store = getStore();
-  const unitData = getCurrentUnitData(store.getState()) as {
+// Export for testing only
+export const getLessonProgressCSVData = (
+  students: {id: number; name: string; familyName?: string}[],
+  unitData: {
     lessons: {title: string; name: string; id: number}[];
-  };
-
-  const unitId = store.getState().unitSelection.scriptId;
-
-  const lessonProgressByStudent =
-    store.getState().sectionProgress.studentLessonProgressByUnit[unitId];
-
-  const students = store.getState().teacherSections
-    .selectedStudents as Student[];
-
+    name: string;
+    id: number;
+  },
+  lessonProgressByStudent: {
+    [studentId: number]: {[lessonId: number]: {completedPercent: number}};
+  }
+) => {
   const columnNames = [
     'Student_Name',
     ...unitData.lessons.map(lesson => lesson.title),
@@ -48,8 +45,28 @@ const downloadLessonProgressCSV = () => {
       ...lessonData,
     };
   });
+  return {unitName: unitData.name, columnNames, table};
+};
 
-  downloadCSV(`lesson_progress_${unitId}.csv`, columnNames, table);
+const downloadLessonProgressCSV = () => {
+  const store = getStore();
+  const unitData = getCurrentUnitData(store.getState()) as {
+    lessons: {title: string; name: string; id: number}[];
+    name: string;
+    id: number;
+  };
+
+  const lessonProgressByStudent =
+    store.getState().sectionProgress.studentLessonProgressByUnit[unitData.id];
+
+  const students = store.getState().teacherSections.selectedStudents;
+
+  const {unitName, columnNames, table} = getLessonProgressCSVData(
+    students,
+    unitData,
+    lessonProgressByStudent
+  );
+  downloadCSV(`lesson_progress_${unitName}.csv`, columnNames, table);
 };
 
 // A custom CSV download function that sets up a fake URL with the CSV and triggers a download
@@ -79,7 +96,9 @@ const downloadCSV = (
   URL.revokeObjectURL(url);
 };
 
-export const DownloadProgressCsv: React.FC = () => {
+interface DownloadProgressCsvProps {}
+
+export const DownloadProgressCsv: React.FC<DownloadProgressCsvProps> = () => {
   const unitId = useSelector(
     (state: {unitSelection: {scriptId: number}}) => state.unitSelection.scriptId
   );

--- a/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
+++ b/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
@@ -2,10 +2,58 @@ import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
 import React from 'react';
 import {useSelector} from 'react-redux';
 
+import {getStore} from '@cdo/apps/redux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
+import {getCurrentUnitData} from '../sectionProgress/sectionProgressRedux';
+
 import styles from './progress-table-v2.module.scss';
+
+const downloadLessonProgressCSV = () => {
+  const store = getStore();
+  const unitData = getCurrentUnitData(store.getState());
+  const unitId = store.getState().unitSelection.scriptId;
+
+  const lessonProgressByStudent =
+    store.getState().sectionProgress.studentLessonProgressByUnit[unitId];
+
+  const students = store.getState().teacherSections.selectedStudents;
+
+  const columnNames = ['Student_Name'];
+
+  console.log('lfm', {unitData, lessonProgressByStudent, students});
+  const table = students.map(student => ({
+    Student_Name: student.name,
+  }));
+
+  downloadCSV(`lesson_progress_${unitId}.csv`, columnNames, table);
+  console.log('lfm', {unitData, lessonProgressByStudent});
+};
+
+const downloadCSV = (
+  fileName: string,
+  columnNames: string[],
+  table: {[columnName: string]: string}[]
+) => {
+  const csvString = [
+    columnNames,
+    ...table.map(row => columnNames.map(columnName => row[columnName])),
+  ]
+    .map(row => row.join(','))
+    .join('\n');
+
+  const blob = new Blob([csvString], {type: 'text/csv'});
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
 
 export const DownloadProgressCsv: React.FC = () => {
   const unitId = useSelector(
@@ -43,6 +91,11 @@ export const DownloadProgressCsv: React.FC = () => {
       }}
     >
       <ul>
+        <li key="lesson test">
+          <button onClick={downloadLessonProgressCSV} type="button">
+            test download lesson
+          </button>
+        </li>
         <li key="level">
           <a
             href={getDownloadUrl('level')}

--- a/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
+++ b/apps/src/templates/sectionProgressV2/DownloadProgressCsv.tsx
@@ -23,7 +23,7 @@ const downloadLessonProgressCSV = () => {
   const columnNames = ['Student_Name'];
 
   console.log('lfm', {unitData, lessonProgressByStudent, students});
-  const table = students.map(student => ({
+  const table = students.map((student: {name: string}) => ({
     Student_Name: student.name,
   }));
 

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -176,40 +176,6 @@ $level-cell-width: 52;
     width: 32px;
     height: 32px;
   }
-
-  .dropdownMenuItem {
-    /* Reset's every elements apperance */
-    background: none repeat scroll 0 0 transparent;
-    border: none !important;
-    border-radius: 0;
-    border-spacing: 0;
-    list-style: none outside none;
-    margin: 0;
-    text-decoration: none;
-    text-indent: 0;
-    box-shadow: none;
-    flex-grow: 1;
-
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-
-    @include typography.body-four;
-    color: var(--neutral-base-black);
-    margin-bottom: 0;
-
-    padding: 0.125rem 0.625rem 0.125rem 0.5rem;
-    gap: 0.25rem;
-
-    &:active {
-      border: 0 !important;
-    }
-
-    &:hover {
-      color: var(--neutral-base-black);
-      text-decoration: none;
-    }
-  }
 }
 
 .lesson {

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -1,3 +1,5 @@
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 @import 'color.scss';
 
 .progressV2Page {
@@ -167,11 +169,46 @@ $level-cell-width: 52;
     }
   }
 
-  .downloadCsv {
+  // CSV download button
+  .downloadCsvDropdown {
     display: flex;
     margin-inline-start: 5px;
-    height: 32px;
     width: 32px;
+    height: 32px;
+  }
+
+  .dropdownMenuItem {
+    /* Reset's every elements apperance */
+    background: none repeat scroll 0 0 transparent;
+    border: none !important;
+    border-radius: 0;
+    border-spacing: 0;
+    list-style: none outside none;
+    margin: 0;
+    text-decoration: none;
+    text-indent: 0;
+    box-shadow: none;
+    flex-grow: 1;
+
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+
+    @include typography.body-four;
+    color: var(--neutral-base-black);
+    margin-bottom: 0;
+
+    padding: 0.125rem 0.625rem 0.125rem 0.5rem;
+    gap: 0.25rem;
+
+    &:active {
+      border: 0 !important;
+    }
+
+    &:hover {
+      color: var(--neutral-base-black);
+      text-decoration: none;
+    }
   }
 }
 

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -122,50 +122,6 @@
   height: 32px;
 }
 
-.dropdownMenuItem {
-  /* Reset's every elements apperance */
-  background: none repeat scroll 0 0 transparent;
-  border: none !important;
-  border-radius: 0;
-  border-spacing: 0;
-  list-style: none outside none;
-  margin: 0;
-  text-decoration: none;
-  text-indent: 0;
-  box-shadow: none;
-  flex-grow: 1;
-
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  color: var(--neutral-base-black);
-
-  padding: 0.5rem 1rem 0.5rem 0.75rem;
-  gap: 0.75rem;
-
-  &:active {
-    border: 0 !important;
-  }
-
-  &:hover {
-    color: var(--neutral-base-black);
-    text-decoration: none;
-  }
-
-  i {
-    font-size: 1.1875rem;
-    line-height: 125%;
-    width: 1.5rem;
-    text-align: center;
-  }
-
-  span {
-    @include typography.body-two;
-    color: inherit;
-    margin-bottom: 0;
-  }
-}
-
 // SectionCardBody
 .sectionCardBody {
   padding: 0 16px 16px 16px;

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -122,6 +122,50 @@
   height: 32px;
 }
 
+.dropdownMenuItem {
+  /* Reset's every elements apperance */
+  background: none repeat scroll 0 0 transparent;
+  border: none !important;
+  border-radius: 0;
+  border-spacing: 0;
+  list-style: none outside none;
+  margin: 0;
+  text-decoration: none;
+  text-indent: 0;
+  box-shadow: none;
+  flex-grow: 1;
+
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--neutral-base-black);
+
+  padding: 0.5rem 1rem 0.5rem 0.75rem;
+  gap: 0.75rem;
+
+  &:active {
+    border: 0 !important;
+  }
+
+  &:hover {
+    color: var(--neutral-base-black);
+    text-decoration: none;
+  }
+
+  i {
+    font-size: 1.1875rem;
+    line-height: 125%;
+    width: 1.5rem;
+    text-align: center;
+  }
+
+  span {
+    @include typography.body-two;
+    color: inherit;
+    margin-bottom: 0;
+  }
+}
+
 // SectionCardBody
 .sectionCardBody {
   padding: 0 16px 16px 16px;

--- a/apps/test/unit/templates/sectionProgressV2/DownloadProgressCsvTest.tsx
+++ b/apps/test/unit/templates/sectionProgressV2/DownloadProgressCsvTest.tsx
@@ -1,0 +1,78 @@
+import {getLessonProgressCSVData} from '@cdo/apps/templates/sectionProgressV2/DownloadProgressCsv';
+import {Student} from '@cdo/apps/types/redux';
+
+describe('getLessonProgressCSVData', () => {
+  it('creates empty CSV data when there are no students or lessons', () => {
+    const students: Student[] = [];
+    const unitData = {
+      lessons: [],
+      name: 'csp4-2025',
+      id: 123,
+    };
+    const lessonProgressByStudent = {};
+
+    const result = getLessonProgressCSVData(
+      students,
+      unitData,
+      lessonProgressByStudent
+    );
+
+    expect(result.columnNames).toEqual(['Student_Name']);
+    expect(result.table).toEqual([]);
+    expect(result.unitName).toEqual('csp4-2025');
+  });
+
+  it('formats data correctly for two students and two lessons', () => {
+    const students = [
+      {id: 101, name: 'Alice', familyName: 'Smith'},
+      {id: 102, name: 'Bob', familyName: 'Jones'},
+    ];
+
+    const unitData = {
+      id: 123,
+      name: 'csp4-2025',
+      lessons: [
+        {id: 1001, title: 'Lesson One', name: 'lesson_one'},
+        {id: 1002, title: 'Lesson Two', name: 'lesson_two'},
+      ],
+    };
+
+    const lessonProgressByStudent = {
+      101: {
+        1001: {completedPercent: 100},
+        1002: {completedPercent: 0},
+      },
+      102: {
+        1001: {completedPercent: 50},
+        1002: {completedPercent: 75},
+      },
+    };
+
+    const result = getLessonProgressCSVData(
+      students,
+      unitData,
+      lessonProgressByStudent
+    );
+
+    expect(result.columnNames).toEqual([
+      'Student_Name',
+      'Lesson One',
+      'Lesson Two',
+    ]);
+
+    expect(result.table).toEqual([
+      {
+        Student_Name: 'Alice Smith',
+        'Lesson One': '100%',
+        'Lesson Two': '0%',
+      },
+      {
+        Student_Name: 'Bob Jones',
+        'Lesson One': '50%',
+        'Lesson Two': '75%',
+      },
+    ]);
+
+    expect(result.unitName).toEqual('csp4-2025');
+  });
+});

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -75,45 +75,21 @@ class TeacherDashboardController < ApplicationController
   end
 
   def download_progress_csv
-    return :bad_request unless params[:unit_id]
     type = params[:type]
 
-    return head :bad_request unless ['level', 'lesson'].include?(type)
+    return head :bad_request unless type == 'level'
 
     level_progress_csv if type == 'level'
-
-    lesson_progress_csv if type == 'lesson'
-  end
-
-  private def lesson_progress_csv
-    deduplicated_students = @section.students.distinct
-
-    progress_table = deduplicated_students.map do |student|
-      {student_name: student.family_name ? "#{student.name} #{student.family_name}" : student.name, student_id: student.id}
-    end
-
-    headers = ['Student Name']
-    send_data(
-      CSV.generate do |csv|
-        csv << headers
-        progress_table.each do |data_row|
-          csv << [data_row[:student_name]]
-        end
-      end,
-      filename: 'lesson_progress.csv',
-      disposition: 'attachment',
-      type: 'text/csv',
-    )
   end
 
   private def level_progress_csv
+    return :bad_request unless params[:unit_id]
+
     unit = Unit.get_from_cache(params[:unit_id])
 
     deduplicated_students = @section.students.distinct
 
     student_progress = script_progress_for_users(deduplicated_students, unit)[0]
-
-    pp 'lfm', student_progress
 
     level_names, progress_table = get_csv_level_data(unit, deduplicated_students, student_progress)
 

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -113,6 +113,8 @@ class TeacherDashboardController < ApplicationController
 
     student_progress = script_progress_for_users(deduplicated_students, unit)[0]
 
+    pp 'lfm', student_progress
+
     level_names, progress_table = get_csv_level_data(unit, deduplicated_students, student_progress)
 
     headers = ['Student Name'].concat(level_names)

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -75,16 +75,38 @@ class TeacherDashboardController < ApplicationController
   end
 
   def download_progress_csv
+    return :bad_request unless params[:unit_id]
     type = params[:type]
 
-    return head :bad_request unless type == 'level'
+    return head :bad_request unless ['level', 'lesson'].include?(type)
 
     level_progress_csv if type == 'level'
+
+    lesson_progress_csv if type == 'lesson'
+  end
+
+  private def lesson_progress_csv
+    deduplicated_students = @section.students.distinct
+
+    progress_table = deduplicated_students.map do |student|
+      {student_name: student.family_name ? "#{student.name} #{student.family_name}" : student.name, student_id: student.id}
+    end
+
+    headers = ['Student Name']
+    send_data(
+      CSV.generate do |csv|
+        csv << headers
+        progress_table.each do |data_row|
+          csv << [data_row[:student_name]]
+        end
+      end,
+      filename: 'lesson_progress.csv',
+      disposition: 'attachment',
+      type: 'text/csv',
+    )
   end
 
   private def level_progress_csv
-    return :bad_request unless params[:unit_id]
-
     unit = Unit.get_from_cache(params[:unit_id])
 
     deduplicated_students = @section.students.distinct


### PR DESCRIPTION
Changes the `download level csv` into a dropdown with level and lesson options.
Downloads a lesson summary CSV with lesson completion percentages. See the results from a section below
 
![image](https://github.com/user-attachments/assets/14ace3a5-928b-4d44-8a45-a92912a098d2)

Progress page for section: 
![image](https://github.com/user-attachments/assets/44c4802a-db48-4ab4-a8ab-0c27d9f7b5e9)

CSV for section:
![image](https://github.com/user-attachments/assets/9cd6d649-08d9-441e-bb67-c71ee5a25eab)

[lesson_progress_492.csv](https://github.com/user-attachments/files/20087321/lesson_progress_492.csv)

Change in tactics: This PR changes the structure from the[ level CSV PR ](https://github.com/code-dot-org/code-dot-org/pull/65561). I initially chose to create the CSV on the BE because `react-csv`, the 3rd-party library that we currently use on the FE to create CSVs did not allow creation of the CSV on button click. The CSV would have to be created on component mount or use some react trickery using refs that is not ideal and confusing. 

However, the BE does not actually have the logic to create the lesson progress data structures, this is all done on the FE in [progressHelpers](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/progress/progressHelpers.js#L255) from the level data. I did not want to recreate this logic on the BE, so I changed back to using FE csv creation.

Instead of using `react-csv` this uses a custom react downloader. Using suggestions from [this](https://dev.to/graciesharma/implementing-csv-data-export-in-react-without-external-libraries-3030) post, in just 10 lines or so, we can create a csv. This has the benefit of using vanilla JS concepts like [createObjectURL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static) and gives us more control over when the csv is created.

Follow up work: Change the level csv creation from BE to FE again.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 
https://codedotorg.atlassian.net/browse/TEACH-1048
