### PR TITLE
Theme the lab2 share modal

### DIFF
--- a/apps/src/code-studio/components/header/ProjectShare.jsx
+++ b/apps/src/code-studio/components/header/ProjectShare.jsx
@@ -9,8 +9,8 @@ import {shareProject} from '../../headerShare';
 
 import styles from './project-header.module.scss';
 
-const ProjectShare = () => {
-  const onProjectShare = () => {
+export default class ProjectShare extends React.Component {
+  shareProject = () => {
     if (Lab2Registry.hasEnabledProjects()) {
       // If we are using Lab2, share using the project manager and
       // shareLab2Project.
@@ -22,21 +22,21 @@ const ProjectShare = () => {
     }
   };
 
-  return (
-    <button
-      type="button"
-      className={classNames(
-        styles.buttonSpacing,
-        'project_share',
-        'header_button',
-        'header_button_light',
-        'no-mc'
-      )}
-      onClick={onProjectShare}
-    >
-      {i18n.share()}
-    </button>
-  );
-};
-
-export default ProjectShare;
+  render() {
+    return (
+      <button
+        type="button"
+        className={classNames(
+          styles.buttonSpacing,
+          'project_share',
+          'header_button',
+          'header_button_light',
+          'no-mc'
+        )}
+        onClick={this.shareProject}
+      >
+        {i18n.share()}
+      </button>
+    );
+  }
+}

--- a/apps/src/code-studio/components/header/ProjectShare.jsx
+++ b/apps/src/code-studio/components/header/ProjectShare.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import {shareLab2Project} from '@cdo/apps/lab2/header/lab2HeaderShare';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import {shareProject} from '../../headerShare';
@@ -11,12 +10,11 @@ import {shareProject} from '../../headerShare';
 import styles from './project-header.module.scss';
 
 const ProjectShare = () => {
-  const theme = useAppSelector(state => state.header.theme);
   const onProjectShare = () => {
     if (Lab2Registry.hasEnabledProjects()) {
       // If we are using Lab2, share using the project manager and
       // shareLab2Project.
-      shareLab2Project(undefined, undefined, theme);
+      shareLab2Project();
     } else {
       // Otherwise, we are using the legacy labs system, get the share url from that system
       // and share using shareProject.

--- a/apps/src/code-studio/components/header/ProjectShare.jsx
+++ b/apps/src/code-studio/components/header/ProjectShare.jsx
@@ -3,18 +3,20 @@ import React from 'react';
 
 import {shareLab2Project} from '@cdo/apps/lab2/header/lab2HeaderShare';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import {shareProject} from '../../headerShare';
 
 import styles from './project-header.module.scss';
 
-export default class ProjectShare extends React.Component {
-  shareProject = () => {
+const ProjectShare = () => {
+  const theme = useAppSelector(state => state.header.theme);
+  const onProjectShare = () => {
     if (Lab2Registry.hasEnabledProjects()) {
       // If we are using Lab2, share using the project manager and
       // shareLab2Project.
-      shareLab2Project();
+      shareLab2Project(undefined, undefined, theme);
     } else {
       // Otherwise, we are using the legacy labs system, get the share url from that system
       // and share using shareProject.
@@ -22,21 +24,21 @@ export default class ProjectShare extends React.Component {
     }
   };
 
-  render() {
-    return (
-      <button
-        type="button"
-        className={classNames(
-          styles.buttonSpacing,
-          'project_share',
-          'header_button',
-          'header_button_light',
-          'no-mc'
-        )}
-        onClick={this.shareProject}
-      >
-        {i18n.share()}
-      </button>
-    );
-  }
-}
+  return (
+    <button
+      type="button"
+      className={classNames(
+        styles.buttonSpacing,
+        'project_share',
+        'header_button',
+        'header_button_light',
+        'no-mc'
+      )}
+      onClick={onProjectShare}
+    >
+      {i18n.share()}
+    </button>
+  );
+};
+
+export default ProjectShare;

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -21,6 +21,7 @@ import {
   showMinimalProjectHeader,
   showProjectBackedHeader,
   showLevelBuilderSaveButton,
+  setTheme,
 } from './headerRedux';
 import progress from './progress';
 import {setCurrentLevelId} from './progressRedux';
@@ -305,6 +306,10 @@ header.showTryAgainDialog = () => {
 
 header.hideTryAgainDialog = () => {
   getStore().dispatch(setShowTryAgainDialog(false));
+};
+
+header.setTheme = theme => {
+  getStore().dispatch(setTheme(theme));
 };
 
 export default header;

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -21,7 +21,6 @@ import {
   showMinimalProjectHeader,
   showProjectBackedHeader,
   showLevelBuilderSaveButton,
-  setTheme,
 } from './headerRedux';
 import progress from './progress';
 import {setCurrentLevelId} from './progressRedux';
@@ -306,10 +305,6 @@ header.showTryAgainDialog = () => {
 
 header.hideTryAgainDialog = () => {
   getStore().dispatch(setShowTryAgainDialog(false));
-};
-
-header.setTheme = theme => {
-  getStore().dispatch(setTheme(theme));
 };
 
 export default header;

--- a/apps/src/code-studio/headerRedux.ts
+++ b/apps/src/code-studio/headerRedux.ts
@@ -1,3 +1,4 @@
+import {Theme} from '@code-dot-org/component-library/common/contexts';
 import {PayloadAction, createSlice} from '@reduxjs/toolkit';
 
 export const possibleHeaders = {
@@ -18,6 +19,7 @@ export interface HeaderReduxState {
   getLevelBuilderChanges: (() => object) | undefined;
   overrideHeaderText: string | undefined;
   overrideOnSaveUrl: string | undefined;
+  theme: Theme | undefined;
 }
 
 const initialState: HeaderReduxState = {
@@ -25,6 +27,7 @@ const initialState: HeaderReduxState = {
   getLevelBuilderChanges: undefined,
   overrideHeaderText: undefined,
   overrideOnSaveUrl: undefined,
+  theme: undefined,
 };
 
 const headerSlice = createSlice({
@@ -65,6 +68,9 @@ const headerSlice = createSlice({
     clearHeader(state) {
       state.currentHeader = undefined;
     },
+    setTheme(state, action: PayloadAction<Theme | undefined>) {
+      state.theme = action.payload;
+    },
   },
 });
 
@@ -74,6 +80,7 @@ export const {
   showProjectBackedHeader,
   showLevelBuilderSaveButton,
   clearHeader,
+  setTheme,
 } = headerSlice.actions;
 
 export default headerSlice.reducer;

--- a/apps/src/code-studio/headerRedux.ts
+++ b/apps/src/code-studio/headerRedux.ts
@@ -1,4 +1,3 @@
-import {Theme} from '@code-dot-org/component-library/common/contexts';
 import {PayloadAction, createSlice} from '@reduxjs/toolkit';
 
 export const possibleHeaders = {
@@ -19,7 +18,6 @@ export interface HeaderReduxState {
   getLevelBuilderChanges: (() => object) | undefined;
   overrideHeaderText: string | undefined;
   overrideOnSaveUrl: string | undefined;
-  theme: Theme | undefined;
 }
 
 const initialState: HeaderReduxState = {
@@ -27,7 +25,6 @@ const initialState: HeaderReduxState = {
   getLevelBuilderChanges: undefined,
   overrideHeaderText: undefined,
   overrideOnSaveUrl: undefined,
-  theme: undefined,
 };
 
 const headerSlice = createSlice({
@@ -68,9 +65,6 @@ const headerSlice = createSlice({
     clearHeader(state) {
       state.currentHeader = undefined;
     },
-    setTheme(state, action: PayloadAction<Theme | undefined>) {
-      state.theme = action.payload;
-    },
   },
 });
 
@@ -80,7 +74,6 @@ export const {
   showProjectBackedHeader,
   showLevelBuilderSaveButton,
   clearHeader,
-  setTheme,
 } = headerSlice.actions;
 
 export default headerSlice.reducer;

--- a/apps/src/lab2/Lab2Registry.ts
+++ b/apps/src/lab2/Lab2Registry.ts
@@ -1,5 +1,7 @@
 // Registry for Lab singletons
 
+import {Theme} from '@code-dot-org/component-library/common/contexts';
+
 import LabMetricsReporter from './Lab2MetricsReporter';
 import ProjectManager from './projects/ProjectManager';
 import {AppName} from './types';
@@ -10,6 +12,7 @@ export default class Lab2Registry {
   private metricsReporter: LabMetricsReporter;
   private lifecycleNotifier: LifecycleNotifier;
   private appName: AppName | null;
+  private theme: Theme | undefined;
 
   private static _instance: Lab2Registry;
 
@@ -18,6 +21,7 @@ export default class Lab2Registry {
     this.metricsReporter = new LabMetricsReporter();
     this.lifecycleNotifier = new LifecycleNotifier();
     this.appName = null;
+    this.theme = undefined;
   }
 
   public static getInstance(): Lab2Registry {
@@ -64,5 +68,13 @@ export default class Lab2Registry {
 
   public getAppName() {
     return this.appName;
+  }
+
+  public setTheme(theme: Theme) {
+    this.theme = theme;
+  }
+
+  public getTheme() {
+    return this.theme;
   }
 }

--- a/apps/src/lab2/header/lab2HeaderShare.js
+++ b/apps/src/lab2/header/lab2HeaderShare.js
@@ -16,7 +16,7 @@ const PROJECT_SHARE_DIALOG_ID = 'project-share-dialog';
 /**
  * Save, then show the share dialog for a Lab2 project.
  */
-export function shareLab2Project(dialogId, finishUrl, theme) {
+export function shareLab2Project(dialogId, finishUrl) {
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   if (!projectManager) {
     return null;
@@ -37,7 +37,6 @@ export function shareLab2Project(dialogId, finishUrl, theme) {
           shareDialogId={dialogId}
           shareUrl={shareUrl}
           finishUrl={finishUrl}
-          theme={theme}
         />
       </Provider>,
       dialogDom

--- a/apps/src/lab2/header/lab2HeaderShare.js
+++ b/apps/src/lab2/header/lab2HeaderShare.js
@@ -16,7 +16,7 @@ const PROJECT_SHARE_DIALOG_ID = 'project-share-dialog';
 /**
  * Save, then show the share dialog for a Lab2 project.
  */
-export function shareLab2Project(dialogId, finishUrl) {
+export function shareLab2Project(dialogId, finishUrl, theme) {
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   if (!projectManager) {
     return null;
@@ -37,6 +37,7 @@ export function shareLab2Project(dialogId, finishUrl) {
           shareDialogId={dialogId}
           shareUrl={shareUrl}
           finishUrl={finishUrl}
+          theme={theme}
         />
       </Provider>,
       dialogDom

--- a/apps/src/lab2/progress/continueOrFinishLesson.ts
+++ b/apps/src/lab2/progress/continueOrFinishLesson.ts
@@ -56,8 +56,7 @@ function handleNavigation(
   // If we have a finish URL, show the finish dialog if present, or redirect to the finish URL.
   if (finishUrl) {
     if (finishDialog) {
-      const labTheme = getState().header.theme;
-      shareLab2Project(finishDialog, finishUrl, labTheme);
+      shareLab2Project(finishDialog, finishUrl);
     } else {
       window.location.href = finishUrl;
     }

--- a/apps/src/lab2/progress/continueOrFinishLesson.ts
+++ b/apps/src/lab2/progress/continueOrFinishLesson.ts
@@ -56,7 +56,8 @@ function handleNavigation(
   // If we have a finish URL, show the finish dialog if present, or redirect to the finish URL.
   if (finishUrl) {
     if (finishDialog) {
-      shareLab2Project(finishDialog, finishUrl);
+      const labTheme = getState().header.theme;
+      shareLab2Project(finishDialog, finishUrl, labTheme);
     } else {
       window.location.href = finishUrl;
     }

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -4,7 +4,6 @@
  * or channel, and will clean up the project manager on level change or unmount.
  */
 
-import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -57,18 +56,11 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
 
   const dispatch = useAppDispatch();
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
-  const {theme} = useTheme();
 
   // When the level changes, reset metadata relating to the project in redux.
   useLifecycleNotifier(LifecycleEvent.LevelLoadStarted, () =>
     dispatch(resetProjectMetadata())
   );
-
-  // We duplicate the theme to the header, because the header does not exist inside
-  // ThemeContext, and it needs to know the theme in order to show modals in the correct theme.
-  useEffect(() => {
-    header.setTheme(theme);
-  }, [theme]);
 
   useEffect(() => {
     // The redux types are very complicated, so in order to re-use this variable

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -64,10 +64,9 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
     dispatch(resetProjectMetadata())
   );
 
-  // We duplicate the theme to the header, because the header does not exist in the context
-  // of the app, and it needs to know the theme in order to show modals in the correct theme.
+  // We duplicate the theme to the header, because the header does not exist inside
+  // ThemeContext, and it needs to know the theme in order to show modals in the correct theme.
   useEffect(() => {
-    console.log('Setting header theme to', theme);
     header.setTheme(theme);
   }, [theme]);
 

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -4,6 +4,7 @@
  * or channel, and will clean up the project manager on level change or unmount.
  */
 
+import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -56,11 +57,19 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
 
   const dispatch = useAppDispatch();
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
+  const {theme} = useTheme();
 
   // When the level changes, reset metadata relating to the project in redux.
   useLifecycleNotifier(LifecycleEvent.LevelLoadStarted, () =>
     dispatch(resetProjectMetadata())
   );
+
+  // We duplicate the theme to the header, because the header does not exist in the context
+  // of the app, and it needs to know the theme in order to show modals in the correct theme.
+  useEffect(() => {
+    console.log('Setting header theme to', theme);
+    header.setTheme(theme);
+  }, [theme]);
 
   useEffect(() => {
     // The redux types are very complicated, so in order to re-use this variable

--- a/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
+++ b/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
@@ -134,7 +134,6 @@ const Lab2ShareDialogWrapper: React.FunctionComponent<
         onSubmitClick={onSubmitClick}
         submissionStatus={submissionStatus}
         channelId={channelId}
-        theme={theme}
       />
     ) : (
       <SubmitProjectDialog

--- a/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
+++ b/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
@@ -1,4 +1,3 @@
-import {Theme} from '@code-dot-org/component-library/common/contexts';
 import React, {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -28,7 +27,7 @@ import ShareDialog from './dialogs/ShareDialog';
  */
 const Lab2ShareDialogWrapper: React.FunctionComponent<
   Lab2ShareDialogWrapperProps
-> = ({shareDialogId, shareUrl, finishUrl, theme}) => {
+> = ({shareDialogId, shareUrl, finishUrl}) => {
   const isProjectLevel =
     useSelector(
       (state: {lab: LabState}) => state.lab.levelProperties?.isProjectLevel
@@ -169,7 +168,6 @@ interface Lab2ShareDialogWrapperProps {
   shareDialogId?: string;
   shareUrl: string;
   finishUrl?: string;
-  theme?: Theme;
 }
 
 export default Lab2ShareDialogWrapper;

--- a/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
+++ b/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
@@ -1,3 +1,4 @@
+import {Theme} from '@code-dot-org/component-library/common/contexts';
 import React, {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -27,7 +28,7 @@ import ShareDialog from './dialogs/ShareDialog';
  */
 const Lab2ShareDialogWrapper: React.FunctionComponent<
   Lab2ShareDialogWrapperProps
-> = ({shareDialogId, shareUrl, finishUrl}) => {
+> = ({shareDialogId, shareUrl, finishUrl, theme}) => {
   const isProjectLevel =
     useSelector(
       (state: {lab: LabState}) => state.lab.levelProperties?.isProjectLevel
@@ -133,6 +134,7 @@ const Lab2ShareDialogWrapper: React.FunctionComponent<
         onSubmitClick={onSubmitClick}
         submissionStatus={submissionStatus}
         channelId={channelId}
+        theme={theme}
       />
     ) : (
       <SubmitProjectDialog
@@ -168,6 +170,7 @@ interface Lab2ShareDialogWrapperProps {
   shareDialogId?: string;
   shareUrl: string;
   finishUrl?: string;
+  theme?: Theme;
 }
 
 export default Lab2ShareDialogWrapper;

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -63,7 +63,7 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
   const {theme} = useTheme();
 
-  // We duplicate the theme to Lab2Registry, because some modals in the header (such as the share modal)
+  // We duplicate the theme to Lab2Registry, because modals opened via the header (such as the share modal)
   // do not have access to the theme context.
   useEffect(() => {
     Lab2Registry.getInstance().setTheme(theme);

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -6,6 +6,7 @@
 // boundary; a fade-in between levels; a loading spinner when a level takes a
 // while to load; and a sad bee when things go wrong.
 
+import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import classNames from 'classnames';
 import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
@@ -60,6 +61,13 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
 
   // Store some server-provided data in redux.
   const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
+  const {theme} = useTheme();
+
+  // We duplicate the theme to Lab2Registry, because some modals in the header (such as the share modal)
+  // do not have access to the theme context.
+  useEffect(() => {
+    Lab2Registry.getInstance().setTheme(theme);
+  }, [theme]);
 
   // Store the level ID provided by App Options in redux if necessary.
   // This is needed on pages without a header, such as the share view.

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -1,5 +1,6 @@
 import Alert from '@code-dot-org/component-library/alert';
 import {Button, LinkButton} from '@code-dot-org/component-library/button';
+import {Theme} from '@code-dot-org/component-library/common/contexts';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Typography from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
@@ -147,6 +148,7 @@ const ShareDialog: React.FunctionComponent<{
   onSubmitClick: () => void;
   submissionStatus: SubmissionStatusType | undefined;
   channelId: string;
+  theme?: Theme;
 }> = ({
   dialogId,
   shareUrl,
@@ -155,6 +157,7 @@ const ShareDialog: React.FunctionComponent<{
   onSubmitClick,
   submissionStatus,
   channelId,
+  theme = 'Dark',
 }) => {
   const dispatch = useAppDispatch();
 
@@ -180,7 +183,7 @@ const ShareDialog: React.FunctionComponent<{
 
   return (
     <FocusLock>
-      <div className={moduleStyles.dialogContainer} data-theme="Light">
+      <div className={moduleStyles.dialogContainer} data-theme={theme}>
         <div id="share-dialog" className={moduleStyles.shareDialog}>
           <Typography
             semanticTag="h1"

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -20,6 +20,8 @@ import trackEvent from '@cdo/apps/util/trackEvent';
 import {ProjectSubmissionStatus} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
+import Lab2Registry from '../../Lab2Registry';
+
 import moduleStyles from './share-dialog.module.scss';
 
 const TEACHER_FEEDBACK_LINK =
@@ -178,10 +180,10 @@ const ShareDialog: React.FunctionComponent<{
       : STUDENT_FEEDBACK_LINK;
   });
 
-  // We pull the theme from header redux because the ShareDialog is not wrapped by the lab's
-  // ThemeProvider (the header is in its own tree). We copy the lab theme to the header redux
-  // in ProjectContainer (where we do our other header management).
-  const theme = useAppSelector(state => state.header.theme);
+  // We pull the theme from Lab2Registry because the ShareDialog is not wrapped by the lab's
+  // ThemeProvider (the header is in its own tree). We copy the lab theme to the registry
+  // in Lab2Wrapper.
+  const theme = Lab2Registry.getInstance().getTheme();
 
   return (
     <FocusLock>

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -9,6 +9,7 @@ import FocusLock from 'react-focus-lock';
 
 import {hideShareDialog} from '@cdo/apps/code-studio/components/shareDialogRedux';
 import DCDO from '@cdo/apps/dcdo';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {ProjectType} from '@cdo/apps/lab2/types';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -19,8 +20,6 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import trackEvent from '@cdo/apps/util/trackEvent';
 import {ProjectSubmissionStatus} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
-
-import Lab2Registry from '../../Lab2Registry';
 
 import moduleStyles from './share-dialog.module.scss';
 

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -1,6 +1,5 @@
 import Alert from '@code-dot-org/component-library/alert';
 import {Button, LinkButton} from '@code-dot-org/component-library/button';
-import {Theme} from '@code-dot-org/component-library/common/contexts';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Typography from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
@@ -148,7 +147,6 @@ const ShareDialog: React.FunctionComponent<{
   onSubmitClick: () => void;
   submissionStatus: SubmissionStatusType | undefined;
   channelId: string;
-  theme?: Theme;
 }> = ({
   dialogId,
   shareUrl,
@@ -157,7 +155,6 @@ const ShareDialog: React.FunctionComponent<{
   onSubmitClick,
   submissionStatus,
   channelId,
-  theme = 'Dark',
 }) => {
   const dispatch = useAppDispatch();
 
@@ -180,6 +177,7 @@ const ShareDialog: React.FunctionComponent<{
       ? TEACHER_FEEDBACK_LINK
       : STUDENT_FEEDBACK_LINK;
   });
+  const theme = useAppSelector(state => state.header.theme);
 
   return (
     <FocusLock>

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -177,6 +177,10 @@ const ShareDialog: React.FunctionComponent<{
       ? TEACHER_FEEDBACK_LINK
       : STUDENT_FEEDBACK_LINK;
   });
+
+  // We pull the theme from header redux because the ShareDialog is not wrapped by the lab's
+  // ThemeProvider (the header is in its own tree). We copy the lab theme to the header redux
+  // in ProjectContainer (where we do our other header management).
   const theme = useAppSelector(state => state.header.theme);
 
   return (

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -57,7 +57,7 @@ const CopyToClipboardButton: React.FunctionComponent<{
       ariaLabel={i18n.copyLinkToProject()}
       text={i18n.copyLinkToProject()}
       type="secondary"
-      color="white"
+      color="black"
       size="m"
       onClick={handleCopyToClipboard}
       className={moduleStyles.shareDialogButton}
@@ -85,7 +85,6 @@ const AfeCareerTourBlock: React.FunctionComponent = () => {
         href={careersUrl}
         text={i18n.careerTourAction()}
         type="primary"
-        color="white"
         size="m"
         target="_blank"
         iconRight={{
@@ -116,7 +115,7 @@ const SubmitButtonInfo: React.FunctionComponent<{
         iconLeft={{iconName: 'award'}}
         text={i18n.submitProjectGallery_header()}
         type="secondary"
-        color="white"
+        color="black"
         size="m"
         onClick={onSubmitClick}
         className={moduleStyles.shareDialogButton}
@@ -181,7 +180,7 @@ const ShareDialog: React.FunctionComponent<{
 
   return (
     <FocusLock>
-      <div className={moduleStyles.dialogContainer}>
+      <div className={moduleStyles.dialogContainer} data-theme="Light">
         <div id="share-dialog" className={moduleStyles.shareDialog}>
           <Typography
             semanticTag="h1"
@@ -249,7 +248,7 @@ const ShareDialog: React.FunctionComponent<{
                     ariaLabel={i18n.keepPlaying()}
                     text={i18n.keepPlaying()}
                     type="secondary"
-                    color="white"
+                    color="black"
                     size="m"
                     onClick={handleClose}
                     className={moduleStyles.keepPlayingButton}
@@ -259,7 +258,6 @@ const ShareDialog: React.FunctionComponent<{
                     href={finishUrl}
                     text={i18n.finish()}
                     type="primary"
-                    color="white"
                     size="m"
                   />
                 </div>
@@ -268,7 +266,6 @@ const ShareDialog: React.FunctionComponent<{
                   ariaLabel={i18n.done()}
                   text={i18n.done()}
                   type="primary"
-                  color="white"
                   size="m"
                   onClick={handleClose}
                 />

--- a/apps/src/lab2/views/dialogs/share-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/share-dialog.module.scss
@@ -2,8 +2,8 @@
 @import '../common.scss';
 
 %dialog {
-  background-color: $light_gray_950;
-  color: $neutral_light;
+  background-color: var(--background-neutral-secondary);
+  color: var(--text-neutral-primary);
   border-radius: 5px;
   padding: 20px 32px;
   width: 600px;
@@ -22,7 +22,7 @@
     font-size: 14px;
 
     .heading {
-      color: $neutral_light;
+      color: var(--text-neutral-primary);
       margin-bottom: 0;
     }
 
@@ -41,22 +41,11 @@
       }
     }
 
-    .share {
-      background-color: $white;
-      padding: 20px;
-      border-radius: 10px;
-      color: white;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 20px;
-    }
-
     .block {
-      background-color: $neutral_dark90;
+      background-color: var(--background-neutral-tertiary);
       padding: 20px;
       border-radius: 10px;
-      color: white;
+      color: var(--text-neutral-primary);
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -82,7 +71,7 @@
       width: 125px;
 
       .QRCodeBorder {
-        background-color: #fff;
+        background-color: var(--background-neutral-white-fixed);
         border-radius: 4px;
         box-sizing: border-box;
         height: 100%;
@@ -98,7 +87,7 @@
       position: absolute;
       top: 0;
       right: 0;
-      color: $neutral_dark30;
+      color: var(--text-neutral-quaternary);
 
       &Icon {
         font-size: 24px;
@@ -112,7 +101,7 @@
 
     .feedbackLink {
       display: flex;
-      color: $neutral_light;
+      color: var(--text-neutral-primary);
       text-decoration: underline;
     }
 

--- a/apps/src/lab2/views/dialogs/share-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/share-dialog.module.scss
@@ -55,9 +55,14 @@
 
       &Afe {
         background-color: #2E4486;
+        color: var(--text-neutral-white-fixed);
 
         img {
           border-radius: 4px;
+        }
+
+        .heading {
+          color: var(--text-neutral-white-fixed);
         }
       }
     }

--- a/apps/src/lab2/views/dialogs/share-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/share-dialog.module.scss
@@ -1,4 +1,3 @@
-@import 'color.scss';
 @import '../common.scss';
 
 %dialog {


### PR DESCRIPTION
The lab2 share dialog was not using themed variables, and required a different approach to getting the theme value from the lab than other elements on the page. This is because the share dialog is rendered via the header, which is a whole different tree from the rest of the page. Therefore, it does not exist inside the `ThemeContext` in lab2 labs.

The simplest solution I could find to this problem was, for lab2 labs, to copy the theme value over to the header redux whenever it changes. I did this by setting up a `useEffect` in ProjectContainer that listens to the theme. The header is controlled entirely by the header redux (which version of the header is visible), so it made sense to put the theme value there. I don't love that we have to duplicate the value to the header redux, if anyone has other ideas let me know! I considered passing the theme in when we set up the header, but that didn't solve for how we respond to theme changes.

Dark mode should be mostly unchanged (there may be a slightly different white text color used to align with dsco). We have a special share modal for Music Lab Jam Session, which is specifically designed for dark mode. I made it readable in light mode but adjust the blue background used since it's unlikely to be seen in light mode.

## Before
<img width="662" alt="Screenshot 2025-05-22 at 2 00 08 PM" src="https://github.com/user-attachments/assets/978ab5e1-a83f-4987-a093-43c7bbc99d97" />
<img width="662" alt="Screenshot 2025-05-22 at 2 00 01 PM" src="https://github.com/user-attachments/assets/e38e6401-cae1-424b-9e17-4ba907bc574b" />


## After
### Dark Mode
<img width="662" alt="Screenshot 2025-05-22 at 2 00 42 PM" src="https://github.com/user-attachments/assets/8b9ef28c-93d6-412c-97c6-d71473128dc6" />
<img width="662" alt="Screenshot 2025-05-22 at 2 00 34 PM" src="https://github.com/user-attachments/assets/0bf26d78-8d73-4867-8eeb-fcbdd8439735" />


### Light Mode
<img width="662" alt="Screenshot 2025-05-22 at 1 52 01 PM" src="https://github.com/user-attachments/assets/88d5b666-5e7e-4a52-a72b-3c485e3a7c4d" />
<img width="662" alt="Screenshot 2025-05-22 at 1 50 42 PM" src="https://github.com/user-attachments/assets/df4830dd-a9be-4689-bbf9-7072d307ae01" />


## Links

- Jira: [CT-1228](https://codedotorg.atlassian.net/browse/CT-1228)

## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
