### PR TITLE
Gets Blockly keyboard shortcuts menu working

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -906,6 +906,12 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
         Blockly.blockly_.ShortcutRegistry.registry.unregister('redo');
         blocklyWrapper.KeyboardNavigation.dispose();
       }
+      // Add the keyboard shortcuts div. This is here to ensure it happens
+      // prior to keyboard nav installation
+      const shortcutDialog = document.createElement('div');
+      shortcutDialog.id = 'shortcuts';
+      document.body.appendChild(shortcutDialog);
+
       blocklyWrapper.KeyboardNavigation = new KeyboardNavigation(workspace);
       // Rerun user theme after Keyboard Experiment bug introduces incorrect theme
       const theme = cdoUtils.getUserTheme(options.theme as GoogleBlockly.Theme);

--- a/apps/src/sites/studio/pages/googleblockly.js
+++ b/apps/src/sites/studio/pages/googleblockly.js
@@ -19,4 +19,9 @@ const messages =
   blocklyLocaleMap['en-us'];
 GoogleBlockly.setLocale(messages);
 
+// Add the keyboard shortcuts div. This is here to ensure it happens prior to the workspace loading
+const shortcutDialog = document.createElement('div');
+shortcutDialog.id = 'shortcuts';
+document.body.appendChild(shortcutDialog);
+
 window.Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly);

--- a/apps/src/sites/studio/pages/googleblockly.js
+++ b/apps/src/sites/studio/pages/googleblockly.js
@@ -19,9 +19,4 @@ const messages =
   blocklyLocaleMap['en-us'];
 GoogleBlockly.setLocale(messages);
 
-// Add the keyboard shortcuts div. This is here to ensure it happens prior to the workspace loading
-const shortcutDialog = document.createElement('div');
-shortcutDialog.id = 'shortcuts';
-document.body.appendChild(shortcutDialog);
-
 window.Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly);


### PR DESCRIPTION
This gets the keyboard shortcuts menu working when a user presses enter on a block and then '/' (as indicated by blockly's tooltip). 

I believe we would customize this in the future, but at least for now it fixes the bug of the tooltip showing up but nothing happening, and it has most of the helpful shortcuts listed.

<img width="603" alt="Screenshot 2025-05-28 at 10 52 31 AM" src="https://github.com/user-attachments/assets/270a0309-c96d-410c-99ad-47110183742e" />



<img width="1201" alt="Screenshot 2025-05-28 at 11 49 52 AM" src="https://github.com/user-attachments/assets/526e852e-44ed-4448-b33b-3ca6ca569b6c" />


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
