### PR TITLE
[MusicLab] Allow PackDialog to close on escape

### DIFF
--- a/apps/src/music/views/PackDialog.tsx
+++ b/apps/src/music/views/PackDialog.tsx
@@ -243,7 +243,14 @@ const PackDialog: React.FunctionComponent<PackDialogProps> = ({player}) => {
 
   return (
     <FocusOn className={styles.focusLock}>
-      <div className={styles.dialogContainer}>
+      <div
+        className={styles.dialogContainer}
+        onKeyDown={event => {
+          if (event.key === 'Escape') {
+            setPackToDefault();
+          }
+        }}
+      >
         <div id="pack-dialog" className={styles.packDialog}>
           <div id="hidden-item" tabIndex={0} role="button" />
           <Typography


### PR DESCRIPTION
The Track Selector did not close on escape. I elected to make an 'escape' keypress the same as the 'skip' button, so the track is set to the default track.

This is tricky to test locally, because the final level of the music intro opens directly to studio. Instead, I overrode a variable to force it to appear locally, ensuring that the esc worked as expected:

<img width="622" alt="Screenshot 2025-06-11 at 3 01 04 PM" src="https://github.com/user-attachments/assets/bf5f6ac1-57e0-4057-a952-36fc55b23a4e" />


https://github.com/user-attachments/assets/965b8172-fedc-493b-816d-49f631c9396f




## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1259

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
