### PR TITLE
Python Lab: change error color to pink in dark mode

### DIFF
--- a/apps/src/codebridge/Console/consoleThemes.ts
+++ b/apps/src/codebridge/Console/consoleThemes.ts
@@ -2,7 +2,7 @@
 // black with white text.
 // We override a few colors to ensure good contrast.
 export const darkTheme = {
-  red: '#ff5f5f',
+  red: '#FF69B4',
   brightBlack: '#b2b2b2',
 };
 


### PR DESCRIPTION
We got feedback that red text on a black background is hard for some people to read. This changes the error color to pink in dark mode, which works better for colorblind users.

## Before
![Screenshot 2025-05-30 at 11 02 04 AM](https://github.com/user-attachments/assets/a539eebf-4783-44dc-9083-c70930638186)

## After
![Screenshot 2025-05-30 at 11 16 49 AM](https://github.com/user-attachments/assets/6f349538-4594-4708-b07e-a7dba047e887)

## Links

- Jira: [CT-1233](https://codedotorg.atlassian.net/browse/CT-1233)
- [Slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1748628244480499)

## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
