### PR TITLE
override constantSuper assumption for blockly only

### DIFF
--- a/apps/babel.config.json
+++ b/apps/babel.config.json
@@ -22,5 +22,11 @@
         "dynamic-import-node"
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "test": "node_modules/blockly/**",
+      "plugins": [["@babel/plugin-transform-classes", {"loose": false}]]
+    }
+  ]
 }

--- a/apps/babel.config.json
+++ b/apps/babel.config.json
@@ -26,7 +26,9 @@
   "overrides": [
     {
       "test": "node_modules/blockly/**",
-      "plugins": [["@babel/plugin-transform-classes", {"loose": false}]]
+      "assumptions": {
+        "constantSuper": false
+      }
     }
   ]
 }


### PR DESCRIPTION
Alternative to:
- https://github.com/code-dot-org/code-dot-org/pull/65894

This PR overrides Babel’s `constantSuper` assumption (enabled implicitly in loose mode) only for Blockly. 
In our environment, `"loose": true` causes Babel to transpile `super.prop = value` as `this.prop = value`. When Blockly introduced the `size_` accessor in `FieldInput`, our transpilation led to infinite recursion: `super.size_ = val` was rewritten as `this.size_ = val`.

This override impacts Blockly only, hopefully avoiding the regressions introduced by https://github.com/code-dot-org/code-dot-org/pull/65894

This change avoids the recursion bug introduced by Babel rewriting `super.size_ = val` as `this.size_ = val`, which broke Blockly’s new accessor-based Field implementation.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
