### PR TITLE
Skip failing eyes test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -173,6 +173,7 @@ Scenario: Teacher views Rubric and Settings tabs
   Then I close my eyes
 
 @eyes
+@skip
 Scenario: Teacher views product tour
   # Teacher signs in and navigates to assessment page
   Given I create an authorized teacher-associated student named "Aiden"


### PR DESCRIPTION
Disables `teacher_tools/rubrics/teacher_view_of_rubric.feature`

See previous DOTDs mentioning issues with this test historically as well.

Current Slack thread: https://codedotorg.slack.com/archives/C045UAX4WKH/p1747888828285929