### PR TITLE
Update color of code blocks in Python Lab/Codebridge

### DIFF
--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -110,8 +110,17 @@ button.validationButton {
     margin-bottom: 5px;
   }
 
+  code, pre {
+    color: var(--text-info-secondary);
+    background-color: var(--background-neutral-primary);
+    border: 1px solid var(--borders-neutral-strong);
+  }
+
+  pre code {
+    border: none;
+  }
+
   code {
-    color: var(--brand-teal-70);
     // Allow code to wrap.
     white-space: pre-wrap;
   }

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -1,5 +1,4 @@
 @import '@code-dot-org/component-library-styles/colors.scss';
-@import '@code-dot-org/component-library-styles/primitiveColors';
 @import 'font.scss';
 
 @keyframes slidein {


### PR DESCRIPTION
This updates the code blocks in the instructions to be properly themed in Python Lab/Codebridge.

## Before
![Screenshot 2025-05-07 at 12 52 58 PM](https://github.com/user-attachments/assets/d93c7e26-8f59-4340-892c-be8b28612621)

## After
### Dark Mode
![Screenshot 2025-05-07 at 12 50 41 PM](https://github.com/user-attachments/assets/a45e910e-264f-4bec-8c42-780374703d24)

### Light Mode (work in progress)
![Screenshot 2025-05-07 at 12 50 27 PM](https://github.com/user-attachments/assets/94e55d52-66b6-430d-bca7-6bf91e946c49)

## Links

- Jira: [CT-1211](https://codedotorg.atlassian.net/browse/CT-1211)

## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
