### PR TITLE
[Music] Update event block text

### DIFF
--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -33,7 +33,7 @@
   "blockly_blockSetLocationNextMeasureTooltip": "go to next measure",
   "blockly_blockSetEffect": "set {effect} to {value}",
   "blockly_blockSetEffectTooltip": "set effect",
-  "blockly_blockTriggered": "{trigger} triggered {when}",
+  "blockly_blockTriggered": "when {trigger} triggered {when} do",
   "blockly_blockTriggeredTooltip": "at trigger",
   "blockly_blockTriggeredAt": "{trigger} triggered at {time}",
   "blockly_blockTriggeredAtTooltip": "at trigger",


### PR DESCRIPTION
This updates the block text for our trigger event block according to this approved proposal doc:
https://docs.google.com/document/d/1UvNO_a-StpAdOfJsT6SBNRRJJxS4Ey_uwRv86FdSg9g/edit?tab=t.0

Specifically, new labels "when" and "do" will bookend the existing fields as shown here:

![image](https://github.com/user-attachments/assets/ab765e74-9139-428d-b07e-4f38a60882d0)

Note that until translations get updated, the block will continue to use the previous text in non-English: 
![image](https://github.com/user-attachments/assets/77a1b6bc-f643-456a-9cb1-5e4a6a1b0279)


Please see the doc linked above or this [lengthy Slack thread](https://codedotorg.slack.com/archives/C07UT279KM1/p1746636402569979) for additional context.
