### PR TITLE
Evaluate Student Learning: seed Skills and LevelsSkills 

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -34,7 +34,7 @@ class Level < ApplicationRecord
   belongs_to :game, optional: true
   has_and_belongs_to_many :concepts
   has_and_belongs_to_many :script_levels
-  has_and_belongs_to_many :skills, join_table: 'levels_skills'
+  has_many :skills, through: :levels_skills
   belongs_to :ideal_level_source, class_name: "LevelSource", optional: true # "see the solution" link uses this
   belongs_to :user, optional: true
   has_one :level_concept_difficulty, dependent: :destroy
@@ -100,6 +100,7 @@ class Level < ApplicationRecord
     use_secondary_finish_button
     skip_url
     stay_on_level_after_submit
+    skill_keys
   )
 
   # Fix STI routing http://stackoverflow.com/a/9463495

--- a/dashboard/app/models/skill.rb
+++ b/dashboard/app/models/skill.rb
@@ -20,7 +20,7 @@ class Skill < ApplicationRecord
   has_and_belongs_to_many :levels, join_table: 'levels_skills'
 
   def self.setup
-    update_columns = [:key, :description, :evaluation_criteria, :concept]
+    update_columns = [:description, :evaluation_criteria, :concept]
     # TODO: Remove this method when the skills are created by levelbuilders
     starter_skills = [
       {

--- a/dashboard/app/models/skill.rb
+++ b/dashboard/app/models/skill.rb
@@ -18,4 +18,32 @@ class Skill < ApplicationRecord
   validates :description, presence: true
 
   has_and_belongs_to_many :levels, join_table: 'levels_skills'
+
+  def self.setup
+    update_columns = [:key, :description, :evaluation_criteria, :concept]
+    # TODO: Remove this method when the skills are created by levelbuilders
+    starter_skills = [
+      {
+        key: "variables_declare",
+        description: "Declare variables correctly",
+        evaluation_criteria: "Did the students declare all of the variables in their code correctly?",
+        concept: "Variables"
+      },
+      {
+        key: "variables_name",
+        description: "Name variables according to conventions",
+        evaluation_criteria: "Are there any spaces in variable names? Are there any misspelled variable names? Do variable names follow casing conventions?",
+        concept: "Variables"
+      },
+      {
+        key: "variables_increment",
+        description: "Increment values stored in variables",
+        evaluation_criteria: "Does the student's added code increment the values stored in the variables correctly?",
+        concept: "Variables"
+      },
+    ]
+    transaction do
+      Skill.import! starter_skills, on_duplicate_key_update: update_columns
+    end
+  end
 end

--- a/dashboard/config/levels/custom/applab/U4 L03 Variables numbers practice 4_2024.level
+++ b/dashboard/config/levels/custom/applab/U4 L03 Variables numbers practice 4_2024.level
@@ -36,7 +36,7 @@
     "expand_debugger": "true",
     "watchers_prepopulated": "[\"petName\",\"petType\",\"petWeight\"]",
     "fail_on_lint_errors": "false",
-  "debugger_disabled": "true",
+    "debugger_disabled": "true",
     "makerlab_enabled": "false",
     "parent_level_id": 15816,
     "mini_rubric": "false",

--- a/dashboard/config/levels/custom/applab/U4 L03 Variables numbers practice 4_2024.level
+++ b/dashboard/config/levels/custom/applab/U4 L03 Variables numbers practice 4_2024.level
@@ -36,7 +36,7 @@
     "expand_debugger": "true",
     "watchers_prepopulated": "[\"petName\",\"petType\",\"petWeight\"]",
     "fail_on_lint_errors": "false",
-    "debugger_disabled": "true",
+  "debugger_disabled": "true",
     "makerlab_enabled": "false",
     "parent_level_id": 15816,
     "mini_rubric": "false",
@@ -46,7 +46,8 @@
     "libraries_enabled": "false",
     "name_suffix": "_2024",
     "ai_enabled": "false",
-    "preload_asset_list": null
+    "preload_asset_list": null,
+    "skill_keys": "[\"variables_name\", \"variables_declare\"]"
   },
   "published": true,
   "notes": "",

--- a/dashboard/config/levels/custom/applab/U4 L03 Variables operator practice 5_2024.level
+++ b/dashboard/config/levels/custom/applab/U4 L03 Variables operator practice 5_2024.level
@@ -60,7 +60,8 @@
     "libraries_enabled": "false",
     "encrypted_examples": "7ANQVbuCLwFxy+sRPRE2KL1M2oSKjKbswp85qxnYoX9qXt/dMvcDqZIX0S08\nwn8odXB02oSKI1aQSiDddMcFFA==\n",
     "name_suffix": "_2024",
-    "preload_asset_list": null
+    "preload_asset_list": null,
+    "skill_keys": "[\"variables_increment\"]"
   },
   "published": true,
   "notes": "",

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -37,6 +37,10 @@ namespace :seed do
   CURRICULUM_CONTENT_DIR = ENV['CURRICULUM_CONTENT_DIR'] || '.'
   CURRICULUM_CONTENT_PATHNAME = Pathname(CURRICULUM_CONTENT_DIR)
 
