### PR TITLE
fix(tools): update to use dynamic path slug

### DIFF
--- a/frontend/apps/marketing/src/components/contentEditorHelper/Tools/Tools.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/Tools/Tools.tsx
@@ -15,7 +15,7 @@ const ContentEditorTools = ({
   isDraftModeEnabled,
   previewLabel,
 }: ContentEditorToolsProps) => {
-  const pageParams = useParams();
+  const pageParams = useParams<{paths: Array<string>; locale: string}>();
   const [shareLinkButtonText, setShareableLinkButtonText] =
     useState('Get shareable link');
 
@@ -29,7 +29,9 @@ const ContentEditorTools = ({
 
   const getEnableDraftModeUrl = () => {
     const draftModeToken = localStorage.getItem('draftToken');
-    return `/api/draft?token=${draftModeToken}&slug=${pageParams.slug}&locale=${pageParams.locale}`;
+    console.log(pageParams);
+
+    return `/api/draft?token=${draftModeToken}&slug=${pageParams.paths?.join('/')}&locale=${pageParams.locale}`;
   };
   const handleEnterDraftMode = () => {
     redirect(getEnableDraftModeUrl());

--- a/frontend/apps/marketing/src/components/contentEditorHelper/Tools/Tools.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/Tools/Tools.tsx
@@ -29,7 +29,6 @@ const ContentEditorTools = ({
 
   const getEnableDraftModeUrl = () => {
     const draftModeToken = localStorage.getItem('draftToken');
-    console.log(pageParams);
 
     return `/api/draft?token=${draftModeToken}&slug=${pageParams.paths?.join('/')}&locale=${pageParams.locale}`;
   };

--- a/frontend/apps/marketing/src/components/contentEditorHelper/Tools/__tests__/Tools.test.tsx
+++ b/frontend/apps/marketing/src/components/contentEditorHelper/Tools/__tests__/Tools.test.tsx
@@ -28,7 +28,10 @@ describe('ContentEditorTools', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useParams as jest.Mock).mockReturnValue({slug: 'test-slug', locale: 'en'});
+    (useParams as jest.Mock).mockReturnValue({
+      paths: ['engineering', 'test-slug'],
+      locale: 'en',
+    });
   });
 
   it('renders the preview label', () => {
@@ -63,7 +66,7 @@ describe('ContentEditorTools', () => {
 
     await waitFor(async () => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        `http://localhost/api/draft?token=null&slug=test-slug&locale=en`,
+        `http://localhost/api/draft?token=null&slug=engineering/test-slug&locale=en`,
       );
 
       expect(await screen.findByText('Copied!')).toBeInTheDocument();


### PR DESCRIPTION
The page path slug was changed to be multi-directory, update the tool to join those slugs.