### PR TITLE
Fix style of lab2 text instructions

### DIFF
--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -115,7 +115,6 @@
   animation: slidein 0.5s;
   display: flex;
   flex-direction: column;
-  flex: 1;
   min-height: 0;
 }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/65699 and fixes a regression introduced by the PR - currently the text instructions stretches to fill the instructions panel vertical space to the bottom. This PR updates instructions so that the text block fills to fit the instructions content.

## Before update

In `music`:
![Screenshot 2025-05-12 at 9 23 17 AM](https://github.com/user-attachments/assets/5ef05211-2ce5-42b4-b82f-bace470bc6fa)


In `aichat`:
![Screenshot 2025-05-12 at 9 53 44 AM](https://github.com/user-attachments/assets/d9097e12-18a9-4154-8263-2901d21247da)



This PR removes `flex: 1` so that the the text block will grow based on content and not fill up the remaining available vertical space.

## After update

In `music`:

https://github.com/user-attachments/assets/aac71b40-f578-4889-abc1-8303d4ecdeb8


In `aichat`:
![Screenshot 2025-05-12 at 9 57 10 AM](https://github.com/user-attachments/assets/5540188e-bd08-421f-9292-ae5dcc753f55)



## Links
[PR comment](https://github.com/code-dot-org/code-dot-org/pull/65699#issuecomment-2870195566)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->




## Testing story
I tested locally in `music` and `aichat` levels (with/without predict, with/without music exemplar).


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
I think there's been discussion about using the same `Instructions` component for all `lab2` labs as currently `pythonlab` uses `ValidatedInstructions` and `music`/`aichat` use `Instructions`. 

In `pythonlab` the background color of the text instructions is gray and the panel background color is a darker gray so that the color contrast is much less pronounced.

![Screenshot 2025-05-12 at 9 41 57 AM](https://github.com/user-attachments/assets/effe7df4-a828-49d0-a2ad-28826d2e7667)

Curious about whether `music`'s instructions text color/style will be updated to match that of `pythonlab`'s instructions text. @markabarrett 

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
