### PR TITLE
Fix(Tooltip): Add hideTail prop

### DIFF
--- a/frontend/packages/component-library/src/tooltip/_Tooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/_Tooltip.tsx
@@ -26,6 +26,7 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   size?: ComponentSizeXSToL;
   /** Tooltip custom styles (used for positioning the tooltip on the go) */
   style?: React.CSSProperties;
+  noTail?: boolean;
 }
 
 export interface TooltipOverlayProps {
@@ -71,6 +72,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       className,
       size = 'm',
       style = {},
+      noTail,
       ...HTMLAttributes
     },
     ref,
@@ -84,6 +86,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           moduleStyles.tooltip,
           moduleStyles[`tooltip-${direction}`],
           moduleStyles[`tooltip-${size}`],
+          noTail && moduleStyles.noTail,
           className,
         )}
         style={style}

--- a/frontend/packages/component-library/src/tooltip/_Tooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/_Tooltip.tsx
@@ -26,6 +26,7 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   size?: ComponentSizeXSToL;
   /** Tooltip custom styles (used for positioning the tooltip on the go) */
   style?: React.CSSProperties;
+  /** Hides the tooltip's tail (arrow). Defaults to false. */
   hideTail?: boolean;
 }
 

--- a/frontend/packages/component-library/src/tooltip/_Tooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/_Tooltip.tsx
@@ -26,7 +26,7 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   size?: ComponentSizeXSToL;
   /** Tooltip custom styles (used for positioning the tooltip on the go) */
   style?: React.CSSProperties;
-  noTail?: boolean;
+  hideTail?: boolean;
 }
 
 export interface TooltipOverlayProps {
@@ -72,7 +72,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       className,
       size = 'm',
       style = {},
-      noTail,
+      hideTail = false,
       ...HTMLAttributes
     },
     ref,
@@ -86,7 +86,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           moduleStyles.tooltip,
           moduleStyles[`tooltip-${direction}`],
           moduleStyles[`tooltip-${size}`],
-          noTail && moduleStyles.noTail,
+          hideTail && moduleStyles.noTail,
           className,
         )}
         style={style}

--- a/frontend/packages/component-library/src/tooltip/__tests__/Tooltip.test.tsx
+++ b/frontend/packages/component-library/src/tooltip/__tests__/Tooltip.test.tsx
@@ -37,42 +37,68 @@ describe('Design System - Tooltip', () => {
     // Tooltip should now be present
     expect(screen.getByText('tooltipText')).toBeInTheDocument();
   });
-});
 
-it('can hide the tooltip imperatively using the hideTooltip method', async () => {
-  const user = userEvent.setup();
+  it('can hide the tooltip imperatively using the hideTooltip method', async () => {
+    const user = userEvent.setup();
 
-  const TestComponent = () => {
-    const tooltipRef = useRef<WithTooltipHandle>(null);
+    const TestComponent = () => {
+      const tooltipRef = useRef<WithTooltipHandle>(null);
 
-    return (
-      <WithTooltip
-        ref={tooltipRef}
-        tooltipProps={{
-          tooltipId: 'tooltip1',
-          text: 'tooltipText',
-          direction: 'onTop',
-          size: 'm',
-        }}
-      >
-        <button type="button" onClick={() => tooltipRef.current?.hideTooltip()}>
-          hover me then click me
-        </button>
-      </WithTooltip>
-    );
-  };
+      return (
+        <WithTooltip
+          ref={tooltipRef}
+          tooltipProps={{
+            tooltipId: 'tooltip1',
+            text: 'tooltipText',
+            direction: 'onTop',
+            size: 'm',
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => tooltipRef.current?.hideTooltip()}
+          >
+            hover me then click me
+          </button>
+        </WithTooltip>
+      );
+    };
 
-  render(<TestComponent />);
+    render(<TestComponent />);
 
-  const tooltipTrigger = screen.getByText('hover me then click me');
+    const tooltipTrigger = screen.getByText('hover me then click me');
 
-  // Hover to show the tooltip
-  await user.hover(tooltipTrigger);
-  expect(await screen.findByText('tooltipText')).toBeInTheDocument();
+    // Hover to show the tooltip
+    await user.hover(tooltipTrigger);
+    expect(await screen.findByText('tooltipText')).toBeInTheDocument();
 
-  // Click to hide tooltip via imperative ref.
-  await user.click(tooltipTrigger);
+    // Click to hide tooltip via imperative ref.
+    await user.click(tooltipTrigger);
 
-  // Tooltip should be removed
-  expect(screen.queryByText('tooltipText')).not.toBeInTheDocument();
+    // Tooltip should be removed
+    expect(screen.queryByText('tooltipText')).not.toBeInTheDocument();
+  });
+
+  it('applies the "noTail" class if hideTail prop is set to true', async () => {
+    const user = userEvent.setup();
+
+    // Tooltip without tail
+    renderWithTooltip({tooltipId: 'tooltipWithoutTail', hideTail: true});
+    const triggerWithoutTail = screen.getByText('hover me');
+    await user.hover(triggerWithoutTail);
+    const tooltipWithoutTail = await screen.findByRole('tooltip');
+    expect(tooltipWithoutTail.className).toMatch(/noTail/);
+  });
+
+  it('omits the "noTail" class if hideTail prop is not included', async () => {
+    const user = userEvent.setup();
+
+    // Tooltip with default tail (hideTail undefined)
+    renderWithTooltip({tooltipId: 'tooltipWithTail'});
+    const triggerWithTail = screen.getByText('hover me');
+    await user.hover(triggerWithTail);
+    const tooltipWithTail = await screen.findByRole('tooltip');
+
+    expect(tooltipWithTail.className).not.toMatch(/noTail/);
+  });
 });

--- a/frontend/packages/component-library/src/tooltip/stories/WithTooltip.story.tsx
+++ b/frontend/packages/component-library/src/tooltip/stories/WithTooltip.story.tsx
@@ -269,3 +269,23 @@ export const ImperativeHideTooltip: StoryFn = () => {
     </div>
   );
 };
