### PR TITLE
upgrade mini_racer to 0.18.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -211,7 +211,7 @@ gem 'retryable' # retry code blocks when they throw exceptions
 # Used by `uglifier` to minify JS assets in the Asset Pipeline.
 gem 'execjs'
 # JavaScript runtime used by ExecJS.
-gem 'mini_racer'
+gem 'mini_racer', '~> 0.18.1'
 
 gem 'jwt', '~> 2.7.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -541,7 +541,7 @@ GEM
     launchy (3.0.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
-    libv8-node (18.16.0.0)
+    libv8-node (23.6.1.0)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -573,9 +573,9 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
-    mini_racer (0.8.0)
-      libv8-node (~> 18.16.0.0)
+    mini_portile2 (2.8.9)
+    mini_racer (0.18.1)
+      libv8-node (~> 23.6.1.0)
     minitest (5.18.0)
     minitest-around (0.5.0)
       minitest (~> 5.0)
@@ -1062,7 +1062,7 @@ DEPENDENCIES
   marketing!
   memory_profiler
   mini_magick (>= 4.10.0)
-  mini_racer
+  mini_racer (~> 0.18.1)
   minitest (~> 5.15)
   minitest-around
   minitest-rails (~> 6.1)


### PR DESCRIPTION
Seems to make `bundle install` easier on Mac x86 (Intel or Rosetta) after upgrading to ruby 3.1.0.

