### PR TITLE
Revert "AI Chat: delete records 90 days old in batches"

### DIFF
--- a/bin/cron/delete_old_ai_chat_data
+++ b/bin/cron/delete_old_ai_chat_data
@@ -16,17 +16,11 @@ def main
   # Pilot data collected before September 30th, 2024 is being retained for analysis.
   pilot_end_date = DateTime.new(2024, 10, 1, 0, 0, 0)
 
-  events_deleted = 0
-  AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).in_batches do |events|
-    events_deleted += events.delete_all
-  end
-  ChatClient.message('cron-daily', "Deleted #{events_deleted} AichatEvent records")
+  destroyed_event_count = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
+  ChatClient.message('cron-daily', "Deleted #{destroyed_event_count} AichatEvent records")
 
-  requests_deleted = 0
-  AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).in_batches do |requests|
-    requests_deleted += requests.delete_all
-  end
-  ChatClient.message('cron-daily', "Deleted #{requests_deleted} AichatRequest records")
+  destroyed_request_count = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
+  ChatClient.message('cron-daily', "Deleted #{destroyed_request_count} AichatRequest records")
 end
 
 main

--- a/bin/cron/delete_old_ai_chat_data
+++ b/bin/cron/delete_old_ai_chat_data
@@ -16,11 +16,21 @@ def main
   # Pilot data collected before September 30th, 2024 is being retained for analysis.
   pilot_end_date = DateTime.new(2024, 10, 1, 0, 0, 0)
 
-  destroyed_event_count = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
-  ChatClient.message('cron-daily', "Deleted #{destroyed_event_count} AichatEvent records")
+  ActiveRecord::Base.connection_pool.with_connection do |conn|
+    old_read_timeout = conn.raw_connection.query_options[:read_timeout]
 
-  destroyed_request_count = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
-  ChatClient.message('cron-daily', "Deleted #{destroyed_request_count} AichatRequest records")
+    begin
+      conn.raw_connection.query_options[:read_timeout] = 300
+
+      destroyed_event_count = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
+      ChatClient.message('cron-daily', "Deleted #{destroyed_event_count} AichatEvent records")
+
+      destroyed_request_count = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
+      ChatClient.message('cron-daily', "Deleted #{destroyed_request_count} AichatRequest records")
+    ensure
+      conn.raw_connection.query_options[:read_timeout] = old_read_timeout
+    end
+  end
 end
 
 main

--- a/bin/cron/delete_old_ai_chat_data
+++ b/bin/cron/delete_old_ai_chat_data
@@ -16,21 +16,11 @@ def main
   # Pilot data collected before September 30th, 2024 is being retained for analysis.
   pilot_end_date = DateTime.new(2024, 10, 1, 0, 0, 0)
 
-  ActiveRecord::Base.connection_pool.with_connection do |conn|
-    old_read_timeout = conn.raw_connection.query_options[:read_timeout]
+  destroyed_event_count = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
+  ChatClient.message('cron-daily', "Deleted #{destroyed_event_count} AichatEvent records")
 
-    begin
-      conn.raw_connection.query_options[:read_timeout] = 300
-
-      destroyed_event_count = AichatEvent.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
-      ChatClient.message('cron-daily', "Deleted #{destroyed_event_count} AichatEvent records")
-
-      destroyed_request_count = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
-      ChatClient.message('cron-daily', "Deleted #{destroyed_request_count} AichatRequest records")
-    ensure
-      conn.raw_connection.query_options[:read_timeout] = old_read_timeout
-    end
-  end
+  destroyed_request_count = AichatRequest.where('created_at BETWEEN ? AND ?', pilot_end_date, ninety_days_ago).delete_all
+  ChatClient.message('cron-daily', "Deleted #{destroyed_request_count} AichatRequest records")
 end
 
 main


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#65665

@sureshc helped me understand that the deletes are happening successfully, just that our Rails client is timing out at 30 seconds.

The version I'm reinstating produces a single simple delete query, whereas the one that I'm reverting produced somewhat confusing queries (see screenshots below -- I actually don't see the delete queries in the logs in the batched version, but I do see record counts being lowed in the production database, so it seems to be working).

I explored a couple of options for temporarily setting a connection to have a longer timeout ([details in this Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1746659566210699)). Unfortunately, none of these work easily.

We looked at "Performance Insights" in the AWS Web Console, where we can see that the delete query for AichatRequests takes 90 seconds, hence the timeout.

**Without batching (restored by this revert)**

<img width="1657" alt="image" src="https://github.com/user-attachments/assets/d98d4354-f85f-4db7-aa16-40865625c8f6" />

**With batching**

<img width="1663" alt="image" src="https://github.com/user-attachments/assets/ba63caf1-0583-4c70-ab10-efd618cbfabc" />


