### PR TITLE
Adding nil check for edge case where section doesn't have unit_group_unit

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -493,7 +493,7 @@ class Section < ApplicationRecord
         course_version_name = unit_group.name
         if script_id
           title_of_current_unit = script.title_for_display
-          link_to_current_unit = if Policies::Courses.modularity_enabled?
+          link_to_current_unit = if Policies::Courses.modularity_enabled? && unit_group_unit
                                    course_unit_path(unit_group, unit_group_unit.position)
                                  else
                                    script_path(script)


### PR DESCRIPTION
In a [previous PR](https://github.com/code-dot-org/code-dot-org/pull/59347) we started to deprecate "alternate" Units. In this change we removed the UnitGroupUnits which linked "alternate" Units and UnitGroups. However, one small complication is that there are still [some Users](https://app.honeybadger.io/projects/3240/faults/120826257/01JW9WQNNR7FAY3D2Y2Q84AWRV?page=0&q=occurred.after%3A%2224+hours+ago%22%E2%80%81) with sections which have a set Unit and UnitGroup, but no longer a UnitGroupUnit linking them. As a workaround, this PR adds a check to make sure the UnitGroupUnit is defined before trying to use it.

## Links
* [Honeybadger Error](https://app.honeybadger.io/projects/3240/faults/120826257/01JW9WQNNR7FAY3D2Y2Q84AWRV?page=0&q=occurred.after%3A%2224+hours+ago%22%E2%80%81)

## Testing story
* Existing unit tests
