### PR TITLE
[ACQ-3324] [DSCO] WithTooltip elements rendered off screen have tooltip position stuck at edge of screen

### DIFF
--- a/frontend/packages/component-library/src/common/helpers/index.ts
+++ b/frontend/packages/component-library/src/common/helpers/index.ts
@@ -33,7 +33,6 @@ export const getAriaPropsFromProps = (props: {
  * @param direction
  * @param tailOffset
  * @param tailLength
- * @param isPositionFixed
  */
 export const calculatePositionedElementStyles = ({
   nodePosition,
@@ -41,90 +40,105 @@ export const calculatePositionedElementStyles = ({
   direction,
   tailOffset,
   tailLength,
-  isPositionFixed = false,
 }: {
   nodePosition: HTMLElement | null;
   positionedElementRef: React.RefObject<HTMLDivElement | null>;
   direction?: ComponentPlacementDirection;
   tailOffset: number;
   tailLength: number;
-  isPositionFixed?: boolean;
 }) => {
-  const styles: React.CSSProperties = {};
+  const styles: React.CSSProperties = {
+    position: 'absolute',
+    inset: '0px auto auto 0px',
+  };
   let effectiveDirection = direction;
 
   if (nodePosition && positionedElementRef.current && direction !== 'none') {
     const rect = nodePosition.getBoundingClientRect();
     const tooltipRect = positionedElementRef.current.getBoundingClientRect();
-    const scrollY = isPositionFixed ? 0 : window.scrollY;
-    const scrollX = isPositionFixed ? 0 : window.scrollX;
-    const textDirection = document.documentElement.dir || 'ltr'; // Default to 'ltr' if not specified
+    const scrollY = window.scrollY;
+    const scrollX = window.scrollX;
+    const viewportHeight = window.innerHeight;
+    const viewportWidth = window.innerWidth;
+    const textDirection = document.documentElement.dir || 'ltr';
     const isLtr = textDirection === 'ltr';
 
-    const verticalMiddlePosition =
-      rect.top + scrollY + rect.height / 2 - tooltipRect.height / 2;
-    const verticalTopPosition =
-      rect.top + scrollY - tooltipRect.height - tailOffset - tailLength;
-    const verticalBottomPosition =
-      rect.top + rect.height + scrollY + tailOffset + tailLength;
+    let top = 0;
+    let left = 0;
 
-    const horizontalMiddlePosition =
-      rect.left + scrollX + rect.width / 2 - tooltipRect.width / 2;
-    const horizontalLeftPosition =
-      rect.left + scrollX - tooltipRect.width - tailOffset - tailLength;
-    const horizontalRightPosition =
-      rect.right + scrollX + tailOffset + tailLength;
+    const calculatePosition = (dir: ComponentPlacementDirection) => {
+      switch (dir) {
+        case 'onRight':
+          top = rect.top + scrollY + rect.height / 2 - tooltipRect.height / 2;
+          left =
+            (isLtr ? rect.right : rect.left - tooltipRect.width) +
+            scrollX +
+            tailOffset +
+            tailLength;
+          break;
+        case 'onBottom':
+          top = rect.bottom + scrollY + tailOffset + tailLength;
+          left = rect.left + scrollX + rect.width / 2 - tooltipRect.width / 2;
+          break;
+        case 'onLeft':
+          top = rect.top + scrollY + rect.height / 2 - tooltipRect.height / 2;
+          left =
+            (isLtr ? rect.left - tooltipRect.width : rect.right) +
+            scrollX -
+            tailOffset -
+            tailLength;
+          break;
+        case 'onTop':
+        default:
+          top =
+            rect.top + scrollY - tooltipRect.height - tailOffset - tailLength;
+          left = rect.left + scrollX + rect.width / 2 - tooltipRect.width / 2;
+          break;
+      }
 
-    // Calculate the tooltip position based on the direction and its tail length
-    switch (direction) {
-      case 'onRight':
-        styles.top = verticalMiddlePosition;
-        styles.left = isLtr ? horizontalRightPosition : horizontalLeftPosition;
-        // Adjust if the tooltip goes offscreen on the right
-        if (styles.left + tooltipRect.width > window.innerWidth) {
-          effectiveDirection = 'onLeft';
-        }
-        break;
-      case 'onBottom':
-        styles.top = verticalBottomPosition;
-        styles.left = horizontalMiddlePosition;
-        // Adjust if the tooltip goes offscreen at the bottom
-        if (styles.top + tooltipRect.height > window.innerHeight) {
-          effectiveDirection = 'onTop';
-        }
-        break;
-      case 'onLeft':
-        styles.top = verticalMiddlePosition;
-        styles.left = isLtr ? horizontalLeftPosition : horizontalRightPosition;
-        // Adjust if the tooltip goes offscreen on the left
-        if (styles.left < 0) {
-          effectiveDirection = 'onRight';
-        }
-        break;
-      case 'onTop':
-      default:
-        styles.top = verticalTopPosition;
-        styles.left = horizontalMiddlePosition;
-        // Adjust if the tooltip goes offscreen at the top
-        if (styles.top < 0) {
-          effectiveDirection = 'onBottom';
-        }
-        break;
+      return {top, left};
+    };
+
+    const fitsInViewport = (pos: {top: number; left: number}) => {
+      return (
+        pos.top >= scrollY &&
+        pos.top + tooltipRect.height <= scrollY + viewportHeight &&
+        pos.left >= scrollX &&
+        pos.left + tooltipRect.width <= scrollX + viewportWidth
+      );
+    };
+
+    let proposedPosition = calculatePosition(direction!);
+    if (!fitsInViewport(proposedPosition)) {
+      // Flip logic
+      const flipDirection = {
+        onRight: 'onLeft',
+        onLeft: 'onRight',
+        onTop: 'onBottom',
+        onBottom: 'onTop',
+      }[direction!];
+
+      const flippedPosition = calculatePosition(
+        flipDirection as ComponentPlacementDirection,
+      );
+      if (fitsInViewport(flippedPosition)) {
+        proposedPosition = flippedPosition;
+        effectiveDirection = flipDirection as ComponentPlacementDirection;
+      }
+      // Otherwise, fallback to original even if partially visible
     }
 
-    // Ensure the tooltip stays within the viewport horizontally
-    if (styles.left + tooltipRect.width > window.innerWidth) {
-      styles.left = window.innerWidth - tooltipRect.width - tailOffset;
-    } else if (styles.left < 0) {
-      styles.left = tailOffset;
-    }
+    // Finally, clamp within viewport to always keep visible:
+    proposedPosition.top = Math.min(
+      Math.max(proposedPosition.top, scrollY + tailOffset),
+      scrollY + viewportHeight - tooltipRect.height - tailOffset,
+    );
+    proposedPosition.left = Math.min(
+      Math.max(proposedPosition.left, scrollX + tailOffset),
+      scrollX + viewportWidth - tooltipRect.width - tailOffset,
+    );
 
-    // Ensure the tooltip stays within the viewport vertically
-    if (styles.top + tooltipRect.height > window.innerHeight) {
-      styles.top = window.innerHeight - tooltipRect.height - tailOffset;
-    } else if (styles.top < 0) {
-      styles.top = tailOffset;
-    }
+    styles.transform = `translate3d(${proposedPosition.left}px, ${proposedPosition.top}px, 0px)`;
   }
 
   return {styles, effectiveDirection};
@@ -140,7 +154,6 @@ export const calculatePositionedElementStyles = ({
  * @param setPositionedElementDirection
  * @param tailOffset
  * @param tailLength
- * @param isPositionFixed
  */
 export const updatePositionedElementStyles = ({
   nodePosition,
@@ -150,7 +163,6 @@ export const updatePositionedElementStyles = ({
   setPositionedElementDirection,
   tailOffset,
   tailLength,
-  isPositionFixed = false,
 }: {
   nodePosition: HTMLElement | null;
   positionedElementRef: React.RefObject<HTMLDivElement | null>;
@@ -163,7 +175,6 @@ export const updatePositionedElementStyles = ({
   >;
   tailOffset: number;
   tailLength: number;
-  isPositionFixed?: boolean;
 }) => {
   const {styles, effectiveDirection} = calculatePositionedElementStyles({
     nodePosition,
@@ -171,7 +182,6 @@ export const updatePositionedElementStyles = ({
     direction,
     tailOffset,
     tailLength,
-    isPositionFixed,
   });
 
   if (

--- a/frontend/packages/component-library/src/common/helpers/index.ts
+++ b/frontend/packages/component-library/src/common/helpers/index.ts
@@ -43,7 +43,7 @@ export const calculatePositionedElementStyles = ({
 }: {
   nodePosition: HTMLElement | null;
   positionedElementRef: React.RefObject<HTMLDivElement | null>;
-  direction?: ComponentPlacementDirection;
+  direction: ComponentPlacementDirection;
   tailOffset: number;
   tailLength: number;
 }) => {
@@ -108,7 +108,7 @@ export const calculatePositionedElementStyles = ({
       );
     };
 
-    let proposedPosition = calculatePosition(direction!);
+    let proposedPosition = calculatePosition(direction);
     if (!fitsInViewport(proposedPosition)) {
       // Flip logic
       const flipDirection = {
@@ -116,7 +116,7 @@ export const calculatePositionedElementStyles = ({
         onLeft: 'onRight',
         onTop: 'onBottom',
         onBottom: 'onTop',
-      }[direction!];
+      }[direction];
 
       const flippedPosition = calculatePosition(
         flipDirection as ComponentPlacementDirection,
@@ -166,7 +166,7 @@ export const updatePositionedElementStyles = ({
 }: {
   nodePosition: HTMLElement | null;
   positionedElementRef: React.RefObject<HTMLDivElement | null>;
-  direction?: ComponentPlacementDirection;
+  direction: ComponentPlacementDirection;
   setPositionedElementStyles: React.Dispatch<
     React.SetStateAction<React.CSSProperties>
   >;

--- a/frontend/packages/component-library/src/popover/WithPopover.tsx
+++ b/frontend/packages/component-library/src/popover/WithPopover.tsx
@@ -50,7 +50,6 @@ const WithPopover: React.FunctionComponent<WithPopoverProps> = ({
         setPositionedElementDirection: setActualDirection,
         tailOffset,
         tailLength,
-        isPositionFixed: true,
       }),
     [nodePosition, popoverRef, setPopoverStyles, popoverProps, tailLength],
   );

--- a/frontend/packages/component-library/src/tooltip/tooltip.module.scss
+++ b/frontend/packages/component-library/src/tooltip/tooltip.module.scss
@@ -52,6 +52,8 @@ $tooltip-span-vertical-top-spacing: 2px;
 .tooltip {
   visibility: hidden;
   position: absolute;
+  inset: 0 auto auto 0;
+  will-change: transform; // improves rendering performance
   z-index: 10;
   display: flex;
   align-items: center;


### PR DESCRIPTION
### [ACQ-3324] [DSCO] WithTooltip elements rendered off screen have tooltip position stuck at edge of screen

* [feat(tooltip): simplify position calculation and improve viewport handling](https://github.com/code-dot-org/code-dot-org/commit/c7b2191f991cdd9845ff4a3d2fe3623a29417a5d)

Currently Tooltip and Popover positioning is broken when trigger element is inside elements with display flex and flex-direction:column with some gap. This PR fixes this and also simplifies calculation.

In case of any regressions feel free to revert.


https://github.com/user-attachments/assets/55174998-44bd-4b9d-97b7-1858f16fe8f0


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [ACQ-3324](https://codedotorg.atlassian.net/browse/ACQ-3324)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
