### PR TITLE
fix(cache): update cache time in view response function

### DIFF
--- a/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
+++ b/aws/cloudformation/standalone/marketing/deployment/marketing.yml.erb
@@ -696,7 +696,7 @@ Resources:
           if (response.headers['cache-control'] === undefined) {
               // This value should match the constant `revalidate` in `frontend/apps/marketing/src/app/[brand]/[locale]/[slug]/page.tsx`
               response.headers['cache-control'] = {
-              value: `s-maxage=3600, stale-while-revalidate=31535400`
+              value: `s-maxage=900, stale-while-revalidate=31535400`
             }
           }
 

--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
@@ -25,7 +25,8 @@ import {getPageHeading} from '@/selectors/contentful/getExperienceEntryFields';
  *
  * With the current value being 15 minutes, it can therefore take [900] * [2 + 1] = 45 minutes for a page to be updated.
  */
-export const revalidate = 900; // Fresh for 15 minutes
+// NOTE: IF UPDATING THIS VALUE, PLEASE ALSO UPDATE THE VALUE IN THE `ViewerResponseCloudFrontFunction` in marketing.yml.erb
+export const revalidate = 900; // Fresh for 15 minutes, SEE ABOVE NOTE
 
 type ExperiencePageProps = {
   params: Promise<{locale?: string; paths?: string; brand?: Brand}>;


### PR DESCRIPTION
A quick PR to make the cache control header consistent between the view response function and the page revalidate value.