### PR TITLE
Fixing modular Unit numbering on CourseOverview page

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1786,9 +1786,9 @@ class Unit < ApplicationRecord
     data
   end
 
-  def summarize_i18n_for_display
+  def summarize_i18n_for_display(unit_group_unit: nil)
     data = summarize_i18n_for_edit
-    data[:title] = title_for_display
+    data[:title] = title_for_display(unit_group_unit: unit_group_unit)
     data
   end
 
@@ -1833,12 +1833,14 @@ class Unit < ApplicationRecord
     unit_group_units&.first&.position
   end
 
-  def title_for_display
+  def title_for_display(unit_group_unit: nil)
+    unit_group_unit ||= Queries::Courses.unit_group_unit(self)
+    unit_group = unit_group_unit&.cached_unit_group
     title = localized_title
     has_prefix = unit_group&.has_numbered_units
     return title unless has_prefix
 
-    position = unit_group_units&.first&.position
+    position = unit_group_unit&.position
     prefix = I18n.t "unit_prefix", n: position
     "#{prefix} - #{title}"
   end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -303,7 +303,7 @@ class UnitGroup < ApplicationRecord
         scripts: units_for_user(user).map do |unit|
           include_lessons = false
           unit_group_unit = unit.unit_group_units.find {|ugu| ugu.unit_group == self}
-          unit.summarize(include_lessons, user, unit_group_unit: unit_group_unit).merge!(unit.summarize_i18n_for_display)
+          unit.summarize(include_lessons, user, unit_group_unit: unit_group_unit).merge!(unit.summarize_i18n_for_display(unit_group_unit: unit_group_unit))
         end,
         teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
         student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -3,6 +3,7 @@ require 'cdo/shared_constants'
 
 class UnitTest < ActiveSupport::TestCase
   include SharedConstants
+  include Minitest::RSpecMocks
 
   self.use_transactional_test_case = true
 
@@ -2671,6 +2672,92 @@ class UnitTest < ActiveSupport::TestCase
     unit_with_ai_tutor = create :unit, :with_levels
     unit_with_ai_tutor.levels[0].update!(ai_tutor_available: true)
     assert unit_with_ai_tutor.has_ai_tutor_level?
+  end
+
+  describe '#title_for_display' do
+    let(:has_numbered_units) {false}
+    let(:unit_group) {create :unit_group, has_numbered_units: has_numbered_units}
+    let(:unit_title) {'my_unit_title'}
+    let(:unit) {create :unit, original_unit_group: unit_group}
+    let(:position) {2}
+    let!(:unit_group_unit) {create :unit_group_unit, script_id: unit.id, course_id: unit_group.id, position: position}
+    let(:unit_group_other) {create :unit_group, has_numbered_units: has_numbered_units}
+    let(:position_other) {1}
+    let!(:unit_group_unit_other) {create :unit_group_unit, script_id: unit.id, course_id: unit_group_other.id, position: position_other}
+
+    before do
+      # Add the unit to another unit_group
+      unit.reload
+      allow(unit).to receive(:localized_title).and_return(unit_title)
+    end
+
+    context 'default unit_group_unit' do
+      let(:subject) {unit.title_for_display}
+
+      context 'has_numbered_units is false' do
+        let(:has_numbered_units) {false}
+
+        it 'returns the unit title' do
+          _(subject).must_equal 'my_unit_title'
+        end
+      end
+
+      context 'has_numbered_units is true' do
+        let(:has_numbered_units) {true}
+
+        it 'returns the unit title with prefix' do
+          _(subject).must_equal 'Unit 2 - my_unit_title'
+        end
+      end
+    end
+
+    context 'unit_group_unit is the original' do
+      let(:subject) {unit.title_for_display(unit_group_unit: unit_group_unit)}
+
+      context 'has_numbered_units is false' do
+        let(:has_numbered_units) {false}
+
+        it 'returns the unit title' do
+          _(subject).must_equal 'my_unit_title'
+        end
+      end
+
+      context 'has_numbered_units is true' do
+        let(:has_numbered_units) {true}
+
+        it 'returns the unit title with prefix' do
+          _(subject).must_equal 'Unit 2 - my_unit_title'
+        end
+      end
+
+      context 'unit_group_unit is the other' do
+        let(:subject) {unit.title_for_display(unit_group_unit: unit_group_unit_other)}
+
+        context 'has_numbered_units is false' do
+          let(:has_numbered_units) {false}
+
+          it 'returns the unit title' do
+            _(subject).must_equal 'my_unit_title'
+          end
+        end
+
+        context 'has_numbered_units is true' do
+          let(:has_numbered_units) {true}
+
+          it 'returns the unit title with prefix' do
+            _(subject).must_equal 'Unit 1 - my_unit_title'
+          end
+
+          context 'position_other is 3' do
+            let(:position_other) {3}
+
+            it 'returns the unit title with prefix' do
+              _(subject).must_equal 'Unit 3 - my_unit_title'
+            end
+          end
+        end
+      end
+    end
   end
 
   private def has_unlaunched_unit?(units)


### PR DESCRIPTION
When looking at the CourseOverview page which has Units shared between multiple UnitGroups, the numbering was off. Sometimes it would skip a number, like "Unit 2", "Unit 3", "Unit 5". The cause of this bug is because the number was coming from the position of the Unit in a different UnitGroup. The fix is to pass the current UnitGroup to the Unit so it knows what its position is.
* Adds `unit_group_unit` param to `Unit#title_for_display` method.

**Before** | **After**
---|---
![image](https://github.com/user-attachments/assets/bdc43b85-55ab-4df0-a11b-619f048f12ef)|![image](https://github.com/user-attachments/assets/263e7b03-9c3d-4bdc-9286-83b63fd54395)


## Links
* [Jira](https://codedotorg.atlassian.net/browse/TEACH-1915)

## Testing story
* unit tests
* Manually tested on (you will need levebuilder permissions)
  * http://localhost-studio.code.org:3000/courses/idaho-digital-literacy-2025
  * http://localhost-studio.code.org:3000/courses/computing-foundations-for-a-digital-age-2025
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
* Fix other places `Unit#title_for_display` and `Unit#summarize_i18n_for_display` are called