+
+export const TailToggleTooltip = MultipleTemplate.bind({});
+TailToggleTooltip.args = {
+  components: [
+    {
+      text: 'Tooltip with tail',
+      tooltipId: 'tooltipWithTail',
+      direction: 'onBottom',
+      size: 'm',
+      hideTail: false,
+    },
+    {
+      text: 'Tooltip without tail',
+      tooltipId: 'tooltipWithoutTail',
+      direction: 'onBottom',
+      size: 'm',
+      hideTail: true,
+    },
+  ],
+};

--- a/frontend/packages/component-library/src/tooltip/stories/WithTooltip.story.tsx
+++ b/frontend/packages/component-library/src/tooltip/stories/WithTooltip.story.tsx
@@ -270,15 +270,14 @@ export const ImperativeHideTooltip: StoryFn = () => {
   );
 };
 
-export const TailToggleTooltip = MultipleTemplate.bind({});
-TailToggleTooltip.args = {
+export const ShowHideTailTooltip = MultipleTemplate.bind({});
+ShowHideTailTooltip.args = {
   components: [
     {
       text: 'Tooltip with tail',
       tooltipId: 'tooltipWithTail',
       direction: 'onBottom',
       size: 'm',
-      hideTail: false,
     },
     {
       text: 'Tooltip without tail',

--- a/frontend/packages/component-library/src/tooltip/tooltip.module.scss
+++ b/frontend/packages/component-library/src/tooltip/tooltip.module.scss
@@ -72,6 +72,12 @@ $tooltip-span-vertical-top-spacing: 2px;
     color: var(--text-neutral-inverse);
     width: max-content;
   }
+
+  &.noTail {
+    &::after {
+      display: none;
+    }
+  }
 }
 
 // Direction
@@ -204,8 +210,4 @@ $tooltip-span-vertical-top-spacing: 2px;
   }
 
   @include tooltip-tail-sizing($xs-tail-length);
-}
-
-.noTail::after {
-  display: none !important;
 }

--- a/frontend/packages/component-library/src/tooltip/tooltip.module.scss
+++ b/frontend/packages/component-library/src/tooltip/tooltip.module.scss
@@ -205,3 +205,7 @@ $tooltip-span-vertical-top-spacing: 2px;
 
   @include tooltip-tail-sizing($xs-tail-length);
 }
+
+.noTail::after {
+  display: none !important;
+}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds a `hideTail` prop to `Tooltip` so that if a tooltip is anticipated to be dynamically positioned, the tail can be hidden since there is no easy way to dynamically place the tail.

After update: new Storybook entry

https://github.com/user-attachments/assets/3cab5d1b-27c4-460f-8828-8687a1ac3c40



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Comment: https://github.com/code-dot-org/code-dot-org/pull/65142#discussion_r2102762980

## Testing story
Added a storybook entry and a couple unit tests.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
