### PR TITLE
fix(caching): ensure ISR without force-static

### DIFF
--- a/.github/workflows/marketing-app-ci.yml
+++ b/.github/workflows/marketing-app-ci.yml
@@ -83,6 +83,7 @@ jobs:
           CONTENTFUL_REVALIDATE_TOKEN=ci-revalidate-test
           DRAFT_MODE_TOKEN=ci-draft-mode
           HOSTNAME=0.0.0.0
+          NEXT_PUBLIC_STAGE=development
           " > .env
 
       - name: Run Docker Container

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -51,7 +51,6 @@
     "cookies-next": "^5.1.0",
     "next": "^15.2.4",
     "next-logger": "^5.0.1",
-    "next-runtime-env": "^3.3.0",
     "pino": "^9.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
@@ -14,13 +14,20 @@ import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
 import {getSeoMetadata} from '@/metadata/seo';
 import {getPageHeading} from '@/selectors/contentful/getExperienceEntryFields';
 
-export const dynamic = 'force-static'; // Ensure ISR is enabled
 export const revalidate = 3600; // Cache for one hour
 
 type ExperiencePageProps = {
   params: Promise<{locale?: string; paths?: string; brand?: Brand}>;
   searchParams: Promise<{[key: string]: string | string[] | undefined}>;
 };
