### PR TITLE
AI Tutor: add dcdo flag and to block start_chat_completion access from AiTutor2

### DIFF
--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -26,7 +26,7 @@ class AichatRequestsController < ApplicationController
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
     end
-    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_aichat? || can_access_aitutor2?(params[:aichatContext][:currentLevelId])
+    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_aichat? || can_access_ai_tutor2?(params[:aichatContext][:currentLevelId])
 
     return head :too_many_requests if should_throttle_request_count?
 
@@ -88,9 +88,9 @@ class AichatRequestsController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
-  private def can_access_aitutor2?(level_id)
+  private def can_access_ai_tutor2?(level_id)
     # AiTutor2 requests only come from python lab levels.
-    return false unless level_id && DCDO.get("aitutor2_chat_completion", true)
+    return false unless level_id && DCDO.get("ai_tutor2_chat_completion", true)
     Level.find(level_id).is_a? Pythonlab
   end
 

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -90,7 +90,7 @@ class AichatRequestsController < ApplicationController
 
   private def can_access_aitutor?(level_id)
     # AI Tutor requests only come from python lab levels.
-    return false unless level_id
+    return false unless level_id && DCDO.get("aitutor2_chat_completion", true)
     Level.find(level_id).is_a? Pythonlab
   end
 

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -26,7 +26,7 @@ class AichatRequestsController < ApplicationController
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
     end
-    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_aichat? || can_access_aitutor?(params[:aichatContext][:currentLevelId])
+    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_aichat? || can_access_aitutor2?(params[:aichatContext][:currentLevelId])
 
     return head :too_many_requests if should_throttle_request_count?
 
@@ -88,8 +88,8 @@ class AichatRequestsController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
-  private def can_access_aitutor?(level_id)
-    # AI Tutor requests only come from python lab levels.
+  private def can_access_aitutor2?(level_id)
+    # AiTutor2 requests only come from python lab levels.
     return false unless level_id && DCDO.get("aitutor2_chat_completion", true)
     Level.find(level_id).is_a? Pythonlab
   end

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -1,7 +1,6 @@
 require 'cdo/throttle'
 
 class AichatRequestsController < ApplicationController
-  include AichatSagemakerHelper
   authorize_resource class: false
 
   AICHAT_REQUEST_COUNT_PREFIX = "aichat/requests/".freeze
@@ -90,12 +89,12 @@ class AichatRequestsController < ApplicationController
 
   private def can_access_ai_tutor2?(level_id)
     # AiTutor2 requests only come from python lab levels.
-    return false unless level_id && DCDO.get("ai_tutor2_chat_completion", true)
+    return false if level_id == nil? || DCDO.get("block_ai_tutor2_chat_completion", false)
     Level.find(level_id).is_a? Pythonlab
   end
 
   private def can_access_aichat?
-    AichatSagemakerHelper.can_request_aichat_chat_completion? && current_user.has_aichat_access?
+    !DCDO.get("block_aichat_chat_completion", false) && current_user.has_aichat_access?
   end
 
   private def should_throttle_request_count?

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -89,7 +89,7 @@ class AichatRequestsController < ApplicationController
 
   private def can_access_ai_tutor2?(level_id)
     # AiTutor2 requests only come from python lab levels.
-    return false if level_id == nil? || DCDO.get("block_ai_tutor2_chat_completion", false)
+    return false if level_id.nil? || DCDO.get("block_ai_tutor2_chat_completion", false)
     Level.find(level_id).is_a? Pythonlab
   end
 

--- a/dashboard/app/helpers/aichat_sagemaker_helper.rb
+++ b/dashboard/app/helpers/aichat_sagemaker_helper.rb
@@ -71,10 +71,6 @@ module AichatSagemakerHelper
     )
   end
 
-  def self.can_request_aichat_chat_completion?
-    DCDO.get("aichat_chat_completion", true)
-  end
-
   def self.get_endpoint_name(model_id)
     "#{model_id}-#{rack_env?(:production) ? 'production' : 'test'}"
   end

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -35,6 +35,12 @@ class AichatRequestsControllerTest < ActionController::TestCase
 
   setup do
     @controller.stubs(:storage_decrypt_channel_id).returns([123, @project_id])
