### PR TITLE
AI Chat: Add access for Idaho AIF course

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -702,6 +702,7 @@ class Section < ApplicationRecord
       problem-solving-with-ai-2024
       artificial-intelligence-foundations-2025
       computing-foundations-for-a-digital-age-2025
+      idaho-digital-literacy-2025
       foundations-of-ai-programming-2025
       ai-and-the-systems-that-power-it-2025
       the-fabric-of-the-internet-and-ai-2025


### PR DESCRIPTION
Adds an Idaho-specific version of AIF for access to AI Chat. Hopefully the last time we have to do this before moving to a more robust access mgmt system 🤞 .