### PR TITLE
Fix Unit title in Unit#summarize* methods

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1562,7 +1562,7 @@ class Unit < ApplicationRecord
       summary = {
         id: id,
         name: name,
-        title: title_for_display,
+        title: title_for_display(unit_group_unit: unit_group_unit),
         description: Services::MarkdownPreprocessor.process(localized_description),
         studentDescription: Services::MarkdownPreprocessor.process(localized_student_description),
         course_id: unit_group_unit&.cached_unit_group&.id,
@@ -1652,10 +1652,10 @@ class Unit < ApplicationRecord
     end
     summary = {
       unitId: id,
-      title: title_for_display,
+      title: title_for_display(unit_group_unit: unit_group_unit),
       name: name,
       unitNumber: unit_position,
-      unitName: title_for_display,
+      unitName: title_for_display(unit_group_unit: unit_group_unit),
       scriptOverviewPdfUrl: get_unit_overview_pdf_url,
       scriptResourcesPdfUrl: get_unit_resources_pdf_url,
       teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
@@ -1676,7 +1676,7 @@ class Unit < ApplicationRecord
       link_path = course_unit_path(unit_group_unit.unit_group, unit_group_unit.position)
     end
     summary = {
-      title: title_for_display,
+      title: title_for_display(unit_group_unit: unit_group_unit),
       name: name,
       link: link_path
     }
@@ -1733,7 +1733,7 @@ class Unit < ApplicationRecord
   def summarize_header(unit_group_unit: nil)
     {
       name: name,
-      displayName: title_for_display,
+      displayName: title_for_display(unit_group_unit: unit_group_unit),
       disablePostMilestone: disable_post_milestone?,
       student_detail_progress_view: student_detail_progress_view?,
       age_13_required: logged_out_age_13_required?,
@@ -1746,7 +1746,7 @@ class Unit < ApplicationRecord
 
   def summarize_for_lesson_show(is_student = false, unit_group_unit: nil)
     {
-      displayName: title_for_display,
+      displayName: title_for_display(unit_group_unit: unit_group_unit),
       link: link(unit_group_unit: unit_group_unit),
       lessonGroups: lesson_groups.select {|lg| lg.lessons.any?(&:has_lesson_plan)}.map {|lg| lg.summarize_for_lesson_dropdown(is_student, unit_group_unit: unit_group_unit)},
       publishedState: get_published_state,


### PR DESCRIPTION
`Unit#title_for_display` needs the `unit_group_unit` parameter to display the correct title for the Unit. This PR adds the `unit_group_unit` context to most of the `summarize*` methods in Unit.

**Before**|**After**
---|---
![Screenshot 2025-05-23 at 3 57 16 PM](https://github.com/user-attachments/assets/61558087-b65a-47c9-96b9-1c2cee08bcfb)|![Screenshot 2025-05-23 at 3 57 43 PM](https://github.com/user-attachments/assets/199f1aef-c4dc-4deb-94c7-c13c234463c9)

*The correct title is "Unit 4 -...."*

## Links
* [Jira](https://codedotorg.atlassian.net/browse/TEACH-1915)

## Testing story
* Manually tested on http://localhost-studio.code.org:3000/courses/idaho-digital-literacy-2025/units/4
  * Also check the lesson pages show the correct Unit title.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
