### PR TITLE
add code to force info interstitial and confirmation via URL params

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -7,7 +7,6 @@ import {
 } from '@code-dot-org/component-library/typography';
 import Drawer from '@mui/material/Drawer';
 import React from 'react';
-import {useSearchParams} from 'react-router-dom';
 
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -33,8 +32,6 @@ interface DrawerData {
 }
 
 export const TeacherHomepageDrawer: React.FC = () => {
-  const [searchParams] = useSearchParams();
-
   const [schoolInfoInterstitialOpen, setSchoolInfoInterstitialOpen] =
     React.useState(false);
   const [schoolInfoConfirmationOpen, setSchoolInfoConfirmationOpen] =
@@ -59,6 +56,7 @@ export const TeacherHomepageDrawer: React.FC = () => {
 
       // If the URL has a query param to show the interstitial or confirmation,
       // we want to set that state to true to open the drawer.
+      const searchParams = new URLSearchParams(window.location.search);
       if (searchParams.get('showSchoolInfoInterstitial') === 'true') {
         setSchoolInfoInterstitialOpen(true);
         // We don't want to set both to true at the same time
@@ -70,7 +68,6 @@ export const TeacherHomepageDrawer: React.FC = () => {
     setExistingSchoolInfo,
     setSchoolInfoInterstitialOpen,
     setSchoolInfoConfirmationOpen,
-    searchParams,
   ]);
   const inUSA = useAppSelector(state => state.currentUser.inUSA);
   const schoolInfo = useSchoolInfo({

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -7,6 +7,7 @@ import {
 } from '@code-dot-org/component-library/typography';
 import Drawer from '@mui/material/Drawer';
 import React from 'react';
+import {useSearchParams} from 'react-router-dom';
 
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -32,6 +33,8 @@ interface DrawerData {
 }
 
 export const TeacherHomepageDrawer: React.FC = () => {
+  const [searchParams] = useSearchParams();
+
   const [schoolInfoInterstitialOpen, setSchoolInfoInterstitialOpen] =
     React.useState(false);
   const [schoolInfoConfirmationOpen, setSchoolInfoConfirmationOpen] =
@@ -44,6 +47,8 @@ export const TeacherHomepageDrawer: React.FC = () => {
   >(undefined);
   const schoolName =
     existingSchoolInfo?.school_name || i18n.schoolInfoDialogDescriptionNoName();
+
+  // Load school data and set the drawer state based on the response.
   React.useEffect(() => {
     HttpClient.fetchJson<DrawerData>(
       '/teacher_dashboard/get_school_info_interstitial_data'
@@ -51,11 +56,21 @@ export const TeacherHomepageDrawer: React.FC = () => {
       setExistingSchoolInfo(data.value.existingSchoolInfo);
       setSchoolInfoInterstitialOpen(data.value.showSchoolInfoInterstitial);
       setSchoolInfoConfirmationOpen(data.value.showSchoolInfoConfirmation);
+
+      // If the URL has a query param to show the interstitial or confirmation,
+      // we want to set that state to true to open the drawer.
+      if (searchParams.get('showSchoolInfoInterstitial') === 'true') {
+        setSchoolInfoInterstitialOpen(true);
+        // We don't want to set both to true at the same time
+      } else if (searchParams.get('showSchoolInfoConfirmation') === 'true') {
+        setSchoolInfoConfirmationOpen(true);
+      }
     });
   }, [
     setExistingSchoolInfo,
     setSchoolInfoInterstitialOpen,
     setSchoolInfoConfirmationOpen,
+    searchParams,
   ]);
   const inUSA = useAppSelector(state => state.currentUser.inUSA);
   const schoolInfo = useSchoolInfo({

--- a/dashboard/app/models/user_level_interaction.rb
+++ b/dashboard/app/models/user_level_interaction.rb
@@ -19,6 +19,9 @@
 #  index_user_level_interactions_on_level_id  (level_id)
 #  index_user_level_interactions_on_user_id   (user_id)
 #
+# Logs for user interactions with levels, such as clicking the run or finish buttons.
+# This contains additional information than just completion status or attempts.
+# These interactions are used to improve insights into student learning.
 class UserLevelInteraction < ApplicationRecord
   belongs_to :user
   belongs_to :level

--- a/dashboard/app/models/user_level_interaction.rb
+++ b/dashboard/app/models/user_level_interaction.rb
@@ -19,9 +19,6 @@
 #  index_user_level_interactions_on_level_id  (level_id)
 #  index_user_level_interactions_on_user_id   (user_id)
 #
-# Logs for user interactions with levels, such as clicking the run or finish buttons.
-# This contains additional information than just completion status or attempts.
-# These interactions are used to improve insights into student learning.
 class UserLevelInteraction < ApplicationRecord
   belongs_to :user
   belongs_to :level

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ai_interaction_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "ai_interaction_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id"
     t.integer "script_id"
@@ -954,7 +954,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "levels_skills", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "levels_skills", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "level_id", null: false
     t.bigint "skill_id", null: false
     t.index ["level_id", "skill_id"], name: "index_levels_skills_on_level_id_and_skill_id"
@@ -2162,7 +2162,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
   end
 
-  create_table "skills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "skills", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "description", null: false
     t.text "evaluation_criteria"
     t.string "concept"
@@ -2219,7 +2219,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
-  create_table "student_work_evaluation_summaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "student_work_evaluation_summaries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "student_work_evaluation_id", null: false
     t.bigint "student_work_evaluation_summary_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -2228,7 +2228,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["student_work_evaluation_summary_id"], name: "fk_rails_d50fa61780"
   end
 
-  create_table "student_work_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "student_work_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.integer "student_id"
     t.integer "requester_id"
@@ -2417,7 +2417,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["user_id", "permission"], name: "index_user_permissions_on_user_id_and_permission", unique: true
   end
 
-  create_table "user_preferences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.json "section_order"
     t.datetime "created_at", precision: 6, null: false

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ai_interaction_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "ai_interaction_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id"
     t.integer "script_id"
@@ -954,7 +954,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "levels_skills", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "levels_skills", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "level_id", null: false
     t.bigint "skill_id", null: false
     t.index ["level_id", "skill_id"], name: "index_levels_skills_on_level_id_and_skill_id"
@@ -2162,7 +2162,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
   end
 
-  create_table "skills", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "skills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "description", null: false
     t.text "evaluation_criteria"
     t.string "concept"
@@ -2219,7 +2219,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
-  create_table "student_work_evaluation_summaries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "student_work_evaluation_summaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "student_work_evaluation_id", null: false
     t.bigint "student_work_evaluation_summary_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -2228,7 +2228,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["student_work_evaluation_summary_id"], name: "fk_rails_d50fa61780"
   end
 
-  create_table "student_work_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "student_work_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.integer "student_id"
     t.integer "requester_id"
@@ -2417,7 +2417,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.index ["user_id", "permission"], name: "index_user_permissions_on_user_id_and_permission", unique: true
   end
 
-  create_table "user_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_preferences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.json "section_order"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
This update adds the option to trigger the new teacher homepage drawer via URL search params. This is for debugging purposes.

https://github.com/user-attachments/assets/ed23a84c-ad74-48df-9128-b4610c84ff78

## Links

[TEACH-1992](https://codedotorg.atlassian.net/browse/TEACH-1992)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
