### PR TITLE
TEACH-2008/update integration tests

### DIFF
--- a/dashboard/test/integration/caching_test.rb
+++ b/dashboard/test/integration/caching_test.rb
@@ -16,6 +16,7 @@ class CachingTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  # TODO: TEACH-1788: This will need to be updated when we change the test fixtures
   test "should get /s/frozen" do
     assert_cached_queries(0) do
       get '/s/frozen'

--- a/dashboard/test/integration/callouts_test.rb
+++ b/dashboard/test/integration/callouts_test.rb
@@ -4,7 +4,7 @@ class CalloutsTest < ActionDispatch::IntegrationTest
   setup do
     Unit.stubs(:should_cache?).returns true
     Rails.application.config.stubs(:levelbuilder_mode).returns false
-    @script = create :script
+    @script = create(:single_unit_course).first_unit
     @lesson_group = create :lesson_group, script: @script
     @lesson = create :lesson, script: @script, lesson_group: @lesson_group
     @maze_data = {game_id: 25, user_id: 1, name: '__bob4', level_num: 'custom', skin: 'birds', short_instructions: 'sdfdfs'}
@@ -13,7 +13,7 @@ class CalloutsTest < ActionDispatch::IntegrationTest
     @level.save!
     @script_level = create(:script_level, levels: [@level], lesson: @lesson, script: @script)
     @level_path = "/levels/#{@level.id}"
-    @script_level_path = "/s/#{@script.name}/lessons/1/levels/1"
+    @script_level_path = "/courses/#{@script.original_unit_group.name}/units/1/lessons/1/levels/1"
     Unit.script_cache.delete @script.name
     Unit.script_cache.delete @script.id.to_s
 

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -10,6 +10,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     setup_script_cache
   end
 
+  # TODO: TEACH-1788: This will need to be updated when we change the test fixtures
   test "script level show" do
     student = create :student
     sign_in student

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -125,6 +125,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     script = create(
       :script,
       :with_levels,
+      :in_unit_group,
       levels_count: 10
     )
     course = create(:single_unit_course, unit: script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, version_year: 'unversioned', family_name: 'hoc-family')

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -66,14 +66,17 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student = create :student
     sign_in student
 
-    sl = create(:script, :with_levels, levels_count: 3).script_levels[2]
+    script = create(:script, :with_levels, levels_count: 3)
+    course = create(:single_unit_course, unit: script)
+    sl = script.script_levels[2]
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
     assert_cached_queries(9) do
       post milestone_path(
         user_id: student.id,
-        script_level_id: sl.id
+        script_level_id: sl.id,
+        course_id: course.id
       ), params: params
       assert_response :success
     end
@@ -83,14 +86,17 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student = create :student
     sign_in student
 
-    sl = create(:script, :with_levels, levels_count: 3).script_levels[1]
+    script = create(:script, :with_levels, levels_count: 3)
+    course = create(:single_unit_course, unit: script)
+    sl = script.script_levels[1]
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
     assert_cached_queries(7) do
       post milestone_path(
         user_id: student.id,
-        script_level_id: sl.id
+        script_level_id: sl.id,
+        course_id: course.id
       ), params: params
       assert_response :success
     end
@@ -100,13 +106,16 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student = create :student
     sign_in student
 
-    sl = create(:script, :with_levels, levels_count: 3).script_levels[2]
+    script = create(:script, :with_levels, levels_count: 3)
+    course = create(:single_unit_course, unit: script)
+    sl = script.script_levels[2]
     params = {program: 'fake program', testResult: 0, result: 'false'}
 
     assert_cached_queries(7) do
       post milestone_path(
         user_id: student.id,
-        script_level_id: sl.id
+        script_level_id: sl.id,
+        course_id: course.id
       ), params: params
       assert_response :success
     end
@@ -128,8 +137,8 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(script)
     sign_in student
 
-    assert_cached_queries(6) do
-      get "/s/#{script.name}"
+    assert_cached_queries(5) do
+      get "/courses/#{course.name}/units/1/"
       assert_response :success
     end
 
