### PR TITLE
SUM - add test and modify logic

### DIFF
--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -140,11 +140,7 @@ const SummaryResponses = ({
     studentWork: response.text,
   }));
 
-  const AiEvaluationMVPUnits = ['csp4-2024', 'csp6-2024', 'allthethings'];
-
-  const aiAnalysisAvailable =
-    AiEvaluationMVPUnits.includes(scriptData.reportingData.unitName) ||
-    scriptData.show_ai_analysis;
+  const hasAiAnalysis = scriptData.show_ai_analysis;
 
   return (
     <div className={styles.summaryContainer} id="summary-container">
@@ -203,7 +199,7 @@ const SummaryResponses = ({
                 size={'s'}
                 name={'showStudentNames'}
               />
-              {aiAnalysisAvailable && (
+              {hasAiAnalysis && (
                 <div className={styles.aiToggleContainer}>
                   <Toggle
                     onChange={toggleAIAnalysis}

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -126,6 +126,13 @@ Scenario: Check free response AI
 
   And I wait until element "p:contains('Ok. Dummy data returned for testing purposes.')" is visible
 
+  # Check that a non-assessment level doesn't show AI analysis
+  Given I am on "http://studio.code.org/s/allthethings/lessons/27/levels/2/summary"
+  And I wait until element "#summary-container" is visible
+  And I dismiss the teacher panel
+
+  And element "label:contains('Show AI Insights')" does not exist
+
 @eyes
 Scenario: Check for Understanding summaries eyes
   Given I am on "http://studio.code.org"


### PR DESCRIPTION
Continuation of https://github.com/code-dot-org/code-dot-org/pull/66161

Adds in test to check for if the level includes a property indicating AI analysis is or is not available. 

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1918)

## Testing story

Tested locally