### PR TITLE
fix(marketing): scroll to components before eyes

### DIFF
--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -13,18 +13,19 @@ test.describe('All the things UI e2e test', () => {
       const allTheThingsPage = new AllTheThingsPage(page, 'en-US');
       await allTheThingsPage.goto();
 
-      const accessibilityScanResults = await new AxeBuilder({page}).analyze(); // 4
+      const accessibilityScanResults = await new AxeBuilder({page}).analyze();
 
       // Do not allow any more accessibility errors. If you fixed one, reduce the number below.
       if (accessibilityScanResults.violations.length > 0) {
         // Log out the violations so we can fix them
         // The current allowed violations are:
         // 1. color contrast on overline
+        // 2. color contrast on overline in action block carousel
         console.warn(
           JSON.stringify(accessibilityScanResults.violations, null, 2),
         );
 
-        expect(accessibilityScanResults.violations.length).toEqual(1);
+        expect(accessibilityScanResults.violations.length).toEqual(2);
       }
     });
   });
@@ -122,6 +123,7 @@ test.describe('All the things UI e2e test', () => {
         await allTheThingsPage.goto();
 
         component = allTheThingsPage.getSectionLocator('Localization');
+        await component.scrollIntoViewIfNeeded();
       });
 
       test(`has localized text`, async () => {
@@ -155,8 +157,9 @@ test.describe('All the things UI e2e test', () => {
     test.describe('action block', () => {
       let component: Locator;
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator('Action Block');
+        await component.scrollIntoViewIfNeeded();
       });
 
       test('renders action block', async () => {
@@ -189,10 +192,11 @@ test.describe('All the things UI e2e test', () => {
     test.describe('full width action block', () => {
       let component: Locator;
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator(
           'Full Width Action Block',
         );
+        await component.scrollIntoViewIfNeeded();
       });
 
       test('renders full width action block', async () => {
@@ -225,8 +229,9 @@ test.describe('All the things UI e2e test', () => {
     test.describe('button', () => {
       let component: Locator;
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator('Button');
+        await component.scrollIntoViewIfNeeded();
       });
 
       test('internal primary button should go to website in same tab', async ({
@@ -274,13 +279,15 @@ test.describe('All the things UI e2e test', () => {
         test.describe(carousel.toLowerCase(), () => {
           let component: Locator;
 
-          test.beforeEach(() => {
+          test.beforeEach(async () => {
             component = allTheThingsPage.getSectionLocator(carousel as Section);
+            await component.scrollIntoViewIfNeeded();
           });
 
           test('eyes', {tag: '@eyes'}, async ({eyes}, testInfo) => {
             await eyes.check(testInfo.title, {
               region: component,
+              fully: true,
             });
           });
         });
@@ -290,8 +297,9 @@ test.describe('All the things UI e2e test', () => {
     test.describe('divider', () => {
       let component: Locator;
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator('Divider');
+        await component.scrollIntoViewIfNeeded();
       });
 
       test('renders', async () => {
@@ -314,8 +322,9 @@ test.describe('All the things UI e2e test', () => {
     test.describe('heading', () => {
       let component: Locator;
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator('Heading');
+        await component.scrollIntoViewIfNeeded();
       });
 
       test('renders', async () => {
@@ -338,8 +347,9 @@ test.describe('All the things UI e2e test', () => {
     test.describe('image', () => {
       let component: Locator;
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator('Image');
+        await component.scrollIntoViewIfNeeded();
       });
 
       test('renders all images with correct alt text', async () => {
@@ -364,8 +374,9 @@ test.describe('All the things UI e2e test', () => {
     test.describe('overline', () => {
       let component: Locator;
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator('Overline');
+        await component.scrollIntoViewIfNeeded();
       });
 
       test('renders', async () => {
@@ -388,8 +399,9 @@ test.describe('All the things UI e2e test', () => {
     test.describe('paragraph', () => {
       let component: Locator;
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator('Paragraph');
+        await component.scrollIntoViewIfNeeded();
       });
 
       test('renders', async () => {
@@ -411,8 +423,9 @@ test.describe('All the things UI e2e test', () => {
     test.describe('text link', () => {
       let component: Locator;
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator('Text Link');
+        await component.scrollIntoViewIfNeeded();
       });
 
       Array.of(
@@ -450,8 +463,9 @@ test.describe('All the things UI e2e test', () => {
       let component: Locator;
       const videoCaptions = [/^$/, 'Video without Fallback'];
 
-      test.beforeEach(() => {
+      test.beforeEach(async () => {
         component = allTheThingsPage.getSectionLocator('Video');
+        await component.scrollIntoViewIfNeeded();
       });
 
       // The default drop in has no caption


### PR DESCRIPTION
For firefox and webkit tests, eyes was previously running on the top of the page but using a specific region. However, this results in some screenshots being clipped due to image lazy loading. Rather, scroll to the region before eyes screenshots.

This helps with the tracing as well to see what exactly the component looks like so this is overall beneficial.
