### PR TITLE
feat(workshops): pre-select program managers regional partner

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/index.tsx
@@ -29,7 +29,6 @@ import {
   Errors,
   FieldConfig,
   Facilitator,
-  RegionalPartner,
   SessionErrors,
   SessionFormState,
   Workshop,
@@ -53,6 +52,7 @@ export const VALIDATION_ERROR =
 
 export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
   config,
+  regionalPartnerData,
 }) => {
   const navigate = useNavigate();
   const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -62,10 +62,6 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
 
   const {data: workshop} = useFetch<Workshop>(
     workshopId ? `/api/v1/pd/workshops/${workshopId}` : ''
-  );
-
-  const {data: regionalPartnerData} = useFetch<RegionalPartner[]>(
-    '/api/v1/regional_partners'
   );
 
   const {data: facilitatorData} = useFetch<Facilitator[]>(
@@ -89,7 +85,8 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
     organizerId: null,
     prereq: '',
     hasPrereq: false,
-    regionalPartnerId: null,
+    regionalPartnerId:
+      regionalPartnerData?.length === 1 ? regionalPartnerData[0].id : null,
     registrationLink: '',
     subject: '',
     suppressEmail: false,
@@ -286,7 +283,7 @@ export const WorkshopFormTemplate: FC<WorkshopFormTemplateProps> = ({
         facilitators={workshopFormState.facilitators}
         regionalPartnerId={workshopFormState.regionalPartnerId}
         errors={workshopErrors}
-        regionalPartnerData={regionalPartnerData}
+        regionalPartnerData={regionalPartnerData ?? []}
         facilitatorData={facilitatorData}
         dispatchWorkshop={dispatchWorkshop}
         config={workshopConfig}

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -51,6 +51,7 @@ export interface WorkshopCourseConfig {
 
 export interface WorkshopFormTemplateProps {
   config?: WorkshopCourseConfig;
+  regionalPartnerData?: RegionalPartner[];
 }
 
 export interface Organizer {

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -173,7 +173,10 @@ const WorkshopDashboard = ({
                     path={path}
                     element={
                       noRouter ? (
-                        <Component {...props} />
+                        <Component
+                          {...props}
+                          regionalPartnerData={regionalPartners}
+                        />
                       ) : (
                         <WithRouterProps component={Component} {...props} />
                       )

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/WorkshopFormTemplateTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/WorkshopFormTemplateTest.jsx
@@ -21,19 +21,23 @@ describe('WorkshopFormTemplate', () => {
     config,
   ]);
   let user;
+
+  const renderDefault = (props = {}) =>
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<WorkshopFormTemplate {...props} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
   beforeEach(() => {
     user = userEvent.setup();
     mockedUseFetch.mockReturnValue({data: null, loading: false, error: null});
   });
 
   it.each(testConfigs)('renders the form for %s', (_, config) => {
-    render(
-      <MemoryRouter initialEntries={['/']}>
-        <Routes>
-          <Route path="/" element={<WorkshopFormTemplate config={config} />} />
-        </Routes>
-      </MemoryRouter>
-    );
+    renderDefault({config});
 
     expect(
       screen.getByText(workshopLabel(`New ${config.label}`))
@@ -48,16 +52,7 @@ describe('WorkshopFormTemplate', () => {
   it.each(testConfigs)(
     'renders field labels and helper messages for %s',
     async (_, config) => {
-      render(
-        <MemoryRouter initialEntries={['/']}>
-          <Routes>
-            <Route
-              path="/"
-              element={<WorkshopFormTemplate config={config} />}
-            />
-          </Routes>
-        </MemoryRouter>
-      );
+      renderDefault({config});
 
       await user.selectOptions(
         screen.getByRole('combobox', {
@@ -76,18 +71,44 @@ describe('WorkshopFormTemplate', () => {
   );
 
   it.each(testConfigs)(
+    'pre-fills regional partner if there is one option for %s',
+    async (_, config) => {
+      renderDefault({
+        config,
+        regionalPartnerData: [{id: 1, name: 'Regional Partner 1'}],
+      });
+
+      const input = screen.getByLabelText(
+        config.fields.regional_partner_id.label
+      );
+      // SimpleDropdown values can only be strings
+      expect(input.value).toBe('1');
+    }
+  );
+
+  it.each(testConfigs)(
+    'does not pre-fill regional partner if there is more than one option for %s',
+    async (_, config) => {
+      renderDefault({
+        config,
+        regionalPartnerData: [
+          {id: 1, name: 'Regional Partner 1'},
+          {id: 2, name: 'Regional Partner 2'},
+        ],
+      });
+
+      const input = screen.getByLabelText(
+        config.fields.regional_partner_id.label
+      );
+      // SimpleDropdown values can only be strings
+      expect(input.value).toBe('');
+    }
+  );
+
+  it.each(testConfigs)(
     'displays required validation errors for %s',
     async (_, config) => {
-      render(
-        <MemoryRouter initialEntries={['/']}>
-          <Routes>
-            <Route
-              path="/"
-              element={<WorkshopFormTemplate config={config} />}
-            />
-          </Routes>
-        </MemoryRouter>
-      );
+      renderDefault({config});
 
       const publishButton = screen.getByRole('button', {name: 'Publish'});
       await user.click(publishButton);


### PR DESCRIPTION
filters regional partners for program managers to just the regional partners they are associated with. if only one regional partner, pre-select it in the workshop form

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [[ACQ-3232] Limit regional partners to only creating workshops with them as RPs - Code.org Jira](https://codedotorg.atlassian.net/browse/ACQ-3232)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
