### PR TITLE
AI Tutor: conditional Python Lab init

### DIFF
--- a/apps/src/lab2/ai/AiTutor2Manager.ts
+++ b/apps/src/lab2/ai/AiTutor2Manager.ts
@@ -73,6 +73,7 @@ export default class AiTutor2Manager {
         channelId: this.channelId || '',
         modelId: AiChatModelIds.CHATGPT,
         systemPrompt: systemPrompts[type],
+        type,
         userMessage: message,
       },
     };

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -18,6 +18,7 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
   getFullPrompt,
 }) => {
   const [askAiTutor, AiTutorResponseView] = useAiTutor2(
+    true,
     getFullPrompt,
     type,
     true

--- a/apps/src/lab2/views/components/aiTutor2/useAiTutor2.tsx
+++ b/apps/src/lab2/views/components/aiTutor2/useAiTutor2.tsx
@@ -64,8 +64,8 @@ export function useAiTutor2(
       );
       if (response) {
         setResponse(response[1].chatMessageText);
-        setLoading(false);
       }
+      setLoading(false);
     },
     [isEnabled, getFullPrompt, type]
   );

--- a/apps/src/lab2/views/components/aiTutor2/useAiTutor2.tsx
+++ b/apps/src/lab2/views/components/aiTutor2/useAiTutor2.tsx
@@ -12,6 +12,7 @@ import moduleStylesFixed from '../AiTutor2ResponseFixed.module.scss';
 import moduleStylesShrink from '../AiTutor2ResponseShrink.module.scss';
 
 export function useAiTutor2(
+  isEnabled: boolean,
   getFullPrompt: (question: string) => string,
   type: AiTutor2MessageType,
   shrink = false
@@ -21,13 +22,17 @@ export function useAiTutor2(
   const channelId = useAppSelector(state => state.lab.channel?.id);
   const [loading, setLoading] = useState<boolean>();
 
-  const managerRef = useRef<AiTutor2Manager>(
-    new AiTutor2Manager(currentLevelId, scriptId, channelId)
+  const managerRef = useRef<AiTutor2Manager | null>(
+    isEnabled ? new AiTutor2Manager(currentLevelId, scriptId, channelId) : null
   );
 
   // This could also be lifecycle hook? or get passed as function arguments?
   // Or return initialize(levelId, scriptId, channelId) and clearResponse() functions to the caller
   useEffect(() => {
+    if (!isEnabled) {
+      return;
+    }
+
     console.log(
       '🤖: creating AiTutor2Manager',
       currentLevelId,
@@ -40,23 +45,29 @@ export function useAiTutor2(
       channelId
     );
     setResponse(undefined);
-  }, [currentLevelId, scriptId, channelId]);
+  }, [isEnabled, currentLevelId, scriptId, channelId]);
 
   const [response, setResponse] = useState<string>();
 
   const askAiTutor2 = useCallback(
     async (question: string) => {
+      if (!isEnabled) {
+        return;
+      }
+
       console.log('🤖: starting chat request', question);
 
       setLoading(true);
-      const response = await managerRef.current.askAiTutor2(
+      const response = await managerRef.current?.askAiTutor2(
         getFullPrompt(question),
         type
       );
-      setResponse(response[1].chatMessageText);
-      setLoading(false);
+      if (response) {
+        setResponse(response[1].chatMessageText);
+        setLoading(false);
+      }
     },
-    [getFullPrompt, type]
+    [isEnabled, getFullPrompt, type]
   );
 
   const AiTutor2Response = loading ? (

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -96,6 +96,10 @@ const PythonlabView: React.FunctionComponent<
     state => state.lab2Project.lastSavedLabConfig
   );
 
+  const isAiTutor2Enabled =
+    levelProperties.aiTutor2Available ||
+    queryParams('show-ai-tutor2') === 'true';
+
   const dispatch = useAppDispatch();
 
   const currentProjectType = useMemo(() => {
@@ -185,6 +189,7 @@ const PythonlabView: React.FunctionComponent<
   };
 
   const [askAiTutor2, AiTutor2Response] = useAiTutor2(
+    isAiTutor2Enabled,
     getAiTutor2FullPrompt,
     'hint'
   );
@@ -223,10 +228,7 @@ const PythonlabView: React.FunctionComponent<
     }
     dispatch(submitPredictResponse({appType: 'pythonlab'}));
 
-    if (
-      levelProperties.aiTutor2Available ||
-      queryParams('show-ai-tutor2') === 'true'
-    ) {
+    if (isAiTutor2Enabled) {
       // Ask a question to AITutor2.
       askAiTutor2("What's wrong with my code, if anything?");
     }


### PR DESCRIPTION
The AI Tutor introduced in https://github.com/code-dot-org/code-dot-org/pull/65737 was showing up in the console log on Python Lab levels where it wasn't being enabled.  It was fairly benign, but we now skip more initialization for the hints in particular. 

Also now sends the message type (`"user"` or `"hint"`) in logs.
