### PR TITLE
fix redirects to the current course including query params

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -61,7 +61,8 @@ class ScriptsController < ApplicationController
       # return a temporary redirect rather than a permanent one, to avoid ever
       # serving a permanent redirect from a unit's new location to its old
       # location during the unit renaming process.
-      redirect_to canonical_path
+      redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
+      redirect_to "#{canonical_path}#{redirect_query_string}"
       return
     end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -72,9 +72,14 @@ class ScriptsController < ApplicationController
 
     # Attempt to redirect user if we think they ended up on the wrong unit overview page.
     override_redirect = VersionRedirectOverrider.override_unit_redirect?(session, @script)
-    if !override_redirect && redirect_unit = redirect_unit(@script, request.locale, @course)
-      redirect_to script_path(redirect_unit) + "?redirect_warning=true"
-      return
+    if !override_redirect && redirect_info = redirect_unit(@script, request.locale, @course)
+      if redirect_info[:redirect_ugu]
+        redirect_to course_unit_path(redirect_info[:redirect_ugu].unit_group, redirect_info[:redirect_ugu].position) + "?redirect_warning=true"
+        return
+      elsif redirect_info[:redirect_unit]
+        redirect_to script_path(redirect_info[:redirect_unit]) + "?redirect_warning=true"
+        return
+      end
     end
 
     # Lastly, if user is assigned to newer version of this unit, we will
@@ -467,7 +472,8 @@ class ScriptsController < ApplicationController
     # Do not redirect if we are already on the correct unit.
     return nil if redirect_unit == unit
 
-    redirect_unit
+    ugu = Queries::Courses.unit_group_unit(redirect_unit, redirect_unit_group)
+    {redirect_unit: redirect_unit, redirect_ugu: ugu}
   end
 
   # Redirect /s/... to /courses/.../units/...

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -73,7 +73,7 @@ class ScriptsController < ApplicationController
 
     # Attempt to redirect user if we think they ended up on the wrong unit overview page.
     override_redirect = VersionRedirectOverrider.override_unit_redirect?(session, @script)
-    if !override_redirect && redirect_info = redirect_unit(@script, request.locale, @course)
+    if !override_redirect && redirect_info = get_redirect_info(@script, request.locale, @course)
       if redirect_info[:redirect_ugu]
         redirect_to course_unit_path(redirect_info[:redirect_ugu].unit_group, redirect_info[:redirect_ugu].position) + "?redirect_warning=true"
         return
@@ -455,7 +455,7 @@ class ScriptsController < ApplicationController
     end
   end
 
-  private def redirect_unit(unit, locale, course)
+  private def get_redirect_info(unit, locale, course)
     # Return nil if unit is nil or we know the user can view the version requested.
     return nil if !unit || unit.can_view_version?(current_user, locale: locale)
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -349,7 +349,7 @@ class ScriptsControllerTest < ActionController::TestCase
       course_course_name: @single_unit_course_2023.name,
       position: 1
     }
-    assert_redirected_to "/s/#{@single_unit_2024.name}?redirect_warning=true"
+    assert_redirected_to "/courses/#{@single_unit_course_2024.name}/units/1?redirect_warning=true"
   end
 
   test "show: redirect from older version to latest stable version of single-unit course for logged out user" do
@@ -357,7 +357,7 @@ class ScriptsControllerTest < ActionController::TestCase
       course_course_name: @single_unit_course_2023.name,
       position: 1
     }
-    assert_redirected_to "/s/#{@single_unit_2024.name}?redirect_warning=true"
+    assert_redirected_to "/courses/#{@single_unit_course_2024.name}/units/1?redirect_warning=true"
   end
 
   test "show: redirect from new unstable version to latest stable version of single-unit course for student" do
@@ -366,7 +366,7 @@ class ScriptsControllerTest < ActionController::TestCase
       course_course_name: @single_unit_course_2025.name,
       position: 1
     }
-    assert_redirected_to "/s/#{@single_unit_2024.name}?redirect_warning=true"
+    assert_redirected_to "/courses/#{@single_unit_course_2024.name}/units/1?redirect_warning=true"
   end
 
   test "show: redirect from new unstable version to latest stable version of single-unit course for logged out user" do
