### PR TITLE
Add border to gray teacher promotion

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -322,6 +322,7 @@
 
   &.promotion-gray {
     background-color: var(--background-neutral-secondary);
+    border: 1px solid var(--borders-neutral-primary);
   }
 
   &.promotion-purple {


### PR DESCRIPTION
From [this](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1745344733077939) slack thread, the gray teacher promotion doesn't have enough contrast and needed a border.

After:
![image](https://github.com/user-attachments/assets/1f6410c3-ee08-46af-9666-f115b74d5f02)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 
https://codedotorg.atlassian.net/browse/TEACH-1872
