### PR TITLE
fix(marketing): allows Video and ActionBlock components to be hidden

### DIFF
--- a/frontend/apps/marketing/src/components/actionBlocks/defaultActionBlock/ActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/actionBlocks/defaultActionBlock/ActionBlock.tsx
@@ -22,6 +22,7 @@ export type ActionBlockContentfulProps = ActionBlockProps & {
 };
 
 const ActionBlock: React.FC<ActionBlockContentfulProps> = ({
+  className,
   overline,
   title,
   description,
@@ -32,6 +33,7 @@ const ActionBlock: React.FC<ActionBlockContentfulProps> = ({
   publishedDate,
 }) => (
   <DSCOActionBlock
+    className={className}
     overline={overline}
     title={title}
     description={description}

--- a/frontend/apps/marketing/src/components/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
@@ -25,6 +25,7 @@ export type FullWidthActionBlockContentfulProps = Omit<
 };
 
 const FullWidthActionBlock: React.FC<FullWidthActionBlockContentfulProps> = ({
+  className,
   image,
   overline,
   title,
@@ -35,6 +36,7 @@ const FullWidthActionBlock: React.FC<FullWidthActionBlockContentfulProps> = ({
   publishedDate,
 }) => (
   <DSCOFullWidthActionBlock
+    className={className}
     image={{src: `https:${image}`}}
     overline={overline}
     title={title}

--- a/frontend/packages/component-library/src/video/Video.tsx
+++ b/frontend/packages/component-library/src/video/Video.tsx
@@ -156,7 +156,9 @@ const Video: React.FC<VideoProps> = ({
     }
   };
   return (
-    <figure className={moduleStyles.videoComponentContainer}>
+    <figure
+      className={classNames(moduleStyles.videoComponentContainer, className)}
+    >
       <div className={moduleStyles.videoWrapper}>{getVideoPlayer()}</div>
       <div className={moduleStyles.footer}>
         {showCaption && <Figcaption>{videoTitle}</Figcaption>}


### PR DESCRIPTION
Fixes an issue where the Video, ActionBlock, and FullWidthActionBlock components were not being hidden in the Contentful editor. Contentful support told us to add a `className` prop to these components and that fixed it.

## Links
Jira ticket: [CMS-748](https://codedotorg.atlassian.net/browse/CMS-748)
Slack convo: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1747249959240089)
Contentful support ticket: [here](https://support.contentful.com/hc/en-us/requests/195389)

## Testing story
Tested locally

----

## Before


https://github.com/user-attachments/assets/34b5fee7-1eee-43f6-8123-daa7f6c3ccc1



## After


https://github.com/user-attachments/assets/9ed9bf0f-b15f-4fb6-a2ee-9fe8199e91b5

