### PR TITLE
Revert "Revert "[Google Blockly] Fix bug with function definition""

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
@@ -121,7 +121,11 @@ export const procedureDefMutator = {
     state['invisible'] = this.invisible;
 
     if (doFullSerialization) {
-      state['fullSerialization'] = true;
+      // If fullSerialization is not true, the system will reuse an existing procedure model by ID.
+      // This is necessary for the modal function editor.
+      // If fullSerialization is true, it will instead use the model created at block instantiation.
+      // This is necessary for single-workspace labs so that multiple functions do not share the same model.
+      state['fullSerialization'] = !Blockly.useModalFunctionEditor;
       const params =
         this.getProcedureModel().getParameters() as ObservableParameterModel[];
 

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
@@ -100,10 +100,17 @@ export const procedureDefMutator = {
   },
 
   /**
-   * Returns a JSON serializable value which represents the extra state of the block.
+   * Returns the state of this block as a JSON serializable object.
+   *
+   * @param doFullSerialization  Tells the block if it should serialize
+   *     its entire state (including data stored in the backing procedure
+   *     model). Used for copy-paste.
    * @returns The state of this block, e.g. the parameters and statements.
    */
-  saveExtraState: function (this: ProcedureBlock) {
+  saveExtraState: function (
+    this: ProcedureBlock,
+    doFullSerialization: boolean
+  ) {
     const state = Object.create(null);
     state['description'] = getBlockDescription(this);
     state['procedureId'] = this.getProcedureModel().getId();
@@ -113,20 +120,22 @@ export const procedureDefMutator = {
     state['userCreated'] = this.userCreated;
     state['invisible'] = this.invisible;
 
-    const params =
-      this.getProcedureModel().getParameters() as ObservableParameterModel[];
-    if (!params.length && this.hasStatements_) return state;
+    if (doFullSerialization) {
+      state['fullSerialization'] = true;
+      const params =
+        this.getProcedureModel().getParameters() as ObservableParameterModel[];
 
-    if (params.length) {
-      state['params'] = params.map(p => {
-        return {
-          name: p.getName(),
-          id: p.getVariableModel().getId(),
-          // Ideally this would be id, and the other would be varId,
-          // but backwards compatibility :/
-          paramId: p.getId(),
-        };
-      });
+      if (params.length) {
+        state['params'] = params.map(p => {
+          return {
+            name: p.getName(),
+            id: p.getVariableModel().getId(),
+            // Ideally this would be id, and the other would be varId,
+            // but backwards compatibility :/
+            paramId: p.getId(),
+          };
+        });
+      }
     }
     if (!this.hasStatements_) {
       state['hasStatements'] = false;


### PR DESCRIPTION
Redo of:
- https://github.com/code-dot-org/code-dot-org/pull/65695
Revert of:
- code-dot-org/code-dot-org#65720

The first attempt at fixing this function bug caused a regression outside of Music Lab where the modal function editor. 
This was caught by an Eyes test:
![Screenshot 2025-05-07 at 12 47 42 PM](https://github.com/user-attachments/assets/7ac8fd52-856d-4062-bcbf-8e673bd4ecd9)


This change updates our `saveExtraState` override to conditionally set `state.fullSerialization = !Blockly.useModalFunctionEditor`. This ensures correct behavior across labs with different workspace setups:

- In labs that do **not** use the modal function editor, functions live in the single workspace. Setting `fullSerialization = true` ensures that copied/duplicated function will use the procedure model that is created when they are instantiated, rather than the already-existing model identified by the copied block's procedure id. This prevents two functions from sharing the same model.
- In labs that **do** use the modal function editor, functions live in a separate workspace. Setting `fullSerialization = false` allows call blocks to re-link to the existing model by `procedureId` without duplicating definitions.

