### PR TITLE
Implement SectionParticipation concern

### DIFF
--- a/dashboard/app/models/concerns/user/section_participation.rb
+++ b/dashboard/app/models/concerns/user/section_participation.rb
@@ -1,0 +1,36 @@
+module User::SectionParticipation
+  extend ActiveSupport::Concern
+
+  def all_sections
+    sections_as_teacher = student? ? [] : sections_instructed.to_a
+    sections_as_teacher.concat(sections_as_student).uniq
+  end
+
+  # Figures out the unique set of courses assigned to sections that this user
+  # is a part of.
+  # @return [Array<Course>]
+  def section_courses
+    # In the future we may want to make it so that if assigned a script, but that
+    # script has a default course, it shows up as a course here
+    all_sections.filter_map(&:unit_group).uniq
+  end
+
+  def sections_as_student_participant
+    sections_as_student.select {|s| !s.pl_section?}
+  end
+
+  def sections_as_pl_participant
+    sections_as_student.select(&:pl_section?)
+  end
+
+  # return the id of the most-recently-created section the user instructs.
+  def last_section_id
+    teacher? ? sections_instructed.where(hidden: false).last&.id : nil
+  end
+
+  # The section which the user most recently joined as a student, or nil if none exists.
+  # @return [Section|nil]
+  def last_joined_section
+    Follower.where(student_user: self).order(created_at: :desc).first.try(:section)
+  end
+end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -102,6 +102,7 @@ class User < ApplicationRecord
   include ProviderFlags
   include Verifiable
   include Age
+  include SectionParticipation
   include PartialRegistration
   include Rails.application.routes.url_helpers
 
@@ -1277,28 +1278,6 @@ class User < ApplicationRecord
     user_course_data + user_script_data
   end
 
-  def sections_as_student_participant
-    sections_as_student.select {|s| !s.pl_section?}
-  end
-
-  def sections_as_pl_participant
-    sections_as_student.select(&:pl_section?)
-  end
-
-  def all_sections
-    sections_as_teacher = student? ? [] : sections_instructed.to_a
-    sections_as_teacher.concat(sections_as_student).uniq
-  end
-
-  # Figures out the unique set of courses assigned to sections that this user
-  # is a part of.
-  # @return [Array<Course>]
-  def section_courses
-    # In the future we may want to make it so that if assigned a script, but that
-    # script has a default course, it shows up as a course here
-    all_sections.filter_map(&:unit_group).uniq
-  end
-
   def visible_scripts
     scripts.map(&:cached).select {|s| [Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview].include?(s.get_published_state)}
   end
@@ -1317,17 +1296,6 @@ class User < ApplicationRecord
     end
 
     all_scripts
-  end
-
-  # return the id of the most-recently-created section the user instructs.
-  def last_section_id
-    teacher? ? sections_instructed.where(hidden: false).last&.id : nil
-  end
-
-  # The section which the user most recently joined as a student, or nil if none exists.
-  # @return [Section|nil]
-  def last_joined_section
-    Follower.where(student_user: self).order(created_at: :desc).first.try(:section)
   end
 
   # Returns integer days since account creation, rounded down

--- a/dashboard/test/models/concerns/user/section_participation_test.rb
+++ b/dashboard/test/models/concerns/user/section_participation_test.rb
@@ -2,12 +2,13 @@ require 'test_helper'
 
 class SectionParticipationTest < ActiveSupport::TestCase
   describe '#all_sections' do
+    subject(:all_sections) {user.all_sections}
     context 'when the user is a studnet' do
       let(:user) {create :student}
 
       it 'returns an empty array' do
-        _(user.all_sections).must_equal []
-        _(user.all_sections.length).must_equal 0
+        _(all_sections).must_equal []
+        _(all_sections.length).must_equal 0
       end
     end
 
@@ -24,17 +25,17 @@ class SectionParticipationTest < ActiveSupport::TestCase
       end
 
       it 'returns sections the user teaches' do
-        _(user.all_sections).must_include section1
-        _(user.all_sections).must_include section2
+        _(all_sections).must_include section1
+        _(all_sections).must_include section2
       end
 
       it 'returns sections the user is enrolled in as a student' do
