### PR TITLE
Remove reference to teacher tool bar in test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -3,6 +3,7 @@ Feature: BubbleChoice
   @properties_encryption_key
   Scenario: Viewing BubbleChoice progress
     Given I create a teacher-associated student named "Alice"
+    Given I am assigned to course "allthethingscourse" and unit "allthethings" with teacher "Teacher_Alice"
 
     # Go to BubbleChoice sublevel
     Given I am on "http://studio.code.org/s/allthethings/lessons/40/levels/1/sublevel/1"
@@ -24,11 +25,22 @@ Feature: BubbleChoice
     # View student's BubbleChoice progress as a teacher
     When I sign in as "Teacher_Alice"
 
+    # View progress from script overview page
+    Given I am on "http://studio.code.org/s/allthethings"
+    And I wait until element "#uitest-view-as-student-selector" is visible
+    Then I select the "Alice" option in dropdown "uitest-view-as-student-selector"
+    And I wait until current URL contains "user_id="
+    And I wait until element "td:contains(Lesson Name)" is visible
+    And I wait until element "td:contains(Bubble Choice)" is visible
+    Then I verify progress for lesson 42 level 1 is "perfect"
+
     # View progress from BubbleChoice activity page
     Given I am on "http://studio.code.org/s/allthethings/lessons/40/levels/1"
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
+    Then I select the "Untitled Section" option in dropdown named "sections"
+    And check that the URL contains "section_id="
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -1,5 +1,4 @@
 Feature: BubbleChoice
-  @no_safari
   @no_mobile
   @properties_encryption_key
   Scenario: Viewing BubbleChoice progress
@@ -24,15 +23,6 @@ Feature: BubbleChoice
 
     # View student's BubbleChoice progress as a teacher
     When I sign in as "Teacher_Alice"
-
-    # View progress from script overview page
-    Given I am on "http://studio.code.org/s/allthethings"
-    And I wait until element ".teacher-panel" is visible
-    When I click selector ".teacher-panel table td:contains(Alice)" once I see it
-    And I wait until current URL contains "user_id="
-    And I wait until element "td:contains(Lesson Name)" is visible
-    And I wait until element "td:contains(Bubble Choice)" is visible
-    Then I verify progress for lesson 42 level 1 is "perfect"
 
     # View progress from BubbleChoice activity page
     Given I am on "http://studio.code.org/s/allthethings/lessons/40/levels/1"

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -26,6 +26,7 @@ Feature: BubbleChoice
     When I sign in as "Teacher_Alice"
 
     # View progress from script overview page
+    Given I use a cookie to mock the DCDO key "teacher-local-nav-v2" as "true"
     Given I am on "http://studio.code.org/s/allthethings"
     And I wait until element "#uitest-view-as-student-selector" is visible
     Then I select the "Alice" option in dropdown "uitest-view-as-student-selector"


### PR DESCRIPTION
Combines two tickets to take out part of a unit test

Given [this PR](https://github.com/code-dot-org/code-dot-org/pull/61636), I do not think the unit level progress should be shown on the page. 


Notes:

- I was unable to recreate the original issue when running the test locally ([see passing test](https://app.saucelabs.com/tests/a5369fa8941241529fe676d430ffc14a#47)).
- When I go to the unit landing page on test (https://test-studio.code.org/s/allthethings) and on local host (http://localhost-studio.code.org:3000/s/allthethings), I do not see the teacher panel, but for some reason, running it through Saucelabs does show the teacher panel. 
- When on test or local, the unit landing page is not auto-re-directing to the unit landing page in the teacher dashboard (see video).  This was another weird thing I noticed, and perhaps connected to some of the weirdness between what we are seeing locally vs. test vs. production.  UPDATE: I think this is because the DCDO flag `"teacher-local-nav-v2"` is not set on test (nor locally for me).  When I changed this to `true` locally, I got the redirect, but still no teacher panel... 


https://github.com/user-attachments/assets/668957d5-08da-4b37-97f7-201467ac453b




## Links

[Reenable test](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?jql=assignee%20%3D%205d4c828efbe7c30cedfc65aa&selectedIssue=TEACH-1703)
[Fix allthethings not loading](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?jql=assignee%20%3D%205d4c828efbe7c30cedfc65aa&selectedIssue=TEACH-1690) - note that I think this is what the core issue is here, but since I was unable to reproduce the issue and there is no recording I cannot be 100% sure.  Re-enabling this will allow me to also see what issue was happening in `test` if it continues. 

## Follow up work
- Understand why the teacher panel is showing when running tests through sauce labs and perhaps as an extension, determine if we should have the unit landing page redirect to the dashboard.  I will connect with Liam/Mark on this to see if this was intentional... although, it seems like we want `test` to match the user experience as much as possible, so I'd be surprised if it were intentional. 
- If not already documented, remove references to the `DCDO` flag in the code base for the flag "teacher-local-nav-v2"
- Notify DOTD that this is somewhat of a speculative fix - will merge in after a deploy and prepare a revert if needed.