### PR TITLE
[MusicLab] Blockly user can now Escape out of SoundsPanel

### DIFF
--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -157,6 +157,10 @@ class FieldSounds extends GoogleBlockly.Field {
         showSoundFilters={MusicRegistry.showSoundFilters}
         defaultMode={defaultMode}
         sortUnrestrictedPacksByType={sortUnrestrictedPacksByType}
+        onClose={() => {
+          this.dropdownDispose_();
+          this.hide_();
+        }}
         onPreview={value => {
           this.playingPreview = value;
           this.renderContent();

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -232,6 +232,7 @@ interface SoundsPanelProps {
   showSoundFilters: boolean;
   defaultMode: Mode;
   sortUnrestrictedPacksByType: boolean;
+  onClose: () => void;
   onSelect: (path: string) => void;
   onPreview: (path: string) => void;
 }
@@ -243,6 +244,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   showSoundFilters,
   defaultMode,
   sortUnrestrictedPacksByType,
+  onClose,
   onSelect,
   onPreview,
 }) => {
@@ -347,6 +349,12 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
     filterButton => availableSoundTypes[filterButton.value]
   );
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      onClose();
+    }
+  };
+
   return (
     <FocusLock>
       <div
@@ -354,6 +362,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
         className={classNames(styles.soundsPanel)}
         aria-modal
         role="dialog"
+        onKeyDown={handleKeyDown}
       >
         {showSoundFilters && (
           <div


### PR DESCRIPTION
There was a bug in which a user could not always escape to close the musicLab sounds panel. This passes down an onClose object (utilizing the existing dropdownDispose and hide functions) so that the SoundsPanel can have an event listener for the escape key. 

I tried using just dispose- it only worked when hide was included.



https://github.com/user-attachments/assets/4f75fccc-f8a1-45ba-9ec6-a292693ff027




## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1254

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
