### PR TITLE
truncate experiments table before each UI test run

### DIFF
--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -58,6 +58,7 @@ DASHBOARD_TEST_TABLES = %w(
   projects
   user_project_storage_ids
 ).freeze
+puts "Truncating #{DASHBOARD_TEST_TABLES} on database #{CDO.dashboard_db_name}"
 DASHBOARD_TEST_TABLES.each do |table|
   # rubocop:disable CustomCops/DashboardDbUsage
   DASHBOARD_DB[table.to_sym].truncate

--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -53,6 +53,7 @@ DASHBOARD_TEST_TABLES = %w(
   channel_tokens
   code_review_comments
   code_reviews
+  experiments
   project_commits
   projects
   user_project_storage_ids

--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -49,7 +49,14 @@ VCR.configure do |c|
 end
 
 # Truncate database tables to ensure repeatable tests.
-DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects project_commits code_review_comments code_reviews).freeze
+DASHBOARD_TEST_TABLES = %w(
+  channel_tokens
+  code_review_comments
+  code_reviews
+  project_commits
+  projects
+  user_project_storage_ids
+).freeze
 DASHBOARD_TEST_TABLES.each do |table|
   # rubocop:disable CustomCops/DashboardDbUsage
   DASHBOARD_DB[table.to_sym].truncate


### PR DESCRIPTION
See [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1747869194225169?thread_ts=1747865757.019719&cid=C0T0PNTM3). The experiments table on test grew to ~20K entries, then a new feature which checked a ruby experiment often failed to pass UI tests due to performance issues. 

To address this comment from the COE:

> Given these numbers, I think it's a good thing that this bug popped up through our UI tests! We were able to catch it before it became a more serious production live-site issue (which it would have as this table kept growing), which is the purpose of our test automation.

The issue which occurred during DTT is NOT representative of a performance issue in production because we cache experiments in prod but [not in test](https://github.com/code-dot-org/code-dot-org/blob/0adc1d262de123bddca79c1533704f4bc9a3a62b/dashboard/config/environments/test.rb#L102).

## Testing story

## Deployment strategy

## Follow-up work
