### PR TITLE
Codebridge: clean up usage of levelPath in logs

### DIFF
--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -37,7 +37,8 @@ const ControlButtons: React.FunctionComponent = () => {
   const {onRun, onStop, labConfig, levelProperties} = useCodebridgeContext();
   const {id: levelId, appName, predictSettings} = levelProperties;
   const isPredictLevel = predictSettings?.isPredictLevel;
-  const levelPath = useAppSelector(state => getCurrentLevel(state)?.path);
+  const levelPath =
+    useAppSelector(state => getCurrentLevel(state)?.path) || 'standalone';
 
   const scriptId = useAppSelector(state => state.lab.scriptId);
   const source = useAppSelector(

--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -7,6 +7,7 @@ import {sendCodebridgeAnalyticsEvent} from '@codebridge/utils/analyticsReporterH
 import React, {useCallback} from 'react';
 
 import {setShowSuggestedPrompts} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
+import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
@@ -36,6 +37,7 @@ const ControlButtons: React.FunctionComponent = () => {
   const {onRun, onStop, labConfig, levelProperties} = useCodebridgeContext();
   const {id: levelId, appName, predictSettings} = levelProperties;
   const isPredictLevel = predictSettings?.isPredictLevel;
+  const levelPath = useAppSelector(state => getCurrentLevel(state)?.path);
 
   const scriptId = useAppSelector(state => state.lab.scriptId);
   const source = useAppSelector(
@@ -70,7 +72,9 @@ const ControlButtons: React.FunctionComponent = () => {
   const handleRun = () => {
     if (onRun) {
       dispatch(setIsRunning(true));
-      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_RUN_CLICK, appName);
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_RUN_CLICK, appName, {
+        levelPath,
+      });
       logUserLevelInteraction({
         levelId: levelId,
         scriptId: scriptId,

--- a/apps/src/codebridge/Settings/SettingsDropdown.tsx
+++ b/apps/src/codebridge/Settings/SettingsDropdown.tsx
@@ -126,7 +126,6 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
         type === 'Console' ? setConsoleFontSize : setEditorFontSize;
       dispatch(reduxAction(selectedKey));
       sendCodebridgeAnalyticsEvent(event, appName, {
-        levelPath: window.location.pathname,
         fontSize: selectedKey,
       });
     }
@@ -138,7 +137,6 @@ const SettingsDropdown: React.FunctionComponent<SettingsDropdownProps> = ({
       new UserPreferences().setGlobalTheme(value);
     }
     sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_THEME_CHANGE, appName, {
-      levelPath: window.location.pathname,
       theme: value,
     });
   };

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -14,7 +14,6 @@ import VersionHistoryButton from '@cdo/apps/lab2/views/components/versionHistory
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {sendPythonCodeToMicroBit} from '@cdo/apps/maker/boards/microBit/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import {appendCustomFrames} from '@cdo/apps/p5lab/redux/animationList';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {currentLocation} from '@cdo/apps/utils';
 import commonI18n from '@cdo/locale';
@@ -59,10 +58,7 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
         type: DialogType.Skip,
         handleConfirm: () => {
           if (skipUrl) {
-            sendCodebridgeAnalyticsEvent(
-              EVENTS.SKIP_TO_PROJECT,
-              appendCustomFrames
-            );
+            sendCodebridgeAnalyticsEvent(EVENTS.SKIP_TO_PROJECT, appName);
             window.location.href = skipUrl;
           }
         },

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -14,6 +14,7 @@ import VersionHistoryButton from '@cdo/apps/lab2/views/components/versionHistory
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {sendPythonCodeToMicroBit} from '@cdo/apps/maker/boards/microBit/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {appendCustomFrames} from '@cdo/apps/p5lab/redux/animationList';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {currentLocation} from '@cdo/apps/utils';
 import commonI18n from '@cdo/locale';
@@ -58,9 +59,10 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
         type: DialogType.Skip,
         handleConfirm: () => {
           if (skipUrl) {
-            sendCodebridgeAnalyticsEvent(EVENTS.SKIP_TO_PROJECT, appName, {
-              levelPath: window.location.pathname,
-            });
+            sendCodebridgeAnalyticsEvent(
+              EVENTS.SKIP_TO_PROJECT,
+              appendCustomFrames
+            );
             window.location.href = skipUrl;
           }
         },

--- a/apps/src/codebridge/hooks/useZoomTracker.ts
+++ b/apps/src/codebridge/hooks/useZoomTracker.ts
@@ -39,7 +39,6 @@ export const useZoomTracker = (appName: string) => {
       sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_ZOOM, appName, {
         zoomPercent: zoomPercent,
         direction,
-        levelPath: window.location.pathname,
       });
     };
 


### PR DESCRIPTION
Sam wanted us to add `levelPath` as a dimension to Python run click logs. As I was working on this, I noticed we currently have two ways of getting the level path for analytics. One way is `window.location.pathname`, and the other is off of redux for the level. For levels inside scripts, this results in the same path; ex. `/courses/allthethingscourse/units/1/lessons/50/levels/1`. However for standalone projects, the pathname results in a unique level path for every project, because of the id in the url. The redux method returns undefined in this case. There is also the case of accessing levels by id; ex via `levels/12345`. The pathname returns `levels/12345`, and redux returns undefined. This is almost always done by internal users, so it's not a large concern.

After discussing with Sam, we don't want the polluting data of all the unique project urls, so we will go with the redux method. If we get undefined, we will set the levelpath to `standalone`. 

We were using the pathname method in a few places in codebridge already (I'm guessing due to copy/pasting from other labs). I removed those here; the only place we care about level path is on run button clicks.

## Links

- Jira: [SL-1263](https://codedotorg.atlassian.net/browse/SL-1263)

## Testing story
Confirmed run click logs now include the levelPath, and other logs do not.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