-        _(user.all_sections).must_include section3
+        _(all_sections).must_include section3
       end
 
       it 'returns all sections the user is part of, regardless of role' do
-        _(user.all_sections).must_equal [section1, section2, section3]
-        _(user.all_sections.size).must_equal 3
+        _(all_sections).must_equal [section1, section2, section3]
+        _(all_sections.size).must_equal 3
       end
     end
   end
@@ -44,13 +45,17 @@ class SectionParticipationTest < ActiveSupport::TestCase
     let(:student) {create :student}
     let(:grand_teacher) {create :teacher}
     let(:unit_group) {create :unit_group, name: 'csd'}
+    subject(:section_courses) {teacher.section_courses}
 
     context 'when a teacher exists as a student in a section' do
       let!(:grand_section) {create :section, user: grand_teacher, unit_group: unit_group}
+      let(:courses) {section_courses}
+
+      before do
+        create :follower, section: grand_section, student_user_id: teacher.id, user: grand_teacher
+      end
 
       it 'returns the courses in which they are a part of' do
-        create :follower, section: grand_section, student_user_id: teacher.id, user: grand_teacher
-        courses = teacher.section_courses
         _(courses.length).must_equal 1
         _(courses.first.name).must_equal 'csd'
       end
@@ -58,10 +63,13 @@ class SectionParticipationTest < ActiveSupport::TestCase
 
     context 'when a teacher exists as a teacher in a section' do
       let!(:section) {create :section, user: teacher, unit_group: unit_group}
+      let(:courses) {section_courses}
+
+      before do
+        create :follower, section: section, student_user_id: student.id, user: teacher
+      end
 
       it 'returns the courses in which they are a part of' do
-        create :follower, section: section, student_user_id: student.id, user: teacher
-        courses = teacher.section_courses
         _(courses.length).must_equal 1
         _(courses.first.name).must_equal 'csd'
       end
@@ -69,10 +77,13 @@ class SectionParticipationTest < ActiveSupport::TestCase
 
     context 'when a student exists in a section' do
       let!(:section) {create :section, user: teacher, unit_group: unit_group}
+      let(:courses) {student.section_courses}
+
+      before do
+        create :follower, section: section, student_user_id: student.id, user: teacher
+      end
 
       it 'returns the courses in which they are a part of' do
-        create :follower, section: section, student_user_id: student.id, user: teacher
-        courses = student.section_courses
         _(courses.length).must_equal 1
         _(courses.first.name).must_equal 'csd'
       end
@@ -85,6 +96,7 @@ class SectionParticipationTest < ActiveSupport::TestCase
     let!(:section1) {create :section, user: section_teacher}
     let!(:section2) {create :section, :teacher_participants, user: section_teacher}
     let!(:section3) {create :section, :facilitator_participants, user: section_teacher}
+    subject(:sections_as_student_participant) {user.sections_as_student_participant}
 
     before do
       create :follower, section: section1, student_user_id: user.id, user: section_teacher
@@ -94,13 +106,13 @@ class SectionParticipationTest < ActiveSupport::TestCase
 
     context 'when the user is in multiple sections' do
       it 'returns the sections where participation_type is "student"' do
-        _(user.sections_as_student_participant).must_equal [section1]
-        _(user.sections_as_student_participant.length).must_equal 1
+        _(sections_as_student_participant).must_equal [section1]
+        _(sections_as_student_participant.length).must_equal 1
       end
 
       it 'does not return the pl sections' do
-        _(user.sections_as_student_participant).wont_include section2
-        _(user.sections_as_student_participant).wont_include section3
+        _(sections_as_student_participant).wont_include section2
+        _(sections_as_student_participant).wont_include section3
       end
     end
   end
@@ -111,6 +123,7 @@ class SectionParticipationTest < ActiveSupport::TestCase
     let!(:section1) {create :section, user: section_teacher}
     let!(:section2) {create :section, :teacher_participants, user: section_teacher}
     let!(:section3) {create :section, :facilitator_participants, user: section_teacher}
+    subject(:sections_as_pl_participant) {user.sections_as_pl_participant}
 
     before do
       create :follower, section: section1, student_user_id: user.id, user: section_teacher
