### PR TITLE
Lab2 theming: better theme source of truth

### DIFF
--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -2,7 +2,7 @@ import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import currentLocale from '@cdo/apps/util/currentLocale';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 
-import {MultiFileSource, ProjectFile, ProjectFileType, Theme} from '../types';
+import {MultiFileSource, ProjectFile, ProjectFileType} from '../types';
 
 // Partial definition of the App Options structure, only defining the
 // pieces we need in this component.
@@ -14,7 +14,7 @@ export interface PartialAppOptions {
   isEditingExemplar: boolean;
   isViewingExemplar: boolean;
   publicCaching: boolean;
-  theme?: Theme;
+  theme?: string;
 }
 
 /**
@@ -77,7 +77,7 @@ export function getAppOptionsViewingExemplar(): boolean | undefined {
   }
 }
 
-export function getAppOptionsTheme(): Theme | undefined {
+export function getAppOptionsTheme(): string | undefined {
   if (hasScriptData('script[data-appoptions]')) {
     const appOptions = getScriptData('appoptions') as PartialAppOptions;
     return appOptions.theme;

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -2,7 +2,7 @@ import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import currentLocale from '@cdo/apps/util/currentLocale';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 
-import {MultiFileSource, ProjectFile, ProjectFileType} from '../types';
+import {MultiFileSource, ProjectFile, ProjectFileType, Theme} from '../types';
 
 // Partial definition of the App Options structure, only defining the
 // pieces we need in this component.
@@ -14,6 +14,7 @@ export interface PartialAppOptions {
   isEditingExemplar: boolean;
   isViewingExemplar: boolean;
   publicCaching: boolean;
+  theme?: Theme;
 }
 
 /**
@@ -75,6 +76,14 @@ export function getAppOptionsViewingExemplar(): boolean | undefined {
     return appOptions.isViewingExemplar;
   }
 }
+
+export function getAppOptionsTheme(): Theme | undefined {
+  if (hasScriptData('script[data-appoptions]')) {
+    const appOptions = getScriptData('appoptions') as PartialAppOptions;
+    return appOptions.theme;
+  }
+}
+
 /**
  * Returns if the lab should presented in a share/play-only view,
  * if present in App Options. Only used in standalone project levels.

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -65,7 +65,7 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
 
   useEffect(() => {
     // Initialize the theme based on the body class, which is set on the server.
-    // This allows us to take advantage of the server-side logic to show the correct theme
+    // This allows us to take advantage of the server-side logic to show the correct loading theme
     // based on the lesson and user preference.
     // We default to dark theme if the body class is not set.
     const bodyClassList = document.body.classList;
@@ -78,8 +78,15 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
 
   // We duplicate the theme to Lab2Registry, because modals opened via the header (such as the share modal)
   // do not have access to the theme context.
+  // We also update the body class to match the theme, so elements such as the footer update correctly.
   useEffect(() => {
     Lab2Registry.getInstance().setTheme(theme);
+    const themeDowncase = theme.toLowerCase();
+    const oldTheme = themeDowncase === 'light' ? 'dark' : 'light';
+    if (document.body.classList.contains(`background-${oldTheme}`)) {
+      document.body.classList.remove(`background-${oldTheme}`);
+    }
+    document.body.classList.add(`background-${themeDowncase}`);
   }, [theme]);
 
   // Store the level ID provided by App Options in redux if necessary.

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -6,14 +6,20 @@
 // boundary; a fade-in between levels; a loading spinner when a level takes a
 // while to load; and a sad bee when things go wrong.
 
-import {useTheme} from '@code-dot-org/component-library/common/contexts';
+import {Theme, useTheme} from '@code-dot-org/component-library/common/contexts';
 import classNames from 'classnames';
 import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
 import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
+import {
+  getAppOptionsLevelId,
+  getAppOptionsTheme,
+  getIsShareView,
+} from '@cdo/apps/lab2/projects/utils';
 import fetchPermissions from '@cdo/apps/lab2/utils/fetchPermissions';
 import {useBrowserTextToSpeech} from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
+import {capitalizeFirstLetter} from '@cdo/apps/util/capitalizeFirstLetter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {PERMISSIONS} from '../constants';
@@ -27,7 +33,6 @@ import {
   setPermissions,
 } from '../lab2Redux';
 import Lab2Registry from '../Lab2Registry';
-import {getAppOptionsLevelId, getIsShareView} from '../projects/utils';
 import {LifecycleEvent} from '../utils';
 
 import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
@@ -64,16 +69,17 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   const {theme, setTheme} = useTheme();
 
   useEffect(() => {
-    // Initialize the theme based on the body class, which is set on the server.
+    // Initialize the theme based on app options, which is set on the server.
     // This allows us to take advantage of the server-side logic to show the correct loading theme
     // based on the lesson and user preference.
     // We default to dark theme if the body class is not set.
-    const bodyClassList = document.body.classList;
-    if (bodyClassList.contains('background-light')) {
-      setTheme('Light');
-    } else {
-      setTheme('Dark');
-    }
+    const appOptionsTheme = getAppOptionsTheme();
+    const upperCasedTheme = appOptionsTheme
+      ? (capitalizeFirstLetter(appOptionsTheme) as Theme)
+      : undefined;
+    const theme = upperCasedTheme || 'Dark';
+
+    setTheme(theme);
   }, [setTheme]);
 
   // We duplicate the theme to Lab2Registry, because modals opened via the header (such as the share modal)

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -3,7 +3,7 @@
  * currently active Lab (determined by the current app name). This
  * helps facilitate level-switching between labs without page reloads.
  */
