### PR TITLE
feat(marketing): support sub-directories in path

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
@@ -10,6 +10,7 @@ import ContentEditorHelper from '@/components/contentEditorHelper';
 import {Brand} from '@/config/brand';
 import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
 import {getExperience} from '@/contentful/get-experience';
+import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
 import {getSeoMetadata} from '@/metadata/seo';
 import {getPageHeading} from '@/selectors/contentful/getExperienceEntryFields';
 
@@ -17,13 +18,15 @@ export const dynamic = 'force-static'; // Ensure ISR is enabled
 export const revalidate = 3600; // Cache for one hour
 
 type ExperiencePageProps = {
-  params: Promise<{locale?: string; slug?: string; brand?: Brand}>;
+  params: Promise<{locale?: string; paths?: string; brand?: Brand}>;
   searchParams: Promise<{[key: string]: string | string[] | undefined}>;
 };
 
 async function getPageProps({params, searchParams}: ExperiencePageProps) {
-  const {locale = 'en-US', slug = 'home-page'} = (await params) || {};
+  const {locale = 'en-US', paths = ['home']} = (await params) || {};
   const isDraftModeEnabled = (await draftMode()).isEnabled;
+
+  const slug = getContentfulSlug(paths);
 
   return {
     experienceResult: await getExperience(

--- a/frontend/apps/marketing/src/contentful/slug/__tests__/getContentfulSlug.test.ts
+++ b/frontend/apps/marketing/src/contentful/slug/__tests__/getContentfulSlug.test.ts
@@ -1,0 +1,33 @@
+import {getContentfulSlug} from '../getContentfulSlug';
+
+describe('getContentfulSlug', () => {
+  it('should return a single string when input is a single string', () => {
+    const result = getContentfulSlug('engineering');
+    expect(result).toBe('engineering');
+  });
+
+  it('should join an array of strings with slashes', () => {
+    const result = getContentfulSlug(['engineering', 'all-the-things']);
+    expect(result).toBe('engineering/all-the-things');
+  });
+
+  it('should return an empty string when input is an empty array', () => {
+    const result = getContentfulSlug([]);
+    expect(result).toBe('');
+  });
+
+  it('should handle an array with one element correctly', () => {
+    const result = getContentfulSlug(['engineering']);
+    expect(result).toBe('engineering');
+  });
+
+  it('should handle special characters in the input array', () => {
+    const result = getContentfulSlug(['engineering', 'all@the#things']);
+    expect(result).toBe('engineering/all@the#things');
+  });
+
+  it('should handle special characters in a single string input', () => {
+    const result = getContentfulSlug('engineering/all@the#things');
+    expect(result).toBe('engineering/all@the#things');
+  });
+});

--- a/frontend/apps/marketing/src/contentful/slug/getContentfulSlug.ts
+++ b/frontend/apps/marketing/src/contentful/slug/getContentfulSlug.ts
@@ -1,0 +1,12 @@
+/**
+ * Joins all page paths into a single string with slashes.
+ * For example, ['engineering', 'all-the-things'] becomes 'engineering/all-the-things'.
+ * @param pagePaths An array of page paths or a single page path string.
+ */
+export function getContentfulSlug(pagePaths: string | string[]): string {
+  if (Array.isArray(pagePaths)) {
+    return pagePaths.join('/');
+  }
+
+  return pagePaths;
+}

--- a/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
@@ -1,0 +1,103 @@
+import {NextRequest, NextFetchEvent, NextResponse} from 'next/server';
+
+import {SUPPORTED_LOCALES} from '@/config/locale';
+import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
+
+import {withLocale} from '../withLocale';
+
+jest.mock('@/contentful/slug/getContentfulSlug', () => ({
+  getContentfulSlug: jest.fn(),
+}));
+
+describe('withLocale middleware', () => {
+  const next = jest.fn();
+  const mockEvent = {} as NextFetchEvent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not redirect if the path contains a supported locale', async () => {
+    const request = {
+      nextUrl: {pathname: '/zh-CN/home'},
+      cookies: {get: jest.fn()},
+    } as unknown as NextRequest;
+
+    SUPPORTED_LOCALES.add('zh-CN');
+    await withLocale(next)(request, mockEvent);
+
+    expect(next).toHaveBeenCalledWith(request, mockEvent);
+    expect(getContentfulSlug).not.toHaveBeenCalled();
+  });
+
+  it('should redirect to the locale path if no locale is present in the path', async () => {
+    const request = {
+      url: 'https://test.code.org',
+      nextUrl: {pathname: '/home', url: 'https://test.code.org/home'},
+      cookies: {get: jest.fn(() => ({value: 'zh-CN'}))},
+    } as unknown as NextRequest;
+
+    SUPPORTED_LOCALES.add('zh-CN');
+    (getContentfulSlug as jest.Mock).mockReturnValue('home');
+
+    const response = await withLocale(next)(request, mockEvent);
+
+    expect(response).toBeInstanceOf(NextResponse);
+    expect(response?.headers.get('location')).toBe(
+      'https://test.code.org/zh-CN/home',
+    );
+  });
+
+  it('should default to "en-US" if the cookie locale is not supported', async () => {
+    const request = {
+      url: 'https://test.code.org',
+      nextUrl: {pathname: '/home', url: 'https://test.code.org/home'},
+      cookies: {get: jest.fn(() => ({value: 'unsupported-locale'}))},
+    } as unknown as NextRequest;
+
+    SUPPORTED_LOCALES.add('en-US');
+    (getContentfulSlug as jest.Mock).mockReturnValue('home');
+
+    const response = await withLocale(next)(request, mockEvent);
+
+    expect(response).toBeInstanceOf(NextResponse);
+    expect(response?.headers.get('location')).toBe(
+      'https://test.code.org/en-US/home',
+    );
+  });
+
+  it('should not redirect if the path is empty', async () => {
+    const request = {
+      nextUrl: {pathname: '/'},
+      cookies: {get: jest.fn()},
+    } as unknown as NextRequest;
+
+    await withLocale(next)(request, mockEvent);
+
+    expect(next).toHaveBeenCalledWith(request, mockEvent);
+    expect(getContentfulSlug).not.toHaveBeenCalled();
+  });
+
+  it('should handle paths with multiple segments correctly', async () => {
+    const request = {
+      url: 'https://test.code.org',
+      nextUrl: {
+        pathname: '/engineering/all-the-things',
+        url: 'https://test.code.org/engineering/all-the-things',
+      },
+      cookies: {get: jest.fn(() => ({value: 'zh-CN'}))},
+    } as unknown as NextRequest;
+
+    SUPPORTED_LOCALES.add('zh-CN');
+    (getContentfulSlug as jest.Mock).mockReturnValue(
+      'engineering/all-the-things',
+    );
+
+    const response = await withLocale(next)(request, mockEvent);
+
+    expect(response).toBeInstanceOf(NextResponse);
+    expect(response?.headers.get('location')).toBe(
+      'https://test.code.org/zh-CN/engineering/all-the-things',
+    );
+  });
+});

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -1,6 +1,7 @@
 import {NextFetchEvent, NextRequest, NextResponse} from 'next/server';
 
 import {SUPPORTED_LOCALES} from '@/config/locale';
+import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
 
 import {MiddlewareFactory} from './types';
 
@@ -10,24 +11,28 @@ import {MiddlewareFactory} from './types';
  * This effectively routes requests as such:
  *
  * /home -> /zh-CN/home
+ * /engineering/all-the-things -> /zh-CN/engineering/all-the-things
  */
 export const withLocale: MiddlewareFactory = next => {
   return async (request: NextRequest, event: NextFetchEvent) => {
     const {pathname} = request.nextUrl;
     const pathParts = pathname.split('/').filter(Boolean);
 
-    if (pathParts.length === 1) {
-      const slug = pathParts[0];
+    const maybeLocale = pathParts[0];
 
-      const cookieLocale = request.cookies.get('language_')?.value;
-      const locale =
-        cookieLocale !== undefined && SUPPORTED_LOCALES.has(cookieLocale)
-          ? cookieLocale
-          : 'en-US';
-      const redirectUrl = new URL(`/${locale}/${slug}`, request.url);
-      return NextResponse.redirect(redirectUrl);
+    if (pathParts.length === 0 || SUPPORTED_LOCALES.has(maybeLocale)) {
+      // If the first part of the path is a supported locale or there are no subpaths, we don't need to redirect
+      return next(request, event);
     }
 
-    return next(request, event);
+    const slug = getContentfulSlug(pathParts);
+
+    const cookieLocale = request.cookies.get('language_')?.value;
+    const locale =
+      cookieLocale !== undefined && SUPPORTED_LOCALES.has(cookieLocale)
+        ? cookieLocale
+        : 'en-US';
+    const redirectUrl = new URL(`/${locale}/${slug}`, request.url);
+    return NextResponse.redirect(redirectUrl);
   };
 };

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
@@ -8,13 +8,9584 @@
         "en-US": "None"
       },
       "slug": {
-        "en-US": "all-the-things"
+        "en-US": "engineering/all-the-things"
       },
       "pageHeading": {
         "en-US": "[Engineering] UI Integration Test"
       },
       "componentTree": {
         "en-US": {
+          "children": [
+            {
+              "id": "4qnfpsV7",
+              "children": [
+                {
+                  "id": "0fJNzzC8",
+                  "children": [
+                    {
+                      "id": "uUa7o1jl",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "R0C45WqvjfIgrCLvhJPSB",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "UUn7E5n5",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "children": {
+                          "key": "204Ys74QveR6n_DzcowIB",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "AXIFq1qJ",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "children": {
+                          "key": "i-CBt91tEkCmZHGzb85xW",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "lgGRRfq5zcVueL3yrxoh9",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Introduction",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "is6sJNT7GqG8M-aved8xI",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "m4M7qU_VBvy3rP_lT7V-J",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "Qkx4iDxSBpSpgdmwqZhqM",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Section",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "sYH6ME1D",
+              "children": [
+                {
+                  "id": "YVm0InSQ",
+                  "children": [
+                    {
+                      "id": "BkKYMhQm",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "d5NKAnwp",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "dxKxFE8C",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "uML982xB",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "b55f9mox",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "children": {
+                          "path": "/TDy6kSns/fields/quoteName/~locale",
+                          "type": "BoundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "VzJgPw9B",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "qQFZT2Ct",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 2",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "QKZo3i6u",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "children": {
+                          "path": "/OBu7LBgD/fields/longQuote/~locale",
+                          "type": "BoundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Paragraph 1",
+                      "definitionId": "paragraph",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "jltL4xD9",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "bvkdCWAp",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 3",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "RydO4DZ5",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "children": {
+                          "key": "M6UV6klE",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Paragraph 1",
+                      "definitionId": "paragraph",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "sQZaBqbWsJUIR6cGO4R7w",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "gyjlsYtE",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "RLcvWIOm",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "oPc8lo0F",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Localization",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "QPXgm7xP",
+              "children": [
+                {
+                  "id": "fCFouSL6",
+                  "children": [
+                    {
+                      "id": "lBfKWG1Q",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "zB9624m9",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "NcFGUcus",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "IRGGNCsc",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "4Z9z51w4",
+                      "children": [
+                        {
+                          "id": "KXc3wv4t",
+                          "children": [
+                            {
+                              "id": "cqVonltI",
+                              "children": [],
+                              "variables": {
+                                "image": {
+                                  "path": "/D06vmzVo/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/sOCuihY3/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "overline": {
+                                  "path": "/Ura63qS4/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "description": {
+                                  "path": "/P3w0MI3x/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "primaryButton": {
+                                  "path": "/0Uc1jnt8/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "publishedDate": {
+                                  "key": "oJDnQp_KZKNrbozA0NkHt",
+                                  "type": "UnboundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/5gQSSrFE/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                }
+                              },
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "Ov2KaMlI",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "z9iS8tow",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "SGrm6TeM",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "GIbKtM99",
+                          "children": [
+                            {
+                              "id": "cNcSAcmb",
+                              "children": [],
+                              "variables": {
+                                "image": {
+                                  "path": "/4rTEErM8/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/qj8MdFqk/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "overline": {
+                                  "path": "/btGygYlg/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "description": {
+                                  "path": "/OkAdGTNN/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "primaryButton": {
+                                  "path": "/wf6Nfy0h/fields/marketingLink/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "publishedDate": {
+                                  "key": "tPJ7tTdvjSJTFWD-yBJSP",
+                                  "type": "UnboundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/L4ppraxB/fields/marketingLink/~locale",
+                                  "type": "BoundValue"
+                                }
+                              },
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "eMXbhJJO",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "hAGyY1mh",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "Aw5CTnlT",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        }
+                      ],
+                      "variables": {
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "24px 24px",
+                            "desktop": "0px 24px"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "key": "36YfTgYM",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfOpenInNewTab": {
+                          "key": "1g7RleiK",
+                          "type": "UnboundValue"
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "column",
+                            "desktop": "row"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "dJNC5rnb",
+                          "type": "UnboundValue"
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "definitionId": "contentful-container",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "XkRIiyuw",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "definitionId": "divider",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "WF9VdUgg",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "rXgI4Mvr",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "Jx09S5tI",
+                      "children": [
+                        {
+                          "id": "pSAn3QNf",
+                          "children": [
+                            {
+                              "id": "HA6kV8lH",
+                              "children": [],
+                              "variables": {
+                                "image": {
+                                  "path": "/3xRBhtEN/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/eeVAmXO7/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "overline": {
+                                  "path": "/eV4HBBLe/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "secondary"
+                                  }
+                                },
+                                "description": {
+                                  "path": "/1V2S6k5O/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "primaryButton": {
+                                  "path": "/iKuwF5UL/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "publishedDate": {
+                                  "key": "QNG0pC1wH1Njlch34RMkL",
+                                  "type": "UnboundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/XC0Orztn/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                }
+                              },
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "rqSvSSLH",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "ZdTFBVAL",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "dWrBnOHy",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "hAm0hXK7",
+                          "children": [
+                            {
+                              "id": "NRvZhJuI",
+                              "children": [],
+                              "variables": {
+                                "image": {
+                                  "path": "/Gac8HyiL/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/289w042P/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "overline": {
+                                  "path": "/pnEVNJEY/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "secondary"
+                                  }
+                                },
+                                "description": {
+                                  "path": "/8W24TK7L/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "primaryButton": {
+                                  "path": "/L1oQ0Cfn/fields/marketingLink/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "publishedDate": {
+                                  "key": "_WdDIbt-5tT6wtW9kafcJ",
+                                  "type": "UnboundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/jgZPQ2f4/fields/marketingLink/~locale",
+                                  "type": "BoundValue"
+                                }
+                              },
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "GGSUj7T7",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "6dweZgN5",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "TC9267aF",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        }
+                      ],
+                      "variables": {
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "24px 24px",
+                            "desktop": "0px 24px"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "24px 24px 24px 24px"
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "key": "xaSe4Rjf",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfOpenInNewTab": {
+                          "key": "TnZjwBke",
+                          "type": "UnboundValue"
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "column",
+                            "desktop": "row"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(247, 248, 250, 1)"
+                          }
+                        },
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "gwYa67z7",
+                          "type": "UnboundValue"
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "definitionId": "contentful-container",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "HT5aw3I7",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "definitionId": "divider",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "aAeOh6L6",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "Tgg1s2D2",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "kAFZ2mur",
+                      "children": [
+                        {
+                          "id": "CC1rbHZN",
+                          "children": [
+                            {
+                              "id": "vKRDeLjD",
+                              "children": [],
+                              "variables": {
+                                "image": {
+                                  "path": "/hbWAEPUa/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/sCyp4umt/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "overline": {
+                                  "path": "/S9wdCChd/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "description": {
+                                  "path": "/VHT0F26i/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "primaryButton": {
+                                  "path": "/NQABxHSW/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "publishedDate": {
+                                  "key": "7eG4kFaj4GjaK65GAb1XH",
+                                  "type": "UnboundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/0HkUraow/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                }
+                              },
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "LY3fwrGF",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "vl7mGMNk",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "Mo4S1GHf",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "MFJ3yTqG",
+                          "children": [
+                            {
+                              "id": "1yfSgGaI",
+                              "children": [],
+                              "variables": {
+                                "image": {
+                                  "path": "/q64yPb2d/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/7Gxx550Y/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "overline": {
+                                  "path": "/qUW7SuUq/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "description": {
+                                  "path": "/PkMzRu3l/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "primaryButton": {
+                                  "path": "/9VSvsbCf/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "publishedDate": {
+                                  "key": "WZMLswwT0kYnFPpZo3TTj",
+                                  "type": "UnboundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/o8e0EuB2/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                }
+                              },
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "JjsxkEPq",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "mI3808f6",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "AKTPfVrs",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "w6KnOUij",
+                          "children": [
+                            {
+                              "id": "KtyKVhex",
+                              "children": [],
+                              "variables": {
+                                "image": {
+                                  "path": "/EGqljg4x/fields/image/~locale/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "title": {
+                                  "path": "/tgGNSw4W/fields/title/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "overline": {
+                                  "path": "/MKnXMzs0/fields/actionBlockOverline/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "background": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "description": {
+                                  "path": "/o5ZyffFl/fields/shortDescription/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "primaryButton": {
+                                  "path": "/TBoKgmUE/fields/primaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "publishedDate": {
+                                  "key": "2KEarucS_dKgkRLyuo98m",
+                                  "type": "UnboundValue"
+                                },
+                                "secondaryButton": {
+                                  "path": "/tqX7SCKc/fields/secondaryLinkRef/~locale",
+                                  "type": "BoundValue"
+                                }
+                              },
+                              "definitionId": "verticalActionBlock",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "lTlx2Ck5",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "byHQXRz8",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "IuXKDn7Q",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        }
+                      ],
+                      "variables": {
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "24px 24px",
+                            "desktop": "0px 24px"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "key": "5rKwB2lO",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfOpenInNewTab": {
+                          "key": "hEDkMrEi",
+                          "type": "UnboundValue"
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "column",
+                            "desktop": "row"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "mp03r8eT",
+                          "type": "UnboundValue"
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "definitionId": "contentful-container",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "OmmiviO_PnQgExsnIQWG2",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "NspNpe6v",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "7SxgQMWi",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "d7bQZFYP",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Action Block",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "pD8UQKqT",
+              "children": [
+                {
+                  "id": "e3oqSxBp",
+                  "children": [
+                    {
+                      "id": "mKmQjjB5",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "0BYMXHkY",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "XQ7TfDn9",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "IAwsxK7N",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "pU9KFVeN",
+                      "children": [],
+                      "variables": {
+                        "image": {
+                          "path": "/FbSNI62I/fields/image/~locale/fields/file/~locale",
+                          "type": "BoundValue"
+                        },
+                        "title": {
+                          "path": "/k5eX10Tv/fields/title/~locale",
+                          "type": "BoundValue"
+                        },
+                        "overline": {
+                          "path": "/zibXm2hu/fields/actionBlockOverline/~locale",
+                          "type": "BoundValue"
+                        },
+                        "background": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "description": {
+                          "path": "/d2JuVKZQ/fields/shortDescription/~locale",
+                          "type": "BoundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "primaryButton": {
+                          "path": "/NqrmKrUA/fields/primaryLinkRef/~locale",
+                          "type": "BoundValue"
+                        },
+                        "publishedDate": {
+                          "key": "zpea3KaVPS0iJXoZMAHok",
+                          "type": "UnboundValue"
+                        },
+                        "secondaryButton": {
+                          "path": "/f5guroL4/fields/secondaryLinkRef/~locale",
+                          "type": "BoundValue"
+                        }
+                      },
+                      "definitionId": "fullWidthActionBlock",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "X3HvQXNU",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "definitionId": "divider",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "qPYEMk2o",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "Xsx7dtxc",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "dtvNdOmk",
+                      "children": [],
+                      "variables": {
+                        "image": {
+                          "path": "/DXDrLIKT/fields/image/~locale/fields/file/~locale",
+                          "type": "BoundValue"
+                        },
+                        "title": {
+                          "path": "/lnB5pwJz/fields/title/~locale",
+                          "type": "BoundValue"
+                        },
+                        "overline": {
+                          "path": "/XvAA9yze/fields/actionBlockOverline/~locale",
+                          "type": "BoundValue"
+                        },
+                        "background": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "description": {
+                          "path": "/MdJaRWGZ/fields/shortDescription/~locale",
+                          "type": "BoundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "primaryButton": {
+                          "path": "/0TXnLT0j/fields/marketingLink/~locale",
+                          "type": "BoundValue"
+                        },
+                        "publishedDate": {
+                          "key": "NZ_PNrjRqoCQaO6_D-taO",
+                          "type": "UnboundValue"
+                        },
+                        "secondaryButton": {
+                          "path": "/uyYAAfql/fields/marketingLink/~locale",
+                          "type": "BoundValue"
+                        }
+                      },
+                      "definitionId": "fullWidthActionBlock",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "RdLeOx6U",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "definitionId": "divider",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "fwnmq3Qj",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "v6A0d7WI",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "SYclWTwE",
+                      "children": [
+                        {
+                          "id": "jPGXtwTT",
+                          "children": [],
+                          "variables": {
+                            "image": {
+                              "path": "/w3A8mGao/fields/image/~locale/fields/file/~locale",
+                              "type": "BoundValue"
+                            },
+                            "title": {
+                              "path": "/x7pyjFFj/fields/title/~locale",
+                              "type": "BoundValue"
+                            },
+                            "overline": {
+                              "path": "/XXpWcD4q/fields/actionBlockOverline/~locale",
+                              "type": "BoundValue"
+                            },
+                            "background": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "secondary"
+                              }
+                            },
+                            "description": {
+                              "path": "/WIYCSsvX/fields/shortDescription/~locale",
+                              "type": "BoundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "primaryButton": {
+                              "path": "/xSo60zbz/fields/primaryLinkRef/~locale",
+                              "type": "BoundValue"
+                            },
+                            "publishedDate": {
+                              "key": "TpH8B3Rf71dRzy9-Eij_B",
+                              "type": "UnboundValue"
+                            },
+                            "secondaryButton": {
+                              "path": "/baGfsFOR/fields/secondaryLinkRef/~locale",
+                              "type": "BoundValue"
+                            }
+                          },
+                          "definitionId": "fullWidthActionBlock",
+                          "patternProperties": {}
+                        }
+                      ],
+                      "variables": {
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "24px 24px 24px 24px"
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "key": "ICrX3vs",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfOpenInNewTab": {
+                          "key": "bAIeQt5",
+                          "type": "UnboundValue"
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "column"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(247, 248, 250, 1)"
+                          }
+                        },
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "fupk4k7",
+                          "type": "UnboundValue"
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "definitionId": "contentful-container",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "ZpinQk1s",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "BS3VZDDS",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "P8671GK5",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "VByM26Dq",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Full Width Action Block",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "8dDKrpX8",
+              "children": [
+                {
+                  "id": "HjMZCQC6",
+                  "children": [
+                    {
+                      "id": "sqnBKCvr",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "lzUBFGk045vgYma7aXjur",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "ZA7w0xDd",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "m5B_-isX7sffstDtAWTWi",
+                          "type": "UnboundValue"
+                        },
+                        "text": {
+                          "key": "hXGMAy_S9tLUATPGf5Zry",
+                          "type": "UnboundValue"
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "purple"
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "Jr3_e_AP72m0PxsOOIzg6",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": ""
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Button",
+                      "definitionId": "button",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "sMndlIZK",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "JwQMnloG",
+                          "type": "UnboundValue"
+                        },
+                        "text": {
+                          "key": "C2eh9B38",
+                          "type": "UnboundValue"
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "black"
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "Xyg0Z-kNXwLoS7tUWKWe4",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "home"
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Button 1",
+                      "definitionId": "button",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "i9TQ90r1",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "6ktx3JHv",
+                          "type": "UnboundValue"
+                        },
+                        "text": {
+                          "key": "7PWBeER6",
+                          "type": "UnboundValue"
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "white"
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "BHheSJr0-DKiQ2KV6nT9b",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "smile"
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "displayName": "Button 2",
+                      "definitionId": "button",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "LLoJaXAe",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "xs"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "definitionId": "divider",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "fdLp3ahg",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "uMhUcdTnHh9zPBFXifvKq",
+                          "type": "UnboundValue"
+                        },
+                        "text": {
+                          "key": "C820WrIq2MCzdJJuM4oiI",
+                          "type": "UnboundValue"
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "purple"
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "Q8S_CqSaOYMVwDMKlR3jr",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": ""
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Left Aligned Button",
+                      "definitionId": "button",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "n4kkpjAV",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "NhzwQJMw",
+                          "type": "UnboundValue"
+                        },
+                        "text": {
+                          "key": "WasTGlxj",
+                          "type": "UnboundValue"
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "purple"
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "jjrfcFBAJ5AspsCCOO2xO",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": ""
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Centered Button",
+                      "definitionId": "button",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "UkQimeF2",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "dczpwBQS",
+                          "type": "UnboundValue"
+                        },
+                        "text": {
+                          "key": "B1N7IJY8",
+                          "type": "UnboundValue"
+                        },
+                        "type": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "purple"
+                          }
+                        },
+                        "ariaLabel": {
+                          "key": "SHqULneHIzJfEOPmKB4fN",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "iconLeftName": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": ""
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Right Aligned Button",
+                      "definitionId": "button",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "vy3Z4qCBqa2yM79waYyZx",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "nM4Jx3EajfRTuaILiaRh1",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "Gs0XOO8d5eKpR2MQKAm8x",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "ZUNHb1QCXiLvRUG9taeN8",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Button",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "gXGGF3fe",
+              "children": [
+                {
+                  "id": "g3bDeJ5Q",
+                  "children": [
+                    {
+                      "id": "kSaqrZkL",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "7tPoQs29dgRnwZubnGEms",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "1xhHBB2q",
+                      "children": [
+                        {
+                          "id": "4aK86X01",
+                          "children": [
+                            {
+                              "id": "zAfKojaP",
+                              "children": [],
+                              "variables": {
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "children": {
+                                  "key": "uyEiVj6ofeCIPPsOLAAcg",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "left"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "paragraph",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfColumnSpan": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "6"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfColumnSpanLock": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "start"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "-hiP47xkS8H9dfmgslbdh",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-single-column",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "ivBBNdu3",
+                          "children": [
+                            {
+                              "id": "gbRF7ltC",
+                              "children": [],
+                              "variables": {
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "children": {
+                                  "key": "fLRxfb9Ecsh1B9F3VCTCi",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "center"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "paragraph",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfColumnSpan": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "6"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfColumnSpanLock": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "h1C3gxnYgR9u4L8CDjo3D",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-single-column",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "2fCB1Xtu",
+                          "children": [
+                            {
+                              "id": "L9hvodcz",
+                              "children": [],
+                              "variables": {
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "children": {
+                                  "key": "3BFpKy2b749t3Z0j19D9a",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "right"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "paragraph",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfColumnSpan": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "6"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfColumnSpanLock": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "end"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "jUIXS8jmgg7N0QAzowItS",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-single-column",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "lv1SSmyU",
+                          "children": [],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfColumnSpan": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "6"
+                              }
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfColumnSpanLock": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "fP6j0_ZupHdFnUUB_Ia5H",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-single-column",
+                          "patternProperties": {}
+                        }
+                      ],
+                      "variables": {
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "10px 10px"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1px solid rgba(0, 0, 0, 1)"
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfColumns": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "[3,3,3,3]"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "10px 10px 10px 10px"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfWrapColumns": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfWrapColumnsCount": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "2"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "PWEyhxSkmxTGO951MgkM_",
+                          "type": "UnboundValue"
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "definitionId": "contentful-columns",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "LC3Zogrcyn7ko8fQM4Nqs",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "FW4Y2V_ECnApbkzqsUbE_",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "PFl39glIFt1TSFfKzC2-Z",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "08mxl1BGFzTbKwyQDG6DD",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Column",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "ti6YFTJB",
+              "children": [
+                {
+                  "id": "uHUM5mzD",
+                  "children": [
+                    {
+                      "id": "eDgH4prd",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "V8YHlFRp",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "uCuOdCYT",
+                      "children": [
+                        {
+                          "id": "a9I1ElrU",
+                          "children": [
+                            {
+                              "id": "FNbhC3Xu",
+                              "children": [],
+                              "variables": {
+                                "children": {
+                                  "key": "op-Qp-gdr8uf9I9-WXcdr",
+                                  "type": "UnboundValue"
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "left"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "heading-xxl"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "heading",
+                              "patternProperties": {}
+                            },
+                            {
+                              "id": "UDIwg6gf",
+                              "children": [],
+                              "variables": {
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "children": {
+                                  "key": "QcBjAcsD-IhgBz5nwADMs",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "left"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "paragraph",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "25%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "XeBIpyktpVkLEy45skA7l",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "2T84aGT0sd1wyPrlXpm_v",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "start"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "cKcaNJOJ3vHPn3yBMhHgh",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "E07pN8W4",
+                          "children": [
+                            {
+                              "id": "o6xpiMNG",
+                              "children": [],
+                              "variables": {
+                                "children": {
+                                  "key": "M8tEEkEnbhdKkkzZSTBRd",
+                                  "type": "UnboundValue"
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "left"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "heading-xxl"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "heading",
+                              "patternProperties": {}
+                            },
+                            {
+                              "id": "NcKsyTr5",
+                              "children": [],
+                              "variables": {
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "children": {
+                                  "key": "l2UKloU9",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "center"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "paragraph",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "25%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "Vbrs8KDX",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "6lSOjmKa",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "zkx5V9ed",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "1vmrSFao",
+                          "children": [
+                            {
+                              "id": "48VmFOtI",
+                              "children": [],
+                              "variables": {
+                                "children": {
+                                  "key": "sfjHI0Y3PWcC6rm8lYfap",
+                                  "type": "UnboundValue"
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "right"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "heading-xxl"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "heading",
+                              "patternProperties": {}
+                            },
+                            {
+                              "id": "VkXRXr2S",
+                              "children": [],
+                              "variables": {
+                                "color": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "primary"
+                                  }
+                                },
+                                "children": {
+                                  "key": "7Cj0SIqV",
+                                  "type": "UnboundValue"
+                                },
+                                "isStrong": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                },
+                                "cfTextAlign": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "right"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "visualAppearance": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "body-one"
+                                  }
+                                },
+                                "removeMarginBottom": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "paragraph",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "25%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1px solid rgba(0, 0, 0, 1)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "yzVjh0Ni",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "18Loxedj",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "end"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "5OJDXQCx",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        }
+                      ],
+                      "variables": {
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "fit-content"
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "key": "IsyZ4DkUsAKB5tReDxD1q",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfOpenInNewTab": {
+                          "key": "rpWptElOUBNuPNQXKsjMo",
+                          "type": "UnboundValue"
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "row"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "mFzwT6KHtA9j1FYYT0dvh",
+                          "type": "UnboundValue"
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "definitionId": "contentful-container",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "_byo2Rxu56P0ZbFndME7R",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "X4E1tjHt",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "6pLrv7NC",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "3kOq2u6E",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Container",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "Clx6dZLd",
+              "children": [
+                {
+                  "id": "BRrxH9Ul",
+                  "children": [
+                    {
+                      "id": "s5HoxC42",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "fvbdsWsT",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "pHAqHABK",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "none"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "displayName": "Divider",
+                      "definitionId": "divider",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "WydkYUZS",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "strong"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "l"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "displayName": "Divider 1",
+                      "definitionId": "divider",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "koY0ISJaPzBIDXqlznL0H",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "FXuaWYztKfKJWXod-xTpd",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "ZClRveUvVcQjBrlrDvtm6",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "zcuX6eaiBiUs3mCXjHYq2",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Divider",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "KpnHx64w",
+              "children": [
+                {
+                  "id": "DiK9VHcn",
+                  "children": [
+                    {
+                      "id": "QeFTqe9z",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "1O9vd7afmvcqJPb-Hst2m",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "s9BWm87K",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "ppcJTpQrNNmiFzRpoKuk7",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "g7eJTxtZ",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "k7cc4DWU",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-lg"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "Og5azalB",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "J8z7Qo1L",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-md"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "aqtlS0Go",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "mCXPy8Sk",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-sm"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "B3ylIbTZ",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "rMO0UpAm",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xs"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "aTtjH3mTVn7fMVJ-xb2nG",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "GQ_meekKAizcWHfsUxUEe",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "JVQR-tfdKQE3G3iyEGd3d",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "k2x0YIUxjaXNGJxbL2xFl",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Heading",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "emFwvLP8",
+              "children": [
+                {
+                  "id": "OX0joJve",
+                  "children": [
+                    {
+                      "id": "AI1IIxgR",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "ZJnqNzR6",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "pW9sYR0b",
+                      "children": [
+                        {
+                          "id": "Jk6x2y8G",
+                          "children": [
+                            {
+                              "id": "8oIklkai",
+                              "children": [],
+                              "variables": {
+                                "src": {
+                                  "path": "/JtSxyKC/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "altText": {
+                                  "key": "KU5oIGN",
+                                  "type": "UnboundValue"
+                                },
+                                "cfWidth": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "100%"
+                                  }
+                                },
+                                "cfHeight": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "fit-content"
+                                  }
+                                },
+                                "decoration": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "none"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "hasRoundedCorners": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "definitionId": "image",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "Idr0CiO",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "JFCnn0N",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "xbPE1--",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "wzdQlRZH",
+                          "children": [
+                            {
+                              "id": "t9aHgC0s",
+                              "children": [],
+                              "variables": {
+                                "src": {
+                                  "path": "/2Te0IAmc/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "altText": {
+                                  "key": "PyeBaTT5",
+                                  "type": "UnboundValue"
+                                },
+                                "cfWidth": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "100%"
+                                  }
+                                },
+                                "cfHeight": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "fit-content"
+                                  }
+                                },
+                                "decoration": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "none"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "hasRoundedCorners": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": false
+                                  }
+                                }
+                              },
+                              "definitionId": "image",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "qYw68TuV",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "8opMv3ky",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "eT6yBrVf",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        }
+                      ],
+                      "variables": {
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "24px 24px",
+                            "desktop": "0px 24px"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "fit-content",
+                            "desktop": "274px"
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "key": "Fe4Bfar",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfOpenInNewTab": {
+                          "key": "baOMaPo",
+                          "type": "UnboundValue"
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "column",
+                            "desktop": "row"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "KBQ3_Cb",
+                          "type": "UnboundValue"
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "definitionId": "contentful-container",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "WWXtCxfi",
+                      "children": [],
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "definitionId": "spacer",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "ZrgPrUKJ",
+                      "children": [
+                        {
+                          "id": "K3kEoR9T",
+                          "children": [
+                            {
+                              "id": "fSh2sEYp",
+                              "children": [],
+                              "variables": {
+                                "src": {
+                                  "path": "/gxYbZM71/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "altText": {
+                                  "key": "m93uQB8b",
+                                  "type": "UnboundValue"
+                                },
+                                "cfWidth": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "100%"
+                                  }
+                                },
+                                "cfHeight": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "fit-content"
+                                  }
+                                },
+                                "decoration": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "border"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "hasRoundedCorners": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "definitionId": "image",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "FHSW9Y15",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "eI0ylAC7",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "uNXnh4Ev",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        },
+                        {
+                          "id": "4q7Agi2K",
+                          "children": [
+                            {
+                              "id": "PLoMFmHU",
+                              "children": [],
+                              "variables": {
+                                "src": {
+                                  "path": "/DtbkKOnf/fields/file/~locale",
+                                  "type": "BoundValue"
+                                },
+                                "altText": {
+                                  "key": "5gWPmo5r",
+                                  "type": "UnboundValue"
+                                },
+                                "cfWidth": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "100%"
+                                  }
+                                },
+                                "cfHeight": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "fit-content"
+                                  }
+                                },
+                                "decoration": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": "shadow"
+                                  }
+                                },
+                                "cfVisibility": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                },
+                                "hasRoundedCorners": {
+                                  "type": "DesignValue",
+                                  "valuesByBreakpoint": {
+                                    "desktop": true
+                                  }
+                                }
+                              },
+                              "definitionId": "image",
+                              "patternProperties": {}
+                            }
+                          ],
+                          "variables": {
+                            "cfGap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "100%"
+                              }
+                            },
+                            "cfBorder": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px solid rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfHeight": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "fit-content"
+                              }
+                            },
+                            "cfMargin": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfPadding": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0 0 0 0"
+                              }
+                            },
+                            "cfFlexWrap": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "nowrap"
+                              }
+                            },
+                            "cfMaxWidth": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "1192px"
+                              }
+                            },
+                            "cfHyperlink": {
+                              "key": "SALwyVOh",
+                              "type": "UnboundValue"
+                            },
+                            "cfVisibility": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": true
+                              }
+                            },
+                            "cfFlexReverse": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": false
+                              }
+                            },
+                            "cfBorderRadius": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "0px"
+                              }
+                            },
+                            "cfOpenInNewTab": {
+                              "key": "VF7rRAiQ",
+                              "type": "UnboundValue"
+                            },
+                            "cfFlexDirection": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "column"
+                              }
+                            },
+                            "cfBackgroundColor": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "rgba(0, 0, 0, 0)"
+                              }
+                            },
+                            "cfVerticalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageUrl": {
+                              "key": "zBYukK4q",
+                              "type": "UnboundValue"
+                            },
+                            "cfHorizontalAlignment": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": "center"
+                              }
+                            },
+                            "cfBackgroundImageOptions": {
+                              "type": "DesignValue",
+                              "valuesByBreakpoint": {
+                                "desktop": {
+                                  "scaling": "fill",
+                                  "alignment": "left top",
+                                  "targetSize": "2000px"
+                                }
+                              }
+                            }
+                          },
+                          "definitionId": "contentful-container",
+                          "patternProperties": {}
+                        }
+                      ],
+                      "variables": {
+                        "cfGap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "24px 24px",
+                            "desktop": "0px 24px"
+                          }
+                        },
+                        "cfWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "100%"
+                          }
+                        },
+                        "cfBorder": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px solid rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfHeight": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "fit-content",
+                            "desktop": "273px"
+                          }
+                        },
+                        "cfMargin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfPadding": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0 0 0 0"
+                          }
+                        },
+                        "cfFlexWrap": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "nowrap"
+                          }
+                        },
+                        "cfMaxWidth": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "1192px"
+                          }
+                        },
+                        "cfHyperlink": {
+                          "key": "5dOroYow",
+                          "type": "UnboundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfFlexReverse": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfBorderRadius": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "0px"
+                          }
+                        },
+                        "cfOpenInNewTab": {
+                          "key": "QDaxYIdJ",
+                          "type": "UnboundValue"
+                        },
+                        "cfFlexDirection": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "mobile": "column",
+                            "desktop": "row"
+                          }
+                        },
+                        "cfBackgroundColor": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "rgba(0, 0, 0, 0)"
+                          }
+                        },
+                        "cfVerticalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageUrl": {
+                          "key": "A43eNziB",
+                          "type": "UnboundValue"
+                        },
+                        "cfHorizontalAlignment": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfBackgroundImageOptions": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": {
+                              "scaling": "fill",
+                              "alignment": "left top",
+                              "targetSize": "2000px"
+                            }
+                          }
+                        }
+                      },
+                      "definitionId": "contentful-container",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "mJJmzfsA",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "8LDk6KB4",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "aPeti3xV",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "7954gvrQ",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Image",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "xHJlZCCH",
+              "children": [
+                {
+                  "id": "85sUjnT6",
+                  "children": [
+                    {
+                      "id": "b2f0KDFZ",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "-KqdBQBCJexO6AUlN6Hdk",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "L9QvdEUS",
+                      "children": [],
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "children": {
+                          "key": "1eCExq2WLGpJwNbRFYPCg",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Overline",
+                      "definitionId": "overline",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "H2y2eW6g",
+                      "children": [],
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "children": {
+                          "key": "Lu9xfUr8",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Overline 1",
+                      "definitionId": "overline",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "K6qaxqTv",
+                      "children": [],
+                      "variables": {
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "l"
+                          }
+                        },
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "children": {
+                          "key": "tgfqSQxT",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Overline 2",
+                      "definitionId": "overline",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "vYKqsBQ5xXnkpbPCxrnKb",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "Ry2EmrfLWGKKxHzN2NKK2",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "MJmfC3N564sY154aazOqg",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "fbxlhQrAD8jhqeEPcb_Zc",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Overline",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "elX9Jq6X",
+              "children": [
+                {
+                  "id": "5XxdQJUA",
+                  "children": [
+                    {
+                      "id": "KesTZnYJ",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "4fZ-pGgFlP7R6tach397W",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "AMYwkYNk",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "children": {
+                          "key": "joR8i87odA3R7JLfvzfCw",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-four"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "zJvuD0HD",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "children": {
+                          "key": "TSFzv7B9",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-two"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Paragraph 1",
+                      "definitionId": "paragraph",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "SJd9fYto",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "secondary"
+                          }
+                        },
+                        "children": {
+                          "key": "avmUJimV",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-two"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Paragraph 2",
+                      "definitionId": "paragraph",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "pl5CZVbe",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "children": {
+                          "key": "hRhxjrt3N9VU1NMl2QRh3",
+                          "type": "UnboundValue"
+                        },
+                        "isStrong": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "body-one"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Paragraph",
+                      "definitionId": "paragraph",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "L6HfuP4oVMvQ_xwZqzQc7",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "REWmmbf2LKIIYFlPSLTFy",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "aDgvlZ6op1gK3MYklFgKX",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "lP2xlEiG4Ur15q_7otUZo",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Paragraph",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "mmiz1hHo",
+              "children": [
+                {
+                  "id": "jIECLTTH",
+                  "children": [
+                    {
+                      "id": "io9EJVj6",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "uqryIUsQ",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "TPp4t_zOnGYYUCQCHczCd",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "patternDark"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                },
+                {
+                  "id": "Ko7M7vnH",
+                  "children": [
+                    {
+                      "id": "RSQxdVwv",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "qM57cKR3J1QPDQnHDERkX",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "wmG6IXrB1B-h8zddto0vr",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "patternPrimary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "g1GOPI4w",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "qhMtsAXw",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "Oor1uCW9",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Section",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "ZX4djoXt",
+              "children": [
+                {
+                  "id": "wrGEKnPn",
+                  "children": [
+                    {
+                      "id": "WF76U7uH",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "ws1Q0E4GP0WIGLne79bIY",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "OYIhzN9w",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "zQNTpdsD",
+                          "type": "UnboundValue"
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "xs"
+                          }
+                        },
+                        "children": {
+                          "key": "ERvTdJXH",
+                          "type": "UnboundValue"
+                        },
+                        "ariaLabel": {
+                          "key": "ReHgFwZk-BHm9gAcpYww7",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Text Link 2",
+                      "definitionId": "link",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "bTLH9bp5",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "L7sMSlH7Y_F-LSZzoglh6",
+                          "type": "UnboundValue"
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "s"
+                          }
+                        },
+                        "children": {
+                          "key": "EX79hiIuw8_2Ria-2tQkj",
+                          "type": "UnboundValue"
+                        },
+                        "ariaLabel": {
+                          "key": "dDFAtpAu4xTWTM3cwvHX_",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Text Link",
+                      "definitionId": "link",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "Bobqy9W3",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "92O5l7Xr",
+                          "type": "UnboundValue"
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "children": {
+                          "key": "lIsy1GAr",
+                          "type": "UnboundValue"
+                        },
+                        "ariaLabel": {
+                          "key": "KGUo-pbAmZDeE_onnJmeM",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Text Link 1",
+                      "definitionId": "link",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "8WDnlPms",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "Icqsu9JA",
+                          "type": "UnboundValue"
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "l"
+                          }
+                        },
+                        "children": {
+                          "key": "nBnzzrrg",
+                          "type": "UnboundValue"
+                        },
+                        "ariaLabel": {
+                          "key": "vNE31MABBbkMScnKL4BMU",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Text Link 1",
+                      "definitionId": "link",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "bBEfl0Ck",
+                      "children": [],
+                      "variables": {
+                        "color": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "primary"
+                          }
+                        },
+                        "margin": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "xs"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "definitionId": "divider",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "5IqQIrwI",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "6znvK3h",
+                          "type": "UnboundValue"
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "children": {
+                          "key": "c6Xllyd",
+                          "type": "UnboundValue"
+                        },
+                        "ariaLabel": {
+                          "key": "4GGacxRsnhMslE0UcSJ97",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Left aligned",
+                      "definitionId": "link",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "MjacnNa2",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "5wXRsLJn",
+                          "type": "UnboundValue"
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "children": {
+                          "key": "PeTivMde",
+                          "type": "UnboundValue"
+                        },
+                        "ariaLabel": {
+                          "key": "0v9inr8Fpqnw8F8ElhUQT",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "center"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Centered",
+                      "definitionId": "link",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "nLDuaCau",
+                      "children": [],
+                      "variables": {
+                        "href": {
+                          "key": "1VT4PEqW",
+                          "type": "UnboundValue"
+                        },
+                        "size": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "m"
+                          }
+                        },
+                        "children": {
+                          "key": "DEtHVoSd",
+                          "type": "UnboundValue"
+                        },
+                        "ariaLabel": {
+                          "key": "46SVVu7SVI_27igWB64S2",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "right"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "isLinkExternal": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Right aligned",
+                      "definitionId": "link",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "7W1Qi2iLcCJo1S5FoTklH",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "ilVAO2EaIUZ0lA5ewKtJI",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "2PSTJ_DqEZxNVxIpr_H8t",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "lgABBbaFeSQbvkWefAwA5",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Text Link",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "UXWNakDB",
+              "children": [
+                {
+                  "id": "rtrOzYi0",
+                  "children": [
+                    {
+                      "id": "AdqCNDR9",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "K0KxrTFkzU8KmLwowRzGo",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "CuFH5tMP",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "Is-QBxBKRvrSLF5e6k8WM",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "e56jD7Ml",
+                      "children": [],
+                      "variables": {
+                        "videoDesc": {
+                          "key": "aL5ooU7rF-Cfhi4sEFovm",
+                          "type": "UnboundValue"
+                        },
+                        "youTubeId": {
+                          "key": "n0l5OgPZtTMQsbZ3GNKiR",
+                          "type": "UnboundValue"
+                        },
+                        "uploadDate": {
+                          "key": "YfZC6-Hmjrj20Loaq6-FT",
+                          "type": "UnboundValue"
+                        },
+                        "videoTitle": {
+                          "key": "FdwpeSt6bn8LpSSV0pbtv",
+                          "type": "UnboundValue"
+                        },
+                        "showCaption": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "videoFallback": {
+                          "key": "qg0XcsQhQK20HDFZctW0_",
+                          "type": "UnboundValue"
+                        }
+                      },
+                      "displayName": "Video",
+                      "definitionId": "video",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "51WBcL8X",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "nOVfFtTI",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "WVvTAVCW",
+                      "children": [],
+                      "variables": {
+                        "videoDesc": {
+                          "key": "7cjXZUvesiyPKoMJZUraJ",
+                          "type": "UnboundValue"
+                        },
+                        "youTubeId": {
+                          "key": "vNAYFsDQ",
+                          "type": "UnboundValue"
+                        },
+                        "uploadDate": {
+                          "key": "aRYsNWTbO_8er8D_crzl2",
+                          "type": "UnboundValue"
+                        },
+                        "videoTitle": {
+                          "key": "uTgCIxZc",
+                          "type": "UnboundValue"
+                        },
+                        "showCaption": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "videoFallback": {
+                          "key": "5OKBDu4C",
+                          "type": "UnboundValue"
+                        }
+                      },
+                      "displayName": "Video 1",
+                      "definitionId": "video",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "jkcCZDp5",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "8tSwOMzw",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "displayName": "Heading 1",
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "x1xIoh5c",
+                      "children": [],
+                      "variables": {
+                        "videoDesc": {
+                          "key": "SQ455se7uXiseEPWsgHS4",
+                          "type": "UnboundValue"
+                        },
+                        "youTubeId": {
+                          "key": "HkS6sKTzMLaB2xX5evo7Z",
+                          "type": "UnboundValue"
+                        },
+                        "uploadDate": {
+                          "key": "UnsmjdqCrmrO4Trj1nuzn",
+                          "type": "UnboundValue"
+                        },
+                        "videoTitle": {
+                          "key": "jNBarAZvvExnBW0FccdXk",
+                          "type": "UnboundValue"
+                        },
+                        "showCaption": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "videoFallback": {
+                          "key": "WWIhqOfAkCpzLs6ZV3raO",
+                          "type": "UnboundValue"
+                        }
+                      },
+                      "displayName": "Video",
+                      "definitionId": "video",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "6AjZi52JdcRm7jrVI6Sal",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "displayName": "Section",
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "G5Iyv0YkdyGi6tu6eXCln",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "YKCODw2Gj_YPupxeh2ON7",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "5S0WDaNvwkgyaaXOaPShS",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Video",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            },
+            {
+              "id": "HkaGv0Z3",
+              "children": [
+                {
+                  "id": "nnW16yI0",
+                  "children": [
+                    {
+                      "id": "89PlsO6u",
+                      "children": [],
+                      "variables": {
+                        "children": {
+                          "key": "zyqjhLXToMUDWS9_Gj5le",
+                          "type": "UnboundValue"
+                        },
+                        "cfTextAlign": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "left"
+                          }
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        },
+                        "visualAppearance": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": "heading-xxl"
+                          }
+                        },
+                        "removeMarginBottom": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": false
+                          }
+                        }
+                      },
+                      "definitionId": "heading",
+                      "patternProperties": {}
+                    },
+                    {
+                      "id": "CzL11C45",
+                      "children": [],
+                      "variables": {
+                        "slides": {
+                          "path": "/9g-7kZ472XQBkhnml-mZ-/fields/slides/~locale",
+                          "type": "BoundValue"
+                        },
+                        "cfVisibility": {
+                          "type": "DesignValue",
+                          "valuesByBreakpoint": {
+                            "desktop": true
+                          }
+                        }
+                      },
+                      "definitionId": "carousel-video",
+                      "patternProperties": {}
+                    }
+                  ],
+                  "variables": {
+                    "id": {
+                      "key": "sU117GEiAbQOFMhXtxs7a",
+                      "type": "UnboundValue"
+                    },
+                    "divider": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "none"
+                      }
+                    },
+                    "padding": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "l"
+                      }
+                    },
+                    "background": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": "primary"
+                      }
+                    },
+                    "cfVisibility": {
+                      "type": "DesignValue",
+                      "valuesByBreakpoint": {
+                        "desktop": true
+                      }
+                    }
+                  },
+                  "definitionId": "section",
+                  "patternProperties": {}
+                }
+              ],
+              "variables": {
+                "cfGap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "100%"
+                  }
+                },
+                "cfBorder": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px solid rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfHeight": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "fit-content"
+                  }
+                },
+                "cfMargin": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfPadding": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0 0 0 0"
+                  }
+                },
+                "cfFlexWrap": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "nowrap"
+                  }
+                },
+                "cfMaxWidth": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "none"
+                  }
+                },
+                "cfHyperlink": {
+                  "key": "C0ZnFmnY1RLOEnDrehvP2",
+                  "type": "UnboundValue"
+                },
+                "cfVisibility": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": true
+                  }
+                },
+                "cfFlexReverse": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": false
+                  }
+                },
+                "cfBorderRadius": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "0px"
+                  }
+                },
+                "cfOpenInNewTab": {
+                  "key": "Enm2i9xxpZNHnLD0K1fpI",
+                  "type": "UnboundValue"
+                },
+                "cfFlexDirection": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "column"
+                  }
+                },
+                "cfBackgroundColor": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "rgba(0, 0, 0, 0)"
+                  }
+                },
+                "cfVerticalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageUrl": {
+                  "key": "-izis13YUPq4WCazZckUr",
+                  "type": "UnboundValue"
+                },
+                "cfHorizontalAlignment": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": "center"
+                  }
+                },
+                "cfBackgroundImageOptions": {
+                  "type": "DesignValue",
+                  "valuesByBreakpoint": {
+                    "desktop": {
+                      "scaling": "fill",
+                      "alignment": "left top",
+                      "targetSize": "2000px"
+                    }
+                  }
+                }
+              },
+              "displayName": "Video Carousel",
+              "definitionId": "contentful-section",
+              "patternProperties": {}
+            }
+          ],
           "breakpoints": [
             {
               "id": "desktop",
@@ -38,9582 +9609,18 @@
               "previewSize": "390px"
             }
           ],
-          "schemaVersion": "2023-09-28",
-          "children": [
-            {
-              "id": "4qnfpsV7",
-              "displayName": "Section",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "is6sJNT7GqG8M-aved8xI",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "m4M7qU_VBvy3rP_lT7V-J",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "Qkx4iDxSBpSpgdmwqZhqM",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "0fJNzzC8",
-                  "displayName": "Introduction",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "lgGRRfq5zcVueL3yrxoh9",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "uUa7o1jl",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "R0C45WqvjfIgrCLvhJPSB",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "UUn7E5n5",
-                      "displayName": "Paragraph",
-                      "definitionId": "paragraph",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "body-one"
-                          }
-                        },
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "204Ys74QveR6n_DzcowIB",
-                          "type": "UnboundValue"
-                        },
-                        "isStrong": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "AXIFq1qJ",
-                      "displayName": "Paragraph",
-                      "definitionId": "paragraph",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "body-one"
-                          }
-                        },
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "i-CBt91tEkCmZHGzb85xW",
-                          "type": "UnboundValue"
-                        },
-                        "isStrong": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "sYH6ME1D",
-              "displayName": "Localization",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "gyjlsYtE",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "RLcvWIOm",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "oPc8lo0F",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "YVm0InSQ",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "sQZaBqbWsJUIR6cGO4R7w",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "BkKYMhQm",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "d5NKAnwp",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "dxKxFE8C",
-                      "displayName": "Heading 1",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "uML982xB",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "b55f9mox",
-                      "displayName": "Paragraph",
-                      "definitionId": "paragraph",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "body-one"
-                          }
-                        },
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "path": "/TDy6kSns/fields/quoteName/~locale",
-                          "type": "BoundValue"
-                        },
-                        "isStrong": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "VzJgPw9B",
-                      "displayName": "Heading 2",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "qQFZT2Ct",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "QKZo3i6u",
-                      "displayName": "Paragraph 1",
-                      "definitionId": "paragraph",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "body-one"
-                          }
-                        },
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "path": "/OBu7LBgD/fields/longQuote/~locale",
-                          "type": "BoundValue"
-                        },
-                        "isStrong": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "jltL4xD9",
-                      "displayName": "Heading 3",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "bvkdCWAp",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "RydO4DZ5",
-                      "displayName": "Paragraph 1",
-                      "definitionId": "paragraph",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "body-one"
-                          }
-                        },
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "M6UV6klE",
-                          "type": "UnboundValue"
-                        },
-                        "isStrong": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "QPXgm7xP",
-              "displayName": "Action Block",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "NspNpe6v",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "7SxgQMWi",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "d7bQZFYP",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "fCFouSL6",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "OmmiviO_PnQgExsnIQWG2",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "lBfKWG1Q",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "zB9624m9",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "NcFGUcus",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "IRGGNCsc",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "4Z9z51w4",
-                      "definitionId": "contentful-container",
-                      "patternProperties": {},
-                      "variables": {
-                        "cfVerticalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfHorizontalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfMargin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfPadding": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfBackgroundColor": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "100%"
-                          }
-                        },
-                        "cfHeight": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "fit-content"
-                          }
-                        },
-                        "cfMaxWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "1192px"
-                          }
-                        },
-                        "cfFlexDirection": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "row",
-                            "mobile": "column"
-                          }
-                        },
-                        "cfFlexReverse": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfFlexWrap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "nowrap"
-                          }
-                        },
-                        "cfBorder": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px solid rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfGap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px 24px",
-                            "mobile": "24px 24px"
-                          }
-                        },
-                        "cfHyperlink": {
-                          "type": "UnboundValue",
-                          "key": "36YfTgYM"
-                        },
-                        "cfOpenInNewTab": {
-                          "type": "UnboundValue",
-                          "key": "1g7RleiK"
-                        },
-                        "cfBorderRadius": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfBackgroundImageUrl": {
-                          "type": "UnboundValue",
-                          "key": "dJNC5rnb"
-                        },
-                        "cfBackgroundImageOptions": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": {
-                              "scaling": "fill",
-                              "alignment": "left top",
-                              "targetSize": "2000px"
-                            }
-                          }
-                        }
-                      },
-                      "children": [
-                        {
-                          "id": "KXc3wv4t",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "Ov2KaMlI"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "z9iS8tow"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "SGrm6TeM"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "cqVonltI",
-                              "definitionId": "verticalActionBlock",
-                              "patternProperties": {},
-                              "variables": {
-                                "overline": {
-                                  "path": "/Ura63qS4/fields/actionBlockOverline/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "title": {
-                                  "path": "/sOCuihY3/fields/title/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "description": {
-                                  "path": "/P3w0MI3x/fields/shortDescription/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "image": {
-                                  "path": "/D06vmzVo/fields/image/~locale/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "primaryButton": {
-                                  "path": "/0Uc1jnt8/fields/primaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "secondaryButton": {
-                                  "path": "/5gQSSrFE/fields/secondaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "background": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "publishedDate": {
-                                  "key": "oJDnQp_KZKNrbozA0NkHt",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "GIbKtM99",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "eMXbhJJO"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "hAGyY1mh"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "Aw5CTnlT"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "cNcSAcmb",
-                              "definitionId": "verticalActionBlock",
-                              "patternProperties": {},
-                              "variables": {
-                                "overline": {
-                                  "path": "/btGygYlg/fields/actionBlockOverline/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "title": {
-                                  "path": "/qj8MdFqk/fields/title/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "description": {
-                                  "path": "/OkAdGTNN/fields/shortDescription/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "image": {
-                                  "path": "/4rTEErM8/fields/image/~locale/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "primaryButton": {
-                                  "path": "/wf6Nfy0h/fields/marketingLink/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "secondaryButton": {
-                                  "path": "/L4ppraxB/fields/marketingLink/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "background": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "publishedDate": {
-                                  "key": "tPJ7tTdvjSJTFWD-yBJSP",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "id": "XkRIiyuw",
-                      "definitionId": "divider",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "margin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "s"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "WF9VdUgg",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "rXgI4Mvr",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "Jx09S5tI",
-                      "definitionId": "contentful-container",
-                      "patternProperties": {},
-                      "variables": {
-                        "cfVerticalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfHorizontalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfMargin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfPadding": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "24px 24px 24px 24px"
-                          }
-                        },
-                        "cfBackgroundColor": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "rgba(247, 248, 250, 1)"
-                          }
-                        },
-                        "cfWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "100%"
-                          }
-                        },
-                        "cfHeight": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "fit-content"
-                          }
-                        },
-                        "cfMaxWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "1192px"
-                          }
-                        },
-                        "cfFlexDirection": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "row",
-                            "mobile": "column"
-                          }
-                        },
-                        "cfFlexReverse": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfFlexWrap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "nowrap"
-                          }
-                        },
-                        "cfBorder": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px solid rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfGap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px 24px",
-                            "mobile": "24px 24px"
-                          }
-                        },
-                        "cfHyperlink": {
-                          "type": "UnboundValue",
-                          "key": "xaSe4Rjf"
-                        },
-                        "cfOpenInNewTab": {
-                          "type": "UnboundValue",
-                          "key": "TnZjwBke"
-                        },
-                        "cfBorderRadius": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfBackgroundImageUrl": {
-                          "type": "UnboundValue",
-                          "key": "gwYa67z7"
-                        },
-                        "cfBackgroundImageOptions": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": {
-                              "scaling": "fill",
-                              "alignment": "left top",
-                              "targetSize": "2000px"
-                            }
-                          }
-                        }
-                      },
-                      "children": [
-                        {
-                          "id": "pSAn3QNf",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "rqSvSSLH"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "ZdTFBVAL"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "dWrBnOHy"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "HA6kV8lH",
-                              "definitionId": "verticalActionBlock",
-                              "patternProperties": {},
-                              "variables": {
-                                "overline": {
-                                  "path": "/eV4HBBLe/fields/actionBlockOverline/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "title": {
-                                  "path": "/eeVAmXO7/fields/title/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "description": {
-                                  "path": "/1V2S6k5O/fields/shortDescription/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "image": {
-                                  "path": "/3xRBhtEN/fields/image/~locale/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "primaryButton": {
-                                  "path": "/iKuwF5UL/fields/primaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "secondaryButton": {
-                                  "path": "/XC0Orztn/fields/secondaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "background": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "secondary"
-                                  }
-                                },
-                                "publishedDate": {
-                                  "key": "QNG0pC1wH1Njlch34RMkL",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "hAm0hXK7",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "GGSUj7T7"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "6dweZgN5"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "TC9267aF"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "NRvZhJuI",
-                              "definitionId": "verticalActionBlock",
-                              "patternProperties": {},
-                              "variables": {
-                                "overline": {
-                                  "path": "/pnEVNJEY/fields/actionBlockOverline/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "title": {
-                                  "path": "/289w042P/fields/title/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "description": {
-                                  "path": "/8W24TK7L/fields/shortDescription/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "image": {
-                                  "path": "/Gac8HyiL/fields/image/~locale/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "primaryButton": {
-                                  "path": "/L1oQ0Cfn/fields/marketingLink/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "secondaryButton": {
-                                  "path": "/jgZPQ2f4/fields/marketingLink/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "background": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "secondary"
-                                  }
-                                },
-                                "publishedDate": {
-                                  "key": "_WdDIbt-5tT6wtW9kafcJ",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "id": "HT5aw3I7",
-                      "definitionId": "divider",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "margin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "s"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "aAeOh6L6",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "Tgg1s2D2",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "kAFZ2mur",
-                      "definitionId": "contentful-container",
-                      "patternProperties": {},
-                      "variables": {
-                        "cfVerticalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfHorizontalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfMargin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfPadding": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfBackgroundColor": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "100%"
-                          }
-                        },
-                        "cfHeight": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "fit-content"
-                          }
-                        },
-                        "cfMaxWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "1192px"
-                          }
-                        },
-                        "cfFlexDirection": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "row",
-                            "mobile": "column"
-                          }
-                        },
-                        "cfFlexReverse": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfFlexWrap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "nowrap"
-                          }
-                        },
-                        "cfBorder": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px solid rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfGap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px 24px",
-                            "mobile": "24px 24px"
-                          }
-                        },
-                        "cfHyperlink": {
-                          "type": "UnboundValue",
-                          "key": "5rKwB2lO"
-                        },
-                        "cfOpenInNewTab": {
-                          "type": "UnboundValue",
-                          "key": "hEDkMrEi"
-                        },
-                        "cfBorderRadius": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfBackgroundImageUrl": {
-                          "type": "UnboundValue",
-                          "key": "mp03r8eT"
-                        },
-                        "cfBackgroundImageOptions": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": {
-                              "scaling": "fill",
-                              "alignment": "left top",
-                              "targetSize": "2000px"
-                            }
-                          }
-                        }
-                      },
-                      "children": [
-                        {
-                          "id": "CC1rbHZN",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "LY3fwrGF"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "vl7mGMNk"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "Mo4S1GHf"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "vKRDeLjD",
-                              "definitionId": "verticalActionBlock",
-                              "patternProperties": {},
-                              "variables": {
-                                "overline": {
-                                  "path": "/S9wdCChd/fields/actionBlockOverline/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "title": {
-                                  "path": "/sCyp4umt/fields/title/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "description": {
-                                  "path": "/VHT0F26i/fields/shortDescription/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "image": {
-                                  "path": "/hbWAEPUa/fields/image/~locale/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "primaryButton": {
-                                  "path": "/NQABxHSW/fields/primaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "secondaryButton": {
-                                  "path": "/0HkUraow/fields/secondaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "background": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "publishedDate": {
-                                  "key": "7eG4kFaj4GjaK65GAb1XH",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "MFJ3yTqG",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "JjsxkEPq"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "mI3808f6"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "AKTPfVrs"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "1yfSgGaI",
-                              "definitionId": "verticalActionBlock",
-                              "patternProperties": {},
-                              "variables": {
-                                "overline": {
-                                  "path": "/qUW7SuUq/fields/actionBlockOverline/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "title": {
-                                  "path": "/7Gxx550Y/fields/title/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "description": {
-                                  "path": "/PkMzRu3l/fields/shortDescription/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "image": {
-                                  "path": "/q64yPb2d/fields/image/~locale/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "primaryButton": {
-                                  "path": "/9VSvsbCf/fields/primaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "secondaryButton": {
-                                  "path": "/o8e0EuB2/fields/secondaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "background": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "publishedDate": {
-                                  "key": "WZMLswwT0kYnFPpZo3TTj",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "w6KnOUij",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "lTlx2Ck5"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "byHQXRz8"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "IuXKDn7Q"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "KtyKVhex",
-                              "definitionId": "verticalActionBlock",
-                              "patternProperties": {},
-                              "variables": {
-                                "overline": {
-                                  "path": "/MKnXMzs0/fields/actionBlockOverline/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "title": {
-                                  "path": "/tgGNSw4W/fields/title/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "description": {
-                                  "path": "/o5ZyffFl/fields/shortDescription/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "image": {
-                                  "path": "/EGqljg4x/fields/image/~locale/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "primaryButton": {
-                                  "path": "/TBoKgmUE/fields/primaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "secondaryButton": {
-                                  "path": "/tqX7SCKc/fields/secondaryLinkRef/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "background": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "publishedDate": {
-                                  "key": "2KEarucS_dKgkRLyuo98m",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "pD8UQKqT",
-              "displayName": "Full Width Action Block",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "BS3VZDDS",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "P8671GK5",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "VByM26Dq",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "e3oqSxBp",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "ZpinQk1s",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "mKmQjjB5",
-                      "displayName": "Heading 1",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "0BYMXHkY",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "XQ7TfDn9",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "IAwsxK7N",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "pU9KFVeN",
-                      "definitionId": "fullWidthActionBlock",
-                      "patternProperties": {},
-                      "variables": {
-                        "overline": {
-                          "path": "/zibXm2hu/fields/actionBlockOverline/~locale",
-                          "type": "BoundValue"
-                        },
-                        "title": {
-                          "path": "/k5eX10Tv/fields/title/~locale",
-                          "type": "BoundValue"
-                        },
-                        "description": {
-                          "path": "/d2JuVKZQ/fields/shortDescription/~locale",
-                          "type": "BoundValue"
-                        },
-                        "image": {
-                          "path": "/FbSNI62I/fields/image/~locale/fields/file/~locale",
-                          "type": "BoundValue"
-                        },
-                        "primaryButton": {
-                          "path": "/NqrmKrUA/fields/primaryLinkRef/~locale",
-                          "type": "BoundValue"
-                        },
-                        "secondaryButton": {
-                          "path": "/f5guroL4/fields/secondaryLinkRef/~locale",
-                          "type": "BoundValue"
-                        },
-                        "background": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "publishedDate": {
-                          "key": "zpea3KaVPS0iJXoZMAHok",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "X3HvQXNU",
-                      "definitionId": "divider",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "margin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "s"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "qPYEMk2o",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "Xsx7dtxc",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "dtvNdOmk",
-                      "definitionId": "fullWidthActionBlock",
-                      "patternProperties": {},
-                      "variables": {
-                        "overline": {
-                          "path": "/XvAA9yze/fields/actionBlockOverline/~locale",
-                          "type": "BoundValue"
-                        },
-                        "title": {
-                          "path": "/lnB5pwJz/fields/title/~locale",
-                          "type": "BoundValue"
-                        },
-                        "description": {
-                          "path": "/MdJaRWGZ/fields/shortDescription/~locale",
-                          "type": "BoundValue"
-                        },
-                        "image": {
-                          "path": "/DXDrLIKT/fields/image/~locale/fields/file/~locale",
-                          "type": "BoundValue"
-                        },
-                        "primaryButton": {
-                          "path": "/0TXnLT0j/fields/marketingLink/~locale",
-                          "type": "BoundValue"
-                        },
-                        "secondaryButton": {
-                          "path": "/uyYAAfql/fields/marketingLink/~locale",
-                          "type": "BoundValue"
-                        },
-                        "background": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "publishedDate": {
-                          "key": "NZ_PNrjRqoCQaO6_D-taO",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "RdLeOx6U",
-                      "definitionId": "divider",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "margin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "s"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "fwnmq3Qj",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "v6A0d7WI",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "SYclWTwE",
-                      "definitionId": "contentful-container",
-                      "patternProperties": {},
-                      "variables": {
-                        "cfVerticalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfHorizontalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfMargin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfPadding": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "24px 24px 24px 24px"
-                          }
-                        },
-                        "cfBackgroundColor": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "rgba(247, 248, 250, 1)"
-                          }
-                        },
-                        "cfWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "100%"
-                          }
-                        },
-                        "cfHeight": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "fit-content"
-                          }
-                        },
-                        "cfMaxWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "1192px"
-                          }
-                        },
-                        "cfFlexDirection": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "column"
-                          }
-                        },
-                        "cfFlexReverse": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfFlexWrap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "nowrap"
-                          }
-                        },
-                        "cfBorder": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px solid rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfGap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfHyperlink": {
-                          "type": "UnboundValue",
-                          "key": "ICrX3vs"
-                        },
-                        "cfOpenInNewTab": {
-                          "type": "UnboundValue",
-                          "key": "bAIeQt5"
-                        },
-                        "cfBorderRadius": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfBackgroundImageUrl": {
-                          "type": "UnboundValue",
-                          "key": "fupk4k7"
-                        },
-                        "cfBackgroundImageOptions": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": {
-                              "scaling": "fill",
-                              "alignment": "left top",
-                              "targetSize": "2000px"
-                            }
-                          }
-                        }
-                      },
-                      "children": [
-                        {
-                          "id": "jPGXtwTT",
-                          "definitionId": "fullWidthActionBlock",
-                          "patternProperties": {},
-                          "variables": {
-                            "overline": {
-                              "path": "/XXpWcD4q/fields/actionBlockOverline/~locale",
-                              "type": "BoundValue"
-                            },
-                            "title": {
-                              "path": "/x7pyjFFj/fields/title/~locale",
-                              "type": "BoundValue"
-                            },
-                            "description": {
-                              "path": "/WIYCSsvX/fields/shortDescription/~locale",
-                              "type": "BoundValue"
-                            },
-                            "image": {
-                              "path": "/w3A8mGao/fields/image/~locale/fields/file/~locale",
-                              "type": "BoundValue"
-                            },
-                            "primaryButton": {
-                              "path": "/xSo60zbz/fields/primaryLinkRef/~locale",
-                              "type": "BoundValue"
-                            },
-                            "secondaryButton": {
-                              "path": "/baGfsFOR/fields/secondaryLinkRef/~locale",
-                              "type": "BoundValue"
-                            },
-                            "background": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "secondary"
-                              }
-                            },
-                            "publishedDate": {
-                              "key": "TpH8B3Rf71dRzy9-Eij_B",
-                              "type": "UnboundValue"
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            }
-                          },
-                          "children": []
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "8dDKrpX8",
-              "displayName": "Button",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "nM4Jx3EajfRTuaILiaRh1",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "Gs0XOO8d5eKpR2MQKAm8x",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "ZUNHb1QCXiLvRUG9taeN8",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "HjMZCQC6",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "vy3Z4qCBqa2yM79waYyZx",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "sqnBKCvr",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "lzUBFGk045vgYma7aXjur",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "ZA7w0xDd",
-                      "displayName": "Button",
-                      "definitionId": "button",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "purple"
-                          }
-                        },
-                        "type": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "text": {
-                          "key": "hXGMAy_S9tLUATPGf5Zry",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "key": "m5B_-isX7sffstDtAWTWi",
-                          "type": "UnboundValue"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "Jr3_e_AP72m0PxsOOIzg6",
-                          "type": "UnboundValue"
-                        },
-                        "iconLeftName": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": ""
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "sMndlIZK",
-                      "displayName": "Button 1",
-                      "definitionId": "button",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "black"
-                          }
-                        },
-                        "type": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "secondary"
-                          }
-                        },
-                        "text": {
-                          "key": "C2eh9B38",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "key": "JwQMnloG",
-                          "type": "UnboundValue"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "Xyg0Z-kNXwLoS7tUWKWe4",
-                          "type": "UnboundValue"
-                        },
-                        "iconLeftName": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "home"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "i9TQ90r1",
-                      "displayName": "Button 2",
-                      "definitionId": "button",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "white"
-                          }
-                        },
-                        "type": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "secondary"
-                          }
-                        },
-                        "text": {
-                          "key": "7PWBeER6",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "key": "6ktx3JHv",
-                          "type": "UnboundValue"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "BHheSJr0-DKiQ2KV6nT9b",
-                          "type": "UnboundValue"
-                        },
-                        "iconLeftName": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "smile"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "LLoJaXAe",
-                      "definitionId": "divider",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "margin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "xs"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "fdLp3ahg",
-                      "displayName": "Left Aligned Button",
-                      "definitionId": "button",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "purple"
-                          }
-                        },
-                        "type": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "text": {
-                          "key": "C820WrIq2MCzdJJuM4oiI",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "type": "UnboundValue",
-                          "key": "uMhUcdTnHh9zPBFXifvKq"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "Q8S_CqSaOYMVwDMKlR3jr",
-                          "type": "UnboundValue"
-                        },
-                        "iconLeftName": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": ""
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "n4kkpjAV",
-                      "displayName": "Centered Button",
-                      "definitionId": "button",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "purple"
-                          }
-                        },
-                        "type": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "text": {
-                          "key": "WasTGlxj",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "type": "UnboundValue",
-                          "key": "NhzwQJMw"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "jjrfcFBAJ5AspsCCOO2xO",
-                          "type": "UnboundValue"
-                        },
-                        "iconLeftName": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": ""
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "UkQimeF2",
-                      "displayName": "Right Aligned Button",
-                      "definitionId": "button",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "purple"
-                          }
-                        },
-                        "type": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "text": {
-                          "key": "B1N7IJY8",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "type": "UnboundValue",
-                          "key": "dczpwBQS"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "SHqULneHIzJfEOPmKB4fN",
-                          "type": "UnboundValue"
-                        },
-                        "iconLeftName": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": ""
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "right"
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "gXGGF3fe",
-              "displayName": "Column",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "FW4Y2V_ECnApbkzqsUbE_",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "PFl39glIFt1TSFfKzC2-Z",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "08mxl1BGFzTbKwyQDG6DD",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "g3bDeJ5Q",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "LC3Zogrcyn7ko8fQM4Nqs",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "kSaqrZkL",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "7tPoQs29dgRnwZubnGEms",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "1xhHBB2q",
-                      "definitionId": "contentful-columns",
-                      "patternProperties": {},
-                      "variables": {
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfBorderRadius": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfBackgroundColor": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfBackgroundImageUrl": {
-                          "key": "PWEyhxSkmxTGO951MgkM_",
-                          "type": "UnboundValue"
-                        },
-                        "cfBackgroundImageOptions": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": {
-                              "scaling": "fill",
-                              "alignment": "left top",
-                              "targetSize": "2000px"
-                            }
-                          }
-                        },
-                        "cfMargin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "100%"
-                          }
-                        },
-                        "cfMaxWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "1192px"
-                          }
-                        },
-                        "cfPadding": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "10px 10px 10px 10px"
-                          }
-                        },
-                        "cfBorder": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "1px solid rgba(0, 0, 0, 1)"
-                          }
-                        },
-                        "cfGap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "10px 10px"
-                          }
-                        },
-                        "cfColumns": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "[3,3,3,3]"
-                          }
-                        },
-                        "cfWrapColumns": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfWrapColumnsCount": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "2"
-                          }
-                        }
-                      },
-                      "children": [
-                        {
-                          "id": "4aK86X01",
-                          "definitionId": "contentful-single-column",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "key": "-hiP47xkS8H9dfmgslbdh",
-                              "type": "UnboundValue"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            },
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "start"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1px solid rgba(0, 0, 0, 1)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfColumnSpan": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "6"
-                              }
-                            },
-                            "cfColumnSpanLock": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "zAfKojaP",
-                              "definitionId": "paragraph",
-                              "patternProperties": {},
-                              "variables": {
-                                "visualAppearance": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "body-one"
-                                  }
-                                },
-                                "color": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "removeMarginBottom": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "children": {
-                                  "key": "uyEiVj6ofeCIPPsOLAAcg",
-                                  "type": "UnboundValue"
-                                },
-                                "isStrong": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfTextAlign": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "left"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "ivBBNdu3",
-                          "definitionId": "contentful-single-column",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "key": "h1C3gxnYgR9u4L8CDjo3D",
-                              "type": "UnboundValue"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            },
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1px solid rgba(0, 0, 0, 1)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfColumnSpan": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "6"
-                              }
-                            },
-                            "cfColumnSpanLock": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "gbRF7ltC",
-                              "definitionId": "paragraph",
-                              "patternProperties": {},
-                              "variables": {
-                                "visualAppearance": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "body-one"
-                                  }
-                                },
-                                "color": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "removeMarginBottom": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "children": {
-                                  "key": "fLRxfb9Ecsh1B9F3VCTCi",
-                                  "type": "UnboundValue"
-                                },
-                                "isStrong": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfTextAlign": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "center"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "2fCB1Xtu",
-                          "definitionId": "contentful-single-column",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "key": "jUIXS8jmgg7N0QAzowItS",
-                              "type": "UnboundValue"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            },
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "end"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1px solid rgba(0, 0, 0, 1)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfColumnSpan": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "6"
-                              }
-                            },
-                            "cfColumnSpanLock": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "L9hvodcz",
-                              "definitionId": "paragraph",
-                              "patternProperties": {},
-                              "variables": {
-                                "visualAppearance": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "body-one"
-                                  }
-                                },
-                                "color": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "removeMarginBottom": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "children": {
-                                  "key": "3BFpKy2b749t3Z0j19D9a",
-                                  "type": "UnboundValue"
-                                },
-                                "isStrong": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfTextAlign": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "right"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "lv1SSmyU",
-                          "definitionId": "contentful-single-column",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "key": "fP6j0_ZupHdFnUUB_Ia5H",
-                              "type": "UnboundValue"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            },
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfColumnSpan": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "6"
-                              }
-                            },
-                            "cfColumnSpanLock": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            }
-                          },
-                          "children": []
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "ti6YFTJB",
-              "displayName": "Container",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "X4E1tjHt",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "6pLrv7NC",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "3kOq2u6E",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "uHUM5mzD",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "_byo2Rxu56P0ZbFndME7R",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "eDgH4prd",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "V8YHlFRp",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "uCuOdCYT",
-                      "definitionId": "contentful-container",
-                      "patternProperties": {},
-                      "variables": {
-                        "cfVerticalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfHorizontalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfMargin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfPadding": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfBackgroundColor": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "100%"
-                          }
-                        },
-                        "cfHeight": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "fit-content"
-                          }
-                        },
-                        "cfMaxWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "1192px"
-                          }
-                        },
-                        "cfFlexDirection": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "row"
-                          }
-                        },
-                        "cfFlexReverse": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfFlexWrap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "nowrap"
-                          }
-                        },
-                        "cfBorder": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px solid rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfGap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfHyperlink": {
-                          "key": "IsyZ4DkUsAKB5tReDxD1q",
-                          "type": "UnboundValue"
-                        },
-                        "cfOpenInNewTab": {
-                          "key": "rpWptElOUBNuPNQXKsjMo",
-                          "type": "UnboundValue"
-                        },
-                        "cfBorderRadius": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfBackgroundImageUrl": {
-                          "key": "mFzwT6KHtA9j1FYYT0dvh",
-                          "type": "UnboundValue"
-                        },
-                        "cfBackgroundImageOptions": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": {
-                              "scaling": "fill",
-                              "alignment": "left top",
-                              "targetSize": "2000px"
-                            }
-                          }
-                        }
-                      },
-                      "children": [
-                        {
-                          "id": "a9I1ElrU",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "start"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "25%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1px solid rgba(0, 0, 0, 1)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "key": "XeBIpyktpVkLEy45skA7l",
-                              "type": "UnboundValue"
-                            },
-                            "cfOpenInNewTab": {
-                              "key": "2T84aGT0sd1wyPrlXpm_v",
-                              "type": "UnboundValue"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "key": "cKcaNJOJ3vHPn3yBMhHgh",
-                              "type": "UnboundValue"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "FNbhC3Xu",
-                              "definitionId": "heading",
-                              "patternProperties": {},
-                              "variables": {
-                                "visualAppearance": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "heading-xxl"
-                                  }
-                                },
-                                "removeMarginBottom": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "children": {
-                                  "key": "op-Qp-gdr8uf9I9-WXcdr",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfTextAlign": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "left"
-                                  }
-                                }
-                              },
-                              "children": []
-                            },
-                            {
-                              "id": "UDIwg6gf",
-                              "definitionId": "paragraph",
-                              "patternProperties": {},
-                              "variables": {
-                                "visualAppearance": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "body-one"
-                                  }
-                                },
-                                "color": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "removeMarginBottom": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "children": {
-                                  "key": "QcBjAcsD-IhgBz5nwADMs",
-                                  "type": "UnboundValue"
-                                },
-                                "isStrong": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfTextAlign": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "left"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "E07pN8W4",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "25%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1px solid rgba(0, 0, 0, 1)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "key": "Vbrs8KDX",
-                              "type": "UnboundValue"
-                            },
-                            "cfOpenInNewTab": {
-                              "key": "6lSOjmKa",
-                              "type": "UnboundValue"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "key": "zkx5V9ed",
-                              "type": "UnboundValue"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "o6xpiMNG",
-                              "definitionId": "heading",
-                              "patternProperties": {},
-                              "variables": {
-                                "visualAppearance": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "heading-xxl"
-                                  }
-                                },
-                                "removeMarginBottom": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "children": {
-                                  "key": "M8tEEkEnbhdKkkzZSTBRd",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfTextAlign": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "left"
-                                  }
-                                }
-                              },
-                              "children": []
-                            },
-                            {
-                              "id": "NcKsyTr5",
-                              "definitionId": "paragraph",
-                              "patternProperties": {},
-                              "variables": {
-                                "visualAppearance": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "body-one"
-                                  }
-                                },
-                                "color": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "removeMarginBottom": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "children": {
-                                  "key": "l2UKloU9",
-                                  "type": "UnboundValue"
-                                },
-                                "isStrong": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfTextAlign": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "center"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "1vmrSFao",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "end"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "25%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1px solid rgba(0, 0, 0, 1)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "key": "yzVjh0Ni",
-                              "type": "UnboundValue"
-                            },
-                            "cfOpenInNewTab": {
-                              "key": "18Loxedj",
-                              "type": "UnboundValue"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "key": "5OJDXQCx",
-                              "type": "UnboundValue"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "48VmFOtI",
-                              "definitionId": "heading",
-                              "patternProperties": {},
-                              "variables": {
-                                "visualAppearance": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "heading-xxl"
-                                  }
-                                },
-                                "removeMarginBottom": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "children": {
-                                  "key": "sfjHI0Y3PWcC6rm8lYfap",
-                                  "type": "UnboundValue"
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfTextAlign": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "right"
-                                  }
-                                }
-                              },
-                              "children": []
-                            },
-                            {
-                              "id": "VkXRXr2S",
-                              "definitionId": "paragraph",
-                              "patternProperties": {},
-                              "variables": {
-                                "visualAppearance": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "body-one"
-                                  }
-                                },
-                                "color": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "primary"
-                                  }
-                                },
-                                "removeMarginBottom": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "children": {
-                                  "key": "7Cj0SIqV",
-                                  "type": "UnboundValue"
-                                },
-                                "isStrong": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfTextAlign": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "right"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "Clx6dZLd",
-              "displayName": "Divider",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "FXuaWYztKfKJWXod-xTpd",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "ZClRveUvVcQjBrlrDvtm6",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "zcuX6eaiBiUs3mCXjHYq2",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "BRrxH9Ul",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "koY0ISJaPzBIDXqlznL0H",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "s5HoxC42",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "fvbdsWsT",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "pHAqHABK",
-                      "displayName": "Divider",
-                      "definitionId": "divider",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "margin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "none"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "WydkYUZS",
-                      "displayName": "Divider 1",
-                      "definitionId": "divider",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "strong"
-                          }
-                        },
-                        "margin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "l"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "KpnHx64w",
-              "displayName": "Heading",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "GQ_meekKAizcWHfsUxUEe",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "JVQR-tfdKQE3G3iyEGd3d",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "k2x0YIUxjaXNGJxbL2xFl",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "DiK9VHcn",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "aTtjH3mTVn7fMVJ-xb2nG",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "QeFTqe9z",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "1O9vd7afmvcqJPb-Hst2m",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "s9BWm87K",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "ppcJTpQrNNmiFzRpoKuk7",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "g7eJTxtZ",
-                      "displayName": "Heading 1",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-lg"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "k7cc4DWU",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "Og5azalB",
-                      "displayName": "Heading 1",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-md"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "J8z7Qo1L",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "aqtlS0Go",
-                      "displayName": "Heading 1",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-sm"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "mCXPy8Sk",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "B3ylIbTZ",
-                      "displayName": "Heading 1",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xs"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "rMO0UpAm",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "right"
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "emFwvLP8",
-              "displayName": "Image",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "8LDk6KB4",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "aPeti3xV",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "7954gvrQ",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "OX0joJve",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "mJJmzfsA",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "AI1IIxgR",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "ZJnqNzR6",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "pW9sYR0b",
-                      "definitionId": "contentful-container",
-                      "patternProperties": {},
-                      "variables": {
-                        "cfVerticalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfHorizontalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfMargin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfPadding": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfBackgroundColor": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "100%"
-                          }
-                        },
-                        "cfHeight": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "274px",
-                            "mobile": "fit-content"
-                          }
-                        },
-                        "cfMaxWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "1192px"
-                          }
-                        },
-                        "cfFlexDirection": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "row",
-                            "mobile": "column"
-                          }
-                        },
-                        "cfFlexReverse": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfFlexWrap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "nowrap"
-                          }
-                        },
-                        "cfBorder": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px solid rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfGap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px 24px",
-                            "mobile": "24px 24px"
-                          }
-                        },
-                        "cfHyperlink": {
-                          "type": "UnboundValue",
-                          "key": "Fe4Bfar"
-                        },
-                        "cfOpenInNewTab": {
-                          "type": "UnboundValue",
-                          "key": "baOMaPo"
-                        },
-                        "cfBorderRadius": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfBackgroundImageUrl": {
-                          "type": "UnboundValue",
-                          "key": "KBQ3_Cb"
-                        },
-                        "cfBackgroundImageOptions": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": {
-                              "scaling": "fill",
-                              "alignment": "left top",
-                              "targetSize": "2000px"
-                            }
-                          }
-                        }
-                      },
-                      "children": [
-                        {
-                          "id": "Jk6x2y8G",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "Idr0CiO"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "JFCnn0N"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "xbPE1--"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "8oIklkai",
-                              "definitionId": "image",
-                              "patternProperties": {},
-                              "variables": {
-                                "src": {
-                                  "path": "/JtSxyKC/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "altText": {
-                                  "key": "KU5oIGN",
-                                  "type": "UnboundValue"
-                                },
-                                "decoration": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "none"
-                                  }
-                                },
-                                "hasRoundedCorners": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfWidth": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "100%"
-                                  }
-                                },
-                                "cfHeight": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "fit-content"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "wzdQlRZH",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "qYw68TuV"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "8opMv3ky"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "eT6yBrVf"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "t9aHgC0s",
-                              "definitionId": "image",
-                              "patternProperties": {},
-                              "variables": {
-                                "src": {
-                                  "path": "/2Te0IAmc/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "altText": {
-                                  "key": "PyeBaTT5",
-                                  "type": "UnboundValue"
-                                },
-                                "decoration": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "none"
-                                  }
-                                },
-                                "hasRoundedCorners": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": false
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfWidth": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "100%"
-                                  }
-                                },
-                                "cfHeight": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "fit-content"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "id": "WWXtCxfi",
-                      "definitionId": "spacer",
-                      "patternProperties": {},
-                      "variables": {
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "m"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "ZrgPrUKJ",
-                      "definitionId": "contentful-container",
-                      "patternProperties": {},
-                      "variables": {
-                        "cfVerticalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfHorizontalAlignment": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfMargin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfPadding": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0 0 0 0"
-                          }
-                        },
-                        "cfBackgroundColor": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "100%"
-                          }
-                        },
-                        "cfHeight": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "273px",
-                            "mobile": "fit-content"
-                          }
-                        },
-                        "cfMaxWidth": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "1192px"
-                          }
-                        },
-                        "cfFlexDirection": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "row",
-                            "mobile": "column"
-                          }
-                        },
-                        "cfFlexReverse": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfFlexWrap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "nowrap"
-                          }
-                        },
-                        "cfBorder": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px solid rgba(0, 0, 0, 0)"
-                          }
-                        },
-                        "cfGap": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px 24px",
-                            "mobile": "24px 24px"
-                          }
-                        },
-                        "cfHyperlink": {
-                          "type": "UnboundValue",
-                          "key": "5dOroYow"
-                        },
-                        "cfOpenInNewTab": {
-                          "type": "UnboundValue",
-                          "key": "QDaxYIdJ"
-                        },
-                        "cfBorderRadius": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "0px"
-                          }
-                        },
-                        "cfBackgroundImageUrl": {
-                          "type": "UnboundValue",
-                          "key": "A43eNziB"
-                        },
-                        "cfBackgroundImageOptions": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": {
-                              "scaling": "fill",
-                              "alignment": "left top",
-                              "targetSize": "2000px"
-                            }
-                          }
-                        }
-                      },
-                      "children": [
-                        {
-                          "id": "K3kEoR9T",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "FHSW9Y15"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "eI0ylAC7"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "uNXnh4Ev"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "fSh2sEYp",
-                              "definitionId": "image",
-                              "patternProperties": {},
-                              "variables": {
-                                "src": {
-                                  "path": "/gxYbZM71/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "altText": {
-                                  "key": "m93uQB8b",
-                                  "type": "UnboundValue"
-                                },
-                                "decoration": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "border"
-                                  }
-                                },
-                                "hasRoundedCorners": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfWidth": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "100%"
-                                  }
-                                },
-                                "cfHeight": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "fit-content"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "id": "4q7Agi2K",
-                          "definitionId": "contentful-container",
-                          "patternProperties": {},
-                          "variables": {
-                            "cfVerticalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfHorizontalAlignment": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "center"
-                              }
-                            },
-                            "cfVisibility": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": true
-                              }
-                            },
-                            "cfMargin": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfPadding": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0 0 0 0"
-                              }
-                            },
-                            "cfBackgroundColor": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "100%"
-                              }
-                            },
-                            "cfHeight": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "fit-content"
-                              }
-                            },
-                            "cfMaxWidth": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "1192px"
-                              }
-                            },
-                            "cfFlexDirection": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "column"
-                              }
-                            },
-                            "cfFlexReverse": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": false
-                              }
-                            },
-                            "cfFlexWrap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "nowrap"
-                              }
-                            },
-                            "cfBorder": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px solid rgba(0, 0, 0, 0)"
-                              }
-                            },
-                            "cfGap": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfHyperlink": {
-                              "type": "UnboundValue",
-                              "key": "SALwyVOh"
-                            },
-                            "cfOpenInNewTab": {
-                              "type": "UnboundValue",
-                              "key": "VF7rRAiQ"
-                            },
-                            "cfBorderRadius": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": "0px"
-                              }
-                            },
-                            "cfBackgroundImageUrl": {
-                              "type": "UnboundValue",
-                              "key": "zBYukK4q"
-                            },
-                            "cfBackgroundImageOptions": {
-                              "type": "DesignValue",
-                              "valuesByBreakpoint": {
-                                "desktop": {
-                                  "scaling": "fill",
-                                  "alignment": "left top",
-                                  "targetSize": "2000px"
-                                }
-                              }
-                            }
-                          },
-                          "children": [
-                            {
-                              "id": "PLoMFmHU",
-                              "definitionId": "image",
-                              "patternProperties": {},
-                              "variables": {
-                                "src": {
-                                  "path": "/DtbkKOnf/fields/file/~locale",
-                                  "type": "BoundValue"
-                                },
-                                "altText": {
-                                  "key": "5gWPmo5r",
-                                  "type": "UnboundValue"
-                                },
-                                "decoration": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "shadow"
-                                  }
-                                },
-                                "hasRoundedCorners": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfVisibility": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": true
-                                  }
-                                },
-                                "cfWidth": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "100%"
-                                  }
-                                },
-                                "cfHeight": {
-                                  "type": "DesignValue",
-                                  "valuesByBreakpoint": {
-                                    "desktop": "fit-content"
-                                  }
-                                }
-                              },
-                              "children": []
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "xHJlZCCH",
-              "displayName": "Overline",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "Ry2EmrfLWGKKxHzN2NKK2",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "MJmfC3N564sY154aazOqg",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "fbxlhQrAD8jhqeEPcb_Zc",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "85sUjnT6",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "vYKqsBQ5xXnkpbPCxrnKb",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "b2f0KDFZ",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "-KqdBQBCJexO6AUlN6Hdk",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "L9QvdEUS",
-                      "displayName": "Overline",
-                      "definitionId": "overline",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "m"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "1eCExq2WLGpJwNbRFYPCg",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "H2y2eW6g",
-                      "displayName": "Overline 1",
-                      "definitionId": "overline",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "secondary"
-                          }
-                        },
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "s"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "Lu9xfUr8",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "K6qaxqTv",
-                      "displayName": "Overline 2",
-                      "definitionId": "overline",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "l"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "tgfqSQxT",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "right"
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "elX9Jq6X",
-              "displayName": "Paragraph",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "REWmmbf2LKIIYFlPSLTFy",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "aDgvlZ6op1gK3MYklFgKX",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "lP2xlEiG4Ur15q_7otUZo",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "5XxdQJUA",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "L6HfuP4oVMvQ_xwZqzQc7",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "KesTZnYJ",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "4fZ-pGgFlP7R6tach397W",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "AMYwkYNk",
-                      "displayName": "Paragraph",
-                      "definitionId": "paragraph",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "body-four"
-                          }
-                        },
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "joR8i87odA3R7JLfvzfCw",
-                          "type": "UnboundValue"
-                        },
-                        "isStrong": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "zJvuD0HD",
-                      "displayName": "Paragraph 1",
-                      "definitionId": "paragraph",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "body-two"
-                          }
-                        },
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "secondary"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "TSFzv7B9",
-                          "type": "UnboundValue"
-                        },
-                        "isStrong": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "SJd9fYto",
-                      "displayName": "Paragraph 2",
-                      "definitionId": "paragraph",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "body-two"
-                          }
-                        },
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "secondary"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "avmUJimV",
-                          "type": "UnboundValue"
-                        },
-                        "isStrong": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "right"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "pl5CZVbe",
-                      "displayName": "Paragraph",
-                      "definitionId": "paragraph",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "body-one"
-                          }
-                        },
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "hRhxjrt3N9VU1NMl2QRh3",
-                          "type": "UnboundValue"
-                        },
-                        "isStrong": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "mmiz1hHo",
-              "displayName": "Section",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "g1GOPI4w",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "qhMtsAXw",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "Oor1uCW9",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "jIECLTTH",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "patternDark"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "TPp4t_zOnGYYUCQCHczCd",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "io9EJVj6",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "uqryIUsQ",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "id": "Ko7M7vnH",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "patternPrimary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "wmG6IXrB1B-h8zddto0vr",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "RSQxdVwv",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "qM57cKR3J1QPDQnHDERkX",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "ZX4djoXt",
-              "displayName": "Text Link",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "ilVAO2EaIUZ0lA5ewKtJI",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "2PSTJ_DqEZxNVxIpr_H8t",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "lgABBbaFeSQbvkWefAwA5",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "wrGEKnPn",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "7W1Qi2iLcCJo1S5FoTklH",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "WF76U7uH",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "ws1Q0E4GP0WIGLne79bIY",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "OYIhzN9w",
-                      "displayName": "Text Link 2",
-                      "definitionId": "link",
-                      "patternProperties": {},
-                      "variables": {
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "xs"
-                          }
-                        },
-                        "children": {
-                          "key": "ERvTdJXH",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "key": "zQNTpdsD",
-                          "type": "UnboundValue"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "ReHgFwZk-BHm9gAcpYww7",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "bTLH9bp5",
-                      "displayName": "Text Link",
-                      "definitionId": "link",
-                      "patternProperties": {},
-                      "variables": {
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "s"
-                          }
-                        },
-                        "children": {
-                          "key": "EX79hiIuw8_2Ria-2tQkj",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "key": "L7sMSlH7Y_F-LSZzoglh6",
-                          "type": "UnboundValue"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "dDFAtpAu4xTWTM3cwvHX_",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "Bobqy9W3",
-                      "displayName": "Text Link 1",
-                      "definitionId": "link",
-                      "patternProperties": {},
-                      "variables": {
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "m"
-                          }
-                        },
-                        "children": {
-                          "key": "lIsy1GAr",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "key": "92O5l7Xr",
-                          "type": "UnboundValue"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "KGUo-pbAmZDeE_onnJmeM",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "8WDnlPms",
-                      "displayName": "Text Link 1",
-                      "definitionId": "link",
-                      "patternProperties": {},
-                      "variables": {
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "l"
-                          }
-                        },
-                        "children": {
-                          "key": "nBnzzrrg",
-                          "type": "UnboundValue"
-                        },
-                        "href": {
-                          "key": "Icqsu9JA",
-                          "type": "UnboundValue"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "vNE31MABBbkMScnKL4BMU",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "bBEfl0Ck",
-                      "definitionId": "divider",
-                      "patternProperties": {},
-                      "variables": {
-                        "color": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "primary"
-                          }
-                        },
-                        "margin": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "xs"
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "5IqQIrwI",
-                      "displayName": "Left aligned",
-                      "definitionId": "link",
-                      "patternProperties": {},
-                      "variables": {
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "m"
-                          }
-                        },
-                        "children": {
-                          "type": "UnboundValue",
-                          "key": "c6Xllyd"
-                        },
-                        "href": {
-                          "type": "UnboundValue",
-                          "key": "6znvK3h"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "4GGacxRsnhMslE0UcSJ97",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "MjacnNa2",
-                      "displayName": "Centered",
-                      "definitionId": "link",
-                      "patternProperties": {},
-                      "variables": {
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "m"
-                          }
-                        },
-                        "children": {
-                          "type": "UnboundValue",
-                          "key": "PeTivMde"
-                        },
-                        "href": {
-                          "type": "UnboundValue",
-                          "key": "5wXRsLJn"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "0v9inr8Fpqnw8F8ElhUQT",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "center"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "nLDuaCau",
-                      "displayName": "Right aligned",
-                      "definitionId": "link",
-                      "patternProperties": {},
-                      "variables": {
-                        "size": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "m"
-                          }
-                        },
-                        "children": {
-                          "type": "UnboundValue",
-                          "key": "DEtHVoSd"
-                        },
-                        "href": {
-                          "type": "UnboundValue",
-                          "key": "1VT4PEqW"
-                        },
-                        "isLinkExternal": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "ariaLabel": {
-                          "key": "46SVVu7SVI_27igWB64S2",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "right"
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "UXWNakDB",
-              "displayName": "Video",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "G5Iyv0YkdyGi6tu6eXCln",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "YKCODw2Gj_YPupxeh2ON7",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "5S0WDaNvwkgyaaXOaPShS",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "rtrOzYi0",
-                  "displayName": "Section",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "6AjZi52JdcRm7jrVI6Sal",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "AdqCNDR9",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "K0KxrTFkzU8KmLwowRzGo",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "CuFH5tMP",
-                      "displayName": "Heading",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "Is-QBxBKRvrSLF5e6k8WM",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "e56jD7Ml",
-                      "displayName": "Video",
-                      "definitionId": "video",
-                      "patternProperties": {},
-                      "variables": {
-                        "videoTitle": {
-                          "key": "FdwpeSt6bn8LpSSV0pbtv",
-                          "type": "UnboundValue"
-                        },
-                        "videoDesc": {
-                          "key": "aL5ooU7rF-Cfhi4sEFovm",
-                          "type": "UnboundValue"
-                        },
-                        "uploadDate": {
-                          "key": "YfZC6-Hmjrj20Loaq6-FT",
-                          "type": "UnboundValue"
-                        },
-                        "youTubeId": {
-                          "key": "n0l5OgPZtTMQsbZ3GNKiR",
-                          "type": "UnboundValue"
-                        },
-                        "videoFallback": {
-                          "key": "qg0XcsQhQK20HDFZctW0_",
-                          "type": "UnboundValue"
-                        },
-                        "showCaption": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "51WBcL8X",
-                      "displayName": "Heading 1",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "nOVfFtTI",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "WVvTAVCW",
-                      "displayName": "Video 1",
-                      "definitionId": "video",
-                      "patternProperties": {},
-                      "variables": {
-                        "videoTitle": {
-                          "key": "uTgCIxZc",
-                          "type": "UnboundValue"
-                        },
-                        "videoDesc": {
-                          "key": "7cjXZUvesiyPKoMJZUraJ",
-                          "type": "UnboundValue"
-                        },
-                        "uploadDate": {
-                          "key": "aRYsNWTbO_8er8D_crzl2",
-                          "type": "UnboundValue"
-                        },
-                        "youTubeId": {
-                          "key": "vNAYFsDQ",
-                          "type": "UnboundValue"
-                        },
-                        "videoFallback": {
-                          "key": "5OKBDu4C",
-                          "type": "UnboundValue"
-                        },
-                        "showCaption": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "jkcCZDp5",
-                      "displayName": "Heading 1",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "8tSwOMzw",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "x1xIoh5c",
-                      "displayName": "Video",
-                      "definitionId": "video",
-                      "patternProperties": {},
-                      "variables": {
-                        "videoTitle": {
-                          "key": "jNBarAZvvExnBW0FccdXk",
-                          "type": "UnboundValue"
-                        },
-                        "videoDesc": {
-                          "key": "SQ455se7uXiseEPWsgHS4",
-                          "type": "UnboundValue"
-                        },
-                        "uploadDate": {
-                          "key": "UnsmjdqCrmrO4Trj1nuzn",
-                          "type": "UnboundValue"
-                        },
-                        "youTubeId": {
-                          "key": "HkS6sKTzMLaB2xX5evo7Z",
-                          "type": "UnboundValue"
-                        },
-                        "videoFallback": {
-                          "key": "WWIhqOfAkCpzLs6ZV3raO",
-                          "type": "UnboundValue"
-                        },
-                        "showCaption": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "HkaGv0Z3",
-              "displayName": "Video Carousel",
-              "definitionId": "contentful-section",
-              "patternProperties": {},
-              "variables": {
-                "cfVerticalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfHorizontalAlignment": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "center"
-                  }
-                },
-                "cfVisibility": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": true
-                  }
-                },
-                "cfMargin": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfPadding": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0 0 0 0"
-                  }
-                },
-                "cfBackgroundColor": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "100%"
-                  }
-                },
-                "cfHeight": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "fit-content"
-                  }
-                },
-                "cfMaxWidth": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "none"
-                  }
-                },
-                "cfFlexDirection": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "column"
-                  }
-                },
-                "cfFlexReverse": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": false
-                  }
-                },
-                "cfFlexWrap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "nowrap"
-                  }
-                },
-                "cfBorder": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px solid rgba(0, 0, 0, 0)"
-                  }
-                },
-                "cfGap": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfHyperlink": {
-                  "key": "C0ZnFmnY1RLOEnDrehvP2",
-                  "type": "UnboundValue"
-                },
-                "cfOpenInNewTab": {
-                  "key": "Enm2i9xxpZNHnLD0K1fpI",
-                  "type": "UnboundValue"
-                },
-                "cfBorderRadius": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": "0px"
-                  }
-                },
-                "cfBackgroundImageUrl": {
-                  "key": "-izis13YUPq4WCazZckUr",
-                  "type": "UnboundValue"
-                },
-                "cfBackgroundImageOptions": {
-                  "type": "DesignValue",
-                  "valuesByBreakpoint": {
-                    "desktop": {
-                      "scaling": "fill",
-                      "alignment": "left top",
-                      "targetSize": "2000px"
-                    }
-                  }
-                }
-              },
-              "children": [
-                {
-                  "id": "nnW16yI0",
-                  "definitionId": "section",
-                  "patternProperties": {},
-                  "variables": {
-                    "background": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "primary"
-                      }
-                    },
-                    "padding": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "l"
-                      }
-                    },
-                    "divider": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": "none"
-                      }
-                    },
-                    "id": {
-                      "key": "sU117GEiAbQOFMhXtxs7a",
-                      "type": "UnboundValue"
-                    },
-                    "cfVisibility": {
-                      "type": "DesignValue",
-                      "valuesByBreakpoint": {
-                        "desktop": true
-                      }
-                    }
-                  },
-                  "children": [
-                    {
-                      "id": "89PlsO6u",
-                      "definitionId": "heading",
-                      "patternProperties": {},
-                      "variables": {
-                        "visualAppearance": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
-                          }
-                        },
-                        "removeMarginBottom": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": false
-                          }
-                        },
-                        "children": {
-                          "key": "zyqjhLXToMUDWS9_Gj5le",
-                          "type": "UnboundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        },
-                        "cfTextAlign": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": "left"
-                          }
-                        }
-                      },
-                      "children": []
-                    },
-                    {
-                      "id": "CzL11C45",
-                      "definitionId": "carousel-video",
-                      "patternProperties": {},
-                      "variables": {
-                        "slides": {
-                          "path": "/9g-7kZ472XQBkhnml-mZ-/fields/slides/~locale",
-                          "type": "BoundValue"
-                        },
-                        "cfVisibility": {
-                          "type": "DesignValue",
-                          "valuesByBreakpoint": {
-                            "desktop": true
-                          }
-                        }
-                      },
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+          "schemaVersion": "2023-09-28"
         }
       },
       "dataSource": {
         "en-US": {
+          "JtSxyKC": {
+            "sys": {
+              "id": "6fdNRFZbNXpiXQd6v7fHen",
+              "type": "Link",
+              "linkType": "Asset"
+            }
+          },
           "0HkUraow": {
             "sys": {
               "id": "7Gumifs6ZTcj2G02BUoqFz",
@@ -9698,13 +9705,6 @@
               "linkType": "Entry"
             }
           },
-          "9g-7kZ472XQBkhnml-mZ-": {
-            "sys": {
-              "id": "20rQYDvS9V3fnwtMyAW0m4",
-              "type": "Link",
-              "linkType": "Entry"
-            }
-          },
           "D06vmzVo": {
             "sys": {
               "id": "7Gumifs6ZTcj2G02BUoqFz",
@@ -9745,13 +9745,6 @@
               "id": "7Gumifs6ZTcj2G02BUoqFz",
               "type": "Link",
               "linkType": "Entry"
-            }
-          },
-          "JtSxyKC": {
-            "sys": {
-              "id": "6fdNRFZbNXpiXQd6v7fHen",
-              "type": "Link",
-              "linkType": "Asset"
             }
           },
           "L1oQ0Cfn": {
@@ -10082,6 +10075,13 @@
               "type": "Link",
               "linkType": "Entry"
             }
+          },
+          "9g-7kZ472XQBkhnml-mZ-": {
+            "sys": {
+              "id": "20rQYDvS9V3fnwtMyAW0m4",
+              "type": "Link",
+              "linkType": "Entry"
+            }
           }
         }
       },
