### PR TITLE
chore(Link): update the gap for external link icon

### DIFF
--- a/frontend/packages/component-library/src/link/link.module.scss
+++ b/frontend/packages/component-library/src/link/link.module.scss
@@ -6,7 +6,7 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  gap: 10px;
+  gap: 0.375rem;
   text-decoration: underline;
 
   &:focus-visible {


### PR DESCRIPTION
Decreases the gap space between the text link and external link icon in the Link component.

## Links
Jira ticket: [CMS-732](https://codedotorg.atlassian.net/browse/CMS-732)

## Testing story
Tested locally and there may be Eyes diffs. 

----

| Before | After |
| ---- | ---- |
| <img width="599" alt="Before" src="https://github.com/user-attachments/assets/76b4d2ba-6f59-41d9-8863-fa2c3bc2f17d" /> | <img width="599" alt="After" src="https://github.com/user-attachments/assets/0471892b-03d8-454a-9b2b-802c5f045634" /> |