@@ -151,13 +160,10 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     unit = create(
       :script,
       :with_levels,
-      levels_count: 10,
-      is_course: true,
-      family_name: 'hoc-family',
-      version_year: 'unversioned',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+      levels_count: 10
     )
-    CourseOffering.add_course_offering(unit)
+    course = create(:single_unit_course, unit: unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, version_year: 'unversioned', family_name: 'hoc-family')
+    CourseOffering.add_course_offering(course)
 
     # make sure the new unit is in the cache
     setup_script_cache
@@ -172,7 +178,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sign_in student
 
     assert_cached_queries(19) do
-      get "/s/#{unit.name}/lessons/1/levels/1"
+      get "/courses/#{course.name}/units/1/lessons/1/levels/1"
       assert_response :success
     end
 

--- a/dashboard/test/integration/lesson_lock_test.rb
+++ b/dashboard/test/integration/lesson_lock_test.rb
@@ -11,7 +11,7 @@ class StageLockTest < ActionDispatch::IntegrationTest
     @section = create :section, user_id: @teacher.id
     Follower.create!(section_id: @section.id, student_user_id: @student.id, user: @teacher)
 
-    @script = create :script
+    @script = create(:single_unit_course).first_unit
     @lesson_group = create :lesson_group, script: @script
     @lockable_lesson = create(:lesson, script: @script, name: 'Lockable Lesson', lockable: true, lesson_group: @lesson_group)
     external = create(:external, name: 'markdown level')
@@ -23,7 +23,7 @@ class StageLockTest < ActionDispatch::IntegrationTest
   test 'authorized teacher viewing lockable lesson contents' do
     sign_in @teacher
 
-    get build_script_level_path(@lockable_external_sl)
+    get build_script_level_path(@lockable_external_sl, unit_group_unit: @script.unit_group_units.first)
     assert_response :success
     assert_includes response.body, 'lorem ipsum'
     assert_select "#locked-lesson", 1
@@ -33,7 +33,7 @@ class StageLockTest < ActionDispatch::IntegrationTest
 
     # This needs to be an integration test rather than a controller test in
     # order to follow the redirect which adds the /page/1 suffix.
-    get build_script_level_path(@lockable_level_group_sl)
+    get build_script_level_path(@lockable_level_group_sl, unit_group_unit: @script.unit_group_units.first)
     follow_redirect!
     assert_response :success
     assert_select '.level-group', 1
@@ -46,13 +46,13 @@ class StageLockTest < ActionDispatch::IntegrationTest
     assert @lockable_level_group_sl.locked?(@student)
     assert @lockable_external_sl.locked?(@student)
 
-    get build_script_level_path(@lockable_external_sl)
+    get build_script_level_path(@lockable_external_sl, unit_group_unit: @script.unit_group_units.first)
     assert_response :success
     refute_includes response.body, 'lorem ipsum'
     assert_select "#locked-lesson", 1
     assert_select "#locked-lesson[data-hidden]", 0
 
-    get build_script_level_path(@lockable_level_group_sl)
+    get build_script_level_path(@lockable_level_group_sl, unit_group_unit: @script.unit_group_units.first)
     follow_redirect!
     assert_response :success
     assert_select '.level-group', 0
@@ -66,12 +66,12 @@ class StageLockTest < ActionDispatch::IntegrationTest
     refute @lockable_level_group_sl.locked?(@student)
     refute @lockable_external_sl.locked?(@student)
 
-    get build_script_level_path(@lockable_external_sl)
+    get build_script_level_path(@lockable_external_sl, unit_group_unit: @script.unit_group_units.first)
     assert_response :success
     assert_includes response.body, 'lorem ipsum'
     assert_select "#locked-lesson", 0
 
-    get build_script_level_path(@lockable_level_group_sl)
+    get build_script_level_path(@lockable_level_group_sl, unit_group_unit: @script.unit_group_units.first)
     follow_redirect!
     assert_response :success
     assert_select '.level-group', 1

