### PR TITLE
feat(marketing): add placeholders for HeroBanner and SkinnyBanner

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
@@ -66,7 +66,7 @@ export const HeroBannerContentfulComponentDefinition: ComponentDefinition = {
       displayName: 'Heading',
       type: 'Text',
       group: 'content',
-      defaultValue: 'Hero Banner heading goes here.',
+      defaultValue: 'Hero Banner heading goes here',
       validations: {
         required: true,
         bindingSourceType: ['entry', 'manual'],

--- a/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
@@ -76,7 +76,6 @@ export const HeroBannerContentfulComponentDefinition: ComponentDefinition = {
       displayName: 'Subheading',
       type: 'Text',
       group: 'content',
-      defaultValue: 'Hero Banner subheading goes here.',
       validations: {
         bindingSourceType: ['entry', 'manual'],
       },

--- a/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
@@ -66,6 +66,7 @@ export const HeroBannerContentfulComponentDefinition: ComponentDefinition = {
       displayName: 'Heading',
       type: 'Text',
       group: 'content',
+      defaultValue: 'Hero Banner heading goes here.',
       validations: {
         required: true,
         bindingSourceType: ['entry', 'manual'],
@@ -75,6 +76,7 @@ export const HeroBannerContentfulComponentDefinition: ComponentDefinition = {
       displayName: 'Subheading',
       type: 'Text',
       group: 'content',
+      defaultValue: 'Hero Banner subheading goes here.',
       validations: {
         bindingSourceType: ['entry', 'manual'],
       },

--- a/frontend/apps/marketing/src/components/contentful/skinnyBanner/SkinnyBannerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/skinnyBanner/SkinnyBannerContentfulDefinition.ts
@@ -32,6 +32,7 @@ export const SkinnyBannerContentfulComponentDefinition: ComponentDefinition = {
       displayName: 'Heading',
       type: 'Text',
       group: 'content',
+      defaultValue: 'Skinny Banner heading goes here.',
       validations: {
         required: true,
         bindingSourceType: ['entry', 'manual'],
@@ -41,6 +42,7 @@ export const SkinnyBannerContentfulComponentDefinition: ComponentDefinition = {
       displayName: 'Description',
       type: 'Text',
       group: 'content',
+      defaultValue: 'Skinny Banner description goes here.',
       validations: {
         bindingSourceType: ['entry', 'manual'],
       },

--- a/frontend/apps/marketing/src/components/contentful/skinnyBanner/SkinnyBannerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/skinnyBanner/SkinnyBannerContentfulDefinition.ts
@@ -32,7 +32,7 @@ export const SkinnyBannerContentfulComponentDefinition: ComponentDefinition = {
       displayName: 'Heading',
       type: 'Text',
       group: 'content',
-      defaultValue: 'Skinny Banner heading goes here.',
+      defaultValue: 'Skinny Banner heading goes here',
       validations: {
         required: true,
         bindingSourceType: ['entry', 'manual'],


### PR DESCRIPTION
Adds placeholder text for Headings and Subheadings on `HeroBanner` and `SkinnyBanner` components in Contentful.

## Links
Jira ticket: [CMS-698](https://codedotorg.atlassian.net/browse/CMS-698)

----



https://github.com/user-attachments/assets/d98c5be3-6e9a-4f82-bb7b-1de2a8f16677



