### PR TITLE
remove editor_type from programming environment files

### DIFF
--- a/dashboard/config/programming_environments/applab.json
+++ b/dashboard/config/programming_environments/applab.json
@@ -3,7 +3,6 @@
   "published": true,
   "description": "App Lab is a programming environment where you can make simple apps. Design an app, code with blocks or JavaScript to make it work, then share your app in seconds.",
   "editor_language": "droplet",
-  "editor_type": "droplet",
   "image_url": "https://images.code.org/256b231dfba4554047795928cd906764-applab-cover.jpg",
   "project_url": "/p/applab",
   "title": "App Lab",

--- a/dashboard/config/programming_environments/gamelab.json
+++ b/dashboard/config/programming_environments/gamelab.json
@@ -3,7 +3,6 @@
   "published": true,
   "description": "Game Lab is a programming environment where you can make exciting games and animations. Draw your characters, code with blocks or JavaScript to make it work, then share your game in seconds.",
   "editor_language": "droplet",
-  "editor_type": "droplet",
   "image_url": "https://images.code.org/ae454e14688d769b8bfc9bef62905194-gamelab-cover.jpg",
   "project_url": "/p/gamelab",
   "title": "Game Lab",

--- a/dashboard/config/programming_environments/spritelab.json
+++ b/dashboard/config/programming_environments/spritelab.json
@@ -4,7 +4,6 @@
   "block_pool_name": "GamelabJr",
   "description": "Sprite Lab is a Blockly programming environment where you can create interactive projects.",
   "editor_language": "blockly",
-  "editor_type": "blockly",
   "image_url": "https://images.code.org/e439bd0d27311a6392df05ae20387173-spritelab-cover.jpg",
   "project_url": "/p/spritelab",
   "title": "Sprite Lab",

--- a/dashboard/config/programming_environments/weblab.json
+++ b/dashboard/config/programming_environments/weblab.json
@@ -3,7 +3,6 @@
   "published": true,
   "description": "Web based HTML/CSS editor.",
   "editor_language": "html/css",
-  "editor_type": "text",
   "image_url": "https://images.code.org/3be43f3f6bae39e44bc74e8be0dab985-weblab-cover.jpg",
   "project_url": "/p/weblab",
   "title": "Web Lab",


### PR DESCRIPTION
This PR removes the `editor_type` field from the following files to unblock failing UI tests and `:code_docs` seed tasks:

- dashboard/config/programming_environments/applab.json
- dashboard/config/programming_environments/gamelab.json
- dashboard/config/programming_environments/spritelab.json
- dashboard/config/programming_environments/weblab.json

The `editor_type` attribute is no longer part of the `ProgrammingEnvironment` model and has been deprecated for some time, probably replaced by `editor_language`. However, because old values still exist in the database and seed logic doesn't unset them, these fields resurfaced when the files were re-saved.

This change should prevent the following error during seeding and UI test runs:

`ActiveModel::UnknownAttributeError: unknown attribute 'editor_type' for ProgrammingEnvironment`


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
