### PR TITLE
Revert "Revert "use unit.hide_within_course" in staging"

### DIFF
--- a/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
@@ -46,9 +46,7 @@ class UnitEditor extends React.Component {
     i18nData: PropTypes.object.isRequired,
     initialPublishedState: PropTypes.oneOf(Object.values(PublishedState))
       .isRequired,
-    //Published state of units in a course can be set to be different than the course overall.
-    //We only use this field for units in a course
-    initialUnitPublishedState: PropTypes.oneOf(Object.values(PublishedState)),
+    initialHideWithinCourse: PropTypes.bool,
     initialInstructionType: PropTypes.oneOf(Object.values(InstructionType))
       .isRequired,
     initialInstructorAudience: PropTypes.oneOf(
@@ -164,8 +162,7 @@ class UnitEditor extends React.Component {
       descriptionShort: this.props.i18nData.descriptionShort || '',
       includeStudentLessonPlans: this.props.initialIncludeStudentLessonPlans,
       useLegacyLessonPlans: this.props.initialUseLegacyLessonPlans,
-      publishedState: this.props.initialPublishedState,
-      unitPublishedState: this.props.initialUnitPublishedState,
+      hideWithinCourse: !!this.props.initialHideWithinCourse,
       instructionType: this.props.initialInstructionType,
       instructorAudience: this.props.initialInstructorAudience,
       participantAudience: this.props.initialParticipantAudience,
@@ -223,16 +220,6 @@ class UnitEditor extends React.Component {
       });
       return;
     } else if (
-      this.state.publishedState === PublishedState.pilot &&
-      this.state.pilotExperiment === ''
-    ) {
-      this.setState({
-        isSaving: false,
-        error:
-          'Please provide a pilot experiment in order to save with published state as pilot.',
-      });
-      return;
-    } else if (
       this.state.isCourse &&
       ((this.state.versionYear !== '' && this.state.familyName === '') ||
         (this.state.versionYear === '' && this.state.familyName !== ''))
@@ -242,60 +229,16 @@ class UnitEditor extends React.Component {
         error: 'Please set both version year and family name.',
       });
       return;
-    } else if (
-      [PublishedState.preview, PublishedState.stable].includes(
-        this.state.publishedState
-      ) &&
-      this.props.isMissingRequiredDeviceCompatibilities
-    ) {
-      this.setState({
-        isSaving: false,
-        error:
-          'Please set all device compatibilities in order to save with published state as preview or stable.',
-      });
-      return;
-    }
-
-    if (this.state.publishedState !== this.props.initialPublishedState) {
-      const msg =
-        'It looks like you are updating the published state. ' +
-        'Are you sure you want to update the published state? ' +
-        'Once you update the published state you can not go back to this published state. ' +
-        'For example once you set the published state to beta you can not go back to in development. ' +
-        'Also once a course as a published state of pilot it can not be fully launched (marked as preview or stable).';
-      if (!window.confirm(msg)) {
-        this.setState({
-          isSaving: false,
-          error: 'Saving cancelled.',
-        });
-        return;
-      }
     }
 
     if (
-      this.state.unitPublishedState !== this.props.initialUnitPublishedState
+      this.state.hideWithinCourse &&
+      this.state.hideWithinCourse !== this.props.initialHideWithinCourse
     ) {
       const msg =
-        'It looks like you are hiding this unit. ' +
-        'Are you sure you want to hide this unit? ';
-      if (!window.confirm(msg)) {
-        this.setState({
-          isSaving: false,
-          error: 'Saving cancelled.',
-        });
-        return;
-      }
-    }
-
-    if (
-      this.state.unitPublishedState === PublishedState.in_development &&
-      this.state.unitPublishedState === this.props.initialUnitPublishedState
-    ) {
-      const msg =
-        'This unit is hidden within the course, meaning it is not ' +
-        'visible on the Course Overview page, Section Dialog, or Teacher ' +
-        'Dashboard. It is still visible to Levelbuilders. Would you ' +
-        'like to continue with saving?';
+        'Hiding this unit means it will not be visible on the Course Overview ' +
+        'page, Section Dialog, or Teacher Dashboard. It will still visible to ' +
+        'Levelbuilders. Would you like to continue with saving?';
       if (!window.confirm(msg)) {
         this.setState({
           isSaving: false,
@@ -316,9 +259,7 @@ class UnitEditor extends React.Component {
       description: this.state.description,
       student_description: this.state.studentDescription,
       announcements: JSON.stringify(this.state.announcements),
-      published_state: this.props.hasCourse
-        ? this.state.unitPublishedState
-        : this.state.publishedState,
+      hide_within_course: this.state.hideWithinCourse,
       instruction_type: this.state.instructionType,
       instructor_audience: this.state.instructorAudience,
       participant_audience: this.state.participantAudience,
@@ -397,16 +338,13 @@ class UnitEditor extends React.Component {
   };
 
   toggleHiddenCourseUnit = () => {
-    const unitPublishedState =
-      this.state.unitPublishedState === PublishedState.in_development
-        ? null
-        : PublishedState.in_development;
-    this.setState({unitPublishedState});
+    const hideWithinCourse = !this.state.hideWithinCourse;
+    this.setState({hideWithinCourse});
   };
 
   render() {
     const allowMajorCurriculumChanges =
-      this.props.initialUnitPublishedState === PublishedState.in_development ||
+      this.props.initialHideWithinCourse ||
       this.props.initialPublishedState === PublishedState.in_development ||
       this.props.initialPublishedState === PublishedState.pilot;
 
@@ -710,7 +648,8 @@ class UnitEditor extends React.Component {
                 />
               </label>
               {this.props.hasCourse &&
-                this.state.publishedState !== PublishedState.in_development && (
+                this.props.initialPublishedState !==
+                  PublishedState.in_development && (
                   <div>
                     <p>
                       Settings in this section change depending on whether this
@@ -718,25 +657,12 @@ class UnitEditor extends React.Component {
                       not look as expected, please add or remove this unit from
                       a course.
                     </p>
-                    {/*
-                   Just use a checkbox instead of a dropdown to set the
-                   published state for now, because (1) units in unit groups
-                   really only need 2 of the 6 possible states at the moment,
-                   but (2) we haven't nailed down how many of these states we
-                   will need in the long term, and (3) we need these 2 states
-                   working now in order to launch the AP CSA pilot. The work to
-                   clean this up is tracked in:
-                   https://codedotorg.atlassian.net/browse/PLAT-1170
-                   */}
                     <label>
                       Hide this unit within this course
                       <input
                         className="unit-test-hide-unit-in-course"
                         type="checkbox"
-                        checked={
-                          this.state.unitPublishedState ===
-                          PublishedState.in_development
-                        }
+                        checked={this.state.hideWithinCourse}
                         style={styles.checkbox}
                         onChange={this.toggleHiddenCourseUnit}
                       />

--- a/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
@@ -106,6 +106,7 @@ class UnitEditor extends React.Component {
     courseOfferingEditorLink: PropTypes.string,
     isCSDCourseOffering: PropTypes.bool,
     isMissingRequiredDeviceCompatibilities: PropTypes.bool,
+    allowMajorCurriculumChanges: PropTypes.bool,
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
@@ -343,10 +344,7 @@ class UnitEditor extends React.Component {
   };
 
   render() {
-    const allowMajorCurriculumChanges =
-      this.props.initialHideWithinCourse ||
-      this.props.initialPublishedState === PublishedState.in_development ||
-      this.props.initialPublishedState === PublishedState.pilot;
+    const {allowMajorCurriculumChanges} = this.props;
 
     return (
       <div>

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -42,7 +42,7 @@ export default function initPage(unitEditorData) {
         name={unitEditorData.script.name}
         i18nData={unitEditorData.i18n}
         initialPublishedState={scriptData.coursePublishedState}
-        initialUnitPublishedState={scriptData.unitPublishedState}
+        initialHideWithinCourse={scriptData.hide_within_course}
         initialInstructionType={scriptData.instructionType}
         initialInstructorAudience={scriptData.instructorAudience}
         initialParticipantAudience={scriptData.participantAudience}

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -103,6 +103,7 @@ export default function initPage(unitEditorData) {
         isMissingRequiredDeviceCompatibilities={
           scriptData.missingRequiredDeviceCompatibilities
         }
+        allowMajorCurriculumChanges={scriptData.allowMajorCurriculumChanges}
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -81,7 +81,7 @@ describe('UnitEditor', () => {
       initialLocales: [],
       isMigrated: false,
       initialPublishedState: PublishedState.in_development,
-      initialUnitPublishedState: null,
+      initialHideWithinCourse: false,
       initialInstructionType: InstructionType.teacher_led,
       initialInstructorAudience: InstructorAudience.teacher,
       initialParticipantAudience: ParticipantAudience.student,
@@ -199,11 +199,11 @@ describe('UnitEditor', () => {
       assert.equal(wrapper.find('.unit-test-hide-unit-in-course').length, 0);
     });
 
-    it('clicking hide unit checkbox updates unit published state', () => {
+    it('clicking hide unit checkbox updates checkbox state', () => {
       const wrapper = createWrapper({
         hasCourse: true,
-        initialPublishedState: 'pilot',
-        initialUnitPublishedState: 'in_development',
+        initialPublishedState: 'stable',
+        initialHideWithinCourse: true,
       });
       assert.equal(wrapper.find('.unit-test-hide-unit-in-course').length, 1);
       assert.equal(
@@ -292,7 +292,7 @@ describe('UnitEditor', () => {
     it('allows changing student facing lesson plan checkbox when allowed to make major curriculum changes to hidden unit', () => {
       const wrapper = createWrapper({
         initialPublishedState: 'stable',
-        initialUnitPublishedState: 'in_development',
+        initialHideWithinCourse: true,
         isMigrated: true,
         initialUseLegacyLessonPlans: false,
       });
@@ -384,7 +384,7 @@ describe('UnitEditor', () => {
         .true;
       saveAndKeepEditingButton.simulate('click');
 
-      // check the the spinner is showing
+      // check that the spinner is showing
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
       expect(unitEditor.state().isSaving).to.equal(true);
 
@@ -422,7 +422,7 @@ describe('UnitEditor', () => {
         .true;
       saveAndKeepEditingButton.simulate('click');
 
-      // check the the spinner is showing
+      // check that the spinner is showing
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
       expect(unitEditor.state().isSaving).to.equal(true);
 
@@ -457,7 +457,7 @@ describe('UnitEditor', () => {
         .true;
       saveAndKeepEditingButton.simulate('click');
 
-      // check the the spinner is showing
+      // check that the spinner is showing
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
       expect(unitEditor.state().isSaving).to.equal(true);
 
@@ -538,117 +538,6 @@ describe('UnitEditor', () => {
             'Error Saving: Please provide a positive number of instructional minutes per week in Unit Calendar Settings.'
           )
       ).to.be.true;
-      $.ajax.restore();
-    });
-
-    it('shows error when published state is pilot but no pilot experiment given', () => {
-      sinon.stub($, 'ajax');
-      const wrapper = createWrapper({});
-
-      const unitEditor = wrapper.find('UnitEditor');
-      unitEditor.setState({
-        publishedState: PublishedState.pilot,
-        pilotExperiment: '',
-      });
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
-      saveAndKeepEditingButton.simulate('click');
-
-      expect($.ajax).to.not.have.been.called;
-
-      expect(unitEditor.state().isSaving).to.equal(false);
-      expect(unitEditor.state().error).to.equal(
-        'Please provide a pilot experiment in order to save with published state as pilot.'
-      );
-
-      expect(
-        wrapper
-          .find('.saveBar')
-          .contains(
-            'Error Saving: Please provide a pilot experiment in order to save with published state as pilot.'
-          )
-      ).to.be.true;
-
-      $.ajax.restore();
-    });
-
-    it('shows error when published state is preview or stable and device compatibility JSON is null', () => {
-      sinon.stub($, 'ajax');
-      const wrapper = createWrapper({
-        isMissingRequiredDeviceCompatibilities: true,
-        hasCourse: true,
-      });
-
-      const unitEditor = wrapper.find('UnitEditor');
-      unitEditor.setState({
-        publishedState: PublishedState.preview,
-        courseOfferingDeviceCompatibilities: null,
-      });
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
-      saveAndKeepEditingButton.simulate('click');
-
-      expect($.ajax).to.not.have.been.called;
-
-      expect(unitEditor.state().isSaving).to.equal(false);
-      expect(unitEditor.state().error).to.equal(
-        'Please set all device compatibilities in order to save with published state as preview or stable.'
-      );
-
-      expect(
-        wrapper
-          .find('.saveBar')
-          .contains(
-            'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
-          )
-      ).to.be.true;
-
-      $.ajax.restore();
-    });
-
-    it('shows error when published state is preview or stable and at least one device compatibility is not set', () => {
-      sinon.stub($, 'ajax');
-      const wrapper = createWrapper({
-        isMissingRequiredDeviceCompatibilities: true,
-        hasCourse: true,
-      });
-
-      const unitEditor = wrapper.find('UnitEditor');
-      unitEditor.setState({
-        publishedState: PublishedState.stable,
-        courseOfferingDeviceCompatibilities:
-          '{"computer":"","chromebook":"ideal","tablet":"ideal","mobile":"not_recommended","no_device":"incompatible"}',
-      });
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
-      saveAndKeepEditingButton.simulate('click');
-
-      expect($.ajax).to.not.have.been.called;
-
-      expect(unitEditor.state().isSaving).to.equal(false);
-      expect(unitEditor.state().error).to.equal(
-        'Please set all device compatibilities in order to save with published state as preview or stable.'
-      );
-
-      expect(
-        wrapper
-          .find('.saveBar')
-          .contains(
-            'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
-          )
-      ).to.be.true;
 
       $.ajax.restore();
     });
@@ -679,7 +568,7 @@ describe('UnitEditor', () => {
         .true;
       saveAndKeepEditingButton.simulate('click');
 
-      // check the the spinner is showing
+      // check that the spinner is showing
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
       expect(unitEditor.state().isSaving).to.equal(true);
 
@@ -758,7 +647,7 @@ describe('UnitEditor', () => {
         .true;
       saveAndKeepEditingButton.simulate('click');
 
-      // check the the spinner is showing
+      // check that the spinner is showing
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
       expect(unitEditor.state().isSaving).to.equal(true);
 
@@ -833,7 +722,7 @@ describe('UnitEditor', () => {
       expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
       saveAndCloseButton.simulate('click');
 
-      // check the the spinner is showing
+      // check that the spinner is showing
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
       expect(unitEditor.state().isSaving).to.equal(true);
 
@@ -864,7 +753,7 @@ describe('UnitEditor', () => {
       expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
       saveAndCloseButton.simulate('click');
 
-      // check the the spinner is showing
+      // check that the spinner is showing
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
       expect(unitEditor.state().isSaving).to.equal(true);
 

--- a/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -276,7 +276,7 @@ describe('UnitEditor', () => {
 
     it('disables changing student facing lesson plan checkbox when not allowed to make major curriculum changes', () => {
       const wrapper = createWrapper({
-        initialPublishedState: 'stable',
+        allowMajorCurriculumChanges: false,
         isMigrated: true,
         initialUseLegacyLessonPlans: false,
       });
@@ -291,8 +291,7 @@ describe('UnitEditor', () => {
 
     it('allows changing student facing lesson plan checkbox when allowed to make major curriculum changes to hidden unit', () => {
       const wrapper = createWrapper({
-        initialPublishedState: 'stable',
-        initialHideWithinCourse: true,
+        allowMajorCurriculumChanges: true,
         isMigrated: true,
         initialUseLegacyLessonPlans: false,
       });

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -356,7 +356,7 @@ class ScriptsController < ApplicationController
 
   private def general_params
     h = params.permit(
-      :published_state,
+      :hide_within_course,
       :instruction_type,
       :instructor_audience,
       :participant_audience,

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1371,7 +1371,7 @@ class Unit < ApplicationRecord
           login_required: general_params[:login_required].nil? ? false : general_params[:login_required], # default false
           wrapup_video: general_params[:wrapup_video],
           family_name: general_params[:family_name].presence ? general_params[:family_name] : nil, # default nil
-          published_state: (unit_group.present? && general_params[:published_state] == unit_group.published_state) ? nil : general_params[:published_state],
+          hide_within_course: general_params[:hide_within_course].nil? ? false : general_params[:hide_within_course], # default false
           instruction_type: unit_group.present? ? nil : general_params[:instruction_type],
           participant_audience: unit_group.present? ? nil : general_params[:participant_audience],
           instructor_audience: unit_group.present? ? nil : general_params[:instructor_audience],
@@ -1554,6 +1554,7 @@ class Unit < ApplicationRecord
         description: Services::MarkdownPreprocessor.process(localized_description),
         studentDescription: Services::MarkdownPreprocessor.process(localized_student_description),
         course_id: unit_group.try(:id),
+        hide_within_course: hide_within_course,
         publishedState: get_published_state,
         instructionType: get_instruction_type,
         instructorAudience: get_instructor_audience,

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1672,6 +1672,7 @@ class Unit < ApplicationRecord
     summary[:coursePublishedState] = unit_group ? unit_group.published_state : published_state
     summary[:unitPublishedState] = unit_group ? published_state : nil
     summary[:isCSDCourseOffering] = unit_group&.course_version&.course_offering&.csd?
+    summary[:allowMajorCurriculumChanges] = allow_major_curriculum_changes?
     summary
   end
 

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1676,7 +1676,7 @@ class Unit < ApplicationRecord
   end
 
   def allow_major_curriculum_changes?
-    get_published_state == PUBLISHED_STATE.in_development || get_published_state == PUBLISHED_STATE.pilot
+    get_published_state == PUBLISHED_STATE.in_development || get_published_state == PUBLISHED_STATE.pilot || hide_within_course
   end
 
   def summarize_for_lesson_edit

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1676,7 +1676,9 @@ class Unit < ApplicationRecord
   end
 
   def allow_major_curriculum_changes?
-    get_published_state == PUBLISHED_STATE.in_development || get_published_state == PUBLISHED_STATE.pilot || hide_within_course
+    unit_group.nil? ||
+      [PUBLISHED_STATE.in_development, PUBLISHED_STATE.pilot].include?(unit_group.published_state) ||
+      hide_within_course
   end
 
   def summarize_for_lesson_edit

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -371,7 +371,7 @@ class UnitGroup < ApplicationRecord
       Unit.get_from_cache(ugu.script_id)
     end
     units.compact.reject do |unit|
-      unit.in_development? && !user&.permission?(UserPermission::LEVELBUILDER)
+      unit.hide_within_course && !user&.permission?(UserPermission::LEVELBUILDER)
     end
   end
 

--- a/dashboard/config/scripts_json/aif1-2025.script_json
+++ b/dashboard/config/scripts_json/aif1-2025.script_json
@@ -24,6 +24,7 @@
     "family_name": null,
     "serialized_at": "2025-05-14 23:56:41 UTC",
     "published_state": "in_development",
+    "hide_within_course": true,
     "instruction_type": null,
     "instructor_audience": null,
     "participant_audience": null,

--- a/dashboard/config/scripts_json/csaif1-preview.script_json
+++ b/dashboard/config/scripts_json/csaif1-preview.script_json
@@ -22,6 +22,7 @@
     "new_name": null,
     "family_name": null,
     "serialized_at": "2025-03-22 02:43:48 UTC",
+    "hide_within_course": true,
     "published_state": "in_development",
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd5-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd5-2023.script_json
@@ -14,6 +14,7 @@
     "new_name": null,
     "family_name": null,
     "serialized_at": "2025-05-12 18:25:46 UTC",
+    "hide_within_course": true,
     "published_state": "in_development",
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd5-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd5-2024.script_json
@@ -13,6 +13,7 @@
     "new_name": null,
     "family_name": null,
     "serialized_at": "2025-01-22 19:00:10 UTC",
+    "hide_within_course": true,
     "published_state": "in_development",
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -762,6 +762,7 @@ module Services
         :new_name,
         :family_name,
         :serialized_at,
+        :hide_within_course,
         :published_state,
         :instruction_type,
         :instructor_audience,

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -625,25 +625,25 @@ class ScriptsControllerTest < ActionController::TestCase
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     sign_in create(:levelbuilder)
 
-    unit = create :script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
+    unit = create :script
     File.stubs(:write).raises('must not modify filesystem')
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
       is_migrated: true,
       lesson_groups: '[]',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
+      login_required: true
     }
     assert_response :forbidden
     unit.reload
-    assert_equal unit.get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
+    refute unit.login_required
   end
 
   test "can update on levelbuilder" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     sign_in create(:levelbuilder)
 
-    unit = create :script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
+    unit = create :script
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts/en.yml'}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
@@ -653,11 +653,11 @@ class ScriptsControllerTest < ActionController::TestCase
       script: {name: unit.name},
       is_migrated: true,
       lesson_groups: '[]',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
+      login_required: true
     }
     assert_response :success
     unit.reload
-    assert_equal unit.get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
+    assert unit.login_required
   end
 
   test "update instruction_type" do
@@ -681,129 +681,23 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_equal unit.get_instruction_type, Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.self_paced
   end
 
-  test "update published state to in_development" do
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in create(:levelbuilder)
-
-    unit = create :script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-    File.stubs(:write).with {|filename, _| filename.end_with? 'scripts/en.yml'}.once
-    File.stubs(:write).with do |filename, contents|
-      filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
-    end
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      is_migrated: true,
-      lesson_groups: '[]',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
-    }
-    assert_response :success
-    unit.reload
-    assert_equal unit.get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
-  end
-
-  test "update published state to pilot" do
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in create(:levelbuilder)
-
-    unit = create :script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
-    File.stubs(:write).with {|filename, _| filename.end_with? 'scripts/en.yml'}.once
-    File.stubs(:write).with do |filename, contents|
-      filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
-    end
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      is_migrated: true,
-      lesson_groups: '[]',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot,
-      pilot_experiment: 'my-pilot'
-    }
-    assert_response :success
-    unit.reload
-    assert_equal unit.get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot
-  end
-
-  test "update published state to beta" do
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in create(:levelbuilder)
-
-    unit = create :script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
-    File.stubs(:write).with {|filename, _| filename.end_with? 'scripts/en.yml'}.once
-    File.stubs(:write).with do |filename, contents|
-      filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
-    end
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      is_migrated: true,
-      lesson_groups: '[]',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-    }
-    assert_response :success
-    unit.reload
-    assert_equal unit.get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-  end
-
-  test "update published state to preview" do
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in create(:levelbuilder)
-
-    unit = create :script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-    File.stubs(:write).with {|filename, _| filename.end_with? 'scripts/en.yml'}.once
-    File.stubs(:write).with do |filename, contents|
-      filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
-    end
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      is_migrated: true,
-      lesson_groups: '[]',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
-    }
-    assert_response :success
-    unit.reload
-    assert_equal unit.get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
-  end
-
-  test "update published state to stable" do
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in create(:levelbuilder)
-
-    unit = create :script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-    File.stubs(:write).with {|filename, _| filename.end_with? 'scripts/en.yml'}.once
-    File.stubs(:write).with do |filename, contents|
-      filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
-    end
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      is_migrated: true,
-      lesson_groups: '[]',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    }
-    assert_response :success
-    unit.reload
-    assert_equal unit.get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-  end
-
   test "can update on test without modifying filesystem" do
     CDO.stubs(:rack_env).returns(:test)
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     sign_in create(:levelbuilder)
 
-    unit = create :script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
+    unit = create :script
     File.stubs(:write).raises('must not modify filesystem')
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
       is_migrated: true,
       lesson_groups: '[]',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
+      login_required: true
     }
     assert_response :success
     unit.reload
-    assert_equal unit.get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
+    assert unit.login_required
   end
 
   test "cannot update on staging" do
@@ -811,18 +705,18 @@ class ScriptsControllerTest < ActionController::TestCase
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     sign_in create(:levelbuilder)
 
-    unit = create :script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
+    unit = create :script
     File.stubs(:write).raises('must not modify filesystem')
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
       is_migrated: true,
       lesson_groups: '[]',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
+      login_required: true
     }
     assert_response :forbidden
     unit.reload
-    assert_equal unit.get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
+    refute unit.login_required
   end
 
   test 'cannot update unmigrated unit' do
@@ -1023,29 +917,6 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_equal Unit.find_by_name(unit.name).get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot
   end
 
-  test 'does not hide unit with blank pilot_experiment' do
-    sign_in create(:levelbuilder)
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-
-    unit = create :script
-    stub_file_writes(unit.name)
-
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      is_migrated: true,
-      lesson_groups: '[]',
-      pilot_experiment: '',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
-    }
-
-    assert_response :success
-
-    assert_nil Unit.find_by_name(unit.name).pilot_experiment
-    # blank pilot_experiment does not cause unit to have published_state of pilot
-    assert_equal Unit.find_by_name(unit.name).get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview
-  end
-
   test 'update: can update general_params' do
     sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
@@ -1204,51 +1075,6 @@ class ScriptsControllerTest < ActionController::TestCase
     unit.reload
 
     assert_nil unit.tts
-  end
-
-  test 'published_state is set to nil for script within course' do
-    sign_in create(:levelbuilder)
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-
-    course = create :unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-    unit = create :script, published_state: nil
-    create :unit_group_unit, unit_group: course, script: unit, position: 1
-    stub_file_writes(unit.name)
-
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      lesson_groups: '[]',
-      is_migrated: true,
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-    }
-    assert_response :success
-    unit.reload
-
-    assert_nil unit.published_state
-  end
-
-  test 'published_state is set for script within course when different' do
-    sign_in create(:levelbuilder)
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-
-    course = create :unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-    unit = create :script, published_state: nil
-    create :unit_group_unit, unit_group: course, script: unit, position: 1
-    stub_file_writes(unit.name)
-
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      lesson_groups: '[]',
-      is_migrated: true,
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
-    }
-    assert_response :success
-    unit.reload
-
-    refute_nil unit.published_state
-    assert_equal Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development, unit.published_state
   end
 
   test 'add lesson to migrated unit' do

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -11,6 +11,7 @@
     },
     "new_name": null,
     "family_name": "test-serialize-seeding-json-family",
+    "hide_within_course": false,
     "published_state": "beta",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -1238,11 +1238,12 @@ class UnitGroupTest < ActiveSupport::TestCase
     assert_equal ['csx1', 'csx2', 'csx3'], csx.units_for_user(teacher).map(&:name)
     assert_equal ['csx1', 'csx2', 'csx3'], csx.units_for_user(levelbuilder).map(&:name)
 
+    csx1.update!(hide_within_course: true)
     csx2.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development)
     csx.reload
 
-    assert_equal ['csx1', 'csx3'], csx.units_for_user(nil).map(&:name)
-    assert_equal ['csx1', 'csx3'], csx.units_for_user(teacher).map(&:name)
+    assert_equal ['csx2', 'csx3'], csx.units_for_user(nil).map(&:name)
+    assert_equal ['csx2', 'csx3'], csx.units_for_user(teacher).map(&:name)
     assert_equal ['csx1', 'csx2', 'csx3'], csx.units_for_user(levelbuilder).map(&:name)
   end
 

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2240,6 +2240,53 @@ class UnitTest < ActiveSupport::TestCase
     assert_nil unit1.next_unit(student)
   end
 
+  test 'does allow major changes to newly created unit' do
+    unit = create :unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
+    assert unit.allow_major_curriculum_changes?
+  end
+
+  test 'does allow major changes to unit within in_development course' do
+    @unit_group.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development)
+    @unit_in_unit_group.update!(published_state: nil)
+    @unit_in_unit_group.reload
+    assert @unit_in_unit_group.allow_major_curriculum_changes?
+  end
+
+  test 'does allow major changes to unit within pilot course' do
+    @unit_group.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot)
+    @unit_in_unit_group.update!(published_state: nil)
+    @unit_in_unit_group.reload
+    assert @unit_in_unit_group.allow_major_curriculum_changes?
+  end
+
+  test 'does not allow major changes to unit within beta course' do
+    @unit_group.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
+    @unit_in_unit_group.update!(published_state: nil)
+    @unit_in_unit_group.reload
+    refute @unit_in_unit_group.allow_major_curriculum_changes?
+  end
+
+  test 'does not allow major changes to unit within stable course' do
+    @unit_group.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    @unit_in_unit_group.update!(published_state: nil)
+    @unit_in_unit_group.reload
+    refute @unit_in_unit_group.allow_major_curriculum_changes?
+  end
+
+  test 'does not allow major changes to in_development unit within stable course' do
+    @unit_group.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    @unit_in_unit_group.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development)
+    @unit_in_unit_group.reload
+    refute @unit_in_unit_group.allow_major_curriculum_changes?
+  end
+
+  test 'does allow major changes to hidden unit within stable course' do
+    @unit_group.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    @unit_in_unit_group.update!(published_state: nil, hide_within_course: true)
+    @unit_in_unit_group.reload
+    assert @unit_in_unit_group.allow_major_curriculum_changes?
+  end
+
   class MigratedScriptCopyTests < ActiveSupport::TestCase
     setup do
       Unit.any_instance.stubs(:write_script_json)


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#65895, restoring  https://github.com/code-dot-org/code-dot-org/pull/65811. The original PR accidentally made curriculum writers unable to add levels to lessons in units which were hidden. 

The issue was that I updated the UnitEditor to look at the new flag when deciding whether to `allowMajorCurriculumChanges`, but I forgot to update LessonEditor: 
* https://github.com/code-dot-org/code-dot-org/blob/630075efad013c5fd25429c565c19ad613b47616/apps/src/levelbuilder/lesson-editor/LessonEditor.jsx#L183

This PR does the following:
* updates LessonEditor to also allow major changes when the unit has `hide_within_course` set, based on `unit.allow_major_curriculum_changes?`
* add unit tests
* updates UnitEditor to also use `unit.allow_major_curriculum_changes?` for consistency

### screenshots

#### visible unit in beta course
![Screenshot 2025-05-15 at 4 21 46 PM](https://github.com/user-attachments/assets/63b5a53d-925c-40be-9a01-ccbe7c9913e9)

#### hidden unit in beta course
![Screenshot 2025-05-15 at 4 22 32 PM](https://github.com/user-attachments/assets/18008859-feb1-49e5-9869-f7eda871b61b)

### Testing story

* new unit tests for `unit.allow_major_curriculum_changes?`
* manual testing shown in screenshots 