### PR TITLE
fix(turbo): prevent turbocache from infinitely growing

### DIFF
--- a/.github/actions/frontend/setup/action.yml
+++ b/.github/actions/frontend/setup/action.yml
@@ -9,12 +9,7 @@ runs:
       run: corepack enable
 
     - name: Cache turborepo
-      uses: actions/cache@v4
-      with:
-        path: frontend/.turbo
-        key: "${{ runner.os }}-turbo-${{ github.sha }}"
-        restore-keys: |
-          ${{ runner.os }}-turbo-
+      uses: rharkor/caching-for-turbo@a1c4079258ae08389be75b57d4d7a70f23c1c66d # v1.8
 
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -9,6 +9,7 @@ on:
       - staging-next
     paths:
       - 'frontend/**'
+      - '.github/**'
 
 env:
   APPLITOOLS_BATCH_ID: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
The previous implementation of turbo cache used Github Action's cache service. However, Turbo does not [clean up old unused artifacts](https://github.com/vercel/turborepo/issues/863) when not using its turbo service, leading to a scenario where the size of the cached item grows by 90 MB per commit. It has reached ~3 GB now which is causing some out of disk errors on actions when it tries to use the cache.

One solution is to clean up old cache entries manually in Github Actions and re-commit that as the cache entry. However, we can instead use the cache service using the [caching-for-turbo](https://github.com/rharkor/caching-for-turbo) action instead (which still leverages Github Actions Cache, but also enables using S3).

In the future we can evaluate whether Vercel's hosted solution or continuing to use Github Actions Cache will be better suited for our needs.