### PR TITLE
Remove disabled pre-workshop survey toggle

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/EmailsReminders.tsx
@@ -71,23 +71,6 @@ export const EmailsReminders: FC<EmailsRemindersProps> = ({
               </div>
             </div>
           )}
-          <div className={commonStyles.toggleWrapper}>
-            <div className={commonStyles.row}>
-              <Toggle
-                label="Pre-workshop survey*"
-                name="pre-workshop survey email"
-                size="s"
-                checked={true}
-                onChange={() => {}}
-                disabled={true}
-              />
-              {/* TODO: blank href for now until we have mailjet email preview links */}
-              <PreviewEmailLink href="" />
-            </div>
-            <BodyFourText>
-              *We require this email for every workshop.
-            </BodyFourText>
-          </div>
         </div>
         <div className={commonStyles.col}>
           <OverlineThreeText>post-workshop emails</OverlineThreeText>


### PR DESCRIPTION
As Sam brought up [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1749052903385469), we were referencing a pre-workshop survey email in the workshop builder form that actually doesn't exist so this PR removes it.

### Existing form
![emailreminder old](https://github.com/user-attachments/assets/382155a1-c766-48d5-be2d-561b02d2c00b)

### With change
![emailreminder new](https://github.com/user-attachments/assets/872219ea-59d9-4f34-86c2-d802f88afbf6)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3332)
Slack discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1749052903385469)

## Testing story
Local testing.
