### PR TITLE
Temporarily disable permanent redirect for level URLs

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -157,7 +157,9 @@ class ScriptLevelsController < ApplicationController
     canonical_path = build_script_level_path(@script_level, @extra_params, course_name: course_name, unit_position: unit_position)
     if request.path != canonical_path && params[:view] != 'summary'
       canonical_path << "?#{request.query_string}" unless request.query_string.empty?
-      redirect_to canonical_path, status: :moved_permanently
+      # TODO: TEACH-1916 Restore :moved_permanently after nested url migration is stable.
+      #redirect_to canonical_path, status: :moved_permanently
+      redirect_to canonical_path
       return
     end
 

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -928,7 +928,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       id: '2'
     }
 
-    assert_response 301 # moved permanently
+    # TODO: TEACH-1916 Return this to 301 after the nested URL change is live and stable.
+    assert_response 302 # moved permanently
     assert_redirected_to '/hoc/2'
   end
 
@@ -949,7 +950,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       id: '2'
     }
 
-    assert_response 301 # moved permanently
+    # TODO: TEACH-1916 Return this to 301 after the nested URL change is live and stable.
+    assert_response 302 # moved permanently
     assert_redirected_to '/flappy/2'
   end
 


### PR DESCRIPTION
Sometimes when a user tries to open a URL to a deprecated level URL, we respond with an HTTP 301 Permanent Redirect response which informs the browser to automatically redirect to the new URL in the future. While we are transitioning from /s/ URLs to /course/.../units/... URLs, we should temporarily remove this permanent redirect just in case we need to roll-back the migration to the new URL format. If we don't do this change, we risk users having a permanent redirect to a URL which no longer works because we rolled back support for it.

## Testing story
* Unit tests

## Future work
* [Jira to revert this](https://codedotorg.atlassian.net/browse/TEACH-1916)