### PR TITLE
AI Tutor: Allow ai chat access for aiTutor2 in python lab

### DIFF
--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -26,7 +26,7 @@ class AichatRequestsController < ApplicationController
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
     end
-    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_chat_completion?(params[:aichatContext][:currentLevelId])
+    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access aichat? || can_access_aitutor(params[:aichatContext][:currentLevelId])
 
     return head :too_many_requests if should_throttle_request_count?
 
@@ -88,16 +88,14 @@ class AichatRequestsController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
-  private def can_access_chat_completion?(level_id = nil)
-    # Special case for AiTutor2 requests coming through python lab levels
-    if level_id
-      level = Level.find(level_id)
-      if level&.type == 'Pythonlab'
-        return true
-      end
-    end
+  private def can_access_aitutor?(level_id)
+    # AI Tutor requests only come from python lab levels.
+    return false unless level_id
+    Level.find(level_id).is_a? Pythonlab
+  end
 
-    return AichatSagemakerHelper.can_request_aichat_chat_completion? && current_user.has_aichat_access?
+  private def can_access_aichat?
+    AichatSagemakerHelper.can_request_aichat_chat_completion? && current_user.has_aichat_access?
   end
 
   private def should_throttle_request_count?

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -26,7 +26,7 @@ class AichatRequestsController < ApplicationController
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
     end
-    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access aichat? || can_access_aitutor(params[:aichatContext][:currentLevelId])
+    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_aichat? || can_access_aitutor?(params[:aichatContext][:currentLevelId])
 
     return head :too_many_requests if should_throttle_request_count?
 

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -23,7 +23,7 @@ class AichatRequestsController < ApplicationController
   # aichatModelCustomizations: {temperature: number; retrievalContexts: string[]; systemPrompt: string;}
   # aichatContext: {currentLevelId: number; scriptId: number; channelId: string;}
   def start_chat_completion
-    return render status: :forbidden, json: {} unless AichatSagemakerHelper.can_request_aichat_chat_completion?
+    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_chat_completion?(params[:aichatContext][:currentLevelId])
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
     end
@@ -72,6 +72,8 @@ class AichatRequestsController < ApplicationController
   # GET /aichat_request/chat_request/:id
   # Get the chat completion request status and response for the given ID.
   def chat_request
+    # This api is now exposed to all signed in users, but return data is
+    # still scoped to user that initiated the request.
     begin
       request = AichatRequest.find(params[:id])
     rescue ActiveRecord::RecordNotFound
@@ -86,6 +88,18 @@ class AichatRequestsController < ApplicationController
       response: request.response
     }
     render(status: :ok, json: response_body)
+  end
+
+  private def can_access_chat_completion?(level_id = nil)
+    # Special case for AiTutor2 requests coming through python lab levels
+    if level_id
+      level = Level.find(level_id)
+      if level&.type == 'Pythonlab'
+        return true
+      end
+    end
+
+    return false unless AichatSagemakerHelper.can_request_aichat_chat_completion? && current_user&.has_aichat_access?
   end
 
   private def should_throttle_request_count?

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -72,8 +72,6 @@ class AichatRequestsController < ApplicationController
   # GET /aichat_request/chat_request/:id
   # Get the chat completion request status and response for the given ID.
   def chat_request
-    # This api is now exposed to all signed in users, but return data is
-    # still scoped to user that initiated the request.
     begin
       request = AichatRequest.find(params[:id])
     rescue ActiveRecord::RecordNotFound

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -23,10 +23,10 @@ class AichatRequestsController < ApplicationController
   # aichatModelCustomizations: {temperature: number; retrievalContexts: string[]; systemPrompt: string;}
   # aichatContext: {currentLevelId: number; scriptId: number; channelId: string;}
   def start_chat_completion
-    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_chat_completion?(params[:aichatContext][:currentLevelId])
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
     end
+    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_chat_completion?(params[:aichatContext][:currentLevelId])
 
     return head :too_many_requests if should_throttle_request_count?
 
@@ -99,7 +99,7 @@ class AichatRequestsController < ApplicationController
       end
     end
 
-    return false unless AichatSagemakerHelper.can_request_aichat_chat_completion? && current_user&.has_aichat_access?
+    return AichatSagemakerHelper.can_request_aichat_chat_completion? && current_user.has_aichat_access?
   end
 
   private def should_throttle_request_count?

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -511,20 +511,15 @@ class Ability
         user.has_ai_tutor_access?
       end
 
