### PR TITLE
Only show the link icon when promo isExternal is set

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromo.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromo.tsx
@@ -26,6 +26,7 @@ export interface TeacherPromoInfo {
   image: string | null;
   isClosable: boolean;
   partnerLogo: string | null;
+  isExternal: boolean;
 }
 
 interface TeacherPromoAdditionalProps {
@@ -59,6 +60,7 @@ const TeacherPromo: React.FC<TeacherPromoProps> = ({
   image,
   isClosable,
   partnerLogo,
+  isExternal,
   onClose,
 }) => {
   return (
@@ -99,7 +101,7 @@ const TeacherPromo: React.FC<TeacherPromoProps> = ({
         href={buttonTarget}
         color="black"
         text={buttonLabel}
-        iconRight={{iconName: 'up-right-from-square'}}
+        iconRight={isExternal ? {iconName: 'up-right-from-square'} : undefined}
         type="secondary"
         size="s"
         className={styles.promotionButton}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
@@ -26,6 +26,7 @@ interface ServerPromotion {
   image?: string;
   is_closable: boolean;
   partner_logo?: string;
+  is_external?: boolean;
 }
 
 const serverPromotionConverter = (serverPromotion: ServerPromotion) => ({
@@ -39,6 +40,7 @@ const serverPromotionConverter = (serverPromotion: ServerPromotion) => ({
   image: serverPromotion.image || null,
   isClosable: serverPromotion.is_closable,
   partnerLogo: serverPromotion.partner_logo || null,
+  isExternal: serverPromotion.is_external || false,
 });
 
 const TEACHER_PROMOTION_LOCAL_STORAGE_KEY = 'teacherPromotionClosed';

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherPromoTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherPromoTest.tsx
@@ -18,6 +18,7 @@ describe('TeacherPromo', () => {
     image: '/image1.png',
     isClosable: true,
     partnerLogo: '/partner_logo.png',
+    isExternal: false,
   };
 
   const onCloseMock = jest.fn();
@@ -61,5 +62,23 @@ describe('TeacherPromo', () => {
     const nonClosablePromo = {...mockPromo, isClosable: false};
     render(<TeacherPromo {...nonClosablePromo} onClose={onCloseMock} />);
     expect(screen.queryByLabelText('Close dialog')).toBeNull();
+  });
+
+  it('renders external icon when isExternal is true', () => {
+    render(
+      <TeacherPromo {...mockPromo} isExternal={true} onClose={onCloseMock} />
+    );
+
+    const linkElement = screen.getByRole('link', {name: 'Learn More'});
+    expect(linkElement.querySelector('i')).toBeInTheDocument();
+  });
+
+  it('does not render external icon when isExternal is false', () => {
+    render(
+      <TeacherPromo {...mockPromo} isExternal={false} onClose={onCloseMock} />
+    );
+
+    const linkElement = screen.getByRole('link', {name: 'Learn More'});
+    expect(linkElement.querySelector('i')).toBeNull();
   });
 });


### PR DESCRIPTION
Based on [this](https://codedotorg.slack.com/archives/C045UAX4WKH/p1745873658689139) thread, we should only show the little link icon when the promotion is to an external site

Note how one does and one does not have the link:
![image](https://github.com/user-attachments/assets/a9118c3d-2e71-436e-bb71-fa77f4377aef)

Image above was taken with modified data for one external promotion. On production, neither promo will have the icon.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 
https://codedotorg.atlassian.net/browse/TEACH-1875

## Testing story
Added unit tests