### PR TITLE
Cache `apps/build` in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -216,7 +216,7 @@ steps:
       - name: mysql
         path: /drone/src/var/lib/mysql
     settings:
-      filename: cache-staging-misc-build-artifacts.tar.gz
+      filename: cache-staging-misc-build-artifacts.with-apps.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -329,7 +329,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-misc-build-artifacts.tar.gz
+      filename: cache-staging-misc-build-artifacts.with-apps.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -353,6 +353,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: 6646bfda5cd973eb102725e17d3dade6b986b372da0ebb87c687d40e29655dfc
+hmac: ee4f15564ccf494831d0a3fdd44d4916b2f5b9314a6f03dd49c546d2e078a25b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -216,7 +216,7 @@ steps:
       - name: mysql
         path: /drone/src/var/lib/mysql
     settings:
-      filename: cache-staging-misc-build-artifacts.tar.gz
+      filename: cache-staging-misc-build-artifacts.with-apps.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -329,7 +329,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-misc-build-artifacts.tar.gz
+      filename: cache-staging-misc-build-artifacts.with-apps.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -337,6 +337,7 @@ steps:
       mount:
         - /home/ci/.rbenv
         - /var/lib/mysql
+        - ./apps/build
 
 volumes:
   - name: rbenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -291,18 +291,19 @@ steps:
     image: bitnami/git
     commands:
       - git lfs install
-      - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 
+      - git clone --branch $DRONE_SOURCE_BRANCH $DRONE_GIT_HTTP_URL . 
+      # - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 
 
-  - name: cache-staging-clone
-    image: plugins/s3-cache
-    settings:
-      filename: cache-staging-clone.tar.gz
-      endpoint: s3://cdo-drone
-      rebuild: true
-      debug: true
-      pull: true
-      mount:
-        - .
+  # - name: cache-staging-clone
+  #   image: plugins/s3-cache
+  #   settings:
+  #     filename: cache-staging-clone.tar.gz
+  #     endpoint: s3://cdo-drone
+  #     rebuild: true
+  #     debug: true
+  #     pull: true
+  #     mount:
+  #       - .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of rbenv and the database, but don't actually run the tests.
@@ -347,10 +348,19 @@ volumes:
 
 trigger:
   branch:
-    - "staging"
-    - "staging-next"
+    exclude:
+      - "production"
+      - "test"
+      - "levelbuilder"
   event:
-    - push
+    - pull_request
+
+# trigger:
+#   branch:
+#     - "staging"
+#     - "staging-next"
+#   event:
+#     - push
 ---
 kind: signature
 hmac: 2592ca7a9dbb42b21906f80b94efbe86eb4cf378cd73706d4b3527b082e95dfc

--- a/.drone.yml
+++ b/.drone.yml
@@ -353,6 +353,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: 2592ca7a9dbb42b21906f80b94efbe86eb4cf378cd73706d4b3527b082e95dfc
+hmac: ee4f15564ccf494831d0a3fdd44d4916b2f5b9314a6f03dd49c546d2e078a25b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -291,19 +291,18 @@ steps:
     image: bitnami/git
     commands:
       - git lfs install
-      - git clone --branch $DRONE_SOURCE_BRANCH $DRONE_GIT_HTTP_URL . 
-      # - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 
+      - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 
 
-  # - name: cache-staging-clone
-  #   image: plugins/s3-cache
-  #   settings:
-  #     filename: cache-staging-clone.tar.gz
-  #     endpoint: s3://cdo-drone
-  #     rebuild: true
-  #     debug: true
-  #     pull: true
-  #     mount:
-  #       - .
+  - name: cache-staging-clone
+    image: plugins/s3-cache
+    settings:
+      filename: cache-staging-clone.tar.gz
+      endpoint: s3://cdo-drone
+      rebuild: true
+      debug: true
+      pull: true
+      mount:
+        - .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of rbenv and the database, but don't actually run the tests.
@@ -348,19 +347,10 @@ volumes:
 
 trigger:
   branch:
-    exclude:
-      - "production"
-      - "test"
-      - "levelbuilder"
+    - "staging"
+    - "staging-next"
   event:
-    - pull_request
-
-# trigger:
-#   branch:
-#     - "staging"
-#     - "staging-next"
-#   event:
-#     - push
+    - push
 ---
 kind: signature
 hmac: 2592ca7a9dbb42b21906f80b94efbe86eb4cf378cd73706d4b3527b082e95dfc

--- a/.drone.yml
+++ b/.drone.yml
@@ -216,7 +216,7 @@ steps:
       - name: mysql
         path: /drone/src/var/lib/mysql
     settings:
-      filename: cache-staging-misc-build-artifacts.with-apps.tar.gz
+      filename: cache-staging-misc-build-artifacts.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -329,7 +329,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-misc-build-artifacts.with-apps.tar.gz
+      filename: cache-staging-misc-build-artifacts.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -353,6 +353,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: ee4f15564ccf494831d0a3fdd44d4916b2f5b9314a6f03dd49c546d2e078a25b
+hmac: 6646bfda5cd973eb102725e17d3dade6b986b372da0ebb87c687d40e29655dfc
 
 ...

--- a/apps/src/accounts/AddParentEmailController.js
+++ b/apps/src/accounts/AddParentEmailController.js
@@ -13,6 +13,8 @@ import AddParentEmailModal from './AddParentEmailModal';
  * The controller subscribes to events emitted by the Rails helper JavaScript
  * to detect success or errors.
  *
+ * no-op change just for testing
+ *
  * Read more:
  * http://guides.rubyonrails.org/working_with_javascript_in_rails.html#rails-ujs-event-handlers
  * https://github.com/rails/jquery-ujs

--- a/apps/src/accounts/AddParentEmailController.js
+++ b/apps/src/accounts/AddParentEmailController.js
@@ -13,8 +13,6 @@ import AddParentEmailModal from './AddParentEmailModal';
  * The controller subscribes to events emitted by the Rails helper JavaScript
  * to detect success or errors.
  *
- * no-op change just for testing
- *
  * Read more:
  * http://guides.rubyonrails.org/working_with_javascript_in_rails.html#rails-ujs-event-handlers
  * https://github.com/rails/jquery-ujs


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/65765; shaves another ~9 minutes off the build process when we don't need to rebuild apps:

[Before (always)](https://drone.cdn-code.org/code-dot-org/code-dot-org/32415/2/1) | [After (no apps changes)](https://drone.cdn-code.org/code-dot-org/code-dot-org/32357/2/6) | [After (with apps changes)](https://drone.cdn-code.org/code-dot-org/code-dot-org/32427)
--- | --- | ---
Finished build:apps (9 minutes) | Finished build:apps (less than a minute) | Finished build:apps (9 minutes)

At the cost of it taking ~10 seconds longer to download the ~500mb-larger cache file:

[Before](https://drone.cdn-code.org/code-dot-org/code-dot-org/32415/2/5) | [After](https://drone.cdn-code.org/code-dot-org/code-dot-org/32357/2/5)
--- | ---
get-cached-staging-misc-build-artifacts 00:45 | get-cached-staging-misc-build-artifacts 00:54 |
`size="984 MB"` | `size="1.4 GB"`