### PR TITLE
add handling for race popup bug

### DIFF
--- a/dashboard/app/helpers/race_interstitial_helper.rb
+++ b/dashboard/app/helpers/race_interstitial_helper.rb
@@ -5,11 +5,14 @@ module RaceInterstitialHelper
     return false if user.teacher?
     return false if user.under_13?
 
-    # Special handling for users affected by a bug
-    bug_date = Time.new(2023, 5)
-    if user.created_at < bug_date && user.races.present?
+    # Special handling for users affected by a bug that prevented race information from being saved.
+    # Users were affected if they were created between May 2023 and February 2024.
+    # PR with the fix: https://github.com/code-dot-org/code-dot-org/pull/56729
+    bug_start_date = Time.new(2023, 5)
+    bug_end_date = Time.new(2024, 2)
+    if (user.created_at < bug_start_date || user.created_at > bug_end_date) && user.races.present?
       return false
-    elsif user.created_at >= bug_date && user.races.present? && user.races != 'closed_dialog'
+    elsif (bug_start_date <= user.created_at && user.created_at <= bug_end_date) && user.races.present? && user.races != 'closed_dialog'
       return false
     end
 

--- a/dashboard/app/helpers/race_interstitial_helper.rb
+++ b/dashboard/app/helpers/race_interstitial_helper.rb
@@ -2,9 +2,16 @@ module RaceInterstitialHelper
   # Determine whether or not to show the race interstitial popup to a user
   def self.show?(user)
     return false if user.nil?
-    return false if user.races
     return false if user.teacher?
     return false if user.under_13?
+
+    # Special handling for users affected by a bug
+    bug_date = Time.new(2023, 5)
+    if user.created_at < bug_date && user.races.present?
+      return false
+    elsif user.created_at >= bug_date && user.races.present? && user.races != 'closed_dialog'
+      return false
+    end
 
     # Covers test cases if we don't have sign in records for a user
     return false if user.days_since_first_sign_in.nil?

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -2218,4 +2218,10 @@ FactoryBot.define do
     content {"Lorem ipsum"}
     is_preset {false}
   end
+
+  factory :sign_in do
+    association :user
+    sign_in_at {Time.now.utc}
+    sign_in_count {1}
+  end
 end

--- a/dashboard/test/helpers/race_interstitial_helper_test.rb
+++ b/dashboard/test/helpers/race_interstitial_helper_test.rb
@@ -55,21 +55,35 @@ class RaceInterstitialHelperTest < ActionView::TestCase
     context 'when closed dialog already' do
       let(:user) {create(:student, current_sign_in_ip: '127.0.0.1', races: 'closed_dialog')}
 
-      context 'when created after bugfix date' do
-        it 'returns true' do
-          _(show?).must_equal true
+      # These tests reference a bug that affected users between May 2023 and February 2024.
+      # PR with the fix: https://github.com/code-dot-org/code-dot-org/pull/56729
+      context 'when created after bug was fixed' do
+        it 'returns false' do
+          _(show?).must_equal false
         end
       end
 
-      context 'when created before bugfix date' do
+      context 'when created before bug was introduced' do
         let(:user) do
           create(:student, current_sign_in_ip: '127.0.0.1', races: 'closed_dialog') do |u|
-            u.created_at = Time.new(2022, 5, 1)
+            u.created_at = Time.new(2023, 4, 1)
           end
         end
 
         it 'returns false' do
           _(show?).must_equal false
+        end
+      end
+
+      context 'when created during bug-affected time period' do
+        let(:user) do
+          create(:student, current_sign_in_ip: '127.0.0.1', races: 'closed_dialog') do |u|
+            u.created_at = Time.new(2023, 6, 1)
+          end
+        end
+
+        it 'returns true' do
+          _(show?).must_equal true
         end
       end
     end

--- a/dashboard/test/helpers/race_interstitial_helper_test.rb
+++ b/dashboard/test/helpers/race_interstitial_helper_test.rb
@@ -6,72 +6,94 @@ class RaceInterstitialHelperTest < ActionView::TestCase
     Geocoder.stubs(:search).returns([mock_us_object])
   end
 
-  def setup
-    mock_geocoder_result('US')
+  describe '.show?' do
+    subject(:show?) {RaceInterstitialHelper.show?(user)}
+    let(:user) {create(:student, current_sign_in_ip: '127.0.0.1')}
+    let!(:sign_in) {create(:sign_in, user: user, sign_in_count: 1, sign_in_at: DateTime.now - 8.days)}
+    let!(:geocoder_result) {mock_geocoder_result('US')}
 
-    # Create a student over 13 with an account that was first
-    # signed into more than a week ago and an associated IP address.
-    # We expect that such a user would see the race interstitial helper.
-    @user = create :student
-    @user.current_sign_in_ip = "127.0.0.1"
+    context 'when teacher' do
+      let(:user) {create(:teacher)}
 
