### PR TITLE
feat: add tooltip to more sessions text in catalog

### DIFF
--- a/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalogCard.jsx
+++ b/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalogCard.jsx
@@ -2,6 +2,7 @@ import {Button, LinkButton} from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Modal from '@code-dot-org/component-library/modal';
 import Tags from '@code-dot-org/component-library/tags';
+import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import {
   BodyOneText,
   BodyTwoText,
@@ -9,7 +10,7 @@ import {
 } from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {Fragment, useState} from 'react';
 
 import {getSessionDate, getSessionTimes} from '../sessionDateUtils';
 
@@ -17,19 +18,22 @@ import GradeLevelsBarDisplay from './GradeLevelsBarDisplay';
 
 import style from './regionalWorkshopCatalog.module.scss';
 
-const buildWorkshopStartText = sessions => {
+const buildSessionDateAndTime = session => {
   const firstSessionDate = getSessionDate({
-    session: sessions[0],
+    session: session,
     format: 'MM/DD/YY',
-    isLocal: sessions[0].is_local,
+    isLocal: session.is_local,
   });
   const {startTime, endTime} = getSessionTimes({
-    session: sessions[0],
+    session: session,
     format: 'h:mmA',
-    isLocal: sessions[0].is_local,
+    isLocal: session.is_local,
   });
-  const firstSessionDateTime = `${firstSessionDate} (${startTime}-${endTime})`;
+  return `${firstSessionDate} (${startTime}-${endTime})`;
+};
 
+const buildWorkshopStartText = sessions => {
+  const firstSessionDateTime = buildSessionDateAndTime(sessions[0]);
   return sessions.length > 1
     ? `${firstSessionDateTime} + ${sessions.length - 1} More`
     : firstSessionDateTime;
@@ -118,12 +122,28 @@ const RegionalWorkshopCatalogCard = ({
             )}
           </div>
           <div className={style.infoBlock}>
-            <span className={style.infoLine}>
-              <div className={style.infoLineIconContainer}>
-                <FontAwesomeV6Icon iconName={'calendar'} />
-              </div>
-              <BodyTwoText>{buildWorkshopStartText(sessions)}</BodyTwoText>
-            </span>
+            <WithTooltip
+              tooltipProps={{
+                tooltipId: sessions[0].start,
+                size: 'xs',
+                text: sessions.map(session => {
+                  const text = buildSessionDateAndTime(session);
+                  return (
+                    <Fragment key={text}>
+                      {text}
+                      <br />
+                    </Fragment>
+                  );
+                }),
+              }}
+            >
+              <span className={style.infoLine}>
+                <div className={style.infoLineIconContainer}>
+                  <FontAwesomeV6Icon iconName={'calendar'} />
+                </div>
+                <BodyTwoText>{buildWorkshopStartText(sessions)}</BodyTwoText>
+              </span>
+            </WithTooltip>
             <span className={style.infoLine}>
               <div className={style.infoLineIconContainer}>
                 <FontAwesomeV6Icon iconName={'screen-users'} />


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds a tooltip containing all workshop session dates and times

https://github.com/user-attachments/assets/ebf962c3-8c11-472c-8951-c20d2a54040c


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3303
- Figma: https://www.figma.com/design/Km9JCLNbayBlTrlnKenumq/New-PL-Program?node-id=3814-28855&t=pN5vZY3dzqkAUFh5-0

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