@@ -10338,7 +10338,7 @@
             "value": "Link"
           },
           "PyeBaTT5": {
-            "value": "Image with shadow"
+            "value": "Image without rounded corners"
           },
           "Q8S_CqSaOYMVwDMKlR3jr": {},
           "QDaxYIdJ": {

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/3BLuF3jm0oTV17RPwLOgC6.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/3BLuF3jm0oTV17RPwLOgC6.json
@@ -17,7 +17,13 @@
         }
       },
       "videoFallbackUrl": {
-        "en-US": "https://videos.ctfassets.net/90t6bu6vlf76/5Unfit2zLyqPp9HofyWU9T/4f0a43abe3dc649dc752ca321f1945c7/what-most-schools-dont-teach.mp4"
+        "en-US": "https://contentful-videos.code.org/90t6bu6vlf76/5Unfit2zLyqPp9HofyWU9T/4f0a43abe3dc649dc752ca321f1945c7/what-most-schools-dont-teach.mp4"
+      },
+      "publishedDate": {
+        "en-US": "2013-02-26T00:00-04:00"
+      },
+      "description": {
+        "en-US": "Learn about a new \"superpower\" that isn't being taught in more than half of U.S. schools.  "
       }
     }
   },

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/3oxrIQkHqzpbTrXqwk0aIa.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/3oxrIQkHqzpbTrXqwk0aIa.json
@@ -17,7 +17,10 @@
         }
       },
       "videoFallbackUrl": {
-        "en-US": "https://videos.ctfassets.net/90t6bu6vlf76/L5PVu2K4eN5rocJTApuC5/fb69b3b7d0a0e95989feec6165725a22/cs-is-everything.mp4"
+        "en-US": "https://contentful-videos.code.org/90t6bu6vlf76/L5PVu2K4eN5rocJTApuC5/fb69b3b7d0a0e95989feec6165725a22/cs-is-everything.mp4"
+      },
+      "publishedDate": {
+        "en-US": "2019-09-29T00:00-04:00"
       }
     }
   },

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/4xyTmh7jAVCC3glKeke0cP.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/4xyTmh7jAVCC3glKeke0cP.json
@@ -17,7 +17,13 @@
         }
       },
       "videoFallbackUrl": {
-        "en-US": "https://videos.ctfassets.net/90t6bu6vlf76/2lkClZGdouHPDUTRZu8LxZ/271ce1df5c6909836589a34212476757/01_howcomputerswork_sm-mp4.mp4"
+        "en-US": "https://contentful-videos.code.org/90t6bu6vlf76/2lkClZGdouHPDUTRZu8LxZ/271ce1df5c6909836589a34212476757/01_howcomputerswork_sm-mp4.mp4"
+      },
+      "publishedDate": {
+        "en-US": "2018-01-30T00:00-04:00"
+      },
+      "description": {
+        "en-US": "Bill Gates kicks off an introduction to the series How Computers Work."
       }
     }
   },

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/53hnyQQVUfylnTa7f24dDJ.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/53hnyQQVUfylnTa7f24dDJ.json
@@ -17,7 +17,7 @@
         }
       },
       "videoFallbackUrl": {
-        "en-US": "https://videos.ctfassets.net/90t6bu6vlf76/1jVlIMJ2yBmzqD1H5hHDNj/9fe6b733248373a6546b44d1bad1baf6/ai-01-intro-to-ai.mp4"
+        "en-US": "https://contentful-videos.code.org/90t6bu6vlf76/1jVlIMJ2yBmzqD1H5hHDNj/9fe6b733248373a6546b44d1bad1baf6/ai-01-intro-to-ai.mp4"
       },
       "publishedDate": {
         "en-US": "2020-12-01T00:00-04:00"

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/7Gumifs6ZTcj2G02BUoqFz.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/7Gumifs6ZTcj2G02BUoqFz.json
@@ -4,9 +4,6 @@
       "title": {
         "en-US": "TEST - Self-Paced PL"
       },
-      "actionBlockOverline": {
-        "en-US": "K-12 Teachers"
-      },
       "shortDescription": {
         "en-US": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eget risus vitae massa semper aliquam quis mattis quam."
       },
@@ -45,6 +42,9 @@
             "id": "5CznPyR4ZsbIkhpwSaUxoe"
           }
         }
