### PR TITLE
Small python lab theming updates

### DIFF
--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -301,7 +301,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
           moduleStyles.buttonInstruction,
           moduleStyles.validationButton
         )}
-        color={'white'}
+        color={'black'}
         size={'s'}
         id={'uitest-validate-button'}
       />

--- a/apps/src/pythonlab/components/ProjectTypePicker.tsx
+++ b/apps/src/pythonlab/components/ProjectTypePicker.tsx
@@ -1,4 +1,5 @@
 import ActionBlock from '@code-dot-org/component-library/actionBlock';
+import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import {CustomDialog} from '@code-dot-org/component-library/dialog';
 import {
   BodyThreeText,
@@ -25,10 +26,12 @@ const ProjectTypePicker: React.FunctionComponent<ProjectTypePickerProps> = ({
 }) => {
   const isNeighborhood = currentProjectType === 'neighborhood';
   const isConsole = currentProjectType === 'console';
+  const {theme} = useTheme();
+  const mode = theme === 'Light' ? 'light' : 'dark';
   return (
-    <div className={moduleStyles.dialogContainer} data-theme="Dark">
+    <div className={moduleStyles.dialogContainer}>
       <CustomDialog
-        mode="dark"
+        mode={mode}
         className={moduleStyles.pickerDialog}
         aria-labelledby="project-picker-title"
         onClose={currentProjectType ? closeDialog : undefined}

--- a/apps/src/pythonlab/components/ProjectTypePicker.tsx
+++ b/apps/src/pythonlab/components/ProjectTypePicker.tsx
@@ -57,7 +57,7 @@ const ProjectTypePicker: React.FunctionComponent<ProjectTypePickerProps> = ({
               image={{src: consoleImage}}
               primaryButton={{
                 text: pythonlabI18n.consoleOnly(),
-                color: 'black',
+                color: 'purple',
                 useAsLink: false,
                 onClick: () => setProjectCallback('console'),
                 iconRight: isConsole
@@ -71,7 +71,7 @@ const ProjectTypePicker: React.FunctionComponent<ProjectTypePickerProps> = ({
               image={{src: neighborhoodImage}}
               primaryButton={{
                 text: pythonlabI18n.neighborhood(),
-                color: 'black',
+                color: 'purple',
                 useAsLink: false,
                 onClick: () => setProjectCallback('neighborhood'),
                 iconRight: isNeighborhood

--- a/apps/test/unit/pythonlab/PythonlabViewTest.tsx
+++ b/apps/test/unit/pythonlab/PythonlabViewTest.tsx
@@ -1,3 +1,4 @@
+import {ThemeProvider} from '@code-dot-org/component-library/common/contexts';
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {Provider} from 'react-redux';
@@ -61,10 +62,12 @@ describe('PythonLabView', () => {
   ) {
     return render(
       <Provider store={store}>
-        <PythonlabView
-          levelProperties={levelProperties}
-          initialSources={initialSources}
-        />
+        <ThemeProvider>
+          <PythonlabView
+            levelProperties={levelProperties}
+            initialSources={initialSources}
+          />
+        </ThemeProvider>
       </Provider>
     );
   }


### PR DESCRIPTION
A couple small theming things I missed in Python Lab:
- Theme the project picker modal
- Use the correct button color for the validate button

## Screenshots
### Validate button before (light mode)
Dark mode is unchanged

<img width="299" alt="Screenshot 2025-05-22 at 3 22 58 PM" src="https://github.com/user-attachments/assets/251ac513-55b6-4e4c-aaaf-39f855c79ef3" />

### Validate button after (light mode)

<img width="299" alt="Screenshot 2025-05-22 at 3 21 26 PM" src="https://github.com/user-attachments/assets/1ebb1b66-0738-4210-bddf-0b3dfed45682" />

### Project Picker
Dark mode is unchanged.
<img width="667" alt="Screenshot 2025-05-22 at 3 21 03 PM" src="https://github.com/user-attachments/assets/21bc3398-39dc-4af2-8959-a4a5d3271b60" />

## Testing story
Tested locally.

## Follow-up work
I'm still not sure what color the project switcher button should be in the workspace header. I started a [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1747948826480089) and will follow up if we want to change it (right now it's black in light mode, which looks a little jarring).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
