### PR TITLE
AI Chat: Remove "load from library" if there are no starter assets

### DIFF
--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -1,3 +1,4 @@
+import {Button, ButtonProps} from '@code-dot-org/component-library/button';
 import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
 import classNames from 'classnames';
 import React, {ChangeEvent, useState} from 'react';
@@ -35,6 +36,10 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
   );
   const numAllowedFiles = MAX_NUM_FILES - numStagedFiles;
   const levelName = useAppSelector(state => state.lab.levelProperties?.name);
+  const hasStarterAssets = useAppSelector(state => {
+    const starterAssets = state.lab.levelProperties?.starterAssets;
+    return starterAssets && Object.keys(starterAssets).length > 0;
+  });
   const [showAssetManager, setShowAssetManager] = useState(false);
 
   const onUploadFiles = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -166,6 +171,51 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
     return null;
   }
 
+  const buttonProps: ButtonProps = {
+    type: 'secondary',
+    color: 'gray',
+    iconLeft: {iconName: 'upload'},
+    text: aichatI18n.upload(),
+  };
+
+  const commonProps = {
+    size: 's',
+    disabled: numStagedFiles >= MAX_NUM_FILES || isDisabled,
+  } as const;
+
+  const uploadButton = hasStarterAssets ? (
+    <ActionDropdown
+      {...commonProps}
+      name="uploadDropdown"
+      labelText={aichatI18n.upload()}
+      triggerButtonProps={buttonProps}
+      className={classNames(styles.upload, styles.dropdown)}
+      options={[
+        {
+          value: 'fromLibrary',
+          label: 'From Library',
+          icon: {iconName: 'copy'},
+          onClick: () => {
+            setShowAssetManager(true);
+            dispatch(
+              sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_OPENED, {
+                source: AssetSource.LEVEL,
+              })
+            );
+          },
+        },
+        {
+          value: 'fromDevice',
+          label: 'From Device',
+          icon: {iconName: 'file-magnifying-glass'},
+          onClick: onDeviceUploadClick,
+        },
+      ]}
+    />
+  ) : (
+    <Button {...buttonProps} {...commonProps} onClick={onDeviceUploadClick} />
+  );
+
   return (
     <>
       {levelName && showAssetManager && (
@@ -178,40 +228,7 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
         />
       )}
       <FileInput />
-      <ActionDropdown
-        name="uploadDropdown"
-        labelText={aichatI18n.upload()}
-        disabled={numStagedFiles >= MAX_NUM_FILES || isDisabled}
-        size="s"
-        className={classNames(styles.upload, styles.dropdown)}
-        triggerButtonProps={{
-          type: 'secondary',
-          color: 'gray',
-          iconLeft: {iconName: 'upload'},
-          text: aichatI18n.upload(),
-        }}
-        options={[
-          {
-            value: 'fromLibrary',
-            label: 'From Library',
-            icon: {iconName: 'copy'},
-            onClick: () => {
-              setShowAssetManager(true);
-              dispatch(
-                sendAnalytics(EVENTS.AICHAT_MULTIMODAL_UPLOAD_OPENED, {
-                  source: AssetSource.LEVEL,
-                })
-              );
-            },
-          },
-          {
-            value: 'fromDevice',
-            label: 'From Device',
-            icon: {iconName: 'file-magnifying-glass'},
-            onClick: onDeviceUploadClick,
-          },
-        ]}
-      />
+      {uploadButton}
     </>
   );
 };

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -216,6 +216,7 @@ export interface LevelProperties {
   isAssessment?: boolean;
   progressionType?: string;
   type?: string;
+  starterAssets?: {[key: string]: string};
 }
 
 // Level configuration data used by project-backed labs that don't require


### PR DESCRIPTION
Removes the "load from library" option for multimodal AI Chat if there are no starter assets on the level. Fortunately we don't need to make an extra API call here as the starter assets mapping is available as part of the level properties object. If there are no starter assets, the upload button directly opens the user's file manager.

Under the hood the upload button changes from an `ActionDropdown` to a `Button`, but thankfully it looks the same since both use the DSCO button styles.

<img width="1512" alt="Screenshot 2025-05-08 at 2 11 49 PM" src="https://github.com/user-attachments/assets/d813b958-e13b-4e7f-90f6-3d1dc0022658" />


https://github.com/user-attachments/assets/e70ed1bc-698d-480f-90b5-2b54afbcc95e

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1412

## Testing story

Tested locally on levels with and without starter assets