### PR TITLE
Evaluate Student Learning: use student id to pull student code 

### DIFF
--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -23,7 +23,8 @@ const StudentCodeDatasetMaker: React.FC = () => {
   const [datasetName, setDatasetName] = useState<string>('');
   const [levelId, setLevelId] = useState<string>('');
   const [unitId, setUnitId] = useState<string>('');
-  const [numSamples, setNumSamples] = useState<string>('25');
+  const [studentIds, setStudentIds] = useState<string>('');
+  // const [numSamples, setNumSamples] = useState<string>('25');
   const [pending, setPending] = useState<boolean>(false);
   const [fetchedSamples, setFetchedSamples] = useState<StudentAnswer[]>([]);
   const [evaluationPending, setEvaluationPending] = useState<boolean>(false);
@@ -44,7 +45,8 @@ const StudentCodeDatasetMaker: React.FC = () => {
   const getStudentCodeSamples = async () => {
     setPending(true);
     const studentWorkRequest = {
-      numSamples: Number(numSamples),
+      // numSamples: Number(numSamples),
+      studentIds: studentIds.split(','),
       unitId: Number(unitId),
       levelId: Number(levelId),
     };
@@ -121,13 +123,21 @@ const StudentCodeDatasetMaker: React.FC = () => {
         <br />
         <br />
         <TextField
+          name="Student Ids"
+          label="Student Ids (comma separated)"
+          onChange={e => setStudentIds(e.target.value)}
+          value={studentIds}
+        />
+        <br />
+        <br />
+        {/* <TextField
           name="Number of Samples"
           label="How many samples of student work do you want?"
           onChange={e => setNumSamples(e.target.value)}
           value={numSamples}
-        />
-        <br />
-        <br />
+        /> */}
+        {/* <br />
+        <br /> */}
         <TextField
           name="Dataset Name"
           label="What do you want to name this dataset?"

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -24,7 +24,6 @@ const StudentCodeDatasetMaker: React.FC = () => {
   const [levelId, setLevelId] = useState<string>('');
   const [unitId, setUnitId] = useState<string>('');
   const [studentIds, setStudentIds] = useState<string>('');
-  // const [numSamples, setNumSamples] = useState<string>('25');
   const [pending, setPending] = useState<boolean>(false);
   const [fetchedSamples, setFetchedSamples] = useState<StudentAnswer[]>([]);
   const [evaluationPending, setEvaluationPending] = useState<boolean>(false);
@@ -45,7 +44,6 @@ const StudentCodeDatasetMaker: React.FC = () => {
   const getStudentCodeSamples = async () => {
     setPending(true);
     const studentWorkRequest = {
-      // numSamples: Number(numSamples),
       studentIds: studentIds.split(','),
       unitId: Number(unitId),
       levelId: Number(levelId),
@@ -130,14 +128,6 @@ const StudentCodeDatasetMaker: React.FC = () => {
         />
         <br />
         <br />
-        {/* <TextField
-          name="Number of Samples"
-          label="How many samples of student work do you want?"
-          onChange={e => setNumSamples(e.target.value)}
-          value={numSamples}
-        /> */}
-        {/* <br />
-        <br /> */}
         <TextField
           name="Dataset Name"
           label="What do you want to name this dataset?"

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentWorkSamplesApi.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentWorkSamplesApi.tsx
@@ -10,10 +10,6 @@ interface StudentWorkRequest {
 export async function fetchStudentCodeSamples(
   studentWorkRequest: StudentWorkRequest
 ): Promise<string | null> {
-  console.log(
-    'studentWorkRequest in StudentWorkSamplesApi',
-    studentWorkRequest
-  );
   try {
     const response = await fetch(`/student_code_samples`, {
       method: 'POST',

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentWorkSamplesApi.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentWorkSamplesApi.tsx
@@ -1,14 +1,19 @@
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
 interface StudentWorkRequest {
-  numSamples: number;
+  numSamples?: number;
   unitId: number;
   levelId: number;
+  studentIds?: string[];
 }
 
 export async function fetchStudentCodeSamples(
   studentWorkRequest: StudentWorkRequest
 ): Promise<string | null> {
+  console.log(
+    'studentWorkRequest in StudentWorkSamplesApi',
+    studentWorkRequest
+  );
   try {
     const response = await fetch(`/student_code_samples`, {
       method: 'POST',

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -63,9 +63,15 @@ class StudentWorkSampleController < ApplicationController
   def fetch_student_code_samples
     level_id = student_work_params[:level_id]
     unit_id = student_work_params[:unit_id]
-    num_samples = student_work_params[:num_samples].to_i
+    # num_samples = student_work_params[:num_samples].to_i
+    student_ids = student_work_params[:student_ids]
+    puts "-------------------------"
+    puts
+    puts "student_ids: #{student_ids}"
+    puts
+    puts "student_work_params: #{student_work_params}"
 
-    return render json: [] if num_samples == 0
+    # return render json: [] if num_samples == 0
 
     begin
       level = Level.find(level_id)
@@ -82,23 +88,23 @@ class StudentWorkSampleController < ApplicationController
     end
 
     # Find users who have worked on this level.
-    student_ids = UserLevel.where(level_id: level.id, script_id: unit_id).pluck(:user_id)
+    # student_ids = UserLevel.where(level_id: level.id, script_id: unit_id).pluck(:user_id)
     code_samples = []
-    have_enough_samples = false
-    student_ids.shuffle.each do |student_id|
-      unless have_enough_samples
-        student_code = get_student_code(student_id, level, unit_id)
-        if student_code[:student_code]
-          code_samples << {
-            level_id: level.id,
-            unit_id: unit_id,
-            student_id: student_id,
-            project_id: student_code[:project_id],
-            student_work: student_code[:student_code]
-          }.transform_keys {|key| key.to_s.camelize(:lower)}
-        end
-        have_enough_samples = code_samples.length >= num_samples
+    # have_enough_samples = false
+    student_ids.each do |student_id|
+      # unless have_enough_samples
+      student_code = get_student_code(student_id.to_i, level, unit_id)
+      if student_code[:student_code]
+        code_samples << {
+          level_id: level.id,
+          unit_id: unit_id,
+          student_id: student_id.to_i,
+          project_id: student_code[:project_id],
+          student_work: student_code[:student_code]
+        }.transform_keys {|key| key.to_s.camelize(:lower)}
       end
+      # have_enough_samples = code_samples.length >= num_samples
+      # end
     end
     render json: code_samples
   end
@@ -134,9 +140,13 @@ class StudentWorkSampleController < ApplicationController
   end
 
   def student_work_params
-    params.transform_keys(&:underscore).permit(
+    puts "-------------------------"
+    puts "params: #{params.inspect}"
+    puts "-------------------------"
+    params.require(:student_work_sample).transform_keys(&:underscore).permit(
       :level_id,
       :unit_id,
+      {student_ids: []},
       :num_samples,
     )
   end

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -63,7 +63,7 @@ class StudentWorkSampleController < ApplicationController
   def fetch_student_code_samples
     level_id = student_work_params[:level_id]
     unit_id = student_work_params[:unit_id]
-    student_ids = student_work_params[:student_ids]
+    student_ids = student_work_params[:student_ids] || []
 
     begin
       level = Level.find(level_id)
@@ -79,7 +79,6 @@ class StudentWorkSampleController < ApplicationController
       return render status: :not_found, json: "Unit with id #{unit_id}"
     end
 
-    # Find users who have worked on this level.
     code_samples = []
     student_ids.each do |student_id|
       student_code = get_student_code(student_id.to_i, level, unit_id)
@@ -127,7 +126,7 @@ class StudentWorkSampleController < ApplicationController
   end
 
   def student_work_params
-    params.require(:student_work_sample).transform_keys(&:underscore).permit(
+    params.transform_keys(&:underscore).permit(
       :level_id,
       :unit_id,
       {student_ids: []},

--- a/dashboard/app/controllers/student_work_sample_controller.rb
+++ b/dashboard/app/controllers/student_work_sample_controller.rb
@@ -63,15 +63,7 @@ class StudentWorkSampleController < ApplicationController
   def fetch_student_code_samples
     level_id = student_work_params[:level_id]
     unit_id = student_work_params[:unit_id]
-    # num_samples = student_work_params[:num_samples].to_i
     student_ids = student_work_params[:student_ids]
-    puts "-------------------------"
-    puts
-    puts "student_ids: #{student_ids}"
-    puts
-    puts "student_work_params: #{student_work_params}"
-
-    # return render json: [] if num_samples == 0
 
     begin
       level = Level.find(level_id)
@@ -88,11 +80,8 @@ class StudentWorkSampleController < ApplicationController
     end
 
     # Find users who have worked on this level.
-    # student_ids = UserLevel.where(level_id: level.id, script_id: unit_id).pluck(:user_id)
     code_samples = []
-    # have_enough_samples = false
     student_ids.each do |student_id|
-      # unless have_enough_samples
       student_code = get_student_code(student_id.to_i, level, unit_id)
       if student_code[:student_code]
         code_samples << {
@@ -103,8 +92,6 @@ class StudentWorkSampleController < ApplicationController
           student_work: student_code[:student_code]
         }.transform_keys {|key| key.to_s.camelize(:lower)}
       end
-      # have_enough_samples = code_samples.length >= num_samples
-      # end
     end
     render json: code_samples
   end
@@ -140,9 +127,6 @@ class StudentWorkSampleController < ApplicationController
   end
 
   def student_work_params
-    puts "-------------------------"
-    puts "params: #{params.inspect}"
-    puts "-------------------------"
     params.require(:student_work_sample).transform_keys(&:underscore).permit(
       :level_id,
       :unit_id,

--- a/dashboard/test/controllers/student_work_sample_controller_test.rb
+++ b/dashboard/test/controllers/student_work_sample_controller_test.rb
@@ -19,7 +19,7 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
   name: "no_user_no_access_test",
   user: nil,
   method: :get,
-  params: {level_id: 123, unit_id: 456, num_samples: 7},
+  params: {level_id: 123, unit_id: 456},
   response: :redirect
 
   # Student cannot fetch student code samples
@@ -27,7 +27,7 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
   name: "student_no_access_test",
   user: :student,
   method: :get,
-  params: {level_id: 123, unit_id: 456, num_samples: 7},
+  params: {level_id: 123, unit_id: 456},
   response: :forbidden
 
   # Teacher cannot fetch student code samples
@@ -35,7 +35,7 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
   name: "teacher_no_access_test",
   user: :teacher,
   method: :get,
-  params: {level_id: 123, unit_id: 456, num_samples: 7},
+  params: {level_id: 123, unit_id: 456},
   response: :forbidden
 
   # Levelbuiilder cannot fetch student code samples
@@ -43,7 +43,7 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
   name: "levelbuilder_no_access_test",
   user: :levelbuilder,
   method: :get,
-  params: {level_id: 123, unit_id: 456, num_samples: 7},
+  params: {level_id: 123, unit_id: 456},
   response: :forbidden
 
   # AI Tutor Access cannot fetch student code samples
@@ -51,7 +51,7 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
   name: "ai_tutor_permissions_no_access_test",
   user: :ai_tutor_access,
   method: :get,
-  params: {level_id: 123, unit_id: 456, num_samples: 7},
+  params: {level_id: 123, unit_id: 456},
   response: :forbidden
 
   # Can fetch student code samples with student_work_access permission
@@ -60,7 +60,7 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
   name: "student_work_dataset_maker_can_access_bogus_params",
   user: :student_work_dataset_maker,
   method: :get,
-  params: {level_id: 123, unit_id: 456, num_samples: 7},
+  params: {level_id: 123, unit_id: 456},
   response: :not_found
 
   # Can fetch student code samples with student_work_access permission
@@ -70,7 +70,7 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
     sign_in(user)
     level = create(:level)
     unit = create(:script)
-    get :fetch_student_code_samples, params: {level_id: level.id, unit_id: unit.id, num_samples: 0}
+    get :fetch_student_code_samples, params: {level_id: level.id, unit_id: unit.id, student_ids: []}
     assert_response :ok
   end
 
@@ -82,7 +82,7 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
     level = create(:level)
     student = create(:student)
     create(:user_level, user: student, level: level, script: unit)
-    get :fetch_student_code_samples, params: {level_id: level.id, unit_id: unit.id, num_samples: 1}
+    get :fetch_student_code_samples, params: {level_id: level.id, unit_id: unit.id, student_ids: [student.id]}
     assert_response :ok
     response_json = JSON.parse(response.body)
     assert response_json.first["studentWork"], 'console.log("Hello World")'


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeHFrMXNreTlibmM4dGd5aTUybW9vZDN0a3lmMmkyMnk5cDFrYnYzZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/2OP9jbHFlFPW/giphy.gif)

Alternate approach for https://github.com/code-dot-org/code-dot-org/pull/66004

We need to pull student code samples so they can be evaluated by AI and reviewed by a human. The current implementation times out because querying the UserLevel table without user_id is impossible because the table stores sooooo many records and there aren't separate indices on unit_id and level_id. Instead, I've modified the Dataset Maker to take in user ids which I can pull from Trevor to circumvent the query timeout. 

Here's a little video of it working locally: 

https://github.com/user-attachments/assets/cb6cce3b-b481-4c59-9680-4a617fdf0705

