### PR TITLE
fix(school association): prompt affected users to re-submit school info

### DIFF
--- a/apps/src/schoolInfo/SchoolInfoInterstitial.jsx
+++ b/apps/src/schoolInfo/SchoolInfoInterstitial.jsx
@@ -17,17 +17,25 @@ import {schoolInfoInvalid} from './utils/schoolInfoInvalid';
 import {updateSchoolInfo} from './utils/updateSchoolInfo';
 
 export default function SchoolInfoInterstitial({
-  scriptData: {existingSchoolInfo, usIp},
+  scriptData: {
+    existingSchoolInfo,
+    usIp,
+    // TODO: ACQ-3300 remove when school info has been updated for affected users
+    affectedByMissingSchoolData,
+  },
   onClose,
 }) {
-  const schoolInfo = useSchoolInfo({
-    usIp,
-    country: existingSchoolInfo.country,
-    schoolName: existingSchoolInfo.school_name,
-    schoolId: existingSchoolInfo.school_id,
-    schoolZip: existingSchoolInfo.school_zip,
-    schoolType: existingSchoolInfo.school_type,
-  });
+  const schoolInfo = useSchoolInfo(
+    {
+      usIp,
+      country: existingSchoolInfo.country,
+      schoolName: existingSchoolInfo.school_name,
+      schoolId: existingSchoolInfo.school_id,
+      schoolZip: existingSchoolInfo.school_zip,
+      schoolType: existingSchoolInfo.school_type,
+    },
+    affectedByMissingSchoolData
+  );
 
   const [showSchoolInfoUnknownError, setShowSchoolInfoUnknownError] =
     useState(false);
@@ -175,6 +183,7 @@ SchoolInfoInterstitial.propTypes = {
       school_zip: PropTypes.string,
       school_type: PropTypes.string,
     }),
+    affectedByMissingSchoolData: PropTypes.bool,
   }).isRequired,
   onClose: PropTypes.func.isRequired,
 };

--- a/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
+++ b/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
@@ -81,6 +81,7 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     schoolZip: detectedZip,
     schoolName: detectedSchoolName,
   });
+  const [schoolsLoading, setSchoolsLoading] = useState(false);
   const [schoolsList, setSchoolsList] = useState<SchoolDropdownOption[]>([]);
 
   // State hooks
@@ -161,9 +162,7 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     (
       zip: string,
       callback: (data: {nces_id: number; name: string}[]) => void
-    ) => {
-      fetchSchoolsAPI(zip, callback);
-    },
+    ) => fetchSchoolsAPI(zip, callback),
     []
   );
 
@@ -189,6 +188,7 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     }
 
     handleSessionStorage(SCHOOL_ZIP_SESSION_KEY, schoolZip);
+    setSchoolsLoading(true);
 
     fetchSchools(schoolZip, data => {
       if (!mounted.current) return;
@@ -197,7 +197,11 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
         .map(constructSchoolOption)
         .sort((a, b) => a.text.localeCompare(b.text));
 
+      setSchoolsLoading(false);
       setSchoolsList(schools);
+    }).catch(error => {
+      setSchoolsLoading(false);
+      console.error(error);
     });
   }, [schoolZip, fetchSchools]);
 
@@ -225,6 +229,7 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     schoolName,
     schoolZip,
     schoolsList,
+    schoolsLoading,
     usIp: initialState.usIp,
     setSchoolId,
     setCountry,

--- a/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
+++ b/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
@@ -17,7 +17,11 @@ import {SchoolDropdownOption, SchoolInfoInitialState} from '../types';
 import {constructSchoolOption} from '../utils/constructSchoolOption';
 import {fetchSchools as fetchSchoolsAPI} from '../utils/fetchSchools';
 