@@ -120,12 +133,12 @@ class SectionParticipationTest < ActiveSupport::TestCase
 
     context 'when the user is in multiple sections' do
       it 'returns the pl sections' do
-        _(user.sections_as_pl_participant).must_equal [section2, section3]
-        _(user.sections_as_pl_participant.length).must_equal 2
+        _(sections_as_pl_participant).must_equal [section2, section3]
+        _(sections_as_pl_participant.length).must_equal 2
       end
 
       it 'does not return sections where participation type is "student"' do
-        _(user.sections_as_pl_participant).wont_include section1
+        _(sections_as_pl_participant).wont_include section1
       end
     end
   end

--- a/dashboard/test/models/concerns/user/section_participation_test.rb
+++ b/dashboard/test/models/concerns/user/section_participation_test.rb
@@ -1,0 +1,220 @@
+require 'test_helper'
+
+class SectionParticipationTest < ActiveSupport::TestCase
+  describe '#all_sections' do
+    context 'when the user is a studnet' do
+      let(:user) {create :student}
+
+      it 'returns an empty array' do
+        _(user.all_sections).must_equal []
+        _(user.all_sections.length).must_equal 0
+      end
+    end
+
+    context 'when the user is a teacher' do
+      let(:user) {create :teacher}
+      let(:secondary_teacher) {create :teacher}
+
+      let!(:section1) {create :section, user: user}
+      let!(:section2) {create :section, user: user}
+      let!(:section3) {create :section, user: secondary_teacher}
+
+      before do
+        create :follower, section: section3, student_user_id: user.id, user: secondary_teacher
+      end
+
+      it 'returns sections the user teaches' do
+        _(user.all_sections).must_include section1
+        _(user.all_sections).must_include section2
+      end
+
+      it 'returns sections the user is enrolled in as a student' do
+        _(user.all_sections).must_include section3
+      end
+
+      it 'returns all sections the user is part of, regardless of role' do
+        _(user.all_sections).must_equal [section1, section2, section3]
+        _(user.all_sections.size).must_equal 3
+      end
+    end
+  end
+
+  describe '#section_courses' do
+    let(:teacher) {create :teacher}
+    let(:student) {create :student}
+    let(:grand_teacher) {create :teacher}
+    let(:unit_group) {create :unit_group, name: 'csd'}
+
+    context 'when a teacher exists as a student in a section' do
+      let!(:grand_section) {create :section, user: grand_teacher, unit_group: unit_group}
+
+      it 'returns the courses in which they are a part of' do
+        create :follower, section: grand_section, student_user_id: teacher.id, user: grand_teacher
+        courses = teacher.section_courses
+        _(courses.length).must_equal 1
+        _(courses.first.name).must_equal 'csd'
+      end
+    end
+
+    context 'when a teacher exists as a teacher in a section' do
+      let!(:section) {create :section, user: teacher, unit_group: unit_group}
+
+      it 'returns the courses in which they are a part of' do
+        create :follower, section: section, student_user_id: student.id, user: teacher
+        courses = teacher.section_courses
+        _(courses.length).must_equal 1
+        _(courses.first.name).must_equal 'csd'
+      end
+    end
+
+    context 'when a student exists in a section' do
+      let!(:section) {create :section, user: teacher, unit_group: unit_group}
+
+      it 'returns the courses in which they are a part of' do
+        create :follower, section: section, student_user_id: student.id, user: teacher
+        courses = student.section_courses
+        _(courses.length).must_equal 1
+        _(courses.first.name).must_equal 'csd'
+      end
+    end
+  end
+
+  describe '#sections_as_student_participant' do
+    let(:section_teacher) {create :teacher}
+    let(:user) {create :user}
+    let!(:section1) {create :section, user: section_teacher}
+    let!(:section2) {create :section, :teacher_participants, user: section_teacher}
+    let!(:section3) {create :section, :facilitator_participants, user: section_teacher}
+
+    before do
+      create :follower, section: section1, student_user_id: user.id, user: section_teacher
+      create :follower, section: section2, student_user_id: user.id, user: section_teacher
+      create :follower, section: section3, student_user_id: user.id, user: section_teacher
+    end
+
+    context 'when the user is in multiple sections' do
+      it 'returns the sections where participation_type is "student"' do
+        _(user.sections_as_student_participant).must_equal [section1]
+        _(user.sections_as_student_participant.length).must_equal 1
+      end
+
+      it 'does not return the pl sections' do
+        _(user.sections_as_student_participant).wont_include section2
+        _(user.sections_as_student_participant).wont_include section3
+      end
+    end
+  end
+
+  describe '#sections_as_pl_participant' do
+    let(:section_teacher) {create :teacher}
+    let(:user) {create :user}
+    let!(:section1) {create :section, user: section_teacher}
+    let!(:section2) {create :section, :teacher_participants, user: section_teacher}
+    let!(:section3) {create :section, :facilitator_participants, user: section_teacher}
+
+    before do
+      create :follower, section: section1, student_user_id: user.id, user: section_teacher
+      create :follower, section: section2, student_user_id: user.id, user: section_teacher
+      create :follower, section: section3, student_user_id: user.id, user: section_teacher
+    end
+
+    context 'when the user is in multiple sections' do
+      it 'returns the pl sections' do
+        _(user.sections_as_pl_participant).must_equal [section2, section3]
+        _(user.sections_as_pl_participant.length).must_equal 2
+      end
+
+      it 'does not return sections where participation type is "student"' do
+        _(user.sections_as_pl_participant).wont_include section1
+      end
+    end
+  end
+
+  describe '#last_section_id' do
+    let(:teacher) {create :teacher}
+    let!(:section1) {create :section, user: teacher}
+    subject(:last_section_id) {teacher.last_section_id}
+
+    context 'when the teacher has one section' do
+      it 'returns the id of that section' do
+        _(last_section_id).must_equal section1.id
+      end
+    end
+
+    context 'when the teacher has multiple sections' do
+      let!(:section2) {create :section, user: teacher}
+      it 'returns the id of the most recently created section' do
+        _(last_section_id).must_equal section2.id
+      end
+    end
+
+    context 'when the teacher has a hidden section' do
+      let!(:section2) {create :section, user: teacher, hidden: true}
+      it 'ignored the hidden section' do
+        _(last_section_id).must_equal section1.id
+      end
+    end
+
+    context 'when the teacher has a deleted section' do
+      let!(:section2) {create :section, user: teacher}
+      before do
+        section2.delete
+      end
+      it 'ignored the deleted section' do
+        _(last_section_id).must_equal section1.id
+      end
+    end
+
+    context 'when the user is a student' do
+      let(:student) {create :student}
+      let(:teacher) {create :teacher}
+
+      before do
+        create :follower, section: section1
+      end
+
+      it 'returns nil' do
+        _(student.last_section_id).must_be_nil
+      end
+    end
+  end
+  describe '#last_joined_section' do
+    let(:student) {create :student}
+    let(:teacher) {create :teacher}
+    let!(:section1) {create :section, user: teacher}
+    let!(:section2) {create :section, user: teacher}
+    let!(:section3) {create :section, user: teacher}
+
+    subject(:last_joined_section) {student.last_joined_section}
+
+    context 'when the student has joined a section' do
+      it 'returns the most recently joined section' do
+        create :follower, section: section1, student_user_id: student.id, user: teacher
+        _(last_joined_section).must_equal section1
+      end
+    end
+
+    context 'when the student has joined multiple sections' do
+      it 'returns the most recently joined section' do
+        Timecop.freeze do
+          create :follower, section: section1, student_user_id: student.id, user: teacher
+          _(student.last_joined_section).must_equal section1
+
+          Timecop.travel 1.second
+          create :follower, section: section2, student_user_id: student.id, user: teacher
+          _(student.last_joined_section).must_equal section2
+
+          Timecop.travel 1.second
+          create :follower, section: section3, student_user_id: student.id, user: teacher
+          _(student.last_joined_section).must_equal section3
+        end
+      end
+    end
+
+    context 'when the student has not joined any sections' do
+      it 'returns nil' do
+        _(last_joined_section).must_be_nil
+      end
+    end
+  end
+end

