### PR TITLE
restore caching for high-usage hoc unit paths

### DIFF
--- a/dashboard/test/integration/routes_test.rb
+++ b/dashboard/test/integration/routes_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 class RoutesTest < ActionDispatch::IntegrationTest
   # Ensure view-only wildcard routes are generated correctly.
   def test_dance_session_cookie_and_cache_headers
-    skip 'enable when we re enable CACHED_UNITS_MAP'
     script = create :script, name: 'dance-2019'
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, relative_position: 1, lesson_group: lesson_group

--- a/dashboard/test/integration/routes_test.rb
+++ b/dashboard/test/integration/routes_test.rb
@@ -4,6 +4,10 @@ class RoutesTest < ActionDispatch::IntegrationTest
   # Ensure view-only wildcard routes are generated correctly.
   def test_dance_session_cookie_and_cache_headers
     script = create :script, name: 'dance-ai-2023'
+    unit_group = create(:unit_group, name: 'dance-ai-2023', published_state: 'stable')
+    create :unit_group_unit, unit_group: unit_group, script: script, position: 1
+    CourseOffering.add_course_offering(unit_group)
+
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, relative_position: 1, lesson_group: lesson_group
     create :script_level, script: script, lesson: lesson

--- a/dashboard/test/integration/routes_test.rb
+++ b/dashboard/test/integration/routes_test.rb
@@ -3,26 +3,26 @@ require 'test_helper'
 class RoutesTest < ActionDispatch::IntegrationTest
   # Ensure view-only wildcard routes are generated correctly.
   def test_dance_session_cookie_and_cache_headers
-    script = create :script, name: 'dance-2019'
+    script = create :script, name: 'dance-ai-2023'
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, relative_position: 1, lesson_group: lesson_group
     create :script_level, script: script, lesson: lesson
     create :script_level, script: script, lesson: lesson, position: 9
     create :script_level, script: script, lesson: lesson, position: 10
 
-    get '/courses/dance-2019/units/1/lessons/1/levels/1'
+    get '/courses/dance-ai-2023/units/1/lessons/1/levels/1'
     assert_caching_enabled response.headers['Cache-Control'],
       ScriptLevelsController::DEFAULT_PUBLIC_CLIENT_MAX_AGE,
       ScriptLevelsController::DEFAULT_PUBLIC_PROXY_MAX_AGE
     assert_nil cookies['_learn_session_test']
 
-    get '/courses/dance-2019/units/1/lessons/1/levels/9'
+    get '/courses/dance-ai-2023/units/1/lessons/1/levels/9'
     assert_caching_enabled response.headers['Cache-Control'],
       ScriptLevelsController::DEFAULT_PUBLIC_CLIENT_MAX_AGE,
       ScriptLevelsController::DEFAULT_PUBLIC_PROXY_MAX_AGE
     assert_nil cookies['_learn_session_test']
 
-    get '/courses/dance-2019/units/1/lessons/1/levels/10'
+    get '/courses/dance-ai-2023/units/1/lessons/1/levels/10'
     assert_caching_disabled response.headers['Cache-Control']
     refute_nil cookies['_learn_session_test']
   end

--- a/dashboard/test/integration/routes_test.rb
+++ b/dashboard/test/integration/routes_test.rb
@@ -10,19 +10,19 @@ class RoutesTest < ActionDispatch::IntegrationTest
     create :script_level, script: script, lesson: lesson, position: 9
     create :script_level, script: script, lesson: lesson, position: 10
 
-    get '/s/dance-2019/lessons/1/levels/1'
+    get '/courses/dance-2019/units/1/lessons/1/levels/1'
     assert_caching_enabled response.headers['Cache-Control'],
       ScriptLevelsController::DEFAULT_PUBLIC_CLIENT_MAX_AGE,
       ScriptLevelsController::DEFAULT_PUBLIC_PROXY_MAX_AGE
     assert_nil cookies['_learn_session_test']
 
-    get '/s/dance-2019/lessons/1/levels/9'
+    get '/courses/dance-2019/units/1/lessons/1/levels/9'
     assert_caching_enabled response.headers['Cache-Control'],
       ScriptLevelsController::DEFAULT_PUBLIC_CLIENT_MAX_AGE,
       ScriptLevelsController::DEFAULT_PUBLIC_PROXY_MAX_AGE
     assert_nil cookies['_learn_session_test']
 
-    get '/s/dance-2019/lessons/1/levels/10'
+    get '/courses/dance-2019/units/1/lessons/1/levels/10'
     assert_caching_disabled response.headers['Cache-Control']
     refute_nil cookies['_learn_session_test']
   end

