### PR TITLE
feat(Carousel): set allowTouchMove to true by default

### DIFF
--- a/frontend/packages/component-library/src/carousel/Carousel.tsx
+++ b/frontend/packages/component-library/src/carousel/Carousel.tsx
@@ -52,7 +52,7 @@ const Carousel: React.FC<CarouselProps> = ({
   showNavArrows = true,
   slidesPerView = 2,
   slidesPerGroup = 2,
-  allowTouchMove = false,
+  allowTouchMove = true,
   autoHeight = false,
   slides,
   className,

--- a/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
+++ b/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
@@ -192,57 +192,6 @@ CarouselWithoutNavArrows.play = async ({
   }
 };
 
-export const CarouselWithTouchMove = SingleTemplate.bind({});
-CarouselWithTouchMove.args = {
-  allowTouchMove: true,
-  slides: Array.from({length: 6}, (_, index) => ({
-    id: `default-slide-${index + 1}`,
-    slide: createBasicSlide(index + 1),
-  })),
-};
-CarouselWithTouchMove.parameters = {
-  docs: {
-    description: {
-      story:
-        'This carousel allows slides to be moved by dragging/touching using the `allowTouchMove` prop. This is disabled by default and should not be used with Video carousels since it impedes the video player controls.',
-    },
-  },
-};
-CarouselWithTouchMove.play = async ({
-  canvasElement,
-}: {
-  canvasElement: HTMLElement;
-}) => {
-  const canvas = within(canvasElement);
-  const navArrowPrev = canvas.queryByLabelText('Previous slide');
-  const navArrowNext = canvas.queryByLabelText('Next slide');
-  const paginationDots = ['Go to slide 1', 'Go to slide 2', 'Go to slide 3'];
-  const slides = [
-    'This is slide 1',
-    'This is slide 2',
-    'This is slide 3',
-    'This is slide 4',
-    'This is slide 5',
-    'This is slide 6',
-  ];
-
-  // check that the navigation arrows are showing
-  await expect(navArrowPrev).toBeInTheDocument();
-  await expect(navArrowNext).toBeInTheDocument();
-
-  // check that the pagination dots are showing
-  for (const dotLabel of paginationDots) {
-    const dot = await canvas.findByLabelText(dotLabel);
-    await expect(dot).toBeInTheDocument();
-  }
-
-  // check that slides are in the carousel
-  for (const slideText of slides) {
-    const heading = await canvas.findByText(slideText);
-    await expect(heading).toBeInTheDocument();
-  }
-};
-
 export const CarouselWithCustomSlidesPerView = SingleTemplate.bind({});
 CarouselWithCustomSlidesPerView.args = {
   slidesPerView: 3,


### PR DESCRIPTION
Sets `allowtouchMove` setting on Swiper to true by default. This will allow the Video Carousels to have touch move. I also removed the Touch Move story in Storybook since it's no longer relevant. 

## Links
Jira ticket: [CMS-762](https://codedotorg.atlassian.net/browse/CMS-762)

## Testing story
Tested locally in Storybook and Contentful

----

## Storybook

https://github.com/user-attachments/assets/1d588e71-0e78-47f0-96ea-9a31fb6929dc

## Contentful


https://github.com/user-attachments/assets/cbbe26ae-7a34-45e9-a486-3678adf902a1