--- a/dashboard/test/models/concerns/user/section_participation_test.rb
+++ b/dashboard/test/models/concerns/user/section_participation_test.rb
@@ -169,11 +169,8 @@ class SectionParticipationTest < ActiveSupport::TestCase
       let(:student) {create :student}
       let(:teacher) {create :teacher}
 
-      before do
-        create :follower, section: section1
-      end
-
       it 'returns nil' do
+        create :follower, section: section1
         _(student.last_section_id).must_be_nil
       end
     end

--- a/dashboard/test/models/concerns/user/section_participation_test.rb
+++ b/dashboard/test/models/concerns/user/section_participation_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class SectionParticipationTest < ActiveSupport::TestCase
   describe '#all_sections' do
     subject(:all_sections) {user.all_sections}
-    context 'when the user is a studnet' do
+    context 'when the user is a student' do
       let(:user) {create :student}
 
       it 'returns an empty array' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3222,46 +3222,6 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  class SectionCourses < ActiveSupport::TestCase
-    setup do
-      @student = create :student
-      @teacher = create :teacher
-      @grand_teacher = create :teacher
-      @unit_group = create :unit_group, name: 'csd'
-    end
-    test "it returns courses in which a teacher exists as a student" do
-      grand_section = create :section, user_id: @grand_teacher.id, unit_group: @unit_group
-      Follower.create!(section_id: grand_section.id, student_user_id: @teacher.id, user: @grand_teacher)
-
-      courses = @teacher.section_courses
-      assert_equal 1, courses.length
-      assert_equal 'csd', courses[0].name
-    end
-
-    test "it returns courses in which a teacher exists as a teacher" do
-      section = create :section, user_id: @teacher.id, unit_group: @unit_group
-      Follower.create!(section_id: section.id, student_user_id: @student.id, user: @teacher)
-
-      courses = @teacher.section_courses
-      assert_equal 1, courses.length
-      assert_equal 'csd', courses[0].name
-    end
-
-    test "it returns courses in which a student exists as a student" do
-      section = create :section, user_id: @teacher.id, unit_group: @unit_group
-      Follower.create!(section_id: section.id, student_user_id: @student.id, user: @teacher)
-
-      courses = @student.section_courses
-      assert_equal 1, courses.length
-      assert_equal 'csd', courses[0].name
-    end
-  end
-
-  test "section_scripts returns an empty array if user has no sections" do
-    user = create :user
-    assert_empty user.section_scripts
-  end
-
   test "section_scripts returns assigned scripts and default scripts in assigned courses" do
     student = create :student
     single_script = create :script
