### PR TITLE
stop filtering course units by assignability in valid_course_offerings

### DIFF
--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -212,7 +212,7 @@ class CourseVersion < ApplicationRecord
         is_recommended: recommended?(locale_code),
         locales: content_root.supported_locale_names,
         locale_codes: content_root.supported_locale_codes,
-        units: units.select {|u| u.course_assignable?(user)}.map do |u|
+        units: units.map do |u|
           unit_group_unit = u.unit_group_units.find {|ugu| ugu.unit_group == content_root}
           u.summarize_for_assignment_dropdown(unit_group_unit: unit_group_unit)
         end.to_h

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1483,6 +1483,43 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test 'valid_course_offerings includes only published courses' do
+    sign_in @teacher
+    get :valid_course_offerings, params: {login_type: Section::LOGIN_TYPE_EMAIL}
+    assert_response :success
+
+    course_offering_ids = JSON.parse(@response.body).keys
+    assert course_offering_ids.include?(@csp_unit_group.course_version.course_offering.id.to_s)
+    assert course_offering_ids.include?(@single_unit_course.course_version.course_offering.id.to_s)
+    refute course_offering_ids.include?(@beta_unit_group.course_version.course_offering.id.to_s)
+  end
+
+  test 'valid_course_offerings includes units of published courses' do
+    @beta_unit_1 = create :unit, original_unit_group: @beta_unit_group
+    create :unit_group_unit, unit_group: @beta_unit_group, script: @beta_unit_1, position: 1
+    @beta_unit_2 = create :unit, original_unit_group: @beta_unit_group
+    create :unit_group_unit, unit_group: @beta_unit_group, script: @beta_unit_2, position: 2
+
+    modular_course = create :unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    create :unit_group_unit, unit_group: modular_course, script: @beta_unit_1, position: 1
+    create :unit_group_unit, unit_group: modular_course, script: @beta_unit_2, position: 2
+    CourseOffering.add_course_offering(modular_course)
+
+    sign_in @teacher
+    get :valid_course_offerings, params: {login_type: Section::LOGIN_TYPE_EMAIL}
+    assert_response :success
+
+    course_offerings = JSON.parse(@response.body)
+
+    co_summary = course_offerings[@csp_unit_group.course_version.course_offering.id.to_s]
+    cv_summary = co_summary['course_versions'][@csp_unit_group.course_version.id.to_s]
+    assert_equal [@csp_script.id.to_s, @csp_script2.id.to_s], cv_summary['units'].keys
+
+    co_summary = course_offerings[modular_course.course_version.course_offering.id.to_s]
+    cv_summary = co_summary['course_versions'][modular_course.course_version.id.to_s]
+    assert_equal [@beta_unit_1.id.to_s, @beta_unit_2.id.to_s], cv_summary['units'].keys
+  end
+
   private def set_up_code_review_groups
     # create a new section to avoid extra unassigned students
     @code_review_group_section = create(:section, user: @teacher, login_type: 'word')


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/TEACH-1934. the root cause is that assigned modular units were not showing up in the Owned Sections table if their original course was not yet published, even if the assigned, modular course was published. The cause for this bug is quite a few steps removed from the OwnedSectionsTable, in the `valid_course_offerings` route. The fix is to stop filtering out the list of units in the `valid_course_offerings` response based on whether they are assignable, because we should be looking only at whether the unit group is assignable now.

## Testing story
* new unit tests for the `valid_course_offerings` method
* manually verified that this fixes my local repro of the problem

## Follow-up work

* [TEACH-1949](https://codedotorg.atlassian.net/browse/TEACH-1949) remove option for CourseVersion to have a Unit as a content root.