### PR TITLE
feat(cache): reduce revalidate period to 15 min

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
@@ -14,7 +14,18 @@ import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
 import {getSeoMetadata} from '@/metadata/seo';
 import {getPageHeading} from '@/selectors/contentful/getExperienceEntryFields';
 
-export const revalidate = 3600; // Cache for one hour
+/**
+ * This sets the time for which a page is considered "fresh" to the upstream requester.
+ *
+ * The Code.org infrastructure currently has two upstream caches in a sequential chain:
+ * 1. Marketing CDN
+ * 2. Code.org front door CDN (targeted to be removed in the future)
+ *
+ * When this revalidate parameter is sent, it can take a total of [revalidate] * [number of upstream chains+1] seconds
+ *
+ * With the current value being 15 minutes, it can therefore take [900] * [2 + 1] = 45 minutes for a page to be updated.
+ */
+export const revalidate = 900; // Fresh for 15 minutes
 
 type ExperiencePageProps = {
   params: Promise<{locale?: string; paths?: string; brand?: Brand}>;

--- a/frontend/apps/marketing/tests/e2e/cache.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/cache.spec.ts
@@ -14,7 +14,7 @@ test.describe('Caching Tests', () => {
 
     const cacheControlHeader = response?.headers()['cache-control'];
     expect(cacheControlHeader).toMatch(
-      /^s-maxage=3600, stale-while-revalidate=\d+$/,
+      /^s-maxage=900, stale-while-revalidate=\d+$/,
     );
   });
 


### PR DESCRIPTION
This PR reduces the revalidate period to 15 mins for which a page is considered "fresh" to the upstream requester.

The Code.org infrastructure currently has two upstream caches in a sequential chain:
1. Marketing CDN
2. Code.org front door CDN (targeted to be removed in the future)

When this revalidate parameter is sent, it can take a total of [revalidate] * [number of upstream chains+1] seconds

With the current value being 15 minutes, it can therefore take [900] * [2 + 1] = 45 minutes for a page to be updated.