### PR TITLE
[CMS-689] Update announcement banner to accept array links

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBanner.tsx
+++ b/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBanner.tsx
@@ -48,7 +48,7 @@ type HeroBannerProps = {
   /** HeroBanner announcement banner text */
   announcementBannerText?: string;
   /** HeroBanner announcement banner link  entry*/
-  announcementBannerLink?: LinkEntry;
+  announcementBannerLink?: LinkEntry[];
 };
 
 const HeroBanner: React.FunctionComponent<HeroBannerProps> = ({
@@ -76,6 +76,7 @@ const HeroBanner: React.FunctionComponent<HeroBannerProps> = ({
 }) => {
   const firstSectionImage = sectionImages?.[0];
   const firstButtonLink = buttonLinks?.[0];
+  const firstAnnouncementBannerLink = announcementBannerLink?.[0];
 
   return (
     <DSCOHeroBanner
@@ -92,13 +93,13 @@ const HeroBanner: React.FunctionComponent<HeroBannerProps> = ({
                 ? {iconName: announcementBannerIconName}
                 : undefined,
               text: announcementBannerText,
-              link: announcementBannerLink
+              link: firstAnnouncementBannerLink
                 ? {
-                    text: announcementBannerLink.fields.label,
-                    'aria-label': announcementBannerLink.fields.ariaLabel,
-                    href: announcementBannerLink.fields.primaryTarget,
+                    text: firstAnnouncementBannerLink.fields.label,
+                    'aria-label': firstAnnouncementBannerLink.fields.ariaLabel,
+                    href: firstAnnouncementBannerLink.fields.primaryTarget,
                     external:
-                      announcementBannerLink.fields.isThisAnExternalLink,
+                      firstAnnouncementBannerLink.fields.isThisAnExternalLink,
                   }
                 : undefined,
             }

--- a/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBannerContentfulDefinition.ts
@@ -173,7 +173,7 @@ export const HeroBannerContentfulComponentDefinition: ComponentDefinition = {
     },
     announcementBannerLink: {
       displayName: 'Announcement Banner Link',
-      type: 'Link',
+      type: 'Array',
       group: 'content',
       description:
         'This is the link that will be used in the announcement banner.',


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
## [CMS-689] Update announcement banner to accept array links

* [feat(HeroBanner): update announcementBannerLink to support multiple links](https://github.com/code-dot-org/code-dot-org/commit/40a54cd00df541105ad4c3d75614bed83e06d609)


https://github.com/user-attachments/assets/e6242cb0-6659-4fe0-ab8b-da3a8d601c00



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [CMS-689](https://codedotorg.atlassian.net/browse/CMS-689)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
