### PR TITLE
Lab2: add "edit in levelbuilder" to extra links

### DIFF
--- a/apps/src/lab2/views/ExtraLinks.tsx
+++ b/apps/src/lab2/views/ExtraLinks.tsx
@@ -36,7 +36,7 @@ async function fetchExtraLinksData(
   ) {
     let url = `/levels/${levelId}/extra_links`;
     if (scriptLevelId) {
-      url += `?script_level_id=${scriptLevelId}`;
+      url += `?scriptLevelId=${scriptLevelId}`;
     }
 
     const levelLinkDataResponse =

--- a/apps/src/lab2/views/ExtraLinks.tsx
+++ b/apps/src/lab2/views/ExtraLinks.tsx
@@ -13,6 +13,7 @@ import moduleStyles from './extra-links.module.scss';
 
 interface ExtraLinksProps {
   levelId: number;
+  scriptLevelId?: string;
   positionRightOfFooter?: boolean;
 }
 
@@ -24,6 +25,7 @@ interface ExtraLinksData {
 async function fetchExtraLinksData(
   permissions: string[],
   levelId: number,
+  scriptLevelId?: string,
   channelId?: string
 ): Promise<ExtraLinksData> {
   // Fetch level link data.
@@ -32,10 +34,13 @@ async function fetchExtraLinksData(
     permissions.includes(PERMISSIONS.LEVELBUILDER) ||
     permissions.includes(PERMISSIONS.PROJECT_VALIDATOR)
   ) {
+    let url = `/levels/${levelId}/extra_links`;
+    if (scriptLevelId) {
+      url += `?script_level_id=${scriptLevelId}`;
+    }
+
     const levelLinkDataResponse =
-      await HttpClient.fetchJson<ExtraLinksLevelData>(
-        `/levels/${levelId}/extra_links`
-      );
+      await HttpClient.fetchJson<ExtraLinksLevelData>(url);
     levelLinkData = levelLinkDataResponse.value;
   }
 
@@ -60,6 +65,7 @@ async function fetchExtraLinksData(
 // then display a modal with the link data.
 const ExtraLinks: React.FunctionComponent<ExtraLinksProps> = ({
   levelId,
+  scriptLevelId,
   positionRightOfFooter,
 }: ExtraLinksProps) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -76,11 +82,13 @@ const ExtraLinks: React.FunctionComponent<ExtraLinksProps> = ({
 
   useEffect(() => {
     setIsLoading(true);
-    fetchExtraLinksData(permissions, levelId, channelId).then(data => {
-      setExtraLinksData(data);
-      setIsLoading(false);
-    });
-  }, [permissions, levelId, channelId]);
+    fetchExtraLinksData(permissions, levelId, scriptLevelId, channelId).then(
+      data => {
+        setExtraLinksData(data);
+        setIsLoading(false);
+      }
+    );
+  }, [permissions, levelId, scriptLevelId, channelId]);
   const {levelLinkData, projectLinkData} = extraLinksData || {};
 
   if (isLoading || (!levelLinkData && !projectLinkData)) {

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -5,6 +5,7 @@
  */
 import React, {Suspense} from 'react';
 
+import {getCurrentScriptLevelId} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {PERMISSIONS} from '@cdo/apps/lab2/constants';
 import {useInitialLabTheme} from '@cdo/apps/lab2/hooks/useInitialLabTheme';
@@ -29,6 +30,7 @@ const LabViewsRenderer: React.FunctionComponent = () => {
   const currentAppName = levelProperties?.appName;
   const exemplarSources = levelProperties?.exemplarSources;
   const levelId = levelProperties?.id;
+  const scriptLevelId = useAppSelector(getCurrentScriptLevelId);
 
   const isBlocked = useAppSelector(state => state.lab.isBlocked);
   const isProjectValidator = useAppSelector(state =>
@@ -76,6 +78,7 @@ const LabViewsRenderer: React.FunctionComponent = () => {
         {!hideExtraLinks && levelId && (
           <ExtraLinks
             levelId={levelId}
+            scriptLevelId={scriptLevelId}
             positionRightOfFooter={extraLinksButtonRightOfFooter}
           />
         )}

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -537,18 +537,25 @@ class LevelsController < ApplicationController
       links[@level.name] << {text: "LCD: #{@level.level_concept_difficulty.concept_difficulties_as_string}", url: ''}
     end
 
+    if params[:script_level_id]
+      script_level = ScriptLevel.find_by(id: params[:scriptLevelId].to_i)
+    end
+
     is_standalone_project = ProjectsController::STANDALONE_PROJECTS.values.pluck(:name).include?(@level.name)
 
     # Curriculum writers rarely need to edit STANDALONE_PROJECTS levels, and accidental edits to these levels
     # can be quite disruptive. As a workaround you can navigate directly to the edit url for these levels.
     # We allow editing from the test environment to enable UI testing of the edit page.
-    if false
+    if (Rails.application.config.levelbuilder_mode || rack_env?(:test)) && !is_standalone_project
       can_edit_level = can? :edit, @level
+
       if can_edit_level
         links[@level.name] << {text: '[E]dit', url: edit_level_path(@level), access_key: 'e'}
+
         if [Javalab, Music, Pythonlab, Weblab2].include?(@level.class)
           links[@level.name] << {text: "[s]tart", url: edit_blocks_level_path(@level, :start_sources), access_key: 's'}
           links[@level.name] << {text: "e[x]emplar", url: edit_exemplar_level_path(@level), access_key: 'x'}
+
           if [Music].include?(@level.class)
             links[@level.name] << {text: "[t]oolbox", url: edit_blocks_level_path(@level, :toolbox_blocks), access_key: 't'}
           end
@@ -571,21 +578,21 @@ class LevelsController < ApplicationController
           {text: '(Cannot edit)', url: ''}
         links["Template Level"] << template_level_edit_link
       end
-    elsif @level&.script_levels.any?
+    elsif script_level
       links[@level.name] << {
         text: 'edit on levelbuilder',
-        url: URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@level.script_levels.first, **(@extra_params || {}))).to_s
+        url: URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(script_level)).to_s
       }
     end
 
     script_level_path_links = []
     script_levels = @level.script_levels.includes(:script)
 
-    script_levels.each do |script_level|
-      script_level_path = build_script_level_path(script_level)
+    script_levels.each do |sl|
+      script_level_path = build_script_level_path(sl)
 
       script_level_path_links << {
-        script: script_level.script.name,
+        script: sl.script.name,
         path: script_level_path
       }
     end

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -537,7 +537,7 @@ class LevelsController < ApplicationController
       links[@level.name] << {text: "LCD: #{@level.level_concept_difficulty.concept_difficulties_as_string}", url: ''}
     end
 
-    if params[:script_level_id]
+    if params[:scriptLevelId]
       script_level = ScriptLevel.find_by(id: params[:scriptLevelId].to_i)
     end
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -536,11 +536,13 @@ class LevelsController < ApplicationController
     if @level.level_concept_difficulty && !@level.level_concept_difficulty.concept_difficulties_as_string.empty?
       links[@level.name] << {text: "LCD: #{@level.level_concept_difficulty.concept_difficulties_as_string}", url: ''}
     end
+
     is_standalone_project = ProjectsController::STANDALONE_PROJECTS.values.pluck(:name).include?(@level.name)
+
     # Curriculum writers rarely need to edit STANDALONE_PROJECTS levels, and accidental edits to these levels
     # can be quite disruptive. As a workaround you can navigate directly to the edit url for these levels.
     # We allow editing from the test environment to enable UI testing of the edit page.
-    if (Rails.application.config.levelbuilder_mode || rack_env?(:test)) && !is_standalone_project
+    if false
       can_edit_level = can? :edit, @level
       if can_edit_level
         links[@level.name] << {text: '[E]dit', url: edit_level_path(@level), access_key: 'e'}
@@ -554,6 +556,7 @@ class LevelsController < ApplicationController
       else
         links[@level.name] << {text: '(Cannot edit)', url: ''}
       end
+
       if @level.is_a?(LevelGroup)
         links["Sublevels"] = @level.levels.map {|sublevel| {text: sublevel.name, url: level_path(sublevel)}}
       end
@@ -563,19 +566,15 @@ class LevelsController < ApplicationController
         links["Template Level"] = [
           {text: project_template_level_name, url: level_path(project_template_level)}
         ]
-        template_level_edit_link =
-          if can_edit_level
-            {text: 'Edit', url: edit_level_path(project_template_level)}
-          else
-            {text: '(Cannot edit)', url: ''}
-          end
+        template_level_edit_link = can_edit_level ?
+          {text: 'Edit', url: edit_level_path(project_template_level)} :
+          {text: '(Cannot edit)', url: ''}
         links["Template Level"] << template_level_edit_link
       end
-
-    elsif @script_level
+    elsif @level&.script_levels.any?
       links[@level.name] << {
         text: 'edit on levelbuilder',
-        url: URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level, @extra_params)).to_s
+        url: URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@level.script_levels.first, **(@extra_params || {}))).to_s
       }
     end
 


### PR DESCRIPTION
For non-lab2 levels, we have an "edit in levelbuilder" option that appears in production that links to the equivalent script level in levelbuilder. This PR adds feature parity for lab2 levels.

<img width="790" alt="edit on levelbuilder" src="https://github.com/user-attachments/assets/c92f528f-2c5e-43d1-9c98-79023d50f1ac" />

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1461

## Testing story

Tested manually that a lab2 level now has this link when viewing a script level (ie, /s/allthethings/...), and continues to not have it if viewing a level directly (ie, /levels/12345).