### PR TITLE
fix(marketing): increase offscreen-images maxLength in .lighthouserc.js

### DIFF
--- a/frontend/apps/marketing/.lighthouserc.js
+++ b/frontend/apps/marketing/.lighthouserc.js
@@ -3,7 +3,7 @@ const assertions = {
   'color-contrast': 'off',
   'errors-in-console': ['error', {maxLength: 4}],
   'inspector-issues': 'off',
-  'offscreen-images': ['error', {minScore: 0.5, maxLength: 3}],
+  'offscreen-images': ['error', {minScore: 0.5, maxLength: 4}],
   'total-byte-weight': ['error', {minScore: 0.5}],
   'unused-css-rules': ['error', {maxLength: 30}],
   'unused-javascript': ['error', {maxLength: 10}],


### PR DESCRIPTION
Increases the `offscreen-images` maxLength to 4 in Lighthouse checks that were failing [here](https://github.com/code-dot-org/code-dot-org/actions/runs/15420515820/job/43396099360). This is due to a background image being applied with CSS on the **Hero Banner with Background Image** section on https://code.marketing-sites.code.org/en-US/engineering/all-the-things.

## Links
Slack convo: [here](https://codedotorg.slack.com/archives/C08ANSH89B5/p1748964204236179?thread_ts=1748961992.292559&cid=C08ANSH89B5)

