### PR TITLE
Codebridge: center no open files message

### DIFF
--- a/apps/src/codebridge/Editor/Editor.tsx
+++ b/apps/src/codebridge/Editor/Editor.tsx
@@ -64,9 +64,11 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
           editorConfigExtensions={editorConfigExtensions}
         />
       ) : (
-        <BodyOneText className={moduleStyles.noOpenFilesMessage}>
-          {codebridgeI18n.noOpenFiles()}
-        </BodyOneText>
+        <div className={moduleStyles.noOpenFilesContainer}>
+          <BodyOneText className={moduleStyles.noOpenFilesMessage}>
+            {codebridgeI18n.noOpenFiles()}
+          </BodyOneText>
+        </div>
       )}
     </div>
   );

--- a/apps/src/codebridge/Editor/styles/editor.module.scss
+++ b/apps/src/codebridge/Editor/styles/editor.module.scss
@@ -9,5 +9,13 @@
 
 .noOpenFilesMessage {
   color: var(--text-neutral-primary);
-  padding: 8px;
+  text-align: center;
+}
+
+.noOpenFilesContainer {
+  width: 100%;
+  height: 100%;    
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION
Minor improvement to center the no open files message in codebridge.

## Before
<img width="1403" alt="Screenshot 2025-05-28 at 11 25 20 AM" src="https://github.com/user-attachments/assets/ad9140ce-2302-45bf-aba1-58f1dfeaef38" />

## After
<img width="1403" alt="Screenshot 2025-05-28 at 11 25 04 AM" src="https://github.com/user-attachments/assets/db26e215-e68e-4962-8178-e3dd9c235815" />


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
