### PR TITLE
CMS-536: Wait for FAQ Accordion to open before running eye test

### DIFF
--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -367,11 +367,13 @@ test.describe('All the things UI e2e test', () => {
         }
       });
 
-      test('eyes', {tag: '@eyes'}, async ({eyes}, testInfo) => {
+      test('eyes', {tag: '@eyes'}, async ({page, eyes}, testInfo) => {
         for (const dialog of await component.getByRole('group').all()) {
           await dialog.click();
           await expect(dialog).toHaveAttribute('open');
         }
+
+        await page.waitForTimeout(500);
 
         await eyes.check(testInfo.title, {region: component});
       });


### PR DESCRIPTION
## Links
- JIRA task: [CMS-536](https://codedotorg.atlassian.net/browse/CMS-536)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66288