### PR TITLE
Skip pegasus landing page eyes tests

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages.feature
@@ -12,5 +12,4 @@ Scenario Outline: Simple page view
   And I sign out
 Examples:
   | url                                                               | test_name                  |
-  | http://code.org/minecraft                                         | minecraft tutorial landing |
-  | http://code.org/starwars                                          | starwars tutorial landing  |
+  | http://hourofcode.com/us/learn                                    | hoc learn landing page     |

--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
@@ -1,3 +1,4 @@
+@skip
 @eyes
 @single_session
 Feature: Looking at tutorial landing pages on Pegasus part Two
@@ -12,5 +13,7 @@ Scenario Outline: Simple page view
   And I sign out
 Examples:
   | url                                                               | test_name                  |
+  | http://code.org/minecraft                                         | minecraft tutorial landing |
+  | http://code.org/starwars                                          | starwars tutorial landing  |
   | http://code.org/tools/applab                                      | app lab tutorial landing   |
   | http://code.org/dance                                             | dance tutorial landing     |

--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_3.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_3.feature
@@ -1,3 +1,4 @@
+@skip
 @eyes
 @single_session
 Feature: Looking at tutorial landing pages on Pegasus part Three

--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_4.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_4.feature
@@ -1,3 +1,4 @@
+@skip
 @eyes
 @single_session
 Feature: Looking at tutorial landing pages on Pegasus part Four
@@ -13,6 +14,5 @@ Scenario Outline: Simple page view
 Examples:
   | url                                                               | test_name                  |
   | http://code.org/student/middle-high                               | middle high student page   |
-  | http://hourofcode.com/us/learn                                    | learn landing page         |
   | http://code.org/ai                                                | ai landing page            |
   | http://code.org/teach                                             | teach landing page         |


### PR DESCRIPTION
Adds a `@skip` to the pegasus_landing_pages.feature tests since these are causing issues and we don't need them anymore with the move to Contentful. I did keep and rearrange the HOC Learn page test since we still need that one. 

## Links
Jira ticket: [CMS-729](https://codedotorg.atlassian.net/browse/CMS-729)