### PR TITLE
Remove Babel loose: true class for Blockly

### DIFF
--- a/apps/babel.config.json
+++ b/apps/babel.config.json
@@ -22,5 +22,11 @@
         "dynamic-import-node"
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "test": "node_modules/blockly/**",
+      "plugins": [["@babel/plugin-transform-classes", {"loose": false}]]
+    }
+  ]
 }


### PR DESCRIPTION
Alternative to:
- https://github.com/code-dot-org/code-dot-org/pull/65894

This PR removes `"loose": true` from the `@babel/plugin-transform-classes` plugin only when transpiling Blockly.

In our environment, `"loose": true` causes Babel to transpile `super.prop = value` as `this.prop = value`. When Blockly introduced the `size_` accessor in `FieldInput`, our transpilation led to infinite recursion: `super.size_ = val` was rewritten as `this.size_ = val`.

This override impacts `node_modules/blockly/**` only, avoiding the regressions introduced by https://github.com/code-dot-org/code-dot-org/pull/65894


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
