### PR TITLE
Revert "fix(marketing): update Editorial Card and FAQ Accordion sections on All The Things"

### DIFF
--- a/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/2rnXDDT2HB8MmwM6u1L4bH.json
@@ -8098,7 +8098,7 @@
                 "cfHeight": {
                   "type": "DesignValue",
                   "valuesByBreakpoint": {
-                    "desktop": "1368px"
+                    "desktop": "fit-content"
                   }
                 },
                 "cfMaxWidth": {
@@ -8175,13 +8175,13 @@
                     "background": {
                       "type": "DesignValue",
                       "valuesByBreakpoint": {
-                        "desktop": "primary"
+                        "desktop": "secondary"
                       }
                     },
                     "padding": {
                       "type": "DesignValue",
                       "valuesByBreakpoint": {
-                        "desktop": "l"
+                        "desktop": "m"
                       }
                     },
                     "divider": {
@@ -10108,7 +10108,7 @@
                 "cfHeight": {
                   "type": "DesignValue",
                   "valuesByBreakpoint": {
-                    "desktop": "389px"
+                    "desktop": "fit-content"
                   }
                 },
                 "cfMaxWidth": {
@@ -10220,7 +10220,7 @@
                         "visualAppearance": {
                           "type": "DesignValue",
                           "valuesByBreakpoint": {
-                            "desktop": "heading-xxl"
+                            "desktop": "heading-xl"
                           }
                         },
                         "removeMarginBottom": {

--- a/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
@@ -53,7 +53,6 @@ export class AllTheThingsPage extends MarketingPage {
     const headingLocator = this.page.getByRole('heading', {
       name: heading,
       exact: true,
-      level: 1, // selects only the h1 in each section
     });
 
     // Go through the top-level sections, finding the one that has this heading


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#66431 — this is causing the staging build to fail. See more [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1749585336873799?thread_ts=1749584968.393149&cid=C07UW4ED66Q) and [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1749587188696519?thread_ts=1749585207.208479&cid=C0T0PNTM3).