### PR TITLE
Fix modular single-unit course redirects

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -344,7 +344,7 @@ class ScriptsController < ApplicationController
       end
       if unit_group&.single_unit_course?
         script = unit_group.units_for_user(current_user).first
-        return script
+        return {script: script, unit_group: unit_group}
       end
     end
 
@@ -362,9 +362,12 @@ class ScriptsController < ApplicationController
         @script = context[:unit]
       end
     else
-      @script = get_unit_by_name
-      raise ActiveRecord::RecordNotFound unless @script
-      @course = @script.original_unit_group
+      result = get_unit_by_name
+      raise ActiveRecord::RecordNotFound unless result
+
+      @script = result[:script]
+      # Use the unit_group from the result if it's a single unit course, otherwise fall back to original logic
+      @course = result[:unit_group] || @script.original_unit_group
       @unit_group_unit = @script.unit_group_units.find {|ugu| ugu.unit_group == @course}
       @unit_position = @unit_group_unit&.position
     end

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -327,12 +327,12 @@ class ScriptsController < ApplicationController
       Unit.get_without_cache(unit_name, with_associated_models: true) :
       Unit.get_from_cache(unit_name, raise_exceptions: false)
 
-    return script if script
+    return {script: script} if script
 
     if Unit.family_names.include?(unit_name)
       script = Unit.get_unit_family_redirect_for_user(unit_name, user: current_user, locale: request.locale)
       Unit.log_redirect(unit_name, script.redirect_to, request, 'unversioned-script-redirect', current_user&.user_type) if script.present?
-      return script
+      return {script: script}
     end
 
     # Redirect to the latest version or the assigned version of a single-unit course
@@ -363,8 +363,7 @@ class ScriptsController < ApplicationController
       end
     else
       result = get_unit_by_name
-      raise ActiveRecord::RecordNotFound unless result
-
+      raise ActiveRecord::RecordNotFound unless result && result[:script]
       @script = result[:script]
       # Use the unit_group from the result if it's a single unit course, otherwise fall back to original logic
       @course = result[:unit_group] || @script.original_unit_group

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -404,6 +404,14 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_redirected_to "/courses/#{@single_unit_course_2024.name}/units/1"
   end
 
+  test "show: redirect to correct course from course family name if single-unit course" do
+    another_course = create :single_unit_course, unit: @single_unit_2024, family_name: 'another-course', version_year: '2024', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    CourseOffering.add_course_offering(another_course)
+
+    get :show, params: {id: another_course.family_name}
+    assert_redirected_to "/courses/#{another_course.name}/units/1"
+  end
+
   test "show: teacher in teacher-local-nav-v2 experiment is redirected to teacher dashboard if course is in a section" do
     # Have the same unit in two different courses to make sure the redirection
     # goes to the course defined in the section.


### PR DESCRIPTION
With single-unit courses, we have the ability to find the correct course if a course's family name is passed into a `/s/` url instead of the proper unit name (`/s/coursea`, for example, redirects to `/courses/coursea-2024/units/1`). If a single-unit course is modular, however, `get_unit_by_name` was only returning the correct unit, leaving the course context to the unit's `original_unit_group`. This PR adds the `unit_group` to the information returned by `get_unit_by_name`, so that the correct course context is captured on redirect.

## Links
[Slack thread ](https://codedotorg.slack.com/archives/C045UAX4WKH/p1748643579092119) with more information about the issue.

## Testing story
Added a unit test to ensure that it redirects to the expected unit
