### PR TITLE
[Music] responsive play area sizing

### DIFF
--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -2,6 +2,7 @@
 
 // Constants
 $timeline-area-height: 200px;
+$work-area-min-height: 50%;
 $default-border-radius: 0;
 $default-spacing: 2px;
 
@@ -24,7 +25,7 @@ $default-spacing: 2px;
   flex: 1;
   display: flex;
   flex-direction: row;
-  max-height: calc(100% - $timeline-area-height);
+  min-height: $work-area-min-height;
   gap: $default-spacing;
   overflow: hidden;
   &.toolboxMode {
@@ -34,7 +35,7 @@ $default-spacing: 2px;
 
 .playArea {
   width: 100%;
-  height: $timeline-area-height;
+  flex: 0 1 $timeline-area-height;
   box-sizing: border-box;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Music Lab's timeline is currently locked at 200px. This is fine most of the time, but can be problematic when the screen size shrinks because it can effectively hide the instructions and workspace area.

![2025-05-09 10-04-49 2025-05-09 10_05_57](https://github.com/user-attachments/assets/7fb10e63-e224-4363-bc87-fa0bf2452d28)

Screenshot of Music Jam level 2 on my cell phone:
![image (311)](https://github.com/user-attachments/assets/6999934f-d660-4588-8174-62c484e449b0)

With this branch I propose tweaking the relationship between the work area (top) and play area (bottom):
- The work area will have a minimum height of 50% of the available space. This will prevent it from completely collapsing.
- The play area will use `flex 0 1 200px`. This allows it to maintain its ideal size (200px) in most cases, but shrink when the screen height is limited.

With changes:

![2025-05-09 10-03-57 2025-05-09 10_06_30](https://github.com/user-attachments/assets/641e7426-060b-4bc1-8466-1a5fd1d597d0)

Noticeably, the entire `when run` now remains visible as well as the top heading of the instructions text.

This doesn't make any further adjustments to the timeline itself since the goal here is just to keep things roughly usable in the most extreme circumstances.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
