### PR TITLE
Disable HOC certificates test due to flake

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/teacher_tools/hour_of_code/hour_of_code_finish.feature
@@ -156,6 +156,9 @@ Scenario: customized dashboard certificate pages with no course name
   And I close my eyes
 
 @eyes
+@skip
+# Disabled 5-19-2025 because of a flake. To be re-enabled when the flake is fixed or investigated.
+# Flake was caused by the twitter icon not appearing.
 Scenario: congrats certificate pages
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible


### PR DESCRIPTION
HOC certificates test failed earlier today due to the twitter icon not appearing

![image](https://github.com/user-attachments/assets/e500cd06-9772-43c6-b814-5daef52d3732)

Created JIRA task: https://codedotorg.atlassian.net/browse/TEACH-1911

