### PR TITLE
Music: tune sharp symbol

### DIFF
--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -320,7 +320,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
                   className={classNames(style, styles.innerCell)}
                   style={{backgroundColor, color}}
                 >
-                  {label.replace('#', '♯')}
+                  {label}
                 </div>
               </button>
 


### PR DESCRIPTION
This goes back to using the number sign (U+0023) instead of the music sharp sign (U+266F) for note names in the "play tune" block.

While the music sharp sign looked fine on localhost, the slightly-different fonts used on production looked wrong.

# after

### production

<img width="78" alt="Screenshot 2025-05-21 at 8 22 34 PM" src="https://github.com/user-attachments/assets/a91f84fe-2f08-4a0d-b896-a343effdf22c" />

# before

### production

<img width="78" alt="Screenshot 2025-05-21 at 8 22 38 PM" src="https://github.com/user-attachments/assets/712511c0-d15b-42c8-86bf-481291c8ec2b" />

### localhost

<img width="78" alt="Screenshot 2025-05-21 at 8 19 50 PM" src="https://github.com/user-attachments/assets/ce30136e-6cbe-41c3-9280-4ce558f7943a" />
