### PR TITLE
[PythonLab] Fixing ellipsis focus

### DIFF
--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -85,10 +85,10 @@ button.button-kebab {
   }
 }
 
-div.row:hover .button-kebab,
-div.notDraggable:focus-within .button-kebab,
-div.draggable:hover .button-kebab,
-div.draggable:focus-within .button-kebab {
+.row:hover > .button-kebab,
+.notDraggable:focus-within > .row > .button-kebab,
+.draggable:hover > .button-kebab,
+.draggable:focus-within > .row > .button-kebab {
   display: inherit;
   height: 20px;
   width: 20px;

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -73,7 +73,12 @@
 // Using button to increase specificity of this class
 // (this allows it to take precedence over the component library button styles)
 button.button-kebab {
-  display: none;
+  opacity: 0;
+  height: 20px;
+  width: 20px;
+  min-width: 20px !important;
+  margin: 2px;
+  transition: none;
 
   // We use important here because the hover, and active styles used by Button
   // are more specific than a single class.
@@ -81,6 +86,7 @@ button.button-kebab {
   // element with the standard hover color.
   &:hover,
   &:active {
+    opacity: 1;
     background-color: var(--background-neutral-quinary) !important;
   }
 }
@@ -88,12 +94,10 @@ button.button-kebab {
 .row:hover > .button-kebab,
 .notDraggable:focus-within > .row > .button-kebab,
 .draggable:hover > .button-kebab,
-.draggable:focus-within > .row > .button-kebab {
-  display: inherit;
-  height: 20px;
-  width: 20px;
+.draggable:focus > .row > .button-kebab,
+button.button-kebab:focus {
+  opacity: 1;
   min-width: 1.25rem;
-  margin: 2px 2px 2px 0;
 }
 
 .nameContainer {

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -91,6 +91,7 @@ button.button-kebab {
   }
 }
 
+// This allows the ellipsis to display when its parent is hovered on or has focus
 .row:hover > .button-kebab,
 .notDraggable:focus-within > .row > .button-kebab,
 .draggable:hover > .button-kebab,

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -91,7 +91,7 @@ button.button-kebab {
   }
 }
 
-// This allows the ellipsis to display when its parent is hovered on or has focus
+// This allows the ellipsis to display when its button host is hovered on or has focus
 .row:hover > .button-kebab,
 .notDraggable:focus-within > .row > .button-kebab,
 .draggable:hover > .button-kebab,

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -76,7 +76,7 @@ button.button-kebab {
   opacity: 0;
   height: 20px;
   width: 20px;
-  min-width: 20px !important;
+  min-width: 20px !important; // !important to override the default button min-width
   margin: 2px;
   transition: none;
 
@@ -98,7 +98,6 @@ button.button-kebab {
 .draggable:focus > .row > .button-kebab,
 button.button-kebab:focus {
   opacity: 1;
-  min-width: 1.25rem;
 }
 
 .nameContainer {

--- a/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
+++ b/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
@@ -27,5 +27,5 @@
 // We need !important because of css specificity- this would be overriden
 // by display: none otherwise.
 button.active {
-  display: inherit !important;
+  opacity: 1 !important;
 }


### PR DESCRIPTION
The issue: the parents and siblings all showed the ellipsis when a single file or folder was hovered on or active. Now the ellipsis will only show for the single relevant file or folder. 


Moved as much of the styling to the button as possible, and only used important when absolutely necessary. Updated from display none vs inherit to opacity because of keyboard focus. With display none, the keyboard cant find the focusable element at all. With opacity, we can bridge the gap to allow the keyboard to find the ellipsis button in the split second between when the parent loses focus and when it is supposed to display itself (also why I had to add another line to add opacity 1 to the button itself on focus). Please reach out to me if you need more explanation! @kelbyhawn and I spent a marathon day on getting it all working!

Images and videos will help explain!

Before:

<img width="351" alt="Screenshot 2025-05-15 at 1 03 51 PM" src="https://github.com/user-attachments/assets/606c30ec-1314-4c14-ba50-d99fc118c95f" />

<img width="352" alt="Screenshot 2025-05-15 at 1 03 46 PM" src="https://github.com/user-attachments/assets/1978f98d-0f87-44be-9f49-dedc33510b31" />


After:
<img width="384" alt="Screenshot 2025-05-15 at 1 03 57 PM" src="https://github.com/user-attachments/assets/10c1b040-74a3-4a37-bde9-8dea1ef45cff" />

<img width="331" alt="Screenshot 2025-05-15 at 1 03 41 PM" src="https://github.com/user-attachments/assets/a41b5382-22d4-46c8-8aba-5fd62cbb053c" />

https://github.com/user-attachments/assets/ada8b875-874f-414b-bd64-0044ebf99088



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1239

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
