### PR TITLE
fix(HeroBanner): remove hardcoded background color

### DIFF
--- a/frontend/packages/component-library/src/cms/heroBanner/heroBanner.module.scss
+++ b/frontend/packages/component-library/src/cms/heroBanner/heroBanner.module.scss
@@ -7,7 +7,6 @@ $mobileBreakpoint: 970px;
 .heroBannerWrapper {
   box-sizing: border-box;
   width: 100%;
-  background: var(--background-neutral-tertiary);
   background-size: cover;
   padding: 4rem 2rem;
 

--- a/frontend/packages/component-library/src/cms/heroBanner/stories/HeroBanner.story.tsx
+++ b/frontend/packages/component-library/src/cms/heroBanner/stories/HeroBanner.story.tsx
@@ -48,6 +48,7 @@ export const WithImage: Story = {
       className: 'custom-image-class',
     },
     VideoComponent: Video,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -70,6 +71,7 @@ export const WithVideo: Story = {
       videoTitle: 'Watch our intro video',
     },
     VideoComponent: Video,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -99,6 +101,7 @@ export const WithPartnerAndCTA: Story = {
       href: '#',
     },
     VideoComponent: Video,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -118,6 +121,7 @@ export const TextOnly: Story = {
     heading: 'Minimalist Hero',
     subHeading: 'Simple and elegant',
     VideoComponent: Video,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -139,6 +143,7 @@ export const LongContent: Story = {
       'The description here is intentionally long to ensure text flows properly across viewports and doesn’t break layout.',
 
     VideoComponent: Video,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -183,6 +188,7 @@ export const WithBackgroundImage: Story = {
     backgroundImageUrl: customBackgroundImage,
     'data-theme': 'Dark',
     VideoComponent: Video,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -229,6 +235,7 @@ export const WithWideText: Story = {
     },
     withWideText: true,
     VideoComponent: Video,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -259,6 +266,7 @@ export const WithAnnouncementBanner: Story = {
         href: '#',
       },
     },
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -325,6 +333,7 @@ export const Tablet: Story = {
       className: 'custom-image-class',
     },
     VideoComponent: Video,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -350,6 +359,7 @@ export const TabletWithHiddenImage: Story = {
     },
     VideoComponent: Video,
     hideImageOnSmallScreen: true,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -374,6 +384,7 @@ export const Mobile: Story = {
       className: 'custom-image-class',
     },
     VideoComponent: Video,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',
@@ -399,6 +410,7 @@ export const MobileWithHiddenImage: Story = {
     },
     VideoComponent: Video,
     hideImageOnSmallScreen: true,
+    backgroundColor: '#e4e6e9',
   },
   parameters: {
     layout: 'fullscreen',


### PR DESCRIPTION
Removes the background color set in the css on the HeroBanner component; this has been there since the beginning, but the changes made in https://github.com/code-dot-org/code-dot-org/pull/66104 broke it. 

## Links
Jira ticket: [CMS-777](https://codedotorg.atlassian.net/browse/CMS-777)

## Testing story
Tested locally, made a followup ticket to add this to All The Things page so we can catch this sooner: [CMS-778](https://codedotorg.atlassian.net/browse/CMS-778)

----

## Before

### Teach page
<img width="1629" alt="Screenshot 2025-05-28 at 10 35 36 AM" src="https://github.com/user-attachments/assets/c1f4da2a-32ed-4de9-a2cb-d8411fc2de52" />

### Videos page
<img width="1629" alt="Screenshot 2025-05-28 at 10 35 59 AM" src="https://github.com/user-attachments/assets/703289de-803b-4acd-aa4d-183f04ccf1e1" />

## After

### Teach page
<img width="1629" alt="Screenshot 2025-05-28 at 10 35 42 AM" src="https://github.com/user-attachments/assets/e73f2e4c-0a51-461f-aa10-05437e10d3e1" />

### Videos page
<img width="1629" alt="Screenshot 2025-05-28 at 10 35 54 AM" src="https://github.com/user-attachments/assets/ee6d4418-3197-4ec2-a2d7-f33c88e40f8b" />
