### PR TITLE
add redirect for /csaif

### DIFF
--- a/frontend/apps/marketing/next.config.ts
+++ b/frontend/apps/marketing/next.config.ts
@@ -1951,6 +1951,11 @@ const nextConfig: NextConfig = {
         destination: 'https://global.code.org/farsi',
         permanent: false,
       },
+      {
+        source: '/csaif',
+        destination: '/curriculum/artificial-intelligence-foundations',
+        permanent: false,
+      },
     ];
   },
 };


### PR DESCRIPTION
Adds a redirect from code.org/csaif to https://code.org/en-US/curriculum/artificial-intelligence-foundations