### PR TITLE
Music: embeddable mini-player count

### DIFF
--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -1,6 +1,5 @@
 class MusiclabController < ApplicationController
   ANALYTICS_KEY = CDO.amplitude_api_key
-  NUM_MINI_PLAYER_PROJECTS = 5
   # The hard-coded list of channel IDs for the mini player if the 'get_channel_ids_from_featured_projects_gallery'
   # DCDO flag is set to `false`. If the DCDO flag is set to `true`, then the channel IDs are randomly selected from
   # the set of active music lab featured projects. See get_selected_channel_ids below.
@@ -40,7 +39,7 @@ class MusiclabController < ApplicationController
 
     view_options(no_header: true, no_footer: true, full_width: true, no_padding_container: true)
 
-    selected_channel_ids = get_selected_channel_ids(params[:channels])
+    selected_channel_ids = get_selected_channel_ids(params[:channels], params[:count])
 
     @projects = get_project_details(selected_channel_ids)
   end
@@ -57,19 +56,22 @@ class MusiclabController < ApplicationController
     render(json: {key: ANALYTICS_KEY})
   end
 
-  private def get_selected_channel_ids(channels_param = nil)
+  private def get_selected_channel_ids(channels_param = nil, count = nil)
     channel_ids_from_params = channels_param.nil? ? [] : channels_param.split(',')
     channel_ids_from_featured_projects = CHANNELS
+
     if DCDO.get('get_channel_ids_from_featured_projects_gallery', true)
       featured_projects = ProjectsList.fetch_active_published_featured_projects('music')[:music]
       if featured_projects
         channel_ids_from_featured_projects = featured_projects.map {|project| project['channel']}
       end
     end
+
     all_channel_ids = channel_ids_from_params.empty? ?
       channel_ids_from_featured_projects :
       channel_ids_from_params
-    all_channel_ids.sample(NUM_MINI_PLAYER_PROJECTS)
+
+    count.nil? ? all_channel_ids.shuffle : all_channel_ids.sample(count.to_i)
   end
 
   private def get_project_details(project_channel_ids)

--- a/pegasus/sites.v3/code.org/public/music/embed.haml
+++ b/pegasus/sites.v3/code.org/public/music/embed.haml
@@ -1,3 +1,0 @@
-%h1 Project beats embed
-
-%iframe{width: 500, height: 300, src: CDO.studio_url("/musiclab/embed?channels=#{request.params['channels']}&library=#{request.params['library']}", CDO.default_scheme)}

--- a/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
@@ -1,7 +1,7 @@
 :ruby
   # FontAwesome icon
   icon_check = "fa-solid fa-check-circle"
-  embed_src = CDO.studio_url(":9000/musiclab/embed?channels=#{request.params['channels']}&library=#{request.params['library']}&count=5", CDO.default_scheme)
+  embed_src = CDO.studio_url("/musiclab/embed?channels=#{request.params['channels']}&library=#{request.params['library']}&count=5", CDO.default_scheme)
   list_items = [hoc_s("music_lab.student_projects.list_create"), hoc_s("music_lab.student_projects.list_artist"),  hoc_s("music_lab.student_projects.list_share")]
 
 .grid-container.gap-2

--- a/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
@@ -1,7 +1,7 @@
 :ruby
   # FontAwesome icon
   icon_check = "fa-solid fa-check-circle"
-  embed_src = CDO.studio_url("/musiclab/embed?channels=#{request.params['channels']}&library=#{request.params['library']}", CDO.default_scheme)
+  embed_src = CDO.studio_url(":9000/musiclab/embed?channels=#{request.params['channels']}&library=#{request.params['library']}&count=5", CDO.default_scheme)
   list_items = [hoc_s("music_lab.student_projects.list_create"), hoc_s("music_lab.student_projects.list_artist"),  hoc_s("music_lab.student_projects.list_share")]
 
 .grid-container.gap-2


### PR DESCRIPTION
This small follow-up to https://github.com/code-dot-org/code-dot-org/pull/57673 removes the hard-coded count of 5 songs in the embeddable mini-player.  

The embed URL can now specify an optional parameter such as `&count=5`.  https://code.org/music uses it to continue showing 5 songs.

This also removes an old test page at https://code.org/music/embed.
