### PR TITLE
Lab2 instructions: make scrollbar not overlap content

### DIFF
--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -116,7 +116,6 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-  overflow-y: auto;
 }
 
 .text-Dark {

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -132,7 +132,7 @@
 
 .textContent {
   height: 100%;
-  padding: 0;
+  padding: 15px 0 5px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -142,7 +142,7 @@
   flex: 1;
   overflow-y: auto;
   min-height: 70px;
-  padding: 10px;
+  padding: 0 10px;
 }
 
 .scrollingContentWithTTS {
@@ -183,7 +183,6 @@
 .buttonInstruction {
   width: 100%;
   height: 38px;
-  margin: 0 0 10px 0;
 }
 
 .markdownText {

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -116,6 +116,7 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  overflow-y: auto;
 }
 
 .text-Dark {
@@ -132,7 +133,7 @@
 
 .textContent {
   height: 100%;
-  padding: 15px 10px 5px;
+  padding: 0;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -142,6 +143,7 @@
   flex: 1;
   overflow-y: auto;
   min-height: 70px;
+  padding: 10px;
 }
 
 .scrollingContentWithTTS {
@@ -156,7 +158,7 @@
 
 %message {
   position: relative;
-  padding: 15px 20px 5px 20px;
+  padding: 15px 20px;
   border-radius: 4px;
   animation: slidein 0.5s;
 }
@@ -187,7 +189,6 @@
 
 .markdownText {
   line-height: 0;
-  overflow-y: auto;
 
   h1,
   h2,


### PR DESCRIPTION
Makes it so the scrollbar in the instructions view no longer overlaps the text of the instructions.

Also a small bit of cleanup to have the "Continue" button have even padding around it (see bottom of videos).

<details>
<summary>🎥 New (total padding between text and instruction container unchanged, just no overlap with scrollbar) 🎥</summary><video src="https://github.com/user-attachments/assets/08fea2e8-272d-42f3-8722-10b2f2795745" /></details> 

<details>
<summary>🎥 Old 🎥</summary><video src="https://github.com/user-attachments/assets/2a5edd06-b1fc-49c1-8a16-936930883537" /></details> 


## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1456

## Testing story

Tested manually at /courses/problem-solving-with-ai-2024/units/1/lessons/9/levels/1/sublevel/1. ~~I also looked at a couple of Python Lab levels in allthethings and didn't see anything that looked out of sorts.~~ Oops, Python Lab has its own instructions component. Checked Music Lab and saw no regressions.