### PR TITLE
Give flaky Regional Workshop Catalog frontend test more time to complete

### DIFF
--- a/apps/test/unit/code-studio/pd/professional_learning/RegionalWorkshopCatalogTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning/RegionalWorkshopCatalogTest.jsx
@@ -263,7 +263,7 @@ describe('RegionalWorkshopCatalog', () => {
       expect(screen.getAllByText('National workshops').length).toBe(2);
       screen.getByText(TEST_NATIONAL_WORKSHOP.name);
     });
-  });
+  }, 10000);
 
   it('immediately shows regional workshops available to given zip code if provided in url', async () => {
     const zip = '98122';


### PR DESCRIPTION
Increases the timeout for a flaky Regional Workshop Catalog test that timed out when staging was building, but I wasn't able to repro it locally.

This passed locally and the intent is to merge ahead of drone to unblock staging.

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1748036958631009)
