### PR TITLE
Add AI Foundations homepage hero banner

### DIFF
--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -64,6 +64,8 @@ class DCDOBase < DynamicConfigBase
       'ai-tutor-teacher-nav-v2': DCDO.get('ai-tutor-teacher-nav-v2', true),
       'music-lab-banner': DCDO.get('music-lab-banner', false),
       'show-download-progress-csv': DCDO.get('show-download-progress-csv', false),
+      # Remove this as part of Pegasus cleanup after the move to the CMS
+      'aif-launch': DCDO.get('aif-launch', false),
     }
   end
 end

--- a/pegasus/sites.v3/code.org/public/css/ai-foundations-hero-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/ai-foundations-hero-banner.scss
@@ -1,0 +1,44 @@
+.ai-foundations-hero-banner {
+  padding: 4rem 2rem;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(90deg, #0f1e2e 0%, #293955 100%);
+
+  .wrapper {
+    display: grid;
+    gap: 1.5rem;
+    margin: 0 auto;
+    max-width: 1020px;
+    position: relative;
+    z-index: 10;
+
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(2, 1fr);
+      align-items: center;
+    }
+  }
+
+  .text-wrapper {
+    position: relative;
+    z-index: 1;
+
+    .overline-one {
+      color: #3cfff7;
+      margin-bottom: 0;
+    }
+
+    h1 {
+      margin-top: 0;
+    }
+  }
+
+  img {
+    width: 100%;
+  }
+
+  @media (max-width: 960px) {
+    figure {
+      margin: 0;
+    }
+  }
+}

--- a/pegasus/sites.v3/code.org/public/images/banners/aif-hero.png
+++ b/pegasus/sites.v3/code.org/public/images/banners/aif-hero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60110bbcaed31ec6b057cf68e7e7c90968ca0919a402c3e90d853d10b5bc4f35
+size 365137

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -40,6 +40,8 @@ style_min: true
 #homepage.supreme-container
   - if !!DCDO.get('exploring-gen-ai-launch', false)
     = view :exploring_gen_ai_hero_banner
+  - if !!DCDO.get('aif-launch', false)
+    = view :ai_foundations_hero_banner
   - else
     = view :homepage_hero
 

--- a/pegasus/sites.v3/code.org/views/ai_foundations_hero_banner.haml
+++ b/pegasus/sites.v3/code.org/views/ai_foundations_hero_banner.haml
@@ -1,0 +1,14 @@
+=inline_css "/generated/ai-foundations-hero-banner.css"
+
+%section.ai-foundations-hero-banner.hero-banner-basic
+  .wrapper
+    .text-wrapper
+      %h1.white
+        =hoc_s("aif_hero_banner.heading")
+      %p.body-two.white
+        =hoc_s("aif_hero_banner.desc")
+      %a.link-button.white{href: "/curriculum/generative-ai", aria: {label: hoc_s("aif_hero_banner.button_aria_Label")}}
+        =hoc_s(:call_to_action_explore_curriculum)
+    %figure
+      %img{src: "/images/banners/aif-hero.png", alt: ""}
+.clear

--- a/pegasus/sites.v3/code.org/views/ai_foundations_hero_banner.haml
+++ b/pegasus/sites.v3/code.org/views/ai_foundations_hero_banner.haml
@@ -7,7 +7,7 @@
         =hoc_s("aif_hero_banner.heading")
       %p.body-two.white
         =hoc_s("aif_hero_banner.desc")
-      %a.link-button.white{href: "/curriculum/generative-ai", aria: {label: hoc_s("aif_hero_banner.button_aria_Label")}}
+      %a.link-button.white{href: "/curriculum/generative-ai", aria: {label: hoc_s("aif_hero_banner.button_aria_label")}}
         =hoc_s(:call_to_action_explore_curriculum)
     %figure
       %img{src: "/images/banners/aif-hero.png", alt: ""}

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -3061,6 +3061,12 @@
   ai_activity_zooniverse: 'Zooniverse - Snapshot Mountain Zebra'
   ai_activity_zooniverse_desc: 'Help protect the endangered Cape Mountain Zebra by identifying the different animals in the images.'
 
+  aif_hero_banner:
+    heading: 'Artificial Intelligence Foundations'
+    desc: 'Prepare students for the future with our newest high school curriculum. Explore the core principles of AI, from machine learning to ethics, through hands-on projects and real-world applications.'
+    button: 'Explore curriculum'
+    button_aria_label: 'Explore the Artificial Intelligence Foundations curriculum'
+
   codeorg_homepage_hoc2018_curriculum: 'Go further with <a href="%{studio_url}/courses" class="hoc2018-curriculum-link">Code.org courses</a>'
   codeorg_homepage_hoc2018_dance_heading: 'Create your own <span class="highlight-word">Dance&nbsp;Party</span>'
   codeorg_homepage_hoc2018_header_line1: 'The Hour of Code is coming...'


### PR DESCRIPTION
Adds a homepage hero banner on code.org for the AI Foundations launch on May 30. Uses the DCDO flag `aif-launch`.

**Note:** The DCDO flag `exploring-gen-ai-launch` will need to be set to `false` before setting `aif-launch` to true. This will hide the current hero banner so this new one shows up.

## Links
Jira ticket: [CMS-571](https://codedotorg.atlassian.net/browse/CMS-571)

## Testing story
Tested locally that the DCD flag works

----


https://github.com/user-attachments/assets/1839db20-07d0-4d0a-a9f2-bd259d1ea83b


