### PR TITLE
fix(favicon): add favicon hint for pegasus compat

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
@@ -62,6 +62,15 @@ export async function generateMetadata({
 
   return {
     title: getPageHeading(experience),
+    // Temporary favicon location for Pegasus compatability.
+    // Remove when Pegasus is deprecated.
+    // TODO: https://codedotorg.atlassian.net/browse/CMS-731
+    icons: [
+      {
+        url: '/images/favicon.ico',
+        href: '/images/favicon.ico',
+      },
+    ],
     ...getSeoMetadata(experience, brand, pageProps.locale),
   };
 }


### PR DESCRIPTION
The favicon on Pegasus is located in the non standard location `/images/favicon.ico`. This PR adds a hint to that location on the marketing side. Once Pegasus is deprecated, the hint can be removed as `/favicon.ico` will be fully available for use which is handled by default by the marketing app.