### PR TITLE
fix(turbo): enable turbo in docker

### DIFF
--- a/.github/workflows/marketing-app-ci.yml
+++ b/.github/workflows/marketing-app-ci.yml
@@ -71,6 +71,12 @@ jobs:
           file: frontend/apps/marketing/Dockerfile
           tags: marketing:test
           push: false
+          network: host # This is required for the `turbo` command to work properly in the Dockerfile.
+          # Note TURBO_TOKEN is not a secret because we use a local turbo instance, it is stubbed out for future use only.
+          build-args: |
+            TURBO_TEAM=${{ vars.TURBO_REPO_TEAM }}
+            TURBO_TOKEN=${{ secrets.TURBO_REPO_TOKEN }}
+            TURBO_API=${{ vars.TURBO_REPO_API }}
 
       - name: Prepare Test Environment
         shell: bash

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -90,6 +90,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          network: host # This is required for the `turbo` command to work properly in the Dockerfile.
+           # Note TURBO_TOKEN is not a secret because we use a local turbo instance, it is stubbed out for future use only.
+          build-args: |
+            TURBO_TEAM=${{ vars.TURBO_REPO_TEAM }}
+            TURBO_TOKEN=${{ secrets.TURBO_REPO_TOKEN }}
+            TURBO_API=${{ vars.TURBO_REPO_API }}
       
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
       - name: Generate artifact attestation

--- a/frontend/apps/marketing/Dockerfile
+++ b/frontend/apps/marketing/Dockerfile
@@ -35,7 +35,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY . .
- 
+
 # Generate a partial monorepo with a pruned lockfile for a target workspace.
 # See: https://turbo.build/repo/docs/reference/prune
 RUN yarn dlx turbo prune @code-dot-org/marketing --docker
@@ -51,6 +51,16 @@ RUN yarn dlx turbo prune @code-dot-org/marketing --docker
 
 FROM base AS builder
 
+# Enable Turborepo
+ARG TURBO_TEAM
+ENV TURBO_TEAM=$TURBO_TEAM
+
+ARG TURBO_TOKEN
+ENV TURBO_TOKEN=$TURBO_TOKEN
+
+ARG TURBO_API
+ENV TURBO_API=$TURBO_API
+
 # Enable corepack
 RUN corepack enable
 
@@ -61,7 +71,6 @@ COPY --link --from=source-code /app/out/json/ .
 RUN yarn install
 
 # Build the project
-COPY --link --from=source-code /app/.turbo .turbo
 COPY --link --from=source-code /app/out/full/ .
 RUN yarn turbo run build
 


### PR DESCRIPTION
The previous PR implementing local turbo missed allowing the docker build to access the local turbo instance.