### PR TITLE
Remove Babel loose: true class except for JS Interpreter and Maker

### DIFF
--- a/apps/babel.config.json
+++ b/apps/babel.config.json
@@ -9,8 +9,7 @@
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-transform-class-properties",
     ["@babel/plugin-transform-regenerator", {"async": true, "asyncGenerators": true}],
-    // needed for IE 9/10 support
-    ["@babel/plugin-transform-classes", {"loose": true}],
+    "@babel/plugin-transform-classes",
     "@babel/plugin-transform-modules-commonjs",
     "@babel/plugin-proposal-optional-chaining"
   ],

--- a/apps/babel.config.json
+++ b/apps/babel.config.json
@@ -21,5 +21,16 @@
         "dynamic-import-node"
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "test": [
+        "apps/src/lib/tools/jsinterpreter/**",
+        "apps/src/maker/**"
+      ],
+      "plugins": [
+        ["@babel/plugin-transform-classes", {"loose": true}]
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Alternative to:
- https://github.com/code-dot-org/code-dot-org/pull/65894

This PR removes `"loose": true` from the `@babel/plugin-transform-classes` plugin only when transpiling Blockly.

In our environment, `"loose": true` causes Babel to transpile `super.prop = value` as `this.prop = value`. When Blockly introduced the `size_` accessor in `FieldInput`, our transpilation led to infinite recursion: `super.size_ = val` was rewritten as `this.size_ = val`.

This override impacts everywhere except two specific folders, hopefully avoiding the regressions introduced by https://github.com/code-dot-org/code-dot-org/pull/65894

This change avoids the recursion bug introduced by Babel rewriting `super.size_ = val` as `this.size_ = val`, which broke Blockly’s new accessor-based Field implementation.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
