### PR TITLE
Fix Regional Partner Search location name if virtual

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -398,12 +398,12 @@ class RegionalPartnerSearch extends Component {
                                     <div>
                                       {workshop.workshop_date_range_string}
                                     </div>
-                                    <div>{workshop.location_name}</div>
                                     <div>
-                                      {workshop.location_address === 'Virtual'
+                                      {workshop.location_name === 'Virtual'
                                         ? workshop.format
-                                        : workshop.location_address}
+                                        : workshop.location_name}
                                     </div>
+                                    <div>{workshop.location_address}</div>
                                   </div>
                                 )
                               )}

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -399,7 +399,11 @@ class RegionalPartnerSearch extends Component {
                                       {workshop.workshop_date_range_string}
                                     </div>
                                     <div>{workshop.location_name}</div>
-                                    <div>{workshop.location_address}</div>
+                                    <div>
+                                      {workshop.location_address === 'Virtual'
+                                        ? workshop.format
+                                        : workshop.location_address}
+                                    </div>
                                   </div>
                                 )
                               )}

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -128,7 +128,7 @@ class RegionalPartner < ApplicationRecord
       future.
       where(subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP).
       order_by_scheduled_start.
-      map {|w| w.slice(:location_name, :location_address, :workshop_date_range_string, :course)}
+      map {|w| w.slice(:format, :location_name, :location_address, :workshop_date_range_string, :course)}
   end
 
   before_validation do |model|


### PR DESCRIPTION
Before moving the workshop format and location to the sessions, some workshops had their `location_name` set as "Virtual" (even when it wasn't) which was misleading on the current Regional Partner Search page. This is a quick fix to show the format if the location name is listed as "Virtual", or otherwise show the name. This isn't a super elegant solution but this page will soon be replaced with the new Regional Workshop Page so it should be fine.

### Shows address if `location_name` is not "Virtual"
![with location name](https://github.com/user-attachments/assets/7953a621-3f23-4242-b855-d0299b58d77d)

### Shows format if `location_name` is "Virtual"
![no location](https://github.com/user-attachments/assets/66401739-5a5f-42c0-be94-07010ac5e165)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3265)
Slack discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1746642054989199)

## Testing story
Local testing.
