### PR TITLE
Evaluate Student Learning: add PII filtering to openai_evaluate_controller

### DIFF
--- a/dashboard/app/controllers/openai_evaluate_controller.rb
+++ b/dashboard/app/controllers/openai_evaluate_controller.rb
@@ -39,6 +39,12 @@ class OpenaiEvaluateController < ApplicationController
       aiReasoning: "The response contains profanity and could not be evaluated.",
     }
 
+    pii_detected_response = {
+      aiEvaluation: "PII detected",
+      evaluationCriteria: "Does the student work contain personally identifying information?",
+      aiReasoning: "The response contains PII and could not be evaluated.",
+    }
+
     if level.is_a?(FreeResponse) && student_work.delete(' ').empty?
       no_attempt_response[:aiReasoning] = "The student response was blank."
       # mimic the format of the response from AI
@@ -51,6 +57,9 @@ class OpenaiEvaluateController < ApplicationController
       return render(status: :ok, json: json_response)
     elsif ProfanityFilter.find_potential_profanity(student_work, "en", {})
       json_response = {"content" => profanity_detected_response.to_json}
+      return render(status: :ok, json: json_response)
+    elsif ShareFiltering.find_pii_failure(student_work)
+      json_response = {"content" => pii_detected_response.to_json}
       return render(status: :ok, json: json_response)
     elsif Rails.env.test?
       # Return dummy data in the test environment

--- a/dashboard/test/controllers/openai_evaluate_controller_test.rb
+++ b/dashboard/test/controllers/openai_evaluate_controller_test.rb
@@ -52,6 +52,22 @@ class OpenaiEvaluateControllerTest < ActionController::TestCase
     assert_equal custom_response["aiReasoning"], "The response contains profanity and could not be evaluated."
   end
 
+  # student response contains PII
+  test 'evaluate returns custom `PII detected` for free response with PII",' do
+    ShareFiltering.stubs(:find_pii_failure).returns 'harry@hogwarts.edu'
+    student = create(:student)
+    sign_in(student)
+    csp_course_offering = create(:csp_course_offering, :with_units)
+    unit = csp_course_offering.course_versions.first.content_root
+    level = create(:free_response)
+    create(:script_level, script: unit, levels: [level])
+    get :evaluate, params: {level_id: level.id, unit_id: unit.id, student_work: "My email is harry@hogwarts.edu", evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}
+    assert_response :ok
+    custom_response = JSON.parse(json_response["content"])
+    assert_equal custom_response["aiEvaluation"], "PII detected"
+    assert_equal custom_response["aiReasoning"], "The response contains PII and could not be evaluated."
+  end
+
   # student did not change starter code on programming level
   test 'evaluate returns custom `no attempt` for unchanged starter code on programming level",' do
     student = create(:student)


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/TEACH-1944

Gotta keep that personal info out. 
![](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3N2M3YTBhcXVpNXcyMWVyOThhcjdudTVyc2FiNDkxMWdtMXFtbzlmMyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/JfKaNOAoN16Pzy24dt/giphy.gif)

This PR adds PII filtering the the OpenAI evaluate controller so we prevent sending student personal details to AI. 
