### PR TITLE
Update `timecop` Gem to `>= 0.9.4`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ group :development, :test do
   gem 'faker', '~> 3.4', require: false
   gem 'fakeredis', require: false
   gem 'mocha', require: false
-  gem 'timecop'
+  gem 'timecop', '>= 0.9.4' # required for Ruby 3.1 support
 
   # For UI testing.
   gem 'cucumber'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -912,7 +912,7 @@ GEM
     tilt (2.0.11)
     time (0.4.1)
       date
-    timecop (0.8.1)
+    timecop (0.9.10)
     timeout (0.3.2)
     timers (4.3.5)
     trailblazer-option (0.1.2)
@@ -1148,7 +1148,7 @@ DEPENDENCIES
   syslog
   thin
   thwait
-  timecop
+  timecop (>= 0.9.4)
   twilio-ruby (< 6.0)
   twitter_cldr (~> 6.12.1)
   uglifier (>= 1.3.0)


### PR DESCRIPTION
To pick up support for Ruby 3.1, in advance of a planned upgrade to that version: https://github.com/travisjeffery/timecop/blob/master/History.md#v094

Otherwise, we get errors like:

```
<internal:timev>:310:in `initialize': no implicit conversion of Hash into Integer (TypeError)
  from /home/ci/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/timecop-0.8.1/lib/timecop/time_extensions.rb:22:in `new'
  from /home/ci/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/timecop-0.8.1/lib/timecop/time_extensions.rb:22:in `new_with_mock_time'
  from <internal:timev>:224:in `now'
  from /home/ci/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/timecop-0.8.1/lib/timecop/time_extensions.rb:14:in `now_with_mock_time'
```

When trying to invoke `Time.now`

## Testing story

Relying on existing tests to validate that this upgrade does not change any functionality on our current version of Ruby. Will verify separately in [a testing branch](https://github.com/code-dot-org/code-dot-org/pull/66141) that it resolves the issue we were having with Ruby 3.1
