### PR TITLE
Ceara/aitt 1002 keep ai diff closed

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -35,19 +35,29 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
   unitDisplayName,
 }) => {
   const sessionStorageKey = 'AiDiffFabOpenStateKey';
-  const localStorageKey = 'AiDiffHasOpenedKey';
+  const localStorageOpenedKey = 'AiDiffHasOpenedKey';
+  const localStorageClosedKey = 'AiDiffHasClosedKey';
 
   // Show the pulse until the user clicks the FAB to open the chat window
   const hasOpened =
-    JSON.parse(tryGetLocalStorage(localStorageKey, false.toString())) || false;
+    JSON.parse(tryGetLocalStorage(localStorageOpenedKey, false.toString())) ||
+    false;
+
+  const hasClosed =
+    JSON.parse(tryGetLocalStorage(localStorageClosedKey, false.toString())) ||
+    false;
 
   // Open the chat window if this is the first time the user has seen the FAB in this
-  // session and they haven't opened the FAB yet.
+  // session and they haven't interacted with the FAB yet.
   // Depends on other logic which sets the open state in session storage.
   const isFirstSession =
     JSON.parse(tryGetSessionStorage(sessionStorageKey, null)) === null &&
-    !hasOpened;
+    !hasOpened &&
+    !hasClosed;
 
+  // Keeps FAB open/closed on new pages in the same tab or window
+  // New tab or window is default closed if they have previously opened/closed the FAB
+  // Default open if they have never opened/closed the fab before (i.e. first time on the site)
   const [isOpen, setIsOpen] = useState(
     JSON.parse(tryGetSessionStorage(sessionStorageKey, isFirstSession)) ||
       isFirstSession
@@ -71,7 +81,9 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
       : EVENTS.AI_DIFF_CHAT_OPENED;
     analyticsReporter.sendEvent(eventName, eventData, PLATFORMS.STATSIG);
     if (eventName === EVENTS.AI_DIFF_CHAT_OPENED) {
-      trySetLocalStorage(localStorageKey, true.toString());
+      trySetLocalStorage(localStorageOpenedKey, true.toString());
+    } else {
+      trySetLocalStorage(localStorageClosedKey, true.toString());
     }
     setIsOpen(!isOpen);
   };

--- a/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
@@ -65,7 +65,13 @@ describe('AIDiffFloatingActionButton', () => {
     expect(screen.getByText('AI Teaching Assistant')).not.toBeVisible();
   });
 
-  it('begins open if no session storage and has not been opened before', () => {
+  it('begins closed if has been closed before', () => {
+    localStorage.setItem('AiDiffHasClosedKey', 'true');
+    renderDefault();
+    expect(screen.getByText('AI Teaching Assistant')).not.toBeVisible();
+  });
+
+  it('begins open if no session or local storage and has not been opened before', () => {
     renderDefault({});
     expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
   });


### PR DESCRIPTION
Change to the default open behavior- previously the AI Diff chat was default open in new windows and tabs until the user had closed, and then *opened* the FAB. Now it is default open on first visit (i.e. there is nothing stored in localStorage), then after the user closes the AI Diff chat it is default to closed on new windows/tabs (i.e. nothing stored in sessionStorage).

Page changes or reloads in the same tab keep the open or closed state.

## Links

Jira: https://codedotorg.atlassian.net/browse/AITT-1002

## Testing story

Added a unit test

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
