### PR TITLE
Evaluate Student Learning: handle when a ULSE doesn't have an associated ULE

### DIFF
--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -114,7 +114,7 @@ class StudentWorkSampleController < ApplicationController
       return render status: :not_found, json: "There are no skill-based evaluations for the level with id #{level.id}"
     end
 
-    user_level_evaluations = user_level_skill_evaluations.map(&:user_level_evaluation)
+    user_level_evaluations = user_level_skill_evaluations.map(&:user_level_evaluation).compact
 
     code_samples = []
     have_enough_samples = false


### PR DESCRIPTION
[TEACH-1890](https://codedotorg.atlassian.net/browse/TEACH-1890)

When trying to fetch AI-evaluated code samples from the Dataset Maker, I was hitting an error that would kill the whole network request. Example in [Honeybadger](https://app.honeybadger.io/projects/3240/faults/120031164). This happens when there is not a UserLevelEvaluation associated with the UserLevelSkillEvaluation we are trying to look at. I'm removing the `nil` UserLevelEvaluations to avoid the error and unblock pulling student code samples for our contractor. 

I don't know 100% yet whether this a bandaid masking a real issue or just a necessary accommodation of variation in old data. 

I queried production and here's what I do know: 

For level id 49911 in unit 446743 there are currently 21,979 UserLevelSkillEvaluations. Of those UserLevelEvaluations, 7,398 do _not_ have associated UserLevelEvaluations. The most recent UserLevelSkillEvaluation with a nil UserLevelEvaluation is from May 6, 2025. _All_ 777 UserLevelEvaluations created since May 6, 2025 _do_ have associated UserLevelEvaluations. 

There's been some historical churn in how and what we store for StudentWorkEvaluations - there was a data migration from old UserLevelEvaluations to new StudentWorkEvaluations, I recently added Rails model associations, etc so my initial thinking is to check the database again next week [TEACH-1891](https://codedotorg.atlassian.net/browse/TEACH-1891). If there are any new (since May 6) UserLevelSkillEvaluations that don't have UserLevelEvaluations, then launch a deeper investigation. 
