### PR TITLE
Remove Host header from marketing site origin cache behaviors

### DIFF
--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -358,7 +358,7 @@ module AWS
     # Don't include the Host and CloudFront-Forwarded-Proto headers in the cache key for
     # S3 origins or the NextJS-based marketing origin. For the marketing site switchover, we
     # manually override the Host header in the marketing-router lambda function.
-    private def exclude_default_headers?(origin_proxy_name)
+    private_class_method def self.exclude_default_headers?(origin_proxy_name)
       ['cdo-assets', 'cdo-restricted', 'marketing'].include?(origin_proxy_name)
     end
   end

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -17,12 +17,8 @@ module AWS
       500 => '/assets/error-pages/500.html'
     }.freeze
     ERROR_CACHE_TTL = 60
-    # Configure CloudFront to forward these headers for S3 origins.
-    S3_FORWARD_HEADERS = %w(
-      Access-Control-Request-Headers
-      Access-Control-Request-Method
-      Origin
-    ).freeze
+    # Default headers to be sent to the origin for most behaviors.
+    DEFAULT_HEADERS = %w(Host CloudFront-Forwarded-Proto)
     # Use the same HTTP Cache configuration as cdo-varnish
     HTTP_CACHE = HttpCache.config(rack_env)
     CACHE_INVALIDATION_MAX_RETRIES = 10
@@ -264,11 +260,9 @@ module AWS
 
     # Returns a CloudFront CacheBehavior Hash compatible with AWS CloudFormation.
     def self.cache_behavior(behavior_config, path = nil)
-      s3 = ['cdo-assets', 'cdo-restricted'].include? behavior_config[:proxy]
-      # Include Host header in CloudFront's cache key to match Varnish for custom origins.
-      # Include S3 forward headers for s3 origins.
-      headers = behavior_config[:headers] +
-        (s3 ? S3_FORWARD_HEADERS : %w(Host CloudFront-Forwarded-Proto))
+      headers = behavior_config[:headers]
+      headers.concat(DEFAULT_HEADERS) unless exclude_default_headers?(behavior_config[:proxy])
+
       cookie_config = behavior_config[:cookies].is_a?(Array) ?
         {
           Forward: 'whitelist',
@@ -359,6 +353,13 @@ module AWS
         resource,
         policy: policy
       )
+    end
+
+    # Don't include the Host and CloudFront-Forwarded-Proto headers in the cache key for
+    # S3 origins or the NextJS-based marketing origin. For the marketing site switchover, we
+    # manually override the Host header in the marketing-router lambda function.
+    private def exclude_default_headers?(origin_proxy_name)
+      ['cdo-assets', 'cdo-restricted', 'marketing'].include?(origin_proxy_name)
     end
   end
 end

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -261,7 +261,7 @@ module AWS
     # Returns a CloudFront CacheBehavior Hash compatible with AWS CloudFormation.
     def self.cache_behavior(behavior_config, path = nil)
       headers = behavior_config[:headers]
-      headers.concat(DEFAULT_HEADERS) unless exclude_default_headers?(behavior_config[:proxy])
+      headers += DEFAULT_HEADERS unless exclude_default_headers?(behavior_config[:proxy])
 
       cookie_config = behavior_config[:cookies].is_a?(Array) ?
         {

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -51,10 +51,10 @@ class HttpCache
   ACCEPT_HEADER = %w(Accept).freeze
   ALLOWLISTED_HEADERS = LANGUAGE_HEADER + COUNTRY_HEADER + ACCEPT_HEADER
   S3_FORWARD_HEADERS = %w(
-      Access-Control-Request-Headers
-      Access-Control-Request-Method
-      Origin
-    ).freeze
+    Access-Control-Request-Headers
+    Access-Control-Request-Method
+    Origin
+  ).freeze
 
   DEFAULT_COOKIES = [
     # Language drop-down selection.

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -50,6 +50,11 @@ class HttpCache
   # Header which lets a client request a response format.
   ACCEPT_HEADER = %w(Accept).freeze
   ALLOWLISTED_HEADERS = LANGUAGE_HEADER + COUNTRY_HEADER + ACCEPT_HEADER
+  S3_FORWARD_HEADERS = %w(
+      Access-Control-Request-Headers
+      Access-Control-Request-Method
+      Origin
+    ).freeze
 
   DEFAULT_COOKIES = [
     # Language drop-down selection.
@@ -185,7 +190,7 @@ class HttpCache
             #
             path: '/assets/*',
             proxy: 'cdo-assets',
-            headers: [],
+            headers: S3_FORWARD_HEADERS,
             cookies: 'none'
           },
           {
@@ -254,13 +259,13 @@ class HttpCache
             #
             path: '/assets/*',
             proxy: 'cdo-assets',
-            headers: [],
+            headers: S3_FORWARD_HEADERS,
             cookies: 'none'
           },
           {
             path: '/restricted/*',
             proxy: 'cdo-restricted',
-            headers: [],
+            headers: S3_FORWARD_HEADERS,
             cookies: 'none',
             trusted_signer: true,
           },


### PR DESCRIPTION
Since we are manually rewriting the Host header for the _next/static cache behavior, we don't want to include the original Host header in the cache key configuration. Even though we were passing an empty array for headers, `cloudfront.rb` was adding `Host` and  `CloudFront-Forwarded-Proto` automatically. This PR makes it so these default headers are not added to cache behaviors for the marketing origin.

S3 origins were already excluded from the logic that added the Host header. In order to clean up this area of the code, I moved the S3 headers to `http_cache.rb` where they can be added directly to the S3 cache behaviors.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/CMS-691)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
