### PR TITLE
Keep ellipsis showing from PopupButton when menu is open

### DIFF
--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -14,7 +14,8 @@
 
 .fileBrowserContents {
   overflow-y: auto;
-  scrollbar-color: var(--background-neutral-senary) var(--background-neutral-secondary);
+  scrollbar-color: var(--background-neutral-senary)
+    var(--background-neutral-secondary);
   height: 100%;
 }
 
@@ -78,7 +79,8 @@ button.button-kebab {
   // are more specific than a single class.
   // We need a different hover color for the kebab button because it is on top of another
   // element with the standard hover color.
-  &:hover, &:active {
+  &:hover,
+  &:active {
     background-color: var(--background-neutral-quinary) !important;
   }
 }
@@ -143,12 +145,12 @@ div.draggable:focus-within .button-kebab {
 }
 
 .backpackErrorMessage {
-  color: var(--text-error-primary);;
+  color: var(--text-error-primary);
   font-size: 1rem;
 }
 
 .dragging {
-  background-color: var(--background-neutral-quaternary);;
+  background-color: var(--background-neutral-quaternary);
 }
 
 .notDraggable:focus-visible,

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -1,5 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
+import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
 import React, {useState, useCallback, useRef, useEffect} from 'react';
 import {createPortal} from 'react-dom';
@@ -93,7 +94,7 @@ export const PopUpButton = ({
             left,
           });
           setUpdatedStyles(true);
-          setComputedButtonStyles(`${className} ${moduleStyles.active}`);
+          setComputedButtonStyles(classNames(className, moduleStyles.active));
         }
       }
     };

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -34,6 +34,7 @@ export const PopUpButton = ({
   const [dropdownStyles, setDropdownStyles] = useState<React.CSSProperties>({});
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const [updatedStyles, setUpdatedStyles] = useState(false);
+  const [computedButtonStyles, setComputedButtonStyles] = useState(className);
   // We need to set the theme here becausse the dropdown is rendered in a portal, outside of the
   // main lab container.
   const {theme} = useTheme();
@@ -41,7 +42,11 @@ export const PopUpButton = ({
   const setIsOpenFalse = useCallback(() => {
     setIsOpen(false);
     document.removeEventListener('click', setIsOpenFalse);
-  }, [setIsOpen]);
+    // Because this operates on a delay, we also have to update the styles on a delay
+    setTimeout(() => {
+      setComputedButtonStyles(className);
+    }, 300);
+  }, [setIsOpen, className]);
 
   const clickHandler = useCallback(
     (
@@ -88,6 +93,7 @@ export const PopUpButton = ({
             left,
           });
           setUpdatedStyles(true);
+          setComputedButtonStyles(`${className} ${moduleStyles.active}`);
         }
       }
     };
@@ -98,7 +104,7 @@ export const PopUpButton = ({
     return () => {
       window.removeEventListener('resize', updateDropdownPositionIfShown);
     };
-  }, [alignment, buttonRef, isOpen]);
+  }, [alignment, buttonRef, isOpen, className]);
 
   // We wait to make the dropdown visible until we've calculated the position
   // it should be in based on its own width and the size of the button.
@@ -111,7 +117,7 @@ export const PopUpButton = ({
   return (
     <>
       <Button
-        className={className}
+        className={computedButtonStyles}
         size="xs"
         icon={{iconStyle: 'solid', iconName}}
         isIconOnly

--- a/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
+++ b/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
@@ -23,3 +23,7 @@
     border-radius: 0.375rem;
   }
 }
+
+button.active {
+  display: inherit !important;
+}

--- a/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
+++ b/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
@@ -24,6 +24,8 @@
   }
 }
 
+// We need !important because of css specificity- this would be overriden
+// by display: none otherwise.
 button.active {
   display: inherit !important;
 }


### PR DESCRIPTION
This also fixes the focus issue- now if you navigate to a file ellipsis button and open the dropdown, once you click escape the focus can return to the ellipsis because it still exists. 

I know this is a bit of a mess but I truly couldn't figure out another way to get it working. 

Here it is in action:

https://github.com/user-attachments/assets/7f13313e-8673-475e-8aab-bc7de404a345



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1235

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
