### PR TITLE
Evaluate Student Learning: log AppLab code execution errors as UserLevelInteractions

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -292,12 +292,12 @@ function handleExecutionError(err, lineNumber, outputString, libraryName) {
     levelId: analyticsData.levelId,
     scriptId: analyticsData.scriptId,
     interaction: UserLevelInteractions.code_execution_error,
-    metadata: {
+    metadata: JSON.stringify({
       error: err,
       lineNumber: lineNumber,
       outputString: outputString,
       libraryName: libraryName,
-    },
+    }),
   });
   // prevent further execution
   Applab.clearEventHandlersKillTickLoop();

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -287,7 +287,18 @@ function queueOnTick() {
 function handleExecutionError(err, lineNumber, outputString, libraryName) {
   outputError(outputString, lineNumber, libraryName);
   Applab.executionError = {err: err, lineNumber: lineNumber};
-
+  const analyticsData = studioApp().analyticsData();
+  logUserLevelInteraction({
+    levelId: analyticsData.levelId,
+    scriptId: analyticsData.scriptId,
+    interaction: UserLevelInteractions.code_execution_error,
+    metadata: {
+      error: err,
+      lineNumber: lineNumber,
+      outputString: outputString,
+      libraryName: libraryName,
+    },
+  });
   // prevent further execution
   Applab.clearEventHandlersKillTickLoop();
 

--- a/dashboard/app/controllers/user_level_interactions_controller.rb
+++ b/dashboard/app/controllers/user_level_interactions_controller.rb
@@ -36,6 +36,7 @@ class UserLevelInteractionsController < ApplicationController
       :school_year,
       :interaction,
       :code_version,
+      :metadata,
     )
     user_level_interaction_params[:user_id] = current_user.id
     user_level_interaction_params[:school_year] = school_year
@@ -45,6 +46,7 @@ class UserLevelInteractionsController < ApplicationController
     project_data = get_project_and_version_id(user_level_interaction_params[:level_id], user_level_interaction_params[:script_id])
     channel = get_channel_for(level, script_id, current_user)
     user_level_interaction_params[:code_version] = project_data[:version_id]
+    params_metadata = JSON.parse(user_level_interaction_params[:metadata] || '{}')
     metadata = {
       course_offering: unit.properties["curriculum_umbrella"],
       version_year: unit.get_course_version.key,
@@ -53,8 +55,8 @@ class UserLevelInteractionsController < ApplicationController
       user_type: current_user.user_type,
       project_id: project_data[:project_id],
       channel: channel,
-    }.to_json
-    user_level_interaction_params[:metadata] = metadata
+    }
+    user_level_interaction_params[:metadata] = metadata.merge(params_metadata).to_json
     user_level_interaction_params
   end
 end

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -51,6 +51,7 @@ module SharedConstants
       click_run: "click_run",
       click_submit: "click_submit",
       click_validate: "click_validate",
+      code_execution_error: "code_execution_error",
     }
   ).freeze
 


### PR DESCRIPTION
As we continued thinking through what data could be useful in reconstructing the story of a student's problem solving on a level, particularly starting to conceptualize would it could mean to identify resiliency in students, we wanted to know the frequency and timing with which a student hits execution errors while running their code. This adds `code_execution_error` as an option for UserLevelInteraction types and logs when a student's code hits and error in App Lab (we're currently focused mostly on CSP unit 4 so scoped to just App Lab). 

<img width="1080" alt="Screenshot 2025-05-19 at 9 45 30 PM" src="https://github.com/user-attachments/assets/fdcbffb5-c197-45c9-b7ee-b0dc1802f7b8" />