-export function useSchoolInfo(initialState: SchoolInfoInitialState) {
+export function useSchoolInfo(
+  initialState: SchoolInfoInitialState,
+  // TODO: ACQ-3300 remove when school info has been updated for affected users
+  affectedByMissingSchoolData?: boolean
+) {
   const mounted = useRef(false);
 
   // Memoized initial values
@@ -30,6 +34,9 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
   );
 
   const detectedSchoolId = useMemo(() => {
+    if (affectedByMissingSchoolData) {
+      return NonSchoolOptions.SELECT_A_SCHOOL;
+    }
     if (initialState.schoolType === NonSchoolOptions.NO_SCHOOL_SETTING) {
       return NonSchoolOptions.NO_SCHOOL_SETTING;
     }
@@ -50,6 +57,7 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     initialState.schoolType,
     initialState.schoolName,
     initialState.schoolZip,
+    affectedByMissingSchoolData,
   ]);
 
   const detectedZip = useMemo(
@@ -62,12 +70,16 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
 
   const detectedSchoolName = useMemo(
     () =>
-      initialState.schoolId
+      initialState.schoolId || affectedByMissingSchoolData
         ? ''
         : initialState.schoolName ||
           sessionStorage.getItem(SCHOOL_NAME_SESSION_KEY) ||
           '',
-    [initialState.schoolName, initialState.schoolId]
+    [
+      initialState.schoolName,
+      initialState.schoolId,
+      affectedByMissingSchoolData,
+    ]
   );
 
   const [state, setState] = useState<{

--- a/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
+++ b/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -15,7 +15,7 @@ import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 
 import {SchoolDropdownOption, SchoolInfoInitialState} from '../types';
 import {constructSchoolOption} from '../utils/constructSchoolOption';
-import {fetchSchools as fetchSchoolsAPI} from '../utils/fetchSchools';
+import {fetchSchools} from '../utils/fetchSchools';
 
 export function useSchoolInfo(
   initialState: SchoolInfoInitialState,
@@ -169,15 +169,6 @@ export function useSchoolInfo(
     });
   };
 
-  // Memoized fetchSchools function using useCallback
-  const fetchSchools = useCallback(
-    (
-      zip: string,
-      callback: (data: {nces_id: number; name: string}[]) => void
-    ) => fetchSchoolsAPI(zip, callback),
-    []
-  );
-
   const handleSessionStorage = (key: string, value: string) => {
     if (sessionStorage.getItem(key) !== value) {
       sessionStorage.setItem(key, value);
@@ -202,20 +193,24 @@ export function useSchoolInfo(
     handleSessionStorage(SCHOOL_ZIP_SESSION_KEY, schoolZip);
     setSchoolsLoading(true);
 
-    fetchSchools(schoolZip, data => {
-      if (!mounted.current) return;
+    fetchSchools(schoolZip)
+      .then(data => {
+        if (!mounted.current) return;
 
-      const schools = data
-        .map(constructSchoolOption)
-        .sort((a, b) => a.text.localeCompare(b.text));
+        const schools = data
+          .map(constructSchoolOption)
+          .sort((a: SchoolDropdownOption, b: SchoolDropdownOption) =>
+            a.text.localeCompare(b.text)
+          );
 
-      setSchoolsLoading(false);
-      setSchoolsList(schools);
-    }).catch(error => {
-      setSchoolsLoading(false);
-      console.error(error);
-    });
-  }, [schoolZip, fetchSchools]);
+        setSchoolsLoading(false);
+        setSchoolsList(schools);
+      })
+      .catch(error => {
+        setSchoolsLoading(false);
+        console.error(error);
+      });
+  }, [schoolZip]);
 
   // Handle schoolId changes
   useEffect(() => {

--- a/apps/src/schoolInfo/utils/fetchSchools.ts
+++ b/apps/src/schoolInfo/utils/fetchSchools.ts
@@ -1,9 +1,8 @@
 import {SCHOOL_ZIP_SEARCH_URL} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 
 export async function fetchSchools(
-  zip: string,
-  callback: (data: {nces_id: number; name: string}[]) => void
-) {
+  zip: string
+): Promise<{nces_id: number; name: string}[]> {
   const searchUrl = `${SCHOOL_ZIP_SEARCH_URL}${zip}`;
   const response = await fetch(searchUrl, {
     headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -12,6 +11,5 @@ export async function fetchSchools(
     throw new Error('Zip code search for schools failed');
   }
   const data = await response.json();
-
-  callback(data);
+  return data;
 }

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -1,5 +1,6 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {
   BodyTwoText,
   Heading2,
@@ -44,6 +45,7 @@ export default function SchoolDataInputs({
   usIp,
   containerClassName,
   includeHeaders = true,
+  schoolsLoading = false,
   fieldNames = {
     country: 'user[school_info_attributes][country]',
     ncesSchoolId: 'user[school_info_attributes][school_id]',
@@ -144,10 +146,10 @@ export default function SchoolDataInputs({
           />
         )}
         {countryIsUS && !inputManually && (
-          <div>
+          <div className={style.schoolsList}>
             <SimpleDropdown
               id="uitest-school-dropdown"
-              disabled={!schoolZipIsValid}
+              disabled={!schoolZipIsValid || schoolsLoading}
               name={fieldNames.ncesSchoolId}
               className={classNames(labelClassName, style.dropdown)}
               labelText={i18n.selectYourSchool()}
@@ -177,6 +179,9 @@ export default function SchoolDataInputs({
                   handleSchoolChange(NonSchoolOptions.NO_SCHOOL_SETTING);
                 }}
               />
+            )}
+            {schoolsLoading && (
+              <FontAwesomeV6Icon iconName="spinner" animationType="spin" />
             )}
           </div>
         )}
@@ -214,6 +219,7 @@ SchoolDataInputs.propTypes = {
   schoolsList: PropTypes.arrayOf(
     PropTypes.shape({value: PropTypes.string, text: PropTypes.string})
   ).isRequired,
+  schoolsLoading: PropTypes.bool,
   usIp: PropTypes.bool,
   setSchoolId: PropTypes.func.isRequired,
   setCountry: PropTypes.func.isRequired,

--- a/apps/src/templates/school-association.module.scss
+++ b/apps/src/templates/school-association.module.scss
@@ -41,6 +41,15 @@
     margin-block: 0.4375rem 0;
     color: $light_negative_500;
   }
+
+  .schoolsList {
+    position: relative;
+    i {
+      position: absolute;
+      right: -22px;
+      top: 38px;
+    }
+  }
 }
 
 .headerContainer {

--- a/apps/test/unit/schoolInfo/utils/fetchSchoolsTest.js
+++ b/apps/test/unit/schoolInfo/utils/fetchSchoolsTest.js
@@ -4,7 +4,6 @@ import {SCHOOL_ZIP_SEARCH_URL} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 window.fetch = jest.fn();
 
 describe('fetchSchools', () => {
-  const mockCallback = jest.fn();
   const zip = '12345';
   const searchUrl = `${SCHOOL_ZIP_SEARCH_URL}${zip}`;
 
@@ -12,7 +11,7 @@ describe('fetchSchools', () => {
     jest.clearAllMocks();
   });
 
-  it('should fetch schools and invoke the callback with data', async () => {
+  it('should fetch schools and return data', async () => {
     const mockData = [
       {nces_id: 1, name: 'Test School 1'},
       {nces_id: 2, name: 'Test School 2'},
@@ -23,24 +22,20 @@ describe('fetchSchools', () => {
       json: jest.fn().mockResolvedValueOnce(mockData),
     });
 
-    await fetchSchools(zip, mockCallback);
+    const result = await fetchSchools(zip);
 
     expect(fetch).toHaveBeenCalledWith(searchUrl, {
       headers: {'X-Requested-With': 'XMLHttpRequest'},
     });
-    expect(mockCallback).toHaveBeenCalledWith(mockData);
+    expect(result).toEqual(mockData);
   });
 
   it('should throw an error when the fetch response is not OK', async () => {
     fetch.mockResolvedValueOnce({ok: false});
 
-    await expect(fetchSchools(zip, mockCallback)).rejects.toThrow(
+    const result = await expect(fetchSchools(zip)).rejects.toThrow(
       'Zip code search for schools failed'
     );
-
-    expect(fetch).toHaveBeenCalledWith(searchUrl, {
-      headers: {'X-Requested-With': 'XMLHttpRequest'},
-    });
-    expect(mockCallback).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
   });
 });

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -22,7 +22,9 @@ import {
 } from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
-jest.mock('@cdo/apps/schoolInfo/utils/fetchSchools');
+jest.mock('@cdo/apps/schoolInfo/utils/fetchSchools', () => ({
+  fetchSchools: jest.fn().mockResolvedValue([]),
+}));
 jest.mock('@cdo/apps/util/AuthenticityTokenStore', () => ({
   getAuthenticityToken: jest.fn().mockReturnValue('authToken'),
 }));

--- a/apps/test/unit/templates/census/CensusTeacherBannerTest.jsx
+++ b/apps/test/unit/templates/census/CensusTeacherBannerTest.jsx
@@ -4,7 +4,9 @@ import React from 'react';
 
 import CensusTeacherBanner from '@cdo/apps/templates/census/CensusTeacherBanner';
 
-jest.mock('@cdo/apps/schoolInfo/utils/fetchSchools');
+jest.mock('@cdo/apps/schoolInfo/utils/fetchSchools', () => ({
+  fetchSchools: jest.fn().mockResolvedValue([]),
+}));
 
 describe('CensusTeacherBannerTest', () => {
   const defaultExistingSchoolInfo = {

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -20,7 +20,7 @@
   = render partial: 'layouts/school_info_confirmation_dialog'
 - elsif SchoolInfoInterstitialHelper.show?(current_user) || @force_school_info_interstitial
   - SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user)
-  = render partial: 'layouts/school_info_interstitial', locals: {show_header: false, user: current_user, form_name: "user[school_info_attributes]"}
+  = render partial: 'layouts/school_info_interstitial'
 
 - if current_user
   = render partial: 'home/homepage'

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -23,7 +23,7 @@
   = render partial: 'layouts/school_info_confirmation_dialog'
 - elsif SchoolInfoInterstitialHelper.show?(current_user) || @force_school_info_interstitial
   - SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user)
-  = render partial: 'layouts/school_info_interstitial'
+  = render partial: 'layouts/school_info_interstitial', locals: {affected_by_missing_school_data: false}
 
 - if current_user
   = render partial: 'home/homepage'

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -11,6 +11,9 @@
 - if current_user && current_user.teacher? && !current_user.accepted_latest_terms?
   - current_user.update_user_tos_version_accept()
   = render partial: 'layouts/implicit_new_user_terms_interstitial'
+- elsif Queries::UserSchoolInfo.affected_by_missing_nces_schools?(current_user)
+  -# TODO: ACQ-3300 remove when school info has been updated for affected users
+  = render partial: 'layouts/school_info_interstitial', locals: {affected_by_missing_school_data: true}
 - elsif InitialSectionCreationInterstitialHelper.show?(current_user, request.gdpr?)
   = render partial: 'layouts/initial_section_creation_interstitial'
 - elsif @show_section_creation_celebration_dialog

--- a/dashboard/app/views/layouts/_school_info_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_school_info_interstitial.html.haml
@@ -8,8 +8,7 @@
 - location = Geocoder.search(request.ip).try(:first)
 -# geocoder sometimes shows localhost's country as RD/Reserved
 - us_ip = location.nil? || ['US', 'RD'].include?(location.country_code.to_s.upcase)
--# TODO: ACQ-3300 remove unless condition when school info has been updated for affected users
-- school_info = Queries::SchoolInfo.current_school(current_user) unless affected_by_missing_school_data
+- school_info = Queries::SchoolInfo.current_school(current_user)
 
 - script_data = {}
 - script_data[:existingSchoolInfo] = {}

--- a/dashboard/app/views/layouts/_school_info_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_school_info_interstitial.html.haml
@@ -8,13 +8,16 @@
 - location = Geocoder.search(request.ip).try(:first)
 -# geocoder sometimes shows localhost's country as RD/Reserved
 - us_ip = location.nil? || ['US', 'RD'].include?(location.country_code.to_s.upcase)
-- school_info = Queries::SchoolInfo.current_school(current_user)
+-# TODO: ACQ-3300 remove unless condition when school info has been updated for affected users
+- school_info = Queries::SchoolInfo.current_school(current_user) unless affected_by_missing_school_data
 
 - script_data = {}
 - script_data[:existingSchoolInfo] = {}
 - if school_info
   - script_data[:existingSchoolInfo] = school_info
 - script_data[:usIp] = us_ip
+-# TODO: ACQ-3300 remove when school info has been updated for affected users
+- script_data[:affectedByMissingSchoolData] = affected_by_missing_school_data
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/layouts/_school_info_interstitial.js'), data: {schoolinfointerstitial: script_data.to_json}}

--- a/dashboard/lib/queries/user_school_info.rb
+++ b/dashboard/lib/queries/user_school_info.rb
@@ -6,4 +6,18 @@ class Queries::UserSchoolInfo
       select {|usi| usi.school_info.complete?}.
       max_by(&:created_at)
   end
+
+  # TODO: ACQ-3300 remove when school info has been updated for affected users
+  def self.affected_by_missing_nces_schools?(user)
+    user_school_info = last_complete(user)
+    school_info = user_school_info&.school_info
+    return false unless school_info
+
+    school_info.country == 'US' &&
+      school_info.school_type.nil? &&
+      school_info.school_id.nil? &&
+      school_info.school_name.present? &&
+      school_info.updated_at > Date.parse('2025-03-17') &&
+      school_info.updated_at < Date.parse('2025-05-07')
+  end
 end

--- a/dashboard/lib/queries/user_school_info.rb
+++ b/dashboard/lib/queries/user_school_info.rb
@@ -9,6 +9,7 @@ class Queries::UserSchoolInfo
 
   # TODO: ACQ-3300 remove when school info has been updated for affected users
   def self.affected_by_missing_nces_schools?(user)
+    return false unless user&.teacher?
     user_school_info = last_complete(user)
     school_info = user_school_info&.school_info
     return false unless school_info


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Teachers who created accounts or updated their school info between 3/17/25 and 5/7/25 likely did not see their school listed as an option to select due to a bug that filtered them out of the results. Therefore we need to prompt those affected users to update their school info the next time they land on the home page. This pr adds a temporary query to identify the affected users, who will be shown the SchoolInfoInterstitial modal to update their info.

Also in this pr is a small ux tweak to show a spinner while the schools list results are fetched, hopefully this helps to prevent teachers from entering their school manually as well.

Teacher user with manually entered school name gets prompted after modifying its `updated_at` column:

https://github.com/user-attachments/assets/4cc39880-22ec-4e96-a5b3-49dc79519aad



This query in the production console returns the number of affected users:
```
User.joins(:school_info)
    .where(school_infos: { country: 'US' })
    .where(school_infos: { school_type: nil })
    .where(school_infos: { school_id: nil })
    .where.not(school_infos: { school_name: nil })
    .where('school_infos.updated_at > ?', Date.parse('2025-03-17'))
    .where('school_infos.updated_at < ?', Date.parse('2025-05-07'))
    .distinct(:id)
    .count
```
this returns `6427` as of 5/21/25

I've created a ticket in the backlog to remove this temporary query once that number goes down substantially https://codedotorg.atlassian.net/browse/ACQ-3300

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3270

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
https://codedotorg.atlassian.net/browse/ACQ-3300
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