-      can [:start_chat_completion, :chat_request], :aichat_request do
-        # Change this to just must be logged in?
-        user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
-      end
-
       can :find_toxicity, :aichat do
         user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
       end
 
       # Additional logic that confirms that a given teacher or student should have access
       # to a given student (or their own, in the case of a student viewer) chat history is in aichat_events_controller.
-      # can [:log_chat_event, :chat_history], :aichat_event do
-      #   user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
-      # end
+      can [:log_chat_event, :chat_history], :aichat_event do
+        user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
+      end
       can :submit_teacher_feedback, :aichat_event do
         user.teacher_can_access_ai_chat?
       end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -170,6 +170,10 @@ class Ability
 
       can :evaluate, :openai_evaluate
 
+      # all signed in users can access the aichat_request endpoint
+      # additional permission logic lives in the controller itself
+      can [:start_chat_completion, :chat_request], :aichat_request
+
       if user.teacher?
         can :manage, Section do |s|
           s.instructors.include?(user)
@@ -508,6 +512,7 @@ class Ability
       end
 
       can [:start_chat_completion, :chat_request], :aichat_request do
+        # Change this to just must be logged in?
         user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
       end
 
@@ -517,9 +522,9 @@ class Ability
 
       # Additional logic that confirms that a given teacher or student should have access
       # to a given student (or their own, in the case of a student viewer) chat history is in aichat_events_controller.
-      can [:log_chat_event, :chat_history], :aichat_event do
-        user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
-      end
+      # can [:log_chat_event, :chat_history], :aichat_event do
+      #   user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
+      # end
       can :submit_teacher_feedback, :aichat_event do
         user.teacher_can_access_ai_chat?
       end

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -8,6 +8,8 @@ class AichatRequestsControllerTest < ActionController::TestCase
     unit_group = create :unit_group, name: 'exploring-gen-ai-2024'
     section = create :section, user: @authorized_teacher1, unit_group: unit_group
     @authorized_student1 = create(:follower, section: section).student_user
+    @unauthorized_student = create(:student)
+    @unauthorized_teacher = create(:teacher)
 
     @level = create(:level)
     @script = create(:script)
@@ -35,22 +37,32 @@ class AichatRequestsControllerTest < ActionController::TestCase
     @controller.stubs(:storage_decrypt_channel_id).returns([123, @project_id])
   end
 
-  users = [:student, :teacher]
-  [
-    :start_chat_completion,
-    [:chat_request, :get, {id: 1}]
-  ].each do |action, method = :post, params = {}|
-    users.each do |user|
-      test_user_gets_response_for action,
-        name: "#{user}_no_access_#{action}_test",
-        user: user,
-        method: method,
-        params: params,
-        response: :forbidden
-    end
+  # start_chat_completion tests
+  test 'start_chat_completion returns forbidden if user is not signed in' do
+    post :start_chat_completion, params: @valid_params_chat_completion, as: :json
+    assert_response :forbidden
   end
 
-  # start_chat_completion tests
+  test 'teachers without access to chat completion get forbidden response' do
+    sign_in(@unauthorized_teacher)
+    post :start_chat_completion, params: @valid_params_chat_completion, as: :json
+    assert_response :forbidden
+  end
+
+  test 'students without access to chat completion get forbidden response' do
+    sign_in(@unauthorized_student)
+    post :start_chat_completion, params: @valid_params_chat_completion, as: :json
+    assert_response :forbidden
+  end
+
+  test 'unauthorized users can access start_chat_completion from python lab levels' do
+    sign_in(@unauthorized_student)
+    @level.stubs(:type).returns('Pythonlab')
+    Level.stubs(:find).with(@level.id).returns(@level)
+    post :start_chat_completion, params: @valid_params_chat_completion, as: :json
+    assert_response :success
+  end
+
   test 'authorized teacher has access to start_chat_completion test' do
     sign_in(@authorized_teacher1)
     post :start_chat_completion, params: @valid_params_chat_completion, as: :json
@@ -139,6 +151,12 @@ class AichatRequestsControllerTest < ActionController::TestCase
   test 'GET chat_request returns forbidden if user is not the requester' do
     sign_in(@authorized_teacher1)
     request = create(:aichat_request, user: @authorized_student1)
