### PR TITLE
fix(onetrust): fix onetrust not loading in prod

### DIFF
--- a/frontend/apps/marketing/src/middleware.ts
+++ b/frontend/apps/marketing/src/middleware.ts
@@ -9,9 +9,10 @@ export const config = {
      * 1. /api routes
      * 2. /_next (Next.js internals)
      * 3. /_static (inside /public)
+     * 4. /onetrust (OneTrust cookie consent)
      * 4. all root files inside /public (e.g. /favicon.ico)
      */
-    '/((?!api/|_next/|_static/|_vercel|[\\w-]+\\.\\w+).*)',
+    '/((?!api/|_next/|onetrust/|_static/|_vercel|[\\w-]+\\.\\w+).*)',
   ],
 };
 

--- a/frontend/apps/marketing/tests/e2e/onetrust.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/onetrust.spec.ts
@@ -1,0 +1,28 @@
+import {expect} from '@playwright/test';
+
+import {test} from './fixtures/base';
+import {MarketingPage} from './pom/marketing';
+
+test.describe('OneTrust Tests', () => {
+  test('does NOT shows onetrust cookie consent in US', async ({page}) => {
+    const marketingPage = new MarketingPage(page);
+    await marketingPage.goto('/en-US/engineering/all-the-things?otgeo=us');
+
+    await expect(
+      page.getByText(
+        'Click the "Cookies Settings" button to review the default cookie settings for this site and/or set your own cookie preferences.',
+      ),
+    ).not.toBeVisible();
+  });
+
+  test('shows onetrust cookie consent in es', async ({page}) => {
+    const marketingPage = new MarketingPage(page);
+    await marketingPage.goto('/en-US/engineering/all-the-things?otgeo=es');
+
+    await expect(
+      page.getByText(
+        'Click the "Cookies Settings" button to review the default cookie settings for this site and/or set your own cookie preferences.',
+      ),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
OneTrust is self-hosted in production and CDN hosted in dev/test. In Production, the locale middleware was added which adds a locale to most paths. OneTrust is not a localizable path as it's a public script, so exclude it from middlewares.