### PR TITLE
fix(marketing): remove directory field and update image carousel on all-the-things json

### DIFF
--- a/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
@@ -7671,7 +7671,7 @@
                 "cfHorizontalAlignment": {
                   "type": "DesignValue",
                   "valuesByBreakpoint": {
-                    "desktop": "center"
+                    "desktop": "start"
                   }
                 },
                 "cfVisibility": {
@@ -7707,7 +7707,7 @@
                 "cfHeight": {
                   "type": "DesignValue",
                   "valuesByBreakpoint": {
-                    "desktop": "1720px"
+                    "desktop": "1730px"
                   }
                 },
                 "cfMaxWidth": {

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
@@ -4,9 +4,6 @@
       "title": {
         "en-US": "❌ [ENGINEERING ONLY] UI Integration Testing"
       },
-      "directory": {
-        "en-US": "None"
-      },
       "slug": {
         "en-US": "/engineering/all-the-things"
       },

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/7Gumifs6ZTcj2G02BUoqFz.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/7Gumifs6ZTcj2G02BUoqFz.json
@@ -53,9 +53,6 @@
       },
       "duration": {
         "en-US": 1
-      },
-      "publishedDate": {
-        "en-US": "2025-05-16"
       }
     }
   },


### PR DESCRIPTION
Removes the directory field from the all the things page to match what's in prod.