### PR TITLE
Re-enable Safari test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -40,9 +40,13 @@ Feature: BubbleChoice
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
-    Then I select the "Untitled Section" option in dropdown named "sections"
+    Then I select the "New Section" option in dropdown with class "uitest-sectionselect"
+    And I wait for 5 seconds
+    And I wait for jquery to load
     And check that the URL contains "section_id="
-    When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
+    Then I wait until element "a:contains(View Teacher Dashboard)" is visible
+    And element ".teacher-panel td:eq(1)" contains text "Alice"
+    And I click selector ".teacher-panel td:eq(1)" to load a new page
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
   # Mobile re-enable ticket: https://codedotorg.atlassian.net/browse/TEACH-1752

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -3,6 +3,7 @@ Feature: BubbleChoice
   @properties_encryption_key
   Scenario: Viewing BubbleChoice progress
     Given I create a teacher-associated student named "Alice"
+    Given I am assigned to course "allthethingscourse" and unit "allthethings" with teacher "Teacher_Alice"
 
     # Go to BubbleChoice sublevel
     Given I am on "http://studio.code.org/s/allthethings/lessons/40/levels/1/sublevel/1"
@@ -24,11 +25,22 @@ Feature: BubbleChoice
     # View student's BubbleChoice progress as a teacher
     When I sign in as "Teacher_Alice"
 
+    # View progress from script overview page
+    Given I am on "http://studio.code.org/s/allthethings"
+    And I wait until element "#uitest-view-as-student-selector" is visible
+    Then I select the "Alice" option in dropdown "uitest-view-as-student-selector"
+    And I wait until current URL contains "user_id="
+    And I wait until element "td:contains(Lesson Name)" is visible
+    And I wait until element "td:contains(Bubble Choice)" is visible
+    Then I verify progress for lesson 42 level 1 is "perfect"
+
     # View progress from BubbleChoice activity page
     Given I am on "http://studio.code.org/s/allthethings/lessons/40/levels/1"
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
+    Then I select the "Untitled Section" option in dropdown named "sections"
+    And check that the URL contains "section_id="
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -1,5 +1,4 @@
 Feature: BubbleChoice
-  @no_safari
   @no_mobile
   @properties_encryption_key
   Scenario: Viewing BubbleChoice progress
@@ -24,15 +23,6 @@ Feature: BubbleChoice
 
     # View student's BubbleChoice progress as a teacher
     When I sign in as "Teacher_Alice"
-
-    # View progress from script overview page
-    Given I am on "http://studio.code.org/s/allthethings"
-    And I wait until element ".teacher-panel" is visible
-    When I click selector ".teacher-panel table td:contains(Alice)" once I see it
-    And I wait until current URL contains "user_id="
-    And I wait until element "td:contains(Lesson Name)" is visible
-    And I wait until element "td:contains(Bubble Choice)" is visible
-    Then I verify progress for lesson 42 level 1 is "perfect"
 
     # View progress from BubbleChoice activity page
     Given I am on "http://studio.code.org/s/allthethings/lessons/40/levels/1"

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -42,8 +42,6 @@ Feature: BubbleChoice
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
     Then I select the "New Section" option in dropdown with class "uitest-sectionselect"
     And I wait for 5 seconds
-    And I wait for jquery to load
-    And check that the URL contains "section_id="
     Then I wait until element "a:contains(View Teacher Dashboard)" is visible
     And element ".teacher-panel td:eq(1)" contains text "Alice"
     And I click selector ".teacher-panel td:eq(1)" to load a new page

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -26,6 +26,7 @@ Feature: BubbleChoice
     When I sign in as "Teacher_Alice"
 
     # View progress from script overview page
+    Given I use a cookie to mock the DCDO key "teacher-local-nav-v2" as "true"
     Given I am on "http://studio.code.org/s/allthethings"
     And I wait until element "#uitest-view-as-student-selector" is visible
     Then I select the "Alice" option in dropdown "uitest-view-as-student-selector"


### PR DESCRIPTION
This failed Safari on test - I tested these changes locally on test and it seemed to go OK. 

Note, once merged in I will give the DOTD a heads up just in case it fails again.  Ideally I can do this after the deploy. 

