### PR TITLE
Remove or skip more Pegasus ui tests

### DIFF
--- a/dashboard/test/ui/features/platform/header_signed_out.feature
+++ b/dashboard/test/ui/features/platform/header_signed_out.feature
@@ -58,6 +58,7 @@ Feature: Header navigation bar - Signed out
     And I see "#header-about"
     And element "#header-about" has "es" text from key "nav.header.about"
 
+  @skip
   @chrome
   Scenario: Signed out user can click on the header links
     Given I am on "http://code.org"

--- a/dashboard/test/ui/features/teacher_tools/courses_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/courses_eyes.feature
@@ -2,6 +2,7 @@
 @no_mobile
 Feature: Courses page
 
+@skip
 @as_student
 Scenario: Student courses
   Given I am on "http://studio.code.org/home"
@@ -24,6 +25,7 @@ Scenario: Teacher courses
   And I see no difference for "teacher courses page"
   And I close my eyes
 
+@skip
 @as_student
 Scenario: Student courses, non-english
   When I open my eyes to test "student courses non-english"
@@ -36,6 +38,7 @@ Scenario: Student courses, non-english
   And I see no difference for "student non-english courses page"
   And I close my eyes
 
+@skip
 Scenario: Signed out courses, learn
   When I open my eyes to test "signed out courses, learn"
   Given I am on "http://code.org/"
@@ -47,6 +50,7 @@ Scenario: Signed out courses, learn
   And I see no difference for "signed-out courses page, learn"
   And I close my eyes
 
+@skip
 Scenario: Signed out courses, teach
   When I open my eyes to test "signed out courses, teach"
   Given I am on "http://code.org/"
@@ -58,6 +62,7 @@ Scenario: Signed out courses, teach
   And I see no difference for "signed-out courses page, teach"
   And I close my eyes
 
+@skip
 Scenario: Signed out courses, non-english
   When I open my eyes to test "signed out courses, non-english"
   Given I am on "http://studio.code.org/home/lang/es"

--- a/dashboard/test/ui/features/teacher_tools/courses_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/courses_eyes.feature
@@ -38,7 +38,6 @@ Scenario: Student courses, non-english
   And I see no difference for "student non-english courses page"
   And I close my eyes
 
-@skip
 Scenario: Signed out courses, learn
   When I open my eyes to test "signed out courses, learn"
   Given I am on "http://code.org/"
@@ -50,7 +49,6 @@ Scenario: Signed out courses, learn
   And I see no difference for "signed-out courses page, learn"
   And I close my eyes
 
-@skip
 Scenario: Signed out courses, teach
   When I open my eyes to test "signed out courses, teach"
   Given I am on "http://code.org/"

--- a/dashboard/test/ui/features/xteam/cookie_banner.feature
+++ b/dashboard/test/ui/features/xteam/cookie_banner.feature
@@ -19,5 +19,4 @@ Scenario Outline: Show cookie banner, dismiss it and confirm it's dismissed
 
 Examples:
   | url                                                               | test_name                  |
-  | http://code.org/about                                             | code.org about             |
-  | http://studio.code.org/s/frozen/lessons/1/levels/1                  | studio.code.org puzzle     |
+  | http://studio.code.org/s/frozen/lessons/1/levels/1                | studio.code.org puzzle     |


### PR DESCRIPTION
Removes and skips several Pegasus UI tests while work is being done to move code.org to Contentful. 

## Links
Jira ticket: [CMS-751](https://codedotorg.atlassian.net/browse/CMS-751)