### PR TITLE
feat(marketing): add image and button placeholders to ActionBlock and FullWidthActionBlock

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/actionBlockContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/actionBlockContentfulDefinition.ts
@@ -52,6 +52,8 @@ export const ActionBlockContentfulComponentDefinition: ComponentDefinition = {
       type: 'Media',
       group: 'content',
       description: 'The image to display in the action block.',
+      defaultValue:
+        'contentful-images.code.org/90t6bu6vlf76/3ObZQWtgyo31ILZ7j8qm4c/421404b4e7ee968584902c697cdca751/action_block_placeholder_image.png',
       validations: {
         bindingSourceType: ['entry', 'asset'],
       },
@@ -62,6 +64,12 @@ export const ActionBlockContentfulComponentDefinition: ComponentDefinition = {
       type: 'Link',
       group: 'content',
       description: 'The primary button of the action block.',
+      defaultValue: {
+        fields: {
+          label: 'Primary button',
+          url: '#',
+        },
+      },
       validations: {
         bindingSourceType: ['entry'],
       },

--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/fullWidthActionBlockContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/fullWidthActionBlockContentfulDefinition.ts
@@ -53,6 +53,8 @@ export const FullWidthActionBlockContentfulComponentDefinition: ComponentDefinit
         type: 'Media',
         group: 'content',
         description: 'The image to display in the action block.',
+        defaultValue:
+          'contentful-images.code.org/90t6bu6vlf76/3ObZQWtgyo31ILZ7j8qm4c/421404b4e7ee968584902c697cdca751/action_block_placeholder_image.png',
         validations: {
           bindingSourceType: ['entry', 'asset'],
         },
@@ -63,6 +65,12 @@ export const FullWidthActionBlockContentfulComponentDefinition: ComponentDefinit
         type: 'Link',
         group: 'content',
         description: 'The primary button of the action block.',
+        defaultValue: {
+          fields: {
+            label: 'Primary button',
+            url: '#',
+          },
+        },
         validations: {
           bindingSourceType: ['entry'],
         },


### PR DESCRIPTION
Adds image and button placeholders on ActionBlock and FullWidthActionBlock components in Contentful. This is added because of feedback from the onboarding session with content editors.

## Links
Jira ticket: [CMS-779](https://codedotorg.atlassian.net/browse/CMS-779)

## Testing story
Tested locally in Contentful

----

https://github.com/user-attachments/assets/3ece3e27-55cc-4fd8-8ea1-6c2038899af0

## Adding content


https://github.com/user-attachments/assets/2f62d0e4-7bcd-450b-98c0-3e45c9978fb0


