### PR TITLE
speculatively update the NewRelic gem to 8.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -189,7 +189,7 @@ gem 'highline', '~> 3.1.0'
 
 gem 'honeybadger', '>= 4.5.6' # error monitoring
 
-gem 'newrelic_rpm', '~> 6.14.0', group: [:staging, :development, :production] # perf/error/etc monitoring
+gem 'newrelic_rpm', '~> 8.3', group: [:staging, :development, :production] # perf/error/etc monitoring
 
 gem 'redcarpet', '~> 3.6.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,7 +617,7 @@ GEM
       net-protocol
     net-ssh (5.2.0)
     netrc (0.11.0)
-    newrelic_rpm (6.14.0)
+    newrelic_rpm (8.16.0)
     nio4r (2.7.0)
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
@@ -1075,7 +1075,7 @@ DEPENDENCIES
   nakayoshi_fork
   naturally
   net-http-persistent
-  newrelic_rpm (~> 6.14.0)
+  newrelic_rpm (~> 8.3)
   nokogiri (>= 1.10.0)
   observer
   octokit


### PR DESCRIPTION
To pick up support for Ruby 3.1; follow up to https://github.com/code-dot-org/code-dot-org/pull/65533, which inadvertently broke NewRelic reporting

See thread at https://codedotorg.slack.com/archives/C0T0PNTM3/p1749508191616149 for more context

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- target: https://github.com/newrelic/newrelic-ruby-agent/blob/dev/CHANGELOG.md#v830
- v8 breaking changes: https://github.com/newrelic/newrelic-ruby-agent/blob/dev/CHANGELOG.md#v800
- v7 breaking changes: https://github.com/newrelic/newrelic-ruby-agent/blob/dev/CHANGELOG.md#v700

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
