### PR TITLE
feat(marketing): update slugs to require leading slash

### DIFF
--- a/frontend/apps/marketing/src/contentful/__tests__/get-experience.test.ts
+++ b/frontend/apps/marketing/src/contentful/__tests__/get-experience.test.ts
@@ -61,7 +61,7 @@ describe('getExperience', () => {
 
     expect(fetchBySlug).toHaveBeenCalledWith({
       client: {},
-      slug: mockSlug,
+      slug: `/${mockSlug}`,
       experienceTypeId: process.env.CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID!,
       localeCode: mockLocaleCode,
     });
@@ -77,7 +77,7 @@ describe('getExperience', () => {
 
     expect(fetchBySlug).toHaveBeenCalledWith({
       client: {},
-      slug: mockSlug,
+      slug: `/${mockSlug}`,
       experienceTypeId: process.env.CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID!,
       localeCode: mockLocaleCode,
     });

--- a/frontend/apps/marketing/src/contentful/get-experience.ts
+++ b/frontend/apps/marketing/src/contentful/get-experience.ts
@@ -10,17 +10,23 @@ const logger = getLogger('contentful');
 
 export const getExperience = cache(
   async (slug: string, localeCode: string, isEditorMode = false) => {
+    // To make it easier for content editors, all slugs begin with `/` for experiences
+    const contentfulSlug = `/${slug}`;
     const startTime = Date.now();
 
-    return await getExperienceFromContentful(slug, localeCode, isEditorMode)
+    return await getExperienceFromContentful(
+      contentfulSlug,
+      localeCode,
+      isEditorMode,
+    )
       .then(({experience, error}) => {
         const duration = Date.now() - startTime;
 
         logger.info(
-          `Successfully fetched SLUG=${slug}, LOCALE=${localeCode}, IS_EDITOR_MODE=${isEditorMode} in ${duration}ms`,
+          `Successfully fetched SLUG=${contentfulSlug}, LOCALE=${localeCode}, IS_EDITOR_MODE=${isEditorMode} in ${duration}ms`,
           {
             operation: 'getExperience',
-            slug,
+            slug: contentfulSlug,
             localeCode,
             duration,
           },

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
@@ -8,7 +8,7 @@
         "en-US": "None"
       },
       "slug": {
-        "en-US": "engineering/all-the-things"
+        "en-US": "/engineering/all-the-things"
       },
       "pageHeading": {
         "en-US": "[Engineering] UI Integration Test"


### PR DESCRIPTION
This PR updates the logic to fetch an experience slug from Contentful to require a leading forward slash. For example, previously the slug would be `engineering/all-the-things`. Now, it will be
`/engineering/all-the-things`.
