### PR TITLE
skip "certificate page with no course name" ui test on mobile

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/certificates/certificates.feature
+++ b/dashboard/test/ui/features/teacher_tools/certificates/certificates.feature
@@ -22,6 +22,7 @@ Feature: Certificate page features
     And I wait to see an image "/certificate_images/"
     And I see custom certificate image with name "Robo Coder" and course "mc"
 
+  @no_mobile
   Scenario: certificate page with no course name
     Given I am on "http://studio.code.org/congrats"
     And I wait until element "#uitest-certificate" is visible


### PR DESCRIPTION
follow up from https://github.com/code-dot-org/code-dot-org/pull/66210, which accidentally started running certain UI test code on mobile by removing the `@eyes` tag.