### PR TITLE
Music: fix play view buttons

### DIFF
--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -114,7 +114,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
             <Button
               text={commonI18n.viewCode()}
               type="tertiary"
-              color="white"
+              color="black"
               size="xs"
               iconLeft={{iconStyle: 'solid', iconName: 'code'}}
               onClick={onViewCode}
@@ -123,7 +123,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
               <Button
                 text={musicI18n.share()}
                 type="tertiary"
-                color="white"
+                color="black"
                 size="xs"
                 iconLeft={{
                   iconStyle: 'solid',
@@ -135,7 +135,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
             <Button
               text={commonI18n.makeMyOwn()}
               type="tertiary"
-              color="white"
+              color="black"
               size="xs"
               iconLeft={{iconStyle: 'regular', iconName: 'pen-to-square'}}
               onClick={onRemix}


### PR DESCRIPTION
Another small follow-up to https://github.com/code-dot-org/code-dot-org/pull/65437, this fixes the color of the small buttons in the music play view.

### before

<img width="388" alt="Screenshot 2025-06-06 at 1 07 12 AM" src="https://github.com/user-attachments/assets/366557a1-2f48-46d8-847f-5f42a99f3a1c" />

### after

<img width="388" alt="Screenshot 2025-06-06 at 1 06 49 AM" src="https://github.com/user-attachments/assets/6cb4b455-6b54-40ce-8dbc-b6517864c2a3" />

