### PR TITLE
remove mini_racer gem from development environment again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -210,7 +210,12 @@ gem 'retryable' # retry code blocks when they throw exceptions
 
 # Used by `uglifier` to minify JS assets in the Asset Pipeline.
 gem 'execjs'
+
 # JavaScript runtime used by ExecJS.
+# TODO: Either resume installing in all environments once Ubuntu and Mac OS
+# support the same version of mini_racer, or remove this dependency entirely
+# once node is installed in production. For more details, see
+# https://codedotorg.atlassian.net/browse/INF-708
 gem 'mini_racer', group: [:staging, :test, :production, :levelbuilder]
 
 gem 'jwt', '~> 2.7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -211,7 +211,7 @@ gem 'retryable' # retry code blocks when they throw exceptions
 # Used by `uglifier` to minify JS assets in the Asset Pipeline.
 gem 'execjs'
 # JavaScript runtime used by ExecJS.
-gem 'mini_racer'
+gem 'mini_racer', group: [:staging, :test, :production, :levelbuilder]
 
 gem 'jwt', '~> 2.7.0'
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -521,6 +521,13 @@ Where [VERSION] is the current version of eventmachine in Gemfile.lock. For exam
 
 - `gem install eventmachine -v 1.2.7 -- --with-openssl-dir=$(brew --prefix libressl)`
 
+#### mini_racer and libv8-node
+
+If `bundle install` fails while installing `mini_racer` or `libv8-node`, try running this first:
+```
+bundle config --local without staging test production levelbuilder
+```
+
 #### Xcode Set Up
 
 OS X: when running `bundle install`, you may need to also run `xcode-select --install`. See [stackoverflow](http://stackoverflow.com/a/39730475/3991031). If this doesn't work, step 9 in the overview will not run correctly. In that case run the following command in the Terminal (found from

--- a/SETUP.md
+++ b/SETUP.md
@@ -29,6 +29,9 @@ You can do Code.org development using macOS, Ubuntu, or Windows (running Ubuntu 
 
 1. `git lfs pull`
 
+1. `bundle config --local without staging test production levelbuilder`
+    - This step prevents installation of gems that are not needed for local development, some of which can break during the next step.
+    
 1. `bundle install`
     - This step often fails to due environment-specific issues. Look in the [Bundle Install Tips](#bundle-install-tips) section below for steps to resolve many common issues.
 


### PR DESCRIPTION
The ruby 3.1 upgrade breaks `bundle install` on Intel Macs (see [slack](https://codedotorg.slack.com/archives/C046G4TRLEN/p1749495343246249)). The proposed workaround is to not install mini_racer in development. Take a peek at the [last time we disabled mini_racer in development](https://github.com/code-dot-org/code-dot-org/pull/47788) to see why this is safe.

## Alternatives

* I tried https://github.com/code-dot-org/code-dot-org/pull/66422, which fixed the problem on Mac, but fails to compile on Ubuntu (see drone run).

## Testing story

The following now works locally:
```
bundle config --local without staging test production levelbuilder
bundle install
```

## Future work

* once Ubuntu supports the latest version of `mini_racer` and `libv8-node`, upgrade both gems to latest and remove the per-environment stipulations added in this PR. or
* [INF-708](https://codedotorg.atlassian.net/browse/INF-708) install node in production, and remove mini_racer gem entirely