### PR TITLE
Evaluate Student Learning: evaluate student code on data pull 

### DIFF
--- a/apps/src/aiEvaluation/aiEvaluationApi.ts
+++ b/apps/src/aiEvaluation/aiEvaluationApi.ts
@@ -10,6 +10,7 @@ export interface StudentAnswer {
   studentDisplayName: string;
   studentWork: string;
   codeVersion?: string;
+  projectId?: string;
 }
 
 export interface AIResponse {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -2079,7 +2079,7 @@ function redirectEditView() {
 
 /**
  * Does a hard redirect if we end up with a hash based projects url. This can
- * happen on IE9, when we save a new project for hte first time.
+ * happen on IE9, when we save a new project for the first time.
  * @returns {boolean} True if we did an actual redirect
  */
 function redirectFromHashUrl() {

--- a/apps/src/levelbuilder/ai-iteration-tools/FreeResponseDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/FreeResponseDatasetMaker.tsx
@@ -1,5 +1,4 @@
 import Button from '@code-dot-org/component-library/button';
-import Checkbox from '@code-dot-org/component-library/checkbox';
 import TextField from '@code-dot-org/component-library/textField';
 import Papa from 'papaparse';
 import React, {useState} from 'react';
@@ -26,8 +25,6 @@ const FreeResponseDatasetMaker: React.FC = () => {
   const [levelId, setLevelId] = useState<string>('');
   const [unitId, setUnitId] = useState<string>('');
   const [numSamples, setNumSamples] = useState<string>('25');
-  const [includeAiEvaluations, setIncludeAiEvaluations] =
-    useState<boolean>(false);
   const [fetchPending, setFetchPending] = useState<boolean>(false);
   const [fetchedSamples, setFetchedSamples] = useState<
     StudentFreeResponseAnswer[]
@@ -50,7 +47,6 @@ const FreeResponseDatasetMaker: React.FC = () => {
   const getStudentFreeResponseAnswers = async () => {
     setFetchPending(true);
     const studentWorkRequest = {
-      includeAiEvaluations: includeAiEvaluations,
       numSamples: Number(numSamples),
       unitId: Number(unitId),
       levelId: Number(levelId),
@@ -105,12 +101,6 @@ const FreeResponseDatasetMaker: React.FC = () => {
         />
         <br />
         <br />
-        <Checkbox
-          name="include AI evaluations"
-          label="Include AI evaluations"
-          onChange={() => setIncludeAiEvaluations(!includeAiEvaluations)}
-          checked={includeAiEvaluations}
-        />
         <TextField
           name="Number of Samples"
           label="How many samples of student work do you want?"
@@ -143,7 +133,7 @@ const FreeResponseDatasetMaker: React.FC = () => {
           <Button
             text="Evaluate Free Responses"
             onClick={getAIEvaluations}
-            disabled={!includeAiEvaluations || fetchedSamples.length === 0}
+            disabled={fetchedSamples.length === 0}
             isPending={evaluationPending}
           />
         </div>
@@ -152,10 +142,7 @@ const FreeResponseDatasetMaker: React.FC = () => {
           <Button
             text="Download CSV"
             onClick={downloadCSV}
-            disabled={
-              evaluatedSamples.length === 0 ||
-              evaluatedSamples.length !== fetchedSamples.length
-            }
+            disabled={evaluatedSamples.length === 0}
           />
         </div>
       </div>

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -1,33 +1,38 @@
 import Button from '@code-dot-org/component-library/button';
-import Checkbox from '@code-dot-org/component-library/checkbox';
 import TextField from '@code-dot-org/component-library/textField';
 import Papa from 'papaparse';
 import React, {useState} from 'react';
 
+import {
+  AIResponse,
+  evaluateStudentWork,
+  StudentAnswer,
+} from '@cdo/apps/aiEvaluation/aiEvaluationApi';
+
 import {fetchStudentCodeSamples} from './StudentWorkSamplesApi';
 
-interface StudentCodeSample {
-  projectId: string;
-  studentCode: string | undefined;
-  codeVersion?: string;
-  userId: number | undefined;
-  evaluation?: string;
-  reasoning?: string;
-  evaluationCriteria?: string;
-}
+type EvaluatedCodeSample = StudentAnswer &
+  AIResponse & {
+    [key in `skill${number}${
+      | 'evaluationCriteria'
+      | 'aiEvaluation'
+      | 'aiReasoning'}`]?: string;
+  };
 
 const StudentCodeDatasetMaker: React.FC = () => {
   const [datasetName, setDatasetName] = useState<string>('');
   const [levelId, setLevelId] = useState<string>('');
   const [unitId, setUnitId] = useState<string>('');
   const [numSamples, setNumSamples] = useState<string>('25');
-  const [includeAiEvaluations, setIncludeAiEvaluations] =
-    useState<boolean>(false);
   const [pending, setPending] = useState<boolean>(false);
-  const [fetchedSamples, setFetchedSamples] = useState<StudentCodeSample[]>([]);
+  const [fetchedSamples, setFetchedSamples] = useState<StudentAnswer[]>([]);
+  const [evaluationPending, setEvaluationPending] = useState<boolean>(false);
+  const [evaluatedSamples, setEvaluatedSamples] = useState<
+    EvaluatedCodeSample[]
+  >([]);
 
   const downloadCSV = () => {
-    const csv = Papa.unparse(fetchedSamples);
+    const csv = Papa.unparse(evaluatedSamples);
     const csvData = new Blob([csv], {type: 'text/csv;charset=utf-8;'});
     const csvURL = window.URL.createObjectURL(csvData);
     const tempLink = document.createElement('a');
@@ -39,7 +44,6 @@ const StudentCodeDatasetMaker: React.FC = () => {
   const getStudentCodeSamples = async () => {
     setPending(true);
     const studentWorkRequest = {
-      includeAiEvaluations: includeAiEvaluations,
       numSamples: Number(numSamples),
       unitId: Number(unitId),
       levelId: Number(levelId),
@@ -48,13 +52,53 @@ const StudentCodeDatasetMaker: React.FC = () => {
     if (!codeSamples) {
       alert('No samples found for the given parameters.');
     } else {
-      const fetchedCodeSamples = codeSamples as unknown as StudentCodeSample[];
+      const fetchedCodeSamples = codeSamples as unknown as StudentAnswer[];
       const filteredCodeSamples = fetchedCodeSamples.filter(
         item => item !== null
       );
       setFetchedSamples(filteredCodeSamples);
     }
     setPending(false);
+  };
+
+  const getAIEvaluations = async () => {
+    setEvaluationPending(true);
+    const responsePromises = fetchedSamples.map(async studentResponse => {
+      const studentWorkToEvaluate = {
+        studentId: studentResponse.studentId,
+        studentDisplayName: studentResponse.studentDisplayName,
+        studentWork: studentResponse.studentWork,
+      };
+      return evaluateStudentResponse(studentWorkToEvaluate as StudentAnswer);
+    });
+    await Promise.allSettled(responsePromises);
+    setEvaluationPending(false);
+  };
+
+  const evaluateStudentResponse = async (studentAnswer: StudentAnswer) => {
+    const aiResponse = await evaluateStudentWork(
+      studentAnswer,
+      parseInt(levelId),
+      parseInt(unitId)
+    );
+    const evaluation: EvaluatedCodeSample = {
+      ...studentAnswer,
+      aiEvaluation: aiResponse.aiEvaluation,
+      aiReasoning: aiResponse.aiReasoning,
+      evaluationCriteria: aiResponse.evaluationCriteria,
+      id: aiResponse.id,
+    };
+    if (aiResponse.skillEvaluations) {
+      // TODO: Use skill id when we have Skills
+      for (let i = 1; i < aiResponse.skillEvaluations.length; i++) {
+        const skillEvaluation = aiResponse.skillEvaluations[i];
+        evaluation[`skill${i}evaluationCriteria`] =
+          skillEvaluation.evaluationCriteria;
+        evaluation[`skill${i}aiEvaluation`] = skillEvaluation.aiEvaluation;
+        evaluation[`skill${i}aiReasoning`] = skillEvaluation.aiReasoning;
+      }
+    }
+    setEvaluatedSamples(prevSamples => [...prevSamples, evaluation]);
   };
 
   return (
@@ -76,12 +120,6 @@ const StudentCodeDatasetMaker: React.FC = () => {
         />
         <br />
         <br />
-        <Checkbox
-          name="include AI evaluations"
-          label="Include AI evaluations"
-          onChange={() => setIncludeAiEvaluations(!includeAiEvaluations)}
-          checked={includeAiEvaluations}
-        />
         <TextField
           name="Number of Samples"
           label="How many samples of student work do you want?"
@@ -112,9 +150,18 @@ const StudentCodeDatasetMaker: React.FC = () => {
         <br />
         <div>
           <Button
+            text="Evaluate Student Code Samples"
+            onClick={getAIEvaluations}
+            disabled={fetchedSamples.length === 0}
+            isPending={evaluationPending}
+          />
+        </div>
+        <br />
+        <div>
+          <Button
             text="Download CSV"
             onClick={downloadCSV}
-            disabled={fetchedSamples.length === 0}
+            disabled={evaluatedSamples.length === 0}
           />
         </div>
       </div>

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentWorkSamplesApi.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentWorkSamplesApi.tsx
@@ -1,7 +1,6 @@
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
 interface StudentWorkRequest {
-  includeAiEvaluations: boolean;
   numSamples: number;
   unitId: number;
   levelId: number;

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -81,14 +81,6 @@ class StudentWorkSampleController < ApplicationController
       return render status: :not_found, json: "Unit with id #{unit_id}"
     end
 
-    if student_work_params[:include_ai_evaluations]
-      fetch_student_code_samples_with_evaluations(level, unit_id, num_samples)
-    else
-      fetch_student_code_samples_without_evaluations(level, unit_id, num_samples)
-    end
-  end
-
-  def fetch_student_code_samples_without_evaluations(level, unit_id, num_samples)
     # Find users who have worked on this level.
     student_ids = UserLevel.where(level_id: level.id, script_id: unit_id).pluck(:user_id)
     code_samples = []
@@ -97,51 +89,14 @@ class StudentWorkSampleController < ApplicationController
       unless have_enough_samples
         student_code = get_student_code(student_id, level, unit_id)
         if student_code[:student_code]
-          code_samples << {level_id: level.id, unit_id: unit_id, user_id: student_id, project_id: student_code[:project_id], student_code: student_code[:student_code]}
-        end
-        have_enough_samples = code_samples.length >= num_samples
-      end
-    end
-    render json: code_samples
-  end
-
-  def fetch_student_code_samples_with_evaluations(level, unit_id, num_samples)
-    # Only user user_level_evaluations that have skills-based evaluations associated with them.
-    user_level_skill_evaluations = UserLevelSkillEvaluation.where(level_id: level.id, unit_id: unit_id)
-
-    if user_level_skill_evaluations.empty?
-      return render status: :not_found, json: "There are no skill-based evaluations for the level with id #{level.id}"
-    end
-
-    user_level_evaluations = user_level_skill_evaluations.map(&:user_level_evaluation).compact
-
-    code_samples = []
-    have_enough_samples = false
-    user_level_evaluations.shuffle.each do |ule|
-      unless have_enough_samples || ule.code_version.nil?
-        student_code = get_student_code(ule.user_id, level, unit_id, ule.code_version)
-        if student_code && student_code[:student_code]
-          code_sample = {
+          code_samples << {
             level_id: level.id,
             unit_id: unit_id,
-            student_id: ule.student_id,
+            student_id: student_id,
             project_id: student_code[:project_id],
-            code_version: student_code[:code_version],
-            student_code: student_code[:student_code],
-            evaluation: ule.evaluation,
-            reasoning: ule.reasoning,
-            evaluation_criteria: ule.evaluation_criteria,
-          }
-          # TODO: Use skill id instead of counter when we have Skills
-          counter = 1
-          ule.user_level_skill_evaluations.each do |ulse|
-            code_sample["skill_evaluation_#{counter}"] = ulse.evaluation
-            code_sample["skill_evaluation_criteria_#{counter}"] = ulse.evaluation_criteria
-            code_sample["skill_evaluation_reasoning_#{counter}"] = ulse.reasoning
-            counter += 1
-          end
+            student_work: student_code[:student_code]
+          }.transform_keys {|key| key.to_s.camelize(:lower)}
         end
-        code_samples << code_sample
         have_enough_samples = code_samples.length >= num_samples
       end
     end
@@ -183,7 +138,6 @@ class StudentWorkSampleController < ApplicationController
       :level_id,
       :unit_id,
       :num_samples,
-      :include_ai_evaluations,
     )
   end
 end

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -89,9 +89,8 @@ class StudentWorkSampleController < ApplicationController
   end
 
   def fetch_student_code_samples_without_evaluations(level, unit_id, num_samples)
-    # We want to pull samples from students who have been assigned to work on the level.
-    sections = Section.where(script_id: unit_id)
-    student_ids = Follower.where(section: sections).pluck(:student_user_id)
+    # Find users who have worked on this level.
+    student_ids = UserLevel.where(level_id: level.id, script_id: unit_id).pluck(:user_id)
     code_samples = []
     have_enough_samples = false
     student_ids.shuffle.each do |student_id|
@@ -158,8 +157,7 @@ class StudentWorkSampleController < ApplicationController
     # For project-template-backed levels, we need to use the channel_token for the associated project template level.
     level_id_for_channel_token = level.project_template_level ? level.project_template_level.id : level.id
     channel_token = ChannelToken.where(storage_id: storage_id, level_id: level_id_for_channel_token, script_id: unit_id).last
-    user_level = UserLevel.where(user_id: user_id, level_id: level.id, script_id: unit_id).last
-    if user_level && channel_token
+    if channel_token
       storage_app_id = channel_token.storage_app_id
       channel_id = storage_encrypt_channel_id(storage_id, storage_app_id)
       s3_filename = "#{base_dir}/#{storage_id}/#{storage_app_id}/main.json"

--- a/dashboard/test/controllers/student_work_sample_controller_test.rb
+++ b/dashboard/test/controllers/student_work_sample_controller_test.rb
@@ -74,51 +74,17 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
-  # Fetch a code sample without evaluations
-  test 'can fetch code sample without evaluations' do
+  # Fetch a code sample
+  test 'can fetch code sample' do
     dataset_maker = create(:student_work_dataset_maker)
     sign_in(dataset_maker)
-    level = create(:level)
     unit = create(:script)
-    section = create(:section, script_id: unit.id)
+    level = create(:level)
     student = create(:student)
-    create(:follower, section: section, student_user: student)
+    create(:user_level, user: student, level: level, script: unit)
     get :fetch_student_code_samples, params: {level_id: level.id, unit_id: unit.id, num_samples: 1}
     assert_response :ok
     response_json = JSON.parse(response.body)
-    assert response_json.first["student_code"], 'console.log("Hello World")'
-  end
-
-  # Asking for a code sample with evaluations when there are no evaluations returns not found
-  test 'include ai_evaluations returns not found for un-evaluated level' do
-    dataset_maker = create(:student_work_dataset_maker)
-    sign_in(dataset_maker)
-    level = create(:level)
-    unit = create(:script)
-    section = create(:section, script_id: unit.id)
-    student = create(:student)
-    create(:follower, section: section, student_user: student)
-    get :fetch_student_code_samples, params: {level_id: level.id, unit_id: unit.id, num_samples: 1, include_ai_evaluations: true}
-    assert_response :not_found
-    assert @response.body, ("There are no skill-based evaluations for the level with id #{level.id}")
-  end
-
-  # Fetch evaluated code sample
-  test 'can fetch code sample with evaluations' do
-    dataset_maker = create(:student_work_dataset_maker)
-    sign_in(dataset_maker)
-    level = create(:level)
-    unit = create(:script)
-    section = create(:section, script_id: unit.id)
-    student = create(:student)
-    create(:follower, section: section, student_user: student)
-    ulse = create(:user_level_skill_evaluation, student_id: student.id, level_id: level.id, unit_id: unit.id)
-    ule = create(:user_level_evaluation, student_id: student.id, level_id: level.id, unit_id: unit.id)
-    create(:student_work_evaluation_summary, student_work_evaluation_id: ulse.id, student_work_evaluation_summary_id: ule.id)
-    get :fetch_student_code_samples, params: {level_id: level.id, unit_id: unit.id, num_samples: 1, include_ai_evaluations: true}
-    assert_response :ok
-    response_json = JSON.parse(response.body)
-    assert response_json.first["student_code"], 'console.log("Hello World")'
-    assert response_json.first["evaluation"], ule.evaluation
+    assert response_json.first["studentWork"], 'console.log("Hello World")'
   end
 end


### PR DESCRIPTION
[TEACH-1903](https://codedotorg.atlassian.net/browse/TEACH-1903)

We are currently blocked on pulling evaluated student code because of there is a mis-match between the `code_version` we store with the evaluation and the versions of a projects stored in s3. You can learn more about this issue in this [doc](https://docs.google.com/document/d/1b26sqnETEf4ZdYUyDQuo8siSSCg7Wi4qipwrfz1ctOY/edit?tab=t.0) Ultimately, we'll need to solve this issue, but in the meantime we need a workaround to pull student code samples.

Previously, we were attempting to pull evaluated student code; we've changed the approach to now evaluate student code _after_ we pull it for the Dataset Maker. We already do something similar for pulling Free Responses https://github.com/code-dot-org/code-dot-org/pull/64668. The pro of this approach that we can bypass the `code_version` mismatch issue to get the human tagging underway to get baseline accuracy scores of skills-based AI evaluation sooner. The downside is that we're only looking at the most recent version of the project so potentially won't get as good of a sense on how the AI is doing with partially completed solutions.

This shows requesting, then evaluating, then downloading student code samples with the changes in this PR. 

https://github.com/user-attachments/assets/d864eb85-5bd5-4a76-96bd-0e65d4dfae8f

and here's the resulting [csv](https://docs.google.com/spreadsheets/d/15Vtrti7VyMU3Bn7KYllP9ZIHGSX__KGjP7V61YQONM0/edit?gid=433713853#gid=433713853) to show how the skills-based evaluations are included. I updated the student_work_controller tests to reflect the update.