### PR TITLE
[Music] Prevent event recursion around block.select()

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -643,12 +643,14 @@ export default class MusicBlocklyWorkspace {
       );
       return;
     }
-
+    // Disable events to prevent recursion.
+    Blockly.Events.disable();
     (this.workspace as GoogleBlockly.WorkspaceSvg)
       .getAllBlocks()
       .forEach(block => {
         block.id === blockId ? block.select() : block.unselect();
       });
+    Blockly.Events.enable();
   }
 
   getSelectedTriggerId(blockId: string) {


### PR DESCRIPTION
After the Blockly v12 upgrade, Music Lab became noticeably sluggish when dragging blocks quickly. Investigation revealed that block.select() now emits a `Blockly.Events.BLOCK_SELECT` event, which was not the case before. This led to repeated firing of our block selected callback.

To mitigate this, we can temporarily disable Blockly events around `block.select()`. This avoids the recursive event firing while preserving the original intent of highlighting the associated timeline element. This fix improves performance and seems to match the behavior seen on production before the upgrade.

Follow-up work may involve a smarter approach to Redux updates that avoids calling `block.select()` entirely when not needed.

## Links

https://codedotorg.slack.com/archives/C04TH8400AU/p1747955889051999


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
