### PR TITLE
Remove Babel loose: true class transform to fix recursion in transpiled accessors

### DIFF
--- a/apps/babel.config.json
+++ b/apps/babel.config.json
@@ -9,8 +9,7 @@
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-transform-class-properties",
     ["@babel/plugin-transform-regenerator", {"async": true, "asyncGenerators": true}],
-    // needed for IE 9/10 support
-    ["@babel/plugin-transform-classes", {"loose": true}],
+    "@babel/plugin-transform-classes",
     "@babel/plugin-transform-modules-commonjs",
     "@babel/plugin-proposal-optional-chaining"
   ],


### PR DESCRIPTION
This PR removes the "loose": true option from the `@babel/plugin-transform-classes` plugin in our `babel.config.json`.

In Babel's loose mode, `super.prop = value` may be transpiled into ES5 as `this.prop = value`. This breaks class accessors that are overridden, turning legitimate `super` calls into recursive `this` calls at runtime.

This caused a regression when upgrading to Blockly `12.0.0-beta.6`, where a new accessor (`size_`) was added to the `Field` base class and overridden in `FieldInput`. In our build, Babel transpiled `super.size_ = value` to `this.size_ = value`, resulting in an infinite loop and `RangeError: Maximum call stack size exceeded`.

We no longer support IE9/10, so this legacy compatibility is hopefully unnecessary.

Related issue filed with Blockly: [Blockly issue #9055](https://github.com/google/blockly/issues/9055)

Internal discussion: [Slack thread](https://codedotorg.slack.com/archives/C08AMQ869QX/p1747328713416609)
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

@stephenliang advised that we should be vigilant as other ES6 classes are now going to be "strict" to check if we have some bugs unrelated.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
