### PR TITLE
chore(Video): open download button in new tab

### DIFF
--- a/frontend/packages/component-library/src/video/Video.tsx
+++ b/frontend/packages/component-library/src/video/Video.tsx
@@ -174,6 +174,8 @@ const Video: React.FC<VideoProps> = ({
             size="xs"
             text={downloadLabel || 'Download'}
             type="secondary"
+            target="_blank"
+            rel="noopener noreferrer"
           />
         )}
       </div>

--- a/frontend/packages/component-library/src/video/__tests__/Video.test.tsx
+++ b/frontend/packages/component-library/src/video/__tests__/Video.test.tsx
@@ -84,6 +84,9 @@ describe('Video Component', () => {
     });
     expect(downloadButton).toBeInTheDocument();
     expect(downloadButton).toHaveAttribute('href', defaultProps.videoFallback);
+
+    // check that the download button opens in a new tab
+    expect(downloadButton).toHaveAttribute('target', '_blank');
   });
 
   it('renders native video player when YouTube video fails and fallback is valid', () => {


### PR DESCRIPTION
Opens the download button in a new tab on Video component.

## Links
Jira ticket: [CMS-768](https://codedotorg.atlassian.net/browse/CMS-768)

## Testing story
Tested locally

----

## Before


https://github.com/user-attachments/assets/b958c937-87d6-4982-b480-ab700860ecc0

## After


https://github.com/user-attachments/assets/9cea9296-87f7-42f1-98d9-8e279f4d2576

