### PR TITLE
AI Tutor: Python Lab URL parameter

### DIFF
--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -15,6 +15,7 @@ import {
   getCurrentLevel,
   nextLevelId,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
 import {
@@ -86,6 +87,9 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
     appName: appType,
     aiTutor2Available,
   } = levelProperties;
+
+  const showAiTutor2 =
+    aiTutor2Available || queryParams('show-ai-tutor2') === 'true';
 
   const scriptId = useAppSelector(state => state.lab.scriptId);
   const hasNextLevel = useSelector(state => nextLevelId(state) !== undefined);
@@ -380,7 +384,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
             </>
           )}
 
-          {aiTutor2Available && AiTutor2ResponseView}
+          {showAiTutor2 && AiTutor2ResponseView}
           {predictSettings?.isPredictLevel && (
             <InstructorsOnly>
               <div className={moduleStyles.bubble}>

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -9,6 +9,7 @@ import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
 import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import {TestResults} from '@cdo/apps/constants';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
@@ -222,8 +223,13 @@ const PythonlabView: React.FunctionComponent<
     }
     dispatch(submitPredictResponse({appType: 'pythonlab'}));
 
-    // Ask a question to AITutor2.
-    askAiTutor2("What's wrong with my code, if anything?");
+    if (
+      levelProperties.aiTutor2Available ||
+      queryParams('show-ai-tutor2') === 'true'
+    ) {
+      // Ask a question to AITutor2.
+      askAiTutor2("What's wrong with my code, if anything?");
+    }
   };
 
   return (

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -4,6 +4,7 @@ import {LayoutProps} from '@codebridge/types';
 import Workspace from '@codebridge/Workspace/Workspace';
 import React from 'react';
 
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import HorizontalOutput from '@cdo/apps/codebridge/Workspace/HorizontalOutput';
 import {useHorizontalLayout} from '@cdo/apps/lab2/hooks/useHorizontalLayout';
 import AiTutor2Chat from '@cdo/apps/lab2/views/components/AiTutor2Chat';
@@ -33,6 +34,9 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
     getAiTutor2FullPrompt,
     levelProperties: {aiTutor2Available},
   } = useCodebridgeContext();
+
+  const showAiTutor2 =
+    aiTutor2Available || queryParams('show-ai-tutor2') === 'true';
 
   const {
     leftPanelWidth,
@@ -66,7 +70,7 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
     minRightPanelWidth: MIN_RIGHT_PANEL_WIDTH,
     appName: 'pythonlab',
     heightOffset: isProjectLevel ? PROJECT_FOOTER_HEIGHT : 0,
-    showingRightmostPanel: aiTutor2Available,
+    showingRightmostPanel: showAiTutor2,
   });
 
   return (
@@ -114,7 +118,7 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
             setOutputHeight={setRightBottomPanelSize}
           />
         </div>
-        {aiTutor2Available && getAiTutor2FullPrompt && (
+        {showAiTutor2 && getAiTutor2FullPrompt && (
           <div style={{width: rightmostPanelWidth}}>
             <PanelContainer
               id="aitutor2"


### PR DESCRIPTION
With this change, the AI Tutor introduced in https://github.com/code-dot-org/code-dot-org/pull/65737 can be used in any Python Lab level when the `?show-ai-tutor2=true` URL parameter is provided.