### PR TITLE
Fixes some render races when the locale changes in the SmallFooter.

### DIFF
--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -74,18 +74,20 @@ export default class SmallFooter extends React.Component {
     );
 
     localization.on('change', info => {
-      this.setState({
-        localeOptions: localization.locales,
-        currentLocale: info.locale,
-      });
+      debounce(() => {
+        this.setState({
+          localeOptions: localization.locales,
+          currentLocale: info.locale,
+        });
+      }, 100);
     });
   }
 
   captureBaseElementDimensions = () => {
     const base = this.refs.base;
     this.setState({
-      baseWidth: base.offsetWidth,
-      baseHeight: base.offsetHeight,
+      baseWidth: base?.offsetWidth || 0,
+      baseHeight: base?.offsetHeight || 0,
     });
   };
 

--- a/apps/src/sharedComponents/footer/I18nDropdown/index.tsx
+++ b/apps/src/sharedComponents/footer/I18nDropdown/index.tsx
@@ -29,6 +29,7 @@ const I18nDropdown: React.FC<I18nDropdownProps> = ({
       method="post"
       id="localeForm"
       style={{marginBottom: '0px'}}
+      data-notranslate=""
     >
       <input type="hidden" name="user_return_to" value={window.location.href} />
       <SimpleDropdown


### PR DESCRIPTION
Just a quick fix for the SmallFooter. It apparently needs to delay rendering because of some resizing logic it performs that doesn't like some refs being invalid. We really need to refactor the entire component, but that's beyond the scope.

This just delays rendering the new locale dropdown state when the locale changes and also marks the dropdown as not-to-translate to remove some noise.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