-    SignIn.create(
-      user_id: @user.id,
-      sign_in_count: 1,
-      sign_in_at: DateTime.now - 8.days
-    )
-  end
+      it 'returns false' do
+        _(show?).must_equal false
+      end
+    end
 
-  test 'do not show race interstitial to teacher' do
-    @user.user_type = User::TYPE_TEACHER
-    refute RaceInterstitialHelper.show?(@user)
-  end
+    context 'when under 13' do
+      let(:user) {create(:student, age: 8)}
 
-  test 'do not show race interstitial to user accounts under 13' do
-    @user.age = 8
-    refute RaceInterstitialHelper.show?(@user)
-  end
+      it 'returns false' do
+        _(show?).must_equal false
+      end
+    end
 
-  test 'do not show race interstitial to user if we do not have sign in information' do
-    SignIn.find_by(
-      user_id: @user.id,
-      sign_in_count: 1
-    ).delete
+    context 'when no sign in information' do
+      let(:sign_in) {nil}
 
-    refute RaceInterstitialHelper.show?(@user)
-  end
+      it 'returns false' do
+        _(show?).must_equal false
+      end
+    end
 
-  test 'do not show race interstitial to user accounts who signed in for the first time less than a week ago' do
-    sign_in = SignIn.find_by(
-      user_id: @user.id,
-      sign_in_count: 1
-    )
-    sign_in.update(sign_in_at: DateTime.now - 3.days)
+    context 'when signed in for the first time less than a week ago' do
+      let(:sign_in) {create(:sign_in, user: user, sign_in_count: 1, sign_in_at: DateTime.now - 3.days)}
 
-    refute RaceInterstitialHelper.show?(@user)
-  end
+      it 'returns false' do
+        _(show?).must_equal false
+      end
+    end
 
-  test 'do not show race interstitial to user accounts that have already entered race information' do
-    @user.update_columns(races: 'white,black')
-    refute RaceInterstitialHelper.show?(@user)
-  end
+    context 'when race already present' do
+      let(:user) {create(:student, current_sign_in_ip: '127.0.0.1', races: 'white,black')}
 
-  test 'do not show race interstitial to user accounts that have closed the dialog already' do
-    @user.update_columns(races: 'closed_dialog')
-    refute RaceInterstitialHelper.show?(@user)
-  end
+      it 'returns false' do
+        _(show?).must_equal false
+      end
+    end
 
-  test 'do not show race interstitial if IP address is nil' do
-    @user.current_sign_in_ip = nil
-    refute RaceInterstitialHelper.show?(@user)
-  end
+    context 'when closed dialog already' do
+      let(:user) {create(:student, current_sign_in_ip: '127.0.0.1', races: 'closed_dialog')}
 
-  test 'do not show race interstitial to non-US users' do
-    mock_geocoder_result('CA')
-    refute RaceInterstitialHelper.show?(@user)
-  end
+      context 'when created after bugfix date' do
+        it 'returns true' do
+          _(show?).must_equal true
+        end
+      end
 
-  test 'show race interstitial to US users' do
-    assert RaceInterstitialHelper.show?(@user)
+      context 'when created before bugfix date' do
+        let(:user) do
+          create(:student, current_sign_in_ip: '127.0.0.1', races: 'closed_dialog') do |u|
+            u.created_at = Time.new(2022, 5, 1)
+          end
+        end
+
+        it 'returns false' do
+          _(show?).must_equal false
+        end
+      end
+    end
+
+    context 'when IP address is nil' do
+      let(:user) {create(:student, current_sign_in_ip: nil)}
+
+      it 'returns false' do
+        _(show?).must_equal false
+      end
+    end
+
+    context 'when non-US user' do
+      let(:geocoder_result) {mock_geocoder_result('CA')}
+
+      it 'returns false' do
+        _(show?).must_equal false
+      end
+    end
+
+    context 'when US user' do
+      it 'returns true' do
+        _(show?).must_equal true
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes an overdue work request that slipped through the cracks. Between May 2023 and February 2024, the student race interstitial was broken, causing a gap in our race/ethnicity data for student accounts created during the '23-'24 school year. @juanmanzojr [fixed](https://github.com/code-dot-org/code-dot-org/pull/56729) the bug in Feb 2024, but the gap in data remained.

This PR is to show the student race interstitial to accounts created during the affected time period, if the races field is nil or equal to `'closed_dialog'`. Even though it has been quite a while, we can collect data for any accounts that are still active. Also refactors the tests for this popup to use the preferred spec style.

## Links

[JIRA for this PR](https://codedotorg.atlassian.net/issues/P20-849)
[Original bug JIRA](https://github.com/code-dot-org/code-dot-org/pull/56729)
[Original bug fix PR](https://github.com/code-dot-org/code-dot-org/pull/56729)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
