### PR TITLE
Disable autocomplete in rails console

### DIFF
--- a/dashboard/.irbrc
+++ b/dashboard/.irbrc
@@ -20,3 +20,6 @@ IRB.conf[:PROMPT][:RAILS_APP] = {
 }
 
 IRB.conf[:PROMPT_MODE] = :RAILS_APP
+
+# Disable autocomplete, which causes perf issues since the Ruby 3.1 upgrade.
+IRB.conf[:USE_AUTOCOMPLETE] = false


### PR DESCRIPTION
Rails 3.1 added autocomplete to the IRB console, which causes significant lag, possibly due to the size of our app, in certain environments. This disables the autocomplete feature to improve Rails console performance.

## Links

[Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1749584320775719)

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
