### PR TITLE
feat(workshops): clear MultiSelectInput on selection

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInput/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInput/index.tsx
@@ -64,13 +64,11 @@ export const MultiSelectInput: React.FC<{
 
   const filteredOptions = useMemo(
     () =>
-      options
-        .filter(option =>
-          option.searchText.some(text =>
-            text.toLowerCase().includes(searchText.toLowerCase())
-          )
+      options.filter(option =>
+        option.searchText.some(text =>
+          text.toLowerCase().includes(searchText.toLowerCase())
         )
-        .slice(0, 100), // Limiting to 100 options for performance
+      ),
     [options, searchText]
   );
 
@@ -99,21 +97,14 @@ export const MultiSelectInput: React.FC<{
     }
   }, [activeIndex, filteredOptions, menuOpen]);
 
-  useEffect(() => {
-    if (activeIndex < 0 && searchText) {
-      setActiveIndex(0);
-    }
-  }, [activeIndex, searchText]);
-
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const {value} = e.currentTarget;
     setSearchText(value);
-    setActiveIndex(-1);
     if (!menuOpen && value) {
       setMenuOpen(true);
     }
     if (!value) {
-      reset();
+      setActiveIndex(-1);
     }
   };
 
@@ -167,10 +158,15 @@ export const MultiSelectInput: React.FC<{
           setActiveIndex(prev => Math.max(prev - 1, 0));
           break;
         case 'Enter':
+          // when filtering the options, Enter selects the first option
+          if (activeIndex < 0 && searchText && filteredOptions[0]) {
+            handleToggleOption(filteredOptions[0].id);
+          }
+        // fallthrough is intentional
+        // Space and Enter act the same when an option is active
+        // eslint-disable-next-line no-fallthrough
         case ' ':
           if (activeIndex >= 0 && filteredOptions[activeIndex]) {
-            // Add a check to ensure an item is actually highlighted
-            e.preventDefault(); // Prevent the default action (change event)
             handleToggleOption(filteredOptions[activeIndex].id);
           }
           break;
@@ -219,6 +215,7 @@ export const MultiSelectInput: React.FC<{
         onClick={e => {
           e.preventDefault();
           e.stopPropagation();
+          if (!menuOpen) setMenuOpen(true);
           inputRef.current?.focus();
         }}
       >
@@ -264,7 +261,6 @@ export const MultiSelectInput: React.FC<{
               onChange={handleInputChange}
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
-              onClick={() => setMenuOpen(true)}
               onKeyDown={handleInputKeyDown}
               role="combobox"
               aria-autocomplete="list"

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInput/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInput/index.tsx
@@ -77,13 +77,14 @@ export const MultiSelectInput: React.FC<{
     [options]
   );
 
-  const activeDescendant = useMemo(
-    () =>
-      activeIndex >= 0 && filteredOptions[activeIndex]
-        ? `${id}-option-${filteredOptions[activeIndex].id}`
-        : undefined,
-    [activeIndex, filteredOptions, id]
-  );
+  const activeDescendant = useMemo(() => {
+    if (activeIndex >= 0 && filteredOptions[activeIndex]) {
+      return `${id}-option-${filteredOptions[activeIndex].id}`;
+    }
+    if (filteredOptions.length === 1) {
+      return `${id}-option-${filteredOptions[0].id}`;
+    }
+  }, [activeIndex, filteredOptions, id]);
 
   // scrolls option into view
   // activeIndex is set when navigating the option menu
@@ -158,8 +159,8 @@ export const MultiSelectInput: React.FC<{
           setActiveIndex(prev => Math.max(prev - 1, 0));
           break;
         case 'Enter':
-          // when filtering the options, Enter selects the first option
-          if (activeIndex < 0 && searchText && filteredOptions[0]) {
+          // when filtering results in a single option, Enter selects it
+          if (activeIndex < 0 && searchText && filteredOptions.length === 1) {
             handleToggleOption(filteredOptions[0].id);
           }
         // fallthrough is intentional
@@ -292,7 +293,8 @@ export const MultiSelectInput: React.FC<{
               {filteredOptions.length > 0 ? (
                 filteredOptions.map((option, i) => {
                   const selected = isOptionSelected(option.id);
-                  const optionFocused = activeIndex === i;
+                  const optionFocused =
+                    activeIndex === i || filteredOptions.length === 1;
                   const optionHovered = isOptionHovered(option.id);
                   const optionHtmlId = `${id}-option-${option.id}`;
 

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInput/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInput/index.tsx
@@ -8,6 +8,8 @@ import {BodyThreeText} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import React, {useState, useRef, useEffect, useCallback, useMemo} from 'react';
 
+import useOutsideClick from '@cdo/apps/util/hooks/useOutsideClick';
+
 import styles from './styles.module.scss';
 
 export type OptionId = string | number;
@@ -20,6 +22,7 @@ export interface Option {
 }
 
 export const MultiSelectInput: React.FC<{
+  name: string;
   label: string;
   options: Option[];
   selectedOptions: OptionId[];
@@ -31,6 +34,7 @@ export const MultiSelectInput: React.FC<{
   emptyStateMessage?: string;
   errorMessage?: string;
 }> = ({
+  name,
   label,
   options,
   selectedOptions,
@@ -45,20 +49,28 @@ export const MultiSelectInput: React.FC<{
   const [searchText, setSearchText] = useState('');
   const [menuOpen, setMenuOpen] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
-  const [focusedOptionId, setFocusedOptionId] = useState<OptionId | null>(null);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const [hoveredOptionId, setHoveredOptionId] = useState<OptionId | null>(null);
 
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const reset = () => {
+    setMenuOpen(false);
+    setSearchText('');
+    setActiveIndex(-1);
+  };
+
   const inputRef = useRef<HTMLInputElement>(null);
-  const optionRefs = useRef<Map<OptionId, HTMLDivElement>>(new Map());
+  const wrapperRef = useOutsideClick<HTMLDivElement>(reset);
+  const optionRefs = useRef<Map<OptionId, HTMLLIElement>>(new Map());
 
   const filteredOptions = useMemo(
     () =>
-      options.filter(option =>
-        option.searchText.some(text =>
-          text.toLowerCase().includes(searchText.toLowerCase())
+      options
+        .filter(option =>
+          option.searchText.some(text =>
+            text.toLowerCase().includes(searchText.toLowerCase())
+          )
         )
-      ),
+        .slice(0, 100), // Limiting to 100 options for performance
     [options, searchText]
   );
 
@@ -67,56 +79,47 @@ export const MultiSelectInput: React.FC<{
     [options]
   );
 
-  // sets focus and scrolls option into view
-  // focusedOptionId is set when navigating the option menu
+  const activeDescendant = useMemo(
+    () =>
+      activeIndex >= 0 && filteredOptions[activeIndex]
+        ? `${id}-option-${filteredOptions[activeIndex].id}`
+        : undefined,
+    [activeIndex, filteredOptions, id]
+  );
+
+  // scrolls option into view
+  // activeIndex is set when navigating the option menu
   // via keyboard interaction
   useEffect(() => {
-    if (focusedOptionId !== null && menuOpen) {
-      const activeElement = optionRefs.current.get(focusedOptionId ?? '');
-      if (activeElement instanceof HTMLDivElement) {
-        activeElement.scrollIntoView({behavior: 'smooth', block: 'nearest'});
-        activeElement.focus();
-      }
+    if (activeIndex >= 0 && filteredOptions[activeIndex] && menuOpen) {
+      const activeElement = optionRefs.current.get(
+        filteredOptions[activeIndex].id ?? ''
+      );
+      activeElement?.scrollIntoView({behavior: 'smooth', block: 'nearest'});
     }
-  }, [focusedOptionId, menuOpen]);
+  }, [activeIndex, filteredOptions, menuOpen]);
 
-  // clear the focusedOptionId when the option menu is closed
   useEffect(() => {
-    if (!menuOpen) {
-      setFocusedOptionId(null);
+    if (activeIndex < 0 && searchText) {
+      setActiveIndex(0);
     }
-  }, [menuOpen]);
-
-  // listen for clicks outside the component to close the option menu
-  // removes the listener when the component unmounts
-  useEffect(() => {
-    const handleClickOutside = (event: Event) => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(event.target as Node)
-      ) {
-        closeMenu({skipFocus: true});
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleClickOutside);
-    };
-  }, []);
+  }, [activeIndex, searchText]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchText(e.target.value);
-    if (!menuOpen) {
+    const {value} = e.currentTarget;
+    setSearchText(value);
+    setActiveIndex(-1);
+    if (!menuOpen && value) {
       setMenuOpen(true);
-    } else if (!e.target.value) {
-      closeMenu({skipFocus: true});
+    }
+    if (!value) {
+      reset();
     }
   };
 
   const handleToggleOption = (optionId: OptionId) => {
+    setSearchText('');
+    setActiveIndex(-1);
     setSelectedOptions(
       selectedOptions.includes(optionId)
         ? selectedOptions.filter(id => id !== optionId)
@@ -130,99 +133,63 @@ export const MultiSelectInput: React.FC<{
 
   const handleClearAll = () => {
     setSelectedOptions([]);
-    closeMenu();
+    reset();
   };
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    switch (e.key) {
-      case 'Enter':
-        if (menuOpen && searchText && filteredOptions.length > 0) {
-          const option = filteredOptions[0];
-          handleToggleOption(option.id);
-          setSearchText('');
-        }
-        break;
-      case 'ArrowDown':
+    const {key} = e;
+
+    // Open menu on ArrowDown/ArrowUp if closed and there are options
+    if (!menuOpen && (key === 'ArrowDown' || key === 'ArrowUp')) {
+      if (filteredOptions.length > 0) {
         e.preventDefault();
         setMenuOpen(true);
-        setFocusedOptionId(filteredOptions[0]?.id ?? null);
-        break;
-      case 'ArrowUp':
-        e.preventDefault();
-        setMenuOpen(true);
-        setFocusedOptionId(
-          filteredOptions[filteredOptions.length - 1]?.id ?? null
-        );
-        break;
-      case 'Tab':
-        if (!anyOptionsSelected) {
-          closeMenu({skipFocus: true});
+        if (key === 'ArrowDown') {
+          setActiveIndex(0);
+        } else {
+          setActiveIndex(filteredOptions.length - 1);
         }
-        break;
-      case 'Escape':
-        closeMenu();
-        break;
-      case 'Backspace':
-        if (searchText === '' && selectedOptions[selectedOptions.length - 1]) {
-          handleToggleOption(selectedOptions[selectedOptions.length - 1]);
-        }
-        break;
+        return;
+      }
     }
-  };
 
-  const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (!filteredOptions.length) return;
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        setFocusedOptionId(prev =>
-          prev === null
-            ? filteredOptions[0]?.id ?? null
-            : filteredOptions[
-                Math.min(
-                  filteredOptions.findIndex(option => option.id === prev) + 1,
-                  filteredOptions.length - 1
-                )
-              ]?.id ?? null
-        );
-        break;
-      case 'ArrowUp':
-        e.preventDefault();
-        setFocusedOptionId(prev =>
-          prev === null
-            ? filteredOptions[filteredOptions.length - 1]?.id ?? null
-            : filteredOptions[
-                Math.max(
-                  filteredOptions.findIndex(option => option.id === prev) - 1,
-                  0
-                )
-              ]?.id ?? null
-        );
-        break;
-      // intentional fallthrough case
-      case 'Escape':
-      case 'Tab':
-        closeMenu({skipFocus: e.key === 'Tab'});
-        break;
+    // Handle navigation and selection if menu is open
+    if (menuOpen) {
+      switch (key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setActiveIndex(prev =>
+            Math.min(prev + 1, filteredOptions.length - 1)
+          );
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setActiveIndex(prev => Math.max(prev - 1, 0));
+          break;
+        case 'Enter':
+        case ' ':
+          if (activeIndex >= 0 && filteredOptions[activeIndex]) {
+            // Add a check to ensure an item is actually highlighted
+            e.preventDefault(); // Prevent the default action (change event)
+            handleToggleOption(filteredOptions[activeIndex].id);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          reset();
+          break;
+        case 'Tab':
+          reset();
+          break;
+      }
     }
-  };
 
-  const handleOptionKeyDown = (
-    e: React.KeyboardEvent<HTMLDivElement>,
-    id: OptionId
-  ) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleToggleOption(id);
-    }
-  };
-
-  const closeMenu = (options?: {skipFocus?: boolean}) => {
-    setMenuOpen(false);
-    setSearchText('');
-    setFocusedOptionId(null);
-    if (!options?.skipFocus) {
-      inputRef.current?.focus();
+    if (key === 'Backspace' && searchText === '') {
+      if (selectedOptions.length > 0) {
+        handleRemoveOption(selectedOptions[selectedOptions.length - 1]);
+      } else {
+        reset();
+      }
     }
   };
 
@@ -231,24 +198,14 @@ export const MultiSelectInput: React.FC<{
     [selectedOptions]
   );
 
-  const isOptionFocused = useCallback(
-    (id: OptionId) => focusedOptionId === id,
-    [focusedOptionId]
-  );
-
   const isOptionHovered = useCallback(
-    (id: OptionId) => hoveredOptionId === id,
-    [hoveredOptionId]
+    (id: OptionId) => hoveredOptionId === id && activeIndex < 0,
+    [hoveredOptionId, activeIndex]
   );
 
   const anyOptionsSelected = useMemo(
     () => selectedOptions.length > 0,
     [selectedOptions]
-  );
-
-  const activeDescendant = useMemo(
-    () => (focusedOptionId ? `${id}-option-${focusedOptionId}` : undefined),
-    [focusedOptionId, id]
   );
 
   return (
@@ -260,21 +217,15 @@ export const MultiSelectInput: React.FC<{
         size={size}
         errorMessage={errorMessage}
         onClick={e => {
-          // prevent label's native click event and stop propagation
           e.preventDefault();
           e.stopPropagation();
-          if (!menuOpen) {
-            inputRef.current?.focus();
-          }
+          inputRef.current?.focus();
         }}
       >
         <div
           className={classNames(styles.container, {
             [styles.focused]: isFocused,
           })}
-          role="combobox"
-          aria-controls={`${id}-listbox`}
-          aria-expanded={menuOpen}
           aria-haspopup="listbox"
         >
           <div className={styles.tagsAndSearchContainer}>
@@ -306,8 +257,8 @@ export const MultiSelectInput: React.FC<{
             <input
               className={styles.searchInput}
               ref={inputRef}
-              type="search"
               id={id}
+              name={name}
               placeholder={placeholder}
               value={searchText}
               onChange={handleInputChange}
@@ -315,11 +266,13 @@ export const MultiSelectInput: React.FC<{
               onBlur={() => setIsFocused(false)}
               onClick={() => setMenuOpen(true)}
               onKeyDown={handleInputKeyDown}
+              role="combobox"
               aria-autocomplete="list"
               aria-controls={`${id}-listbox`}
+              aria-expanded={menuOpen}
+              aria-activedescendant={activeDescendant}
               aria-labelledby={`${id}-label`}
-              aria-label="filter options"
-              autoComplete="off"
+              autoComplete="new-password"
             />
           </div>
           {anyOptionsSelected && (
@@ -331,37 +284,38 @@ export const MultiSelectInput: React.FC<{
           )}
 
           {menuOpen && (
-            <div
-              className={styles.multiSelectMenu}
+            <ul
+              className={classNames(styles.multiSelectMenu, {
+                [styles.keyboardNav]: activeIndex >= 0,
+              })}
               id={`${id}-listbox`}
               role="listbox"
-              aria-multiselectable
-              aria-activedescendant={activeDescendant}
+              aria-multiselectable="true"
               aria-labelledby={`${id}-label`}
-              tabIndex={-1}
-              onKeyDown={handleMenuKeyDown}
             >
               {filteredOptions.length > 0 ? (
                 filteredOptions.map((option, i) => {
                   const selected = isOptionSelected(option.id);
-                  const optionFocused = isOptionFocused(option.id);
+                  const optionFocused = activeIndex === i;
                   const optionHovered = isOptionHovered(option.id);
-                  const optionId = `${id}-option-${option.id}`;
+                  const optionHtmlId = `${id}-option-${option.id}`;
 
                   return (
-                    <div
+                    <li
                       key={option.id}
-                      id={optionId}
+                      id={optionHtmlId}
                       className={classNames(styles.option, {
-                        [styles.hover]: i === 0 && searchText.length,
+                        [styles.focused]: optionFocused,
                       })}
-                      onClick={() => handleToggleOption(option.id)}
-                      onKeyDown={e => handleOptionKeyDown(e, option.id)}
+                      onMouseDown={e => {
+                        e.preventDefault();
+                        handleToggleOption(option.id);
+                        inputRef.current?.focus();
+                      }}
                       onMouseEnter={() => setHoveredOptionId(option.id)}
                       onMouseLeave={() => setHoveredOptionId(null)}
                       role="option"
                       aria-selected={selected}
-                      tabIndex={-1}
                       ref={el =>
                         el
                           ? optionRefs.current.set(option.id, el)
@@ -383,15 +337,17 @@ export const MultiSelectInput: React.FC<{
                           aria-hidden
                         />
                       )}
-                    </div>
+                    </li>
                   );
                 })
               ) : (
-                <BodyThreeText className={styles.emptyState}>
-                  {emptyStateMessage}
-                </BodyThreeText>
+                <li>
+                  <BodyThreeText className={styles.emptyState}>
+                    {emptyStateMessage}
+                  </BodyThreeText>
+                </li>
               )}
-            </div>
+            </ul>
           )}
         </div>
       </FormFieldWrapper>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInput/styles.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInput/styles.module.scss
@@ -80,6 +80,13 @@
     overflow-y: auto;
     background-color: var(--background-neutral-primary);
     padding: 0.25rem 0;
+    margin: 0;
+
+    &:not(.keyboardNav) {
+      .option:hover {
+        background-color: var(--background-neutral-tertiary);
+      }
+    }
 
     .option {
       cursor: pointer;
@@ -89,9 +96,11 @@
       align-items: center;
       position: relative;
 
-      &:focus-visible {
+      &:focus-visible,
+      &.focused {
         @include focus-styles;
         outline-offset: -2px;
+        background-color: var(--background-neutral-tertiary);
       }
 
       .optionLabelText {
@@ -105,11 +114,6 @@
             color: var(--text-neutral-secondary);
           }
         }
-      }
-
-      &:hover,
-      &.hover {
-        background-color: var(--background-neutral-tertiary);
       }
     }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
@@ -108,6 +108,7 @@ export const PartnerFacilitator: FC<PartnerFacilitatorProps> = ({
               )}
             >
               <MultiSelectInput
+                name={fields.facilitators.stateKey}
                 label={fields.facilitators.label}
                 options={facilitatorOptions}
                 selectedOptions={facilitators}

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInputTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/MultiSelectInputTest.jsx
@@ -38,7 +38,7 @@ describe('MultiSelectInput', () => {
     window.HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
   });
 
-  const getInputElement = () => screen.getByRole('searchbox');
+  const getInputElement = () => screen.getByRole('combobox');
   const getMenuElement = () => screen.getByRole('listbox');
   const getOptionFromDropdown = optionText => {
     const listbox = getMenuElement();
@@ -67,7 +67,7 @@ describe('MultiSelectInput', () => {
 
       // Check if tags are rendered
       // Look for the tag container first
-      const multiSelectContainer = screen.getByRole('combobox');
+      const multiSelectContainer = screen.getByRole('combobox').parentNode;
       expect(
         within(multiSelectContainer).getByText('Option 1')
       ).toBeInTheDocument();
@@ -89,7 +89,8 @@ describe('MultiSelectInput', () => {
         'test-multiselect-listbox'
       );
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
-      expect(combobox).toHaveAttribute('aria-haspopup', 'listbox');
+      const popupContainer = combobox.closest('[aria-haspopup="listbox"]');
+      expect(popupContainer).toBeInTheDocument();
 
       const input = getInputElement();
       expect(input).toHaveAttribute('aria-autocomplete', 'list');
@@ -291,7 +292,7 @@ describe('MultiSelectInput', () => {
       expect(getOptionFromDropdown('Option 3')).toBeInTheDocument();
     });
 
-    it('selects a focused option on Enter or Space', async () => {
+    it('selects an active option on Enter or Space', async () => {
       const mockSetSelectedOptions = jest.fn();
       const user = userEvent.setup();
 
@@ -315,6 +316,7 @@ describe('MultiSelectInput', () => {
       expect(mockSetSelectedOptions).toHaveBeenCalledWith(['1']);
 
       // focus on second menu option
+      await user.keyboard('{ArrowDown}');
       await user.keyboard('{ArrowDown}');
 
       // press Space
@@ -444,14 +446,37 @@ describe('MultiSelectInput', () => {
       const listbox = getMenuElement();
       expect(listbox).toBeInTheDocument();
       let option1 = getOptionFromDropdown('Option 1');
-      expect(option1).toHaveFocus();
+      let option2 = getOptionFromDropdown('Option 2');
+      expect(option1).toHaveAttribute(
+        'class',
+        expect.stringContaining('focused')
+      );
+      expect(option2).not.toHaveAttribute(
+        'class',
+        expect.stringContaining('focused')
+      );
 
       await user.keyboard('{ArrowDown}');
-      let option2 = getOptionFromDropdown('Option 2');
-      expect(option2).toHaveFocus();
+
+      expect(option1).not.toHaveAttribute(
+        'class',
+        expect.stringContaining('focused')
+      );
+      expect(option2).toHaveAttribute(
+        'class',
+        expect.stringContaining('focused')
+      );
 
       await user.keyboard('{ArrowUp}');
-      expect(option1).toHaveFocus();
+
+      expect(option1).toHaveAttribute(
+        'class',
+        expect.stringContaining('focused')
+      );
+      expect(option2).not.toHaveAttribute(
+        'class',
+        expect.stringContaining('focused')
+      );
     });
 
     it('focuses the input when tabbing in', async () => {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
this pr ensures the input clears when a user makes a selection from the list.

also includes:

- accessibility improvement
  - use `aria-activedescendent` with a combobox
  - basically, the focus never changes from the input used as the typeahead search
  - instead screen readers announce the active options using `aria-activedescendent`
  - logic in multiple keydown handlers is now consolidated in the input keydown handler
  - updated tests
- swapped in `useOutsideClick` custom hook to close the menu and reset state
- fixed a bug where pressing Space while typing in the input would select the first item
- pressing Enter while filtering the list will now only select the first option if it's the only option available
- use `ul` and `li` instead of divs for menu list
- hide cursor hover styles when keyboard navigating list

https://github.com/user-attachments/assets/1a09e67e-85fa-4622-8f03-be5f25b04b62


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [[ACQ-3227] Clear input when facilitator is selected - Code.org Jira](https://codedotorg.atlassian.net/browse/ACQ-3227)

## Testing story

Some tests needed to be modified due to some selectors no longer targeting the correct elements and checking option focus was irrelevant now that the input maintains focus

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
