### PR TITLE
Python Lab: Update workspace header height

### DIFF
--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -58,6 +58,8 @@
 
 .workspaceHeader {
   border-bottom: 1px solid var(--borders-neutral-primary);
+  height: 2rem;
+  min-height: 2rem;
 }
 
 .centerHeaderContent {


### PR DESCRIPTION
Small update to change the workspace header from the default 30px to 2rem, as requested by design. This gives the project picker button a bit more breathing room.

## Before
<img width="134" alt="Screenshot 2025-05-21 at 1 21 07 PM" src="https://github.com/user-attachments/assets/7cd136d1-b0e6-4fde-a657-8b9f3fa9325d" />

## After
<img width="134" alt="Screenshot 2025-05-21 at 1 21 21 PM" src="https://github.com/user-attachments/assets/610653a1-1929-4193-892b-b4622e3c740f" />

## Links

- Jira: [CT-1227](https://codedotorg.atlassian.net/browse/CT-1227)

## Testing story
Tested locally.

## Follow-up work
It's possible Mark may want other headers adjusted, when he's back I will confirm with him if that's the case and can make follow-ups. In [this thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1747427861853519) the concern was with the switcher button, which is only present in the workspace header.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
