### PR TITLE
chore(marketing): update Tools heading in CurriculumSnapshot

### DIFF
--- a/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/CurriculumSnapshot.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/CurriculumSnapshot.tsx
@@ -49,7 +49,7 @@ const CurriculumSnapshot: React.FunctionComponent<CurriculumSnapshotProps> = ({
     addItem('Duration', 'clock', duration);
     addItem('Devices', 'desktop', devices);
     addItem('Topics', 'book', topics);
-    addItem('Programming Tools', 'screwdriver-wrench', devTools);
+    addItem('Tools', 'screwdriver-wrench', devTools);
     addItem('Professional Learning', 'chalkboard-user', proLearning);
     addItem('Accessibility', 'universal-access', accessibility);
     addItem('Languages supported', 'language', languages);

--- a/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/__tests__/CurriculumSnapshot.test.tsx
+++ b/frontend/apps/marketing/src/components/snapshots/curriculumSnapshot/__tests__/CurriculumSnapshot.test.tsx
@@ -44,7 +44,7 @@ describe('CurriculumSnapshot component', () => {
     expect(curriculumSnapshot).toBeVisible();
     expect(curriculumSnapshot).toHaveTextContent(
       'Grades: 1, 1st; Level: 2, 2nd; Duration: 3, 3rd; Devices: 4, 4th; Topics: 5, 5th; ' +
-        'Programming Tools: 6, 6th; Professional Learning: 7, 7th; Accessibility: 8, 8th; Languages supported: 9, 9th',
+        'Tools: 6, 6th; Professional Learning: 7, 7th; Accessibility: 8, 8th; Languages supported: 9, 9th',
     );
   });
 


### PR DESCRIPTION
Updates "Programming Tools" label to "Tools" on the CurriculumSnapshot component in Contentful.

## Links
Jira ticket: [CMS-744](https://codedotorg.atlassian.net/browse/CMS-744)

## Testing story
Tested locally

----

## Before
<img width="1025" alt="Before" src="https://github.com/user-attachments/assets/6bb4eb20-8780-457e-abe5-074deded40ad" />

## After
<img width="1025" alt="After" src="https://github.com/user-attachments/assets/fdc0ddf2-14a2-4551-af57-82e220325092" />