--- a/dashboard/test/integration/lessons_test.rb
+++ b/dashboard/test/integration/lessons_test.rb
@@ -8,6 +8,7 @@ class LessonsTest < ActionDispatch::IntegrationTest
     File.stubs(:write)
 
     @script = create :script, name: 'unit-1', is_migrated: true
+    @course = create(:single_unit_course, unit: @script)
     lesson_group = create :lesson_group, script: @script
     @lesson = create(
       :lesson,
@@ -74,14 +75,14 @@ class LessonsTest < ActionDispatch::IntegrationTest
   end
 
   test 'lesson show page contains expected data' do
-    get script_lesson_path(@lesson.script, @lesson)
+    get course_unit_lesson_path(@course, 1, @lesson)
     assert_response :success
     assert_select 'script[data-lesson]', 1
     lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
     assert_equal 'lesson overview', lesson_data['overview']
-    assert_equal '/s/unit-1', lesson_data['unit']['link']
-    assert_equal script_lesson_path(@lesson.script, @lesson), lesson_data['unit']['lessonGroups'][0]['lessons'][0]['link']
-    assert_equal script_lesson_path(@lesson2.script, @lesson2), lesson_data['unit']['lessonGroups'][0]['lessons'][1]['link']
+    assert_equal "/courses/#{@course.name}/units/1", lesson_data['unit']['link']
+    assert_equal course_unit_lesson_path(@course, 1, @lesson), lesson_data['unit']['lessonGroups'][0]['lessons'][0]['link']
+    assert_equal course_unit_lesson_path(@course, 1, @lesson2), lesson_data['unit']['lessonGroups'][0]['lessons'][1]['link']
     assert_equal 'Standard Description', lesson_data['standards'][0]['description']
     assert_equal 'Opportunity Standard Description', lesson_data['opportunityStandards'][0]['description']
   end

--- a/dashboard/test/integration/redirects_test.rb
+++ b/dashboard/test/integration/redirects_test.rb
@@ -111,12 +111,12 @@ class RedirectsTest < ActionDispatch::IntegrationTest
     get '/courses/course-with-bonus/units/1'
     assert :success
 
-    # TODO: Figure out stage urls?
     get '/s/script-with-bonus/stage/1/extras?section_id=999999'
     assert_redirected_to '/s/script-with-bonus/lessons/1/extras?section_id=999999'
+    follow_redirect!
+    assert_redirected_to '/courses/course-with-bonus/units/1/lessons/1/extras?section_id=999999'
   end
 
-  # TODO: Figure out lockable urls?
   test 'redirects urls with lockable and puzzle to lockable and levels' do
     @unit = create :script, name: 'test-script'
     create :single_unit_course, unit: @unit, name: 'test-course'
@@ -127,9 +127,13 @@ class RedirectsTest < ActionDispatch::IntegrationTest
 
     get '/s/test-script/lockable/1/puzzle/1'
     assert_redirected_to '/s/test-script/lockable/1/levels/1'
+    follow_redirect!
+    assert_redirected_to '/courses/test-course/units/1/lockable/1/levels/1'
 
     get '/s/test-script/lockable/1/puzzle/1/page/1'
     assert_redirected_to '/s/test-script/lockable/1/levels/1/page/1'
+    follow_redirect!
+    assert_redirected_to '/courses/test-course/units/1/lockable/1/levels/1/page/1'
 
     # ideally we would just return a 404, but it is easier to implement a
     # redirect to a url which 404s.

--- a/dashboard/test/integration/redirects_test.rb
+++ b/dashboard/test/integration/redirects_test.rb
@@ -74,20 +74,21 @@ class RedirectsTest < ActionDispatch::IntegrationTest
     assert_equal 'es-ES', cookies[:language_]
   end
 
+  # TODO: TEACH-1788: This will need to be updated when we change the test fixtures
   test 'redirects urls with stage and puzzle to lessons and levels' do
-    get '/s/allthethings/stage/1/puzzle/1'
-    assert_redirected_to '/s/allthethings/lessons/1/levels/1'
+    get '/courses/allthethingscourse/units/1/stage/1/puzzle/1'
+    assert_redirected_to '/courses/allthethingscourse/units/1/lessons/1/levels/1'
 
-    get '/s/allthethings/stage/40/puzzle/1/sublevel/1'
-    assert_redirected_to '/s/allthethings/lessons/40/levels/1/sublevel/1'
+    get '/courses/allthethingscourse/units/1/stage/40/puzzle/1/sublevel/1'
+    assert_redirected_to 'courses/allthethingscourse/units/1/lessons/40/levels/1/sublevel/1'
 
-    get '/s/allthethings/stage/33/puzzle/1/page/1'
-    assert_redirected_to '/s/allthethings/lessons/33/levels/1/page/1'
+    get '/courses/allthethingscourse/units/1/stage/33/puzzle/1/page/1'
+    assert_redirected_to '/courses/allthethingscourse/units/1/lessons/33/levels/1/page/1'
 
     # ideally we would just return a 404, but it is easier to implement a
     # redirect to a url which 404s.
-    get '/s/allthethings/stage/1/puzzle'
-    assert_redirected_to '/s/allthethings/lessons/1/levels'
+    get '/courses/allthethingscourse/units/1/stage/1/puzzle'
+    assert_redirected_to '/courses/allthethingscourse/units/1/lessons/1/levels'
     e = assert_raises(ActionController::RoutingError) do
       follow_redirect!
     end
@@ -96,6 +97,7 @@ class RedirectsTest < ActionDispatch::IntegrationTest
 
   test 'redirects urls with stage for lesson extras' do
     script = create :script, name: 'script-with-bonus', lesson_extras_available: true
+    create :single_unit_course, name: 'course-with-bonus', unit: script
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, lesson_group: lesson_group
     create :script_level, script: script, lesson: lesson
@@ -106,15 +108,18 @@ class RedirectsTest < ActionDispatch::IntegrationTest
 
     sign_in(@teacher)
 
-    get '/s/script-with-bonus'
+    get '/courses/course-with-bonus/units/1'
     assert :success
 
+    # TODO: Figure out stage urls?
     get '/s/script-with-bonus/stage/1/extras?section_id=999999'
     assert_redirected_to '/s/script-with-bonus/lessons/1/extras?section_id=999999'
   end
 
+  # TODO: Figure out lockable urls?
   test 'redirects urls with lockable and puzzle to lockable and levels' do
     @unit = create :script, name: 'test-script'
+    create :single_unit_course, unit: @unit, name: 'test-course'
     @lesson_group = create :lesson_group, script: @unit
     @lockable_lesson = create(:lesson, script: @unit, lockable: true, lesson_group: @lesson_group, has_lesson_plan: false, absolute_position: 1, relative_position: 1)
     @level_group = create(:level_group, :with_sublevels, name: 'assessment 1')
@@ -139,5 +144,16 @@ class RedirectsTest < ActionDispatch::IntegrationTest
   test 'redirects weblab code studio share link to codeprojects' do
     get "http://#{CDO.dashboard_hostname}/projects/weblab/abcdef"
     assert_redirected_to "http://#{CDO.codeprojects_hostname}/abcdef/"
+  end
+
+  test 'redirects to /courses/ from /s/' do
+    single_unit_course = create :single_unit_course, name: 'single-unit-course'
+
+    get "/s/#{single_unit_course.first_unit.name}"
+    assert_redirected_to "/courses/#{single_unit_course.name}/units/1"
+
+    multi_unit_course = create :unit_group, :with_units, name: 'multi-unit-course'
+    get "/s/#{multi_unit_course.default_units.last.name}"
+    assert_redirected_to "/courses/#{multi_unit_course.name}/units/#{multi_unit_course.default_unit_group_units.last.position}"
   end
 end

--- a/dashboard/test/integration/redirects_test.rb
+++ b/dashboard/test/integration/redirects_test.rb
@@ -76,19 +76,19 @@ class RedirectsTest < ActionDispatch::IntegrationTest
 
   # TODO: TEACH-1788: This will need to be updated when we change the test fixtures
   test 'redirects urls with stage and puzzle to lessons and levels' do
-    get '/courses/allthethingscourse/units/1/stage/1/puzzle/1'
-    assert_redirected_to '/courses/allthethingscourse/units/1/lessons/1/levels/1'
+    get '/s/allthethings/stage/1/puzzle/1'
+    assert_redirected_to '/s/allthethings/lessons/1/levels/1'
 
-    get '/courses/allthethingscourse/units/1/stage/40/puzzle/1/sublevel/1'
-    assert_redirected_to 'courses/allthethingscourse/units/1/lessons/40/levels/1/sublevel/1'
+    get '/s/allthethings/stage/40/puzzle/1/sublevel/1'
+    assert_redirected_to '/s/allthethings/lessons/40/levels/1/sublevel/1'
 
-    get '/courses/allthethingscourse/units/1/stage/33/puzzle/1/page/1'
-    assert_redirected_to '/courses/allthethingscourse/units/1/lessons/33/levels/1/page/1'
+    get '/s/allthethings/stage/33/puzzle/1/page/1'
+    assert_redirected_to '/s/allthethings/lessons/33/levels/1/page/1'
 
     # ideally we would just return a 404, but it is easier to implement a
     # redirect to a url which 404s.
-    get '/courses/allthethingscourse/units/1/stage/1/puzzle'
-    assert_redirected_to '/courses/allthethingscourse/units/1/lessons/1/levels'
+    get '/s/allthethings/stage/1/puzzle'
+    assert_redirected_to '/s/allthethings/lessons/1/levels'
     e = assert_raises(ActionController::RoutingError) do
       follow_redirect!
     end

--- a/dashboard/test/integration/rubrics_test.rb
+++ b/dashboard/test/integration/rubrics_test.rb
@@ -8,6 +8,7 @@ class RubricsTest < ActionDispatch::IntegrationTest
     sign_in @teacher
 
     @unit = create :script, :with_levels, lessons_count: 4, name: 'test-unit'
+    create(:single_unit_course, unit: @unit)
     @first_script_level = @unit.script_levels.first
     @rubric = create :rubric, :with_learning_goals, lesson: @first_script_level.lesson, level: @first_script_level.levels.first
     @last_script_level = @unit.script_levels.last
@@ -15,7 +16,7 @@ class RubricsTest < ActionDispatch::IntegrationTest
   end
 
   test 'canShowTaScoresAlert is true by default' do
-    get build_script_level_path(@first_script_level)
+    get build_script_level_path(@first_script_level, unit_group_unit: @unit.unit_group_units.first)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
     assert rubric_data['canShowTaScoresAlert']
@@ -25,7 +26,7 @@ class RubricsTest < ActionDispatch::IntegrationTest
     learning_goal = create :learning_goal_teacher_evaluation, learning_goal: @rubric.learning_goals.first, teacher: @teacher, understanding: nil
 
     # ignore learning goal without understanding
-    get build_script_level_path(@last_script_level)
+    get build_script_level_path(@last_script_level, unit_group_unit: @unit.unit_group_units.first)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
     assert rubric_data['canShowTaScoresAlert']
@@ -33,14 +34,14 @@ class RubricsTest < ActionDispatch::IntegrationTest
     learning_goal.update!(understanding: 1)
 
     # can show alert after understanding is set
-    get build_script_level_path(@last_script_level)
+    get build_script_level_path(@last_script_level, unit_group_unit: @unit.unit_group_units.first)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
     refute rubric_data['canShowTaScoresAlert']
   end
 
   test 'set_seen_ta_scores sets canShowTaScoresAlert to false' do
-    get build_script_level_path(@first_script_level)
+    get build_script_level_path(@first_script_level, unit_group_unit: @unit.unit_group_units.first)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
     assert rubric_data['canShowTaScoresAlert']
@@ -49,14 +50,14 @@ class RubricsTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # can no longer show alert for this lesson
-    get build_script_level_path(@first_script_level)
+    get build_script_level_path(@first_script_level, unit_group_unit: @unit.unit_group_units.first)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
     refute rubric_data['canShowTaScoresAlert']
 
     # can still show alert for other lessons
     refute_equal @last_script_level.lesson, @first_script_level.lesson
-    get build_script_level_path(@last_script_level)
+    get build_script_level_path(@last_script_level, unit_group_unit: @unit.unit_group_units.first)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
     assert rubric_data['canShowTaScoresAlert']
@@ -69,16 +70,17 @@ class RubricsTest < ActionDispatch::IntegrationTest
     end
 
     # cannot show alert for other lessons in same unit
-    get build_script_level_path(@last_script_level)
+    get build_script_level_path(@last_script_level, unit_group_unit: @unit.unit_group_units.first)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
     refute rubric_data['canShowTaScoresAlert']
 
     # cannot show alert for lessons in other unit
     unit = create :script, :with_levels, name: 'test-unit-2'
+    create(:single_unit_course, unit: unit)
     script_level = unit.script_levels.first
     create :rubric, lesson: script_level.lesson, level: script_level.levels.first
-    get build_script_level_path(script_level)
+    get build_script_level_path(script_level, unit_group_unit: unit.unit_group_units.first)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
     refute rubric_data['canShowTaScoresAlert']

--- a/dashboard/test/integration/scripts_test.rb
+++ b/dashboard/test/integration/scripts_test.rb
@@ -69,7 +69,6 @@ class ScriptsTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  # TODO: Figure out instruction urls?
   test 'levelbuilder instructions for csp2-2020' do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     sign_in(create(:levelbuilder))

--- a/dashboard/test/integration/scripts_test.rb
+++ b/dashboard/test/integration/scripts_test.rb
@@ -16,13 +16,14 @@ class ScriptsTest < ActionDispatch::IntegrationTest
     sign_in @teacher
 
     @unit = create :script, name: 'csp1-2020'
+    create :single_unit_course, unit: @unit, name: 'csp-2020'
     @lesson_group = create :lesson_group, script: @unit
     @lockable_lesson = create(:lesson, script: @unit, name: 'Assessment Day', lockable: true, lesson_group: @lesson_group, has_lesson_plan: true, absolute_position: 15, relative_position: 14)
     @level_group = create(:level_group, :with_sublevels, name: 'assessment 1')
     @lockable_level_group_sl = create(:script_level, script: @unit, lesson: @lockable_lesson, levels: [@level_group], assessment: true)
 
-    get build_script_level_path(@lockable_level_group_sl)
-    assert_includes @response.body, '/s/csp1-2020/lessons/14/'
+    get build_script_level_path(@lockable_level_group_sl, unit_group_unit: @unit.unit_group_units.first)
+    assert_includes @response.body, '/courses/csp-2020/units/1/lessons/14/'
     follow_redirect!
     assert_response :success
     assert_select '.level-group', 1
@@ -34,13 +35,14 @@ class ScriptsTest < ActionDispatch::IntegrationTest
     sign_in @teacher
 
     @unit = create :script, name: 'csp2-2020'
+    create :single_unit_course, unit: @unit, name: 'csp-2020'
     @lesson_group = create :lesson_group, script: @unit
     @lockable_lesson = create(:lesson, script: @unit, name: 'Assessment Day', lockable: true, lesson_group: @lesson_group, has_lesson_plan: true, absolute_position: 9, relative_position: 9)
     @level_group = create(:level_group, :with_sublevels, name: 'assessment 1')
     @lockable_level_group_sl = create(:script_level, script: @unit, lesson: @lockable_lesson, levels: [@level_group], assessment: true)
 
-    get build_script_level_path(@lockable_level_group_sl)
-    assert_includes @response.body, '/s/csp2-2020/lessons/9/'
+    get build_script_level_path(@lockable_level_group_sl, unit_group_unit: @unit.unit_group_units.first)
+    assert_includes @response.body, '/courses/csp-2020/units/1/lessons/9/'
     follow_redirect!
     assert_response :success
     assert_select '.level-group', 1
@@ -48,12 +50,10 @@ class ScriptsTest < ActionDispatch::IntegrationTest
     assert_select "#locked-lesson[data-hidden]", 1
   end
 
-  test 'assigned student can follow script family redirect' do
-    unit = create(
-      :script, name: 'coursez-2020', family_name: 'coursez', version_year: 'unversioned', is_course: true,
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-    )
-    CourseOffering.add_course_offering(unit)
+  test 'assigned student can follow single-unit course family redirect' do
+    unit = create :script, name: 'coursez-2020'
+    single_unit_course = create(:single_unit_course, name: 'coursez-2020', family_name: 'coursez', version_year: '2020', unit: unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    CourseOffering.add_course_offering(single_unit_course)
 
     teacher = create :teacher
     section = create :section, teacher: teacher, script: unit
@@ -62,18 +62,20 @@ class ScriptsTest < ActionDispatch::IntegrationTest
 
     sign_in student
 
-    get "/s/#{unit.family_name}"
+    get "/s/#{single_unit_course.family_name}"
     assert_response :redirect
-    assert_match %r{/s/#{unit.name}$}, @response.headers['Location']
+    assert_match %r{/courses/#{single_unit_course.name}/units/1$}, @response.headers['Location']
     follow_redirect!
     assert_response :success
   end
 
-  test 'levelbuilder instrictions for csp2-2020' do
+  # TODO: Figure out instruction urls?
+  test 'levelbuilder instructions for csp2-2020' do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     sign_in(create(:levelbuilder))
 
     @unit = create :script, name: 'csp2-2020'
+    create :single_unit_course, unit: @unit, name: 'csp-2020'
     @lesson_group = create :lesson_group, script: @unit
     @lockable_lesson = create(:lesson, script: @unit, name: 'Assessment Day', lockable: true, lesson_group: @lesson_group, has_lesson_plan: true, absolute_position: 9, relative_position: 9)
     @level_group = create(:level_group, :with_sublevels, name: 'assessment 1')
@@ -93,6 +95,7 @@ class ScriptsTest < ActionDispatch::IntegrationTest
     sign_in(create(:levelbuilder))
 
     @unit = create :script, name: 'csp2-2020'
+    create :single_unit_course, unit: @unit, name: 'csp-2020'
     lesson_group = create :lesson_group, script: @unit
     @lesson = create(
       :lesson,

--- a/dashboard/test/integration/session_cookie_test.rb
+++ b/dashboard/test/integration/session_cookie_test.rb
@@ -18,7 +18,7 @@ class SessionCookieTest < ActionDispatch::IntegrationTest
 
     assert_nil cookies['_learn_session_test']
   end
-
+  # TODO: TEACH-1788: This will need to be updated when we change the test fixtures
   test 'session cookie not set in publicly cached lesson plan' do
     ScriptConfig.stubs(:allows_public_caching_for_script).returns(true)
     get '/s/jigsaw/lessons/1'


### PR DESCRIPTION
After the standalone-unit migration and URL restructure, we need to update all unit tests to reference single-unit courses and the correct `/courses/.../units/...` URLs. This is the first PR to make test changes

## Links
- Jira: [TEACH-1678](https://codedotorg.atlassian.net/browse/TEACH-1678) (the main task)
- Jira: [TEACH-2008](https://codedotorg.atlassian.net/browse/TEACH-2008) (the sub task)

## Follow-up work
There are many tests to be updated. To make reviews easier, the work will be broken up into several PRs. To see a list of all groupings, look at the main task [TEACH-1678](https://codedotorg.atlassian.net/browse/TEACH-1678)