+    get :chat_request, params: {id: request.id}, as: :json
+    assert_response :forbidden
+  end
+
+  test 'GET chat_request returns forbidden if user is not signed in' do
+    request = create(:aichat_request, user: @authorized_teacher1)
     get :chat_request, params: {id: request.id}, as: :json
     assert_response :forbidden
   end

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -57,9 +57,9 @@ class AichatRequestsControllerTest < ActionController::TestCase
 
   test 'unauthorized users can access start_chat_completion from python lab levels' do
     sign_in(@unauthorized_student)
-    @level.stubs(:type).returns('Pythonlab')
-    Level.stubs(:find).with(@level.id).returns(@level)
-    post :start_chat_completion, params: @valid_params_chat_completion, as: :json
+    python_lab_level = create :pythonlab
+    params_with_python_level = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(currentLevelId: python_lab_level.id))
+    post :start_chat_completion, params: params_with_python_level, as: :json
     assert_response :success
   end
 

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -961,9 +961,7 @@ class AbilityTest < ActiveSupport::TestCase
   test 'teacher meeting AI Chat access requirements can perform AI Chat actions' do
     teacher = create :teacher
     teacher.stubs(:teacher_can_access_ai_chat?).returns(true)
-    [:start_chat_completion, :chat_request].each do |action|
-      assert Ability.new(teacher).can? action, :aichat_request
-    end
+    # :aichat_request actions are tested via the aichat_requests_controller tests.
     assert Ability.new(teacher).can? :log_chat_event, :aichat_event
     assert Ability.new(teacher).can? :chat_history, :aichat_event
   end
@@ -971,9 +969,7 @@ class AbilityTest < ActiveSupport::TestCase
   test 'teacher not meeting AI Chat access requirements cannot perform AI Chat actions' do
     teacher = create :teacher
     teacher.stubs(:teacher_can_access_ai_chat?).returns(false)
-    [:start_chat_completion, :chat_request].each do |action|
-      refute Ability.new(teacher).can? action, :aichat_request
-    end
+    # :aichat_request actions are tested via the aichat_requests_controller tests.
     refute Ability.new(teacher).can? :log_chat_event, :aichat_event
     refute Ability.new(teacher).can? :chat_history, :aichat_event
   end
@@ -981,9 +977,7 @@ class AbilityTest < ActiveSupport::TestCase
   test 'student meeting AI Chat access requirements can perform AI Chat actions' do
     student = create :student
     student.stubs(:student_can_access_ai_chat?).returns(true)
-    [:start_chat_completion, :chat_request].each do |action|
-      assert Ability.new(student).can? action, :aichat_request
-    end
+    # :aichat_request actions are tested via the aichat_requests_controller tests.
     assert Ability.new(student).can? :log_chat_event, :aichat_event
     assert Ability.new(student).can? :chat_history, :aichat_event
   end
@@ -991,9 +985,7 @@ class AbilityTest < ActiveSupport::TestCase
   test 'student not meeting AI Chat access requirements cannot perform AI Chat actions' do
     student = create :student
     student.stubs(:student_can_access_ai_chat?).returns(false)
-    [:start_chat_completion, :chat_request].each do |action|
-      refute Ability.new(student).can? action, :aichat_request
-    end
+    # :aichat_request actions are tested via the aichat_requests_controller tests.
     refute Ability.new(student).can? :log_chat_event, :aichat_event
     refute Ability.new(student).can? :chat_history, :aichat_event
   end


### PR DESCRIPTION
Since the use case for AiTutor2 is quite different than that of aichat levels, we wanted to relax some of the restrictions for usage of the API for python lab levels from which AiTutor2 requests originate.

This change moves some of the access logic out of ability.rb (now basic access only requires signed in user) and into the controller actions themselves. For `start_chat_completion` there is no functional change in access from aichat levels.  `chat_request` isn't able to use the same restrictions since we do not have the `levelId` in that context, so it now allows all signed in users to call it, but it is functionally the same given that only the user who initiated the request can view the response and status.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [slack discussion](https://codedotorg.slack.com/archives/C08S29NDZ5E/p1747948467195559?thread_ts=1747835967.690799&cid=C08S29NDZ5E)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Updated controller tests to cover the new cases and tested locally.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

I want to add a DCDO flag to be able to switch off the special case python lab permissions. I was having some trouble stubbing/testing it correctly and I don't want to delay this PR so I will do that in a fast follow. 
- https://github.com/code-dot-org/code-dot-org/pull/66146
