### PR TITLE
fix(onetrust): use cookielaw for marketing sites

### DIFF
--- a/frontend/apps/marketing/src/providers/onetrust/OneTrustLoader.tsx
+++ b/frontend/apps/marketing/src/providers/onetrust/OneTrustLoader.tsx
@@ -27,7 +27,7 @@ const OneTrustLoader = ({brand}: {brand: Brand}) => {
 
       {/* OneTrust SDK script. */}
       <Script
-        src={getOnetrustStubScriptPath(brand)}
+        src={getOnetrustStubScriptPath()}
         data-domain-script={getOneTrustDomainId(brand)}
         strategy={'beforeInteractive'}
       />

--- a/frontend/apps/marketing/src/providers/onetrust/config/__tests__/index.test.ts
+++ b/frontend/apps/marketing/src/providers/onetrust/config/__tests__/index.test.ts
@@ -39,7 +39,7 @@ describe('OneTrust Config Functions', () => {
       getStageMock.mockReturnValue('production');
       const result = getOnetrustAutoBlockScriptPath(Brand.CODE_DOT_ORG);
       expect(result).toBe(
-        '/_next/static/public/onetrust/code.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d/OtAutoBlock.js',
+        'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d/OtAutoBlock.js',
       );
     });
 
@@ -47,7 +47,7 @@ describe('OneTrust Config Functions', () => {
       getStageMock.mockReturnValue('production');
       const result = getOnetrustAutoBlockScriptPath(Brand.HOUR_OF_CODE);
       expect(result).toBe(
-        '/_next/static/public/onetrust/hourofcode.com/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345/OtAutoBlock.js',
+        'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345/OtAutoBlock.js',
       );
     });
 
@@ -65,7 +65,7 @@ describe('OneTrust Config Functions', () => {
       getStageMock.mockReturnValue('production');
       const result = getOnetrustStubScriptPath(Brand.CODE_DOT_ORG);
       expect(result).toBe(
-        '/_next/static/public/onetrust/code.org/scripttemplates/otSDKStub.js',
+        'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js',
       );
     });
 

--- a/frontend/apps/marketing/src/providers/onetrust/config/index.ts
+++ b/frontend/apps/marketing/src/providers/onetrust/config/index.ts
@@ -19,19 +19,12 @@ function getOneTrustDomainIdByBrand(brand: Brand) {
 /**
  * Returns the OneTrust asset base path. For production, it is self-hosted. For pre-production, it is sourced from the
  * OneTrust CDN so that it enables live testing without having to upload new self-hosted files.
- * @param brand Code.org brand
  */
-function getOneTrustAssetBasePath(brand: Brand) {
+function getOneTrustAssetBasePath() {
   const stage = getStage();
 
   switch (stage) {
-    case 'production':
-      /**
-       * TODO: Once Pegasus is deprecated, uncomment this line and remove the extra cp from package.json in
-       * copy:static-assets to the .next/static/public directory
-       * https://codedotorg.atlassian.net/browse/CMS-786
-       */
-      return `/_next/static/public/onetrust/${brand}`;
+    // Always use cdn.cookielaw.org until OneTrust fixes self-hosting on a relative path
     default:
       return `https://cdn.cookielaw.org`;
   }
@@ -59,13 +52,12 @@ export function getOneTrustDomainId(brand: Brand) {
  * @param brand Code.org brand
  */
 export function getOnetrustAutoBlockScriptPath(brand: Brand) {
-  return `${getOneTrustAssetBasePath(brand)}/consent/${getOneTrustDomainId(brand)}/OtAutoBlock.js`;
+  return `${getOneTrustAssetBasePath()}/consent/${getOneTrustDomainId(brand)}/OtAutoBlock.js`;
 }
 
 /**
  * Returns the OneTrust SDK script path
- * @param brand Code.org brand
  */
-export function getOnetrustStubScriptPath(brand: Brand) {
-  return `${getOneTrustAssetBasePath(brand)}/scripttemplates/otSDKStub.js`;
+export function getOnetrustStubScriptPath() {
+  return `${getOneTrustAssetBasePath()}/scripttemplates/otSDKStub.js`;
 }


### PR DESCRIPTION
This PR updates the marketing sites to use the cookielaw domain for OneTrust due to a bug in their self-hosted script preventing usage in a relative path script. Once OneTrust fixes the relative path bug, self-hosted scripts can be re-enabled.