### PR TITLE
Lab2: fix header font

### DIFF
--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -96,9 +96,12 @@ button.validationButton {
   h3,
   h4 {
     margin: 0 0 10px 0;
-    font-family: $barlowSemiCondensed-semibold;
     font-size: 1.75em;
     line-height: 1.2em;
+
+    &, em, strong {
+      font-family: $barlowSemiCondensed-semibold;
+    }
   }
 
   ol, ul {

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -194,9 +194,12 @@
   h3,
   h4 {
     margin: 0 0 10px 0;
-    font-family: $barlowSemiCondensed-semibold;
     font-size: 1.75em;
     line-height: 1.2em;
+
+    &, em, strong {
+      font-family: $barlowSemiCondensed-semibold;
+    }
   }
 
   ol,

--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -95,9 +95,12 @@ $text-horizontal-padding: 2.6cqw;
 
       h1, h2, h3, h4 {
         margin: 0 0 1cqw 0;
-        font-family: $barlowSemiCondensed-semibold;
         font-size: 3cqw;
         line-height: 1.2em;
+
+        &, em, strong {
+          font-family: $barlowSemiCondensed-semibold;
+        }
       }
 
       p {


### PR DESCRIPTION
In the case that markdown for instructions or a panel has a heading that includes **strong** or *em* text, the font now remains Barlow, rather than switching to Figree.

### before

#### instructions

<img width="513" alt="Screenshot 2025-06-06 at 11 24 53 AM" src="https://github.com/user-attachments/assets/2595fc9f-4436-4c2e-b333-f28fce27902e" />

#### panel

<img width="503" alt="Screenshot 2025-06-06 at 11 18 01 AM" src="https://github.com/user-attachments/assets/e1c4f774-6b10-45f9-a632-55f0a110ba60" />

### after

#### instructions

<img width="513" alt="Screenshot 2025-06-06 at 11 23 43 AM" src="https://github.com/user-attachments/assets/4a3fd8de-499c-4119-99c0-9929f418d679" />

#### panel

<img width="503" alt="Screenshot 2025-06-06 at 11 18 21 AM" src="https://github.com/user-attachments/assets/a38e098d-e797-41b4-bcb1-2e93e3bcaf50" />

