### PR TITLE
Music: absolute tune notes

### DIFF
--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -118,13 +118,15 @@ export default class FieldTune extends GoogleBlockly.Field {
       this.backgroundElement
     );
 
-    const {events, scaleMode} = this.getValue();
+    const {events, scaleMode, relative} = this.getValue();
     const key = MusicRegistry.player.getKey();
 
-    const mapFn = (event: InstrumentTickEvent) => ({
-      ...event,
-      note: convertRelativeToAbsolutePitch(key, event.note),
-    });
+    const mapFn = relative
+      ? (event: InstrumentTickEvent) => ({
+          ...event,
+          note: convertRelativeToAbsolutePitch(key, event.note),
+        })
+      : (event: InstrumentTickEvent) => event;
 
     const notes = events
       .map(mapFn)

--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -80,7 +80,7 @@ export const DEFAULT_TUNE: InstrumentEventValue = {
   instrument: 'piano',
   events: [],
   length: DEFAULT_TUNE_LENGTH,
-  relative: true,
+  relative: false,
   scaleMode: 'simple',
 };
 

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -54,10 +54,12 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
       ...initialValue,
       events: initialValue.events.map(event => ({
         ...event,
-        note: convertRelativeToAbsolutePitch(
-          MusicRegistry.player.getKey(),
-          event.note
-        ),
+        note: initialValue.relative
+          ? convertRelativeToAbsolutePitch(
+              MusicRegistry.player.getKey(),
+              event.note
+            )
+          : event.note,
       })),
     };
     return convertedValue;
@@ -74,7 +76,9 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
       ...currentValue,
       events: currentValue.events.map(event => ({
         ...event,
-        note: convertAbsoluteToRelativePitch(key, event.note),
+        note: currentValue.relative
+          ? convertAbsoluteToRelativePitch(key, event.note)
+          : event.note,
       })),
     };
     onChange(convertedValue);


### PR DESCRIPTION
This changes the "play tune" block to once again store notes as absolute values rather than relative (as had been introduced in https://github.com/code-dot-org/code-dot-org/pull/65667).  "C4" is stored as 60.  

As we considered adding major or minor key information to each song, we realized we would have to make additional adjustments to relative notes since the tonic would change.  This was getting quite complicated; we're opting for simplicity for now.  The previous support for relative notes remains available if we want to do that work in the future.
