### PR TITLE
[Python Lab] Move header button tooltips to bottom

### DIFF
--- a/apps/src/codebridge/Settings/SettingsButton.tsx
+++ b/apps/src/codebridge/Settings/SettingsButton.tsx
@@ -22,9 +22,10 @@ const SettingsButton: React.FunctionComponent = () => {
 
   const settingsTooltipProps: TooltipProps = {
     text: commonI18n.settings(),
-    direction: 'onLeft',
+    direction: 'onBottom',
     tooltipId: 'settings-tooltip',
     size: 'xs',
+    hideTail: true,
   };
 
   return (

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -36,16 +36,18 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
 
   const feedbackTooltipProps: TooltipProps = {
     text: commonI18n.feedback(),
-    direction: 'onLeft',
+    direction: 'onBottom',
     tooltipId: 'feedback-tooltip',
     size: 'xs',
+    hideTail: true,
   };
 
   const documentationTooltipProps: TooltipProps = {
     text: commonI18n.documentation(),
-    direction: 'onLeft',
+    direction: 'onBottom',
     tooltipId: 'documentation-tooltip',
     size: 'xs',
+    hideTail: true,
   };
 
   const documentationUrl = `${currentLocation().origin}/docs/ide/${appName}`;

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
@@ -87,9 +87,10 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
 
   const tooltipProps: TooltipProps = {
     text: commonI18n.versionHistory_header(),
-    direction: 'onLeft',
+    direction: 'onBottom',
     tooltipId: 'version-history-tooltip',
     size: 'xs',
+    hideTail: true,
   };
 
   return (


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Now that DSCO tooltips are dynamically placed via https://github.com/code-dot-org/code-dot-org/pull/65142, we move the `pythonlab` header button tooltips to the bottom.
Currently, the tooltip covers up the header buttons to the left of the focused button so that the user has to move mouse below focused button, and then back up to access left-adjacent header buttons.

We hide the tail because the tail is not dynamically re-positioned if the tooltip moves from default position. https://github.com/code-dot-org/code-dot-org/pull/65142#discussion_r2102762980




## Before update



https://github.com/user-attachments/assets/3b618a3d-52c5-4195-a7a3-9ffdb54457dc


## After update

In `pythonlab`:

https://github.com/user-attachments/assets/3948ef7a-861a-4bc1-8c98-17da54dda9b7


In `pythonlab` with different layouts, `weblab2` and standalone `pythonlab` project:


https://github.com/user-attachments/assets/12e78b0e-a89f-4487-9ff2-ee262846c8bf



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/CT-1229
- [Checked with product](https://codedotorg.slack.com/archives/C06JELCAPT9/p1748359346870279)

## Testing story
Tested locally in `pythonlab` and `weblab2` levels including `pythonlab` standalone projects (both types).

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
