### PR TITLE
[All Labs Keyboard Nav] Ensure BlocklyActiveFocus gets focus outlines

### DIFF
--- a/apps/src/blockly/addons/cdoCss.ts
+++ b/apps/src/blockly/addons/cdoCss.ts
@@ -12,7 +12,7 @@ export default function initializeCss(blocklyWrapper: BlocklyWrapperType) {
       padding: 0px;
       margin: 0px;
     }
-    .blocklyDropdownField:focus {
+    .blocklyActiveFocus:focus {
       outline: -webkit-focus-ring-color auto 5px;
       border-radius: 2px;
     }


### PR DESCRIPTION
This is a simplification that picks up the blocklyActiveFocus state and applies a focus! I had done this just for the dropdown field and went to do it for the repeat variable as well and realized they were all getting the blocklyActiveFocus class and I could just use that!

Before:

https://github.com/user-attachments/assets/d0593a84-122d-488b-8fb7-8c85779c5ae6



After (showing off highlighting for all these): 

https://github.com/user-attachments/assets/cc506a1f-28b9-456d-a54f-ff176b486a7e




## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1273

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