--- a/dashboard/test/lib/feature_mode_manager_test.rb
+++ b/dashboard/test/lib/feature_mode_manager_test.rb
@@ -37,7 +37,6 @@ class FeatureModeManagerTest < ActiveSupport::TestCase
   end
 
   def test_get_mode_returns_nil_if_hoc_gatekeeper_property_does_not_match
-    skip 'enable when we re enable CACHED_UNITS_MAP'
     FeatureModeManager.set_mode('normal', @gatekeeper, @dcdo, HOC_UNITS, CSF_UNITS)
     @gatekeeper.set('postMilestone', where: {script_name: HOC_UNIT}, value: false)
     assert_nil FeatureModeManager.get_mode(@gatekeeper, @dcdo, HOC_UNITS, CSF_UNITS)
@@ -77,7 +76,6 @@ class FeatureModeManagerTest < ActiveSupport::TestCase
   end
 
   def test_allows
-    skip 'enable when we re enable CACHED_UNITS_MAP'
     FeatureModeManager.set_mode('normal', @gatekeeper, @dcdo, HOC_UNITS, CSF_UNITS)
 
     assert FeatureModeManager.allows(@gatekeeper, 'normal', 'postMilestone', HOC_UNIT)

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -883,7 +883,6 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test 'uncached lesson path helpers' do
-    skip 'enable when we re enable CACHED_UNITS_MAP'
     hoc_unit = create :script, name: 'dance-ai-2023'
     hoc_lesson_group = create :lesson_group, script: hoc_unit
     hoc_lesson = create :lesson, script: hoc_unit, lesson_group: hoc_lesson_group

--- a/dashboard/test/ui/features/platform/login_redirect.feature
+++ b/dashboard/test/ui/features/platform/login_redirect.feature
@@ -1,6 +1,6 @@
 Feature: Navigating to a level page with login required
 
-# The 'starwars' level is specifically chosen because it is a level that is
+# The 'mc' level is specifically chosen because it is a level that is
 # seeded in the test environment (see list in dashboard/lib/tasks/seed.rake)
 # and is a cached unit. (see lib/cdo/http_cache.rb for that fixed listing)
 #
@@ -10,14 +10,14 @@ Feature: Navigating to a level page with login required
 Scenario: Student navigates to provided cached level link with a login_required parameter
   Given I create a student named "Carah Student"
   And I sign out
-  Given I am on "http://studio.code.org/courses/starwars/units/1/lessons/1/levels/1?login_required=true"
+  Given I am on "http://studio.code.org/courses/mc/units/1/lessons/1/levels/1?login_required=true"
   Then I wait until I am on "http://studio.code.org/users/sign_in"
   And I wait to see "#signin"
   And I fill in username and password for "Carah Student"
   And I click "#signin-button" to load a new page
-  Then I wait until I am on "http://studio.code.org/courses/starwars/units/1/lessons/1/levels/1"
+  Then I wait until I am on "http://studio.code.org/courses/mc/units/1/lessons/1/levels/1"
 
 Scenario: Student already logged in navigates to provided cached level link with a login_required parameter
   Given I create a student who has never signed in named "François Student" and go home
-  And I am on "http://studio.code.org/courses/starwars/units/1/lessons/1/levels/1?login_required=true"
-  Then I wait until I am on "http://studio.code.org/courses/starwars/units/1/lessons/1/levels/1"
+  And I am on "http://studio.code.org/courses/mc/units/1/lessons/1/levels/1?login_required=true"
+  Then I wait until I am on "http://studio.code.org/courses/mc/units/1/lessons/1/levels/1"

--- a/dashboard/test/ui/features/platform/login_redirect.feature
+++ b/dashboard/test/ui/features/platform/login_redirect.feature
@@ -7,8 +7,6 @@ Feature: Navigating to a level page with login required
 # These tests are meant to track regressions on redirect-after-login.
 # See https://codedotorg.atlassian.net/browse/TEACH-758 for more details.
 
-# TODO: re enable after re enabling CACHED_UNITS_MAP
-@skip
 Scenario: Student navigates to provided cached level link with a login_required parameter
   Given I create a student named "Carah Student"
   And I sign out
@@ -19,8 +17,6 @@ Scenario: Student navigates to provided cached level link with a login_required 
   And I click "#signin-button" to load a new page
   Then I wait until I am on "http://studio.code.org/courses/starwars/units/1/lessons/1/levels/1"
 
