### PR TITLE
Use Updated Drone Image when Rebuilding Cache

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -307,7 +307,7 @@ steps:
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of rbenv and the database, but don't actually run the tests.
   - name: prepare-ui-tests
-    image: codedotorg/code-dot-org:1.15
+    image: codedotorg/code-dot-org:1.16
     pull: always
     environment:
       PROPERTIES_ENCRYPTION_KEY:
@@ -353,6 +353,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: 8f32947335d2c9bb7f8660606dcce33bdf0ded6eb01b9382cd02252b93b850c8
+hmac: d706a958430c49a672f3c7c5a42209f54dd4cc1aada7d68e2489307e2d98b275
 
 ...


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/65533, which updated the image being used to actually run the tests, but missed the one used to update the cache, resulting in broken builds.

See thread at https://codedotorg.slack.com/archives/C046G4TRLEN/p1749497149668169 for more context