### PR TITLE
chore(workshops): clean up from workshop refactor launch

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -126,8 +126,6 @@ export interface WorkshopRequest
   id?: number;
   facilitators: number[];
   organizer_id: number | null;
-  // TODO: ACQ-3081 remove legacyForm2025 flag
-  legacyForm2025?: boolean | null;
 }
 
 export interface CourseOffering {

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/utils.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/utils.ts
@@ -85,7 +85,6 @@ export const workshopStateToApi = (
   course_offerings: workshop.courseOfferings.map(offering => Number(offering)),
   participant_group_type: workshop.participantGroupType || null,
   time_zone: workshop.timeZone || null,
-  legacyForm2025: null,
 });
 
 export const sessionStateToApi = (

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/utilsTest.ts
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/utilsTest.ts
@@ -359,7 +359,6 @@ describe('workshopStateToApi', () => {
       course_offerings: [1, 2, 3],
       participant_group_type: 'Test Group',
       time_zone: 'America/Denver',
-      legacyForm2025: null,
     };
 
     const apiFormat = workshopStateToApi(workshopState);
@@ -408,7 +407,6 @@ describe('workshopStateToApi', () => {
       course_offerings: [],
       participant_group_type: null,
       time_zone: 'America/Denver',
-      legacyForm2025: null,
     };
 
     const apiFormat = workshopStateToApi(workshopState);
@@ -457,7 +455,6 @@ describe('workshopStateToApi', () => {
       course_offerings: [],
       participant_group_type: null,
       time_zone: 'America/Denver',
-      legacyForm2025: null,
     };
 
     const apiFormat = workshopStateToApi(workshopState);

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -341,7 +341,6 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
       :hidden,
       :grades,
       :time_zone,
-      :legacyForm2025
     ]
 
     allowed_params.delete :regional_partner_id unless can_update_regional_partner

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -65,7 +65,6 @@ class Pd::Enrollment < ApplicationRecord
   before_validation :autoupdate_user_field
   before_save :set_application_id
   after_create :set_default_scholarship_info
-  after_save :enroll_in_corresponding_online_learning, if: -> {!deleted? && (saved_change_to_user_id? || saved_change_to_email?)}
   after_save :authorize_teacher_account
 
   serialized_attrs %w(
@@ -338,12 +337,6 @@ class Pd::Enrollment < ApplicationRecord
   protected def autoupdate_user_field
     resolved_user = resolve_user
     self.user = resolve_user if resolved_user
-  end
-
-  protected def enroll_in_corresponding_online_learning
-    if user && workshop.associated_online_course
-      Plc::UserCourseEnrollment.find_or_create_by(user: user, plc_course: workshop.associated_online_course)
-    end
   end
 
   protected def check_school_info(school_info_attr)

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -666,68 +666,6 @@ class Pd::Workshop < ApplicationRecord
     end
   end
 
-  def location_address_tba?
-    %w(tba tbd n/a).include?(location_address.try(:downcase))
-  end
-
-  def location_address_virtual?
-    ['virtual', 'virtual workshop'].include? location_address.try(:downcase)
-  end
-
-  def process_location
-    result = nil
-
-    unless location_address.blank? || location_address_tba? || location_address_virtual?
-      begin
-        Geocoder.with_errors do
-          # Geocoder can raise a number of errors including SocketError, with a common base of StandardError
-          # See https://github.com/alexreisner/geocoder#error-handling
-          Retryable.retryable(on: StandardError) do
-            result = Geocoder.search(location_address).try(:first)
-          end
-        end
-      rescue StandardError => exception
-        # Log geocoding errors to honeybadger but don't fail
-        Honeybadger.notify(exception,
-          error_message: 'Error geocoding workshop location_address',
-          context: {
-            pd_workshop_id: id,
-            location_address: location_address
-          }
-        )
-      end
-    end
-
-    unless result
-      self.processed_location = nil
-      return
-    end
-
-    self.processed_location = {
-      latitude: result.latitude,
-      longitude: result.longitude,
-      city: result.city,
-      state: result.state,
-      formatted_address: result.formatted_address
-    }.to_json
-  end
-
-  # Retrieve a single location value (like city or state) from the processed
-  # location hash. Attribute can be passed as a string or symbol
-  def get_processed_location_value(key)
-    return unless processed_location
-    location_hash = JSON.parse processed_location
-    location_hash[key.to_s]
-  end
-
-  def location_city
-    get_processed_location_value('city')
-  end
-
-  def location_state
-    get_processed_location_value('state')
-  end
-
   # Min number of days a teacher must attend for it to count.
   # @return [Integer]
   def min_attendance_days

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -387,12 +387,15 @@ class Pd::Workshop < ApplicationRecord
   end
 
   def friendly_name
-    start_time = sessions.empty? ? '' : sessions.first.start.strftime('%m/%d/%y')
+    first_session = sessions.first
+    start_time = first_session&.start&.strftime('%m/%d/%y')
+    session_location_name = first_session&.location_name
     course_title = name.presence || (subject ? "#{course} #{subject}" : course)
     course_title += ' workshop' unless course_title.downcase.end_with?('workshop')
 
     # Limit the friendly name to 255 chars
-    name = "#{course_title} on #{start_time} at #{location_name}"
+    name = "#{course_title} on #{start_time}"
+    name += " at #{session_location_name}" if session_location_name.present?
     name += " in #{friendly_location}" if friendly_location.present?
     name[0...255]
   end
@@ -421,10 +424,10 @@ class Pd::Workshop < ApplicationRecord
   # 3. known variant of TBA or no location address at all: 'Location TBA'
   # 4. unprocessable location that is not TBA: use user-entered string
   def friendly_location
-    return 'Virtual Workshop' if location_address_virtual? || virtual?
-    return "#{location_city} #{location_state}" if processed_location
-    return 'Location TBA' if location_address_tba? || !location_address.presence
-    return location_address
+    return 'Virtual Workshop' if virtual?
+    first_session = sessions.first
+    return 'Location TBA' unless first_session&.location_address.presence
+    return first_session.location_address
   end
 
   # Returns date and location (only date if no location specified)

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -394,7 +394,8 @@ class Pd::Workshop < ApplicationRecord
     course_title += ' workshop' unless course_title.downcase.end_with?('workshop')
 
     # Limit the friendly name to 255 chars
-    name = "#{course_title} on #{start_time}"
+    name = course_title.to_s
+    name += " on #{start_time}" if start_time.present?
     name += " at #{session_location_name}" if session_location_name.present?
     name += " in #{friendly_location}" if friendly_location.present?
     name[0...255]

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -74,11 +74,7 @@ class Pd::Workshop < ApplicationRecord
     # If true, our system will not send enrollees reminders related to this workshop.
     # If the subject is not in the MUST_SUPPRESS_EMAIL_SUBJECTS constant, this attribute
     # can be set to be true or false from the UI
-    'suppress_email',
-    # TODO: ACQ-3081
-    # temporary flag that skips some of the config based workshop validation if the
-    # flag indicating workshop is created or updated via the legacy form
-    'legacyForm2025'
+    'suppress_email'
   ]
 
   before_validation :sanitize_time_zone
@@ -89,15 +85,10 @@ class Pd::Workshop < ApplicationRecord
   validates_length_of :location_name, :location_address, maximum: 255
   validate :sessions_must_start_on_separate_days
   validate :subject_must_be_valid_for_course
-  # TODO: ACQ-3081 remove on_map & funded validation when we are ready to remove the legacy form
-  validates_inclusion_of :on_map, in: [true, false], if: :legacyForm2025?
-  validates_inclusion_of :funded, in: [true, false], if: :legacyForm2025?
-  validates_inclusion_of :third_party_provider, in: %w(friday_institute), allow_nil: true
   validate :not_funded_subjects_must_not_be_funded
   validate :valid_registration_link_format, if: :registration_link
-
-  validate :config_validation, unless: :legacyForm2025?
   validate :valid_grades
+  validate :config_validation
 
   validates :funding_type,
     inclusion: {in: FUNDING_TYPES, if: :funded_csf?},

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -82,7 +82,6 @@ class Pd::Workshop < ApplicationRecord
   validates_inclusion_of :course, in: COURSES
   validates :capacity, numericality: {only_integer: true, greater_than: 0, less_than: 10000}
   validates_length_of :notes, maximum: 65535
-  validates_length_of :location_name, :location_address, maximum: 255
   validate :sessions_must_start_on_separate_days
   validate :subject_must_be_valid_for_course
   validate :valid_registration_link_format, if: :registration_link
@@ -90,9 +89,6 @@ class Pd::Workshop < ApplicationRecord
   validate :config_validation
 
   before_create :set_registration_link
-
-  before_save :process_location, if: -> {location_address_changed?}
-  auto_strip_attributes :location_name, :location_address
 
   before_save :assign_regional_partner, if: -> {organizer_id_changed? && !regional_partner_id?}
   def assign_regional_partner

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -712,10 +712,6 @@ class Pd::Workshop < ApplicationRecord
     Rails.application.routes.url_helpers.pd_workshop_dashboard_url + "/workshops/#{id}"
   end
 
-  def associated_online_course
-    ::UnitGroup.find_by(name: WORKSHOP_COURSE_ONLINE_LEARNING_MAPPING[course]).try(:plc_course) if WORKSHOP_COURSE_ONLINE_LEARNING_MAPPING[course]
-  end
-
   # Get all the teachers that have actually attended this workshop via the attendence.
   def attending_teachers
     sessions.flat_map(&:attendances).flat_map(&:teacher).uniq

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -85,14 +85,9 @@ class Pd::Workshop < ApplicationRecord
   validates_length_of :location_name, :location_address, maximum: 255
   validate :sessions_must_start_on_separate_days
   validate :subject_must_be_valid_for_course
-  validate :not_funded_subjects_must_not_be_funded
   validate :valid_registration_link_format, if: :registration_link
   validate :valid_grades
   validate :config_validation
-
-  validates :funding_type,
-    inclusion: {in: FUNDING_TYPES, if: :funded_csf?},
-    absence: {unless: :funded_csf?}
 
   before_create :set_registration_link
 
@@ -114,12 +109,6 @@ class Pd::Workshop < ApplicationRecord
   def subject_must_be_valid_for_course
     unless SUBJECTS[course]&.include?(subject) || (!SUBJECTS[course] && !subject)
       errors.add(:subject, 'must be a valid option for the course')
-    end
-  end
-
-  def not_funded_subjects_must_not_be_funded
-    if NOT_FUNDED_SUBJECTS.include?(subject) && funded?
-      errors.add :properties, 'Admin/Counselor - Welcome workshop must not be funded'
     end
   end
 
@@ -866,10 +855,6 @@ class Pd::Workshop < ApplicationRecord
     course == COURSE_CSF && subject == SUBJECT_CSF_201
   end
 
-  def funded_csf?
-    course == COURSE_CSF && funded
-  end
-
   def future_or_current_teachercon_or_fit?
     [
       Pd::Workshop::SUBJECT_TEACHER_CON,
@@ -878,7 +863,11 @@ class Pd::Workshop < ApplicationRecord
       state != Pd::Workshop::STATE_ENDED
   end
 
+  # deprecated
   def funding_summary
+    # funded is no longer a required field
+    # new workshops will not have a funding_summary
+    return '' if funded.nil?
     (funded ? 'Yes' : 'No') + (funding_type.present? ? ": #{funding_type}" : '')
   end
 

--- a/dashboard/app/models/pd/workshop_constants.rb
+++ b/dashboard/app/models/pd/workshop_constants.rb
@@ -15,8 +15,6 @@ module Pd
       COURSE_CSP => CDO.code_org_url('/educate/csp'),
       COURSE_CSA => CDO.code_org_url('/educate/csa'),
       COURSE_CSD => CDO.code_org_url('/educate/csd'),
-      COURSE_CS_IN_S => CDO.code_org_url('/curriculum/science'),
-      COURSE_CS_IN_A => CDO.code_org_url('/educate/algebra'),
       COURSE_ECS => 'http://www.exploringcs.org/'
     }.freeze
 

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -347,7 +347,7 @@ module Api::V1::Pd
     test 'update appends to the timestamp log if summer workshop is changed' do
       summer_workshop = create :summer_workshop,
         sessions_from: Date.new(2019, 6, 1),
-        processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+        session_location_address: 'Orchard Park NY'
 
       sign_in @program_manager
       @csd_teacher_application_with_partner.update(status_timestamp_change_log: '[]')
@@ -371,7 +371,7 @@ module Api::V1::Pd
     test 'update does not append to the timestamp log if summer workshop is not changed' do
       summer_workshop = create :summer_workshop,
         sessions_from: Date.new(2019, 6, 1),
-        processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+        session_location_address: 'Orchard Park NY'
 
       sign_in @program_manager
       @csd_teacher_application_with_partner.update(status_timestamp_change_log: '[]')
@@ -563,7 +563,7 @@ module Api::V1::Pd
       Timecop.freeze(time) do
         workshop = create :summer_workshop,
           sessions_from: Date.new(2020, 1, 1),
-          processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+          session_location_address: 'Orchard Park NY'
         create :pd_enrollment, workshop: workshop, user: @serializing_teacher
 
         application = create(
@@ -654,7 +654,7 @@ module Api::V1::Pd
       Timecop.freeze(time) do
         workshop = create :summer_workshop,
           sessions_from: Date.new(2020, 1, 1),
-          processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+          session_location_address: 'Orchard Park NY'
         create :pd_enrollment, workshop: workshop, user: @serializing_teacher
 
         application = create(

--- a/dashboard/test/controllers/api/v1/pd/regional_partner_workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/regional_partner_workshops_controller_test.rb
@@ -25,7 +25,7 @@ module Api::V1::Pd
         [@program_manager, @partner_organizer, @non_partner_organizer].map do |organizer|
           [csd_options, csp_options].map do |course_options|
             create :workshop, organizer: organizer, num_sessions: 5, sessions_from: first_session_time,
-              location_address: 'Code.org, Seattle, WA', **course_options
+              session_location_address: 'Code.org, Seattle, WA', **course_options
           end
         end.flatten
 

--- a/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
@@ -60,8 +60,7 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
     create :pd_workshop_participant, workshop: @organizer_workshop, enrolled: true, attended: true
 
     # Non-CSF workshop from a different organizer
-    @other_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_ECS,
-      subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
+    @other_workshop = create :byo_workshop, :ended
   end
 
   [:admin, :workshop_organizer, :program_manager].each do |user_type|

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -447,30 +447,15 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
 
   test 'cannot update a Build Your Own Workshop without pl topics' do
     sign_in create :admin
-    session_start = tomorrow_at 9
-    session_end = session_start + 8.hours
-    byo_params =
+    workshop = create :pd_workshop, participant_group_type: 'Regional', course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, subject: nil, course_offerings: [] << (create :course_offering)
+    byo_params_with_nil_course_offerings =
       {
-        location_address: 'Seattle, WA',
-        on_map: true,
-        funded: false,
         course: Pd::Workshop::COURSE_BUILD_YOUR_OWN,
-        course_offerings: [] << (create :course_offering),
+        course_offerings: nil,
         subject: nil,
-        capacity: 10,
-        virtual: false,
-        suppress_email: false,
-        sessions_attributes: [
-          {
-            start: session_start,
-            end: session_end
-          }
-        ]
       }
 
-    workshop = create :pd_workshop, funded: false, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, subject: nil, course_offerings: [] << (create :course_offering)
-
-    put :update, params: {id: workshop.id, pd_workshop: byo_params.merge(course_offerings: nil)}
+    put :update, params: {id: workshop.id, pd_workshop: byo_params_with_nil_course_offerings}
     assert_response :bad_request
   end
 

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -16,18 +16,14 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
 
     @workshop = create(
       :workshop,
-      :funded,
       organizer: @organizer,
       facilitators: [@facilitator],
       regional_partner: @regional_partner,
-      on_map: true
     )
     @organizer_workshop = create(
       :workshop,
-      :funded,
       organizer: @workshop_organizer,
       facilitators: [@facilitator],
-      on_map: true,
       num_sessions: 0
     )
 

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -725,63 +725,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     }
   end
 
-  test 'updating virtual field in CSP/CSA summer workshop within a month of starting as a non-ws-admin raises error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @organizer
-    workshop = create :csp_summer_workshop, organizer: @organizer
-
-    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, funding_type: nil, virtual: true)}
-    assert_response :bad_request
-    assert_includes(response.body, 'non-workshop-admin cannot change CSP/CSA Summer Workshop virtual field within a month of it starting.')
-  end
-
-  test 'updating virtual field in CSP/CSA summer workshop within a month of starting as a ws-admin does not raise error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @workshop_admin
-    workshop = create :csp_summer_workshop, organizer: @organizer
-
-    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, funding_type: nil, virtual: true)}
-    assert_response :success
-  end
-
-  test 'updating virtual field in CSP/CSA summer workshop before a month of starting as a non-ws-admin does not raise error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @organizer
-
-    # Using '32.days' instead of '1.month' due to the inconsistency of the length of 'month' and it guarantees at least 1 month has passed.
-    session_start = (tomorrow_at 9) + 32.days
-    session_end = session_start + 8.hours
-    session = create :pd_session, start: session_start, end: session_end
-    workshop = create :workshop, workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, organizer: @organizer, funding_type: nil, sessions: [session])
-
-    put :update, params: {id: workshop.id, pd_workshop: {virtual: true}}
-
-    assert_response :success
-  end
-
-  test 'updating virtual field in CSP/CSA non-summer workshop within a month of starting as a non-ws-admin does not raise error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @organizer
-    workshop = create :csp_academic_year_workshop, organizer: @organizer
-
-    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1, funding_type: nil, virtual: true)}
-    assert_response :success
-  end
-
-  test 'updating virtual field in non-CSP/CSA summer workshop within a month of starting as a non-ws-admin does not raise error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @organizer
-    workshop = create :csd_summer_workshop, organizer: @organizer
-
-    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_SUMMER_WORKSHOP, funding_type: nil, virtual: true)}
-    assert_response :success
-  end
-
   # Update sessions via embedded attributes
 
   test 'organizers can add workshop sessions' do

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -1397,7 +1397,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
       capacity: 10,
       virtual: false,
       suppress_email: false,
