### PR TITLE
Music: tune field

### DIFF
--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -96,9 +96,12 @@ button.validationButton {
   h3,
   h4 {
     margin: 0 0 10px 0;
-    font-family: $barlowSemiCondensed-semibold;
     font-size: 1.75em;
     line-height: 1.2em;
+
+    &, em, strong {
+      font-family: $barlowSemiCondensed-semibold;
+    }
   }
 
   ol, ul {

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -96,12 +96,9 @@ button.validationButton {
   h3,
   h4 {
     margin: 0 0 10px 0;
+    font-family: $barlowSemiCondensed-semibold;
     font-size: 1.75em;
     line-height: 1.2em;
-
-    &, em, strong {
-      font-family: $barlowSemiCondensed-semibold;
-    }
   }
 
   ol, ul {

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -165,7 +165,7 @@ export default class FieldTune extends GoogleBlockly.Field {
       GoogleBlockly.utils.dom.createSvgElement(
         'rect',
         {
-          fill: selectedColor || 'white',
+          fill: selectedColor,
           x: graphNote.x,
           y: graphNote.y,
           width: graphNote.width,

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -10,7 +10,7 @@ import {
 import {getNoteName, convertRelativeToAbsolutePitch} from '../utils/Notes';
 import {
   generateGraphDataFromTune,
-  getNoteColor,
+  getNoteColorInfo,
   TuneGraphEvent,
   getDisplayNotes,
 } from '../utils/Tunes';
@@ -108,7 +108,7 @@ export default class FieldTune extends GoogleBlockly.Field {
     GoogleBlockly.utils.dom.createSvgElement(
       'rect',
       {
-        fill: '#292f36', // color.neutral_dark,
+        fill: color.neutral_dark,
         x: 1,
         y: 1,
         width: FIELD_WIDTH,
@@ -143,8 +143,6 @@ export default class FieldTune extends GoogleBlockly.Field {
             displayNote => displayNote.note === event.note
           ) !== -1
       );
-    //isNoteAvailableInScaleMode(key, event.note, scaleMode)
-    //);
 
     const graphNotes: TuneGraphEvent[] = generateGraphDataFromTune({
       notes,
@@ -157,20 +155,17 @@ export default class FieldTune extends GoogleBlockly.Field {
     });
 
     graphNotes.forEach(graphNote => {
-      const color = getNoteColor(
+      const {selectedColor} = getNoteColorInfo(
         scaleMode,
         displayNotes.findIndex(
           displayNote => displayNote.note === graphNote.note
         )
       );
-      /*const color = displayNotes.find(
-        displayNote => displayNote.note === graphNote.note
-      )?.colors?.backgroundSelected;*/
 
       GoogleBlockly.utils.dom.createSvgElement(
         'rect',
         {
-          fill: color || 'white',
+          fill: selectedColor || 'white',
           x: graphNote.x,
           y: graphNote.y,
           width: graphNote.width,

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -10,8 +10,9 @@ import {
 import {getNoteName, convertRelativeToAbsolutePitch} from '../utils/Notes';
 import {
   generateGraphDataFromTune,
-  isNoteAvailableInScaleMode,
+  getNoteColor,
   TuneGraphEvent,
+  getDisplayNotes,
 } from '../utils/Tunes';
 import InstrumentGrid from '../views/InstrumentGrid';
 
@@ -107,7 +108,7 @@ export default class FieldTune extends GoogleBlockly.Field {
     GoogleBlockly.utils.dom.createSvgElement(
       'rect',
       {
-        fill: color.neutral_dark90,
+        fill: '#292f36', // color.neutral_dark,
         x: 1,
         y: 1,
         width: FIELD_WIDTH,
@@ -127,11 +128,23 @@ export default class FieldTune extends GoogleBlockly.Field {
         })
       : (event: InstrumentTickEvent) => event;
 
+    const displayNotes = getDisplayNotes(
+      'notes',
+      scaleMode,
+      this.getValue().instrument,
+      key
+    );
+
     const notes = events
       .map(mapFn)
-      .filter((event: InstrumentTickEvent) =>
-        isNoteAvailableInScaleMode(key, event.note, scaleMode)
+      .filter(
+        (event: InstrumentTickEvent) =>
+          displayNotes.findIndex(
+            displayNote => displayNote.note === event.note
+          ) !== -1
       );
+    //isNoteAvailableInScaleMode(key, event.note, scaleMode)
+    //);
 
     const graphNotes: TuneGraphEvent[] = generateGraphDataFromTune({
       notes,
@@ -144,10 +157,20 @@ export default class FieldTune extends GoogleBlockly.Field {
     });
 
     graphNotes.forEach(graphNote => {
+      const color = getNoteColor(
+        scaleMode,
+        displayNotes.findIndex(
+          displayNote => displayNote.note === graphNote.note
+        )
+      );
+      /*const color = displayNotes.find(
+        displayNote => displayNote.note === graphNote.note
+      )?.colors?.backgroundSelected;*/
+
       GoogleBlockly.utils.dom.createSvgElement(
         'rect',
         {
-          fill: '#68d1f7',
+          fill: color || 'white',
           x: graphNote.x,
           y: graphNote.y,
           width: graphNote.width,

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -170,7 +170,6 @@ export default class FieldTune extends GoogleBlockly.Field {
           y: graphNote.y,
           width: graphNote.width,
           height: graphNote.height,
-          rx: 1,
         },
         this.backgroundElement
       );

--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -2,11 +2,17 @@ import {
   InstrumentTickEvent,
   ScaleMode,
 } from '../player/interfaces/InstrumentEvent';
+import MusicLibrary from '../player/MusicLibrary';
 
-import {getNotesInKey} from './Notes';
+import {getNoteName, getNotesInKey, Key} from './Notes';
 
 export const START_OCTAVE = 4;
 export const DISPLAY_OCTAVES = 3;
+
+export type EditorType = 'drums' | 'notes';
+
+export const integers = (length: number, start: number = 0) =>
+  Array.from({length}, (_, i) => i + start);
 
 export const isNoteAvailableInScaleMode = (
   key: number,
@@ -19,6 +25,7 @@ export const isNoteAvailableInScaleMode = (
 
 // A single event from a tune to be rendered in a graph.
 export interface TuneGraphEvent {
+  note: number;
   x: number;
   y: number;
   width: number;
@@ -56,8 +63,10 @@ export function generateGraphDataFromTune({
   const useWidth = width - 2 * padding - noteWidth;
   const useHeight = height - 2 * padding - noteHeight;
 
+  //const displayNotes = getDisplayNotes();
   return notes.map(note => {
     return {
+      note: note.note,
       x: 1 + ((note.tick - 1) * useWidth) / (16 - 1) + padding,
       y:
         1 +
@@ -68,4 +77,62 @@ export function generateGraphDataFromTune({
       height: noteHeight,
     };
   });
+}
+
+const noteColorsSimple = [
+  '#ee0916',
+  '#ff7b00',
+  '#ff0',
+  '#0f0',
+  '#0ff',
+  '#1a9cff',
+  '#c88eee',
+];
+
+//$colors-simple: #ee0916, #ff7b00, #ff0, #0f0, #0ff, #1a9cff, #c88eee;
+//$colors-simple-darker: #bb0710, #bd5b00, #7a7a00, #008a00, #008080, #0076d1, #9930df;
+
+export function getDisplayNotes(
+  editorType: EditorType,
+  scaleMode: ScaleMode,
+  instrument: string,
+  rootKey: Key
+) {
+  if (editorType === 'drums') {
+    const kitFolder = MusicLibrary.getInstance()?.kits.find(
+      kit => kit.id === instrument
+    );
+    return (
+      kitFolder?.sounds.map((sound, i) => ({
+        name: sound.name,
+        note: i,
+        colors: null,
+      })) || []
+    );
+  }
+  let noteValues;
+  if (scaleMode === 'chromatic') {
+    noteValues = integers(DISPLAY_OCTAVES * 12 + 1, START_OCTAVE * 12);
+  } else {
+    noteValues = getNotesInKey(rootKey, START_OCTAVE, DISPLAY_OCTAVES);
+  }
+
+  const colors = {backgroundSelected: 'yellow'};
+
+  return noteValues.map(note => ({note, name: getNoteName(note), colors}));
+}
+
+export function getInstruments(editorType: EditorType) {
+  if (editorType === 'drums') {
+    return MusicLibrary.getInstance()?.kits || [];
+  }
+  return MusicLibrary.getInstance()?.instruments || [];
+}
+
+export function getNoteColor(scaleMode: ScaleMode, noteIndex: number) {
+  if (scaleMode === 'chromatic') {
+    return '#3cfff7';
+  } else {
+    return noteColorsSimple[noteIndex % noteColorsSimple.length];
+  }
 }

--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -63,7 +63,6 @@ export function generateGraphDataFromTune({
   const useWidth = width - 2 * padding - noteWidth;
   const useHeight = height - 2 * padding - noteHeight;
 
-  //const displayNotes = getDisplayNotes();
   return notes.map(note => {
     return {
       note: note.note,
@@ -104,9 +103,7 @@ export function getDisplayNotes(
     noteValues = getNotesInKey(rootKey, START_OCTAVE, DISPLAY_OCTAVES);
   }
 
-  const colors = {backgroundSelected: 'yellow'};
-
-  return noteValues.map(note => ({note, name: getNoteName(note), colors}));
+  return noteValues.map(note => ({note, name: getNoteName(note)}));
 }
 
 export function getInstruments(editorType: EditorType) {

--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -92,7 +92,6 @@ export function getDisplayNotes(
       kitFolder?.sounds.map((sound, i) => ({
         name: sound.name,
         note: i,
-        colors: null,
       })) || []
     );
   }

--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -4,7 +4,7 @@ import {
 } from '../player/interfaces/InstrumentEvent';
 import MusicLibrary from '../player/MusicLibrary';
 
-import {getNoteName, getNotesInKey, Key} from './Notes';
+import {getNoteName, getNotesInKey, Key, isBlackKey} from './Notes';
 
 export const START_OCTAVE = 4;
 export const DISPLAY_OCTAVES = 3;
@@ -79,19 +79,6 @@ export function generateGraphDataFromTune({
   });
 }
 
-const noteColorsSimple = [
-  '#ee0916',
-  '#ff7b00',
-  '#ff0',
-  '#0f0',
-  '#0ff',
-  '#1a9cff',
-  '#c88eee',
-];
-
-//$colors-simple: #ee0916, #ff7b00, #ff0, #0f0, #0ff, #1a9cff, #c88eee;
-//$colors-simple-darker: #bb0710, #bd5b00, #7a7a00, #008a00, #008080, #0076d1, #9930df;
-
 export function getDisplayNotes(
   editorType: EditorType,
   scaleMode: ScaleMode,
@@ -129,10 +116,38 @@ export function getInstruments(editorType: EditorType) {
   return MusicLibrary.getInstance()?.instruments || [];
 }
 
-export function getNoteColor(scaleMode: ScaleMode, noteIndex: number) {
-  if (scaleMode === 'chromatic') {
-    return '#3cfff7';
+const noteColorsSimple = [
+  '#ee0916',
+  '#ff7b00',
+  '#ff0',
+  '#0f0',
+  '#0ff',
+  '#1a9cff',
+  '#c88eee',
+];
+
+const noteColorsSimpleKeys = [
+  '#bb0710',
+  '#bd5b00',
+  '#7a7a00',
+  '#008a00',
+  '#008080',
+  '#0076d1',
+  '#9930df',
+];
+
+export function getNoteColorInfo(scaleMode: ScaleMode, noteValue: number) {
+  if (scaleMode === 'simple') {
+    return {
+      textColor: 'white',
+      keyColor: noteColorsSimpleKeys[noteValue % noteColorsSimpleKeys.length],
+      selectedColor: noteColorsSimple[noteValue % noteColorsSimple.length],
+    };
   } else {
-    return noteColorsSimple[noteIndex % noteColorsSimple.length];
+    return {
+      textColor: isBlackKey(noteValue) ? 'white' : 'black',
+      keyColor: isBlackKey(noteValue) ? 'black' : 'white',
+      selectedColor: '#3cfff7',
+    };
   }
 }

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -155,7 +155,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
         'chromatic',
         currentValue.instrument,
         MusicRegistry.player.getKey()
-      ).sort((a, b) => b.note - a.note), // Sort descending
+      ),
     [editorType, currentValue.instrument]
   );
 
@@ -166,7 +166,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
         scaleMode || 'simple',
         currentValue.instrument,
         MusicRegistry.player.getKey()
-      ).sort((a, b) => b.note - a.note), // Sort descending
+      ),
     [editorType, scaleMode, currentValue.instrument]
   );
 
@@ -180,14 +180,9 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
       return {style: styles.textLabel, label: name};
     }
 
-    const noteIndex =
-      interfaceMode === 'simple'
-        ? displayNotes.findIndex(displayNote => displayNote.note === note)
-        : note;
-
     const {textColor, keyColor, selectedColor} = getNoteColorInfo(
       interfaceMode,
-      noteIndex
+      displayNotes.findIndex(displayNote => displayNote.note === note)
     );
 
     const pitchRowClass = displayNotes.find(
@@ -221,8 +216,8 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
     const cellHeightWithGap = parseInt(cellHeight) + parseInt(rowGap);
 
     return [
-      scrollStartRow * cellHeightWithGap,
-      topVisibleRow * cellHeightWithGap - parseInt(peekHeight),
+      -(scrollStartRow * cellHeightWithGap),
+      -(topVisibleRow * cellHeightWithGap - parseInt(peekHeight)),
     ];
   }, [displayNotes.length, editorType, scaleMode]);
 
@@ -282,7 +277,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
         scrollEnd={scrollEnd}
         className={classNames(styles[`sequence-editor-${interfaceMode}`])}
       >
-        {allNotes.map(({note, name}, i) => {
+        {allNotes.map(({note, name}) => {
           const {
             pitchRowClass,
             style,

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -202,24 +202,23 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
   };
 
   const [scrollStart, scrollEnd] = useMemo(() => {
-    const {cellHeight, rowGap, displayRows, peekHeight} = styles;
+    const {cellHeight, rowGap, peekHeight} = styles;
     if (editorType !== 'notes') {
       return [0, 0];
     }
 
     const notesInOctave = scaleMode === 'chromatic' ? 12 : 7;
     // Scroll so that the middle octave is at the bottom of the editor.
-    const topVisibleRow =
-      displayNotes.length - notesInOctave - parseInt(displayRows);
-    // Start scrolling a few rows below
-    const scrollStartRow = topVisibleRow + 3;
+    const firstVisibleRow = notesInOctave;
+    // Start scrolling from a few rows beyond.
+    const scrollStartRow = firstVisibleRow + 3;
     const cellHeightWithGap = parseInt(cellHeight) + parseInt(rowGap);
 
     return [
       -(scrollStartRow * cellHeightWithGap),
-      -(topVisibleRow * cellHeightWithGap - parseInt(peekHeight)),
+      -(firstVisibleRow * cellHeightWithGap - parseInt(peekHeight)),
     ];
-  }, [displayNotes.length, editorType, scaleMode]);
+  }, [editorType, scaleMode]);
 
   return (
     <div className={styles.container} data-theme="Dark">

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -21,11 +21,12 @@ import {
   convertRelativeToAbsolutePitch,
   convertAbsoluteToRelativePitch,
 } from '../../utils/Notes';
+import {EditorType, getDisplayNotes, integers} from '../../utils/Tunes';
 import LoadingOverlay from '../LoadingOverlay';
 import PreviewControlsV2 from '../PreviewControlsV2';
 import EaseIntoView from '../util/EaseIntoView';
 
-import {getDisplayNotes, getInstruments, integers} from './util';
+import {getInstruments} from './util';
 
 import styles from './styles.module.scss';
 
@@ -35,8 +36,6 @@ interface Props {
   editorType: EditorType;
   lengthMeasures: number;
 }
-
-export type EditorType = 'drums' | 'notes';
 
 /**
  * Instrument grid editor for selecting notes in a pattern.

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -17,11 +17,15 @@ import {
 } from '../../player/interfaces/InstrumentEvent';
 import {
   getPitchName,
-  isBlackKey,
   convertRelativeToAbsolutePitch,
   convertAbsoluteToRelativePitch,
 } from '../../utils/Notes';
-import {EditorType, getDisplayNotes, integers} from '../../utils/Tunes';
+import {
+  EditorType,
+  getDisplayNotes,
+  integers,
+  getNoteColorInfo,
+} from '../../utils/Tunes';
 import LoadingOverlay from '../LoadingOverlay';
 import PreviewControlsV2 from '../PreviewControlsV2';
 import EaseIntoView from '../util/EaseIntoView';
@@ -171,41 +175,20 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
   const interfaceMode =
     editorType === 'drums' ? 'drums' : scaleMode || 'simple';
 
-  const colorsSimple = styles.colorsSimple.split(',');
-  const colorsSimpleDarker = styles.colorsSimpleDarker.split(',');
-
   const getRowInfo = (name: string, note: number) => {
     if (interfaceMode === 'drums') {
       return {style: styles.textLabel, label: name};
     }
 
-    let color = undefined,
-      backgroundColor = undefined,
-      selectedBackgroundColor = undefined;
+    const noteIndex =
+      interfaceMode === 'simple'
+        ? displayNotes.findIndex(displayNote => displayNote.note === note)
+        : note;
 
-    if (interfaceMode === 'simple') {
-      const displayNoteIndex = displayNotes.findIndex(
-        displayNote => displayNote.note === note
-      );
-      if (displayNoteIndex !== -1) {
-        color = 'white';
-        selectedBackgroundColor =
-          colorsSimple[(21 - displayNoteIndex) % colorsSimple.length];
-        backgroundColor =
-          colorsSimpleDarker[
-            (21 - displayNoteIndex) % colorsSimpleDarker.length
-          ];
-      }
-    }
-
-    if (backgroundColor === undefined) {
-      backgroundColor = isBlackKey(note) ? styles.black : styles.white;
-      color = isBlackKey(note) ? styles.white : styles.black;
-    }
-
-    if (selectedBackgroundColor === undefined) {
-      selectedBackgroundColor = styles.selectedColor;
-    }
+    const {textColor, keyColor, selectedColor} = getNoteColorInfo(
+      interfaceMode,
+      noteIndex
+    );
 
     const pitchRowClass = displayNotes.find(
       displayNote => displayNote.note === note
@@ -217,9 +200,9 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
       pitchRowClass,
       style: styles.keyLabel,
       label: getPitchName(note),
-      backgroundColor,
-      color,
-      selectedBackgroundColor,
+      textColor,
+      keyColor,
+      selectedColor,
     };
   };
 
@@ -304,9 +287,9 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
             pitchRowClass,
             style,
             label,
-            backgroundColor,
-            color,
-            selectedBackgroundColor,
+            textColor,
+            keyColor,
+            selectedColor,
           } = getRowInfo(name, note);
 
           return (
@@ -326,7 +309,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
               >
                 <div
                   className={classNames(style, styles.innerCell)}
-                  style={{backgroundColor, color}}
+                  style={{backgroundColor: keyColor, color: textColor}}
                 >
                   {label}
                 </div>
@@ -349,7 +332,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
                         )}
                         style={{
                           backgroundColor: isSelected(note, tick)
-                            ? selectedBackgroundColor
+                            ? selectedColor
                             : undefined,
                         }}
                       />

--- a/apps/src/music/views/InstrumentGrid/styles.module.scss
+++ b/apps/src/music/views/InstrumentGrid/styles.module.scss
@@ -1,8 +1,6 @@
 @import '../../../mixins.scss';
 @import 'color.scss';
 
-$colors-simple: #ee0916, #ff7b00, #ff0, #0f0, #0ff, #1a9cff, #c88eee;
-$colors-simple-darker: #bb0710, #bd5b00, #7a7a00, #008a00, #008080, #0076d1, #9930df;
 $colors-drums: #6c5ce7, #0984e3, #00cec9, #00b894, #a29bfe, #74b9ff, #81ecec, #55efc4;
 $cell-width: 25px;
 $cell-height: 18px;
@@ -16,8 +14,6 @@ $peek-height: 5px;
   rowGap: $row-gap;
   displayRows: $display-rows;
   peekHeight: $peek-height;
-  colorsSimple: $colors-simple;
-  colorsSimpleDarker: $colors-simple-darker;
   black: $black;
   white: $white;
   selectedColor: var(--brand-aqua-50);

--- a/apps/src/music/views/InstrumentGrid/styles.module.scss
+++ b/apps/src/music/views/InstrumentGrid/styles.module.scss
@@ -61,6 +61,7 @@ $peek-height: 5px;
 .sequence-editor-chromatic {
   @extend %sequence-editor;
   max-height: ($cell-height + $row-gap) * $display-rows + ($peek-height * 2);
+  flex-direction: column-reverse;
 }
 
 .pitchRow {

--- a/apps/src/music/views/InstrumentGrid/util.ts
+++ b/apps/src/music/views/InstrumentGrid/util.ts
@@ -1,36 +1,5 @@
-import {ScaleMode} from '../../player/interfaces/InstrumentEvent';
 import MusicLibrary from '../../player/MusicLibrary';
-import {getNoteName, getNotesInKey, Key} from '../../utils/Notes';
-import {START_OCTAVE, DISPLAY_OCTAVES} from '../../utils/Tunes';
-
-import {EditorType} from '.';
-
-export const integers = (length: number, start: number = 0) =>
-  Array.from({length}, (_, i) => i + start);
-
-export function getDisplayNotes(
-  editorType: EditorType,
-  scaleMode: ScaleMode,
-  instrument: string,
-  rootKey: Key
-) {
-  if (editorType === 'drums') {
-    const kitFolder = MusicLibrary.getInstance()?.kits.find(
-      kit => kit.id === instrument
-    );
-    return (
-      kitFolder?.sounds.map((sound, i) => ({name: sound.name, note: i})) || []
-    );
-  }
-  let noteValues;
-  if (scaleMode === 'chromatic') {
-    noteValues = integers(DISPLAY_OCTAVES * 12 + 1, START_OCTAVE * 12);
-  } else {
-    noteValues = getNotesInKey(rootKey, START_OCTAVE, DISPLAY_OCTAVES);
-  }
-
-  return noteValues.map(note => ({note, name: getNoteName(note)}));
-}
+import {EditorType} from '../../utils/Tunes';
 
 export function getInstruments(editorType: EditorType) {
   if (editorType === 'drums') {

--- a/apps/src/music/views/util/EaseIntoView.tsx
+++ b/apps/src/music/views/util/EaseIntoView.tsx
@@ -1,5 +1,9 @@
 import React, {useEffect, useRef} from 'react';
 
+const clamp = (number: number, min: number, max: number) => {
+  return Math.min(Math.max(number, min), max);
+};
+
 const animationFramesPerSecond = 60;
 
 // EaseIntoView: This component does an eased scroll of the container's content,
@@ -72,12 +76,28 @@ const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
             0,
             (scrollStep.current - delayFrames) / frames
           );
-          const scrollPosition =
+          const desiredScrollPosition =
             scrollStart - (scrollStart - scrollEnd) * easeOutSine(progress);
 
-          containerRef.current?.scroll(0, scrollPosition);
+          const maxScrollPosition =
+            containerRef.current?.scrollHeight -
+            containerRef.current?.clientHeight;
 
-          lastScrollPosition.current = scrollPosition;
+          // Avoid attempting to over-scroll, which will be misinterpeted as the user scrolling
+          // manually by a check above.
+          const clampedScrollPosition = clamp(
+            desiredScrollPosition,
+            -maxScrollPosition,
+            maxScrollPosition
+          );
+
+          containerRef.current?.scroll({
+            top: clampedScrollPosition,
+            left: 0,
+            behavior: 'instant',
+          });
+
+          lastScrollPosition.current = clampedScrollPosition;
 
           scrollStep.current++;
 


### PR DESCRIPTION
This updates the rendering of the "play tune" block's field to render notes with the same colors as the editor.  Credit to @mikeharv for thinking of this.

This involved factoring out some utility code to be shared between the field and the editor.  

It now renders the editor's notes from bottom-to-top using a reverse flex direction, which has the handy side effect of pinning the row at the bottom of the editor, rather than the one at the top, when toggling scale mode.

https://github.com/user-attachments/assets/324248a5-c9c3-4987-b0fe-3cecb9b2bc5b

