### PR TITLE
feat(workshops): add facilitators courses json column to course offerings

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -23,6 +23,7 @@
 #  published_date                   :datetime
 #  self_paced_pl_course_offering_id :integer
 #  ai_teaching_assistant_available  :boolean          default(FALSE), not null
+#  facilitator_course_permissions   :json
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20250530162508_add_facilitator_course_permissions_to_course_offerings.rb
+++ b/dashboard/db/migrate/20250530162508_add_facilitator_course_permissions_to_course_offerings.rb
@@ -1,0 +1,5 @@
+class AddFacilitatorCoursePermissionsToCourseOfferings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :course_offerings, :facilitator_course_permissions, :json
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_05_12_180227) do
+ActiveRecord::Schema.define(version: 2025_05_30_162508) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -501,6 +501,7 @@ ActiveRecord::Schema.define(version: 2025_05_12_180227) do
     t.datetime "published_date"
     t.integer "self_paced_pl_course_offering_id"
     t.boolean "ai_teaching_assistant_available", default: false, null: false
+    t.json "facilitator_course_permissions"
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds a migration that adds a `facilitators_courses` json column to the `course_offerings` table. The column will hold a json array of course names, determining which facilitators have permission to facilitate byo workshops covering those course offerings (topics).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3222

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