-      legacyForm2025: true,
       sessions_attributes: [
         {
           start: session_start,

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -447,10 +447,9 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
 
   test 'cannot update a Build Your Own Workshop without pl topics' do
     sign_in create :admin
-    workshop = create :pd_workshop, participant_group_type: 'Regional', course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, subject: nil, course_offerings: [] << (create :course_offering)
+    workshop = create :byo_workshop
     byo_params_with_nil_course_offerings =
       {
-        course: Pd::Workshop::COURSE_BUILD_YOUR_OWN,
         course_offerings: nil,
         subject: nil,
       }

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -1389,14 +1389,14 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     session_end = session_start + 8.hours
     {
       location_address: 'Seattle, WA',
-      on_map: true,
-      funded: true,
-      funding_type: Pd::Workshop::FUNDING_TYPE_PARTNER,
       course: Pd::Workshop::COURSE_CSF,
       subject: Pd::Workshop::SUBJECT_CSF_101,
       capacity: 10,
       virtual: false,
       suppress_email: false,
+      name: 'Cool workshop',
+      description: 'This is a great workshop',
+      grades: ['K', '1'],
       sessions_attributes: [
         {
           start: session_start,

--- a/dashboard/test/controllers/pd/professional_learning_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_controller_test.rb
@@ -526,11 +526,11 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
     distant_rp_pm = create :program_manager, regional_partner: distant_rp
 
     test_course_offerings = [] << (create :course_offering)
-    nearby_regional_ws_1 = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: nearby_rp_pm_1
-    nearby_regional_ws_2 = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: nearby_rp_pm_2
-    nearby_national_ws = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'National', organizer: nearby_rp_pm_2
-    create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: distant_rp_pm
-    distant_national_ws = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'National', organizer: distant_rp_pm
+    nearby_regional_ws_1 = create :byo_workshop, organizer: nearby_rp_pm_1
+    nearby_regional_ws_2 = create :byo_workshop, course_offerings: test_course_offerings, organizer: nearby_rp_pm_2
+    nearby_national_ws = create :byo_workshop, course_offerings: test_course_offerings, participant_group_type: 'National', organizer: nearby_rp_pm_2
+    create :byo_workshop, course_offerings: test_course_offerings, organizer: distant_rp_pm
+    distant_national_ws = create :byo_workshop, course_offerings: test_course_offerings, participant_group_type: 'National', organizer: distant_rp_pm
 
     reg_ws_data_response = get :regional_workshop_data, params: {zip_code: "11111"}
     assert_response :success
@@ -547,9 +547,9 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
     rp.mappings.find_or_create_by!(zip_code: "11111")
     pm = create :program_manager, regional_partner: rp
     test_course_offerings = [] << (create :course_offering)
-    not_started_ws = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: pm
-    create :workshop, :in_progress, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: pm
-    create :workshop, :ended, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: pm
+    not_started_ws = create :byo_workshop, course_offerings: test_course_offerings, organizer: pm
+    create :byo_workshop, :in_progress, course_offerings: test_course_offerings, organizer: pm
+    create :byo_workshop, :ended, course_offerings: test_course_offerings, organizer: pm
 
     reg_ws_data_response = get :regional_workshop_data, params: {zip_code: "11111"}
     assert_response :success
@@ -566,9 +566,9 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
     rp.mappings.find_or_create_by!(zip_code: "11111")
     pm = create :program_manager, regional_partner: rp
     test_course_offerings = [] << (create :course_offering)
-    hidden_nil_ws = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: pm
-    hidden_false_ws = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: pm, hidden: false
-    create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: pm, hidden: true
+    hidden_nil_ws = create :byo_workshop, course_offerings: test_course_offerings, organizer: pm
+    hidden_false_ws = create :byo_workshop, course_offerings: test_course_offerings, organizer: pm, hidden: false
+    create :byo_workshop, course_offerings: test_course_offerings, organizer: pm, hidden: true
 
     reg_ws_data_response = get :regional_workshop_data, params: {zip_code: "11111"}
     assert_response :success
@@ -588,7 +588,7 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
     create :workshop, course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP, organizer: pm
     create :workshop, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP, organizer: pm
     create :workshop, course: Pd::Workshop::COURSE_CSA, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP, organizer: pm
-    byow = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, course_offerings: test_course_offerings, participant_group_type: 'Regional', organizer: pm
+    byow = create :byo_workshop, course_offerings: test_course_offerings, organizer: pm
 
     DCDO.stubs(:get).with('pl-teacher-application-off-season', false).returns(true)
 
@@ -629,7 +629,7 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
     create :workshop, course: Pd::Workshop::COURSE_CSA, subject: Pd::Workshop::SUBJECT_WORKSHOP_1, organizer: pm
 
     # Non-[CSD, CSP, CSA] workshop
-    byow = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, participant_group_type: 'Regional', course_offerings: test_course_offerings, organizer: pm
+    byow = create :byo_workshop, course_offerings: test_course_offerings, organizer: pm
 
     DCDO.stubs(:get).with('pl-teacher-application-off-season', false).returns(false)
 

--- a/dashboard/test/controllers/pd/professional_learning_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_controller_test.rb
@@ -32,7 +32,8 @@ class Pd::ProfessionalLearningControllerTest < ActionController::TestCase
 
   test 'Admin workshops do not show up as pending exit surveys' do
     # Fake Admin workshop, which should produce an exit survey
-    admin_workshop = create :admin_workshop, :ended
+    admin_workshop = build :admin_workshop, :ended
+    admin_workshop.save(validate: false)
 
     # Given a teacher that attended the workshop
     teacher = create :teacher

--- a/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
@@ -5,6 +5,7 @@ class Pd::WorkshopCertificateControllerTest < ActionController::TestCase
     @user = create :teacher
     sign_in(@user)
     @workshop = create :workshop, num_sessions: 1, course: Pd::Workshop::COURSE_CSD
+    @workshop.update_columns(name: nil)
     @enrollment = create :pd_enrollment, :with_attendance, workshop: @workshop
 
     facilitator_1 = create :facilitator, name: 'Facilitator 1'
@@ -42,6 +43,7 @@ class Pd::WorkshopCertificateControllerTest < ActionController::TestCase
 
   test 'Generates certificate for CSF 101 workshop' do
     workshop = create :csf_intro_workshop
+    workshop.update_columns(name: nil)
     enrollment = create :pd_enrollment, :with_attendance, workshop: workshop
 
     mock_image = expect_renders_certificate
@@ -82,7 +84,8 @@ class Pd::WorkshopCertificateControllerTest < ActionController::TestCase
     workshop = build :workshop,
       num_sessions: 1,
       course: Pd::Workshop::COURSE_CSD,
-      subject: Pd::Workshop::SUBJECT_CSD_TEACHER_CON
+      subject: Pd::Workshop::SUBJECT_CSD_TEACHER_CON,
+      name: nil
     # workshop subject is deprecated so validation must be skipped
     workshop.save(validate: false)
     enrollment = create :pd_enrollment, :with_attendance, workshop: workshop
@@ -106,7 +109,8 @@ class Pd::WorkshopCertificateControllerTest < ActionController::TestCase
     workshop = build :workshop,
       num_sessions: 1,
       course: Pd::Workshop::COURSE_CSP,
-      subject: Pd::Workshop::SUBJECT_CSP_TEACHER_CON
+      subject: Pd::Workshop::SUBJECT_CSP_TEACHER_CON,
+      name: nil
     # workshop subject is deprecated so validation must be skipped
     workshop.save(validate: false)
     enrollment = create :pd_enrollment, :with_attendance, workshop: workshop

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -542,12 +542,8 @@ module Pd
 
     private def setup_build_your_own_ended_workshop
       @regional_partner = create :regional_partner
-      @byo_workshop = create :pd_workshop,
+      @byo_workshop = create :byo_workshop,
         :ended,
-        funded: false,
-        course: Pd::Workshop::COURSE_BUILD_YOUR_OWN,
-        subject: nil,
-        course_offerings: [] << (create :course_offering),
         num_facilitators: 1
 
       @byo_enrollment = create :pd_enrollment, :from_user, workshop: @byo_workshop

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -122,8 +122,6 @@ FactoryBot.define do
 
       course {Pd::Workshop::COURSE_CSF}
       capacity {30}          # Average capacity
-      on_map {true}          # About 60% are on the map
-      funded               # About 90% are funded
       num_sessions {1}       # Most have 1 session
       num_facilitators {1}   # Most have 1 facilitator
       each_session_hours {7} # The most common session length
@@ -152,8 +150,6 @@ FactoryBot.define do
       csp
 
       capacity {30}          # Average capacity
-      on_map {false}         # Never on the map
-      funded               # More than half are funded
       num_facilitators {2}   # Most have 2 facilitators
 
       # Some specific academic year workshops are usually two days instead of one.
@@ -267,8 +263,6 @@ FactoryBot.define do
       course {Pd::Workshop::COURSE_FACILITATOR}
       subject {nil}
       capacity {100}         # Typical capacity
-      on_map {false}         # Never on map
-      funded {false}         # Never funded
       num_sessions {2}       # Most have 2 sessions
       num_facilitators {0}   # Most have no facilitators
       each_session_hours {8} # The most common session length
@@ -279,8 +273,6 @@ FactoryBot.define do
       subject {Pd::Workshop::SUBJECT_FIT}
       course {Pd::Workshop::COURSE_CSP} # CSD is also valid
       capacity {100}         # Typical capacity
-      on_map {false}         # Never on map
-      funded               # Sometimes funded (50%)
       num_sessions {2}       # Most have 2 sessions
       num_facilitators {2}   # Most have 2 facilitators
       each_session_hours {8} # The most common session length
@@ -290,8 +282,6 @@ FactoryBot.define do
       course {Pd::Workshop::COURSE_ADMIN}
       subject {nil}
       capacity {35}          # Average capacity
-      on_map {false}         # Never on map
-      funded               # More than half are funded
       num_sessions {1}       # Most have 1 session
       num_facilitators {0}   # Most have no facilitators
       each_session_hours {2} # The most common session length
@@ -301,8 +291,6 @@ FactoryBot.define do
       course {Pd::Workshop::COURSE_ADMIN_COUNSELOR}
       subject {Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_WELCOME}
       capacity {35}          # Average capacity
-      on_map {false}         # Never on map
-      funded {false}         # Never funded
       num_sessions {1}       # Most have 1 session
       num_facilitators {1}   # Want to work with facilitators
       each_session_hours {2} # Not sure on session length
@@ -312,11 +300,34 @@ FactoryBot.define do
       course {Pd::Workshop::COURSE_COUNSELOR}
       subject {nil}
       capacity {40}          # Average capacity
-      on_map {false}         # Never on map
-      funded               # All funded
       num_sessions {1}       # Most have 1 session
       num_facilitators {0}   # Most have no facilitators
       each_session_hours {6} # The most common session length
+    end
+
+    factory :byo_workshop do
+      course {Pd::Workshop::COURSE_BUILD_YOUR_OWN}
+      subject {nil}
+      participant_group_type {'Regional'}
+      capacity {40}          # Average capacity
+      num_sessions {1}       # Most have 1 session
+      num_facilitators {0}   # Most have no facilitators
+      each_session_hours {6} # The most common session length
+
+      transient do
+        course_offerings {[]} # Allow overriding course offerings
+      end
+
+      after(:build) do |workshop, evaluator|
+        if evaluator.course_offerings.empty?
+          # Create a default course offering if none are provided
+          workshop.course_offerings << build(:course_offering)
+        else
+          evaluator.course_offerings.each do |offering|
+            workshop.course_offerings << offering
+          end
+        end
+      end
     end
   end
 end

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -130,14 +130,14 @@ FactoryBot.define do
       # Our most common workshop type as of August 2019.
       trait :intro do
         subject {Pd::Workshop::SUBJECT_CSF_101}
-        location_name {'Walkerville Elementary School'}
+        session_location_name {'Walkerville Elementary School'}
       end
       factory(:csf_intro_workshop, aliases: [:csf_101_workshop]) {intro}
 
       # CSF Deep Dive, also known as CSF 201
       trait :deep_dive do
         subject {Pd::Workshop::SUBJECT_CSF_201}
-        location_name {'Third Street Elementary School'}
+        session_location_name {'Third Street Elementary School'}
       end
       factory(:csf_deep_dive_workshop, aliases: [:csf_201_workshop]) {deep_dive}
     end
@@ -173,7 +173,7 @@ FactoryBot.define do
       # CSP Academic Year Workshops
       trait :csp do
         course {Pd::Workshop::COURSE_CSP}
-        location_name {'Bayside High School'}
+        session_location_name {'Bayside High School'}
 
         # Possible subjects:
         # Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
@@ -189,7 +189,7 @@ FactoryBot.define do
       # CSD Academic Year Workshops
       trait :csd do
         course {Pd::Workshop::COURSE_CSD}
-        location_name {'Sunrise Middle School'}
+        session_location_name {'Sunrise Middle School'}
 
         # Possible subjects:
         # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
@@ -205,7 +205,7 @@ FactoryBot.define do
       # CSA Academic Year Workshops
       trait :csa do
         course {Pd::Workshop::COURSE_CSA}
-        location_name {'Greendale Community College'}
+        session_location_name {'Greendale Community College'}
 
         # Possible subjects:
         # Pd::Workshop::SUBJECT_CSA_WORKSHOP_1
@@ -224,7 +224,7 @@ FactoryBot.define do
       # CSP local summer workshop by default
       csp
 
-      location_name {'Greendale Community College'}
+      session_location_name {'Greendale Community College'}
       on_map {false}         # Never on the map
       funded {false}         # Less than half are funded
       num_facilitators {2}   # Most have 2 facilitators

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -34,7 +34,6 @@ FactoryBot.define do
     capacity {10}
     on_map {true}
     funded {false}
-    legacyForm2025 {true}
 
     #
     # Traits

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -28,12 +28,12 @@ FactoryBot.define do
     end
 
     association :organizer, factory: :workshop_organizer
-    location_name {'Hogwarts School of Witchcraft and Wizardry'}
     course {Pd::Workshop::COURSES.first}
     subject {Pd::Workshop::SUBJECTS[course].try(&:first)}
     capacity {10}
-    on_map {true}
-    funded {false}
+    name {'Cool workshop'}
+    description {'A really cool workshop'}
+    grades {['K', '1']}
 
     #
     # Traits

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -19,7 +19,9 @@ FactoryBot.define do
       virtual {false}
       num_facilitators {0}
       sessions_from {Time.zone.today + 9.hours} # Start time of the first session, then one per day after that.
-      session_location {nil}
+      session_location_name {nil}
+      session_location_address {nil}
+      session_meeting_link {nil}
       each_session_hours {6}
       num_enrollments {0}
       enrolled_and_attending_users {0}
@@ -76,7 +78,9 @@ FactoryBot.define do
             start: evaluator.sessions_from + i.days,
             duration_hours: evaluator.each_session_hours,
             session_format: evaluator.virtual ? 'virtual' : 'in_person',
-            location_name: evaluator.session_location
+            location_name: evaluator.session_location_name,
+            location_address: evaluator.session_location_address,
+            meeting_link: evaluator.session_meeting_link
           }]
           params.prepend :with_assigned_code if evaluator.assign_session_code
           workshop.sessions << build(:pd_session, *params)

--- a/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
@@ -70,11 +70,12 @@ module Pd::Payment
     test 'attendance' do
       # Create a workshop with 4 sessions, which will be capped at 3
       # TIME_CONSTRAINTS: COURSE_ECS => {SUBJECT_ECS_PHASE_4 => {min_days: 2, max_days: 3, max_hours: 18}}
-      workshop = create :workshop, :ended,
+      workshop = build :workshop, :ended,
         on_map: true, funded: true,
         course: Pd::Workshop::COURSE_ECS,
         subject: Pd::Workshop::SUBJECT_ECS_PHASE_4,
         num_sessions: 4
+      workshop.save(validate: false)
 
       # Attend 1 session, below min. Should count as 0.
       teacher_below_min_attendance = create :pd_workshop_participant, workshop: workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_district_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_district_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 module Pd::Payment
   class PaymentCalculatorDistrictTest < ActiveSupport::TestCase
     setup do
-      @workshop = build :workshop, :ended,
-        on_map: false, funded: false,
-        course: Pd::Workshop::COURSE_CS_IN_A,
-        subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2,
+      @workshop = create :workshop, :ended,
+        on_map: false,
+        funded: false,
         num_sessions: 3,
         num_facilitators: 2
-      @workshop.save(validate: false)
+
+      @workshop.update_columns(course: Pd::Workshop::COURSE_CS_IN_A, subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2)
 
       # One unqualified teacher, below min attendance
       create :pd_workshop_participant, workshop: @workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_district_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_district_test.rb
@@ -3,12 +3,13 @@ require 'test_helper'
 module Pd::Payment
   class PaymentCalculatorDistrictTest < ActiveSupport::TestCase
     setup do
-      @workshop = create :workshop, :ended,
+      @workshop = build :workshop, :ended,
         on_map: false, funded: false,
         course: Pd::Workshop::COURSE_CS_IN_A,
         subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2,
         num_sessions: 3,
         num_facilitators: 2
+      @workshop.save(validate: false)
 
       # One unqualified teacher, below min attendance
       create :pd_workshop_participant, workshop: @workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_standard_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_standard_test.rb
@@ -6,14 +6,13 @@ module Pd::Payment
 
     setup do
       # TIME_CONSTRAINTS: COURSE_ECS => {SUBJECT_ECS_PHASE_4 => {min_days: 2, max_days: 3, max_hours: 18}}
-      @workshop = build :workshop, :ended,
-        on_map: true, funded: true,
-        course: Pd::Workshop::COURSE_ECS,
-        subject: Pd::Workshop::SUBJECT_ECS_PHASE_4,
+      @workshop = create :workshop, :ended,
+        on_map: true,
+        funded: true,
         num_sessions: 3,
         num_facilitators: 2
 
-      @workshop.save(validate: false)
+      @workshop.update_columns(course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_4)
 
       # One unqualified teacher, below min attendance
       create :pd_workshop_participant, workshop: @workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_standard_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_standard_test.rb
@@ -6,12 +6,14 @@ module Pd::Payment
 
     setup do
       # TIME_CONSTRAINTS: COURSE_ECS => {SUBJECT_ECS_PHASE_4 => {min_days: 2, max_days: 3, max_hours: 18}}
-      @workshop = create :workshop, :ended,
+      @workshop = build :workshop, :ended,
         on_map: true, funded: true,
         course: Pd::Workshop::COURSE_ECS,
         subject: Pd::Workshop::SUBJECT_ECS_PHASE_4,
         num_sessions: 3,
         num_facilitators: 2
+
+      @workshop.save(validate: false)
 
       # One unqualified teacher, below min attendance
       create :pd_workshop_participant, workshop: @workshop,

--- a/dashboard/test/lib/pd/payment/payment_factory_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_factory_test.rb
@@ -3,11 +3,13 @@ require 'test_helper'
 module Pd::Payment
   class PaymentFactoryTest < ActiveSupport::TestCase
     test 'district calculator' do
-      workshop_cs_in_a = create :workshop, :ended, on_map: false, funded: false,
+      workshop_cs_in_a = build :workshop, :ended, on_map: false, funded: false,
         course: Pd::Workshop::COURSE_CS_IN_A, subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2
+      workshop_cs_in_a.save(validate: false)
 
-      workshop_cs_in_s = create :workshop, :ended, on_map: false, funded: false,
+      workshop_cs_in_s = build :workshop, :ended, on_map: false, funded: false,
         course: Pd::Workshop::COURSE_CS_IN_S, subject: Pd::Workshop::SUBJECT_CS_IN_S_PHASE_2
+      workshop_cs_in_s.save(validate: false)
 
       assert_equal PaymentCalculatorDistrict, PaymentFactory.get_calculator_class(workshop_cs_in_a)
       assert_equal PaymentCalculatorDistrict, PaymentFactory.get_calculator_class(workshop_cs_in_s)
@@ -23,16 +25,19 @@ module Pd::Payment
 
     test 'standard calculator' do
       # Mix of public and private types
-      workshop_ecs = create :workshop, :ended, on_map: false, funded: true,
+      workshop_ecs = build :workshop, :ended, on_map: false, funded: true,
         course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
+      workshop_ecs.save(validate: false)
 
       workshop_csp = create :csp_academic_year_workshop, :ended, on_map: true, funded: true
 
-      workshop_cs_in_a = create :workshop, :ended, on_map: false, funded: true,
+      workshop_cs_in_a = build :workshop, :ended, on_map: false, funded: true,
         course: Pd::Workshop::COURSE_CS_IN_A, subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2
+      workshop_cs_in_a.save(validate: false)
 
-      workshop_cs_in_s = create :workshop, :ended, on_map: true, funded: true,
+      workshop_cs_in_s = build :workshop, :ended, on_map: true, funded: true,
         course: Pd::Workshop::COURSE_CS_IN_S, subject: Pd::Workshop::SUBJECT_CS_IN_S_PHASE_2
+      workshop_cs_in_s.save(validate: false)
 
       assert_equal PaymentCalculatorStandard, PaymentFactory.get_calculator_class(workshop_ecs)
       assert_equal PaymentCalculatorStandard, PaymentFactory.get_calculator_class(workshop_csp)

--- a/dashboard/test/lib/pd/payment/workshop_summary_test.rb
+++ b/dashboard/test/lib/pd/payment/workshop_summary_test.rb
@@ -34,7 +34,8 @@ module Pd::Payment
     end
 
     test 'workshop summary reports nil for attendance count for all sessions attendance for admin workshop' do
-      @ended_admin_workshop = create :admin_workshop, :ended
+      @ended_admin_workshop = build :admin_workshop, :ended
+      @ended_admin_workshop.save(validate: false)
       @workshop_summary = WorkshopSummary.new(
         workshop: @ended_admin_workshop,
         pay_period: 'a pay period',

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -128,7 +128,6 @@ class WorkshopMailerTest < ActionMailer::TestCase
   test 'exit survey email links are complete urls' do
     test_cases = [
       {course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP},
-      {course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2},
       {course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_WORKSHOP_1},
       {course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1},
     ]
@@ -148,16 +147,9 @@ class WorkshopMailerTest < ActionMailer::TestCase
   test 'facilitator and organizer email links are complete urls' do
     csf_workshop = create :csf_intro_workshop
     csf_enrollment = create :pd_enrollment, workshop: csf_workshop
-    ecs_workshop = create :workshop, :ended, num_facilitators: 1, course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
-    ecs_enrollment = create :pd_enrollment, workshop: ecs_workshop
     mails = []
 
-    mails << Pd::WorkshopMailer.facilitator_enrollment_reminder(ecs_workshop.facilitators.first, ecs_workshop)
-    mails << Pd::WorkshopMailer.organizer_enrollment_reminder(ecs_workshop)
-    mails << Pd::WorkshopMailer.organizer_cancel_receipt(ecs_enrollment)
     mails << Pd::WorkshopMailer.organizer_cancel_receipt(csf_enrollment)
-    mails << Pd::WorkshopMailer.organizer_enrollment_receipt(ecs_enrollment)
-    mails << Pd::WorkshopMailer.organizer_should_close_reminder(ecs_workshop)
     mails << Pd::WorkshopMailer.organizer_should_close_reminder(csf_workshop)
     mails << Pd::WorkshopMailer.facilitator_detail_change_notification(csf_workshop.facilitators.first, csf_workshop)
     mails << Pd::WorkshopMailer.organizer_detail_change_notification(csf_workshop)
@@ -168,7 +160,6 @@ class WorkshopMailerTest < ActionMailer::TestCase
   test 'teacher cancel receipt links are complete urls' do
     test_cases = [
       {course: Pd::Workshop::COURSE_CSF, subject: Pd::Workshop::SUBJECT_CSF_101},
-      {course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2}
     ]
 
     test_cases.each do |test_case|
@@ -183,9 +174,6 @@ class WorkshopMailerTest < ActionMailer::TestCase
   test 'teacher enrollment receipt links are complete urls' do
     test_cases = [
       {course: Pd::Workshop::COURSE_ADMIN_COUNSELOR, subject: Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_SLP_INTRO},
-      {course: Pd::Workshop::COURSE_CS_IN_A, subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_3},
-      {course: Pd::Workshop::COURSE_CS_IN_S, subject: Pd::Workshop::SUBJECT_CS_IN_S_PHASE_3_SEMESTER_1},
-      {course: Pd::Workshop::COURSE_CS_IN_S, subject: Pd::Workshop::SUBJECT_CS_IN_S_PHASE_3_SEMESTER_2},
       {course: Pd::Workshop::COURSE_CSA, subject: Pd::Workshop::SUBJECT_CSA_WORKSHOP_1},
       {course: Pd::Workshop::COURSE_CSA, subject: Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP},
       {course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_WORKSHOP_1},
@@ -193,11 +181,6 @@ class WorkshopMailerTest < ActionMailer::TestCase
       {course: Pd::Workshop::COURSE_CSF, subject: Pd::Workshop::SUBJECT_CSF_101},
       {course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1},
       {course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP},
-      {course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_4},
-      {course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_UNIT_3},
-      {course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_UNIT_4},
-      {course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_UNIT_5},
-      {course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_UNIT_6},
     ]
 
     test_cases.each do |test_case|

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -139,12 +139,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     local_summer_workshop = create :csp_summer_workshop, :ended
     local_summer_enrollment = create :pd_enrollment, workshop: local_summer_workshop
 
-    byo_workshop = create :pd_workshop,
-      :ended,
-      funded: false,
-      course: Pd::Workshop::COURSE_BUILD_YOUR_OWN,
-      subject: nil,
-      course_offerings: [] << (create :course_offering)
+    byo_workshop = create :byo_workshop, :ended
     byo_enrollment = create :pd_enrollment, workshop: byo_workshop
 
     studio_url = ->(path) {CDO.studio_url(path, CDO.default_scheme)}
@@ -616,7 +611,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     teacher = create :teacher
     assert_empty teacher.permissions
 
-    workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_BUILD_YOUR_OWN
+    workshop = create :byo_workshop
     create :pd_enrollment, workshop: workshop, user: teacher
 
     assert teacher.permission? UserPermission::AUTHORIZED_TEACHER

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -495,10 +495,10 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     # professional learning landing page.
     # Root cause: WHERE subject != 'xyz' implicitly excludes rows where subject IS NULL too.
 
-    # Ended Admin workshop with attendance; Admin workshops have no subject.
-    admin_workshop = create :admin_workshop, :ended
-    expected_enrollment = create :pd_enrollment, workshop: admin_workshop
-    create :pd_attendance, session: admin_workshop.sessions.first, enrollment: expected_enrollment
+    # Ended byo workshop with attendance; byo workshops have no subject.
+    byo_workshop = create :byo_workshop, :ended
+    expected_enrollment = create :pd_enrollment, workshop: byo_workshop
+    create :pd_attendance, session: byo_workshop.sessions.first, enrollment: expected_enrollment
 
     assert_equal [expected_enrollment], Pd::Enrollment.with_surveys
   end

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -375,60 +375,6 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert_equal [enrollment], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
   end
 
-  test 'enrolling in class automatically enrolls in online learning' do
-    Pd::Workshop::WORKSHOP_COURSE_ONLINE_LEARNING_MAPPING.each do |course, plc_course_name|
-      workshop = create :workshop, course: course, subject: Pd::Workshop::SUBJECTS[course].first
-      plc_course = create :plc_course, name: plc_course_name
-      teacher = create :teacher
-      create :pd_enrollment, user: teacher, workshop: workshop
-
-      assert_equal 1, Plc::UserCourseEnrollment.where(user: teacher, plc_course: plc_course).size
-    end
-
-    workshop = create :workshop, course: 'Counselor'
-    teacher = create :teacher
-    assert_no_difference('Plc::UserCourseEnrollment.count') do
-      create :pd_enrollment, user: teacher, workshop: workshop
-    end
-  end
-
-  test 'enrolling in class, and then later having the user field updated enrolls in online learning' do
-    teacher = create :teacher
-    create :plc_course, name: 'ECS Support'
-    workshop = create :workshop, course: Pd::Workshop::COURSE_ECS
-    enrollment = create :pd_enrollment, user: nil, workshop: workshop
-
-    assert_creates Plc::UserCourseEnrollment do
-      enrollment.update(user: teacher)
-    end
-    assert_equal 'ECS Support', Plc::UserCourseEnrollment.find_by(user: teacher).plc_course.name
-  end
-
-  test 'enrolling in class while not logged in still associates the user' do
-    teacher = create :teacher
-    create :plc_course, name: 'ECS Support'
-    workshop = create :workshop, course: Pd::Workshop::COURSE_ECS
-
-    assert_creates Plc::UserCourseEnrollment do
-      create :pd_enrollment, user: nil, workshop: workshop, email: teacher.email
-    end
-
-    assert_equal 'ECS Support', Plc::UserCourseEnrollment.find_by(user: teacher).plc_course.name
-  end
-
-  test 'enrolling in class without an account creates enrollment when the user is created' do
-    create :plc_course, name: 'ECS Support'
-    workshop = create :workshop, course: Pd::Workshop::COURSE_ECS
-    user_email = "#{SecureRandom.hex}@code.org"
-    create :pd_enrollment, user: nil, email: user_email, workshop: workshop
-
-    teacher = assert_creates Plc::UserCourseEnrollment do
-      create(:teacher, email: user_email)
-    end
-
-    assert_equal 'ECS Support', Plc::UserCourseEnrollment.find_by(user: teacher).plc_course.name
-  end
-
   test 'attendance scopes' do
     workshop = create :workshop, num_sessions: 2
     teacher = create :teacher

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1650,27 +1650,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal nil, workshop.time_zone
   end
 
-  test 'config_validation is skipped when legacyForm2025 is true' do
-    workshop = build :pd_workshop, legacyForm2025: true
+  test 'workshop config_validation' do
+    workshop = build :pd_workshop
 
-    # Ensure the workshop is valid even if it would fail config_validation
-    assert workshop.valid?
-  end
-
-  test 'config_validation is called when legacyForm2025 is false' do
-    workshop = build :pd_workshop, legacyForm2025: false
-
-    # newly required fields missing in factory definition of workshop
-    refute workshop.valid?
-    assert_includes workshop.errors.full_messages, 'Please select at least one grade level'
-    assert_includes workshop.errors.full_messages, 'Name is required'
-    assert_includes workshop.errors.full_messages, 'Description is required'
-  end
-
-  test 'config_validation is called when legacyForm2025 is nil' do
-    workshop = build :pd_workshop, legacyForm2025: nil
-
-    # newly required fields missing in factory definition of workshop
     refute workshop.valid?
     assert_includes workshop.errors.full_messages, 'Please select at least one grade level'
     assert_includes workshop.errors.full_messages, 'Name is required'

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -356,14 +356,15 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     Pd::Workshop.process_ends
   end
 
-  test 'account_required_for_attendance?' do
+  # counselor_workshop and admin_workshop have been archived so it no longer passes validation
+  # create a regular workshop and update_columns without validating to test function
+  test 'account_required_for_attendance' do
     normal_workshop = create :workshop, :ended
     counselor_workshop = create :workshop, :ended
     counselor_workshop.update_columns(course: Pd::Workshop::COURSE_COUNSELOR, subject: nil)
     admin_workshop = create :workshop, :ended
     admin_workshop.update_columns(course: Pd::Workshop::COURSE_ADMIN, subject: nil)
-    admin_counselor_workshop = create :workshop, :ended
-    admin_counselor_workshop.update_columns(course: Pd::Workshop::COURSE_ADMIN_COUNSELOR, subject: Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_WELCOME)
+    admin_counselor_workshop = create :admin_counselor_workshop, :ended
 
     assert normal_workshop.account_required_for_attendance?
     refute counselor_workshop.account_required_for_attendance?

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1475,7 +1475,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'registration_link does not default to anything if applications are not required' do
-    workshop = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, subject: nil, course_offerings: [] << (create :course_offering)
+    workshop = create :byo_workshop
 
     assert_nil workshop.registration_link
   end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1575,14 +1575,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.valid?
   end
 
-  test 'workshops third_party_provider must be nil or from specified list' do
-    workshop = build :workshop, third_party_provider: 'unknown_pd_provider'
-    refute workshop.valid?
-
-    workshop.third_party_provider = nil
-    assert workshop.valid?
-  end
-
   test 'CSP summer workshop must require teacher application' do
     workshop = create :csp_summer_workshop, regional_partner: @regional_partner
     assert workshop.require_application?

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -358,9 +358,12 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'account_required_for_attendance?' do
     normal_workshop = create :workshop, :ended
-    counselor_workshop = create :counselor_workshop, :ended
-    admin_workshop = create :admin_workshop, :ended
-    admin_counselor_workshop = create :admin_counselor_workshop, :ended
+    counselor_workshop = create :workshop, :ended
+    counselor_workshop.update_columns(course: Pd::Workshop::COURSE_COUNSELOR, subject: nil)
+    admin_workshop = create :workshop, :ended
+    admin_workshop.update_columns(course: Pd::Workshop::COURSE_ADMIN, subject: nil)
+    admin_counselor_workshop = create :workshop, :ended
+    admin_counselor_workshop.update_columns(course: Pd::Workshop::COURSE_ADMIN_COUNSELOR, subject: Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_WELCOME)
 
     assert normal_workshop.account_required_for_attendance?
     refute counselor_workshop.account_required_for_attendance?
@@ -378,7 +381,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_exit_surveys with attendance but no account gets email for counselor or admin' do
-    workshop = create :counselor_workshop, :ended
+    workshop = create :workshop, :ended
+    workshop.update_columns(course: Pd::Workshop::COURSE_COUNSELOR, subject: nil)
 
     enrollment = create :pd_enrollment, workshop: workshop
     create :pd_attendance_no_account, session: workshop.sessions.first, enrollment: enrollment

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -524,17 +524,14 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'friendly name' do
-    Geocoder.expects(:search).returns([])
     workshop = create :pd_workshop,
       course: Pd::Workshop::COURSE_BUILD_YOUR_OWN,
       subject: nil,
       name: "Test Workshop",
       course_offerings: [] << (create :course_offering),
       num_facilitators: 1,
-      location_name: 'Code.org',
-      location_address: 'Seattle, WA',
       participant_group_type: 'Regional',
-      sessions: [create(:pd_session, start: Date.new(2016, 9, 1))]
+      sessions: [create(:pd_session, start: Date.new(2016, 9, 1), location_name: 'Code.org', location_address: 'Seattle, WA', session_format: 'in_person')]
 
     # with name ending in 'Workshop'
     assert_equal 'Test Workshop on 09/01/16 at Code.org in Seattle, WA', workshop.friendly_name
@@ -544,15 +541,15 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal 'New Name workshop on 09/01/16 at Code.org in Seattle, WA', workshop.friendly_name
 
     # with course that doesn't require a name, and no subject
-    workshop.update!(course: Pd::Workshop::COURSE_ADMIN, name: '')
+    workshop.update_columns(course: Pd::Workshop::COURSE_ADMIN, name: '')
     assert_equal 'Admin workshop on 09/01/16 at Code.org in Seattle, WA', workshop.friendly_name
 
     # with subject
-    workshop.update!(course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_UNIT_5)
+    workshop.update_columns(course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_UNIT_5)
     assert_equal 'Exploring Computer Science Unit 5 - Data workshop on 09/01/16 at Code.org in Seattle, WA', workshop.friendly_name
 
     # truncated at 255 chars
-    workshop.update!(location_name: "blah" * 60)
+    workshop.sessions.first.update!(location_name: "blah" * 60)
     assert workshop.friendly_name.start_with? 'Exploring Computer Science Unit 5 - Data workshop on 09/01/16 at blahblahblah'
     assert workshop.friendly_name.length == 255
   end
@@ -1228,12 +1225,12 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'friendly_location with no location returns tba' do
-    workshop = build :workshop, location_address: '', processed_location: nil
+    workshop = build :workshop
     assert_equal 'Location TBA', workshop.friendly_location
   end
 
   test 'friendly_location with virtual location' do
-    workshop = build :workshop, location_address: 'virtual', processed_location: nil
+    workshop = build :workshop, virtual: true
     assert_equal 'Virtual Workshop', workshop.friendly_location
   end
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1196,8 +1196,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'date_and_location_name with no location but with sessions' do
-    workshop = build :workshop, num_sessions: 5, sessions_from: Date.new(2017, 3, 30),
-      processed_location: nil
+    workshop = build :workshop, num_sessions: 5, sessions_from: Date.new(2017, 3, 30)
 
     assert_equal 'March 30 - April 3, 2017, Location TBA', workshop.date_and_location_name
   end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1250,68 +1250,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal regional_partner, workshop.regional_partner
   end
 
-  test 'csf funded workshops require a funding type' do
-    workshop = build :workshop, course: Pd::Workshop::COURSE_CSF,
-      funded: true, funding_type: nil
-    refute workshop.valid?
-
-    workshop.funding_type = Pd::Workshop::FUNDING_TYPE_FACILITATOR
-    assert workshop.valid?
-  end
-
-  test 'csf unfunded workshops do not accept a funding type' do
-    workshop = build :workshop, course: Pd::Workshop::COURSE_CSF,
-      funded: false, funding_type: Pd::Workshop::FUNDING_TYPE_FACILITATOR
-    refute workshop.valid?
-
-    workshop.funding_type = nil
-    assert workshop.valid?
-  end
-
-  test 'non-csf workshops do not accept a funding type' do
-    [
-      [{funded: true, funding_type: Pd::Workshop::FUNDING_TYPE_FACILITATOR}, false],
-      [{funded: false, funding_type: Pd::Workshop::FUNDING_TYPE_FACILITATOR}, false],
-      [{funded: true, funding_type: nil}, true],
-      [{funded: false, funding_type: nil}, true]
-    ].each do |params, expected_validity|
-      workshop = build :workshop, course: Pd::Workshop::COURSE_CSP, **params
-      assert_equal(
-        expected_validity,
-        workshop.valid?,
-        "Expected #{params} to be #{expected_validity ? 'valid' : 'invalid'}"
-      )
-    end
-  end
-
-  test 'funded_friendly_name' do
-    [
-      [
-        {funded: false},
-        'No'
-      ],
-      [
-        {course: Pd::Workshop::COURSE_CSP, funded: true},
-        'Yes'
-      ],
-      [
-        {course: Pd::Workshop::COURSE_CSF, funded: true, funding_type: Pd::Workshop::FUNDING_TYPE_PARTNER},
-        'Yes: partner'
-      ],
-      [
-        {course: Pd::Workshop::COURSE_CSF, funded: true, funding_type: Pd::Workshop::FUNDING_TYPE_FACILITATOR},
-        'Yes: facilitator'
-      ]
-    ].each do |params, expected|
-      workshop = build :workshop, **params
-      assert_equal(
-        expected,
-        workshop.funding_summary,
-        "Expected #{params} funded_friendly_name to be #{expected}"
-      )
-    end
-  end
-
   test 'nearest' do
     target = create :workshop, sessions_from: Time.zone.today + 1.week
 
@@ -1459,17 +1397,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.valid?
 
     workshop.suppress_email = true
-    assert workshop.valid?
-  end
-
-  test 'EIR:Admin/Counselor Welcome workshop must not be funded' do
-    workshop = build :admin_counselor_workshop, course: COURSE_ADMIN_COUNSELOR
-
-    workshop.subject = SUBJECT_ADMIN_COUNSELOR_WELCOME
-    workshop.funded = true
-    refute workshop.valid?
-
-    workshop.funded = false
     assert workshop.valid?
   end
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1643,7 +1643,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'workshop config_validation' do
-    workshop = build :pd_workshop
+    workshop = build :pd_workshop, grades: nil, name: nil, description: nil
 
     refute workshop.valid?
     assert_includes workshop.errors.full_messages, 'Please select at least one grade level'

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -317,14 +317,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'end workshop sends exit surveys to facilitators for Build Your Own workshops' do
-    byo_workshop = create :pd_workshop,
+    byo_workshop = create :byo_workshop,
       :ended,
-      funded: false,
-      course: Pd::Workshop::COURSE_BUILD_YOUR_OWN,
-      subject: nil,
-      course_offerings: [] << (create :course_offering),
-      num_facilitators: 1,
-      participant_group_type: 'Regional'
+      num_facilitators: 1
     byo_workshop.start!
 
     Pd::Workshop.any_instance.expects(:send_exit_surveys)
@@ -529,13 +524,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'friendly name' do
-    workshop = create :pd_workshop,
-      course: Pd::Workshop::COURSE_BUILD_YOUR_OWN,
-      subject: nil,
+    workshop = create :byo_workshop,
       name: "Test Workshop",
-      course_offerings: [] << (create :course_offering),
       num_facilitators: 1,
-      participant_group_type: 'Regional',
       sessions: [create(:pd_session, start: Date.new(2016, 9, 1), location_name: 'Code.org', location_address: 'Seattle, WA', session_format: 'in_person')]
 
     # with name ending in 'Workshop'

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1078,66 +1078,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     refute @workshop.organizer_or_facilitator?(another_facilitator)
   end
 
-  test 'process_location is called when location_address changes' do
-    @workshop.expects(:process_location).once
-    @workshop.update!(location_address: '1501 4th Ave, Seattle WA')
-
-    # Changing another field does not process location
-    @workshop.expects(:process_location).never
-    @workshop.update!(location_name: 'Code.org')
-
-    # Setting location_address to the same value does not process location
-    @workshop.expects(:process_location).never
-    @workshop.update!(location_address: '1501 4th Ave, Seattle WA')
-  end
-
-  test 'process_location' do
-    mock_geocoder_result = [
-      OpenStruct.new(
-        latitude: 47.610183,
-        longitude: -122.337401,
-        city: 'Seattle',
-        state: 'WA',
-        formatted_address: '1501 4th Ave, Seattle, WA 98101, USA'
-      )
-    ]
-    expected_processed_location = '{"latitude":47.610183,"longitude":-122.337401,"city":"Seattle","state":"WA","formatted_address":"1501 4th Ave, Seattle, WA 98101, USA"}'
-    Honeybadger.expects(:notify).never
-
-    # Normal lookup
-    Geocoder.expects(:search).with('1501 4th Ave, Seattle WA').returns(mock_geocoder_result)
-    @workshop.location_address = '1501 4th Ave, Seattle WA'
-    @workshop.process_location
-    assert_equal expected_processed_location, @workshop.processed_location
-
-    # Nonexistent location clears processed_location
-    Geocoder.expects(:search).with('nonexistent location').returns([])
-    @workshop.location_address = 'nonexistent location'
-    @workshop.process_location
-    assert_nil @workshop.processed_location
-
-    # Don't bother looking up blank addresses, TBA/TBDs, or virtual locations
-    ['', 'tba', 'TBA', 'tbd', 'N/A', 'virtual', 'Virtual workshop'].each do |address|
-      Geocoder.expects(:search).never
-      @workshop.location_address = address
-      @workshop.process_location
-      assert_nil @workshop.processed_location
-    end
-
-    # Retry on errors
-    Geocoder.expects(:search).with('1501 4th Ave, Seattle WA').raises(SocketError).then.returns(mock_geocoder_result).twice
-    @workshop.location_address = '1501 4th Ave, Seattle WA'
-    @workshop.process_location
-    assert_equal expected_processed_location, @workshop.processed_location
-
-    # Repeated errors are logged to honeybadger
-    Honeybadger.expects(:notify).once
-    Geocoder.expects(:search).with('1501 4th Ave, Seattle WA').raises(SocketError).twice
-    @workshop.location_address = '1501 4th Ave, Seattle WA'
-    @workshop.process_location
-    assert_nil @workshop.processed_location
-  end
-
   test 'suppress_reminders? is true for certain subjects by default' do
     suppressed = [
       # workshop subject is deprecated so validation must be skipped
@@ -1262,21 +1202,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal 'March 30 - April 3, 2017', workshop.friendly_date_range
   end
 
-  test 'date_and_location_name with processed location and sessions' do
-    workshop = build :workshop, num_sessions: 5, sessions_from: Date.new(2017, 3, 30),
-      processed_location: {city: 'Seattle', state: 'WA'}.to_json
-
-    assert_equal 'March 30 - April 3, 2017, Seattle WA', workshop.date_and_location_name
-  end
-
-  test 'date_and_location_name with processed location but no sessions' do
-    workshop = build :workshop,
-      processed_location: {city: 'Seattle', state: 'WA'}.to_json,
-      num_sessions: 0
-
-    assert_equal 'Dates TBA, Seattle WA', workshop.date_and_location_name
-  end
-
   test 'date_and_location_name with no location but with sessions' do
     workshop = build :workshop, num_sessions: 5, sessions_from: Date.new(2017, 3, 30),
       processed_location: nil
@@ -1285,48 +1210,21 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'date_and_location_name with no location nor sessions' do
-    workshop = create :workshop, processed_location: nil, num_sessions: 0
+    workshop = create :workshop, num_sessions: 0
 
     assert_equal 'Dates TBA, Location TBA', workshop.date_and_location_name
   end
 
   test 'date_and_location_name for teachercon' do
-    workshop = build :workshop, :teachercon, num_sessions: 5, sessions_from: Date.new(2017, 3, 30),
-      processed_location: {city: 'Seattle', state: 'WA'}.to_json
+    workshop = build :workshop, :teachercon, num_sessions: 5, sessions_from: Date.new(2017, 3, 30), session_location_address: 'Seattle WA'
 
     assert_equal 'March 30 - April 3, 2017, Seattle WA TeacherCon', workshop.date_and_location_name
   end
 
   test 'date_and_location_name with virtual location and sessions' do
-    workshop = build :workshop, num_sessions: 5, sessions_from: Date.new(2017, 3, 30),
-      location_address: 'virtual'
-    workshop.process_location
+    workshop = build :workshop, num_sessions: 5, sessions_from: Date.new(2017, 3, 30), virtual: true
 
     assert_equal 'March 30 - April 3, 2017, Virtual Workshop', workshop.date_and_location_name
-  end
-
-  test 'date_and_location_name with virtual location but no sessions' do
-    workshop = build :workshop, num_sessions: 0, sessions_from: Date.new(2017, 3, 30),
-      location_address: 'virtual'
-    workshop.process_location
-
-    assert_equal 'Dates TBA, Virtual Workshop', workshop.date_and_location_name
-  end
-
-  test 'friendly_location TBA' do
-    workshop = build :workshop, location_address: 'tba'
-    assert_equal 'Location TBA', workshop.friendly_location
-  end
-
-  test 'friendly_location with a city and state' do
-    workshop = build :workshop, location_address: 'Seattle, WA',
-      processed_location: {city: 'Seattle', state: 'WA'}.to_json
-    assert_equal 'Seattle WA', workshop.friendly_location
-  end
-
-  test 'friendly_location with an unprocessable location address returns the address as entered' do
-    workshop = build :workshop, location_address: 'my custom unprocessable location', processed_location: nil
-    assert_equal 'my custom unprocessable location', workshop.friendly_location
   end
 
   test 'friendly_location with no location returns tba' do

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -579,7 +579,7 @@ And(/^I create a workshop for course "([^"]*)" ([a-z]+) by "([^"]*)" with (\d+) 
       course: course,
       organizer_id: organizer.id,
       capacity: number.to_i,
-      session_location: 'Buffalo',
+      session_location_name: 'Buffalo',
       num_sessions: 1,
       sessions_from: Date.new(2018, 4, 1),
       enrolled_and_attending_users: number_type == 'people' ? number.to_i : 0


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Model updates:
- Removes legacy workshop validation
  - workshop `location_name` length limit of 255 characters removed
  - `on_map`
  - `funded`
  - `funding_type`
  - `third_party_provider`
  - `not_funded_subjects_must_not_be_funded`
- Removes `legacyForm2025` serialized attribute and conditional validation that depends on it
- Remove `enroll_in_corresponding_online_learning` function called in enrollment.rb after save hook, that was for archived workshop courses
- Removes `associated_online_course` function from workshop.rb, used in `enroll_in_corresponding_online_learning` in enrollment model
- Remove `process_location` function called in workshop model `before_save`
- Update workshop `friendly_name` and `friendly_location` to use first session's location data
- Remove unused workshop `funded_csf?` function
- Deprecate workshop `funding_summary` so new workshops with nil `funded` attribute return an empty string but old workshops still have the summary
- Remove unused `workshop_constants`, including links that return 404s for `/curriculum/science` and `/educate/algebra`, as well as `FUNDING_TYPES` and `WORKSHOP_COURSE_ONLINE_LEARNING_MAPPING`

Testing:
- Updates the workshop factory, removing deprecated attributes and adding newly required ones
- Adds transient attributes to the factory for session location data, rather than workshop location
- If a workshop created in a test is archived, like `COURSE_ECS`, attempts to replace it with an active workshop
- If the logic is specific to an archived course, either delete the test or build the workshop and save it without validating the model 
  - `workshop.save(validate: false)`
  - or `workshop.update_columns(...)` if the test depends on the workshop factory's `after_create` hook, like tests that also create workshop facilitators
- Remove tests around changing the workshop's virtual attribute, which has been deprecated
- Adds a `byo_workshop` trait to the workshop factory for convenience
- Removes mailer tests for archived workshops

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3081
- Jira: https://codedotorg.atlassian.net/browse/ACQ-3216

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
