### PR TITLE
fix(cloudfront): update cache policies

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -785,7 +785,7 @@ Resources:
             RestrictionType: none
 
         Logging:
-          Bucket: "cdo-logs"
+          Bucket: "cdo-logs.s3.amazonaws.com"
           Prefix: !Sub "AWSLogs/${AWS::AccountId}/CloudFront/${SubdomainName}.${BaseDomainName}/"
           IncludeCookies: false
 

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -726,6 +726,19 @@ Resources:
         Comment: Adds Cache-Control if not present
         Runtime: cloudfront-js-2.0
 
+  # For immutable static assets (hashed assets like JS/CSS files), ensure that the Cache-Control header is set to immutable
+  ImmutableStaticAssetsResponseHeadersPolicy:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: !Sub "${AWS::StackName}-Assets-ResponseHeader-Policy"
+        Comment: "Ensure immutable static assets have Cache-Control header set to immutable"
+        CustomHeadersConfig:
+          Items:
+            - Header: cache-control
+              Override: false # Do not override the cache control from the origin if it is available
+              Value: public, max-age=31536000, immutable
+
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -756,7 +769,7 @@ Resources:
           TargetOriginId: marketing-sites-application-origin
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
-          CachePolicyId: !Ref ApplicationCachingPolicy
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Managed-CachingDisabled (Disabled until this distribution becomes the main one instead of daisy chained)
           OriginRequestPolicyId: "216adef6-5c7f-47e4-b989-5492eafa07d3" # AllViewer
           FunctionAssociations:
             - EventType: viewer-response
@@ -798,6 +811,7 @@ Resources:
             PathPattern: /_next/*
             TargetOriginId: marketing-sites-static-assets-origin
             ViewerProtocolPolicy: redirect-to-https
+            ResponseHeadersPolicyId: !Ref ImmutableStaticAssetsResponseHeadersPolicy
 
   CloudFrontDistributionDNS:
     Type: AWS::Route53::RecordSet

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -784,6 +784,11 @@ Resources:
           GeoRestriction:
             RestrictionType: none
 
+        Logging:
+          Bucket: "cdo-logs"
+          Prefix: !Sub "AWSLogs/${AWS::AccountId}/CloudFront/${SubdomainName}.${BaseDomainName}/"
+          IncludeCookies: false
+
         CacheBehaviors:
           # Path: /api/*
           # Description: Marketing application API routes

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -784,6 +784,7 @@ Resources:
           GeoRestriction:
             RestrictionType: none
 
+        # Temporary until distribution becomes the main one, after which Real Time Logging is enabled to avoid double counting between Pegasus and this distribution.
         Logging:
           Bucket: "cdo-logs.s3.amazonaws.com"
           Prefix: !Sub "AWSLogs/${AWS::AccountId}/CloudFront/${SubdomainName}.${BaseDomainName}/"

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -813,6 +813,7 @@ Resources:
               - HEAD
               - OPTIONS
             CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
+            Compress: true
             PathPattern: /_next/*
             TargetOriginId: marketing-sites-static-assets-origin
             ViewerProtocolPolicy: redirect-to-https


### PR DESCRIPTION
The marketing cdn currently does not set cache control headers for the `/_next` behavior causing the dasiy chained distribution to not cache these assets (always miss). Ensure that these assets are immutably cached as they are hashed and are safe to be cached indefinetly.

Additionally, disable caching on the main page paths as it causes a double caching behavior which is quite confusing for content editors to wait for content to become live.