@@ -374,7 +374,7 @@ class ScriptsControllerTest < ActionController::TestCase
       course_course_name: @single_unit_course_2025.name,
       position: 1
     }
-    assert_redirected_to "/s/#{@single_unit_2024.name}?redirect_warning=true"
+    assert_redirected_to "/courses/#{@single_unit_course_2024.name}/units/1?redirect_warning=true"
   end
 
   test "show: redirect from new unstable version of single-unit course to assigned version for student" do
@@ -387,7 +387,7 @@ class ScriptsControllerTest < ActionController::TestCase
       course_course_name: @single_unit_course_2025.name,
       position: 1
     }
-    assert_redirected_to "/s/#{@single_unit_2023.name}?redirect_warning=true"
+    assert_redirected_to "/courses/#{@single_unit_course_2023.name}/units/1?redirect_warning=true"
   end
 
   test "show: do not redirect teacher to latest stable version of single-unit course" do
@@ -410,6 +410,29 @@ class ScriptsControllerTest < ActionController::TestCase
 
     get :show, params: {id: another_course.family_name}
     assert_redirected_to "/courses/#{another_course.name}/units/1"
+  end
+
+  test "show: redirect from older version to latest stable version of a modular single-unit course for student" do
+    modular_single_unit_course_2023 = create :single_unit_course, family_name: "modular-single-unit-course", version_year: '2023', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, unit: @single_unit_2023
+    modular_single_unit_course_2024 = create :single_unit_course, family_name: "modular-single-unit-course", version_year: '2024', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, unit: @single_unit_2024
+
+    sign_in create(:student)
+    get :show, params: {
+      course_course_name: modular_single_unit_course_2023.name,
+      position: 1
+    }
+    assert_redirected_to "/courses/#{modular_single_unit_course_2024.name}/units/1?redirect_warning=true"
+  end
+
+  test "show: redirect from older version to latest stable version of a modular single-unit course for logged out user" do
+    modular_single_unit_course_2023 = create :single_unit_course, family_name: "modular-single-unit-course", version_year: '2023', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, unit: @single_unit_2023
+    modular_single_unit_course_2024 = create :single_unit_course, family_name: "modular-single-unit-course", version_year: '2024', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, unit: @single_unit_2024
+
+    get :show, params: {
+      course_course_name: modular_single_unit_course_2023.name,
+      position: 1
+    }
+    assert_redirected_to "/courses/#{modular_single_unit_course_2024.name}/units/1?redirect_warning=true"
   end
 
   test "show: teacher in teacher-local-nav-v2 experiment is redirected to teacher dashboard if course is in a section" do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1925,6 +1925,12 @@ class ScriptsControllerTest < ActionController::TestCase
         get :show, params: {course_course_name: course.name, position: unit_position}
         assert_response :success
       end
+
+      it '/s/:id?foo=bar does redirect with query params' do
+        sign_in user
+        get :show, params: {id: unit.name, foo: 'bar'}
+        assert_redirected_to "/courses/#{course.name}/units/#{unit_position}?foo=bar"
+      end
     end
   end
 end


### PR DESCRIPTION
This PR contains two fixes to unit redirects. 

The first is a second part to [TEACH-1931](https://codedotorg.atlassian.net/browse/TEACH-1931), fixing query params on redirects for single-unit courses. 
https://studio.code.org/s/coursea?viewAs=Instructor
**redirected to** https://studio.code.org/courses/coursea-2024/units/1
**when it should've redirected to** https://studio.code.org/courses/coursea-2024/units/1?viewAs=Instructor.

The second is fixing an incorrect version redirect for modular single-unit courses. Instead of using the current course, it was using the unit's original course.
https://studio.code.org/courses/foundations-gen-ai-2024/units/1 (also happens without /units/1) 
**redirected to**  https://studio.code.org/courses/exploring-gen-ai-2025/units/1?redirect_warning=true 
**when it should've redirected to** https://studio.code.org/courses/foundations-gen-ai-2025/units/1?redirect_warning=true. 

## Links
- Jira: [TEACH-1931](https://codedotorg.atlassian.net/browse/TEACH-1931)
- Jira: [TEACH-1971](https://codedotorg.atlassian.net/browse/TEACH-1971)

## Testing story
Tests for both cases added to `scripts_controller.rb`
