### PR TITLE
disable profanity filtering for TA Assessment

### DIFF
--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -237,10 +237,7 @@ class EvaluateRubricJob < ApplicationJob
     channel_id = get_channel_id(user, script_level)
     code, project_version = read_user_code(channel_id)
 
-    # Check for PII / sharing failures
-    # Get the 2-character language code from the user's preferred locale
-    locale = (user.locale || 'en')[0...2]
-    ShareFiltering.find_failure(code, locale, exceptions: true)
+    ShareFiltering.find_pii_failure(code, exceptions: true)
 
     openai_params = AiRubricConfig.get_openai_params(lesson_s3_name, code)
     response = get_openai_evaluations(openai_params)

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -150,36 +150,6 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     assert_includes exception.message, "Couldn't find Rubric"
   end
 
-  test "job fails when the code contains profanity" do
-    AiRubricConfig.stubs(:get_lesson_s3_name).with(@script_level).returns('fake-lesson-s3-name')
-
-    # create a project
-    channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, @storage_id, @script_level.script_id)
-    channel_id = channel_token.channel
-
-    violating_code = 'damn'
-
-    stub_project_source_data(channel_id, code: violating_code)
-
-    stub_lesson_s3_data
-
-    stub_get_openai_evaluations(code: violating_code)
-
-    ShareFiltering.stubs(:find_failure).with(violating_code, 'en', exceptions: true).raises(
-      ProfanityFilterException.new(
-        "Profanity Failure",
-        ShareFailure.new('profanity', 'damn')
-      )
-    )
-
-    # run the job
-    perform_enqueued_jobs do
-      EvaluateRubricJob.perform_later(user_id: @student.id, requester_id: @student.id, script_level_id: @script_level.id)
-    end
-
-    assert_equal SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PROFANITY_VIOLATION], RubricAiEvaluation.where(user_id: @student.id).first.status
-  end
-
   test "job fails when the code contains PII violations" do
     AiRubricConfig.stubs(:get_lesson_s3_name).with(@script_level).returns('fake-lesson-s3-name')
 
@@ -195,10 +165,10 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
 
     stub_get_openai_evaluations(code: violating_code)
 
-    ShareFiltering.stubs(:find_share_failure).with(violating_code, 'en', exceptions: true).raises(
+    ShareFiltering.stubs(:find_pii_failure).with(violating_code, exceptions: true).raises(
       PIIFilterException.new(
         "PII Failure",
-        ShareFailure.new('email', '123-456-7890')
+        ShareFailure.new('phone', '123-456-7890')
       )
     )
 


### PR DESCRIPTION
Finishes [TEACH-1926](https://codedotorg.atlassian.net/browse/TEACH-1926). See [slack](https://codedotorg.slack.com/archives/C050HE4QDHR/p1747263001550489). I also opened a new work item to re-enable profanity filtering: https://codedotorg.atlassian.net/browse/TEACH-1930

## Testing story

updated unit tests