-# TODO: re enable after re enabling CACHED_UNITS_MAP
-@skip
 Scenario: Student already logged in navigates to provided cached level link with a login_required parameter
   Given I create a student who has never signed in named "François Student" and go home
   And I am on "http://studio.code.org/courses/starwars/units/1/lessons/1/levels/1?login_required=true"

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -66,46 +66,24 @@ class HttpCache
   ].freeze
 
   # A list of script levels that should not be cached, even though they are
-  # in a cacheable script
+  # in a cacheable script. prediction levels are not cacheable.
   # TODO TEACH-1634 support the /courses/ path
   UNCACHED_UNIT_LEVEL_PATHS = [
     '/courses/dance-2019/units/1/lessons/1/levels/10',
     '/courses/dance-ai-2023/units/1/lessons/1/levels/10',
-    '/courses/poem-art-2021/units/1/lessons/1/levels/9',
-    '/courses/poem-art-2021/units/1/lessons/1/levels/2', # prediction levels are not cacheable
-    '/courses/poem-art-2021/units/1/lessons/1/levels/5', # prediction levels are not cacheable
-    '/courses/hello-world-food-2021/units/1/lessons/1/levels/11',
-    '/courses/hello-world-animals-2021/units/1/lessons/1/levels/11',
-    '/courses/hello-world-retro-2021/units/1/lessons/1/levels/11',
-    '/courses/hello-world-emoji-2021/units/1/lessons/1/levels/11',
-    '/courses/hello-world-space-2022/units/1/lessons/1/levels/11',
-    '/courses/hello-world-soccer-2022/units/1/lessons/1/levels/11',
-    '/courses/outbreak/units/1/lessons/1/levels/10'
   ]
 
   # A map from script name to script level URL pattern.
   CACHED_UNITS_MAP = %w(
     aquatic
-    starwars
-    starwarsblocks
-    mc
-    frozen
-    minecraft
-    hero
-    sports
-    basketball
     dance-2019
     dance-ai-2023
-    oceans
-    poem-art-2021
-    hello-world-food-2021
-    hello-world-animals-2021
-    hello-world-retro-2021
-    hello-world-emoji-2021
-    hello-world-space-2022
-    hello-world-soccer-2022
+    frozen
+    hero
+    mc
+    minecraft
     music-jam-2024
-    outbreak
+    starwarsblocks
   ).map do |script_name|
     # Most scripts use the default route pattern.
     # Assume all cached units are in single unit courses.

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -69,18 +69,18 @@ class HttpCache
   # in a cacheable script
   # TODO TEACH-1634 support the /courses/ path
   UNCACHED_UNIT_LEVEL_PATHS = [
-    '/s/dance-2019/lessons/1/levels/10',
-    '/s/dance-ai-2023/lessons/1/levels/10',
-    '/s/poem-art-2021/lessons/1/levels/9',
-    '/s/poem-art-2021/lessons/1/levels/2', # prediction levels are not cacheable
-    '/s/poem-art-2021/lessons/1/levels/5', # prediction levels are not cacheable
-    '/s/hello-world-food-2021/lessons/1/levels/11',
-    '/s/hello-world-animals-2021/lessons/1/levels/11',
-    '/s/hello-world-retro-2021/lessons/1/levels/11',
-    '/s/hello-world-emoji-2021/lessons/1/levels/11',
-    '/s/hello-world-space-2022/lessons/1/levels/11',
-    '/s/hello-world-soccer-2022/lessons/1/levels/11',
-    '/s/outbreak/lessons/1/levels/10'
+    '/courses/dance-2019/units/1/lessons/1/levels/10',
+    '/courses/dance-ai-2023/units/1/lessons/1/levels/10',
+    '/courses/poem-art-2021/units/1/lessons/1/levels/9',
+    '/courses/poem-art-2021/units/1/lessons/1/levels/2', # prediction levels are not cacheable
+    '/courses/poem-art-2021/units/1/lessons/1/levels/5', # prediction levels are not cacheable
+    '/courses/hello-world-food-2021/units/1/lessons/1/levels/11',
+    '/courses/hello-world-animals-2021/units/1/lessons/1/levels/11',
+    '/courses/hello-world-retro-2021/units/1/lessons/1/levels/11',
+    '/courses/hello-world-emoji-2021/units/1/lessons/1/levels/11',
+    '/courses/hello-world-space-2022/units/1/lessons/1/levels/11',
+    '/courses/hello-world-soccer-2022/units/1/lessons/1/levels/11',
+    '/courses/outbreak/units/1/lessons/1/levels/10'
   ]
 
   # A map from script name to script level URL pattern.
@@ -108,7 +108,8 @@ class HttpCache
     outbreak
   ).map do |script_name|
     # Most scripts use the default route pattern.
