### PR TITLE
chore(lighthouse): reduce text compress allowance

### DIFF
--- a/frontend/apps/marketing/.lighthouserc.js
+++ b/frontend/apps/marketing/.lighthouserc.js
@@ -7,7 +7,7 @@ const assertions = {
   'total-byte-weight': ['error', {minScore: 0.5}],
   'unused-css-rules': ['error', {maxLength: 30}],
   'unused-javascript': ['error', {maxLength: 10}],
-  'uses-text-compression': ['error', {maxLength: 80}],
+  'uses-text-compression': ['error', {maxLength: 5}],
   'third-party-cookies': 'off',
   'uses-rel-preconnect': 'off',
   'link-text': 'off', // re-enable after CMS-497


### PR DESCRIPTION
Now that text compression is enabled on `/_next`, we can reduce the allowance on for the `uses-text-compression` rule.
