### PR TITLE
chore(Video): hide download button on mobile

### DIFF
--- a/frontend/packages/component-library/src/video/video.module.scss
+++ b/frontend/packages/component-library/src/video/video.module.scss
@@ -80,6 +80,10 @@
 
   .download {
     margin-top: 0.25rem;
+
+    @media (max-width: 640px) {
+      display: none;
+    }
   }
 
   // Align the download button to the right


### PR DESCRIPTION
Hides the download button on mobile on the Video component.

## Links
Jira ticket: [CMS-763](https://codedotorg.atlassian.net/browse/CMS-763)

## Testing story
Tested locally on Storybook and Contentful

----

## Storybook

https://github.com/user-attachments/assets/548d5cea-7385-495f-a6b2-45e0c4c43619

## Contentful


https://github.com/user-attachments/assets/fb8cbb30-40d7-4725-b147-18f0fa52541d

