### PR TITLE
[Lab2] Add userSharingDisabled to currentUserRedux

### DIFF
--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -76,18 +76,6 @@ export function getAppOptionsViewingExemplar(): boolean | undefined {
     return appOptions.isViewingExemplar;
   }
 }
-
-/**
- * Returns the value of userSharingDisabled provided by App Options, if available.
- * This can be used to tell if the current user has sharing disabled for advanced projects.
- */
-export function getAppOptionsUserSharingDisabled(): boolean | undefined {
-  if (hasScriptData('script[data-appoptions]')) {
-    const appOptions = getScriptData('appoptions') as PartialAppOptions;
-    return appOptions.userSharingDisabled;
-  }
-}
-
 /**
  * Returns if the lab should presented in a share/play-only view,
  * if present in App Options. Only used in standalone project levels.

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -14,7 +14,6 @@ export interface PartialAppOptions {
   isEditingExemplar: boolean;
   isViewingExemplar: boolean;
   publicCaching: boolean;
-  userSharingDisabled: boolean;
 }
 
 /**

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -14,6 +14,7 @@ export interface PartialAppOptions {
   isEditingExemplar: boolean;
   isViewingExemplar: boolean;
   publicCaching: boolean;
+  userSharingDisabled: boolean;
 }
 
 /**
@@ -75,6 +76,18 @@ export function getAppOptionsViewingExemplar(): boolean | undefined {
     return appOptions.isViewingExemplar;
   }
 }
+
+/**
+ * Returns the value of userSharingDisabled provided by App Options, if available.
+ * This can be used to tell if the current user has sharing disabled for advanced projects.
+ */
+export function getAppOptionsUserSharingDisabled(): boolean | undefined {
+  if (hasScriptData('script[data-appoptions]')) {
+    const appOptions = getScriptData('appoptions') as PartialAppOptions;
+    return appOptions.userSharingDisabled;
+  }
+}
+
 /**
  * Returns if the lab should presented in a share/play-only view,
  * if present in App Options. Only used in standalone project levels.

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -35,4 +35,5 @@ export interface CurrentUserState {
   isLti: boolean;
   aiDifferentiationEnabled: boolean;
   hasCompletedAiDifferentiationWelcome: boolean;
+  userSharingDisabled: boolean;
 }

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -130,6 +130,7 @@ const initialState = {
   usStateCode: null,
   inSection: null,
   userCreatedAt: null,
+  userSharingDisabled: false,
 };
 
 export default function currentUser(state = initialState, action) {
@@ -268,6 +269,7 @@ export default function currentUser(state = initialState, action) {
       is_verified_instructor,
       has_completed_ai_differentiation_welcome,
       educator_role,
+      sharing_disabled,
     } = action.serverUser;
     analyticsReport.setUserProperties(
       id,
@@ -312,6 +314,7 @@ export default function currentUser(state = initialState, action) {
       age,
       inSection: in_section,
       userCreatedAt: created_at,
+      userSharingDisabled: sharing_disabled,
     };
   }
 

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -74,6 +74,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         ai_differentiation_enabled: !current_user.ai_differentiation_toggled_off?,
         has_completed_ai_differentiation_welcome: current_user.has_completed_ai_differentiation_welcome?,
         educator_role: current_user.educator_role,
+        sharing_disabled: current_user.sharing_disabled,
       }
     else
       render json: {

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -767,6 +767,7 @@ module LevelsHelper
     end
     app_options[:share] = level_options[:share] if level_options[:share]
     app_options[:public_caching] = @public_caching
+    app_options[:user_sharing_disabled] = current_user&.sharing_disabled?
     app_options.camelize_keys
   end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -767,7 +767,6 @@ module LevelsHelper
     end
     app_options[:share] = level_options[:share] if level_options[:share]
     app_options[:public_caching] = @public_caching
-    app_options[:user_sharing_disabled] = current_user&.sharing_disabled?
     app_options.camelize_keys
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
In anticipation of adding Python Lab to the projects page and create new project header dropdown, we plan to limit this project type to users age 13 and over or younger users who are in a teacher section. Thus, we make `userSharingDisabled` available to `lab2` projects via `currentUserRedux`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [Python Lab launch plan](https://docs.google.com/document/d/1dtb2rS16ZALkkUSmaJttIR7DiNw9wH1_3uq9_R7R430/edit?tab=t.0#heading=h.osndlkhyubu4)
- Jira: https://codedotorg.atlassian.net/browse/SL-1248
- [Slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1747425861467699?thread_ts=1747238526.894379&cid=C06JELCAPT9)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
