### PR TITLE
Evaluate Student Learning: add key column to Skills table

### DIFF
--- a/dashboard/app/models/skill.rb
+++ b/dashboard/app/models/skill.rb
@@ -8,6 +8,11 @@
 #  concept             :string(255)
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  key                 :string(255)      not null
+#
+# Indexes
+#
+#  index_skills_on_key  (key) UNIQUE
 #
 class Skill < ApplicationRecord
   validates :description, presence: true

--- a/dashboard/db/migrate/20250509130059_add_key_to_skills.rb
+++ b/dashboard/db/migrate/20250509130059_add_key_to_skills.rb
@@ -1,0 +1,6 @@
+class AddKeyToSkills < ActiveRecord::Migration[6.1]
+  def change
+    add_column :skills, :key, :string, null: false
+    add_index :skills, :key, unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_05_05_164605) do
+ActiveRecord::Schema.define(version: 2025_05_09_130059) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2166,6 +2166,8 @@ ActiveRecord::Schema.define(version: 2025_05_05_164605) do
     t.string "concept"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "key", null: false
+    t.index ["key"], name: "index_skills_on_key", unique: true
   end
 
   create_table "stages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Extracted from #65473 

Partial for [TEACH-1796](https://codedotorg.atlassian.net/browse/TEACH-1796)

We need to add Skills and LevelsSkills to the seeding process to keep them in sync between Levelbuilder and Production. This PR isolates the migration to add key to Skills as part of that work. 
