### PR TITLE
fix(marketing): update placeholder image urls on ActionBlock and FullWidthActionBlock

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/actionBlockContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/actionBlockContentfulDefinition.ts
@@ -53,7 +53,7 @@ export const ActionBlockContentfulComponentDefinition: ComponentDefinition = {
       group: 'content',
       description: 'The image to display in the action block.',
       defaultValue:
-        'contentful-images.code.org/90t6bu6vlf76/3ObZQWtgyo31ILZ7j8qm4c/421404b4e7ee968584902c697cdca751/action_block_placeholder_image.png',
+        'https://contentful-images.code.org/90t6bu6vlf76/3ObZQWtgyo31ILZ7j8qm4c/421404b4e7ee968584902c697cdca751/action_block_placeholder_image.png?fm=avif',
       validations: {
         bindingSourceType: ['entry', 'asset'],
       },

--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/fullWidthActionBlockContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/fullWidthActionBlockContentfulDefinition.ts
@@ -54,7 +54,7 @@ export const FullWidthActionBlockContentfulComponentDefinition: ComponentDefinit
         group: 'content',
         description: 'The image to display in the action block.',
         defaultValue:
-          'contentful-images.code.org/90t6bu6vlf76/3ObZQWtgyo31ILZ7j8qm4c/421404b4e7ee968584902c697cdca751/action_block_placeholder_image.png',
+          'https://contentful-images.code.org/90t6bu6vlf76/3ObZQWtgyo31ILZ7j8qm4c/421404b4e7ee968584902c697cdca751/action_block_placeholder_image.png?fm=avif',
         validations: {
           bindingSourceType: ['entry', 'asset'],
         },


### PR DESCRIPTION
Updates the image placeholder image url on ActionBlock and FullWidthActionBlock components. The update in this PR: https://github.com/code-dot-org/code-dot-org/pull/66352 to format images as avif should fix this on production.

## Links
Jira ticket: [CMS-812](https://codedotorg.atlassian.net/browse/CMS-812)
Original PR: https://github.com/code-dot-org/code-dot-org/pull/66173

## Testing story
Tested locally on Contentful, will add default drop ins to All The Things in a followup [CMS-813](https://codedotorg.atlassian.net/browse/CMS-813).

---- 

## On production
<img width="1630" alt="Screenshot 2025-06-06 at 8 36 47 AM" src="https://github.com/user-attachments/assets/6d3ffaf8-51a3-41d8-8fd2-7860b979ceb5" />


## Locally w/ fix

### ActionBlock
<img width="1630" alt="Screenshot 2025-06-06 at 8 31 04 AM" src="https://github.com/user-attachments/assets/8e0ba0ca-157d-46a6-a847-2bf895ca0999" />

### FullWidthActionBlock
<img width="1630" alt="Screenshot 2025-06-06 at 8 35 31 AM" src="https://github.com/user-attachments/assets/74d22ea5-2dcc-4284-84e3-873db8271fae" />

