### PR TITLE
Add AIF to marketing initiative filters on Curriculum Catalog

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1925,6 +1925,7 @@
   "map": "Map",
   "mapsToCSTAStandards": "Maps to [CSTA Standards]({cstaLink})",
   "markedAsKeepWorking": "Marked as 'keep working'",
+  "marketingInitiativeAIF": "AI Foundations",
   "marketingInitiativeCSA": "AP CSA",
   "marketingInitiativeCSC": "CS Connections",
   "marketingInitiativeCSD": "CS Discoveries",

--- a/apps/src/templates/teacherDashboard/CourseOfferingHelpers.jsx
+++ b/apps/src/templates/teacherDashboard/CourseOfferingHelpers.jsx
@@ -67,6 +67,7 @@ export const translatedCourseOfferingDurationsWithTime = {
 };
 
 export const translatedCourseOfferingMarketingInitiatives = {
+  aif: i18n.marketingInitiativeAIF(),
   csa: i18n.marketingInitiativeCSA(),
   csc: i18n.marketingInitiativeCSC(),
   csd: i18n.marketingInitiativeCSD(),


### PR DESCRIPTION
Add AIF to marketing initiative filters on Curriculum Catalog.

### With no filters
![no filter](https://github.com/user-attachments/assets/13d0032d-0274-4ac5-8b54-a4b94f25b12f)

### With AIF filter applied
![with filter](https://github.com/user-attachments/assets/850dcb52-ab66-4cbe-a851-f68efe1b0f6e)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3293)

## Testing story
Local testing.
