### PR TITLE
Python Lab: border radius polish and remove unneeded styles

### DIFF
--- a/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
+++ b/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
@@ -4,6 +4,7 @@
   position: absolute;
   cursor: pointer;
   border: 1px solid var(--borders-neutral-primary);
+  border-radius: 4px;
   background-color: var(--background-neutral-secondary);
   color: var(--text-neutral-primary);
   min-width: 100px;

--- a/apps/src/codebridge/Settings/settings-dropdown.module.scss
+++ b/apps/src/codebridge/Settings/settings-dropdown.module.scss
@@ -9,6 +9,7 @@ $space-l: 8px;
   position: absolute;
   cursor: pointer;
   border: 1px solid var(--borders-neutral-primary);
+  border-radius: 4px;
   background-color: var(--background-neutral-secondary);
   scrollbar-color: var(--text-neutral-tertiary) var(--background-neutral-secondary);
   color: var(--text-neutral-primary);

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -3,7 +3,6 @@
 .workspace {
   color: var(--text-neutral-primary);
   overflow: hidden;
-  z-index: 2;
 }
 
 .workspaceContainer {

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -18,6 +18,7 @@ $space-xl: 10px;
   vertical-align: top;
   z-index: 1000;
   right: 0;
+  border-radius: 4px;
 }
 
 .header {

--- a/apps/src/pythonlab/components/projectTypePicker.module.scss
+++ b/apps/src/pythonlab/components/projectTypePicker.module.scss
@@ -7,6 +7,7 @@
 
 .pickerDialog {
   padding: 24px 32px;
+  border-radius: 4px;
 }
 
 .boldWarning {

--- a/apps/src/pythonlab/components/projectTypePicker.module.scss
+++ b/apps/src/pythonlab/components/projectTypePicker.module.scss
@@ -5,11 +5,6 @@
   max-width: 600px;
 }
 
-// Ensures the dialog and overlay are on top of other Python Lab elements.
-div.dialogContainer > div[role='presentation'] {
-  z-index: 5;
-}
-
 .pickerDialog {
   padding: 24px 32px;
 }


### PR DESCRIPTION
A couple small polish items in Python Lab:
- Put a border-radius of 4px on all the pop up dialogs/modals. This stemmed from [CT-1213](https://codedotorg.atlassian.net/browse/CT-1213) saying the project picker modal should have rounded corners "like settings and version history", which don't currently have rounded corners. I looked at the figma and there were 4px rounded corners on those modals, which we missed. I also updated the pop up button to have the same border radius.
- Remove a few unnecessary z-indices. Sanchit did some investigation into z-indexes for #65862. It uncovered one that was in the Python Lab workspace that I traced back to trying to fix the version history modal overlapping with the console. We have since moved the modal to a portal, so that was not needed.
- We also had a z-index on the project picker modal, but the modal has since been improved and doesn't need it.

## Before

<img width="684" alt="Screenshot 2025-05-21 at 10 22 52 AM" src="https://github.com/user-attachments/assets/b3eb6b56-e255-4a4f-b3e7-3a0f43e87d39" />
<img width="145" alt="Screenshot 2025-05-21 at 10 22 31 AM" src="https://github.com/user-attachments/assets/94f4e4c1-a625-459f-ab43-9ee26eff1fe9" />
<img width="199" alt="Screenshot 2025-05-21 at 10 22 20 AM" src="https://github.com/user-attachments/assets/305de066-bdca-4f1b-834a-13829a1f35e8" />
<img width="431" alt="Screenshot 2025-05-21 at 10 22 11 AM" src="https://github.com/user-attachments/assets/c977c1bb-143c-4aa3-89bd-0fe1b1b77180" />
<img width="431" alt="Screenshot 2025-05-21 at 10 22 03 AM" src="https://github.com/user-attachments/assets/60860b65-dbc4-4acd-b5a5-c6246f066b27" />

## After
<img width="684" alt="Screenshot 2025-05-21 at 10 23 47 AM" src="https://github.com/user-attachments/assets/ba988857-6bc1-4017-9dbb-242be5a5c376" />
<img width="144" alt="Screenshot 2025-05-21 at 10 24 18 AM" src="https://github.com/user-attachments/assets/d76616ea-fc6f-46b1-8ee5-2672c0896d9d" />
<img width="199" alt="Screenshot 2025-05-21 at 10 24 27 AM" src="https://github.com/user-attachments/assets/dd9c3a3d-87a5-40f9-8c75-0549dc7a83cf" />
<img width="428" alt="Screenshot 2025-05-21 at 10 24 08 AM" src="https://github.com/user-attachments/assets/20cee9ad-3f91-4abb-af36-f0cc7cd9dd27" />
<img width="428" alt="Screenshot 2025-05-21 at 10 24 00 AM" src="https://github.com/user-attachments/assets/ad9588c3-622c-46aa-a971-33bddda549a9" />


## Links

- Jira: [CT-1213](https://codedotorg.atlassian.net/browse/CT-1213). The issue in that ticket relating to the logo still showing up when the picker is up will be fixed by #65862.

## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
