### PR TITLE
Teach-1865/modularity support in section progress

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,9 +211,9 @@ GEM
     aws-sdk-autoscaling (1.128.0)
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-bedrockagentruntime (1.38.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
-      aws-sigv4 (~> 1.5)
+    aws-sdk-bedrockagentruntime (1.10.0)
+      aws-sdk-core (~> 3, >= 3.193.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-cloudformation (1.124.0)
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sigv4 (~> 1.5)
@@ -1168,4 +1168,4 @@ RUBY VERSION
    ruby 3.1.0p0
 
 BUNDLED WITH
-   2.5.17
+   2.3.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,9 +211,9 @@ GEM
     aws-sdk-autoscaling (1.128.0)
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-bedrockagentruntime (1.10.0)
-      aws-sdk-core (~> 3, >= 3.193.0)
-      aws-sigv4 (~> 1.1)
+    aws-sdk-bedrockagentruntime (1.38.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-cloudformation (1.124.0)
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sigv4 (~> 1.5)
@@ -1168,4 +1168,4 @@ RUBY VERSION
    ruby 3.1.0p0
 
 BUNDLED WITH
-   2.3.22
+   2.5.17

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -38,9 +38,9 @@ export const finishedLoadingCoursesWithProgress = () => ({
 
 // Selectors
 export const getSelectedUnitId = state => state.unitSelection.scriptId;
-export const getSelectedCourseId = state => state.unitSelection.courseVersionId;
+export const getSelectedCourseVersionId = state => state.unitSelection.courseVersionId;
 
-export const getSelectedCourse = state => {
+export const getSelectedCourseVersion = state => {
   const courseVersionId = getSelectedCourseId(state);
   return state.unitSelection.coursesWithProgress.find(
     c => c.id === courseVersionId
@@ -138,7 +138,7 @@ export default function unitSelection(state = initialState, action) {
     const firstUnit = firstCourse ? firstCourse.units[0] : null;
 
     // If the currently selected Unit is the new set of coursesWithProgress,
-    // the default to selecting the first Unit.
+    // then default to selecting the first Unit.
     let scriptId = firstUnit?.id;
     let courseVersionId = firstCourse?.id;
     if (state.scriptId && state.courseVersionId) {
@@ -159,8 +159,6 @@ export default function unitSelection(state = initialState, action) {
     return {
       ...state,
       coursesWithProgress: action.coursesWithProgress,
-      // This automatically selects the first unit of the first course
-      // unless a Unit is already set
       scriptId: scriptId,
       courseVersionId: courseVersionId,
     };

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -86,6 +86,10 @@ export const getSelectedUnitPosition = state => {
   return getSelectedUnit(state) ? getSelectedUnit(state).position : null;
 };
 
+export const getSelectedCourseId = state => {
+  return getSelectedUnit(state) ? getSelectedUnit(state).course_id : null;
+};
+
 export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
   const state = getState();
   const selectedSection =

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -38,21 +38,22 @@ export const finishedLoadingCoursesWithProgress = () => ({
 
 // Selectors
 export const getSelectedUnitId = state => state.unitSelection.scriptId;
-export const getSelectedCourseVersionId = state => state.unitSelection.courseVersionId;
+export const getSelectedCourseVersionId = state =>
+  state.unitSelection.courseVersionId;
 
 export const getSelectedCourseVersion = state => {
-  const courseVersionId = getSelectedCourseId(state);
+  const courseVersionId = getSelectedCourseVersionId(state);
   return state.unitSelection.coursesWithProgress.find(
     c => c.id === courseVersionId
   );
 };
 
 export const getSelectedCourseName = state => {
-  return getSelectedCourse(state)?.course_name || null;
+  return getSelectedCourseVersion(state)?.course_name || null;
 };
 
 const getSelectedUnit = state => {
-  const courseVersionId = getSelectedCourseId(state);
+  const courseVersionId = getSelectedCourseVersionId(state);
   const unitId = getSelectedUnitId(state);
   if (!courseVersionId || !unitId) {
     return null;

--- a/apps/src/templates/UnitSelectorV2.jsx
+++ b/apps/src/templates/UnitSelectorV2.jsx
@@ -9,6 +9,8 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
   asyncLoadCoursesWithProgress,
   setUnit,
+  getSelectedCourseId,
+  getSelectedUnitPosition,
 } from '@cdo/apps/redux/unitSelectionRedux';
 import {loadUnitProgress} from '@cdo/apps/templates/sectionProgress/sectionProgressLoader';
 import i18n from '@cdo/locale';
@@ -38,6 +40,8 @@ function UnitSelectorV2({
   sectionId,
   unitId,
   courseVersionId,
+  courseId,
+  unitPosition,
   coursesWithProgress,
   className,
   setUnit,
@@ -60,9 +64,7 @@ function UnitSelectorV2({
         .split('-')
         .map(id => parseInt(id));
       setUnit(newUnitId, newCourseVersionId);
-      // TODO: TEACH-1938 Pass the newCourseVersionId to the progress API
-      // loadUnitProgress(newUnitId, newCourseVersionId, sectionId);
-      loadUnitProgress(newUnitId, sectionId);
+      loadUnitProgress(newUnitId, sectionId, courseId, unitPosition);
 
       recordEvent('change_script', sectionId, {
         old_script_id: unitId,
@@ -75,7 +77,7 @@ function UnitSelectorV2({
         unitId: newUnitId,
       });
     },
-    [unitId, setUnit, sectionId]
+    [unitId, setUnit, sectionId, courseId, unitPosition]
   );
 
   const itemGroups = coursesWithProgress
@@ -132,6 +134,8 @@ UnitSelectorV2.propTypes = {
   filterToSelectedCourse: PropTypes.bool,
   unitId: PropTypes.number,
   courseVersionId: PropTypes.number,
+  courseId: PropTypes.number,
+  unitPosition: PropTypes.number,
   sectionId: PropTypes.number,
   coursesWithProgress: PropTypes.array.isRequired,
   setUnit: PropTypes.func.isRequired,
@@ -148,6 +152,8 @@ export default connect(
   state => ({
     unitId: state.unitSelection.scriptId,
     courseVersionId: state.unitSelection.courseVersionId,
+    courseId: getSelectedCourseId(state),
+    unitPosition: getSelectedUnitPosition(state),
     sectionId: state.teacherSections.selectedSectionId,
     coursesWithProgress: state.unitSelection.coursesWithProgress,
     isLoadingCourses: state.unitSelection.isLoadingCoursesWithProgress,

--- a/apps/src/templates/UnitSelectorV2.jsx
+++ b/apps/src/templates/UnitSelectorV2.jsx
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {getStore} from '@cdo/apps/redux';
 import {
   asyncLoadCoursesWithProgress,
   setUnit,
@@ -64,7 +65,10 @@ function UnitSelectorV2({
         .split('-')
         .map(id => parseInt(id));
       setUnit(newUnitId, newCourseVersionId);
-      loadUnitProgress(newUnitId, sectionId, courseId, unitPosition);
+      const currentState = getStore().getState();
+      const newCourseId = getSelectedCourseId(currentState);
+      const newUnitPosition = getSelectedUnitPosition(currentState);
+      loadUnitProgress(newUnitId, sectionId, newCourseId, newUnitPosition);
 
       recordEvent('change_script', sectionId, {
         old_script_id: unitId,
@@ -77,7 +81,7 @@ function UnitSelectorV2({
         unitId: newUnitId,
       });
     },
-    [unitId, setUnit, sectionId, courseId, unitPosition]
+    [unitId, setUnit, sectionId]
   );
 
   const itemGroups = coursesWithProgress

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -6,7 +6,11 @@ import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import logToCloud from '@cdo/apps/logToCloud';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
+import {
+  getSelectedCourseId,
+  getSelectedUnitPosition,
+  setUnit,
+} from '@cdo/apps/redux/unitSelectionRedux';
 import ProgressTableView from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableView';
 import SectionProgressToggle from '@cdo/apps/templates/sectionProgress/SectionProgressToggle';
 import StandardsView from '@cdo/apps/templates/sectionProgress/standards/StandardsView';
@@ -43,6 +47,8 @@ class SectionProgress extends Component {
     //Provided by redux
     scriptId: PropTypes.number,
     courseVersionId: PropTypes.number,
+    courseId: PropTypes.number,
+    unitPosition: PropTypes.number,
     sectionId: PropTypes.number,
     currentView: PropTypes.oneOf(Object.values(ViewType)),
     setCurrentView: PropTypes.func.isRequired,
@@ -64,8 +70,13 @@ class SectionProgress extends Component {
   }
 
   componentDidMount() {
-    if (this.props.scriptId) {
-      loadUnitProgress(this.props.scriptId, this.props.sectionId)?.then(() => {
+    if (this.props.scriptId && this.props.courseId && this.props.unitPosition) {
+      loadUnitProgress(
+        this.props.scriptId,
+        this.props.sectionId,
+        this.props.courseId,
+        this.props.unitPosition
+      )?.then(() => {
         this.setState(state => ({
           ...state,
           loadedSectionId: this.props.sectionId,
@@ -77,9 +88,16 @@ class SectionProgress extends Component {
   componentDidUpdate(prevProps) {
     if (
       prevProps.scriptId !== this.props.scriptId ||
-      prevProps.sectionId !== this.props.sectionId
+      prevProps.sectionId !== this.props.sectionId ||
+      prevProps.courseId !== this.props.courseId ||
+      prevProps.unitPosition !== this.props.unitPosition
     ) {
-      loadUnitProgress(this.props.scriptId, this.props.sectionId)?.then(() => {
+      loadUnitProgress(
+        this.props.scriptId,
+        this.props.sectionId,
+        this.props.courseId,
+        this.props.unitPosition
+      )?.then(() => {
         this.setState(state => ({
           ...state,
           loadedSectionId: this.props.sectionId,
@@ -322,6 +340,8 @@ export default connect(
   state => ({
     scriptId: state.unitSelection.scriptId,
     courseVersionId: state.unitSelection.courseVersionId,
+    courseId: getSelectedCourseId(state),
+    unitPosition: getSelectedUnitPosition(state),
     sectionId: state.teacherSections.selectedSectionId,
     currentView: state.sectionProgress.currentView,
     scriptData: getCurrentUnitData(state),

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -24,7 +24,7 @@ import {
 
 const NUM_STUDENTS_PER_PAGE = 20;
 
-export function loadUnitProgress(scriptId, sectionId) {
+export function loadUnitProgress(scriptId, sectionId, courseId, unitPosition) {
   const state = getStore().getState().sectionProgress;
   const sectionData = getStore().getState().teacherSections.sections[sectionId];
   const students = getStore().getState().teacherSections.selectedStudents;
@@ -59,12 +59,12 @@ export function loadUnitProgress(scriptId, sectionId) {
     studentLastUpdateByUnit: {},
   };
 
-  // Get the script data
-  // TODO: TEACH-1865
-  // Use /dashboardapi/script_structure/courses/:course_name/units/:unit_position
-  const scriptRequest = fetch(`/dashboardapi/script_structure/${scriptId}`, {
-    credentials: 'include',
-  })
+  const scriptRequest = fetch(
+    `/dashboardapi/script_structure/courses/${courseId}/units/${unitPosition}`,
+    {
+      credentials: 'include',
+    }
+  )
     .then(response => response.json())
     .then(scriptData => {
       structureLatencyMs = new Date().getTime() - startTime;

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -49,6 +49,7 @@ export function loadUnitProgress(scriptId, sectionId, courseId, unitPosition) {
     logToCloud.addPageAction(logToCloud.PageAction.LoadScriptProgressStarted, {
       sectionId,
       scriptId,
+      courseId,
     });
   }
 

--- a/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
@@ -61,8 +61,17 @@ function StandardsReport({
         window.opener.teacherDashboardStoreInformation.scriptId;
       const courseVersionIdFromTD =
         window.opener.teacherDashboardStoreInformation.courseVersionId;
+      const courseIdFromTD =
+        window.opener.teacherDashboardStoreInformation.courseId;
+      const unitPositionFromTD =
+        window.opener.teacherDashboardStoreInformation.unitPosition;
       setUnit(scriptIdFromTD, courseVersionIdFromTD);
-      loadUnitProgress(scriptIdFromTD, sectionId, courseId, unitPosition);
+      loadUnitProgress(
+        scriptIdFromTD,
+        sectionId,
+        courseIdFromTD,
+        unitPositionFromTD
+      );
     } catch (e) {
       throw new Error(
         '/standards_report must be opened from the `generate PDF report` button of the Standards tab on the v1 progress page on a section assigned to curriculum that has standards (e.g. `Course C (2023)`).'

--- a/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
@@ -9,6 +9,8 @@ import {
   getSelectedScriptFriendlyName,
   getSelectedScriptDescription,
   setUnit,
+  getSelectedCourseId,
+  getSelectedUnitPosition,
 } from '@cdo/apps/redux/unitSelectionRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {getCurrentUnitData} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
@@ -34,6 +36,8 @@ import StandardsReportHeader from './StandardsReportHeader';
 
 function StandardsReport({
   scriptId,
+  courseId,
+  unitPosition,
   sectionId,
   scriptFriendlyName,
   scriptData,
@@ -58,13 +62,20 @@ function StandardsReport({
       const courseVersionIdFromTD =
         window.opener.teacherDashboardStoreInformation.courseVersionId;
       setUnit(scriptIdFromTD, courseVersionIdFromTD);
-      loadUnitProgress(scriptIdFromTD, sectionId);
+      loadUnitProgress(scriptIdFromTD, sectionId, courseId, unitPosition);
     } catch (e) {
       throw new Error(
         '/standards_report must be opened from the `generate PDF report` button of the Standards tab on the v1 progress page on a section assigned to curriculum that has standards (e.g. `Course C (2023)`).'
       );
     }
-  }, [sectionId, setTeacherCommentForReport, setUnit, numStudentsInSection]);
+  }, [
+    sectionId,
+    setTeacherCommentForReport,
+    setUnit,
+    numStudentsInSection,
+    courseId,
+    unitPosition,
+  ]);
 
   const getLinkToOverview = () => {
     return scriptData ? `${scriptData.path}?section_id=${sectionId}` : null;
@@ -179,6 +190,8 @@ function StandardsReport({
 StandardsReport.propTypes = {
   //redux
   scriptId: PropTypes.number,
+  courseId: PropTypes.number,
+  unitPosition: PropTypes.number,
   sectionId: PropTypes.number.isRequired,
   scriptFriendlyName: PropTypes.string.isRequired,
   scriptData: unitDataPropType,
@@ -224,6 +237,8 @@ const styles = {
 export default connect(
   state => ({
     scriptId: state.unitSelection.scriptId,
+    courseId: getSelectedCourseId(state),
+    unitPosition: getSelectedUnitPosition(state),
     sectionId: state.teacherSections.selectedSectionId,
     scriptData: getCurrentUnitData(state),
     scriptFriendlyName: getSelectedScriptFriendlyName(state),

--- a/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
@@ -6,6 +6,10 @@ import {connect} from 'react-redux';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {
+  getSelectedCourseId,
+  getSelectedUnitPosition,
+} from '@cdo/apps/redux/unitSelectionRedux';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
@@ -29,6 +33,8 @@ class StandardsViewHeaderButtons extends Component {
     setTeacherCommentForReport: PropTypes.func.isRequired,
     scriptId: PropTypes.number,
     courseVersionId: PropTypes.number,
+    courseId: PropTypes.number,
+    unitPosition: PropTypes.number,
     selectedLessons: PropTypes.array.isRequired,
     unpluggedLessons: PropTypes.array.isRequired,
     fetchStudentLevelScores: PropTypes.func,
@@ -99,6 +105,8 @@ class StandardsViewHeaderButtons extends Component {
       teacherComment: this.state.comment,
       scriptId: this.props.scriptId,
       courseVersionId: this.props.courseVersionId,
+      courseId: this.props.courseId,
+      unitPosition: this.props.unitPosition,
     };
     firehoseClient.putRecord(
       {
@@ -219,6 +227,8 @@ export default connect(
   state => ({
     scriptId: state.unitSelection.scriptId,
     courseVersionId: state.unitSelection.courseVersionId,
+    courseId: getSelectedCourseId(state),
+    unitPosition: getSelectedUnitPosition(state),
     selectedLessons: state.sectionStandardsProgress.selectedLessons,
     unpluggedLessons: getUnpluggedLessonsForScript(state),
   }),

--- a/apps/src/templates/sectionProgressV2/ProgressTableV2.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressTableV2.jsx
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
+import {
+  getSelectedCourseId,
+  getSelectedUnitPosition,
+} from '@cdo/apps/redux/unitSelectionRedux';
 import {studentShape} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import stringKeyComparator from '@cdo/apps/util/stringKeyComparator';
 
@@ -34,6 +38,8 @@ function ProgressTableV2({
   expandedLessonIds,
   isSkeleton,
   unitId,
+  courseId,
+  unitPosition,
   levelProgressByStudent,
   isLoadingSectionData,
 }) {
@@ -51,9 +57,17 @@ function ProgressTableV2({
 
   React.useEffect(() => {
     if (!isSkeleton && filteredStudents.length !== students.length) {
-      loadUnitProgress(unitId, sectionId);
+      loadUnitProgress(unitId, sectionId, courseId, unitPosition);
     }
-  }, [filteredStudents, students, unitId, sectionId, isSkeleton]);
+  }, [
+    filteredStudents,
+    students,
+    unitId,
+    sectionId,
+    isSkeleton,
+    courseId,
+    unitPosition,
+  ]);
 
   const sortedStudents = React.useMemo(() => {
     if (isSkeleton && filteredStudents.length === 0) {
@@ -171,6 +185,8 @@ ProgressTableV2.propTypes = {
   expandedLessonIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   isSkeleton: PropTypes.bool,
   unitId: PropTypes.number,
+  courseId: PropTypes.number,
+  unitPosition: PropTypes.number,
   levelProgressByStudent: PropTypes.objectOf(
     PropTypes.objectOf(studentLevelProgressType)
   ),
@@ -183,6 +199,8 @@ export default connect(state => ({
   students: state.teacherSections.selectedStudents,
   unitData: getCurrentUnitData(state),
   unitId: state.unitSelection.scriptId,
+  courseId: getSelectedCourseId(state),
+  unitPosition: getSelectedUnitPosition(state),
   levelProgressByStudent:
     state.sectionProgress.studentLevelProgressByUnit[
       state.unitSelection.scriptId

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -10,7 +10,6 @@ import {
   getSelectedCourseId,
   getSelectedUnitPosition,
 } from '@cdo/apps/redux/unitSelectionRedux';
-import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
 import {unitDataPropType} from '../sectionProgress/sectionProgressConstants';

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -6,6 +6,11 @@ import {useParams} from 'react-router-dom';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {
+  getSelectedCourseId,
+  getSelectedUnitPosition,
+} from '@cdo/apps/redux/unitSelectionRedux';
+import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
 import {unitDataPropType} from '../sectionProgress/sectionProgressConstants';
@@ -26,6 +31,8 @@ import styles from './progress-table-v2.module.scss';
 function SectionProgressV2({
   scriptId,
   sectionId,
+  courseId,
+  unitPosition,
   unitData,
   isLoadingProgress,
   isRefreshingProgress,
@@ -68,9 +75,11 @@ function SectionProgressV2({
       !isRefreshingProgress &&
       sectionId &&
       scriptId &&
+      courseId &&
+      unitPosition &&
       isMounted // only update loaded data if component is still mounted.
     ) {
-      loadUnitProgress(scriptId, sectionId).then(() =>
+      loadUnitProgress(scriptId, sectionId, courseId, unitPosition).then(() =>
         setLoadedData({scriptId, sectionId})
       );
     }
@@ -80,6 +89,8 @@ function SectionProgressV2({
   }, [
     scriptId,
     sectionId,
+    courseId,
+    unitPosition,
     unitData,
     isLoadingProgress,
     isRefreshingProgress,
@@ -140,6 +151,8 @@ function SectionProgressV2({
 SectionProgressV2.propTypes = {
   scriptId: PropTypes.number,
   sectionId: PropTypes.number,
+  courseId: PropTypes.number,
+  unitPosition: PropTypes.number,
   unitData: unitDataPropType,
   isLoadingProgress: PropTypes.bool.isRequired,
   isRefreshingProgress: PropTypes.bool.isRequired,
@@ -154,6 +167,8 @@ export default connect(
   state => ({
     scriptId: state.unitSelection.scriptId,
     sectionId: state.teacherSections.selectedSectionId,
+    courseId: getSelectedCourseId(state),
+    unitPosition: getSelectedUnitPosition(state),
     unitData: getCurrentUnitData(state),
     isLoadingProgress: state.sectionProgress.isLoadingProgress,
     isRefreshingProgress: state.sectionProgress.isRefreshingProgress,

--- a/apps/src/templates/teacherDashboard/teacherDashboardTestHelpers.js
+++ b/apps/src/templates/teacherDashboard/teacherDashboardTestHelpers.js
@@ -475,17 +475,19 @@ export const fakeCoursesWithProgress = [
     units: [
       {
         id: 2,
+        course_id: 4,
         version_year: '2018',
         key: 'coursea-2018',
         name: 'Course A (2018)',
-        position: null,
+        position: 1,
       },
       {
         id: 1,
+        course_id: 1,
         version_year: '2017',
         key: 'coursea-2017',
         name: 'Course A (2017)',
-        position: null,
+        position: 1,
       },
     ],
   },
@@ -495,6 +497,7 @@ export const fakeCoursesWithProgress = [
     units: [
       {
         id: 5,
+        course_id: 2,
         version_year: null,
         key: 'csd1-2018',
         name: 'Unit 1',
@@ -502,6 +505,7 @@ export const fakeCoursesWithProgress = [
       },
       {
         id: 6,
+        course_id: 2,
         version_year: null,
         key: 'csd2-2018',
         name: 'Unit 2',
@@ -515,6 +519,7 @@ export const fakeCoursesWithProgress = [
     units: [
       {
         id: 9,
+        course_id: 3,
         version_year: 'unversioned',
         key: 'flappy',
         name: 'Flappy',

--- a/apps/test/unit/redux/unitSelectionReduxTest.js
+++ b/apps/test/unit/redux/unitSelectionReduxTest.js
@@ -40,26 +40,26 @@ describe('unitSelectionRedux', () => {
         };
         expect(getSelectedUnitName(state)).toBeNull();
       });
+    });
 
-      describe('with section selected', () => {
-        it('returns the script name of the selected script', () => {
-          const state = {
-            unitSelection: {
-              scriptId: 5,
-              courseVersionId: 2,
-              coursesWithProgress: fakeCoursesWithProgress,
-            },
-            teacherSections: {
-              selectedSectionId: 99,
-              sections: {
-                99: {
-                  courseVersionId: 2,
-                },
+    describe('with section selected', () => {
+      it('returns the script name of the selected script', () => {
+        const state = {
+          unitSelection: {
+            scriptId: 5,
+            courseVersionId: 2,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+          teacherSections: {
+            selectedSectionId: 99,
+            sections: {
+              99: {
+                courseVersionId: 2,
               },
             },
-          };
-          expect(getSelectedUnitName(state)).toEqual('csd1-2018');
-        });
+          },
+        };
+        expect(getSelectedUnitName(state)).toEqual('csd1-2018');
       });
     });
 
@@ -87,60 +87,106 @@ describe('unitSelectionRedux', () => {
         expect(getSelectedScriptDescription(state)).toEqual(null);
       });
     });
+  });
 
-    describe('getSelectedUnitPosition', () => {
-      describe('with no section selected', () => {
-        it('returns the script name of the selected script', () => {
-          const state = {
-            unitSelection: {
-              scriptId: 5,
-              courseVersionId: 2,
-              coursesWithProgress: fakeCoursesWithProgress,
-            },
-          };
-          expect(getSelectedUnitPosition(state)).toEqual(1);
-        });
-
-        it('returns null if no script is selected', () => {
-          const state = {
-            unitSelection: {
-              scriptId: null,
-              coursesWithProgress: fakeCoursesWithProgress,
-            },
-          };
-          expect(getSelectedUnitPosition(state)).toBeNull();
-        });
+  describe('getSelectedUnitPosition', () => {
+    describe('with no section selected', () => {
+      it('returns the script name of the selected script', () => {
+        const state = {
+          unitSelection: {
+            scriptId: 5,
+            courseVersionId: 2,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+        };
+        expect(getSelectedUnitPosition(state)).toEqual(1);
       });
 
-      describe('with section selected', () => {
-        it('returns the script name of the selected script', () => {
-          const state = {
-            unitSelection: {
-              scriptId: 5,
-              courseVersionId: 2,
-              coursesWithProgress: fakeCoursesWithProgress,
-            },
-            teacherSections: {
-              selectedSectionId: 99,
-              sections: {
-                99: {
-                  courseVersionId: 2,
-                },
-              },
-            },
-          };
-          expect(getSelectedUnitPosition(state)).toEqual(1);
-        });
+      it('returns null if no script is selected', () => {
+        const state = {
+          unitSelection: {
+            scriptId: null,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+        };
+        expect(getSelectedUnitPosition(state)).toBeNull();
       });
     });
 
-    describe('setUnit', () => {
-      it('sets the Unit', () => {
-        const action = setUnit(130, 999);
-        const nextState = unitSelection(initialState, action);
-        expect(nextState.scriptId).toEqual(130);
-        expect(nextState.courseVersionId).toEqual(999);
+    describe('with section selected', () => {
+      it('returns the script name of the selected script', () => {
+        const state = {
+          unitSelection: {
+            scriptId: 5,
+            courseVersionId: 2,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+          teacherSections: {
+            selectedSectionId: 99,
+            sections: {
+              99: {
+                courseVersionId: 2,
+              },
+            },
+          },
+        };
+        expect(getSelectedUnitPosition(state)).toEqual(1);
       });
+    });
+  });
+
+  describe('getSelectedCourseId', () => {
+    describe('with no section selected', () => {
+      it('returns the course id of the selected script', () => {
+        const state = {
+          unitSelection: {
+            scriptId: 2,
+            courseVersionId: 1,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+        };
+        expect(getSelectedCourseId(state)).toEqual(4);
+      });
+
+      it('returns null if no script is selected', () => {
+        const state = {
+          unitSelection: {
+            scriptId: null,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+        };
+        expect(getSelectedCourseId(state)).toBeNull();
+      });
+    });
+
+    describe('with section selected', () => {
+      it('returns the course id of the selected script', () => {
+        const state = {
+          unitSelection: {
+            scriptId: 2,
+            courseVersionId: 1,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+          teacherSections: {
+            selectedSectionId: 99,
+            sections: {
+              99: {
+                courseVersionId: 2,
+              },
+            },
+          },
+        };
+        expect(getSelectedCourseId(state)).toEqual(4);
+      });
+    });
+  });
+
+  describe('setUnit', () => {
+    it('sets the Unit', () => {
+      const action = setUnit(130, 999);
+      const nextState = unitSelection(initialState, action);
+      expect(nextState.scriptId).toEqual(130);
+      expect(nextState.courseVersionId).toEqual(999);
     });
   });
 });

--- a/apps/test/unit/redux/unitSelectionReduxTest.js
+++ b/apps/test/unit/redux/unitSelectionReduxTest.js
@@ -62,30 +62,30 @@ describe('unitSelectionRedux', () => {
         expect(getSelectedUnitName(state)).toEqual('csd1-2018');
       });
     });
+  });
 
-    describe('getSelectedScriptDescription', () => {
-      it('returns the script description of the selected script', () => {
-        const state = {
-          unitSelection: {
-            scriptId: 9,
-            courseVersionId: 3,
-            coursesWithProgress: fakeCoursesWithProgress,
-          },
-        };
-        expect(getSelectedScriptDescription(state)).toEqual(
-          'Make a flappy game!'
-        );
-      });
+  describe('getSelectedScriptDescription', () => {
+    it('returns the script description of the selected script', () => {
+      const state = {
+        unitSelection: {
+          scriptId: 9,
+          courseVersionId: 3,
+          coursesWithProgress: fakeCoursesWithProgress,
+        },
+      };
+      expect(getSelectedScriptDescription(state)).toEqual(
+        'Make a flappy game!'
+      );
+    });
 
-      it('returns null if no script is selected', () => {
-        const state = {
-          unitSelection: {
-            scriptId: null,
-            coursesWithProgress: fakeCoursesWithProgress,
-          },
-        };
-        expect(getSelectedScriptDescription(state)).toEqual(null);
-      });
+    it('returns null if no script is selected', () => {
+      const state = {
+        unitSelection: {
+          scriptId: null,
+          coursesWithProgress: fakeCoursesWithProgress,
+        },
+      };
+      expect(getSelectedScriptDescription(state)).toEqual(null);
     });
   });
 

--- a/apps/test/unit/redux/unitSelectionReduxTest.js
+++ b/apps/test/unit/redux/unitSelectionReduxTest.js
@@ -4,6 +4,7 @@ import unitSelection, {
   getSelectedUnitPosition,
   getSelectedScriptDescription,
   setCoursesWithProgress,
+  getSelectedCourseId,
 } from '@cdo/apps/redux/unitSelectionRedux';
 import {fakeCoursesWithProgress} from '@cdo/apps/templates/teacherDashboard/teacherDashboardTestHelpers';
 

--- a/apps/test/unit/templates/UnitSelectorV2Test.jsx
+++ b/apps/test/unit/templates/UnitSelectorV2Test.jsx
@@ -5,6 +5,11 @@ import {fakeCoursesWithProgress} from '@cdo/apps/templates/teacherDashboard/teac
 import {UnconnectedUnitSelectorV2} from '@cdo/apps/templates/UnitSelectorV2';
 
 jest.mock('@cdo/apps/templates/sectionProgress/sectionProgressLoader');
+jest.mock('@cdo/apps/redux/unitSelectionRedux', () => ({
+  ...jest.requireActual('@cdo/apps/redux/unitSelectionRedux'),
+  getSelectedCourseId: jest.fn(() => 123),
+  getSelectedUnitPosition: jest.fn(() => 1),
+}));
 
 const DEFAULT_PROPS = {
   coursesWithProgress: fakeCoursesWithProgress,

--- a/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
+++ b/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
@@ -16,6 +16,8 @@ const DEFAULT_PROPS = {
   setCurrentView: () => {},
   setUnit: () => {},
   scriptId: 123,
+  courseId: 1,
+  unitPosition: 1,
   sectionId: 2,
   currentView: ViewType.SUMMARY,
   scriptData: {

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -315,7 +315,7 @@ describe('sectionProgressLoader.loadScript', () => {
         }),
       });
 
-      loadUnitProgress(0, selectedSectionId);
+      loadUnitProgress(0, selectedSectionId, 0, 0);
       expect(startLoadingProgressStub).to.have.not.been.called;
       expect(startRefreshingProgressStub).to.have.been.calledOnce;
       expect(addDataByUnitStub).to.have.been.calledOnce;
@@ -363,7 +363,7 @@ describe('sectionProgressLoader.loadScript', () => {
           then: sinon.stub().callsArgWith(0, secondServerProgressResponse),
         }),
       });
-      loadUnitProgress(123, selectedSectionId);
+      loadUnitProgress(123, selectedSectionId, 1, 1);
       expect(addDataByUnitStub).to.have.been.calledWith(fullExpectedResult);
       progressHelpers.processedLevel.restore();
     });
@@ -403,7 +403,7 @@ describe('sectionProgressLoader.loadScript', () => {
           }),
         });
 
-        loadUnitProgress(0, selectedSectionId);
+        loadUnitProgress(0, selectedSectionId, 0, 0);
         expect(startLoadingProgressStub).to.have.been.calledOnce;
         expect(startRefreshingProgressStub).to.have.not.been.called;
         expect(addDataByUnitStub).to.have.been.calledOnce;
@@ -448,7 +448,7 @@ describe('sectionProgressLoader.loadScript', () => {
             then: sinon.stub().callsArgWith(0, {}),
           }),
         });
-        loadUnitProgress(0, selectedSectionId);
+        loadUnitProgress(0, selectedSectionId, 0, 0);
         expect(addDataByUnitStub).to.have.been.calledWith(expectedResult);
         progressHelpers.processedLevel.restore();
       });
@@ -466,7 +466,7 @@ describe('sectionProgressLoader.loadScript', () => {
             then: sinon.stub().callsArgWith(0, serverProgressResponse),
           }),
         });
-        loadUnitProgress(123, selectedSectionId);
+        loadUnitProgress(123, selectedSectionId, 1, 1);
         expect(addDataByUnitStub).to.have.been.calledWith(fullExpectedResult);
         progressHelpers.processedLevel.restore();
       });
@@ -489,7 +489,7 @@ describe('sectionProgressLoader.loadScript', () => {
             then: sinon.stub().callsArgWith(0, serverProgressResponse),
           }),
         });
-        loadUnitProgress(123, selectedSectionId);
+        loadUnitProgress(123, selectedSectionId, 1, 1);
         expect(addDataByUnitStub).to.have.been.calledWith(fullExpectedResult);
         progressHelpers.processedLevel.restore();
       });
@@ -517,7 +517,7 @@ describe('sectionProgressLoader.loadScript', () => {
             then: sinon.stub().callsArgWith(0, serverProgressResponse),
           }),
         });
-        loadUnitProgress(123, selectedSectionId);
+        loadUnitProgress(123, selectedSectionId, 1, 1);
         expect(addDataByUnitStub).to.have.been.calledWith(expectedResult);
         progressHelpers.processedLevel.restore();
       });

--- a/apps/test/unit/templates/sectionProgressV2/ProgressTableV2Test.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressTableV2Test.jsx
@@ -29,6 +29,8 @@ const SECTION_ID = 11;
 const UNIT_DATA = getScriptData(5);
 const DEFAULT_PROPS = {
   isSkeleton: false,
+  courseId: 2,
+  unitPositon: 3,
 };
 
 const LESSON_ID_1 = UNIT_DATA.lessons[0].id;

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -2001,6 +2001,7 @@ class Unit < ApplicationRecord
     unit_group_unit ||= unit_group_units&.first
     {
       id: id,
+      course_id: unit_group_unit&.course_id,
       key: name,
       version_year: version_year,
       name: launched? ? localized_title : localized_title + " *",

--- a/dashboard/test/ui/features/teacher_tools/modular_courses.feature
+++ b/dashboard/test/ui/features/teacher_tools/modular_courses.feature
@@ -99,6 +99,8 @@ Feature: Using Modular Courses
 
     Then I select the "Course 2019" option in dropdown "uitest-sidebar-section-dropdown"
     And I wait until element "#ui-test-progress-table-v2" is visible
+    And I wait until element "#unit-selector-v2" is visible
+    And I select the "UI Test Shared Unit" option in dropdown "unit-selector-v2"
     And I wait until element "#ui-test-lesson-header-1" is visible
     And I click selector "#ui-test-lesson-header-1"
     And I wait until element "#ui-test-courses-ui-test-course-2019-units-3-lessons-1-levels-1-cell-data" is visible

--- a/dashboard/test/ui/features/teacher_tools/modular_courses.feature
+++ b/dashboard/test/ui/features/teacher_tools/modular_courses.feature
@@ -94,7 +94,7 @@ Feature: Using Modular Courses
     And I select the "UI Test Shared Unit" option in dropdown "unit-selector-v2"
     And I wait until element "#ui-test-lesson-header-1" is visible
     And I click selector "#ui-test-lesson-header-1"
-    And I wait until element "#ui-test-courses-ui-test-course-2017-units-1-lessons-1-levels-1-cell-data" is visible
+    And I wait until element "#ui-test-courses-ui-test-course-2017-units-3-lessons-1-levels-1-cell-data" is visible
     Then I see no difference for "modular course progress - first section"
 
     Then I select the "Course 2019" option in dropdown "uitest-sidebar-section-dropdown"
@@ -103,7 +103,7 @@ Feature: Using Modular Courses
     And I select the "UI Test Shared Unit" option in dropdown "unit-selector-v2"
     And I wait until element "#ui-test-lesson-header-1" is visible
     And I click selector "#ui-test-lesson-header-1"
-    And I wait until element "#ui-test-courses-ui-test-course-2019-units-1-lessons-1-levels-1-cell-data" is visible
+    And I wait until element "#ui-test-courses-ui-test-course-2019-units-3-lessons-1-levels-1-cell-data" is visible
     Then I see no difference for "modular course progress - second section"
 
     And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/modular_courses.feature
+++ b/dashboard/test/ui/features/teacher_tools/modular_courses.feature
@@ -99,8 +99,6 @@ Feature: Using Modular Courses
 
     Then I select the "Course 2019" option in dropdown "uitest-sidebar-section-dropdown"
     And I wait until element "#ui-test-progress-table-v2" is visible
-    And I wait until element "#unit-selector-v2" is visible
-    And I select the "UI Test Shared Unit" option in dropdown "unit-selector-v2"
     And I wait until element "#ui-test-lesson-header-1" is visible
     And I click selector "#ui-test-lesson-header-1"
     And I wait until element "#ui-test-courses-ui-test-course-2019-units-3-lessons-1-levels-1-cell-data" is visible

--- a/dashboard/test/ui/features/teacher_tools/modular_courses.feature
+++ b/dashboard/test/ui/features/teacher_tools/modular_courses.feature
@@ -2,6 +2,7 @@
 Feature: Using Modular Courses
   Background:
     Given I am on "http://studio.code.org/home"
+    When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
 
   Scenario: Navigating within modular courses
     Given I create a teacher named "Teacher_Sally"
@@ -88,15 +89,21 @@ Feature: Using Modular Courses
     And I sign in as "Teacher_Sally" and go home
 
     And I click selector "a:contains(Course 2017)" once I see it to load a new page
-    And I wait until element ".progress-table" is visible
-    And I wait until element "#uitest-course-dropdown" is visible
-    And I select the "UI Test Shared Unit" option in dropdown "uitest-course-dropdown"
+    And I wait until element "#ui-test-progress-table-v2" is visible
+    And I wait until element "#unit-selector-v2" is visible
+    And I select the "UI Test Shared Unit" option in dropdown "unit-selector-v2"
+    And I wait until element "#ui-test-lesson-header-1" is visible
+    And I click selector "#ui-test-lesson-header-1"
+    And I wait until element "#ui-test-courses-ui-test-course-2017-units-1-lessons-1-levels-1-cell-data" is visible
     Then I see no difference for "modular course progress - first section"
 
     Then I select the "Course 2019" option in dropdown "uitest-sidebar-section-dropdown"
-    And I wait until element ".progress-table" is visible
-    And I wait until element "#uitest-course-dropdown" is visible
-    And I select the "UI Test Shared Unit" option in dropdown "uitest-course-dropdown"
+    And I wait until element "#ui-test-progress-table-v2" is visible
+    And I wait until element "#unit-selector-v2" is visible
+    And I select the "UI Test Shared Unit" option in dropdown "unit-selector-v2"
+    And I wait until element "#ui-test-lesson-header-1" is visible
+    And I click selector "#ui-test-lesson-header-1"
+    And I wait until element "#ui-test-courses-ui-test-course-2019-units-1-lessons-1-levels-1-cell-data" is visible
     Then I see no difference for "modular course progress - second section"
 
     And I close my eyes


### PR DESCRIPTION
Depends on https://github.com/code-dot-org/code-dot-org/pull/66364

Right now, the links on the progress page always defaults to the original course URL instead of the current course's URL. This PR updates the method to use the currently selected course instead. 
<img width="500" height="226" alt="Screenshot 2025-07-17 at 10 36 09 AM" src="https://github.com/user-attachments/assets/a999eabf-0e08-4eca-81cf-39b1d91338b1" />
<img width="881" height="430" alt="Screenshot 2025-07-17 at 10 36 44 AM" src="https://github.com/user-attachments/assets/e601be49-5332-400a-9214-efb8ceee1264" />



## Links
Jira: [TEACH-1865](https://codedotorg.atlassian.net/browse/TEACH-1865)


## Testing story
Manually verified and updated unit/UI tests
