### PR TITLE
Enable Marketing Site to be Provisioned in a non us-east-1 Region

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -25,6 +25,9 @@ Parameters:
   WebApplicationServerSecretsARN:
     Type: String
     Description: AWS Secret ARN that contains passwords and API Keys used by the Next.js web application server.
+  RoleBoundary:
+    Type: String
+    Description: The IAM Policy that any Role created by this template must apply as a Permissions Boundary.
 
 Mappings:
   # Cloudfront Mappings
@@ -62,14 +65,6 @@ Mappings:
       PrefixList: pl-4ea04527
     us-west-2:
       PrefixList: pl-82a045eb
-
-  ImportedPoliciesMap:
-    development:
-      policy: IAM-MarketingSitesPermissionsBoundaryDevelopment
-    test:
-      policy: IAM-MarketingSitesPermissionsBoundaryTest
-    production:
-      policy: IAM-MarketingSitesPermissionsBoundaryProduction
 
 Resources:
   ###########################
@@ -314,8 +309,7 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
         Version: "2012-10-17"
-      PermissionsBoundary:
-        Fn::ImportValue: !FindInMap [ImportedPoliciesMap, !Ref 'EnvironmentType', policy]
+      PermissionsBoundary: !Ref RoleBoundary
 
   FargateServiceTaskDef:
     Type: AWS::ECS::TaskDefinition
@@ -439,8 +433,7 @@ Resources:
             Resource:
               - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/ecs/${AWS::StackName}"
               - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/ecs/${AWS::StackName}:log-stream:*"
-      PermissionsBoundary:
-        Fn::ImportValue: !FindInMap [ImportedPoliciesMap, !Ref 'EnvironmentType', policy]
+      PermissionsBoundary: !Ref RoleBoundary
   FargateService:
     Type: AWS::ECS::Service
     Properties:
@@ -565,8 +558,7 @@ Resources:
                   - cloudwatch:DeleteAlarms
                   - ecs:DescribeServices
                 Resource: '*'
-      PermissionsBoundary:
-        Fn::ImportValue: !FindInMap [ImportedPoliciesMap, !Ref 'EnvironmentType', policy]
+      PermissionsBoundary: !Ref RoleBoundary
 
   StaticAssetsBucket:
     Type: AWS::S3::Bucket

--- a/frontend/apps/marketing/cicd/README.md
+++ b/frontend/apps/marketing/cicd/README.md
@@ -26,5 +26,6 @@ This is a work in progress, and this implementation does not represent the final
             --subdomain_name code \
             --container_image_hash sha256:24116f75756f3d80af73d7a2ba43e91ef3d89f0302fea8ece356530360a1b938 \
             --role_arn  arn:aws:iam::123456789:role/admin/CloudFormationMarketingSitesTestRole \
-            --web_application_server_secrets_arn arn:aws:secretsmanager:us-east-1:123456789:secret:marketing-sites/test/marketing-sites.test-code.org/code-abc123
+            --web_application_server_secrets_arn arn:aws:secretsmanager:us-east-1:123456789:secret:marketing-sites/test/marketing-sites.test-code.org/code-abc123 \
+            --cloudformation_role_boundary arn:aws:iam::123456789:policy/marketing-sites-role-permissions-boundary-test
 ```


### PR DESCRIPTION
While IAM is a global service, we can't import the marketing site permissions boundary Policy in a different AWS Region from the one where the IAM Stack is provisioned. Make the boundary an argument passed to the deploy script.

## Testing story

Successfully tested on a test marketing site.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
