### PR TITLE
Redirect the old Regional Partner Search to the Workshop Catalog

### DIFF
--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -622,7 +622,7 @@ Dashboard::Application.routes.draw do
         post :replace_mappings
       end
     end
-    get 'regional-partner-search', to: 'regional_partners#regional_partner_search'
+    get 'regional-partner-search', to: redirect('/professional-learning/workshops')
 
     scope path: '/admin' do
       # internal report dashboards


### PR DESCRIPTION
This PR effectively launches the Workshop Catalog, which has been hidden in plain sight on production for a few weeks. 🥳 

Ticket to clean up the regional partner search page: https://codedotorg.atlassian.net/browse/ACQ-3318