### PR TITLE
Modify UI for DSL levels on bubble choice levels

### DIFF
--- a/apps/src/levelbuilder/level-editor/EditChildLevelSettings.jsx
+++ b/apps/src/levelbuilder/level-editor/EditChildLevelSettings.jsx
@@ -1,6 +1,7 @@
 // This component will be used to edit the settings of any child levels
 // The component will take in the following props:
 // Child levels: an array of objects representing the child levels
+import Link from '@code-dot-org/component-library/link';
 import PropTypes from 'prop-types';
 import React, {useState, useCallback} from 'react';
 
@@ -93,6 +94,39 @@ const EditChildLevelSettings = ({initialChildLevelSettings}) => {
       });
   }
 
+  const uiForEditingSublevelData = (childLevel, index) => (
+    <div>
+      <div className={styles.fieldRow}>
+        <label>Display Name</label>
+        <input
+          type="text"
+          value={childLevel.properties.display_name}
+          onChange={e => handleDisplayNameChange(index, e.target.value)}
+        />
+      </div>
+      <BubbleChoiceDescriptionEditor
+        description={childLevel.properties.bubble_choice_description || ''}
+        index={index}
+        handleDescriptionChange={handleDescriptionChange}
+      />
+      <div className={styles.fieldRow}>
+        <label>Thumbnail URL</label>
+        <ImageInput
+          updateImageUrl={newImageUrl =>
+            handleThumbnailUrlChange(index, newImageUrl)
+          }
+          initialImageUrl={childLevel.properties.thumbnail_url || ''}
+          showPreview
+        />
+      </div>
+      <button type="button" onClick={() => handleSave(index)}>
+        Save
+      </button>
+    </div>
+  );
+
+  const levelEditorUrl = childLevelId => `/levels/${childLevelId}/edit`;
+
   return (
     <>
       <div>
@@ -106,38 +140,22 @@ const EditChildLevelSettings = ({initialChildLevelSettings}) => {
               <hr />
               <CollapsibleSection headerContent={childLevel.name}>
                 <div>
-                  <div className={styles.fieldRow}>
-                    <label>Display Name</label>
-                    <input
-                      type="text"
-                      value={childLevel.properties.display_name}
-                      onChange={e =>
-                        handleDisplayNameChange(index, e.target.value)
-                      }
-                    />
-                  </div>
-                  <BubbleChoiceDescriptionEditor
-                    description={
-                      childLevel.properties.bubble_choice_description || ''
-                    }
-                    index={index}
-                    handleDescriptionChange={handleDescriptionChange}
-                  />
-                  <div className={styles.fieldRow}>
-                    <label>Thumbnail URL</label>
-                    <ImageInput
-                      updateImageUrl={newImageUrl =>
-                        handleThumbnailUrlChange(index, newImageUrl)
-                      }
-                      initialImageUrl={
-                        childLevel.properties.thumbnail_url || ''
-                      }
-                      showPreview
-                    />
-                  </div>
-                  <button type="button" onClick={() => handleSave(index)}>
-                    Save
-                  </button>
+                  {childLevel.isDslDefined && (
+                    <div className={styles.warningMessage}>
+                      Note: This level is a DSL level. To make changes to the
+                      title, description, or thumbnail, you must edit the DSL
+                      level directly. You can do that at
+                      <Link
+                        text={'the level edit page'}
+                        href={levelEditorUrl(childLevel.id)}
+                        openInNewTab={true}
+                        external={true}
+                        size="s"
+                      />
+                    </div>
+                  )}
+                  {!childLevel.isDslDefined &&
+                    uiForEditingSublevelData(childLevel, index)}
                 </div>
               </CollapsibleSection>
             </div>

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -876,6 +876,16 @@ class Level < ApplicationRecord
     }
   end
 
+  def summarize_for_sublevel_edit
+    {
+      name: name,
+      id: id,
+      type: type,
+      properties: properties,
+      isDslDefined: is_a?(DSLDefined)
+    }
+  end
+
   # Summarize the properties for a lab2 level.
   # Called by ScriptLevelsController.level_properties.
   # These properties are usually just the serialized properties for

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -880,7 +880,6 @@ class Level < ApplicationRecord
     {
       name: name,
       id: id,
-      type: type,
       properties: properties,
       isDslDefined: is_a?(DSLDefined)
     }

--- a/dashboard/app/views/levels/editors/fields/_child_level_bubble_choice_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_child_level_bubble_choice_fields.html.haml
@@ -6,4 +6,4 @@
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path('js/levels/editors/fields/_child_level_bubble_choice_fields.js'),
-        data: {childlevels: @level.sublevels.to_json}}
+        data: {childlevels: @level.sublevels.map(&:summarize_for_sublevel_edit).to_json}}


### PR DESCRIPTION


https://github.com/user-attachments/assets/2dd5de63-4409-49e2-905c-0719d138d6c2




**ISSUE:**  DSL sublevels weren't saving correctly when the thumbnail, name, and description were being edited on the bubble choice page. 

**ACTION:** 
- This is a temporary fix (which might become a permanent fix) that removes the UI for DSL sub-levels on the Bubble Choice edit page.  
- Instead, if a sublevel is a DSL level, the UI will direct levelbuilder users to the DSL level edit page via a link.
- There should be no change for users who are editing non-DSL levels on the bubble choice level edit page

**FOLLOW UPS**:
- required: reach out to T&L on this change
- optional: look further into saving DSL data on this page.
- more optional: get the "Save" button on the level edit page to save data for the sublevels too (it took me longer than it should to "see" the save button in the section - that feels very missable.  Perhaps adding a pop-up too when saving the full level if the sub-level info hasn't been saved would also help ease usability issues.


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?jql=assignee%20%3D%205d4c828efbe7c30cedfc65aa&selectedIssue=TEACH-1879)

## Testing story

Local testing.