### PR TITLE
fix: add additional logging when a browser error occurs

### DIFF
--- a/frontend/apps/marketing/src/otel/errorHandler.ts
+++ b/frontend/apps/marketing/src/otel/errorHandler.ts
@@ -1,6 +1,8 @@
 import NewRelicAgent from '@/providers/newrelic/agent';
 export function handleError(error: Error, errorTraceId: string) {
   console.error(error, errorTraceId);
+  console.log(`Error ${errorTraceId} received ${error.message}`);
+  console.log(`Error ${errorTraceId} stack ${error.stack}`);
 
   NewRelicAgent.then(agent => {
     if (agent) {

--- a/frontend/apps/marketing/src/otel/errorHandler.ts
+++ b/frontend/apps/marketing/src/otel/errorHandler.ts
@@ -1,8 +1,9 @@
 import NewRelicAgent from '@/providers/newrelic/agent';
 export function handleError(error: Error, errorTraceId: string) {
   console.error(error, errorTraceId);
-  console.log(`Error ${errorTraceId} received ${error.message}`);
-  console.log(`Error ${errorTraceId} stack ${error.stack}`);
+  console.debug(
+    `Error ${errorTraceId} received ${error.message}, ${error.stack}`,
+  );
 
   NewRelicAgent.then(agent => {
     if (agent) {


### PR DESCRIPTION
When an error occurs, the browser simply logs out "Error" in Playwright's tracer. This logs out the error with its message and stack at the INFO level in case the Error is not serialized.