### PR TITLE
Re-sign Drone after Ruby 3.1 Upgrade

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -353,6 +353,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: 6646bfda5cd973eb102725e17d3dade6b986b372da0ebb87c687d40e29655dfc
+hmac: 8f32947335d2c9bb7f8660606dcce33bdf0ded6eb01b9382cd02252b93b850c8
 
 ...


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/65533

I forgot to re-sign `.drone.yml` after changing the target image from `codedotorg/code-dot-org:ruby-3.1` to `codedotorg/code-dot-org:1.16`