+
+/**
+ * Activates incremental static regeneration (ISR) for this page.
+ * Currently, no pages are generated at build time. Pages are rather generated using on-demand ISR.
+ */
+export async function generateStaticParams() {
+  return [];
+}
 
 async function getPageProps({params, searchParams}: ExperiencePageProps) {
   const {locale = 'en-US', paths = ['home']} = (await params) || {};

--- a/frontend/apps/marketing/src/app/[brand]/layout.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/layout.tsx
@@ -1,5 +1,4 @@
 import {GoogleAnalytics} from '@next/third-parties/google';
-import {PublicEnvScript} from 'next-runtime-env';
 
 import Footer from '@/components/footer';
 import Header from '@/components/header';
@@ -7,6 +6,7 @@ import {Brand} from '@/config/brand';
 import {getGoogleAnalyticsMeasurementId} from '@/config/ga4';
 import OrganizationJsonLd from '@/config/jsonLd/OrganizationJsonLd';
 import {getStage} from '@/config/stage';
+import EnvironmentLoader from '@/providers/environment';
 import OneTrustLoader from '@/providers/onetrust/OneTrustLoader';
 import OneTrustProvider from '@/providers/onetrust/OneTrustProvider';
 import {generateBootstrapValues} from '@/providers/statsig/statsig-backend';
@@ -33,7 +33,7 @@ export default async function Layout({
 
   return (
     <>
-      <PublicEnvScript disableNextScript={true} />
+      <EnvironmentLoader />
       <OneTrustLoader brand={brand} />
 
       <OneTrustProvider>

--- a/frontend/apps/marketing/src/components/contentEditorHelper/ContentEditorHelper.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/ContentEditorHelper.tsx
@@ -13,7 +13,7 @@ import TokenPrompt from './TokenPrompt';
 
 import styles from './styles.module.scss';
 
-type ContentEditorToolsProps = {
+export type ContentEditorToolsProps = {
   isDraftModeEnabled: boolean;
 };
 
@@ -84,6 +84,7 @@ const ContentEditorHelper = ({isDraftModeEnabled}: ContentEditorToolsProps) => {
         (searchParams.get('contentEditor') === 'true' ||
           isDraftModeEnabled) && (
           <Button
+            data-testid="content-editor-popover"
             className={styles.floatingButton}
             color={'destructive'}
             text={previewLabel}

--- a/frontend/apps/marketing/src/components/contentEditorHelper/index.ts
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/index.ts
@@ -1,3 +1,0 @@
-import ContentEditorHelper from './ContentEditorHelper';
-
-export default ContentEditorHelper;

--- a/frontend/apps/marketing/src/components/contentEditorHelper/index.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/index.tsx
@@ -1,0 +1,15 @@
+import {Suspense} from 'react';
+
+import ContentEditorHelper, {
+  ContentEditorToolsProps,
+} from './ContentEditorHelper';
+
+const ContentEditorHelperWrapper = (props: ContentEditorToolsProps) => {
+  return (
+    <Suspense>
+      <ContentEditorHelper {...props} />
+    </Suspense>
+  );
+};
+
+export default ContentEditorHelperWrapper;

--- a/frontend/apps/marketing/src/config/stage.ts
+++ b/frontend/apps/marketing/src/config/stage.ts
@@ -1,9 +1,9 @@
-import {env} from 'next-runtime-env';
+import {getEnv} from '@/providers/environment';
 
 export type Stage = 'development' | 'pr' | 'test' | 'production';
 
 export function getStage(): Stage {
-  const stage = env('NEXT_PUBLIC_STAGE') as Stage;
+  const stage = getEnv('NEXT_PUBLIC_STAGE') as Stage;
 
   switch (stage) {
     case 'development':

--- a/frontend/apps/marketing/src/providers/environment/EnvironmentLoader.tsx
+++ b/frontend/apps/marketing/src/providers/environment/EnvironmentLoader.tsx
@@ -1,0 +1,20 @@
+import Script from 'next/script';
+
+import {PUBLIC_ENV_KEY} from '@/providers/environment/constants';
+
+const EnvironmentLoader = () => {
+  const publicEnvironmentVariables = {
+    NEXT_PUBLIC_STAGE: process.env.NEXT_PUBLIC_STAGE,
+  };
+
+  return (
+    <Script
+      strategy={'beforeInteractive'}
+      dangerouslySetInnerHTML={{
+        __html: `window['${PUBLIC_ENV_KEY}'] = ${JSON.stringify(publicEnvironmentVariables)}`,
+      }}
+    />
+  );
+};
+
+export default EnvironmentLoader;

--- a/frontend/apps/marketing/src/providers/environment/constants.ts
+++ b/frontend/apps/marketing/src/providers/environment/constants.ts
@@ -1,0 +1,1 @@
+export const PUBLIC_ENV_KEY = '__ENV';

--- a/frontend/apps/marketing/src/providers/environment/index.ts
+++ b/frontend/apps/marketing/src/providers/environment/index.ts
@@ -1,0 +1,15 @@
+import {PUBLIC_ENV_KEY} from '@/providers/environment/constants';
+
+import EnvironmentLoader from './EnvironmentLoader';
+
+export function getEnv(key: string) {
+  // Grab environment variable from the browser
+  if (typeof window !== 'undefined') {
+    return window[PUBLIC_ENV_KEY][key];
+  }
+
+  // Grab environment variable from node server
+  return process.env[key];
+}
+
+export default EnvironmentLoader;

--- a/frontend/apps/marketing/src/types/environment.d.ts
+++ b/frontend/apps/marketing/src/types/environment.d.ts
@@ -1,0 +1,12 @@
+import {PUBLIC_ENV_KEY} from '@/providers/environment/constants';
+
+declare global {
+  interface Window {
+    [PUBLIC_ENV_KEY]: {
+      NEXT_PUBLIC_STAGE: string;
+      [key: string]: string;
+    };
+  }
+}
+
+export {};

--- a/frontend/apps/marketing/tests/e2e/cache.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/cache.spec.ts
@@ -1,14 +1,13 @@
 import {expect} from '@playwright/test';
 
-import {getStage} from '@/config/stage';
-
 import {test} from './fixtures/base';
 import {AllTheThingsPage} from './pom/all-the-things';
+import {getTestStage} from './utils/stage';
 
 test.describe('Caching Tests', () => {
   test('should cache by default', async ({page, browserName}) => {
     test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    test.skip(getStage() === 'development', 'Only runs in Docker mode');
+    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
 
     const allTheThingsPage = new AllTheThingsPage(page, 'en-US');
     const response = await allTheThingsPage.goto();
@@ -24,7 +23,7 @@ test.describe('Caching Tests', () => {
     browserName,
   }) => {
     test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    test.skip(getStage() === 'development', 'Only runs in Docker mode');
+    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
 
     const allTheThingsPage = new AllTheThingsPage(page, 'en-US');
     const response = await allTheThingsPage.enableDraftMode(
@@ -53,9 +52,33 @@ test.describe('Caching Tests', () => {
     );
   });
 
+  test('should not render experiences if draft mode is enabled with search param expEditor=true', async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
+
+    const allTheThingsPage = new AllTheThingsPage(page, 'en-US');
+    await allTheThingsPage.enableDraftMode(process.env.DRAFT_MODE_TOKEN);
+
+    // Go to the same page with the expEditor=true query param
+    await allTheThingsPage.goto(
+      '/engineering/all-the-things?expEditorMode=true',
+    );
+
+    // Check that <main> exists
+    await expect(page.locator('main')).toHaveCount(1);
+
+    // Check that <main> has nothing except an optional content editor popover.
+    await expect(
+      page.locator('main > *:not(button:has-text("Draft Version"))'),
+    ).toHaveCount(0);
+  });
+
   test('should 401 with an invalid token', async ({page, browserName}) => {
     test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    test.skip(getStage() === 'development', 'Only runs in Docker mode');
+    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
 
     const allTheThingsPage = new AllTheThingsPage(page, 'en-US');
     const response = await allTheThingsPage.enableDraftMode('invalid-token');

--- a/frontend/apps/marketing/tests/e2e/environment.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/environment.spec.ts
@@ -1,0 +1,23 @@
+import {expect} from '@playwright/test';
+
+import {test} from './fixtures/base';
+import {AllTheThingsPage} from './pom/all-the-things';
+import {getAppStageFromTestStage, getTestStage} from './utils/stage';
+
+test.describe('Environment Variable Tests', () => {
+  test('should set the correct environment variables on the client', async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
+
+    const allTheThingsPage = new AllTheThingsPage(page, 'en-US');
+    await allTheThingsPage.goto();
+
+    // The window['__ENV'] variable should be set to the appropriate environment variables
+    await expect(page.evaluate(() => window['__ENV'])).resolves.toEqual({
+      NEXT_PUBLIC_STAGE: getAppStageFromTestStage(),
+    });
+  });
+});

--- a/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
@@ -27,8 +27,12 @@ export class AllTheThingsPage extends MarketingPage {
     return await super.enableDraftMode(token, 'engineering/all-the-things');
   }
 
-  async goto() {
-    return await super.goto('/engineering/all-the-things');
+  async goto(path?: string) {
+    if (!path) {
+      return await super.goto('/engineering/all-the-things');
+    }
+
+    return await super.goto(path);
   }
 
   getSectionLocator(heading: Section): Locator {

--- a/frontend/apps/marketing/tests/e2e/utils/stage.ts
+++ b/frontend/apps/marketing/tests/e2e/utils/stage.ts
@@ -1,0 +1,32 @@
+export function getTestStage() {
+  const stage = process.env.STAGE;
+
+  switch (stage) {
+    case 'development':
+      return 'development';
+    case 'pr':
+      return 'pr';
+    case 'test':
+      return 'test';
+    case 'production':
+      return 'production';
+    default:
+      throw new Error(`Invalid stage: ${stage}`);
+  }
+}
+
+export function getAppStageFromTestStage() {
+  const stage = process.env.STAGE;
+
+  switch (stage) {
+    case 'pr':
+    case 'localhost':
+      return 'development';
+    case 'test':
+      return 'test';
+    case 'production':
+      return 'production';
+    default:
+      throw new Error(`Invalid stage: ${stage}`);
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1113,7 +1113,6 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     next: "npm:^15.2.4"
     next-logger: "npm:^5.0.1"
-    next-runtime-env: "npm:^3.3.0"
     pino: "npm:^9.6.0"
     pino-pretty: "npm:^13.0.0"
     playwright-core: "npm:~1.49.1"
@@ -3405,13 +3404,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/env@npm:14.2.28"
-  checksum: 10c0/edf665a7bfb14a5e74e40bad8355e4d72f2c86d5698fc541b03b42e719e57c8db1ba37fa615228954519689bed5add2c271f3e6caaa197d894471763cfbc88ee
-  languageName: node
-  linkType: hard
-
 "@next/env@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/env@npm:15.2.4"
@@ -3428,24 +3420,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/swc-darwin-arm64@npm:14.2.28"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@next/swc-darwin-arm64@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/swc-darwin-arm64@npm:15.2.4"
   conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@next/swc-darwin-x64@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/swc-darwin-x64@npm:14.2.28"
-  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3456,24 +3434,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/swc-linux-arm64-gnu@npm:14.2.28"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@next/swc-linux-arm64-gnu@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/swc-linux-arm64-gnu@npm:15.2.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@next/swc-linux-arm64-musl@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/swc-linux-arm64-musl@npm:14.2.28"
-  conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -3484,24 +3448,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/swc-linux-x64-gnu@npm:14.2.28"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@next/swc-linux-x64-gnu@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/swc-linux-x64-gnu@npm:15.2.4"
   conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@next/swc-linux-x64-musl@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/swc-linux-x64-musl@npm:14.2.28"
-  conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -3512,31 +3462,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/swc-win32-arm64-msvc@npm:14.2.28"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@next/swc-win32-arm64-msvc@npm:15.2.4":
   version: 15.2.4
   resolution: "@next/swc-win32-arm64-msvc@npm:15.2.4"
   conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@next/swc-win32-ia32-msvc@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/swc-win32-ia32-msvc@npm:14.2.28"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@next/swc-win32-x64-msvc@npm:14.2.28":
-  version: 14.2.28
-  resolution: "@next/swc-win32-x64-msvc@npm:14.2.28"
-  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5295,16 +5224,6 @@ __metadata:
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10c0/33002f74f6f885f04c132960835fdfc474186983ea567606db62e86acd0680ca82f34647e8e610f4e1e422d1c16fce729dde22cd3b797ab1fd9061a825dabca4
-  languageName: node
-  linkType: hard
-
-"@swc/helpers@npm:0.5.5":
-  version: 0.5.5
-  resolution: "@swc/helpers@npm:0.5.5"
-  dependencies:
-    "@swc/counter": "npm:^0.1.3"
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/21a9b9cfe7e00865f9c9f3eb4c1cc5b397143464f7abee76a2c5366e591e06b0155b5aac93fe8269ef8d548df253f6fd931e9ddfc0fd12efd405f90f45506e7d
   languageName: node
   linkType: hard
 
@@ -14522,77 +14441,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-runtime-env@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "next-runtime-env@npm:3.3.0"
-  dependencies:
-    next: "npm:^14"
-    react: "npm:^18"
-  peerDependencies:
-    next: ^14
-    react: ^18
-  checksum: 10c0/7e59dfd138badc7925cd3f42ff826d7121f8e53399957f61906d1e10957a855b1f21f750984431cb448c9371f400170898e5e3125beef58ac7e9d1b74e073a87
-  languageName: node
-  linkType: hard
-
-"next@npm:^14":
-  version: 14.2.28
-  resolution: "next@npm:14.2.28"
-  dependencies:
-    "@next/env": "npm:14.2.28"
-    "@next/swc-darwin-arm64": "npm:14.2.28"
-    "@next/swc-darwin-x64": "npm:14.2.28"
-    "@next/swc-linux-arm64-gnu": "npm:14.2.28"
-    "@next/swc-linux-arm64-musl": "npm:14.2.28"
-    "@next/swc-linux-x64-gnu": "npm:14.2.28"
-    "@next/swc-linux-x64-musl": "npm:14.2.28"
-    "@next/swc-win32-arm64-msvc": "npm:14.2.28"
-    "@next/swc-win32-ia32-msvc": "npm:14.2.28"
-    "@next/swc-win32-x64-msvc": "npm:14.2.28"
-    "@swc/helpers": "npm:0.5.5"
-    busboy: "npm:1.6.0"
-    caniuse-lite: "npm:^1.0.30001579"
-    graceful-fs: "npm:^4.2.11"
-    postcss: "npm:8.4.31"
-    styled-jsx: "npm:5.1.1"
-  peerDependencies:
-    "@opentelemetry/api": ^1.1.0
-    "@playwright/test": ^1.41.2
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    sass: ^1.3.0
-  dependenciesMeta:
-    "@next/swc-darwin-arm64":
-      optional: true
-    "@next/swc-darwin-x64":
-      optional: true
-    "@next/swc-linux-arm64-gnu":
-      optional: true
-    "@next/swc-linux-arm64-musl":
-      optional: true
-    "@next/swc-linux-x64-gnu":
-      optional: true
-    "@next/swc-linux-x64-musl":
-      optional: true
-    "@next/swc-win32-arm64-msvc":
-      optional: true
-    "@next/swc-win32-ia32-msvc":
-      optional: true
-    "@next/swc-win32-x64-msvc":
-      optional: true
-  peerDependenciesMeta:
-    "@opentelemetry/api":
-      optional: true
-    "@playwright/test":
-      optional: true
-    sass:
-      optional: true
-  bin:
-    next: dist/bin/next
-  checksum: 10c0/c3300970c7d633cfde371e59ef3f1b08bd5403b7f5b43bc07ec16e17d8d82b993115c61cca003cec3e8dd3fe72d1fbe2bb366f76a8e91e39c80b0f9fe7cc41df
-  languageName: node
-  linkType: hard
-
 "next@npm:^15.2.4":
   version: 15.2.4
   resolution: "next@npm:15.2.4"
@@ -16426,7 +16274,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18, react@npm:^18.3.1":
+"react@npm:^18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:
@@ -18053,22 +17901,6 @@ __metadata:
   peerDependencies:
     webpack: ^5.0.0
   checksum: 10c0/8f8027fc5c6e91400cbb60066e7db3315810f8eaa0d19b2a254936eb0bec399ba8a7043b1789da9d05ab7c3ba50faf9267765ae0bf3571e48aa34ecdc774be37
-  languageName: node
-  linkType: hard
-
-"styled-jsx@npm:5.1.1":
-  version: 5.1.1
-  resolution: "styled-jsx@npm:5.1.1"
-  dependencies:
-    client-only: "npm:0.0.1"
-  peerDependencies:
-    react: ">= 16.8.0 || 17.x.x || ^18.0.0-0"
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-    babel-plugin-macros:
-      optional: true
-  checksum: 10c0/42655cdadfa5388f8a48bb282d6b450df7d7b8cf066ac37038bd0499d3c9f084815ebd9ff9dfa12a218fd4441338851db79603498d7557207009c1cf4d609835
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When using [dynamic mode](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) `force-static`, Nextjs will force cookies,
headers, and useSearchParams to empty values. In draft mode, this
results in search parameters to be empty despite not using ISR. When a
content editor views a page on Contentful Experience Builder, it will
thus render the page despite not needing the static version. This works
for the most part but in patterns, it will request for a slug that does
not exist.

Instead, ensure that ISR can be done without `force-static`. To do this,
a couple changes needed to be made to remove reliance on dynamic APIs:

1. Remove `next-runtime-env`, which was used to inject certain variables
from the backend to the frontend `window` object. This has been replaced
by a lightweight implementation.
2. Add a `<Suspense>` boundary around the content editor tools as it
requires the use of `useSearchParams`.