-import {useTheme} from '@code-dot-org/component-library/common/contexts';
+import {Theme, useTheme} from '@code-dot-org/component-library/common/contexts';
 import React, {Suspense, useEffect, useMemo} from 'react';
 
 import {getCurrentLesson} from '@cdo/apps/code-studio/progressReduxSelectors';
@@ -12,6 +12,7 @@ import {setIsLoadingTheme} from '@cdo/apps/lab2/lab2Redux';
 import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {Level} from '@cdo/apps/types/progressTypes';
+import {capitalizeFirstLetter} from '@cdo/apps/util/capitalizeFirstLetter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {lab2EntryPoints} from '../../../lab2EntryPoints';
@@ -70,8 +71,11 @@ const LabViewsRenderer: React.FunctionComponent = () => {
         // otherwise fall back to the first supported theme.
         // We will only use the app options theme if we are not using the user preference,
         // so it is safe to use that statically set theme.
-        if (initialTheme && supportedThemes.includes(initialTheme)) {
-          setTheme(initialTheme);
+        const upperCasedTheme = initialTheme
+          ? (capitalizeFirstLetter(initialTheme) as Theme)
+          : undefined;
+        if (upperCasedTheme && supportedThemes.includes(upperCasedTheme)) {
+          setTheme(upperCasedTheme);
         } else {
           setTheme(supportedThemes[0]);
         }

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -66,8 +66,10 @@ const LabViewsRenderer: React.FunctionComponent = () => {
       dispatch(setIsLoadingTheme(true));
 
       const setThemeHelper = () => {
-        // Use the theme from level properties if it exists and is supported,
+        // Use the theme from app options if it exists and is supported,
         // otherwise fall back to the first supported theme.
+        // We will only use the app options theme if we are not using the user preference,
+        // so it is safe to use that statically set theme.
         if (initialTheme && supportedThemes.includes(initialTheme)) {
           setTheme(initialTheme);
         } else {

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -17,7 +17,10 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {lab2EntryPoints} from '../../../lab2EntryPoints';
 import {PERMISSIONS} from '../constants';
 import ProgressContainer from '../progress/ProgressContainer';
-import {getAppOptionsViewingExemplar} from '../projects/utils';
+import {
+  getAppOptionsTheme,
+  getAppOptionsViewingExemplar,
+} from '../projects/utils';
 
 import NoExemplarPage from './components/NoExemplarPage';
 import ExtraLinks from './ExtraLinks';
@@ -34,6 +37,7 @@ const LabViewsRenderer: React.FunctionComponent = () => {
   const currentAppName = levelProperties?.appName;
   const exemplarSources = levelProperties?.exemplarSources;
   const levelId = levelProperties?.id;
+  const initialTheme = getAppOptionsTheme();
 
   const isBlocked = useAppSelector(state => state.lab.isBlocked);
   const isProjectValidator = useAppSelector(state =>
@@ -62,16 +66,10 @@ const LabViewsRenderer: React.FunctionComponent = () => {
       dispatch(setIsLoadingTheme(true));
 
       const setThemeHelper = () => {
-        // If the body has a class use that to set the theme, if its supported by the lab.
-        // Otherwise, use the first supported theme.
-        // We will only run this if we are not using the user preference, so it's safe to pull
-        // from the body class, as the user is not dynamically changing the theme.
-        const bodyClassList = document.body.classList;
-        const bodyTheme = bodyClassList.contains('background-light')
-          ? 'Light'
-          : 'Dark';
-        if (supportedThemes.includes(bodyTheme)) {
-          setTheme(bodyTheme);
+        // Use the theme from level properties if it exists and is supported,
+        // otherwise fall back to the first supported theme.
+        if (initialTheme && supportedThemes.includes(initialTheme)) {
+          setTheme(initialTheme);
         } else {
           setTheme(supportedThemes[0]);
         }
@@ -94,7 +92,14 @@ const LabViewsRenderer: React.FunctionComponent = () => {
         setThemeHelper();
       }
     }
-  }, [currentAppName, setTheme, useThemeUserPreference, signInState, dispatch]);
+  }, [
+    currentAppName,
+    setTheme,
+    useThemeUserPreference,
+    signInState,
+    dispatch,
+    initialTheme,
+  ]);
 
   // Do not render lab view if project is blocked and user is not a project validator.
   if (!currentAppName || (isBlocked && !isProjectValidator)) {

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -769,6 +769,12 @@ module LevelsHelper
     end
     app_options[:share] = level_options[:share] if level_options[:share]
     app_options[:public_caching] = @public_caching
+    if @script_level&.lesson
+      app_options[:theme] = @script_level.lesson.get_background_for_user(current_user)
+    elsif @level.is_a?(Pythonlab) && current_user
+      theme_preference = UserPreference.find_by(user_id: current_user.id)&.theme
+      app_options[:theme] = (theme_preference && theme_preference['global']) || 'dark'
+    end
     app_options.camelize_keys
   end
 


### PR DESCRIPTION
Follow up to #66142, specifically [this comment](https://github.com/code-dot-org/code-dot-org/pull/66142#discussion_r2114676077). 

This fixes a couple issues. First was when you switched themes, we didn't update the body class. This is only a problem for the copyright footer, which if you went from light -> dark would stay visible, but not be styled with a dark background and white text, but if you went from dark -> light it would disappear because it would have white text on a white background. Now when we switch themes we update the body class too. When you reloaded the page the copyright footer would render correctly, because the body class would be set correctly.

We also now pull the theme in `LabViewsRenderer` for labs that aren't using the user preference from app options rather than the body class. We can't do that anymore because of the change above, and it was a brittle way to maintain a source of truth of what the backend thinks the theme should be. We think this is an appropriate use for app options because it is a piece of data that combines both user and level/lesson data, and it is only changed on page load. There may be an opportunity in the future to make an api that combines user and level data, but that was out of scope here.

## Links

- Jira: [CT-1231](https://codedotorg.atlassian.net/browse/CT-1231). This change fixed some slightly buggy behavior so I will handle the other follow-ups separately.

## Testing story
Tested locally on various progressions.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
