### PR TITLE
[Google Blockly] Fix overlap logic

### DIFF
--- a/apps/src/blockly/addons/cdoSerializationHelpers.ts
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.ts
@@ -535,12 +535,14 @@ export function cleanUp(
     let collider = getCollider(block);
 
     const {viewWidth} = workspace.getMetrics();
-    const maximumX = viewWidth - SPACE_BETWEEN_BLOCKS;
+    const maximumX = viewWidth - WORKSPACE_PADDING;
     const blockOutOfBounds = workspace.RTL
       ? collider.x - collider.width < 0
       : collider.x + collider.width > maximumX;
     if (blockOutOfBounds) {
-      x = workspace.RTL ? collider.width : maximumX - collider.width;
+      x = workspace.RTL
+        ? Math.min(collider.width, maximumX)
+        : Math.max(maximumX - collider.width, WORKSPACE_PADDING);
       block.moveTo(new Blockly.utils.Coordinate(x, y));
       collider = getCollider(block);
     }


### PR DESCRIPTION
This is a fix forward to:
- https://github.com/code-dot-org/code-dot-org/pull/65913

With this, we will prevent a block from pushing into workspace padding if its right end is out of the view area.

This was potentially related to consistent failures with a UI test for smaller screens:
- https://saucelabs.com/tests/7794fd11919b4378956ae87b168a0e7f
- https://app.saucelabs.com/tests/9cd5c082c19c4a57bea00a01aaeac120#216

**Before:**
![image](https://github.com/user-attachments/assets/e4838d3e-ade7-48a0-8bd2-1407ed2382a6)


**After:**
![image](https://github.com/user-attachments/assets/08091f70-a80a-4a6a-8843-e0c94cd25cba)


## Links


https://codedotorg.slack.com/archives/C03DBDN67B7/p1747667049825089
