### PR TITLE
[Google Blockly] set workspace.options.disabled correctly

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -864,6 +864,12 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.showUnusedBlocks = options.showUnusedBlocks;
     blocklyWrapper.blockLimitMap = cdoUtils.createBlockLimitMap();
     blocklyWrapper.isDarkTheme = isDarkTheme(options.theme);
+
+    // Only allow toggling disabled blocks in start mode.
+    // This is also important for ensuring that Blockly does not
+    // mistakenly keep orphaned blocks disabled when they are connected.
+    options.disable = blocklyWrapper.isStartMode;
+
     const workspace = blocklyWrapper.blockly_.inject(
       container,
       options


### PR DESCRIPTION
After merging the Blockly v12 upgrade yesterday, @sanchitmalhotra126 [noticed a regression](https://codedotorg.slack.com/archives/C04TH8400AU/p1748034173837169) where disabled/orphaned blocks on the workspace did not become enabled once connected. 

![Screenshot 2025-05-23 at 2 02 25 PM](https://github.com/user-attachments/assets/23cc126e-ae49-4ea4-b0e8-338279c1e096)

(This was made slightly more confusing because currently our shadow blocks look just like disabled blocks. That's something to unpack later.)

As of v12, Blockly requires using the new `setDisabledReason()` block method instead of `setEnabled()` and `setDisabled()`. A block is only considered enabled if it has no `.disableReasons`. In order to handle older disabled blocks that do not have reasons (ie. any disabled blocks in our levels projects made before today), Blockly will assume they were manually disabled by the user if the workspace is set to allow manual disabling/enabled. We have not used this option before, instead preventing students from toggling this state simply by removing the context menu options that make it possible. This setting is on by default, which means we need to ensure our workspace are created with it explicitly turned off.  An exception is made for Start Mode so that levelbuilders may force a block to stay disabled if desired.

This is explained in further detail in the comment found below:
https://github.com/google/blockly/blob/cc9384ae87aeb25c47c158261fe1dc8d381240a4/core/block.ts#L1426

With this change I was able to verify that disabled blocks become enabled when they are no longer orphaned. This matches are functionality from before v12.
<img width="706" alt="image" src="https://github.com/user-attachments/assets/9716ac24-503d-4aea-8f50-2a1c708d8445" />
