### PR TITLE
Codebridge: Bold Active File in File Browser

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
@@ -33,17 +33,17 @@ export const FileRow: React.FunctionComponent<FileRowProps> = ({
 }) => {
   const {openFile} = useCodebridgeContext();
   const dropdownOptions = useFileRowOptions(item, hasValidationFile);
-  const isOpen = item.active || false;
+  const isActive = item.active || false;
   const className = useMemo(() => {
     const classes = [];
-    if (isOpen) {
-      classes.push(moduleStyles.openFile);
+    if (isActive) {
+      classes.push(moduleStyles.activeFile);
     }
     if (isDragging) {
       classes.push(moduleStyles.dragging);
     }
     return classNames(...classes);
-  }, [isOpen, isDragging]);
+  }, [isActive, isDragging]);
 
   return (
     <ItemRow

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
@@ -1,6 +1,7 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {ProjectFile} from '@codebridge/types';
-import React from 'react';
+import classNames from 'classnames';
+import React, {useMemo} from 'react';
 
 import {FileRowIcon} from './FileRowIcon';
 import {FileRowName} from './FileRowName';
@@ -32,6 +33,17 @@ export const FileRow: React.FunctionComponent<FileRowProps> = ({
 }) => {
   const {openFile} = useCodebridgeContext();
   const dropdownOptions = useFileRowOptions(item, hasValidationFile);
+  const isOpen = item.active || false;
+  const className = useMemo(() => {
+    const classes = [];
+    if (isOpen) {
+      classes.push(moduleStyles.openFile);
+    }
+    if (isDragging) {
+      classes.push(moduleStyles.dragging);
+    }
+    return classNames(...classes);
+  }, [isOpen, isDragging]);
 
   return (
     <ItemRow
@@ -41,7 +53,7 @@ export const FileRow: React.FunctionComponent<FileRowProps> = ({
       IconComponent={FileRowIcon}
       NameComponent={FileRowName}
       openFunction={openFile}
-      className={isDragging ? moduleStyles.dragging : undefined}
+      className={className}
     />
   );
 };

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -163,3 +163,7 @@ button.button-kebab:focus {
   outline-offset: 2px;
   border-radius: 0.375rem;
 }
+
+.openFile {
+  font-weight: bold;
+}

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -164,6 +164,6 @@ button.button-kebab:focus {
   border-radius: 0.375rem;
 }
 
-.openFile {
+.activeFile {
   font-weight: bold;
 }


### PR DESCRIPTION
This is a small change to bold the active file in the file browser, to add an additional indicator of which file is currently active. If no files are active, nothing is bolded.
## Before
<img width="1403" alt="Screenshot 2025-05-28 at 9 55 08 AM" src="https://github.com/user-attachments/assets/0d91d6f9-2c27-43b2-9433-cc8578636dd1" />

## After
<img width="1403" alt="Screenshot 2025-05-28 at 10 02 12 AM" src="https://github.com/user-attachments/assets/c46c4479-cbd7-4b7c-90ce-b490cd38ce20" />

## Links

- Jira: [CT-383](https://codedotorg.atlassian.net/browse/CT-383)

## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
