### PR TITLE
[MusicLab] Make Exemplar Player Keyboard Navigable

### DIFF
--- a/apps/src/music/views/ExemplarPlayerView.tsx
+++ b/apps/src/music/views/ExemplarPlayerView.tsx
@@ -101,7 +101,7 @@ const ExemplarPlayerView: React.FunctionComponent<ExemplarPlayerViewProps> = ({
         tabIndex={0}
         onClick={onPress}
         onKeyDown={event => {
-          if (event.key === 'Enter' || event.key === ' ') {
+          if (event.key === 'Enter') {
             onPress();
           }
         }}

--- a/apps/src/music/views/ExemplarPlayerView.tsx
+++ b/apps/src/music/views/ExemplarPlayerView.tsx
@@ -70,6 +70,14 @@ const ExemplarPlayerView: React.FunctionComponent<ExemplarPlayerViewProps> = ({
     }
   });
 
+  const onPress = () => {
+    const action = exemplarIsPlaying ? 'stop' : 'play';
+    analyticsReporter?.onButtonClicked(`exemplar-player-${action}`, {
+      title,
+    });
+    exemplarIsPlaying ? onStopSong() : onPlaySong();
+  };
+
   useEffect(() => {
     if (isPlaying && exemplarIsPlaying) {
       onStopSong();
@@ -89,12 +97,13 @@ const ExemplarPlayerView: React.FunctionComponent<ExemplarPlayerViewProps> = ({
       <div
         className={moduleStyles.entry}
         key={'exemplar-player'}
-        onClick={() => {
-          const action = exemplarIsPlaying ? 'stop' : 'play';
-          analyticsReporter?.onButtonClicked(`exemplar-player-${action}`, {
-            title,
-          });
-          exemplarIsPlaying ? onStopSong() : onPlaySong();
+        role="button" // Makes the div behave like a button for accessibility
+        tabIndex={0}
+        onClick={onPress}
+        onKeyDown={event => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            onPress();
+          }
         }}
       >
         <div


### PR DESCRIPTION
The button wasn't reachable by keyboard. This gives it the appropriate role and tabIndex, and allows users to press with the Enter key. Ordinarily a button like this would work with both space and enter, but because we have the run button listening for a space, I'm moving forward with only the enter key for now. 

https://github.com/user-attachments/assets/0cb84266-e464-4be2-96cc-c35db38ad3dd


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1274

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
