### PR TITLE
fix: Automated merge branch already exists

### DIFF
--- a/bin/cron/deploy_to_test
+++ b/bin/cron/deploy_to_test
@@ -27,12 +27,11 @@ def main
     head: 'staging',
     title: 'DTT (Staging > Test) [robo-dtt]'
   )
-  if pr_number.nil?
+  if pr_number.nil?å
     raise Exception.new('DepoyToTest::Unable to find or create a Pull Request that merges the staging branch into the test branch.')
   end
-  
   unless GitHub.merge_pull_request(pr_number)
-    raise Exception.new("DepoyToTest::Failed to merge Pull Request #{pr_number"')
+    raise Exception.new("DepoyToTest::Failed to merge Pull Request #{pr_number}")
   end
 
   ChatClient.message(

--- a/bin/cron/deploy_to_test
+++ b/bin/cron/deploy_to_test
@@ -28,11 +28,11 @@ def main
     title: 'DTT (Staging > Test) [robo-dtt]'
   )
   if pr_number.nil?
-    raise Exception.new('GitHub.find_or_create_pull_request failed.')
+    raise Exception.new('DepoyToTest::Unable to find or create a Pull Request that merges the staging branch into the test branch.')
   end
   
   unless GitHub.merge_pull_request(pr_number)
-    raise Exception.new('GitHub.merge_pull_request Failed to merge pull request.')
+    raise Exception.new("DepoyToTest::Failed to merge Pull Request #{pr_number"')
   end
 
   ChatClient.message(

--- a/bin/cron/deploy_to_test
+++ b/bin/cron/deploy_to_test
@@ -22,13 +22,17 @@ def main
 
   # TODO(asher): Add a reviewer (namely the next DOTD), add appropriate tags
   # (particularly deploy).
-  pr_number = GitHub.create_and_merge_pull_request(
+  pr_number = GitHub.find_or_create_pull_request(
     base: 'test',
     head: 'staging',
     title: 'DTT (Staging > Test) [robo-dtt]'
   )
   if pr_number.nil?
-    raise Exception.new('GitHub.create_and_merge_pull_request failed.')
+    raise Exception.new('GitHub.find_or_create_pull_request failed.')
+  end
+  
+  unless GitHub.merge_pull_request(pr_number)
+    raise Exception.new('GitHub.merge_pull_request Failed to merge pull request.')
   end
 
   ChatClient.message(

--- a/bin/cron/deploy_to_test
+++ b/bin/cron/deploy_to_test
@@ -27,9 +27,6 @@ def main
     head: 'staging',
     title: 'DTT (Staging > Test) [robo-dtt]'
   )
-  if pr_number.nil?å
-    raise Exception.new('DepoyToTest::Unable to find or create a Pull Request that merges the staging branch into the test branch.')
-  end
   unless GitHub.merge_pull_request(pr_number)
     raise Exception.new("DepoyToTest::Failed to merge Pull Request #{pr_number}")
   end


### PR DESCRIPTION
Automated merge of staging branch into test branch should not fail when Pull Request already exists

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
https://codedotorg.atlassian.net/browse/INF-1468

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
