### PR TITLE
AI Chat: fix starter assets upload dialog overlap

### DIFF
--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -2,7 +2,7 @@
 @import './common.scss';
 
 .labContainer {
-  position: fixed;
+  position: absolute;
   top: $top-spacing;
   bottom: 0;
   left: 0;

--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -6,7 +6,6 @@
 .controlsContainer {
   display: flex;
   background-color: $light_gray_950;
-  z-index: 70;
   border-radius: $default-border-radius;
   position: relative;
   padding: 10px;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -79,13 +79,6 @@ body.music-black, body.background-dark {
   color: $neutral_light;
 }
 
-body.background-dark, body.background-light {
-  .header-wrapper .header {
-    position: fixed;
-    z-index: 1;
-  }
-}
-
 // For modern Lab2 labs, prevent the entire body from scrolling.
 // All content is typically displayed on the page at once, and
 // internal components manage their own scroll behavior.

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -191,7 +191,7 @@ class ScriptLevelsController < ApplicationController
     end
 
     # The lesson might contain a background that should be applied to all levels.
-    lesson_background = @script_level.lesson.properties['background'] if @script_level.level.uses_lab2? && @script_level.lesson
+    lesson_background = @script_level.lesson.properties['background'] if @level.uses_lab2? && @script_level.lesson
     @body_classes = lesson_background ? "background-#{lesson_background}" : @level.properties['background']
 
     @rubric = @script_level.lesson.rubric


### PR DESCRIPTION
Second attempt at https://github.com/code-dot-org/code-dot-org/pull/65400, informed by z-index related findings outlined in https://codedotorg.slack.com/archives/C044AGTKW3D/p1746205276812619

The main driver of this is to fix the z-index issues with the AI Chat assets modal, but this also fixes a few other things:
- Correctly applies the lesson background to lab2 sublevels - previously, we were checking the `script_level.level.uses_lab2?` to determine whether to apply the background, and a quirk of sublevels is that their `script_level` refers to the parent level. This is easily fixed by checking `@level.uses_lab2?` directly.
- Removes an unneeded z-index in the Music Lab controls component - tracing back through the commit history, this was an old holdover from when the beat pad used to be floating over the workspace.

Notes:
- This removes the `position: fixed` and `z-index: 1` from the `body` when applying the `background-light/dark` classes. Discussed this with @breville in person - this was initially added to fix some undesired overscroll behavior, but it seems that this has since been addressed by other changes and/or no longer reproes in the same way. Using fixed position and z-index header, combined with the lab2 position change was the original culprit for the z-index regressions last time around, so I'm hopeful that we shouldn't have any of the same issues this time. See the above Slack thread for more context on why this interaction was causing issues.
- I opted to leave in the `z-index: 2` in the Python Lab workspace, also referenced in the above thread. Based on @molly-moen's comment, it seems like we can probably remove it, but it wasn't causing any issues after the aforementioned changes were made, so I kept it as is just to avoid risk since I'm less familiar with that code 🙂

Screenshots:
<img width="1512" alt="Screenshot 2025-05-14 at 12 36 51 PM" src="https://github.com/user-attachments/assets/f9509f82-0bf0-4b30-92d2-13f5502b2abf" />
<img width="1512" alt="Screenshot 2025-05-14 at 12 39 44 PM" src="https://github.com/user-attachments/assets/bfb841ca-4411-4070-8d4b-67ad9484fd18" />
<img width="1512" alt="Screenshot 2025-05-14 at 12 41 34 PM" src="https://github.com/user-attachments/assets/62c2bfda-b0db-4ff7-b0e2-d80faadaabb1" />


## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1422

## Testing story

Tested locally on various lab2 levels. Verified that
- No z-index related regressions occurred as far as I could tell
- The lesson background was correctly applied to lab2 sublevels
- No regressions to music lab as a result of the z-index removal