### PR TITLE
Adding modularity support to :retrieve_lessons_for_dropdown

### DIFF
--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -89,10 +89,22 @@ class SectionsController < ApplicationController
     section = Section.find(params[:id])
     lessons = []
     if section.script_id
-      unit = Unit.find(section.script_id)
-      lessons << {text: unit.title_for_display.sub(" - ", ": "), value: unit.link}
+      unit = Unit.get_from_cache(section.script_id)
+      unit_group = UnitGroup.get_from_cache(section.course_id)
+      unit_group_unit = Queries::Courses.unit_group_unit(unit, unit_group)
+      lessons << {text: unit.title_for_display(unit_group_unit: unit_group_unit).sub(" - ", ": "), value: unit.link(unit_group_unit: unit_group_unit)}
       unit.lesson_groups.each do |lesson_group|
-        lessons.concat(lesson_group.lessons.select(&:has_lesson_plan).map {|lesson| {text: 'Lesson ' + lesson.relative_position.to_s + ': ' + lesson.localized_name, value: script_lesson_path(unit, lesson) << '/levels/1'}})
+        lessons.concat(lesson_group.lessons.select(&:has_lesson_plan).map do |lesson|
+          path = script_lesson_script_level_path(unit, lesson, 1)
+          if Policies::Courses.modularity_enabled? && unit_group_unit && unit_group
+            path = course_unit_lesson_script_level_path(unit_group, unit_group_unit.position, lesson, 1)
+          end
+          {
+            text: 'Lesson ' + lesson.relative_position.to_s + ': ' + lesson.localized_name,
+            value: path,
+          }
+        end
+        )
       end
     end
     render json: lessons

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class SectionsControllerTest < ActionController::TestCase
+  include Minitest::RSpecMocks
+
   self.use_transactional_test_case = true
 
   setup_all do
@@ -293,5 +295,48 @@ class SectionsControllerTest < ActionController::TestCase
     assert_response :success
     response_json = JSON.parse(@response.body)
     assert_equal response_json, [{"text"=>"Flappy Code", "value"=>"/s/flappy"}, {"text"=>"Lesson 1: Flappy Code", "value"=>"/s/flappy/lessons/1/levels/1"}]
+  end
+
+  describe '#retrieve_lessons_for_dropdown' do
+    let(:teacher) {create :teacher}
+    let(:unit_group) {create :unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable}
+    let(:unit) {create :unit, :with_levels, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable}
+    let(:unit_position) {1}
+    let!(:unit_group_unit) {create :unit_group_unit, unit_group: unit_group, script: unit, position: unit_position}
+    let(:lesson) {unit.lessons.first}
+    let(:section) {create :section, user: teacher, script: unit, unit_group: unit_group, login_type: 'email'}
+    let(:response) {JSON.parse(@response.body, symbolize_names: true)}
+    let(:response_unit) {response.first}
+    let(:response_lesson) {response.second}
+
+    before do
+      sign_in teacher
+      lesson.update!(has_lesson_plan: true)
+      get :retrieve_lessons_for_dropdown, params: {id: section.id}
+    end
+
+    it 'returns success' do
+      assert_response :success
+    end
+
+    it 'returns Array' do
+      _(response).must_be_instance_of Array
+    end
+
+    it 'returns unit name' do
+      _(response_unit[:text]).must_equal unit.title_for_display(unit_group_unit: unit_group_unit)
+    end
+
+    it 'returns unit path' do
+      _(response_unit[:value]).must_equal "/courses/#{unit_group.name}/units/#{unit_position}"
+    end
+
+    it 'returns lesson name' do
+      _(response_lesson[:text]).must_equal "Lesson #{lesson.relative_position}: #{lesson.localized_name}"
+    end
+
+    it 'returns lesson path' do
+      _(response_lesson[:value]).must_equal "/courses/#{unit_group.name}/units/#{unit_position}/lessons/1/levels/1"
+    end
   end
 end


### PR DESCRIPTION
In the cards which display the teacher's Sections on Teacher Dashboard v2, the Unit name is shown and there is a dropdown to quickly select a lesson in the Unit. This PR adds support for Modular Units.
* Fixes the display name for the Unit assigned to the Section.
* Uses a nested URL for the Unit.
* Uses nested URLs for the Lessons.

## Testing story
* Unit tests
* Manually tested on http://localhost-studio.code.org:3000/teacher_dashboard/home 

## Screenshot
![Screenshot 2025-05-28 at 12 25 06 AM](https://github.com/user-attachments/assets/e904bf2a-5807-43f0-8d7c-b69c4e828fde)
