### PR TITLE
[Google Blockly] Fix trashcan weight

### DIFF
--- a/apps/src/blockly/addons/cdoTrashcan.ts
+++ b/apps/src/blockly/addons/cdoTrashcan.ts
@@ -57,9 +57,10 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
     this.workspace.getComponentManager().addComponent({
       component: this,
       // Weight determines the order of drag targets. The toolbox is also a drag
-      // target (weight 1). onDragEnter/Exit/Over are only called for the first
+      // target (weight 0). onDragEnter/Exit/Over are only called for the first
       // drag target, so the trashcan needs to have a smaller weight than the toolbox.
-      weight: 0,
+      // See Blockly.ComponentManager.ComponentWeight for other weights from core.
+      weight: -1,
       capabilities: [
         Blockly.ComponentManager.Capability.DELETE_AREA,
         Blockly.ComponentManager.Capability.DRAG_TARGET,


### PR DESCRIPTION
After merging the Blockly v12 upgrade yesterday, @breville [noticed](https://codedotorg.slack.com/archives/C04TH8400AU/p1747961343810769?thread_ts=1747961014.106909&cid=C04TH8400AU) that the Trashcan lid was no longer animating when dragging blocks to it.

After investigating, I determined that was due to a change in v12 where the Toolbox component was given a lower `weight` than it previously had. This was done to give the Toolbox precedence over the flyout: https://github.com/google/blockly/pull/8432

However, we customize the position of the trashcan, moving it from the workspace to the toolbox area. This means we need to give it a lower weight than either of the other components. Previously the Toolbox weight was 1, but now it's 0. The fix here is to lower our Trashcan's weight from 0 to -1.

Before:
![before](https://github.com/user-attachments/assets/98b51157-6a45-4dc8-8387-020edd460fe0)

After:
![after](https://github.com/user-attachments/assets/effeb333-3dd9-40f5-8656-a8043b54f73a)



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
