### PR TITLE
Fix dashboard redirects for Modular Units in scripts_controller

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -38,8 +38,8 @@ class ScriptsController < ApplicationController
         end
         return
       end
-      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.default_units&.any? {|u| u.id == @script.id}}
-        most_recent_section = current_user.sections_instructed.select {|s| s.script_id == @script.id || s.unit_group&.default_units&.any? {|u| u.id == @script.id}}.last
+      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.id == @course.id}
+        most_recent_section = current_user.sections_instructed.select {|s| s.script_id == @script.id || s.unit_group&.id == @course.id}.last
         section_id = params[:section_id]
         section_id ||= most_recent_section&.id
         if section_id

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -404,9 +404,13 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_redirected_to "/courses/#{@single_unit_course_2024.name}/units/1"
   end
 
-  test "show: teacher in teacher-local-nav-v2 experiment is redirected to teacher dashboard if unit is in a section" do
+  test "show: teacher in teacher-local-nav-v2 experiment is redirected to teacher dashboard if course is in a section" do
+    # Have the same unit in two different courses to make sure the redirection
+    # goes to the course defined in the section.
+    original_course = create :unit_group, name: 'original-course'
     experiment_course = create :unit_group, name: 'experiment-course'
-    experiment_script = create :script, name: 'experiment-script'
+    experiment_script = create :script, name: 'experiment-script', original_unit_group: original_course
+    create :unit_group_unit, unit_group: original_course, script: experiment_script, position: 1
     create :unit_group_unit, unit_group: experiment_course, script: experiment_script, position: 1
     experiment_teacher = create :teacher
     experiment_section = create :section, user: experiment_teacher, unit_group: experiment_course
@@ -419,6 +423,50 @@ class ScriptsControllerTest < ActionController::TestCase
       position: 1
     }
     assert_redirected_to "/teacher_dashboard/sections/#{experiment_section.id}/courses/#{experiment_course.name}/units/1"
+  end
+
+  test "show: teacher in teacher-local-nav-v2 experiment is redirected to teacher dashboard if unit is in a section" do
+    # Have the same unit in two different courses to make sure the redirection
+    # goes to the course defined in the section.
+    original_course = create :unit_group, name: 'original-course'
+    experiment_course = create :unit_group, name: 'experiment-course'
+    experiment_script = create :script, name: 'experiment-script', original_unit_group: original_course
+    create :unit_group_unit, unit_group: original_course, script: experiment_script, position: 1
+    create :unit_group_unit, unit_group: experiment_course, script: experiment_script, position: 1
+    experiment_teacher = create :teacher
+    experiment_section = create :section, user: experiment_teacher, script: experiment_script
+    SingleUserExperiment.find_or_create_by!(min_user_id: experiment_teacher.id, name: 'teacher-local-nav-v2')
+
+    sign_in experiment_teacher
+
+    get :show, params: {
+      course_course_name: experiment_course.name,
+      position: 1
+    }
+    assert_redirected_to "/teacher_dashboard/sections/#{experiment_section.id}/courses/#{experiment_course.name}/units/1"
+  end
+
+  test "show: teacher in teacher-local-nav-v2 experiment is NOT redirected to teacher dashboard if unit is NOT in a section" do
+    # Have the same unit in two different courses to make sure the redirection
+    # goes to the course defined in the section.
+    original_course = create :unit_group, name: 'original-course'
+    experiment_course = create :unit_group, name: 'experiment-course'
+    experiment_script = create :script, name: 'experiment-script', original_unit_group: original_course
+    experiment_script_2 = create :script, name: 'experiment-script-2', original_unit_group: original_course
+    create :unit_group_unit, unit_group: original_course, script: experiment_script, position: 1
+    create :unit_group_unit, unit_group: experiment_course, script: experiment_script, position: 1
+    create :unit_group_unit, unit_group: experiment_course, script: experiment_script_2, position: 2
+    experiment_teacher = create :teacher
+    section = create :section, user: experiment_teacher, unit_group: original_course
+    SingleUserExperiment.find_or_create_by!(min_user_id: experiment_teacher.id, name: 'teacher-local-nav-v2')
+
+    sign_in experiment_teacher
+
+    get :show, params: {
+      course_course_name: experiment_course.name,
+      position: 1
+    }
+    assert_redirected_to course_unit_path(experiment_course, 1, section_id: section.id)
   end
 
   test "show: should remove user_id url param from non-dashboard unit overview when teacher local nav v2 experiment enabled" do


### PR DESCRIPTION
Bug
1. Have a section with Course `foundations-of-ai-programming-2025`
2. Visit http://localhost-studio.code.org:3000/courses/aif-testing-modularity-2025/units/1
3. Redirects to teacher_dashboard and a different Course.
4. It should redirect to http://localhost-studio.code.org:3000/courses/aif-testing-modularity-2025/units/1

The redirect was being caused because it was comparing each sections original_unit_group against the current Unit's original_unit_group. This is what enables the the redirect to sometimes go to a completely different UnitGroup. This PR changes the logic to instead check the UnitGroup directly assigned to the section and compare that to the UnitGroup in the URL.

## Testing story
* Manually tested 
* Bug bash
* Unit tests

