### PR TITLE
Update logo classname on Microsoft partnership view to fix header logo spacing on code.org/minecraft

### DIFF
--- a/pegasus/sites.v3/code.org/views/ai_microsoft_block.erb
+++ b/pegasus/sites.v3/code.org/views/ai_microsoft_block.erb
@@ -10,7 +10,7 @@
       margin: 0 auto;
     }
 
-    .logo {
+    .microsoft-logo {
       width: 210px;
       margin-top: -4px;
     }
@@ -19,7 +19,7 @@
 <p class="microsoft-partnership">
   <%= I18n.t("ai_in_partnership_with", default: "In partnership with") %>
   &nbsp;
-  <img class="logo" src="images/avatars/microsoft.png" alt="<%= I18n.t("microsoft_logo_alt", default: "Microsoft logo")%>" >
+  <img class="microsoft-logo" src="images/avatars/microsoft.png" alt="<%= I18n.t("microsoft_logo_alt", default: "Microsoft logo")%>" >
 </p>
 <p class="microsoft-thanks">
   <%= I18n.t("ai_microsoft_thanks", default: "We thank Microsoft for supporting our vision and mission to ensure every child has the opportunity to learn computer science and the skills to succeed in the 21st century.") %>


### PR DESCRIPTION
Adds a more specific classname to the Microsoft logo on `ai_microsoft_block.erb` to fix spacing on the header on https://code.org/minecraft. This will have no UI changes on the Microsoft blurb itself and this isn't used on any other pages.

## Links
Jira ticket: [ACQ-3288](https://codedotorg.atlassian.net/browse/ACQ-3288)

## Testing story
Tested locally, and this will have an Eyes diff on the Microsoft page test.

----

| Before | After | 
| ---- | ---- |
| <img width="1359" alt="Before" src="https://github.com/user-attachments/assets/72dfb8b5-0549-4098-a070-37226317e73d" /> | <img width="1359" alt="After" src="https://github.com/user-attachments/assets/e4049a12-775a-4a3c-bdf7-eebc89bc2ad0" /> |