+      },
+      "actionBlockOverline": {
+        "en-US": "K-12 Teachers"
       },
       "experienceLevel": {
         "en-US": [

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/entries.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/entries.json
@@ -3,12 +3,12 @@
   "49SifjEqSHArcx1iEiSw4o",
   "5CznPyR4ZsbIkhpwSaUxoe",
   "7Gumifs6ZTcj2G02BUoqFz",
+  "4SDvKKtx0qpCDwFTizoPVx",
   "53hnyQQVUfylnTa7f24dDJ",
   "3BLuF3jm0oTV17RPwLOgC6",
   "3oxrIQkHqzpbTrXqwk0aIa",
   "4xyTmh7jAVCC3glKeke0cP",
   "20rQYDvS9V3fnwtMyAW0m4",
-  "4SDvKKtx0qpCDwFTizoPVx",
   "1hQeP2bdFuIFm5kuYeefew",
   "2rnXDDT2HB8MmwM6u1L4bH"
 ]

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -33,9 +33,9 @@ test.describe('All the things UI e2e test', () => {
       page,
     }) => {
       const allTheThingsPage = new MarketingPage(page);
-      await allTheThingsPage.goto('/all-the-things');
+      await allTheThingsPage.goto('/engineering/all-the-things');
 
-      await page.waitForURL('**/en-US/all-the-things');
+      await page.waitForURL('**/en-US/engineering/all-the-things');
     });
 
     test('should redirect from localeless paths to localized paths using the language cookie', async ({
@@ -58,9 +58,9 @@ test.describe('All the things UI e2e test', () => {
         },
       ]);
 
-      await allTheThingsPage.goto('/all-the-things');
+      await allTheThingsPage.goto('/engineering/all-the-things');
 
-      await page.waitForURL('**/zh-CN/all-the-things');
+      await page.waitForURL('**/zh-CN/engineering/all-the-things');
     });
 
     test('should redirect from localeless paths to localized english when language cookie is invalid', async ({
@@ -83,9 +83,9 @@ test.describe('All the things UI e2e test', () => {
         },
       ]);
 
-      await allTheThingsPage.goto('/all-the-things');
+      await allTheThingsPage.goto('/engineering/all-the-things');
 
-      await page.waitForURL('**/en-US/all-the-things');
+      await page.waitForURL('**/en-US/engineering/all-the-things');
     });
   });
 