-    [script_name, "/s/#{script_name}/lessons/*"]
+    # Assume all cached units are in single unit courses.
+    [script_name, "/courses/#{script_name}/units/1/lessons/*"]
   end.to_h.merge(
     # Add the "special case" routes here.
     'hourofcode' => '/hoc/*',

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -68,30 +68,19 @@ class HttpCache
   # A list of script levels that should not be cached, even though they are
   # in a cacheable script. prediction levels are not cacheable.
   UNCACHED_UNIT_LEVEL_PATHS = [
-    '/courses/dance-2019/units/1/lessons/1/levels/10',
     '/courses/dance-ai-2023/units/1/lessons/1/levels/10',
   ]
 
   # A map from script name to script level URL pattern.
   CACHED_UNITS_MAP = %w(
     aquatic
-    dance-2019
     dance-ai-2023
-    frozen
-    hero
     mc
-    minecraft
     music-jam-2024
-    starwarsblocks
   ).map do |script_name|
-    # Most scripts use the default route pattern.
     # Assume all cached units are in single unit courses.
     [script_name, "/courses/#{script_name}/units/1/lessons/*"]
-  end.to_h.merge(
-    # Add the "special case" routes here.
-    'hourofcode' => '/hoc/*',
-    'flappy' => '/flappy/*'
-  ).freeze
+  end.to_h.freeze
 
   def self.cached_scripts
     CACHED_UNITS_MAP.keys

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -67,7 +67,6 @@ class HttpCache
 
   # A list of script levels that should not be cached, even though they are
   # in a cacheable script. prediction levels are not cacheable.
-  # TODO TEACH-1634 support the /courses/ path
   UNCACHED_UNIT_LEVEL_PATHS = [
     '/courses/dance-2019/units/1/lessons/1/levels/10',
     '/courses/dance-ai-2023/units/1/lessons/1/levels/10',

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -67,55 +67,53 @@ class HttpCache
 
   # A list of script levels that should not be cached, even though they are
   # in a cacheable script
-  # TODO: re enable after moving to /courses/ paths
+  # TODO TEACH-1634 support the /courses/ path
   UNCACHED_UNIT_LEVEL_PATHS = [
-    # '/s/dance-2019/lessons/1/levels/10',
-    # '/s/dance-ai-2023/lessons/1/levels/10',
-    # '/s/poem-art-2021/lessons/1/levels/9',
-    # '/s/poem-art-2021/lessons/1/levels/2', # prediction levels are not cacheable
-    # '/s/poem-art-2021/lessons/1/levels/5', # prediction levels are not cacheable
-    # '/s/hello-world-food-2021/lessons/1/levels/11',
-    # '/s/hello-world-animals-2021/lessons/1/levels/11',
-    # '/s/hello-world-retro-2021/lessons/1/levels/11',
-    # '/s/hello-world-emoji-2021/lessons/1/levels/11',
-    # '/s/hello-world-space-2022/lessons/1/levels/11',
-    # '/s/hello-world-soccer-2022/lessons/1/levels/11',
-    # '/s/outbreak/lessons/1/levels/10'
+    '/s/dance-2019/lessons/1/levels/10',
+    '/s/dance-ai-2023/lessons/1/levels/10',
+    '/s/poem-art-2021/lessons/1/levels/9',
+    '/s/poem-art-2021/lessons/1/levels/2', # prediction levels are not cacheable
+    '/s/poem-art-2021/lessons/1/levels/5', # prediction levels are not cacheable
+    '/s/hello-world-food-2021/lessons/1/levels/11',
+    '/s/hello-world-animals-2021/lessons/1/levels/11',
+    '/s/hello-world-retro-2021/lessons/1/levels/11',
+    '/s/hello-world-emoji-2021/lessons/1/levels/11',
+    '/s/hello-world-space-2022/lessons/1/levels/11',
+    '/s/hello-world-soccer-2022/lessons/1/levels/11',
+    '/s/outbreak/lessons/1/levels/10'
   ]
 
   # A map from script name to script level URL pattern.
-  CACHED_UNITS_MAP = {}
-  # TODO: re enable cached unit map after moving to /courses/ paths
-  # CACHED_UNITS_MAP = %w(
-  #   aquatic
-  #   starwars
-  #   starwarsblocks
-  #   mc
-  #   frozen
-  #   minecraft
-  #   hero
-  #   sports
-  #   basketball
-  #   dance-2019
-  #   dance-ai-2023
-  #   oceans
-  #   poem-art-2021
-  #   hello-world-food-2021
-  #   hello-world-animals-2021
-  #   hello-world-retro-2021
-  #   hello-world-emoji-2021
-  #   hello-world-space-2022
-  #   hello-world-soccer-2022
-  #   music-jam-2024
-  #   outbreak
-  # ).map do |script_name|
-  #   # Most scripts use the default route pattern.
-  #   [script_name, "/s/#{script_name}/lessons/*"]
-  # end.to_h.merge(
-  #   # Add the "special case" routes here.
-  #   'hourofcode' => '/hoc/*',
-  #   'flappy' => '/flappy/*'
-  # ).freeze
+  CACHED_UNITS_MAP = %w(
+    aquatic
+    starwars
+    starwarsblocks
+    mc
+    frozen
+    minecraft
+    hero
+    sports
+    basketball
+    dance-2019
+    dance-ai-2023
+    oceans
+    poem-art-2021
+    hello-world-food-2021
+    hello-world-animals-2021
+    hello-world-retro-2021
+    hello-world-emoji-2021
+    hello-world-space-2022
+    hello-world-soccer-2022
+    music-jam-2024
+    outbreak
+  ).map do |script_name|
+    # Most scripts use the default route pattern.
+    [script_name, "/s/#{script_name}/lessons/*"]
+  end.to_h.merge(
+    # Add the "special case" routes here.
+    'hourofcode' => '/hoc/*',
+    'flappy' => '/flappy/*'
+  ).freeze
 
   def self.cached_scripts
     CACHED_UNITS_MAP.keys
@@ -304,17 +302,16 @@ class HttpCache
           # should not be cached in CloudFront. Use CloudFront Behavior
           # precedence rules to not cache these paths, but all paths in
           # CACHED_UNITS_MAP that don't match this path will be cached.
-          # TODO: re-enable these behaviors after moving to /courses/ paths
-          # {
-          #   path: UNCACHED_UNIT_LEVEL_PATHS,
-          #   headers: ALLOWLISTED_HEADERS,
-          #   cookies: allowlisted_cookies
-          # },
-          # {
-          #   path: CACHED_UNITS_MAP.values,
-          #   headers: ALLOWLISTED_HEADERS,
-          #   cookies: default_cookies
-          # },
+          {
+            path: UNCACHED_UNIT_LEVEL_PATHS,
+            headers: ALLOWLISTED_HEADERS,
+            cookies: allowlisted_cookies
+          },
+          {
+            path: CACHED_UNITS_MAP.values,
+            headers: ALLOWLISTED_HEADERS,
+            cookies: default_cookies
+          },
           {
             path: '/api/v1/projects/gallery/public/*',
             headers: [],

--- a/lib/cdo/script_config.rb
+++ b/lib/cdo/script_config.rb
@@ -8,19 +8,26 @@ require_relative 'http_cache'
 UNCACHED_HOC_UNITS = %w(
   artist
   basketball
+  dance-2019
+  flappy
+  frozen
   hello-world-animals-2021
   hello-world-emoji-2021
   hello-world-food-2021
   hello-world-retro-2021
   hello-world-soccer-2022
   hello-world-space-2022
+  hero
+  hourofcode
   iceage
   infinity
+  minecraft
   outbreak
   playlab
   poem-art-2021
   sports
   starwars
+  starwarsblocks
 ).freeze
 
 class ScriptConfig

--- a/lib/cdo/script_config.rb
+++ b/lib/cdo/script_config.rb
@@ -5,7 +5,23 @@
 
 require_relative 'http_cache'
 
-UNCACHED_HOC_UNITS = %w(playlab artist infinity iceage).freeze
+UNCACHED_HOC_UNITS = %w(
+  artist
+  basketball
+  hello-world-animals-2021
+  hello-world-emoji-2021
+  hello-world-food-2021
+  hello-world-retro-2021
+  hello-world-soccer-2022
+  hello-world-space-2022
+  iceage
+  infinity
+  outbreak
+  playlab
+  poem-art-2021
+  sports
+  starwars
+).freeze
 
 class ScriptConfig
   # Returns true if the script level path is excluded from caching, even if it


### PR DESCRIPTION
* Reverts code-dot-org/code-dot-org#65995
*  updates paths from `/s/...` to `/courses/.../units/1`
* removes low usage HOC units from the list of cached units (see [HOC 2024 usage](https://docs.google.com/spreadsheets/d/1Pr04NSqK9_bmcVzW7FGY9hYw7uaGvXFx7jp8jVTid3g/edit?gid=1566297911#gid=1566297911))

## Links

Jira: https://codedotorg.atlassian.net/browse/TEACH-1634

## Testing story

- Restores and updates existing test coverage which was disabled in the original PR
- manually verified that i can load the remaining `UNCACHED_UNIT_LEVEL_PATHS` in the browser without being redirected