+    DCDO.stubs(:get).with('aitutor2_chat_completion', anything).returns(true)
+    DCDO.stubs(:get).with('aichat_chat_completion', anything).returns(true)
+    DCDO.stubs(:get).with('aichat_request_limit_per_min', anything).returns(AichatRequestsController::DEFAULT_REQUEST_LIMIT_PER_MIN)
+    DCDO.stubs(:get).with('aichat_polling_interval_ms', anything).returns(AichatRequestsController::DEFAULT_POLLING_INTERVAL_MS)
+    DCDO.stubs(:get).with('aichat_polling_backoff_rate', anything).returns(AichatRequestsController::DEFAULT_POLLING_BACKOFF_RATE)
+    DCDO.stubs(:get).with('throttle_time_default', anything).returns(60)
   end
 
   # start_chat_completion tests
@@ -61,6 +67,15 @@ class AichatRequestsControllerTest < ActionController::TestCase
     params_with_python_level = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(currentLevelId: python_lab_level.id))
     post :start_chat_completion, params: params_with_python_level, as: :json
     assert_response :success
+  end
+
+  test 'DCDO flag blocks access to start_chat_completion from python lab levels' do
+    sign_in(@unauthorized_student)
+    DCDO.stubs(:get).with('aitutor2_chat_completion', true).returns(false)
+    python_lab_level = create :pythonlab
+    params_with_python_level = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(currentLevelId: python_lab_level.id))
+    post :start_chat_completion, params: params_with_python_level, as: :json
+    assert_response :forbidden
   end
 
   test 'authorized teacher has access to start_chat_completion test' do

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -35,7 +35,7 @@ class AichatRequestsControllerTest < ActionController::TestCase
 
   setup do
     @controller.stubs(:storage_decrypt_channel_id).returns([123, @project_id])
-    DCDO.stubs(:get).with('aitutor2_chat_completion', anything).returns(true)
+    DCDO.stubs(:get).with('ai_tutor2_chat_completion', anything).returns(true)
     DCDO.stubs(:get).with('aichat_chat_completion', anything).returns(true)
     DCDO.stubs(:get).with('aichat_request_limit_per_min', anything).returns(AichatRequestsController::DEFAULT_REQUEST_LIMIT_PER_MIN)
     DCDO.stubs(:get).with('aichat_polling_interval_ms', anything).returns(AichatRequestsController::DEFAULT_POLLING_INTERVAL_MS)
@@ -71,7 +71,7 @@ class AichatRequestsControllerTest < ActionController::TestCase
 
   test 'DCDO flag blocks access to start_chat_completion from python lab levels' do
     sign_in(@unauthorized_student)
-    DCDO.stubs(:get).with('aitutor2_chat_completion', true).returns(false)
+    DCDO.stubs(:get).with('ai_tutor2_chat_completion', true).returns(false)
     python_lab_level = create :pythonlab
     params_with_python_level = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(currentLevelId: python_lab_level.id))
     post :start_chat_completion, params: params_with_python_level, as: :json

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -35,8 +35,8 @@ class AichatRequestsControllerTest < ActionController::TestCase
 
   setup do
     @controller.stubs(:storage_decrypt_channel_id).returns([123, @project_id])
-    DCDO.stubs(:get).with('ai_tutor2_chat_completion', anything).returns(true)
-    DCDO.stubs(:get).with('aichat_chat_completion', anything).returns(true)
+    DCDO.stubs(:get).with('block_ai_tutor2_chat_completion', anything).returns(false)
+    DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(false)
     DCDO.stubs(:get).with('aichat_request_limit_per_min', anything).returns(AichatRequestsController::DEFAULT_REQUEST_LIMIT_PER_MIN)
     DCDO.stubs(:get).with('aichat_polling_interval_ms', anything).returns(AichatRequestsController::DEFAULT_POLLING_INTERVAL_MS)
     DCDO.stubs(:get).with('aichat_polling_backoff_rate', anything).returns(AichatRequestsController::DEFAULT_POLLING_BACKOFF_RATE)
