### PR TITLE
CMS-506: Remove margin bottom from last element in RichText

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/richText/richText.module.scss
+++ b/frontend/apps/marketing/src/components/contentful/richText/richText.module.scss
@@ -2,9 +2,10 @@
 
 .richText {
   & > * {
-    margin: 0 0 1rem;
+    margin: 1rem 0 0;
 
-    &:last-child {
+    &:first-child,
+    &:empty {
       margin: 0;
     }
 


### PR DESCRIPTION
## Before
<img width="100%" alt="before" src="https://github.com/user-attachments/assets/df4c75cc-b63f-43ad-9e44-0d7570f5e4c4" />

## After
<img width="100%" alt="after" src="https://github.com/user-attachments/assets/646da1d9-c863-4019-85be-96ad8c1e2efe" />

## Links
- JIRA task: [CMS-506](https://codedotorg.atlassian.net/browse/CMS-506)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/65246