### PR TITLE
AI Chat: Add PDF page limits and warnings to starter asset dialog

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -288,6 +288,7 @@
     "object-fit-images": "^3.2.3",
     "papaparse": "^5.4.1",
     "path-browserify": "^1.0.1",
+    "pdf-lib": "^1.17.1",
     "pepjs": "^0.4.3",
     "pixelmatch": "^5.2.0",
     "playground-io": "code-dot-org/playground-io#v0.6.0-cdo.2",

--- a/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
@@ -13,12 +13,12 @@ import {getPageCount} from './utils';
 import styles from './starter-assets-dialog.module.scss';
 
 interface FileIconProps extends AssetData {
-  //asset: AssetData;
   levelName: string;
   onSelect?: (selected: boolean) => void;
   selected?: boolean;
   canSelect?: boolean;
   onDelete?: (filename: string) => void;
+  showWarnings?: boolean;
 }
 
 const FileIcon: React.FC<FileIconProps> = ({
@@ -31,6 +31,7 @@ const FileIcon: React.FC<FileIconProps> = ({
   canSelect = true,
   selected,
   onDelete,
+  showWarnings = false,
 }) => {
   const url = `${getFileUrl(filename, levelName)}?${timestamp}`;
   const [pageCount, setPageCount] = useState<number>();
@@ -107,7 +108,7 @@ const FileIcon: React.FC<FileIconProps> = ({
               <BodyThreeText className={styles.fileDetail}>
                 {pageCount} Pages
               </BodyThreeText>
-              {pageCount > PDF_PAGE_WARNING && (
+              {showWarnings && pageCount > PDF_PAGE_WARNING && (
                 <WarningIcon text="This PDF has many pages and may result in degraded performance." />
               )}
             </div>
@@ -117,10 +118,11 @@ const FileIcon: React.FC<FileIconProps> = ({
               <BodyThreeText className={styles.fileDetail}>
                 {width} x {height}
               </BodyThreeText>
-              {(width > IMAGE_DIMENSION_WARNING ||
-                height > IMAGE_DIMENSION_WARNING) && (
-                <WarningIcon text="This image is large and may result in degraded performance." />
-              )}
+              {showWarnings &&
+                (width > IMAGE_DIMENSION_WARNING ||
+                  height > IMAGE_DIMENSION_WARNING) && (
+                  <WarningIcon text="This image is large and may result in degraded performance." />
+                )}
             </div>
           )}
         </div>

--- a/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
@@ -1,36 +1,64 @@
 import {Button} from '@code-dot-org/component-library/button';
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import {BodyThreeText} from '@code-dot-org/component-library/typography';
-import React, {memo} from 'react';
+import React, {memo, useEffect, useRef, useState} from 'react';
 
 import {getFileUrl} from './api';
+import {IMAGE_DIMENSION_WARNING, PDF_PAGE_WARNING} from './constants';
 import {AssetData} from './types';
+import {getPageCount} from './utils';
 
 import styles from './starter-assets-dialog.module.scss';
 
-interface FileIconProps {
-  asset: AssetData;
+interface FileIconProps extends AssetData {
+  //asset: AssetData;
   levelName: string;
   onSelect?: (selected: boolean) => void;
   selected?: boolean;
   canSelect?: boolean;
-  onDelete?: () => void;
+  onDelete?: (filename: string) => void;
 }
 
 const FileIcon: React.FC<FileIconProps> = ({
-  asset,
+  filename,
+  size,
+  category,
+  timestamp,
   levelName,
   onSelect,
   canSelect = true,
   selected,
   onDelete,
 }) => {
-  const {filename, category, timestamp} = asset;
   const url = `${getFileUrl(filename, levelName)}?${timestamp}`;
+  const [pageCount, setPageCount] = useState<number>();
+  const [dimensions, setDimensions] = useState<[number, number]>();
+  const [loadingMetadata, setLoadingMetadata] = useState(true);
+
+  useEffect(() => {
+    if (filename.endsWith('.pdf')) {
+      getPageCount(url).then(count => {
+        setPageCount(count);
+        setLoadingMetadata(false);
+      });
+    }
+  }, [url, filename]);
+
+  const imgRef = useRef<HTMLImageElement>(null);
+  const onImgLoad = () => {
+    setDimensions([
+      imgRef.current?.naturalWidth || 0,
+      imgRef.current?.naturalHeight || 0,
+    ]);
+    setLoadingMetadata(false);
+  };
+  const [width, height] = dimensions || [];
+
   return (
     <div className={styles.fileIconWrapper}>
-      {onSelect && (
+      {onSelect && !loadingMetadata && (
         <Checkbox
           checked={selected || false}
           onChange={event => onSelect(event.target.checked)}
@@ -39,36 +67,69 @@ const FileIcon: React.FC<FileIconProps> = ({
           disabled={!selected && !canSelect}
         />
       )}
-      {onDelete && (
+      {onDelete && !loadingMetadata && (
         <Button
           size="xs"
           isIconOnly={true}
-          onClick={onDelete}
+          onClick={() => onDelete(filename)}
           icon={{iconName: 'trash'}}
           color="destructive"
           type="secondary"
         />
+      )}
+      {loadingMetadata && (
+        <div className={styles.loadingIcon}>
+          <FontAwesomeV6Icon iconName="spinner" animationType={'spin'} />
+        </div>
       )}
       <button
         className={styles[`file-icon-${category}`]}
         type="button"
         onClick={() => window.open(url, '_blank')}
       >
-        {category === 'image' && <img src={url} alt={filename} />}
+        {category === 'image' && (
+          <img onLoad={onImgLoad} ref={imgRef} src={url} alt={filename} />
+        )}
         {category === 'pdf' && (
           <div className={styles.pdfIcon}>
             <FontAwesomeV6Icon iconName="file" />
           </div>
         )}
-        <BodyThreeText className={styles.filename}>
-          {truncateFilename(filename)}
-        </BodyThreeText>
+        <div className={styles.fileInfo}>
+          <BodyThreeText className={styles.filename}>
+            {truncateFilename(filename)}
+          </BodyThreeText>
+          <BodyThreeText className={styles.fileSize}>
+            {getSizeText(size)}
+          </BodyThreeText>
+          {pageCount && (
+            <div className={styles.fileInfoRow}>
+              <BodyThreeText className={styles.fileDetail}>
+                {pageCount} Pages
+              </BodyThreeText>
+              {pageCount > PDF_PAGE_WARNING && (
+                <WarningIcon text="This PDF has many pages and may result in degraded performance." />
+              )}
+            </div>
+          )}
+          {width && height && (
+            <div className={styles.fileInfoRow}>
+              <BodyThreeText className={styles.fileDetail}>
+                {width} x {height}
+              </BodyThreeText>
+              {(width > IMAGE_DIMENSION_WARNING ||
+                height > IMAGE_DIMENSION_WARNING) && (
+                <WarningIcon text="This image is large and may result in degraded performance." />
+              )}
+            </div>
+          )}
+        </div>
       </button>
     </div>
   );
 };
 
-const MAX_CHARACTERS = 35;
+const MAX_CHARACTERS = 20;
 
 function truncateFilename(filename: string) {
   if (filename.length < MAX_CHARACTERS) {
@@ -76,10 +137,36 @@ function truncateFilename(filename: string) {
   }
 
   return (
-    filename.substring(0, 20) +
+    filename.substring(0, MAX_CHARACTERS - 10) +
     '...' +
-    filename.substring(filename.length - 10, filename.length)
+    filename.substring(filename.length - 7, filename.length)
   );
 }
+
+function getSizeText(size: number) {
+  if (size < 1000) {
+    return `${size} B`;
+  } else if (size < 1000000) {
+    return `${Math.round(size / 1000)} KB`;
+  } else {
+    return `${Math.round(size / 1000000)} MB`;
+  }
+}
+
+const WarningIcon: React.FC<{text: string}> = ({text}) => (
+  <WithTooltip
+    tooltipProps={{
+      text,
+      tooltipId: 'warning-tooltip',
+      direction: 'onTop',
+      size: 'xs',
+    }}
+  >
+    <FontAwesomeV6Icon
+      className={styles.warningIcon}
+      iconName="triangle-exclamation"
+    />
+  </WithTooltip>
+);
 
 export default memo(FileIcon);

--- a/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
@@ -2,7 +2,7 @@ import Modal from '@code-dot-org/component-library/modal';
 import React, {useState} from 'react';
 
 import FileIcon from './FileIcon';
-import {ErrorAlert, Loading} from './shared';
+import {DialogAlert, Loading} from './shared';
 import {AssetData, CommonProps, DialogProps} from './types';
 
 import styles from './starter-assets-dialog.module.scss';
@@ -20,7 +20,7 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
   levelName,
   onSelect,
   limit,
-  errorMessage,
+  alert,
 }) => {
   const [selectedFiles, setSelectedFiles] = useState<AssetData[]>([]);
 
@@ -36,8 +36,8 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
     <div className={styles.modalBody} id="dsco-dialog-description">
       {assets.map(asset => (
         <FileIcon
+          {...asset}
           key={asset.filename}
-          asset={asset}
           levelName={levelName}
           selected={selectedFiles.includes(asset)}
           onSelect={selected => onSelectAsset(selected, asset)}
@@ -64,9 +64,7 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
       }}
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={loading ? <Loading /> : <ModalBody />}
-      customBottomContent={
-        errorMessage && <ErrorAlert message={errorMessage} />
-      }
+      customBottomContent={alert && <DialogAlert {...alert} />}
     />
   );
 };

--- a/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
@@ -32,21 +32,6 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
     }
   };
 
-  const ModalBody = () => (
-    <div className={styles.modalBody} id="dsco-dialog-description">
-      {assets.map(asset => (
-        <FileIcon
-          {...asset}
-          key={asset.filename}
-          levelName={levelName}
-          selected={selectedFiles.includes(asset)}
-          onSelect={selected => onSelectAsset(selected, asset)}
-          canSelect={!limit || selectedFiles.length < limit}
-        />
-      ))}
-    </div>
-  );
-
   const primaryOnClick = () => {
     onSelect(selectedFiles);
     onClose();
@@ -63,7 +48,24 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
         disabled: selectedFiles.length === 0,
       }}
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
-      customContent={loading ? <Loading /> : <ModalBody />}
+      customContent={
+        loading ? (
+          <Loading />
+        ) : (
+          <div className={styles.modalBody} id="dsco-dialog-description">
+            {assets.map(asset => (
+              <FileIcon
+                {...asset}
+                key={asset.filename}
+                levelName={levelName}
+                selected={selectedFiles.includes(asset)}
+                onSelect={selected => onSelectAsset(selected, asset)}
+                canSelect={!limit || selectedFiles.length < limit}
+              />
+            ))}
+          </div>
+        )
+      }
       customBottomContent={alert && <DialogAlert {...alert} />}
     />
   );

--- a/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {fetchLevelAssets} from './api';
 import SelectAssetsDialog, {SelectProps} from './SelectAssetsDialog';
-import {AssetData} from './types';
+import {AssetData, UpdateAlertCallback} from './types';
 import UploadAssetDialog, {UploadProps} from './UploadAssetDialog';
 
 /**
@@ -46,8 +46,8 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
 
   const clearAlert = useCallback(() => setAlert(undefined), []);
 
-  const updateAlert = useCallback(
-    (message: string, type: 'danger' | 'warning', error?: Error) => {
+  const updateAlert: UpdateAlertCallback = useCallback(
+    (message, type, error) => {
       setAlert({message, type});
       if (type === 'danger') {
         onError?.(message, error);

--- a/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/StarterAssetsDialog.tsx
@@ -13,32 +13,10 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
   const {levelName, mode, onError} = props;
   const [assets, setAssets] = useState<AssetData[]>([]);
   const [loading, setLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | undefined>(
-    undefined
-  );
-
-  const abortControllerRef = useRef(new AbortController());
-
-  const fetchAssets = useCallback(async () => {
-    const signal = abortControllerRef.current.signal;
-
-    setLoading(true);
-    try {
-      const assets = await fetchLevelAssets(levelName, signal);
-      setAssets(assets);
-    } catch (error) {
-      onError?.(error as Error);
-      setDefaultErrorMessage();
-    }
-    setLoading(false);
-  }, [levelName, onError]);
-
-  useEffect(() => {
-    fetchAssets();
-
-    const controller = abortControllerRef.current;
-    return () => controller.abort();
-  }, [fetchAssets]);
+  const [alert, setAlert] = useState<{
+    message: string;
+    type: 'danger' | 'warning';
+  }>();
 
   const addAsset = useCallback(
     (asset: AssetData) => {
@@ -66,38 +44,56 @@ const StarterAssetsDialog: React.FC<SelectProps | UploadProps> = props => {
     [assets]
   );
 
-  const handleError = useCallback(
-    (error: Error, userErrorMessage?: string) => {
-      onError?.(error);
-      if (userErrorMessage) {
-        setErrorMessage(userErrorMessage);
-      } else {
-        setDefaultErrorMessage();
+  const clearAlert = useCallback(() => setAlert(undefined), []);
+
+  const updateAlert = useCallback(
+    (message: string, type: 'danger' | 'warning', error?: Error) => {
+      setAlert({message, type});
+      if (type === 'danger') {
+        onError?.(message, error);
       }
     },
     [onError]
   );
 
-  const clearError = () => setErrorMessage(undefined);
-  const setDefaultErrorMessage = () =>
-    setErrorMessage('Something went wrong. Please try again!');
+  const abortControllerRef = useRef(new AbortController());
+  const fetchAssets = useCallback(async () => {
+    const signal = abortControllerRef.current.signal;
+
+    setLoading(true);
+    try {
+      const assets = await fetchLevelAssets(levelName, signal);
+      setAssets(assets);
+    } catch (error) {
+      updateAlert('Failed to fetch assets', 'danger', error as Error);
+    }
+    setLoading(false);
+  }, [levelName, updateAlert]);
+
+  useEffect(() => {
+    fetchAssets();
+
+    const controller = abortControllerRef.current;
+    return () => controller.abort();
+  }, [fetchAssets]);
 
   const dialogProps = {
     assets,
     loading,
-    errorMessage,
-    // Used by UploadAssetDialog
-    addAsset,
-    removeAsset,
-    handleError,
-    clearError,
+    alert,
   };
 
   if (mode === 'select') {
     return <SelectAssetsDialog {...props} {...dialogProps} />;
   }
 
-  return <UploadAssetDialog {...props} {...dialogProps} />;
+  return (
+    <UploadAssetDialog
+      {...props}
+      {...dialogProps}
+      {...{addAsset, removeAsset, updateAlert, clearAlert}}
+    />
+  );
 };
 
 export default StarterAssetsDialog;

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -1,13 +1,19 @@
 import Modal from '@code-dot-org/component-library/modal';
-import React, {ChangeEvent, useState} from 'react';
+import React, {ChangeEvent, useCallback, useState} from 'react';
 
 import useHiddenFileInput from '@cdo/apps/util/hooks/useHiddenFileInput';
 import {isNetworkError} from '@cdo/apps/util/HttpClient';
 
 import {deleteFile, uploadFile} from './api';
+import {
+  IMAGE_DIMENSION_WARNING,
+  PDF_PAGE_LIMIT,
+  PDF_PAGE_WARNING,
+} from './constants';
 import FileIcon from './FileIcon';
-import {ErrorAlert, Loading} from './shared';
-import {CommonProps, DialogProps} from './types';
+import {DialogAlert, Loading} from './shared';
+import {CommonProps, UploadDialogProps} from './types';
+import {getImageDimensions, getPageCount} from './utils';
 
 import styles from './starter-assets-dialog.module.scss';
 
@@ -25,19 +31,18 @@ const ACCEPTED_FILE_TYPES = [
 
 export interface UploadProps extends CommonProps {
   mode: 'upload';
-  clearError?: () => void;
 }
 
-const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
+const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
   onClose,
   assets,
   addAsset,
   removeAsset,
   loading,
   levelName,
-  handleError,
-  errorMessage,
-  clearError,
+  updateAlert,
+  alert,
+  clearAlert,
 }) => {
   const [requestInProgress, setRequestInProgress] = useState<
     'upload' | 'delete'
@@ -49,18 +54,45 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       return;
     }
 
+    // Starter Assets API only supports one file upload at a time.
+    const file = files[0];
+
+    if (file.name.endsWith('.pdf')) {
+      const pageCount = (await getPageCount(file)) || 0;
+      if (pageCount > PDF_PAGE_LIMIT) {
+        updateAlert(
+          `PDFs must be less than ${PDF_PAGE_LIMIT} pages. Please try a smaller file.`,
+          'danger'
+        );
+        return;
+      } else if (pageCount > PDF_PAGE_WARNING) {
+        updateAlert(
+          `WARNING: ${file.name} is ${pageCount} pages long. PDFs with many pages and lots of text will increase response times, potentially resulting in timeouts.`,
+          'warning'
+        );
+      }
+    }
+
+    if (file.type.includes('image')) {
+      const {width, height} = await getImageDimensions(file);
+      if (width > IMAGE_DIMENSION_WARNING || height > IMAGE_DIMENSION_WARNING) {
+        updateAlert(
+          `WARNING: ${file.name} is ${width} x ${height} pixels. Images with large dimensions may result in degraded performance.`,
+          'warning'
+        );
+      }
+    }
+
     setRequestInProgress('upload');
     try {
-      // Starter Assets API only supports one file upload at a time.
-      const asset = await uploadFile(files[0], levelName);
+      const asset = await uploadFile(file, levelName);
       addAsset(asset);
     } catch (error) {
-      let userErrorMessage;
-      if (isNetworkError(error) && error.getDetails().status === 413) {
-        userErrorMessage =
-          'Images must be less than 20 MB, and PDFs less than 5 MB. Please try a smaller asset.';
-      }
-      handleError(error as Error, userErrorMessage);
+      const errorMessage =
+        isNetworkError(error) && error.getDetails().status === 413
+          ? 'Images must be less than 20 MB, and PDFs less than 5 MB. Please try a smaller asset.'
+          : 'Something went wrong. Please try again.';
+      updateAlert(errorMessage, 'danger', error as Error);
     }
     setRequestInProgress(undefined);
   };
@@ -70,17 +102,24 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
     ACCEPTED_FILE_TYPES.join(',')
   );
 
-  const onDelete = async (filename: string) => {
-    clearError?.();
-    setRequestInProgress('delete');
-    try {
-      await deleteFile(filename, levelName);
-      removeAsset(filename);
-    } catch (error) {
-      handleError(error as Error);
-    }
-    setRequestInProgress(undefined);
-  };
+  const onDelete = useCallback(
+    async (filename: string) => {
+      clearAlert();
+      setRequestInProgress('delete');
+      try {
+        await deleteFile(filename, levelName);
+        removeAsset(filename);
+      } catch (error) {
+        updateAlert(
+          'Error deleting file. Please try again',
+          'danger',
+          error as Error
+        );
+      }
+      setRequestInProgress(undefined);
+    },
+    [clearAlert, levelName, removeAsset, updateAlert]
+  );
 
   const ModalBody = () => {
     return (
@@ -89,10 +128,10 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
         <div className={styles.modalBody} id="dsco-dialog-description">
           {assets.map(asset => (
             <FileIcon
+              {...asset}
               key={asset.filename}
-              asset={asset}
               levelName={levelName}
-              onDelete={() => onDelete(asset.filename)}
+              onDelete={onDelete}
             />
           ))}
         </div>
@@ -115,7 +154,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       primaryButtonProps={{
         text: buttonText,
         onClick: () => {
-          clearError?.();
+          clearAlert();
           openFileInput();
         },
         iconLeft: {
@@ -126,9 +165,7 @@ const UploadAssetDialog: React.FC<DialogProps & UploadProps> = ({
       }}
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={loading ? <Loading /> : <ModalBody />}
-      customBottomContent={
-        errorMessage && <ErrorAlert message={errorMessage} />
-      }
+      customBottomContent={alert && <DialogAlert {...alert} />}
     />
   );
 };

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -121,24 +121,6 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
     [clearAlert, levelName, removeAsset, updateAlert]
   );
 
-  const ModalBody = () => {
-    return (
-      <>
-        <FileInput />
-        <div className={styles.modalBody} id="dsco-dialog-description">
-          {assets.map(asset => (
-            <FileIcon
-              {...asset}
-              key={asset.filename}
-              levelName={levelName}
-              onDelete={onDelete}
-            />
-          ))}
-        </div>
-      </>
-    );
-  };
-
   const buttonText =
     requestInProgress === 'upload'
       ? 'Uploading...'
@@ -164,7 +146,25 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
         disabled: loading || !!requestInProgress,
       }}
       secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
-      customContent={loading ? <Loading /> : <ModalBody />}
+      customContent={
+        loading ? (
+          <Loading />
+        ) : (
+          <>
+            <FileInput />
+            <div className={styles.modalBody} id="dsco-dialog-description">
+              {assets.map(asset => (
+                <FileIcon
+                  {...asset}
+                  key={asset.filename}
+                  levelName={levelName}
+                  onDelete={onDelete}
+                />
+              ))}
+            </div>
+          </>
+        )
+      }
       customBottomContent={alert && <DialogAlert {...alert} />}
     />
   );

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -61,7 +61,7 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
       const pageCount = (await getPageCount(file)) || 0;
       if (pageCount > PDF_PAGE_LIMIT) {
         updateAlert(
-          `PDFs must be less than ${PDF_PAGE_LIMIT} pages. Please try a smaller file.`,
+          `${file.name} is ${pageCount} pages long. PDFs must be less than ${PDF_PAGE_LIMIT} pages. Please try a smaller file.`,
           'danger'
         );
         return;
@@ -159,6 +159,7 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
                   key={asset.filename}
                   levelName={levelName}
                   onDelete={onDelete}
+                  showWarnings={true}
                 />
               ))}
             </div>

--- a/apps/src/lab2/views/components/starterAssetsDialog/api.ts
+++ b/apps/src/lab2/views/components/starterAssetsDialog/api.ts
@@ -36,5 +36,5 @@ export async function deleteFile(filename: string, levelName: string) {
 }
 
 export function getFileUrl(filename: string, levelName: string) {
-  return `${getPath(levelName)}/${filename}`;
+  return `${getPath(levelName)}/${encodeURIComponent(filename)}`;
 }

--- a/apps/src/lab2/views/components/starterAssetsDialog/constants.ts
+++ b/apps/src/lab2/views/components/starterAssetsDialog/constants.ts
@@ -1,0 +1,3 @@
+export const PDF_PAGE_WARNING = 10;
+export const PDF_PAGE_LIMIT = 25;
+export const IMAGE_DIMENSION_WARNING = 2048;

--- a/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/shared.tsx
@@ -4,9 +4,12 @@ import React from 'react';
 
 import styles from './starter-assets-dialog.module.scss';
 
-const ErrorAlert: React.FC<{message: string}> = ({message}) => (
+const DialogAlert: React.FC<{message: string; type: 'danger' | 'warning'}> = ({
+  message,
+  type,
+}) => (
   <div className={styles.alertContainer}>
-    <Alert text={message} type="danger" size="xs" className={styles.alert} />
+    <Alert text={message} type={type} size="xs" className={styles.alert} />
   </div>
 );
 
@@ -16,4 +19,4 @@ const Loading: React.FC = () => (
   </div>
 );
 
-export {ErrorAlert, Loading};
+export {DialogAlert, Loading};

--- a/apps/src/lab2/views/components/starterAssetsDialog/starter-assets-dialog.module.scss
+++ b/apps/src/lab2/views/components/starterAssetsDialog/starter-assets-dialog.module.scss
@@ -33,6 +33,11 @@
   align-items: flex-start;
 }
 
+.loadingIcon {
+  font-size: 13px;
+  min-width: 1.5rem;
+}
+
 %file-icon {
   @include remove-button-styles;
   display: flex;
@@ -42,9 +47,35 @@
   text-align: center;
   gap: 8px;
 
+  .fileInfo {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+
+    .fileInfoRow {
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      gap: 4px;
+    }
+  }
+
   .filename {
     width: 100%;
     overflow-wrap: break-word;
+  }
+
+  .fileDetail {
+    color: var(--text-neutral-quaternary)
+  }
+}
+
+.warningIcon {
+  font-size: 13px;
+  color: var(--text-warning-primary);
+  &:hover {
+    color: var(--text-warning-secondary);
   }
 }
 

--- a/apps/src/lab2/views/components/starterAssetsDialog/types.ts
+++ b/apps/src/lab2/views/components/starterAssetsDialog/types.ts
@@ -21,13 +21,15 @@ export interface DialogProps {
   alert?: {message: string; type: 'danger' | 'warning'};
 }
 
+export type UpdateAlertCallback = <T extends 'danger' | 'warning'>(
+  message: string,
+  type: T,
+  error?: T extends 'danger' ? Error : never
+) => void;
+
 export interface UploadDialogProps extends DialogProps {
   addAsset: (asset: AssetData) => void;
   removeAsset: (filename: string) => void;
-  updateAlert: (
-    message: string,
-    type: 'danger' | 'warning',
-    error?: Error
-  ) => void;
+  updateAlert: UpdateAlertCallback;
   clearAlert: () => void;
 }

--- a/apps/src/lab2/views/components/starterAssetsDialog/types.ts
+++ b/apps/src/lab2/views/components/starterAssetsDialog/types.ts
@@ -12,14 +12,22 @@ export interface AssetData {
 export interface CommonProps {
   onClose: () => void;
   levelName: string;
-  onError?: (error: Error) => void;
+  onError?: (message: string, error?: Error) => void;
 }
 
 export interface DialogProps {
   assets: AssetData[];
+  loading: boolean;
+  alert?: {message: string; type: 'danger' | 'warning'};
+}
+
+export interface UploadDialogProps extends DialogProps {
   addAsset: (asset: AssetData) => void;
   removeAsset: (filename: string) => void;
-  loading: boolean;
-  handleError: (error: Error, userErrorMessage?: string) => void;
-  errorMessage?: string;
+  updateAlert: (
+    message: string,
+    type: 'danger' | 'warning',
+    error?: Error
+  ) => void;
+  clearAlert: () => void;
 }

--- a/apps/src/lab2/views/components/starterAssetsDialog/utils.ts
+++ b/apps/src/lab2/views/components/starterAssetsDialog/utils.ts
@@ -1,0 +1,27 @@
+import {PDFDocument} from 'pdf-lib';
+
+export async function getImageDimensions(file: File) {
+  return new Promise<{width: number; height: number}>((resolve, reject) => {
+    const img = new Image();
+    img.src = URL.createObjectURL(file);
+    img.onload = () => {
+      resolve({width: img.width, height: img.height});
+    };
+    img.onerror = () => {
+      reject(new Error('Failed to load image'));
+    };
+  });
+}
+
+export async function getPageCount(url: string | File) {
+  try {
+    const pdfData =
+      url instanceof File
+        ? await url.arrayBuffer()
+        : await fetch(url).then(res => res.arrayBuffer());
+    const pdf = await PDFDocument.load(pdfData);
+    return pdf.getPageCount();
+  } catch (error) {
+    console.error('Error loading PDF:', error);
+  }
+}

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -5327,6 +5327,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pdf-lib/standard-fonts@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@pdf-lib/standard-fonts@npm:1.0.0"
+  dependencies:
+    pako: "npm:^1.0.6"
+  checksum: 10/0dfcedbd16e3f48afcac321f153d81f49ea6030030fa1e05a07bde359629949e27b3d77b39a5c7b0b0ff8af09912765f62a911cd67d488d4dc0b3c1c5ca106f0
+  languageName: node
+  linkType: hard
+
+"@pdf-lib/upng@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@pdf-lib/upng@npm:1.0.1"
+  dependencies:
+    pako: "npm:^1.0.10"
+  checksum: 10/eecac72f36d51b67acb09f61a7bbb55577ceb6232aa0c1a827aea003126787cede07ad391c0c789ab36164a9a86d1634768c2cf941148743e155de7ed6c34fc3
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -10409,6 +10427,7 @@ __metadata:
     object-fit-images: "npm:^3.2.3"
     papaparse: "npm:^5.4.1"
     path-browserify: "npm:^1.0.1"
+    pdf-lib: "npm:^1.17.1"
     pepjs: "npm:^0.4.3"
     pixelmatch: "npm:^5.2.0"
     playground-io: "code-dot-org/playground-io#v0.6.0-cdo.2"
@@ -22271,7 +22290,7 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
-"pako@npm:~1.0.2, pako@npm:~1.0.5":
+"pako@npm:^1.0.10, pako@npm:^1.0.11, pako@npm:^1.0.6, pako@npm:~1.0.2, pako@npm:~1.0.5":
   version: 1.0.11
   resolution: "pako@npm:1.0.11"
   checksum: 10/1ad07210e894472685564c4d39a08717e84c2a68a70d3c1d9e657d32394ef1670e22972a433cbfe48976cb98b154ba06855dcd3fcfba77f60f1777634bec48c0
@@ -22587,6 +22606,18 @@ canvg@gabelerner/canvg:
   version: 1.1.2
   resolution: "pathe@npm:1.1.2"
   checksum: 10/f201d796351bf7433d147b92c20eb154a4e0ea83512017bf4ec4e492a5d6e738fb45798be4259a61aa81270179fce11026f6ff0d3fa04173041de044defe9d80
+  languageName: node
+  linkType: hard
+
+"pdf-lib@npm:^1.17.1":
+  version: 1.17.1
+  resolution: "pdf-lib@npm:1.17.1"
+  dependencies:
+    "@pdf-lib/standard-fonts": "npm:^1.0.0"
+    "@pdf-lib/upng": "npm:^1.0.1"
+    pako: "npm:^1.0.11"
+    tslib: "npm:^1.11.1"
+  checksum: 10/ea8c2c0c813d89ca359a0c831cb2e8a581c569ed44b074316f917942b5baa101f878ce922f1cb87e6f41a035008ba75b52267480aee5d65a5e68c445ee83bc37
   languageName: node
   linkType: hard
 
@@ -28346,7 +28377,7 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.13.0, tslib@npm:^1.8.1":
+"tslib@npm:^1.11.1, tslib@npm:^1.13.0, tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 10/7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb


### PR DESCRIPTION
Adds a number of updates to the level starter assets manager, in an effort to limit uploads of and highlight potentially problematic files (PDFs with many pages, or large images). While we have overall size limits that will reject the file upload, there are still other issues that were causing errors and timeouts for students. Changes include:

- Showing file size, PDF page counts, and image dimensions in the file picker UI
- Showing warning icons if uploaded PDFs or images are large and may contribute to slow load times and/or timeouts
- Show warning alert if uploading a file that's above these warning limits (2048px for images, 10 pages for PDFs)
- Prevent PDF uploads over a higher limit (currently 25 pages).

Note that I made use of the [pdf-lib](https://classic.yarnpkg.com/en/package/pdf-lib) library to process PDF documents.

Levelbuilder-facing view, default:
<img width="802" alt="Screenshot 2025-05-12 at 12 52 38 PM" src="https://github.com/user-attachments/assets/0b3bee5f-3116-4651-93c8-ffc62e286ee9" />

Warning icon with tooltips:
<img width="806" alt="Screenshot 2025-05-12 at 12 53 11 PM" src="https://github.com/user-attachments/assets/f636315a-4ebd-4e73-bfac-22b46a0a3580" />
<img width="801" alt="Screenshot 2025-05-12 at 12 53 16 PM" src="https://github.com/user-attachments/assets/d5a8f549-fe73-4fa3-a281-e40e0ee5217a" />

Upload warnings:
<img width="887" alt="Screenshot 2025-05-12 at 12 53 37 PM" src="https://github.com/user-attachments/assets/f96ea960-78a4-460f-a14b-2502e5e7a7af" />
<img width="805" alt="Screenshot 2025-05-12 at 12 54 24 PM" src="https://github.com/user-attachments/assets/40a11b93-5a55-49f5-96bf-d59b1ea2cd0f" />

PDF upload error:
<img width="795" alt="Screenshot 2025-05-12 at 12 55 35 PM" src="https://github.com/user-attachments/assets/c7696e4b-8aca-45e1-9962-d437c9976ebc" />

Student-facing view (no warning icons):
<img width="686" alt="Screenshot 2025-05-12 at 12 49 29 PM" src="https://github.com/user-attachments/assets/edc0736a-9d71-4d45-9d98-192ef8907d6a" />

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1442

## Testing story

Tested locally on allthethings.