@@ -69,9 +69,9 @@ class AichatRequestsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'DCDO flag blocks access to start_chat_completion from python lab levels' do
+  test 'ai_tutor2 DCDO flag blocks access to start_chat_completion from python lab levels' do
     sign_in(@unauthorized_student)
-    DCDO.stubs(:get).with('ai_tutor2_chat_completion', true).returns(false)
+    DCDO.stubs(:get).with('block_ai_tutor2_chat_completion', anything).returns(true)
     python_lab_level = create :pythonlab
     params_with_python_level = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(currentLevelId: python_lab_level.id))
     post :start_chat_completion, params: params_with_python_level, as: :json
@@ -144,14 +144,9 @@ class AichatRequestsControllerTest < ActionController::TestCase
     assert_response :too_many_requests
   end
 
-  test 'can_request_aichat_chat_completion returns false when DCDO flag is set to `false`' do
-    DCDO.stubs(:get).with('aichat_chat_completion', true).returns(false)
-    assert_equal false, AichatSagemakerHelper.can_request_aichat_chat_completion?
-  end
-
-  test 'returns forbidden when DCDO flag is set to `false`' do
-    AichatSagemakerHelper.stubs(:can_request_aichat_chat_completion?).returns(false)
+  test 'aichat DCDO flag blocks start_chat_completion from non python lab levels' do
     sign_in(@authorized_teacher1)
+    DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(true)
     post :start_chat_completion, params: @valid_params_chat_completion, as: :json
     assert_response :forbidden
   end

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -78,6 +78,29 @@ class AichatRequestsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test 'ai_tutor2 DCDO flag does not block start_chat_completion from non python lab levels' do
+    sign_in(@authorized_teacher1)
+    DCDO.stubs(:get).with('block_ai_tutor2_chat_completion', anything).returns(true)
+    post :start_chat_completion, params: @valid_params_chat_completion, as: :json
+    assert_response :success
+  end
+
+  test 'aichat DCDO flag does not block access to start_chat_completion from python lab levels' do
+    sign_in(@unauthorized_student)
+    DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(true)
+    python_lab_level = create :pythonlab
+    params_with_python_level = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(currentLevelId: python_lab_level.id))
+    post :start_chat_completion, params: params_with_python_level, as: :json
+    assert_response :success
+  end
+
+  test 'aichat DCDO flag blocks start_chat_completion from non python lab levels' do
+    sign_in(@authorized_teacher1)
+    DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(true)
+    post :start_chat_completion, params: @valid_params_chat_completion, as: :json
+    assert_response :forbidden
+  end
+
   test 'authorized teacher has access to start_chat_completion test' do
     sign_in(@authorized_teacher1)
     post :start_chat_completion, params: @valid_params_chat_completion, as: :json
@@ -142,13 +165,6 @@ class AichatRequestsControllerTest < ActionController::TestCase
     sign_in(@authorized_teacher1)
     post :start_chat_completion, params: @valid_params_chat_completion, as: :json
     assert_response :too_many_requests
-  end
-
-  test 'aichat DCDO flag blocks start_chat_completion from non python lab levels' do
-    sign_in(@authorized_teacher1)
-    DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(true)
-    post :start_chat_completion, params: @valid_params_chat_completion, as: :json
-    assert_response :forbidden
   end
 
   # chat_request tests


### PR DESCRIPTION
Follow-up for #66066 

 - Add a DCDO flag to be able to turn off access to start_chat_completion from python lab levels.
 - Address this https://github.com/code-dot-org/code-dot-org/pull/66066#discussion_r2111031181 from previous PR , tweaking naming slightly to match the convention used in level properties (`ai_tutor2_available` and url param `show-ai-tutor2`)
 - Update naming of aichat DCDO flag to be a bit more descriptive and match up with the new ai_tutor2 dcdo flag naming.

## Testing story

Added UTs 

For DCDO flags, checked production, test, and staging to make sure `aichat_chat_completion` flag has not been set to false, ensuring that there is no risk with introducing the new `block_aichat_chat_completion` (default false) in its place.  Looked in dynamo db table in prod, and in dashboard-console in all 3 environments.
