### PR TITLE
fix(RichText): correct typography paragraph margins

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/richText/RichText.tsx
+++ b/frontend/apps/marketing/src/components/contentful/richText/RichText.tsx
@@ -46,7 +46,7 @@ const extractNodeContent = (node: RichTextNode): ReactNode[] => {
 
   switch (node.nodeType) {
     case 'text': {
-      if (!node.value) return [node.value];
+      if (!node.value) return [];
 
       return [
         node.marks.reduce((value: ReactNode, {type}: Mark) => {

--- a/frontend/apps/marketing/src/components/contentful/richText/RichText.tsx
+++ b/frontend/apps/marketing/src/components/contentful/richText/RichText.tsx
@@ -46,6 +46,8 @@ const extractNodeContent = (node: RichTextNode): ReactNode[] => {
 
   switch (node.nodeType) {
     case 'text': {
+      if (!node.value) return [node.value];
+
       return [
         node.marks.reduce((value: ReactNode, {type}: Mark) => {
           switch (type) {
@@ -79,8 +81,10 @@ const richTextRenderOptions: Options = {
       const paragraphContent = extractNodeContent(paragraphNode);
       // The Rich Text Editor wraps each line in a <p> tag, which acts as a spacer.
       // Replaces empty paragraphs with a <br /> To comply with HTML a11y guidelines.
-      return paragraphContent.length ? (
-        <BodyTwoText>{paragraphContent}</BodyTwoText>
+      return paragraphContent.some(content => content) ? (
+        <BodyTwoText className={moduleStyles.richTextParagraph}>
+          {paragraphContent}
+        </BodyTwoText>
       ) : (
         <br />
       );

--- a/frontend/apps/marketing/src/components/contentful/richText/richText.module.scss
+++ b/frontend/apps/marketing/src/components/contentful/richText/richText.module.scss
@@ -1,7 +1,12 @@
 @use '@code-dot-org/component-library-styles/font.scss' as font;
 
 .richText {
-  & > * {
+  & > br:last-child {
+    display: none;
+  }
+
+  & > *,
+  .richTextParagraph {
     margin: 1rem 0 0;
 
     &:first-child,
@@ -9,7 +14,8 @@
       margin: 0;
     }
 
-    p {
+    p,
+    .richTextParagraph {
       margin: 0;
     }
   }
@@ -22,7 +28,8 @@
     font-weight: font.$semi-bold-font-weight;
   }
 
-  p {
+  p,
+  .richTextParagraph {
     white-space: pre-wrap;
   }
 


### PR DESCRIPTION
## Before
![before](https://github.com/user-attachments/assets/3e8d6baa-2d00-4441-982a-c807b7ccff04)

## After
<img width="100%" alt="preview" src="https://github.com/user-attachments/assets/6beb8809-dfea-4fa2-87db-b4eba31c15a0" />

## Links
- JIRA task: [CMS-506](https://codedotorg.atlassian.net/browse/CMS-506)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66153