### PR TITLE
deflake modularity ui test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/modular_courses.feature
+++ b/dashboard/test/ui/features/teacher_tools/modular_courses.feature
@@ -30,7 +30,7 @@ Feature: Using Modular Courses
     And I wait to see ".header_popup_link"
     Then I open the progress drop down of the current page
     And I wait until element "a:contains(View Unit Overview)" is visible
-    Then I click selector "a:contains(View Unit Overview)"
+    Then I click selector "a:contains(View Unit Overview)" to load a new page
 
     # Check that the unit breadcrumb works
     And I wait until element ".unit-overview-top-row" is visible
@@ -64,7 +64,7 @@ Feature: Using Modular Courses
     And I wait to see ".header_popup_link"
     Then I open the progress drop down of the current page
     And I wait until element "a:contains(View Unit Overview)" is visible
-    Then I click selector "a:contains(View Unit Overview)"
+    Then I click selector "a:contains(View Unit Overview)" to load a new page
 
     # Check that the unit breadcrumb works
     And I wait until element ".unit-overview-top-row" is visible


### PR DESCRIPTION
In order to deflake the modular course UI test, we need to wait for page load after clicking the Unit Overview button