### PR TITLE
Revert "Revert "speculatively update the NewRelic gem to 8.3""

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -189,7 +189,7 @@ gem 'highline', '~> 3.1.0'
 
 gem 'honeybadger', '>= 4.5.6' # error monitoring
 
-gem 'newrelic_rpm', '~> 6.14.0', group: [:staging, :development, :production] # perf/error/etc monitoring
+gem 'newrelic_rpm', '~> 8.3', group: [:staging, :development, :production] # perf/error/etc monitoring
 
 gem 'redcarpet', '~> 3.6.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,7 +617,7 @@ GEM
       net-protocol
     net-ssh (5.2.0)
     netrc (0.11.0)
-    newrelic_rpm (6.14.0)
+    newrelic_rpm (8.16.0)
     nio4r (2.7.0)
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
@@ -1075,7 +1075,7 @@ DEPENDENCIES
   nakayoshi_fork
   naturally
   net-http-persistent
-  newrelic_rpm (~> 6.14.0)
+  newrelic_rpm (~> 8.3)
   nokogiri (>= 1.10.0)
   observer
   octokit

--- a/cookbooks/cdo-apps/templates/default/newrelic.yml.erb
+++ b/cookbooks/cdo-apps/templates/default/newrelic.yml.erb
@@ -176,6 +176,15 @@ common: &default_settings
   # implications if your memcached keys are sensitive
   # capture_memcache_keys: true
 
+  # Override default instrumentation method for gems that need it. In v7, the
+  # NewRelic gem defaulted to Prepending rather than Method Chaining for
+  # instrumenting third-party gems. This unfortunately breaks on Sinatra 2.2.3,
+  # so we explicitly instruct it to use the old default instead.
+  # TODO infra: update our Sinatra gem and remove this configuration.
+  # See https://github.com/newrelic/newrelic-ruby-agent/pull/565
+  instrumentation:
+    sinatra: chain
+
 # Application Environments
 # ------------------------------------------
 # Environment-specific settings are in this section.


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#66419; second attempt at https://github.com/code-dot-org/code-dot-org/pull/66416

Our first attempt broke during the DTP with a `SystemStackError: stack level too deep`:

```
Jun 10 01:23:05 production-daemon bundle[1291907]: [1291907] ! Unable to load application: SystemStackError: stack level too deep
Jun 10 01:23:05 production-daemon bundle[1291907]: bundler: failed to load command: puma (/usr/local/bin/puma)
Jun 10 01:23:05 production-daemon bundle[1291907]: /usr/local/lib/ruby/gems/3.1.0/gems/newrelic_rpm-8.16.0/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb:47:in `synchronize': stack level too deep (SystemStackError)
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/newrelic_rpm-8.16.0/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb:47:in `try_to_use'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/newrelic_rpm-8.16.0/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb:36:in `block in build_with_tracing'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/newrelic_rpm-8.16.0/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb:35:in `each'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/newrelic_rpm-8.16.0/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb:35:in `build_with_tracing'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/newrelic_rpm-8.16.0/lib/new_relic/agent/instrumentation/sinatra/prepend.rb:28:in `build'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/honeybadger-4.12.1/lib/honeybadger/init/sinatra.rb:16:in `build_with_honeybadger'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/newrelic_rpm-8.16.0/lib/new_relic/agent/instrumentation/sinatra/prepend.rb:28:in `block in build'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/newrelic_rpm-8.16.0/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb:39:in `build_with_tracing'
Jun 10 01:23:05 production-daemon bundle[1291907]:          ... 9874 levels...
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.5.17/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.5.17/exe/bundle:20:in `<top (required)>'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/bin/bundle:25:in `load'
Jun 10 01:23:05 production-daemon bundle[1291907]:         from /usr/local/bin/bundle:25:in `<main>'
Jun 10 01:23:05 production-daemon systemd[1]: pegasus.service: Main process exited, code=exited, status=1/FAILURE
```

This possibility was called out in NewRelic's [6 to 7 migration guide](https://docs.newrelic.com/docs/apm/agents/ruby-agent/getting-started/migration-7x-guide/#prepend-instrumentation), which also includes a recommended resolution: explicitly configure NewRelic to use the former default instrumentation method rather than the new default.

## Testing story

I tweaked some configs to enable New Relic for local development:

```diff
diff --git a/config.yml.erb b/config.yml.erb
index 05bac36d802..05ee6d90d9f 100644
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -251,7 +251,7 @@ acapela_ephemeral_password:
 
 # Credentials for new relic logging. Used to log apps build times.
 new_relic_license_key:
-newrelic_logging: false
+newrelic_logging: true
 
 # Credentials for Google-federated AWS access.
 # (Deprecated: move these configuration values to AWS config file)
diff --git a/pegasus/router.rb b/pegasus/router.rb
index 8982ab46873..76de912d62b 100644
--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -23,7 +23,7 @@ require 'sass'
 require 'sass/plugin'
 require 'haml'
 
-if rack_env?(:production)
+if rack_env?(:development)
   require 'newrelic_rpm'
   # Enable GC profiler for New Relic instrumentation.
   GC::Profiler.enable
```

And manually added a `pegasus/config/newrelic.yml` file. I confirmed that starting up a pegasus server failed with a similar stack trace to what we saw in production, then confirmed that applying this PR's change to the config file was sufficient to allow the server to start up successfully.

## Links

See thread at https://codedotorg.slack.com/archives/C0T0PNTM3/p1749508191616149 for more context