### PR TITLE
chore(marketing): open external links in a new tab on ActionBlock, FullWidthActionBlock, and ActionBlockCarousel

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/ActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/ActionBlock.tsx
@@ -84,6 +84,10 @@ const ActionBlock: React.FC<ActionBlockContentfulProps> = ({
             iconRight: secondaryButton.fields.isThisAnExternalLink
               ? externalLinkIconProps
               : undefined,
+            ...(secondaryButton.fields.isThisAnExternalLink && {
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            }),
           }
         : undefined
     }

--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/ActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/ActionBlock.tsx
@@ -68,6 +68,10 @@ const ActionBlock: React.FC<ActionBlockContentfulProps> = ({
             iconRight: primaryButton.fields.isThisAnExternalLink
               ? externalLinkIconProps
               : undefined,
+            ...(primaryButton.fields.isThisAnExternalLink && {
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            }),
           }
         : undefined
     }

--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/__tests__/ActionBlock.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/__tests__/ActionBlock.test.tsx
@@ -99,7 +99,7 @@ describe('ActionBlock', () => {
         }}
         secondaryButton={{
           fields: {
-            ...defaultProps.primaryButton.fields,
+            ...defaultProps.secondaryButton.fields,
             isThisAnExternalLink: true,
           },
         }}
@@ -107,6 +107,36 @@ describe('ActionBlock', () => {
     );
 
     expect(queryAllByTestId('font-awesome-v6-icon')).toHaveLength(2);
+  });
+
+  it('opens external links in a new tab', () => {
+    const {getByLabelText} = render(
+      <ActionBlock
+        {...defaultProps}
+        primaryButton={{
+          fields: {
+            ...defaultProps.primaryButton.fields,
+            isThisAnExternalLink: true,
+          },
+        }}
+        secondaryButton={{
+          fields: {
+            ...defaultProps.secondaryButton.fields,
+            isThisAnExternalLink: true,
+          },
+        }}
+      />,
+    );
+
+    expect(getByLabelText('Test Primary Button aria label')).toHaveAttribute(
+      'target',
+      '_blank',
+    );
+
+    expect(getByLabelText('Test Secondary Button aria label')).toHaveAttribute(
+      'target',
+      '_blank',
+    );
   });
 
   it('renders New tag if publishedDate is within 3 months of the current date', () => {

--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
@@ -71,6 +71,10 @@ const FullWidthActionBlock: React.FC<FullWidthActionBlockContentfulProps> = ({
             iconRight: primaryButton.fields.isThisAnExternalLink
               ? externalLinkIconProps
               : undefined,
+            ...(primaryButton.fields.isThisAnExternalLink && {
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            }),
           }
         : undefined
     }

--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/FullWidthActionBlock.tsx
@@ -87,6 +87,10 @@ const FullWidthActionBlock: React.FC<FullWidthActionBlockContentfulProps> = ({
             iconRight: secondaryButton.fields.isThisAnExternalLink
               ? externalLinkIconProps
               : undefined,
+            ...(secondaryButton.fields.isThisAnExternalLink && {
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            }),
           }
         : undefined
     }

--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/__tests__/FullWidthActionBlock.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/__tests__/FullWidthActionBlock.test.tsx
@@ -111,7 +111,7 @@ describe('ActionBlock', () => {
         }}
         secondaryButton={{
           fields: {
-            ...defaultProps.primaryButton.fields,
+            ...defaultProps.secondaryButton.fields,
             isThisAnExternalLink: true,
           },
         }}
@@ -119,6 +119,36 @@ describe('ActionBlock', () => {
     );
 
     expect(queryAllByTestId('font-awesome-v6-icon')).toHaveLength(2);
+  });
+
+  it('opens external links in a new tab', () => {
+    const {getByLabelText} = render(
+      <FullWidthActionBlock
+        {...defaultProps}
+        primaryButton={{
+          fields: {
+            ...defaultProps.primaryButton.fields,
+            isThisAnExternalLink: true,
+          },
+        }}
+        secondaryButton={{
+          fields: {
+            ...defaultProps.secondaryButton.fields,
+            isThisAnExternalLink: true,
+          },
+        }}
+      />,
+    );
+
+    expect(getByLabelText('Test Primary Button aria label')).toHaveAttribute(
+      'target',
+      '_blank',
+    );
+
+    expect(getByLabelText('Test Secondary Button aria label')).toHaveAttribute(
+      'target',
+      '_blank',
+    );
   });
 
   it('renders New tag if publishedDate is within 3 months of the current date', () => {

--- a/frontend/apps/marketing/src/components/contentful/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
+++ b/frontend/apps/marketing/src/components/contentful/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
@@ -106,6 +106,10 @@ const ActionBlockCarousel: React.FC<ActionBlockCarouselProps> = ({
                       iconRight: secondaryLinkRef.fields.isThisAnExternalLink
                         ? externalLinkIconProps
                         : undefined,
+                      ...(secondaryLinkRef.fields.isThisAnExternalLink && {
+                        target: '_blank',
+                        rel: 'noopener noreferrer',
+                      }),
                     }
                   : undefined
               }

--- a/frontend/apps/marketing/src/components/contentful/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
+++ b/frontend/apps/marketing/src/components/contentful/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
@@ -89,6 +89,10 @@ const ActionBlockCarousel: React.FC<ActionBlockCarouselProps> = ({
                       iconRight: primaryLinkRef.fields.isThisAnExternalLink
                         ? externalLinkIconProps
                         : undefined,
+                      ...(primaryLinkRef.fields.isThisAnExternalLink && {
+                        target: '_blank',
+                        rel: 'noopener noreferrer',
+                      }),
                     }
                   : undefined
               }


### PR DESCRIPTION
Opens external links on ActionBlock, FullWidthActionBlock, and ActionBlockCarousel components in Contentful.

## Links
Jira ticket: [CMS-725](https://codedotorg.atlassian.net/browse/CMS-725)

## Testing story
Tested locally in Contentful and added unit tests to ActionBlock and FullWidthActionBlock (ActionBlockCarousel doesn't have unit tests due to Swiper). 

----

## ActionBlock and FullWidthActionBlock


https://github.com/user-attachments/assets/31e89a6d-6568-4b45-889b-7bab52f4ba1f

## ActionBlockCarousel


https://github.com/user-attachments/assets/fab20cdf-b27f-4cd6-ba63-fb47f29f97c7

## Secondary buttons


https://github.com/user-attachments/assets/299911e1-29f2-4d84-871b-03837b0b7e63



https://github.com/user-attachments/assets/df5b3122-8718-470b-b740-e2e1f6f29920

