### PR TITLE
fix(workshops): use regional partners api v1 endpoint

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/sections/PartnerFacilitator.tsx
@@ -9,7 +9,6 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import {useSelector} from 'react-redux';
 import {useParams} from 'react-router-dom';
 
 import {useDebounce} from '@cdo/apps/util/hooks/useDebounce';
@@ -44,12 +43,8 @@ export const PartnerFacilitator: FC<PartnerFacilitatorProps> = ({
 
   const {data: facilitatorData} = useFetch<Facilitator[]>(facilitatorUrl);
 
-  const regionalPartnerData = useSelector(
-    ({
-      regionalPartners: {regionalPartners},
-    }: {
-      regionalPartners: {regionalPartners: RegionalPartner[]};
-    }) => regionalPartners
+  const {data: regionalPartnerData} = useFetch<RegionalPartner[]>(
+    '/api/v1/regional_partners'
   );
 
   const debouncedCourseOfferings = useDebounce<

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/WorkshopFormTemplateTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/WorkshopFormTemplateTest.jsx
@@ -19,7 +19,6 @@ const mockedUseFetch = useFetch;
 // mock redux store
 const initialState = {
   mapbox: {mapboxAccessToken: 'test-token'},
-  regionalPartners: {regionalPartners: [{id: 1, name: 'Bill Smith'}]},
 };
 
 describe('WorkshopFormTemplate', () => {
@@ -54,7 +53,16 @@ describe('WorkshopFormTemplate', () => {
       getState: mockGetState,
       subscribe: () => {},
     };
-    mockedUseFetch.mockReturnValue({data: null, loading: false, error: null});
+    mockedUseFetch.mockImplementation(url => {
+      if (url.includes('/api/v1/regional_partners')) {
+        return {
+          data: [{id: 1, name: 'Bill Smith'}],
+          loading: false,
+          error: null,
+        };
+      }
+      return {data: null, loading: false, error: null};
+    });
   });
 
   it.each(testConfigs)('renders the form for %s', (_, config) => {
@@ -112,14 +120,18 @@ describe('WorkshopFormTemplate', () => {
   it.each(testConfigs)(
     'does not pre-fill regional partner if there is more than one option for %s',
     async (_, config) => {
-      mockGetState.mockReturnValue({
-        ...initialState,
-        regionalPartners: {
-          regionalPartners: [
-            {id: 1, name: 'Bill Smith'},
-            {id: 2, name: 'Jane Yates'},
-          ],
-        },
+      mockedUseFetch.mockImplementation(url => {
+        if (url.includes('/api/v1/regional_partners')) {
+          return {
+            data: [
+              {id: 1, name: 'Bill Smith'},
+              {id: 2, name: 'Jane Yates'},
+            ],
+            loading: false,
+            error: null,
+          };
+        }
+        return {data: null, loading: false, error: null};
       });
       renderDefault({
         config,

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/PartnerFacilitatorTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/components/PartnerFacilitatorTest.jsx
@@ -1,8 +1,5 @@
-import {configureStore} from '@reduxjs/toolkit';
-import '@testing-library/jest-dom';
 import {render} from '@testing-library/react';
 import React, {useReducer} from 'react';
-import {Provider} from 'react-redux';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 
 import {workshopReducer} from '@cdo/apps/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/reducers/workshopReducer';
@@ -25,25 +22,17 @@ const byoCourseName = 'Build Your Own Workshop';
 
 const config = WorkshopCourseConfigs.find(c => c.label === byoCourseName);
 const errors = {};
-const store = configureStore({
-  reducer: {
-    regionalPartners: () => ({regionalPartners: [{id: 1, name: 'Partner 1'}]}),
-  },
-  preloadedState: {},
-});
 
 const PartnerFacilitatorWithState = (props = {}) => {
   const [state, dispatch] = useReducer(workshopReducer, initialWorkshopState);
   return (
-    <Provider store={store}>
-      <PartnerFacilitator
-        config={config}
-        errors={errors}
-        dispatchWorkshop={dispatch}
-        {...state}
-        {...props}
-      />
-    </Provider>
+    <PartnerFacilitator
+      config={config}
+      errors={errors}
+      dispatchWorkshop={dispatch}
+      {...state}
+      {...props}
+    />
   );
 };
 
@@ -109,6 +98,13 @@ describe('PartnerFacilitator', () => {
       expect(mockedUseFetch).toHaveBeenCalledWith(
         `/api/v1/pd/course_facilitators?course_offerings=1&course_offerings=2`
       );
+    });
+  });
+
+  describe('Regional partners', () => {
+    it('fetches regional partners', async () => {
+      render(<PartnerFacilitatorWithState />);
+      expect(mockedUseFetch).toHaveBeenCalledWith('/api/v1/regional_partners');
     });
   });
 });


### PR DESCRIPTION
the workshop dashboard parent route receives regional partners through server rendered haml and I made the mistake of thinking that was what was used in the old workshop form, but it turned out that there's a separate api request to the api v1 regional partners controller that returns all regional partners for facilitator users creating workshops. this fetches the regional partners in the section component that needs them rather than getting them from redux

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3341

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
