### PR TITLE
Use default keymap for codemirror accept completion including 'Enter'

### DIFF
--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -88,7 +88,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
       ...editorConfig,
 
       onEditorUpdate,
-      autocompletion({defaultKeymap: false}),
+      autocompletion(),
       ...editorConfigExtensions,
     ];
 

--- a/apps/src/lab2/views/components/editor/editorConfig.ts
+++ b/apps/src/lab2/views/components/editor/editorConfig.ts
@@ -1,10 +1,7 @@
 import {
   closeBrackets,
   closeBracketsKeymap,
-  startCompletion,
-  closeCompletion,
   acceptCompletion,
-  moveCompletionSelection,
 } from '@codemirror/autocomplete';
 import {
   defaultKeymap,
@@ -30,18 +27,9 @@ import {
   rectangularSelection,
 } from '@codemirror/view';
 
-// These are the almost same as the default keybindings for autocomplete,
-// except that we changed acceptCompletion to use Tab instead of Enter.
-const autocompleteKeybindings = [
-  {key: 'Ctrl-Space', run: startCompletion},
-  {mac: 'Alt-`', run: startCompletion},
-  {key: 'Escape', run: closeCompletion},
-  {key: 'ArrowDown', run: moveCompletionSelection(true)},
-  {key: 'ArrowUp', run: moveCompletionSelection(false)},
-  {key: 'PageDown', run: moveCompletionSelection(true, 'page')},
-  {key: 'PageUp', run: moveCompletionSelection(false, 'page')},
-  {key: 'Tab', run: acceptCompletion},
-];
+// We use default keybindings for autocomplete, but we add 'Tab' to also accept completion.
+// 'Enter' accepts completion by default: https://github.com/codemirror/autocomplete/blob/ab0a89942b237bbc13735604b018d10c0101b5ea/src/index.ts#L39-L48
+const autocompleteKeybindings = [{key: 'Tab', run: acceptCompletion}];
 
 // Extensions for codemirror. Based on @codemirror/basic-setup, with javascript-specific
 // extensions removed (lint, autocomplete). This is the base configuration for all codemirror


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the CodeMirror autocompletion in `lab2`'s `CodeEditor` so that the default keymap is used. This includes 'Enter' for accepting completion: https://codemirror.net/docs/ref/#autocomplete.completionKeymap

https://github.com/code-dot-org/code-dot-org/pull/61799 updated autocomplete to use 'Tab' instead of 'Enter'. We want to continue to allowing 'Tab' to accept completion. However, the other default key mappings are desirable so I updated config to add 'Tab', but then use the default key bindings since they match what we currently have implemented.

I tested in both `pythonlab` and `weblab2` and both 'Enter' and 'Tab' keys accept completion. The up/down arrows continue to be used to navigate through completion option.

'Esc' is supposed to close the completion dropdown, but currently the key is mapped to moving user out of the code editor - ~~not sure if this is expected.~~ cc: @hannahbergam. 
UPDATE: Hannah confirmed this is undesirable. Created a follow-up ticket.

## After update

Using keyboard navigation to access autocompletion dropdown, navigation, and selection - 'Enter' for selection - in `pythonlab` and `weblab2`.

https://github.com/user-attachments/assets/7ea94f7f-1e36-425c-885b-68a5be4ef501


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/CT-1219

## Testing story
Tested locally on `pythonlab` and `weblab2` levels.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
'Esc' is supposed to close the completion dropdown, but currently when 'Esc' key is pressed, the user is moved out of the code editor: https://codedotorg.atlassian.net/browse/SL-1241

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
