### PR TITLE
feat(WithTooltip): removes TooltipOverlay to enable inline tooltips

### DIFF
--- a/frontend/packages/component-library/src/tags/_Tag.tsx
+++ b/frontend/packages/component-library/src/tags/_Tag.tsx
@@ -2,7 +2,7 @@ import React, {HTMLAttributes, memo, useCallback} from 'react';
 
 import CloseButton from '@/closeButton/CloseButton';
 import FontAwesomeV6Icon from '@/fontAwesomeV6Icon';
-import {WithTooltip} from '@/tooltip';
+import {WithTooltip, WithTooltipProps} from '@/tooltip';
 
 import moduleStyles from './tags.module.scss';
 
@@ -64,7 +64,7 @@ const Tag: React.FunctionComponent<TagProps> = props => {
     type = 'default',
   } = props;
   const tooltipWrapper = useCallback(
-    (children: React.ReactNode) =>
+    (children: WithTooltipProps['children']) =>
       tooltipContent && tooltipId ? (
         <WithTooltip
           tooltipProps={{

--- a/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
@@ -5,10 +5,10 @@ import {
   useRef,
   useState,
   useCallback,
-  ReactNode,
   HTMLAttributes,
   forwardRef,
   useImperativeHandle,
+  ReactElement,
 } from 'react';
 import {createPortal} from 'react-dom';
 
@@ -31,7 +31,8 @@ export interface WithTooltipHandle {
 }
 
 export interface WithTooltipProps {
-  children: ReactNode;
+  children: ReactElement<HTMLAttributes<HTMLElement>>;
+  /** DEPRECATED */
   tooltipOverlayClassName?: string;
   tooltipProps: TooltipProps;
 }
@@ -159,8 +160,15 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
 
     // Check if children prop is a valid React element and clone it with ariaDescribedBy attribute
     // and additional event handlers to make sure the tooltip is displayed correctly
+    const isValid = isValidElement<HTMLAttributes<HTMLElement>>(children);
+    if (!isValid) {
+      console.warn(
+        'Child of WithTooltip is not a valid element. returning child without tooltip',
+      );
+      return children;
+    }
     const componentToWrap =
-      isValidElement<HTMLAttributes<HTMLElement>>(children) &&
+      isValid &&
       cloneElement(children, {
         'aria-describedby': tooltipProps.tooltipId,
         onFocus: (event: React.FocusEvent<HTMLElement>) => {
@@ -181,8 +189,8 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
         },
       });
 
-    return (
-      <TooltipOverlay className={tooltipOverlayClassName}>
+    const component = (
+      <>
         {componentToWrap}
         {showTooltip &&
           createPortal(
@@ -196,7 +204,15 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
             />,
             document.body,
           )}
+      </>
+    );
+
+    return tooltipOverlayClassName ? (
+      <TooltipOverlay className={tooltipOverlayClassName}>
+        {component}
       </TooltipOverlay>
+    ) : (
+      component
     );
   },
 );

--- a/frontend/packages/component-library/src/tooltip/_Tooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/_Tooltip.tsx
@@ -37,8 +37,11 @@ export interface TooltipOverlayProps {
   className?: string;
 }
 
-/** TooltipOverlay component
+/** DEPRECATED TooltipOverlay component
  * Used to wrap the element that needs a Tooltip + Tooltip itself to make sure the Tooltip is displayed correctly
+ *
+ * TooltipOverlay is no longer necessary, but keeping for backwards compatibility
+ * since some implementations still use the tooltipOverlayClassName prop
  * */
 export const TooltipOverlay: React.FunctionComponent<TooltipOverlayProps> = ({
   children,

--- a/frontend/packages/component-library/src/tooltip/stories/WithTooltip.story.tsx
+++ b/frontend/packages/component-library/src/tooltip/stories/WithTooltip.story.tsx
@@ -288,3 +288,44 @@ ShowHideTailTooltip.args = {
     },
   ],
 };
+
+export const InlineTooltip: StoryFn = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        alignItems: 'flex-start',
+      }}
+    >
+      <p>
+        Here's some text that's not wrapped in a tooltip...{' '}
+        <WithTooltip
+          tooltipProps={{
+            text: 'This tooltip can wrap inline elements',
+            direction: 'onRight',
+            tooltipId: 'inline-tooltip-1',
+            size: 'xs',
+          }}
+        >
+          <span>but this text is wrapped in a tooltip</span>
+        </WithTooltip>
+      </p>
+      <p>
+        Here's some text that precedes a link that has a tooltip{' '}
+        <WithTooltip
+          tooltipProps={{
+            text: 'This tooltip can wrap inline elements',
+            direction: 'onBottom',
+            tooltipId: 'inline-tooltip-2',
+            size: 'xs',
+          }}
+        >
+          <a href="/">link with tooltip</a>
+        </WithTooltip>{' '}
+        and some text after the link
+      </p>
+    </div>
+  );
+};


### PR DESCRIPTION
this pr deprecates `tooltipOverlayClassName` prop and only renders `TooltipOverlay` if `tooltipOverlayClassName` prop is used. this ensures backwards compatibility with existing implementations of `WithTooltip`

the `WithTooltipProps` also are updated so that the `children` prop is restricted to `ReactElement` instead of `ReactNode`. `ReactNode` allows all valid children including strings, numbers etc. Since `WithTooltip` functions by cloning the `children` prop and adding html element attributes like `aria-describedby` and `onMouseEnter`, 

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
