### PR TITLE
Correct labeling of AIF Facilitator page and permission from 'AI Fundamentals' to 'AI Foundations'

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshopConstants.js
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshopConstants.js
@@ -5,7 +5,7 @@ const COURSE_CSF = 'CS Fundamentals';
 const COURSE_CSD = 'CS Discoveries';
 const COURSE_CSP = 'CS Principles';
 const COURSE_CSA = 'Computer Science A';
-const COURSE_AIF = 'AI Fundamentals';
+const COURSE_AIF = 'AI Foundations';
 const COURSE_BUILD_YOUR_OWN = 'Build Your Own Workshop';
 
 const MAX_SESSIONS = 10;

--- a/dashboard/app/views/pd/professional_learning/facilitator/aif.html.haml
+++ b/dashboard/app/views/pd/professional_learning/facilitator/aif.html.haml
@@ -1,8 +1,8 @@
-- @page_title = 'AI Fundamentals Facilitator Landing Page'
+- @page_title = 'AI Foundations Facilitator Landing Page'
 
 %top
 
-%h1{style: "padding: 1rem 0;"} AI Fundamentals Facilitator Landing Page
+%h1{style: "padding: 1rem 0;"} AI Foundations Facilitator Landing Page
 
 %iframe{style: "width: 800px; height: 1200px", src: "https://docs.google.com/document/d/e/2PACX-1vSgNYvNmYxujCK7jXgWepuvRsfrm40otT5YZgZun0RXchI7q3t4C1WHaJgAL4dZHrLJyOzAS4_29_hh/pub?embedded=true"}
 %br

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -8,7 +8,7 @@ module Pd
       COURSE_FACILITATOR = 'Facilitator'.freeze,
       COURSE_ADMIN_COUNSELOR = 'Admin/Counselor Workshop'.freeze,
       COURSE_BUILD_YOUR_OWN = 'Build Your Own Workshop'.freeze,
-      COURSE_AIF = 'AI Fundamentals'.freeze,
+      COURSE_AIF = 'AI Foundations'.freeze,
     ].freeze
 
     ARCHIVED_COURSES = [


### PR DESCRIPTION
Corrects labeling of AIF Facilitator page and permission from "AI Fundamentals" to "AI Foundations". As a followup, I'll make sure each facilitator that currently has the "AI Fundamentals" permission will instead have the "AI Foundations" permission.
![update facilitator](https://github.com/user-attachments/assets/5446fced-23bb-4e94-97db-e05a66ab3bf9)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3322)
