### PR TITLE
Adds arrow key navigation to popup button dropdowns

### DIFF
--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -130,6 +130,22 @@ export const PopUpButton = ({
         createPortal(
           <FocusTrap
             focusTrapOptions={{
+              isKeyForward: event => {
+                if (event.key === 'ArrowDown') {
+                  event.stopPropagation();
+                  return true;
+                }
+                // If we remove this line, tab will move focus but focus will
+                // not be trapped. Same with shift+tab below.
+                return event.key === 'Tab';
+              },
+              isKeyBackward: event => {
+                if (event.key === 'ArrowUp') {
+                  event.stopPropagation();
+                  return true;
+                }
+                return event.key === 'Tab' && event.shiftKey;
+              },
               clickOutsideDeactivates: true,
               fallbackFocus: initialFocusId
                 ? `#${initialFocusId}`


### PR DESCRIPTION
We found during user testing that users expect to be able to navigate these dropdowns with arrow keys. 


This took a wild exploration of every combination of preventDefault and stopPropagation that you can imagine. focus-trap-react is supposed to keep working with tab and shift+tab if you just add another way to navigate forward and backward (in this case, arrowDown and arrowUp), but I found that the focus wasn't actually trapped with those keys unless I added them in explicitly. Additionally, the arrow keys close the menu unless I stopPropagation. 

This video isn't all that helpful but I am pressing all sorts of keys back to back to test out that all combinations work in both directions, and that focus is indeed still trapped. I would really love having another person check out this branch for testing!


https://github.com/user-attachments/assets/114e83da-c8fe-4ee4-865a-726b255fe46f



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1231

## Testing story

Tested forward and backward with both sets of keys (arrow and tab), ensuring focus moved and stayed trapped. Additionally, I tested that enter and space still worked to open the items, and esc still worked to close. 

I also checked that click events still happen as expected.


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
