### PR TITLE
feat(workshops): allow session end times up to 10pm

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/components/SessionPart.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/SessionsEditor/components/SessionPart.tsx
@@ -55,7 +55,7 @@ export const SessionPart: FC<{
 }) => {
   const timeOptions = useMemo(() => {
     const startTime = moment().startOf('day').add(7, 'hours');
-    const endTime = moment().startOf('day').add(19, 'hours');
+    const endTime = moment().startOf('day').add(22, 'hours');
     const timeOptions: {value: string; text: string}[] = [];
 
     while (startTime.isSameOrBefore(endTime)) {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Session end times were limited to 7pm, this extends that to 10pm

![Screenshot 2025-05-09 at 3 01 20 PM](https://github.com/user-attachments/assets/80ceba84-1c23-4b93-9e5c-b1c0c239ce3b)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [[ACQ-3240] Make the latest end time for a workshop 10 pm - Code.org Jira](https://codedotorg.atlassian.net/browse/ACQ-3240)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