+  timed_task_with_logging skills: :environment do
+    Skill.setup
+  end
+
   timed_task_with_logging videos: :environment do
     Video.setup(CURRICULUM_CONTENT_DIR)
   end
@@ -254,10 +258,12 @@ namespace :seed do
     :environment,
     :check_migrations,
     :games,
+    :skills,
     :deprecated_blockly_levels,
     :child_dsls,
     :custom_levels,
     :parent_dsls,
+    :levels_skills,
     :code_docs,
     :blocks,
     :standards,
@@ -464,6 +470,21 @@ namespace :seed do
   timed_task_with_logging custom_levels: :environment do
     level_name = ENV.fetch('LEVEL_NAME', nil)
     LevelLoader.load_custom_levels(level_name, CURRICULUM_CONTENT_DIR)
+  end
+
+  timed_task_with_logging levels_skills: :environment do
+    levels_with_skills = Level.all.select do |level|
+      level.skill_keys.present?
+    end
+    levels_with_skills.each do |level|
+      JSON.parse(level.skill_keys).each do |skill_key|
+        skill_id = Skill.find_by_key(skill_key).id
+        LevelsSkill.find_or_create_by!(
+          skill_id: skill_id,
+          level_id: level.id
+        )
+      end
+    end
   end
 
   timed_task_with_logging deprecated_blockly_levels: :environment do

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -473,9 +473,7 @@ namespace :seed do
   end
 
   timed_task_with_logging levels_skills: :environment do
-    levels_with_skills = Level.all.select do |level|
-      level.skill_keys.present?
-    end
+    levels_with_skills = Level.where('properties like ?', '%"skill_keys":%').all
     levels_with_skills.each do |level|
       JSON.parse(level.skill_keys).each do |skill_key|
         skill_id = Skill.find_by_key(skill_key).id


### PR DESCRIPTION
[TEACH-1796](https://codedotorg.atlassian.net/browse/TEACH-1796)

We need to keep levelbuilder and production ids in sync for Skills and LevelSkills. This PR adds  Skills and LevelsSkills to the seeding process. Additionally, I've added skill_keys for the LevelsSkills we've been hardcoding for evaluations. 

Up next, I'll use these Skills and LevelsSkills instead of the placeholder skills in [evaluate_system_prompt_helper.rb](https://github.com/code-dot-org/code-dot-org/blob/81e8223c1cf3929a779400fe0dd660b483c01680/dashboard/app/helpers/ai_system_prompts/evaluate_system_prompt_helper.rb#L25)

When I run `bundle exec rake seed:skills` locally, I see the expected Skills in the database: 

<img width="1023" alt="Screenshot 2025-05-28 at 2 34 18 PM" src="https://github.com/user-attachments/assets/90581735-e645-453b-a0f3-ae269bf3289d" />

After seeding the 2 canary levels `LEVEL_NAME="U4 L03 Variables operator practice 5_2024" bundle exec rake seed:custom_levels` and `LEVEL_NAME="U4 L03 Variables numbers practice 4_2024" bundle exec rake seed:custom_levels` and then seeding LevelsSkills `bundle exec rake seed:levels_skills` I see the expected LevelsSkills in the database: 

<img width="598" alt="Screenshot 2025-05-28 at 2 24 41 PM" src="https://github.com/user-attachments/assets/2df11ca1-64b0-4cc4-850a-c32f3e243077" />



