### PR TITLE
Lab2: Refactor theme logic into a hook

### DIFF
--- a/apps/src/lab2/hooks/useInitialLabTheme.ts
+++ b/apps/src/lab2/hooks/useInitialLabTheme.ts
@@ -1,0 +1,96 @@
+import {Theme, useTheme} from '@code-dot-org/component-library/common/contexts';
+import {useEffect, useMemo} from 'react';
+
+import {getCurrentLesson} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {setIsLoadingTheme} from '@cdo/apps/lab2/lab2Redux';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {getAppOptionsTheme} from '@cdo/apps/lab2/projects/utils';
+import {AppName} from '@cdo/apps/lab2/types';
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
+import {SignInState} from '@cdo/apps/templates/currentUserRedux';
+import {Level} from '@cdo/apps/types/progressTypes';
+import {capitalizeFirstLetter} from '@cdo/apps/util/capitalizeFirstLetter';
+import {NetworkError} from '@cdo/apps/util/HttpClient';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {lab2EntryPoints} from '../../../lab2EntryPoints';
+
+interface UseInitialLabThemeProps {
+  currentAppName?: AppName;
+  levelProperties?: {
+    appName?: string;
+  };
+}
+
+export const useInitialLabTheme = ({
+  currentAppName,
+  levelProperties,
+}: UseInitialLabThemeProps) => {
+  const {setTheme} = useTheme();
+  const {signInState} = useAppSelector(state => state.currentUser);
+  const dispatch = useAppDispatch();
+  const initialTheme = getAppOptionsTheme();
+  const lesson = useAppSelector(state => getCurrentLesson(state));
+
+  // We only use the global user preference for theme if the current lesson has
+  // at least one python lab level or the current level is a python lab level.
+  const useThemeUserPreference = useMemo(
+    () =>
+      levelProperties?.appName === 'pythonlab' ||
+      lesson?.levels.some((level: Level) => level.app === 'pythonlab'),
+    [lesson?.levels, levelProperties?.appName]
+  );
+
+  useEffect(() => {
+    if (currentAppName) {
+      const supportedThemes = lab2EntryPoints[currentAppName]?.themes;
+      dispatch(setIsLoadingTheme(true));
+
+      const setThemeHelper = () => {
+        // Use the theme from app options if it exists and is supported,
+        // otherwise fall back to the first supported theme.
+        // We will only use the app options theme if we are not using the user preference,
+        // so it is safe to use that statically set theme.
+        const upperCasedTheme = initialTheme
+          ? (capitalizeFirstLetter(initialTheme) as Theme)
+          : undefined;
+        if (upperCasedTheme && supportedThemes.includes(upperCasedTheme)) {
+          setTheme(upperCasedTheme);
+        } else {
+          setTheme(supportedThemes[0]);
+        }
+        dispatch(setIsLoadingTheme(false));
+      };
+
+      if (useThemeUserPreference && signInState === SignInState.SignedIn) {
+        const fetchAndSetTheme = async () => {
+          const userTheme = await new UserPreferences().getGlobalTheme(
+            (error: NetworkError) =>
+              Lab2Registry.getInstance()
+                .getMetricsReporter()
+                .logError('Error fetching theme', undefined, {
+                  message: error.response,
+                })
+          );
+          if (userTheme && supportedThemes.includes(userTheme)) {
+            setTheme(userTheme);
+            dispatch(setIsLoadingTheme(false));
+          } else {
+            setThemeHelper();
+          }
+        };
+
+        fetchAndSetTheme();
+      } else {
+        setThemeHelper();
+      }
+    }
+  }, [
+    currentAppName,
+    setTheme,
+    useThemeUserPreference,
+    signInState,
+    dispatch,
+    initialTheme,
+  ]);
+};

--- a/apps/src/lab2/hooks/useInitialLabTheme.ts
+++ b/apps/src/lab2/hooks/useInitialLabTheme.ts
@@ -22,6 +22,7 @@ interface UseInitialLabThemeProps {
   };
 }
 
