### PR TITLE
Evaluate Student Learning: add script_id and level_id composite index on user_levels

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -20,7 +20,8 @@
 #
 # Indexes
 #
-#  index_user_levels_unique  (user_id,script_id,level_id,deleted_at) UNIQUE
+#  index_user_levels_on_script_and_level  (script_id,level_id)
+#  index_user_levels_unique               (user_id,script_id,level_id,deleted_at) UNIQUE
 #
 
 require 'cdo/activity_constants'

--- a/dashboard/db/migrate/20250521003627_add_index_to_user_levels_on_script_id_and_level_id.rb
+++ b/dashboard/db/migrate/20250521003627_add_index_to_user_levels_on_script_id_and_level_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToUserLevelsOnScriptIdAndLevelId < ActiveRecord::Migration[6.1]
+  def change
+    add_index :user_levels, [:script_id, :level_id], name: 'index_user_levels_on_script_and_level'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_05_12_180227) do
+ActiveRecord::Schema.define(version: 2025_05_21_003627) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2384,6 +2384,7 @@ ActiveRecord::Schema.define(version: 2025_05_12_180227) do
     t.integer "time_spent"
     t.datetime "deleted_at"
     t.text "properties"
+    t.index ["script_id", "level_id"], name: "index_user_levels_on_script_and_level"
     t.index ["user_id", "script_id", "level_id", "deleted_at"], name: "index_user_levels_unique", unique: true
   end
 


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/65911

Oh boy. Ok, so I was optimistic that we would be able to pull student code, but on production we hit a timeout 🤦‍♀️ because of course we did because there are gajilliions of more UserLevels on production than I have locally. Here's the [Honeybadger error](https://app.honeybadger.io/projects/3240/faults/120491165) and here's the production-console output that confirms the part of the query that times out is `UserLevel.where... `
<img width="1078" alt="Screenshot 2025-05-20 at 8 17 29 PM" src="https://github.com/user-attachments/assets/0e02c0db-cce6-4bd7-884d-384a106b82a7" />

Then, I thought, what if I limit to just the first 100 we find - still too slow. 🐢 
<img width="1078" alt="Screenshot 2025-05-20 at 8 20 51 PM" src="https://github.com/user-attachments/assets/d01b07d9-2aae-47ac-9158-8721be3ed413" />

Then, I checked the user_level.rb model file and discovered we don't have indices on `script_id` and `level_id` because in all the other other places we query the UserLevels table we have a `user_id` to include in the query. 

This PR adds a composite index for script_id and level_id on UserLevels, which should speed up that query. 

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZnJ5c2pmem1ubnI2NmwyYWFsZzZpeThxamZxanJuOXNjcjF1ZjQ3ZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/8GmUS2rjYl3aZ6e3vy/giphy.gif)
