### PR TITLE
[Codebridge] Added weblab and pythonlab shortcuts for run button, console, and editor

### DIFF
--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -67,6 +67,57 @@ export const Codebridge = React.memo(
 
     const currentProjectVersion = useRef(projectVersion);
     useEffect(() => {
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'r') {
+          // R: Run the code
+          const editorElement = document.querySelector(
+            '#uitest-codebridge-run'
+          );
+          if (editorElement) {
+            (editorElement as HTMLElement).focus();
+            (editorElement as HTMLElement).click();
+          }
+          event.preventDefault();
+        } else if (event.key === 'e') {
+          // E: Navigate to the editor
+          const editorElement = document.querySelector(
+            '#uitest-codebridge-editor'
+          );
+          if (editorElement) {
+            (editorElement as HTMLElement).focus();
+            // Simulate pressing the Enter key
+            const enterKeyEvent = new KeyboardEvent('keydown', {
+              key: 'Enter',
+              code: 'Enter',
+              keyCode: 13, // Key code for Enter
+              which: 13, // Which code for Enter
+              bubbles: true, // Ensures the event bubbles up the DOM
+            });
+            editorElement.dispatchEvent(enterKeyEvent);
+          }
+          event.preventDefault();
+        } else if (event.key === 'o') {
+          // O: Navigate to the console output
+          const consoleElement = document.querySelector(
+            '.xterm-helper-textarea'
+          );
+          if (consoleElement) {
+            (consoleElement as HTMLElement).focus();
+          }
+          event.preventDefault();
+        }
+      };
+
+      // Attach the event listener
+      document.addEventListener('keydown', handleKeyDown);
+      console.log('added keydown listener');
+
+      // Cleanup the event listener on unmount
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+      };
+    }, []);
+    useEffect(() => {
       if (projectVersion !== currentProjectVersion.current) {
         sourceUtilities.replaceSource(source);
         currentProjectVersion.current = projectVersion;

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -69,6 +69,7 @@ export const Codebridge = React.memo(
 
     // Adds keyboard shortcuts for Run (r), Console (o) and Editor (e),
     // which are preceded by Control (Windows/Linux) or Command (macOS).
+    // Runs on mount (see empty dependency list).
     useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
         // Check if Control (Windows/Linux) or Command (macOS) is pressed
@@ -110,13 +111,13 @@ export const Codebridge = React.memo(
 
       // Attach the event listener
       document.addEventListener('keydown', handleKeyDown);
-      console.log('added keydown listener');
 
       // Cleanup the event listener on unmount
       return () => {
         document.removeEventListener('keydown', handleKeyDown);
       };
     }, []);
+
     useEffect(() => {
       if (projectVersion !== currentProjectVersion.current) {
         sourceUtilities.replaceSource(source);

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -25,6 +25,10 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import moduleStyles from './styles/codebridgeContainer.module.scss';
 import './styles/codebridge.scss';
 
+const RUN_BUTTON_ID = '#uitest-codebridge-run';
+const EDITOR_ID = '#uitest-codebridge-editor';
+const CONSOLE_CLASS = '.xterm-helper-textarea';
+
 type CodebridgeProps = {
   source: MultiFileSource;
   config: ConfigType;
@@ -67,45 +71,46 @@ export const Codebridge = React.memo(
 
     const currentProjectVersion = useRef(projectVersion);
 
-    // Adds keyboard shortcuts for Run (r), Console (o) and Editor (e),
+    // Adds keyboard shortcuts for Editor (1), Run (2), and Console (3)
     // which are preceded by Control (Windows/Linux) or Command (macOS).
     // Runs on mount (see empty dependency list).
     useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
         // Check if Control (Windows/Linux) or Command (macOS) is pressed
         const isControlOrCommand = event.ctrlKey || event.metaKey;
-        if (isControlOrCommand && event.key === 'r') {
-          const editorElement = document.querySelector(
-            '#uitest-codebridge-run'
-          );
-          if (editorElement) {
-            // Click will run code and then move focus to console
-            (editorElement as HTMLElement).click();
+        const editorElement = document.querySelector(EDITOR_ID);
+        const runButton = document.querySelector(RUN_BUTTON_ID);
+        const consoleElement = document.querySelector(CONSOLE_CLASS);
+        if (isControlOrCommand) {
+          switch (event.key) {
+            case '1':
+              if (editorElement) {
+                (editorElement as HTMLElement).focus();
+                // Also simulate 'Enter' to actually enter the editor
+                const enterKeyEvent = new KeyboardEvent('keydown', {
+                  key: 'Enter',
+                  keyCode: 13,
+                  bubbles: true,
+                });
+                editorElement.dispatchEvent(enterKeyEvent);
+              }
+              event.preventDefault();
+              break;
+            case '2':
+              if (runButton) {
+                (runButton as HTMLElement).click();
+              }
+              event.preventDefault();
+              break;
+            case '3':
+              if (consoleElement) {
+                (consoleElement as HTMLElement).focus();
+              }
+              event.preventDefault();
+              break;
+            default:
+              break;
           }
-          event.preventDefault();
-        } else if (isControlOrCommand && event.key === 'e') {
-          const editorElement = document.querySelector(
-            '#uitest-codebridge-editor'
-          );
-          if (editorElement) {
-            (editorElement as HTMLElement).focus();
-            // Also simulate 'Enter' to actually enter the editor
-            const enterKeyEvent = new KeyboardEvent('keydown', {
-              key: 'Enter',
-              keyCode: 13,
-              bubbles: true,
-            });
-            editorElement.dispatchEvent(enterKeyEvent);
-          }
-          event.preventDefault();
-        } else if (isControlOrCommand && event.key === 'o') {
-          const consoleElement = document.querySelector(
-            '.xterm-helper-textarea'
-          );
-          if (consoleElement) {
-            (consoleElement as HTMLElement).focus();
-          }
-          event.preventDefault();
         }
       };
 

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -78,7 +78,7 @@ export const Codebridge = React.memo(
             '#uitest-codebridge-run'
           );
           if (editorElement) {
-            // Click will move focus to console
+            // Click will run code and then move focus to console
             (editorElement as HTMLElement).click();
           }
           event.preventDefault();

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -66,38 +66,38 @@ export const Codebridge = React.memo(
     const sourceUtilities = useSourceUtilities(dispatch);
 
     const currentProjectVersion = useRef(projectVersion);
+
+    // Adds keyboard shortcuts for Run (r), Console (o) and Editor (e),
+    // which are preceded by Control (Windows/Linux) or Command (macOS).
     useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'r') {
-          // R: Run the code
+        // Check if Control (Windows/Linux) or Command (macOS) is pressed
+        const isControlOrCommand = event.ctrlKey || event.metaKey;
+        if (isControlOrCommand && event.key === 'r') {
           const editorElement = document.querySelector(
             '#uitest-codebridge-run'
           );
           if (editorElement) {
-            (editorElement as HTMLElement).focus();
+            // Click will move focus to console
             (editorElement as HTMLElement).click();
           }
           event.preventDefault();
-        } else if (event.key === 'e') {
-          // E: Navigate to the editor
+        } else if (isControlOrCommand && event.key === 'e') {
           const editorElement = document.querySelector(
             '#uitest-codebridge-editor'
           );
           if (editorElement) {
             (editorElement as HTMLElement).focus();
-            // Simulate pressing the Enter key
+            // Also simulate 'Enter' to actually enter the editor
             const enterKeyEvent = new KeyboardEvent('keydown', {
               key: 'Enter',
-              code: 'Enter',
-              keyCode: 13, // Key code for Enter
-              which: 13, // Which code for Enter
-              bubbles: true, // Ensures the event bubbles up the DOM
+              keyCode: 13,
+              bubbles: true,
             });
             editorElement.dispatchEvent(enterKeyEvent);
           }
           event.preventDefault();
-        } else if (event.key === 'o') {
-          // O: Navigate to the console output
+        } else if (isControlOrCommand && event.key === 'o') {
           const consoleElement = document.querySelector(
             '.xterm-helper-textarea'
           );

--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -132,6 +132,7 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
             aria-label={i18n.codeEditorDescription()}
             ref={containerRef}
             role="application"
+            id="uitest-codebridge-editor"
           >
             {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
             <Editor


### PR DESCRIPTION
Adds keyboard shortcuts for the run button (ctrl + 2), the editor (ctrl + 1) and the console output (ctrl + 3) for PythonLab (and the edit shortcut works for Weblab). 

I added this in Codebridge so it would work for pythonlab and weblab.

Below is a video! It's a bit hard to follow unless you can see the focus, which I use the shortcuts to move between run button, editor, and output. 

This is after hearing from the Maryland School for the Blind kids that they'd like a quicker way to navigate between the most important parts of the page!

I elected to use ctrl + instead of just the letters so that the shortcuts also work from within (and don't interfere with) the text editors (console and workspace editor).

I have a mac, so would appreciate someone testing this on another device!

https://github.com/user-attachments/assets/7de5f288-373a-4d08-944b-168f506963c1




## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1236

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
