### PR TITLE
CMS-785: Fix HeroBanner width in flex container

### DIFF
--- a/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
+++ b/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
@@ -96,7 +96,7 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
   <section
     role="banner"
     data-theme={HTMLAttributes['data-theme']}
-    className={className}
+    className={classNames(moduleStyles.heroBanner, className)}
     {...HTMLAttributes}
   >
     {announcementBannerProps && (

--- a/frontend/packages/component-library/src/cms/heroBanner/heroBanner.module.scss
+++ b/frontend/packages/component-library/src/cms/heroBanner/heroBanner.module.scss
@@ -4,6 +4,10 @@
 
 $mobileBreakpoint: 970px;
 
+.heroBanner {
+  width: 100%;
+}
+
 .heroBannerWrapper {
   box-sizing: border-box;
   width: 100%;


### PR DESCRIPTION
## Before
<img width="100%" alt="before" src="https://github.com/user-attachments/assets/9e6451a8-2767-4ffd-b19d-34145a1fbb4a" />

## After
<img width="100%" alt="after" src="https://github.com/user-attachments/assets/041c661d-f37c-4bfb-87ef-c2766e87ee6b" />


## Links
- JIRA task: [CMS-785](https://codedotorg.atlassian.net/browse/CMS-785)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66104