--- a/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
@@ -24,11 +24,11 @@ export class AllTheThingsPage extends MarketingPage {
   }
 
   async enableDraftMode(token: string = 'ci-draft-mode') {
-    return await super.enableDraftMode(token, 'all-the-things');
+    return await super.enableDraftMode(token, 'engineering/all-the-things');
   }
 
   async goto() {
-    return await super.goto('/all-the-things');
+    return await super.goto('/engineering/all-the-things');
   }
 
   getSectionLocator(heading: Section): Locator {

--- a/frontend/apps/marketing/tests/e2e/scripts/commands/fork.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/commands/fork.ts
@@ -12,7 +12,7 @@ export async function fork(createOrUpdateEntry: CreateOrUpdateEntryType) {
   // Change the slug and title for clarity
   const username = os.userInfo().username;
   const title = `[${username}] All The Things - ${new Date().toISOString()}`;
-  const slug = `all-the-things-${username}-${Date.now()}`;
+  const slug = `engineering/all-the-things-${username}-${Date.now()}`;
 
   snapshotData.fields.slug['en-US'] = slug;
   snapshotData.fields.title['en-US'] = title;


### PR DESCRIPTION
This PR adds support for sub-directories in the path rather than a single slug. For example, the slug `engineering/all-the-things` previously would throw a 404 because the route does not exist in the application. By implementing dynamic routes[1], all page paths after the locale are considered potentially valid parts of a slug.

The logic will reconstruct up to 2-levels deep into the equivalent slug entry in Contentful. For example, the page at URL
`code.org/engineering/all-the-things` would result in the page parameter array `['engineering', 'all-the-things']`. This is then recombined as `engineering/all-the-things`.

Since we only support 2-levels deep, any further slug parts are discarded and an error will be returned. If a directory is present, the code will check to ensure that the directory is one of the valid possible directories which will plug in to the future Breadcrumb feature.

[1] https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes