### PR TITLE
Fix assessment level progress update in Lab2

### DIFF
--- a/apps/src/code-studio/progressReduxSelectors.js
+++ b/apps/src/code-studio/progressReduxSelectors.js
@@ -193,7 +193,9 @@ const levelWithProgress = (
     status = levelProgress.status;
     locked = levelProgress.locked;
     teacherFeedbackReviewState = levelProgress.teacherFeedbackReviewState;
-  } else if (level.kind !== LevelKind.assessment) {
+  } else if (
+    !(level.kind === LevelKind.assessment && level.app === 'level_group')
+  ) {
     // if we don't have levelProgress, get the status from `levelResults`.
     // however, `levelResults` doesn't track per-page results for multi-page
     // assessments, so for assessments we leave default values.


### PR DESCRIPTION
On Lab2 levels, assessment level bubbles weren't turning purple after level completion (until a page refresh or reload). It seems this is because we had logic that prevented assessment levels from having their `status` updated after an async progress update. This logic however was specific to a case with multi-page, level group based assessment levels, and doesn't seem to apply to general assessment levels (i.e. any Lab2 levels in a progression that are marked as "assessment"). I checked this with Dan [here](https://codedotorg.slack.com/archives/C079YTSNMM4/p1748020965716689). The fix here is just to explicitly check for assessment levels that are also multi-page/level groups when deciding whether to skip the status update. 

Before:

https://github.com/user-attachments/assets/35ca01a6-c496-44c7-b468-0750c6060594

After:

https://github.com/user-attachments/assets/26d878d6-aa78-4908-911f-e9625bb16aa1

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1417

## Testing story

Tested locally on a few sample assessment levels (Music & AI Chat)