### PR TITLE
Add redirect for original RP Contact Form URL

### DIFF
--- a/pegasus/sites.v3/code.org/public/professional-learning/contact-regional-partner.redirect
+++ b/pegasus/sites.v3/code.org/public/professional-learning/contact-regional-partner.redirect
@@ -1,0 +1,1 @@
+https://studio.code.org/professional-learning/contact-regional-partner


### PR DESCRIPTION
Adds redirect for original RP Contact Form to the new form. As part of the [original PR](https://github.com/code-dot-org/code-dot-org/pull/65373), I added a redirect for /educate/professional-learning/contact-regional-partner but forgot to add one for /professional-learning/contact-regional-partner. This PR adds that in.

https://github.com/user-attachments/assets/827f7aca-d837-44fa-b3b9-18e7477cd566

## Testing story
Local testing.
