### PR TITLE
Python Lab: Minimum validation duration

### DIFF
--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -43,7 +43,7 @@ import ValidationResults from './ValidationResults';
 
 import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.module.scss';
 
-const MINIMUM_VALIDATION_TIME = 1500; // 1 second
+const MINIMUM_VALIDATION_TIME = 1500; // 1.5 seconds
 
 interface InstructionsProps {
   /** Additional callback to fire before navigating to the next level. */

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -43,6 +43,8 @@ import ValidationResults from './ValidationResults';
 
 import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.module.scss';
 
+const MINIMUM_VALIDATION_TIME = 1500; // 1 second
+
 interface InstructionsProps {
   /** Additional callback to fire before navigating to the next level. */
   beforeNextLevel?: () => void;
@@ -167,9 +169,10 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
         scriptId: scriptId,
         interaction: UserLevelInteractions.click_validate,
       });
-      onRun(true, dispatch, source).finally(() =>
-        dispatch(setIsValidating(false))
-      );
+      Promise.allSettled([
+        onRun(true, dispatch, source),
+        new Promise(resolve => setTimeout(resolve, MINIMUM_VALIDATION_TIME)),
+      ]).then(() => dispatch(setIsValidating(false)));
       dispatch(setHasValidated(true));
       dispatch(setShowSuggestedPrompts(true));
     } else {


### PR DESCRIPTION
Before this change, running validation in Python Lab could finish very quickly, causing the red "Stop validation" button to appear too briefly to see properly.  This change proposes a minimum duration for the validation to prevent the UI from flashing so quickly.

### before

https://github.com/user-attachments/assets/b3e68164-0818-4f62-9223-9ccb3db99ced

### after

https://github.com/user-attachments/assets/0b8163be-dd4c-4d84-b816-3efec0a30ac5
