### PR TITLE
Block lab2 open-ended projects if sharing is disabled

### DIFF
--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -200,3 +200,5 @@ export const OPEN_ENDED_LEGACY_PROJECT_TYPES = [
   'poetry',
   'playlab',
 ];
+
+export const OPEN_ENDED_LAB2_PROJECT_TYPES = ['pythonlab', 'weblab2'];

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -12,6 +12,7 @@ import {
   ThunkDispatch,
 } from '@reduxjs/toolkit';
 
+import {OPEN_ENDED_LAB2_PROJECT_TYPES} from '@cdo/apps/constants';
 import {
   getPublicCaching,
   getAppOptionsEditBlocks,
@@ -100,7 +101,9 @@ export interface LabState {
   // If this lab should presented in a "share" or "play-only" view, which may hide certain UI elements.
   isShareView: boolean | undefined;
   // If this lab is blocked because abuse score >= 15.
-  isBlocked: boolean | undefined;
+  isBlockedAbuse: boolean | undefined;
+  // If this lab/project is blocked for project non-owners (excluding owner's teacher).
+  projectSharingDisabled: boolean | undefined;
   overrideValidations: Validation[] | undefined;
   permissions: string[];
 }
@@ -116,7 +119,8 @@ const initialState: LabState = {
   levelProperties: undefined,
   scriptId: undefined,
   isShareView: undefined,
-  isBlocked: undefined,
+  isBlockedAbuse: undefined,
+  projectSharingDisabled: undefined,
   overrideValidations: undefined,
   permissions: [],
 };
@@ -269,12 +273,16 @@ export const setUpWithLevel = createAsyncThunk<
 
     Lab2Registry.getInstance().setProjectManager(projectManager);
     // Load channel and source.
-    const {sources, channel, abuseScore} = await setUpAndLoadProject(
-      projectManager,
-      thunkAPI.dispatch
-    );
+    const {sources, channel, abuseScore, sharingDisabled} =
+      await setUpAndLoadProject(projectManager, thunkAPI.dispatch);
     setProjectAndLevelData(
-      {initialSources: sources, channel, levelProperties, abuseScore},
+      {
+        initialSources: sources,
+        channel,
+        levelProperties,
+        abuseScore,
+        sharingDisabled,
+      },
       thunkAPI.signal.aborted,
       thunkAPI.dispatch,
       thunkAPI.getState
@@ -386,14 +394,19 @@ const labSlice = createSlice({
         levelProperties: LevelProperties;
         initialSources?: ProjectSources;
         abuseScore?: number;
+        sharingDisabled?: boolean;
       }>
     ) {
+      const levelProperties = action.payload.levelProperties;
       state.channel = action.payload.channel;
-      state.levelProperties = action.payload.levelProperties;
+      state.levelProperties = levelProperties;
       state.initialSources = action.payload.initialSources;
       if (typeof action.payload.abuseScore === 'number') {
-        state.isBlocked = action.payload.abuseScore >= 15 ? true : false;
+        state.isBlockedAbuse = action.payload.abuseScore >= 15 ? true : false;
       }
+      state.projectSharingDisabled =
+        action.payload.sharingDisabled &&
+        OPEN_ENDED_LAB2_PROJECT_TYPES.includes(levelProperties.appName);
     },
     setIsShareView(state, action: PayloadAction<boolean>) {
       state.isShareView = action.payload;
@@ -525,6 +538,7 @@ function setProjectAndLevelData(
     channel?: Channel;
     initialSources?: ProjectSources;
     abuseScore?: number;
+    sharingDisabled?: boolean;
   },
   aborted: boolean,
   dispatch: ThunkDispatch<unknown, unknown, AnyAction>,
@@ -545,7 +559,8 @@ function setProjectAndLevelData(
       data.channel,
       data.initialSources,
       data.abuseScore,
-      isReadOnlyWorkspace(getState())
+      isReadOnlyWorkspace(getState()),
+      data.sharingDisabled
     );
 }
 

--- a/apps/src/lab2/projects/ChannelsStore.ts
+++ b/apps/src/lab2/projects/ChannelsStore.ts
@@ -29,6 +29,8 @@ export interface ChannelsStore {
   unpublish: (channel: Channel) => Promise<Response>;
 
   getAbuseScore: (channel: Channel) => Promise<number>;
+
+  getSharingDisabled: (channel: Channel) => Promise<boolean>;
 }
 
 // Note: We don't need to actually save a channel for local storage.
@@ -74,6 +76,11 @@ export class LocalChannelsStore implements ChannelsStore {
   getAbuseScore() {
     // Abuse score is not supported for local storage.
     return Promise.resolve(0);
+  }
+
+  getSharingDisabled() {
+    // sharingDisabled is not supported for local storage.
+    return Promise.resolve(false);
   }
 }
 
@@ -121,5 +128,9 @@ export class RemoteChannelsStore implements ChannelsStore {
 
   getAbuseScore(channel: Channel) {
     return channelsApi.fetchAbuseScore(channel.id);
+  }
+
+  getSharingDisabled(channel: Channel) {
+    return channelsApi.fetchSharingDisabled(channel.id);
   }
 }

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -105,7 +105,10 @@ export default class ProjectManager {
 
     this.lastChannel = channel;
     const abuseScore = await this.channelsStore.getAbuseScore(channel);
-    return {sources, channel, abuseScore};
+    const sharingDisabled = await this.channelsStore.getSharingDisabled(
+      channel
+    );
+    return {sources, channel, abuseScore, sharingDisabled};
   }
 
   // Restore the given version of the project. This will call restore on the sources store

--- a/apps/src/lab2/projects/channelsApi.ts
+++ b/apps/src/lab2/projects/channelsApi.ts
@@ -45,3 +45,12 @@ export async function fetchAbuseScore(channelId: string): Promise<number> {
   );
   return value.abuse_score;
 }
+
+export async function fetchSharingDisabled(
+  channelId: string
+): Promise<boolean> {
+  const {value} = await HttpClient.fetchJson<{sharing_disabled: boolean}>(
+    `${rootUrl}/${channelId}/sharing_disabled`
+  );
+  return value.sharing_disabled;
+}

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -53,6 +53,7 @@ export interface ProjectAndSources {
   sources?: ProjectSources;
   channel: Channel;
   abuseScore?: number;
+  sharingDisabled?: boolean;
 }
 
 /// ------ SOURCES ------ ///

--- a/apps/src/lab2/utils/LifecycleNotifier.tsx
+++ b/apps/src/lab2/utils/LifecycleNotifier.tsx
@@ -17,7 +17,8 @@ type CallbackArgs = {
     channel: Channel | undefined,
     initialSources: ProjectSources | undefined,
     abuseScore: number | undefined,
-    isReadOnly: boolean | undefined
+    isReadOnly: boolean | undefined,
+    projectSharingDisabled: boolean | undefined
   ];
 };
 

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -48,7 +48,9 @@ export interface Lab2WrapperProps {
 const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   const isLoading: boolean = useSelector(isLabLoading);
   const isPageError: boolean = useSelector(hasPageError);
-  const isBlocked = useAppSelector(state => state.lab.isBlocked);
+  const {isBlockedAbuse, projectSharingDisabled} = useAppSelector(
+    state => state.lab
+  );
   const dispatch = useAppDispatch();
   const isProjectValidator = useAppSelector(state =>
     state.lab.permissions?.includes(PERMISSIONS.PROJECT_VALIDATOR)
@@ -116,6 +118,12 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   useLifecycleNotifier(LifecycleEvent.LevelChangeRequested, cancel);
   useLifecycleNotifier(LifecycleEvent.LevelLoadStarted, cancel);
 
+  const blockedType = isBlockedAbuse
+    ? 'projectAbuse'
+    : projectSharingDisabled
+    ? 'projectSharingDisabled'
+    : undefined;
+
   return (
     <ErrorBoundary
       fallback={<ErrorFallbackPage />}
@@ -139,8 +147,11 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
         <Loading isLoading={isLoading} />
 
         {isPageError && <ErrorUI message={errorMessage} />}
-        {isBlocked && (
-          <ProjectBlockedUI isProjectValidator={isProjectValidator} />
+        {blockedType && (
+          <ProjectBlockedUI
+            blockedType={blockedType}
+            isProjectValidator={isProjectValidator}
+          />
         )}
       </div>
     </ErrorBoundary>

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -30,7 +30,9 @@ const LabViewsRenderer: React.FunctionComponent = () => {
   const exemplarSources = levelProperties?.exemplarSources;
   const levelId = levelProperties?.id;
 
-  const isBlocked = useAppSelector(state => state.lab.isBlocked);
+  const {isBlockedAbuse, projectSharingDisabled} = useAppSelector(
+    state => state.lab
+  );
   const isProjectValidator = useAppSelector(state =>
     state.lab.permissions?.includes(PERMISSIONS.PROJECT_VALIDATOR)
   );
@@ -43,7 +45,10 @@ const LabViewsRenderer: React.FunctionComponent = () => {
   });
 
   // Do not render lab view if project is blocked and user is not a project validator.
-  if (!currentAppName || (isBlocked && !isProjectValidator)) {
+  if (
+    !currentAppName ||
+    ((isBlockedAbuse || projectSharingDisabled) && !isProjectValidator)
+  ) {
     return null;
   }
 

--- a/apps/src/lab2/views/ProjectBlockedUI.tsx
+++ b/apps/src/lab2/views/ProjectBlockedUI.tsx
@@ -9,13 +9,41 @@ import Lab2Registry from '../Lab2Registry';
 
 import moduleStyles from './Lab2Wrapper.module.scss';
 
+type BlockedType = 'projectAbuse' | 'projectSharingDisabled';
+
 export const ProjectBlockedUI: React.FunctionComponent<{
+  blockedType: BlockedType;
   isProjectValidator: boolean;
-}> = ({isProjectValidator}) => {
+}> = ({blockedType, isProjectValidator}) => {
   const [showAlert, setShowAlert] = useState(true);
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   const shareUrl = projectManager ? projectManager.getShareUrl() : null;
   const isOwner = useAppSelector(state => state.lab.channel?.isOwner || false);
+  const abuseExclamationProps = {
+    isOwner,
+    i18n:
+      blockedType === 'projectAbuse'
+        ? {
+            tos: i18n.tosLong({url: 'http://code.org/tos'}),
+            contact_us: i18n.contactUs({
+              url: `https://support.code.org/hc/en-us/requests/new?&description=${encodeURIComponent(
+                `Abuse error for project at url: ${shareUrl}`
+              )}`,
+            }),
+            edit_project: i18n.editProject(),
+            go_to_code_studio: i18n.goToCodeStudio(),
+          }
+        : {
+            tos: i18n.sharingDisabled({
+              sign_in_url: 'https://studio.code.org/users/sign_in',
+            }),
+            contact_us: i18n.contactUs({
+              url: 'https://support.code.org/hc/en-us/requests/new',
+            }),
+            edit_project: i18n.editProject(),
+            go_to_code_studio: i18n.goToCodeStudio(),
+          },
+  };
 
   if (isProjectValidator) {
     return (
@@ -23,7 +51,7 @@ export const ProjectBlockedUI: React.FunctionComponent<{
         id="blocked-project-ui-container-project-validator"
         className={moduleStyles.blockedProjectUIContainerProjectValidator}
       >
-        {showAlert && (
+        {showAlert && blockedType === 'projectAbuse' && (
           <Alert
             text={i18n.tosWithoutLink()}
             type={alertTypes.danger}
@@ -34,26 +62,14 @@ export const ProjectBlockedUI: React.FunctionComponent<{
         )}
       </div>
     );
-  } else {
-    return (
-      <div
-        id="blocked-project-ui-container"
-        className={moduleStyles.blockedProjectUIContainer}
-      >
-        <AbuseExclamation
-          i18n={{
-            tos: i18n.tosLong({url: 'http://code.org/tos'}),
-            contact_us: i18n.contactUs({
-              url: `https://support.code.org/hc/en-us/requests/new?&description=${encodeURIComponent(
-                `Abuse error for project at url: ${shareUrl}`
-              )}`,
-            }),
-            edit_project: i18n.editProject(),
-            go_to_code_studio: i18n.goToCodeStudio(),
-          }}
-          isOwner={isOwner}
-        />
-      </div>
-    );
   }
+
+  return (
+    <div
+      id="blocked-project-ui-container"
+      className={moduleStyles.blockedProjectUIContainer}
+    >
+      <AbuseExclamation {...abuseExclamationProps} />
+    </div>
+  );
 };


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR blocks `lab2` open-ended standalone projects (`pythonlab` and `weblab2`) if sharing is disabled for non-owners. For project owners and teachers of project owners, the project is still accessible. 
Note that `get_sharing_disabled` in `projects.rb` determines if the current user can view the project:
https://github.com/code-dot-org/code-dot-org/blob/95a53666ec2ca3ed4d6ca8a0a58dae6d8400c213/dashboard/legacy/middleware/helpers/projects.rb#L218-L238


This PR follows up https://github.com/code-dot-org/code-dot-org/pull/63125 and https://github.com/code-dot-org/code-dot-org/pull/63187 which implemented blocking of `lab2` projects if the were deemed abusive.

I added a Channels API fetch request for `/sharing_disabled` which is called on when the `lab2` project is loaded.
Since there are now two ways that a project is blocked, I added logic to account for this in `Lab2Wrapper` and `LabViewsRenderer` and updated `ProjectBlockedUi` accordingly.

## After update

If a user has sharing disabled, then their project is blocked if other users attempt to view project. Exceptions are the project owner, teachers of the project owner, and project validators.

Blocked UI for Python Lab:

<img width="1413" alt="Screenshot 2025-06-09 at 4 21 46 PM" src="https://github.com/user-attachments/assets/10e51925-7494-4040-b557-cf7babbb5fff" />

Note that the lab content is not rendered:
<img width="1412" alt="Screenshot 2025-06-09 at 4 24 09 PM" src="https://github.com/user-attachments/assets/1b6e8ec9-cc62-4000-9e52-c3944b12be2a" />


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/SL-1270

## Testing story
I tested locally with a student account with age under 13, a teacher account which had the student in a teacher section. Also checked as a signed-out and signed-in user which was not a teacher of the young student.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
