### PR TITLE
fix(marketing): move width style inline on Error page sad bee image

### DIFF
--- a/frontend/apps/marketing/src/components/error/Error.tsx
+++ b/frontend/apps/marketing/src/components/error/Error.tsx
@@ -106,6 +106,7 @@ export default function Error(props: ErrorProps) {
           className={errorStyles.sadBeeContainer}
           src={sadBeeImage.src}
           alt=""
+          style={{width: '7.125rem'}}
         />
       )}
       <Overline removeMarginBottom={false} size={'l'} color={'primary'}>

--- a/frontend/apps/marketing/src/components/error/error.module.scss
+++ b/frontend/apps/marketing/src/components/error/error.module.scss
@@ -9,7 +9,6 @@
 
 .sadBeeContainer {
   display: inline-block;
-  width: 7.125rem;
   height: auto;
 }
 


### PR DESCRIPTION
Moves the sad bee image `width` style inline instead of in the css to prevent a giant image if stylesheet isn’t loaded. 

## Links
Jira ticket: [CMS-789](https://codedotorg.atlassian.net/browse/CMS-789)
Slack convo: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1748558403499169?thread_ts=1748558349.600149&cid=C07UW4ED66Q)

## Testing story
Tested locally

----

<img width="1629" alt="Screenshot 2025-06-02 at 8 06 19 AM" src="https://github.com/user-attachments/assets/3b9a38fa-7b3c-4957-91b0-53f2c06145cd" />

## With stylesheet removed

<img width="1629" alt="Screenshot 2025-06-02 at 8 09 46 AM" src="https://github.com/user-attachments/assets/b44efe95-4001-428d-a1aa-bc068c962a4b" />

