### PR TITLE
fix(workshops): repair custom dropdown layout after dsco change

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/styles.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/styles.module.scss
@@ -140,9 +140,9 @@
       }
 
       div:nth-of-type(2) {
-        top: 100%;
+        top: 70%;
         padding: 0;
-        margin-top: 4px;
+        box-sizing: border-box;
       }
 
       > button {

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/styles.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/styles.module.scss
@@ -134,6 +134,11 @@
         }
       }
 
+      div:first-of-type,
+      div:last-of-type {
+        margin: 0;
+      }
+
       div:nth-of-type(2) {
         top: 100%;
         padding: 0;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Custom dropdown spacing is done with margin instead of flex/gap like the other inputs. this fixes the style overrides in the workshop form so that the input label and helper message explicitly have their margins removed and replaced with flex gap. There is a ticket [here](https://codedotorg.atlassian.net/browse/DESIGN2-289) to modify the custom dropdown dsco component to use flex gap instead, but this ensures margin changes in the dsco side won't affect the layout of the workshop form

BEFORE:
![Screenshot 2025-05-21 at 9 31 25 AM](https://github.com/user-attachments/assets/71179056-8d5b-4ddc-9fe0-975cb0d96d45)

AFTER:
![Screenshot 2025-05-21 at 9 31 03 AM](https://github.com/user-attachments/assets/f65c0a1a-2540-4e6a-b19e-cdd3e0c9c068)

I also noticed the custom dropdown menu was a few pixels wider than the input, so I updated its box-sizing to match
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
