### PR TITLE
Lab2: Add padding to details summary instructions panel markdown

### DIFF
--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -199,7 +199,8 @@
     line-height: 1.2em;
   }
 
-  ol, ul {
+  ol,
+  ul {
     font-size: 14px;
     line-height: 0;
     margin: 0 0 10px 20px;
@@ -222,6 +223,9 @@
 
   details {
     line-height: 1.2;
+    summary {
+      margin: 4px 0;
+    }
   }
 }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Collapsible sections in aichat instructions panels look wonky, but we think they look OK in Python Lab.  This adds some padding to make collapsible sections in lab2 instructions look more like Python lab's.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1423

## Testing story

Tested locally. Searched level files for ::: details examples and compared before and after for music lab to make sure this extra padding doesn't make existing instructions in lab2 labs look bad. Seems fine to me.

python lab that we'd like to emulate: 
![image](https://github.com/user-attachments/assets/d50c2710-10fe-4e95-bec8-d27379d20457)

| ai chat before | ai chat after |
| - | - |
| ![image](https://github.com/user-attachments/assets/bbcd88ff-5ea2-4a13-8510-6a4444fd9355) |  ![image](https://github.com/user-attachments/assets/f1402d47-921c-4fc1-92ad-c948940c060a) |

music lab comparison:

https://github.com/user-attachments/assets/5478fce2-54cf-408e-b59d-07f3b901c389