@@ -3272,27 +3232,6 @@ class UserTest < ActiveSupport::TestCase
     (create :section, unit_group: course_with_script).students << student
 
     assert_equal [single_script, unit_group_unit], student.section_scripts
-  end
-
-  test "last_joined_section returns the most recently joined section" do
-    student = create :student
-    teacher = create :teacher
-
-    section_1 = create :section, user_id: teacher.id
-    section_2 = create :section, user_id: teacher.id
-    section_3 = create :section, user_id: teacher.id
-
-    Timecop.freeze do
-      assert_nil student.last_joined_section
-      Follower.create!(section_id: section_1.id, student_user_id: student.id, user: teacher)
-      assert_equal section_1, student.last_joined_section
-      Timecop.travel 1
-      Follower.create!(section_id: section_3.id, student_user_id: student.id, user: teacher)
-      assert_equal section_3, student.last_joined_section
-      Timecop.travel 1
-      Follower.create!(section_id: section_2.id, student_user_id: student.id, user: teacher)
-      assert_equal section_2, student.last_joined_section
-    end
   end
 
   test 'from_omniauth: creates new user if user with matching credentials does not exist' do


### PR DESCRIPTION
This PR adds a new `SectionParticipation concern`, which is included in the User model. This is part of an ongoing effort to modularize the User model by use of concerns. It does the following: 

 - Move the following methods from `user.rb` to `section_participation.rb`
    - `all_sections`
    - `section_courses`
    - `sections_as_student_participant`
    - `sections_as_pl_participant`
    - `last_section_id`
    - `last_joined_section`
  - Move existing unit tests and convert to spec style syntax
  - Write new unit tests for previously untested methods
    - `all_sections`
    - `sections_as_student_participant`
    - `sections_as_pl_participant`
    - `last_section_id`
  - Include new concern into `user.rb`

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
