### PR TITLE
fix(marketing): update Error page styles

### DIFF
--- a/frontend/apps/marketing/src/components/error/Error.tsx
+++ b/frontend/apps/marketing/src/components/error/Error.tsx
@@ -112,11 +112,19 @@ export default function Error(props: ErrorProps) {
         ERROR {props.statusCode}
       </Overline>
 
-      <Typography visualAppearance={'heading-xxl'} semanticTag={'h1'}>
+      <Typography
+        visualAppearance={'heading-xxl'}
+        semanticTag={'h1'}
+        className={errorStyles.errorHeading}
+      >
         {getHeadingText()}
       </Typography>
 
-      <Typography visualAppearance={'body-two'} semanticTag={'p'}>
+      <Typography
+        visualAppearance={'body-two'}
+        semanticTag={'p'}
+        className={errorStyles.errorBody}
+      >
         {getDescriptionText()}
       </Typography>
 

--- a/frontend/apps/marketing/src/components/error/error.module.scss
+++ b/frontend/apps/marketing/src/components/error/error.module.scss
@@ -3,13 +3,22 @@
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  padding: 6.25rem 1rem;
+  padding: 6.25rem 2rem;
+  text-align: center;
 }
 
 .sadBeeContainer {
   display: inline-block;
-  width: auto;
+  width: 7.125rem;
   height: auto;
+}
+
+.errorHeading {
+  margin-bottom: 1.5rem;
+}
+
+.errorBody {
+  margin-block: 0 2rem;
 }
 
 .callToActionContainer {


### PR DESCRIPTION
Applies the updates in this [commit](https://github.com/code-dot-org/code-dot-org/pull/66000#issuecomment-2901631180) that was overwritten in https://github.com/code-dot-org/code-dot-org/pull/66000#event-17775333965 to fix styles on the Error pages.

## Links
Jira ticket: [CMS-765](https://codedotorg.atlassian.net/browse/CMS-765)

----

## Bee-fore

<img width="1629" alt="Before" src="https://github.com/user-attachments/assets/184208cd-f216-4673-be59-cd8c509a70c8" />

## After
<img width="1629" alt="After" src="https://github.com/user-attachments/assets/2ab32b07-660e-4de1-b932-1fed051aa8c8" />

