### PR TITLE
fix(revalidate): remove leading slash from revalidate api

### DIFF
--- a/frontend/apps/marketing/src/app/api/revalidate/__tests__/route.test.ts
+++ b/frontend/apps/marketing/src/app/api/revalidate/__tests__/route.test.ts
@@ -30,7 +30,7 @@ describe('POST /api/revalidate', () => {
   it('should return 403 if the secret is invalid', async () => {
     mockEnv('valid-secret');
     const request = mockRequest({
-      pagePaths: {'en-US': 'test-path', 'zh-CN': 'test-path'},
+      pagePaths: {'en-US': '/test-path', 'zh-CN': '/test-path'},
       secret: 'invalid-secret',
     });
 
@@ -47,7 +47,7 @@ describe('POST /api/revalidate', () => {
   it('should return 500 if revalidatePath throws an error', async () => {
     mockEnv('valid-secret');
     const request = mockRequest({
-      pagePaths: {'en-US': 'test-path', 'zh-CN': 'test-path'},
+      pagePaths: {'en-US': '/test-path', 'zh-CN': '/test-path'},
       secret: 'valid-secret',
     });
     mockRevalidatePath.mockImplementation(() => {
@@ -67,7 +67,7 @@ describe('POST /api/revalidate', () => {
   it('should return 200 and revalidate the path if the secret is valid', async () => {
     mockEnv('valid-secret');
     const request = mockRequest({
-      pagePaths: {'en-US': 'test-path', 'zh-CN': 'test-path'},
+      pagePaths: {'en-US': '/test-path', 'zh-CN': '/test-path'},
       secret: 'valid-secret',
     });
 

--- a/frontend/apps/marketing/src/app/api/revalidate/route.ts
+++ b/frontend/apps/marketing/src/app/api/revalidate/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: Request) {
   try {
     const pathsToRevalidate = Object.entries(pagePaths).reduce(
       (accumulator, [locale, slug]) => {
-        accumulator.push(`/${locale}/${slug}`);
+        accumulator.push(`/${locale}${slug}`);
 
         return accumulator;
       },


### PR DESCRIPTION
This is a quick fix to remove the extraneous leading slash now that slugs have a leading slash.