+// Determine and set the theme for the lab that is currently being loaded.
 export const useInitialLabTheme = ({
   currentAppName,
   levelProperties,

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -3,27 +3,16 @@
  * currently active Lab (determined by the current app name). This
  * helps facilitate level-switching between labs without page reloads.
  */
-import {Theme, useTheme} from '@code-dot-org/component-library/common/contexts';
-import React, {Suspense, useEffect, useMemo} from 'react';
+import React, {Suspense} from 'react';
 
-import {getCurrentLesson} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {queryParams} from '@cdo/apps/code-studio/utils';
-import {setIsLoadingTheme} from '@cdo/apps/lab2/lab2Redux';
-import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
-import {SignInState} from '@cdo/apps/templates/currentUserRedux';
-import {Level} from '@cdo/apps/types/progressTypes';
-import {capitalizeFirstLetter} from '@cdo/apps/util/capitalizeFirstLetter';
-import {NetworkError} from '@cdo/apps/util/HttpClient';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {lab2EntryPoints} from '../../../lab2EntryPoints';
 import {PERMISSIONS} from '../constants';
+import {useInitialLabTheme} from '../hooks/useInitialLabTheme';
 import ProgressContainer from '../progress/ProgressContainer';
-import {
-  getAppOptionsTheme,
-  getAppOptionsViewingExemplar,
-} from '../projects/utils';
+import {getAppOptionsViewingExemplar} from '../projects/utils';
 
 import NoExemplarPage from './components/NoExemplarPage';
 import ExtraLinks from './ExtraLinks';
@@ -40,7 +29,6 @@ const LabViewsRenderer: React.FunctionComponent = () => {
   const currentAppName = levelProperties?.appName;
   const exemplarSources = levelProperties?.exemplarSources;
   const levelId = levelProperties?.id;
-  const initialTheme = getAppOptionsTheme();
 
   const isBlocked = useAppSelector(state => state.lab.isBlocked);
   const isProjectValidator = useAppSelector(state =>
@@ -48,73 +36,11 @@ const LabViewsRenderer: React.FunctionComponent = () => {
   );
 
   const isViewingExemplar = getAppOptionsViewingExemplar();
-  const lesson = useAppSelector(state => getCurrentLesson(state));
-  const {signInState} = useAppSelector(state => state.currentUser);
-  const dispatch = useAppDispatch();
 
-  // We only use the global user preference for theme if the current lesson has
-  // at least one python lab level or the current level is a python lab level.
-  const useThemeUserPreference = useMemo(
-    () =>
-      levelProperties?.appName === 'pythonlab' ||
-      lesson?.levels.some((level: Level) => level.app === 'pythonlab'),
-    [lesson?.levels, levelProperties?.appName]
-  );
-
-  // Set the theme for the current app.
-  const {setTheme} = useTheme();
-  useEffect(() => {
-    if (currentAppName) {
-      const supportedThemes = lab2EntryPoints[currentAppName]?.themes;
-      dispatch(setIsLoadingTheme(true));
-
-      const setThemeHelper = () => {
-        // Use the theme from app options if it exists and is supported,
-        // otherwise fall back to the first supported theme.
-        // We will only use the app options theme if we are not using the user preference,
-        // so it is safe to use that statically set theme.
-        const upperCasedTheme = initialTheme
-          ? (capitalizeFirstLetter(initialTheme) as Theme)
-          : undefined;
-        if (upperCasedTheme && supportedThemes.includes(upperCasedTheme)) {
-          setTheme(upperCasedTheme);
-        } else {
-          setTheme(supportedThemes[0]);
-        }
-        dispatch(setIsLoadingTheme(false));
-      };
-
-      if (useThemeUserPreference && signInState === SignInState.SignedIn) {
-        const fetchAndSetTheme = async () => {
-          const userTheme = await new UserPreferences().getGlobalTheme(
-            (error: NetworkError) =>
-              Lab2Registry.getInstance()
-                .getMetricsReporter()
-                .logError('Error fetching theme', undefined, {
-                  message: error.response,
-                })
-          );
-          if (userTheme && supportedThemes.includes(userTheme)) {
-            setTheme(userTheme);
-            dispatch(setIsLoadingTheme(false));
-          } else {
-            setThemeHelper();
-          }
-        };
-
-        fetchAndSetTheme();
-      } else {
-        setThemeHelper();
-      }
-    }
-  }, [
+  useInitialLabTheme({
     currentAppName,
-    setTheme,
-    useThemeUserPreference,
-    signInState,
-    dispatch,
-    initialTheme,
-  ]);
+    levelProperties,
+  });
 
   // Do not render lab view if project is blocked and user is not a project validator.
   if (!currentAppName || (isBlocked && !isProjectValidator)) {

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -6,13 +6,13 @@
 import React, {Suspense} from 'react';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
+import {PERMISSIONS} from '@cdo/apps/lab2/constants';
+import {useInitialLabTheme} from '@cdo/apps/lab2/hooks/useInitialLabTheme';
+import ProgressContainer from '@cdo/apps/lab2/progress/ProgressContainer';
+import {getAppOptionsViewingExemplar} from '@cdo/apps/lab2/projects/utils';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {lab2EntryPoints} from '../../../lab2EntryPoints';
-import {PERMISSIONS} from '../constants';
-import {useInitialLabTheme} from '../hooks/useInitialLabTheme';
-import ProgressContainer from '../progress/ProgressContainer';
-import {getAppOptionsViewingExemplar} from '../projects/utils';
 
 import NoExemplarPage from './components/NoExemplarPage';
 import ExtraLinks from './ExtraLinks';


### PR DESCRIPTION
This is a pure refactor to move the initial theme logic into a hook rather than having it all in `LabViewsRenderer`.

## Links

- Jira: [CT-1231](https://codedotorg.atlassian.net/browse/CT-1231)

## Testing story
Tested locally that everything still works the same.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
