### PR TITLE
Fix errors in sample data scripts

### DIFF
--- a/dashboard/lib/mega_section.rb
+++ b/dashboard/lib/mega_section.rb
@@ -47,6 +47,7 @@ class MegaSection
       name: 'CSF - Mega Section',
       script_name_1: 'coursea-2019',
       script_name_2: 'coursea-2018',
+      unit_group_1_name: 'coursea-2019',
     )
 
     puts "Created section and progress in #{Time.now - mid_time} seconds"
@@ -101,12 +102,13 @@ class MegaSection
   def self.create_section(options)
     script_1 = Unit.get_from_cache(options[:script_name_1])
     script_2 = Unit.get_from_cache(options[:script_name_2])
+    unit_group_1 = UnitGroup.get_from_cache(options[:unit_group_1_name])
     script_levels_1 = script_1.script_levels.includes(:levels)
     script_levels_2 = script_2.script_levels.includes(:levels)
-
+    grades = Array(options[:grade])
     # Create the section
-    section = create :section, script: script_1,
-      **options.slice(:teacher, :name, :login_type, :grade)
+    section = create :section, script: script_1, grade: grades, unit_group: unit_group_1,
+      **options.slice(:teacher, :name, :login_type)
 
     # Create students
     students = []
@@ -150,8 +152,8 @@ class MegaSection
         teacher_feedbacks << build(:teacher_feedback,
           student_id: student_user.id,
           teacher_id: section.teacher.id,
-          script_level_id: script_level.id,
-          level_id: script_level.levels.first.id,
+          level: script_level.level,
+          script: script_level.script,
           comment: tiny_lipsum
         )
       end
@@ -170,8 +172,8 @@ class MegaSection
         teacher_feedbacks << build(:teacher_feedback,
           student_id: student_user.id,
           teacher_id: section.teacher.id,
-          script_level_id: script_level.id,
-          level_id: script_level.levels.first.id,
+          level: script_level.level,
+          script: script_level.script,
           comment: tiny_lipsum
         )
       end

--- a/dashboard/lib/sample_data.rb
+++ b/dashboard/lib/sample_data.rb
@@ -32,43 +32,43 @@ class SampleData
 
     create_section(
       teacher: teacher, name: 'CSF 1',
-      login_type: Section::LOGIN_TYPE_PICTURE, grade: 2, age_min: 7,
-      age_max_inclusive: 9, script_name: 'coursea-2018', num_students: 30,
+      login_type: Section::LOGIN_TYPE_PICTURE, grade: [2], age_min: 7,
+      age_max_inclusive: 9, script_name: 'coursea-2024', unit_group_name: 'coursea-2024', num_students: 30,
       use_imperfect_results: true
     )
 
     create_section(
       teacher: teacher, name: 'CSF 2 (Large)',
-      login_type: Section::LOGIN_TYPE_PICTURE, grade: 2, age_min: 7,
-      age_max_inclusive: 9, script_name: 'coursea-2018', num_students: 150,
+      login_type: Section::LOGIN_TYPE_PICTURE, grade: [2], age_min: 7,
+      age_max_inclusive: 9, script_name: 'coursea-2024', unit_group_name: 'coursea-2024', num_students: 150,
       use_imperfect_results: true
     )
 
     create_section(
       teacher: teacher, name: 'CSD 1',
-      login_type: Section::LOGIN_TYPE_EMAIL, grade: 7, age_min: 13,
-      age_max_inclusive: 14, script_name: 'csd1-2018', num_students: 30,
+      login_type: Section::LOGIN_TYPE_EMAIL, grade: [7], age_min: 13,
+      age_max_inclusive: 14, script_name: 'csd1-2024', unit_group_name: 'csd-2024', num_students: 30,
       use_imperfect_results: false
     )
 
     create_section(
       teacher: teacher, name: 'CSD 2 (Large)',
-      login_type: Section::LOGIN_TYPE_EMAIL, grade: 7, age_min: 13,
-      age_max_inclusive: 14, script_name: 'csd1-2018', num_students: 150,
+      login_type: Section::LOGIN_TYPE_EMAIL, grade: [7], age_min: 13,
+      age_max_inclusive: 14, script_name: 'csd1-2024', unit_group_name: 'csd-2024', num_students: 150,
       use_imperfect_results: false
     )
 
     create_section(
       teacher: teacher, name: 'CSP 1',
-      login_type: Section::LOGIN_TYPE_EMAIL, grade: 10, age_min: 14,
-      age_max_inclusive: 16, script_name: 'csp1-2018', num_students: 30,
+      login_type: Section::LOGIN_TYPE_EMAIL, grade: [10], age_min: 14,
+      age_max_inclusive: 16, script_name: 'csp1-2024', unit_group_name: 'csp-2024', num_students: 30,
       use_imperfect_results: false
     )
 
     create_section(
       teacher: teacher, name: 'CSP 2 (Large)',
-      login_type: Section::LOGIN_TYPE_EMAIL, grade: 10, age_min: 14,
-      age_max_inclusive: 16, script_name: 'csp1-2018', num_students: 150,
+      login_type: Section::LOGIN_TYPE_EMAIL, grade: [10], age_min: 14,
+      age_max_inclusive: 16, script_name: 'csp1-2024', unit_group_name: 'csp-2024', num_students: 150,
       use_imperfect_results: false
     )
   end
@@ -139,10 +139,11 @@ class SampleData
   #    results. (CSF allows imperfect results, CSD and CSP do not.)
   def self.create_section(options)
     script = Unit.get_from_cache(options[:script_name])
+    unit_group = UnitGroup.get_from_cache(options[:unit_group_name])
     level_count = script.script_levels.count
 
     # Create the section
-    section = create :section, script: script,
+    section = create :section, script: script, unit_group: unit_group,
       **options.slice(:teacher, :name, :login_type, :grade)
 
     current_student = 0


### PR DESCRIPTION
We currently have two sample data scripts that don't work.

mega_section.rb creates one large section with 750 students for a teacher it creates
sample_data.rb creates 6 sections for a teacher it creates and randomly adds students and student progress

These were both failing to create sections effectively. 

This PR fixes:
* Adds a unit_group to each section so that the course/unit are displayed on the homepage
* Fixes a breaking bug where grades were a number instead of an array
* Update courses to 2024 to be more current and useful

This PR was mostly done so I could test the scripts and understand them to create a new one. These will most likely not be used for skill dashboard synthetic data.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1909