### PR TITLE
fix(marketing): update Editorial Card and FAQ Accordion sections on All The Things

### DIFF
--- a/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
@@ -10220,7 +10220,7 @@
                         "visualAppearance": {
                           "type": "DesignValue",
                           "valuesByBreakpoint": {
-                            "desktop": "heading-xl"
+                            "desktop": "heading-xxl"
                           }
                         },
                         "removeMarginBottom": {

--- a/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
@@ -8098,7 +8098,7 @@
                 "cfHeight": {
                   "type": "DesignValue",
                   "valuesByBreakpoint": {
-                    "desktop": "fit-content"
+                    "desktop": "1368px"
                   }
                 },
                 "cfMaxWidth": {
@@ -8175,13 +8175,13 @@
                     "background": {
                       "type": "DesignValue",
                       "valuesByBreakpoint": {
-                        "desktop": "secondary"
+                        "desktop": "primary"
                       }
                     },
                     "padding": {
                       "type": "DesignValue",
                       "valuesByBreakpoint": {
-                        "desktop": "m"
+                        "desktop": "l"
                       }
                     },
                     "divider": {
@@ -10108,7 +10108,7 @@
                 "cfHeight": {
                   "type": "DesignValue",
                   "valuesByBreakpoint": {
-                    "desktop": "fit-content"
+                    "desktop": "389px"
                   }
                 },
                 "cfMaxWidth": {

--- a/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
@@ -53,6 +53,7 @@ export class AllTheThingsPage extends MarketingPage {
     const headingLocator = this.page.getByRole('heading', {
       name: heading,
       exact: true,
+      level: 1, // selects only the h1 in each section
     });
 
     // Go through the top-level sections, finding the one that has this heading


### PR DESCRIPTION
Updates the Editorial Card section background color and padding and the FAQ Accordion heading to an h1 to match the rest of the sections. Also set the height of these sections to fixed to prevent any shifting.

The FAQ heading change also allows a change that finds sections by h1 only to avoid multiple sections matching the "Heading" header (see failures [here](https://github.com/code-dot-org/code-dot-org/actions/runs/15567978339/job/43836825683)).

## Links
Jira ticket: [CMS-814](https://codedotorg.atlassian.net/browse/CMS-814)
Related PR: https://github.com/code-dot-org/code-dot-org/pull/66414

----

## Editorial Card bg is now white and has the default padding
<img width="1630" alt="Screenshot 2025-06-10 at 12 01 30 PM" src="https://github.com/user-attachments/assets/8a3bea83-8767-4d32-9019-b8142f22e166" />

## FAQ Accordion has an h1
<img width="1630" alt="Screenshot 2025-06-10 at 12 01 37 PM" src="https://github.com/user-attachments/assets/98df72ea-cb16-47bc-a87c-b74ec93a8449" />

