### PR TITLE
check current course when finding course versions

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1595,7 +1595,7 @@ class Unit < ApplicationRecord
         age_13_required: logged_out_age_13_required?,
         show_course_unit_version_warning: !unit_group_unit&.cached_unit_group&.has_dismissed_version_warning?(user) && has_older_course_progress,
         show_script_version_warning: !user_unit&.version_warning_dismissed && !has_older_course_progress && has_older_unit_progress,
-        course_versions: summarize_course_versions(user, locale_code),
+        course_versions: summarize_course_versions(user, locale_code, unit_group: unit_group_unit&.cached_unit_group),
         supported_locales: supported_locales,
         section_hidden_unit_info: section_hidden_unit_info(user),
         pilot_experiment: get_pilot_experiment,
@@ -1799,7 +1799,9 @@ class Unit < ApplicationRecord
   # will always return false for participants so they will fall into the second check for
   # launched and can_view_version?. For instructors if course_assignable? is false then
   # launched will also be false.
-  def summarize_course_versions(user = nil, locale_code = 'en-us')
+  def summarize_course_versions(user = nil, locale_code = 'en-us', unit_group: nil)
+    unit_group ||= original_unit_group
+
     return {} if unit_group && !unit_group.single_unit_course?
 
     if unit_group&.single_unit_course?

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -1158,8 +1158,37 @@ class UnitTest < ActiveSupport::TestCase
 
     UnitGroup.any_instance.expects(:summarize_course_versions).once.returns(versioned_single_unit_course25.course_version&.course_offering&.course_versions)
     course_versions = single_unit.summarize_course_versions(create(:teacher))
-    puts course_versions.inspect
     assert_equal 2, course_versions.count
+  end
+
+  test 'summarize_course_versions for modular single-unit course' do
+    modular_unit = create :unit, name: 'modular-unit'
+
+    # original course versions
+    original_course_offering = create(:course_offering, key: 'original-course', display_name: 'original-course')
+    original_course_2024 = create :unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, name: 'original-course-2024', family_name: 'original-course', version_year: '2024'
+    original_course_2025 = create :unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, name: 'original-course-2025', family_name: 'original-course', version_year: '2025'
+    create :unit_group_unit, unit_group: original_course_2024, script: modular_unit, position: 1
+    create :unit_group_unit, unit_group: original_course_2024, script: (create :unit), position: 2
+    create :unit_group_unit, unit_group: original_course_2025, script: modular_unit, position: 1
+    create :unit_group_unit, unit_group: original_course_2025, script: (create :unit), position: 2
+    create :course_version, key: '2024', display_name: '2024', course_offering: original_course_offering, content_root: original_course_2024
+    create :course_version, key: '2025', display_name: '2025', course_offering: original_course_offering, content_root: original_course_2025
+
+    # modular course versions
+    modular_course_offering = create(:course_offering, key: 'modular-course', display_name: 'modular-course')
+    modular_single_unit_course24 = create(:single_unit_course, unit: modular_unit, name: 'mod-single-unit-2024', family_name: 'modular-single-unit-course', version_year: '2024', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    modular_single_unit_course25 = create(:single_unit_course, unit: modular_unit, name: 'mod-single-unit-2025', family_name: 'modular-single-unit-course', version_year: '2025', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    create(:course_version, :with_unit_group, key: '2024', course_offering: modular_course_offering, display_name: '2024', content_root: modular_single_unit_course24)
+    create(:course_version, :with_unit_group, key: '2025', course_offering: modular_course_offering, display_name: '2025', content_root: modular_single_unit_course25)
+
+    original_course_versions = modular_unit.summarize_course_versions(create(:teacher))
+    assert_equal 0, original_course_versions.count
+
+    single_unit_course_versions = modular_unit.summarize_course_versions(create(:teacher), unit_group: modular_single_unit_course25)
+    assert_equal 2, single_unit_course_versions.count
+    assert_equal 'mod-single-unit-2024', single_unit_course_versions.values[0][:name]
+    assert_equal 'mod-single-unit-2025', single_unit_course_versions.values[1][:name]
   end
 
   test 'summarize excludes unlaunched versions' do


### PR DESCRIPTION
When determining course versions for a single-unit course, we were looking at the unit's original course. Instead, we should be checking the current course's course versions. If no course is specified, we fallback to the original course.

**Before**
![Screenshot 2025-06-02 at 4 12 55 PM](https://github.com/user-attachments/assets/7471004d-c282-405c-993f-79cbdfe0116b)

**After**
![Screenshot 2025-06-02 at 4 14 49 PM](https://github.com/user-attachments/assets/ae13d806-e815-4c1d-a6af-85ba129d72bb)

## Links
- [Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1748884320931989) with more information


## Testing story
Added a unit test to check that the current course is used instead of the original course version.
