### PR TITLE
SUM - add new UI test for AI feedback on summary pages

### DIFF
--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -140,7 +140,7 @@ const SummaryResponses = ({
     studentWork: response.text,
   }));
 
-  const AiEvaluationMVPUnits = ['csp4-2024', 'csp6-2024'];
+  const AiEvaluationMVPUnits = ['csp4-2024', 'csp6-2024', 'allthethings'];
   const aiAnalysisAvailable = AiEvaluationMVPUnits.includes(
     scriptData.reportingData.unitName
   );

--- a/dashboard/app/controllers/openai_evaluate_controller.rb
+++ b/dashboard/app/controllers/openai_evaluate_controller.rb
@@ -52,6 +52,15 @@ class OpenaiEvaluateController < ApplicationController
     elsif ProfanityFilter.find_potential_profanity(student_work, "en", {})
       json_response = {"content" => profanity_detected_response.to_json}
       return render(status: :ok, json: json_response)
+    elsif Rails.env.test?
+      # Return dummy data in the test environment
+      dummy_response = {
+        aiEvaluation: "Ok",
+        evaluationCriteria: "This is a test environment, so no real AI call was made.",
+        aiReasoning: "Dummy data returned for testing purposes."
+      }
+      json_response = {"content" => dummy_response.to_json}
+      return render(status: :ok, json: json_response)
     else
       system_prompt = AiSystemPrompts::EvaluateSystemPromptHelper.get_system_prompt(level, unit, evaluation_type)
       student_work_message = [{role: "user", content: student_work}]

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -104,6 +104,28 @@ Scenario: Check for Understanding summaries
   And element "p:contains('Sally')" does not exist
   And I wait until element "a:contains('Show hidden responses')" is visible
 
+Scenario: Check free response AI
+  Given I am on "http://studio.code.org"
+
+  Given I create an authorized teacher-associated student named "Sally"
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/"
+  And I type "sample response" into ".free-response > textarea"
+  And I press ".submitButton" using jQuery to load a new page
+
+  When I sign in as "Teacher_Sally"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
+
+  And I wait until element "#summary-container" is visible
+  And I dismiss the teacher panel
+
+  And I click selector "label:contains('Show AI Insights')" once I see it
+  And I click selector "button:contains('Evaluate student responses')" once I see it
+  And I wait until element "p:contains('Proficient: 1')" is visible
+
+  And I click selector "a:contains('View detailed analysis')" once I see it
+
+  And I wait until element "p:contains('Ok. Dummy data returned for testing purposes.')" is visible
+
 @eyes
 Scenario: Check for Understanding summaries eyes
   Given I am on "http://studio.code.org"


### PR DESCRIPTION
- Add basic UI test for AI analysis for FRQ Response.
- Modify function that is used to call open AI if in `test` environment so that no actual call to openAi is made
- This test passed locally. 

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1719)