### PR TITLE
feat(marketing): add health checks

### DIFF
--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -282,6 +282,10 @@ Resources:
     Properties:
       Port: 80
       Protocol: HTTP
+      HealthCheckPath: /api/health_check
+      # Only HTTP Status 200 is considered healthy
+      Matcher:
+        HttpCode: 200
       TargetGroupAttributes:
         - Key: stickiness.enabled
           Value: "false"
@@ -402,7 +406,6 @@ Resources:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
       EnableECSManagedTags: false
-      HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
       DesiredCount: 3
       AvailabilityZoneRebalancing: ENABLED

--- a/frontend/apps/marketing/src/app/api/health_check/route.ts
+++ b/frontend/apps/marketing/src/app/api/health_check/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return new Response('OK', {status: 200});
+}


### PR DESCRIPTION
This PR adds a simple health check endpoint at `/api/health_check`. This endpoint is intended to be used by ALB.