### PR TITLE
AI Chat: only show new user modal once to teachers

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -107,11 +107,10 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
         'teacherSawAichatOnboarding',
         'no'
       );
-      if (!teacherSawAichatOnboardingModal) {
-        return ModalTypes.TEACHER_ONBOARDING;
-      }
 
-      return undefined;
+      return teacherSawAichatOnboardingModal === 'yes'
+        ? undefined
+        : ModalTypes.TEACHER_ONBOARDING;
     };
 
     dispatch(setShowModalType(modalToShow()));

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -185,8 +185,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   const onCloseModal = useCallback(() => {
     // We only want to show the teacher onboarding modal the first time a teacher user
     // interacts with the aichat tool. Thus, we store a value in local storage when
-    // closing the modal. After the first time viewing the modal, the teacher user
-    // sees the warning modal on page load from then on.
+    // closing the modal.
     if (
       isUserTeacher &&
       showModalType === ModalTypes.TEACHER_ONBOARDING &&

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -7,11 +7,7 @@ import {useSelector} from 'react-redux';
 import TeacherOnboardingModal from '@cdo/apps/aichat/views/TeacherOnboardingModal';
 import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarningModal';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {
-  isLevelbuilderEnvironment,
-  tryGetLocalStorage,
-  trySetLocalStorage,
-} from '@cdo/apps/utils';
+import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 
 import {ModalTypes} from '../constants';
 import aichatI18n from '../locale';
@@ -102,20 +98,23 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   );
 
   useEffect(() => {
-    // Skip showing the modal on levelbuilder
-    if (isLevelbuilderEnvironment()) {
-      return;
-    }
+    const modalToShow = () => {
+      if (!isUserTeacher) {
+        return ModalTypes.WARNING;
+      }
 
-    const teacherSawAichatOnboardingModal = tryGetLocalStorage(
-      'teacherSawAichatOnboarding',
-      'no'
-    );
-    const modalToShow =
-      isUserTeacher && teacherSawAichatOnboardingModal !== 'yes'
-        ? ModalTypes.TEACHER_ONBOARDING
-        : ModalTypes.WARNING;
-    dispatch(setShowModalType(modalToShow));
+      const teacherSawAichatOnboardingModal = tryGetLocalStorage(
+        'teacherSawAichatOnboarding',
+        'no'
+      );
+      if (!teacherSawAichatOnboardingModal) {
+        return ModalTypes.TEACHER_ONBOARDING;
+      }
+
+      return undefined;
+    };
+
+    dispatch(setShowModalType(modalToShow()));
   }, [isUserTeacher, dispatch]);
 
   useEffect(() => {

--- a/dashboard/test/ui/features/star_labs/aichat/chat.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/chat.feature
@@ -33,6 +33,7 @@ Feature: Model customizations and interactions in AI Chat Lab
 
     Given I reload the page
     And I dismiss the teacher panel
+    And I wait until element "#system-prompt" is visible
     Then element "#system-prompt" has text "You are a safe chatbot"
 
   Scenario: Publishing model enables published view and saves

--- a/dashboard/test/ui/features/star_labs/aichat/chat.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/chat.feature
@@ -32,8 +32,6 @@ Feature: Model customizations and interactions in AI Chat Lab
     Then I wait until element ".uitest-aichat-chat-alert" contains text "System prompt has been updated"
 
     Given I reload the page
-    And I click selector "#ui-close-dialog" once I see it
-    And I wait until element "#ui-close-dialog" is not visible
     And I dismiss the teacher panel
     Then element "#system-prompt" has text "You are a safe chatbot"
 
@@ -60,8 +58,6 @@ Feature: Model customizations and interactions in AI Chat Lab
     And I wait until element "#uitest-presentation-view-header" contains text "Jeeves"
 
     Given I reload the page
-    And I click selector "#ui-close-dialog" once I see it
-    And I wait until element "#ui-close-dialog" is not visible
     And I dismiss the teacher panel
     When I click selector "#uitest-user-view-button" once I see it
     Then I wait until element "#uitest-presentation-view-header" contains text "Jeeves"

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -105,8 +105,6 @@ Feature: BubbleChoice
     And I wait until element ".teacher-panel" is visible
     Then I select the "New Section" option in dropdown with class "uitest-sectionselect"
     Then I verify progress for the sublevel with selector ".teacher-panel .progress-bubble:first" is "not_tried"
-    And I click selector "#ui-close-dialog" once I see it
-    And I wait until element "#ui-close-dialog" is not visible
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it
     And I wait until element "#lab2-aichat" is visible
     Then I verify progress for the sublevel with selector ".teacher-panel .progress-bubble:first" is "perfect"


### PR DESCRIPTION
Only show the "Welcome to AI Chat Lab" modal once to teachers. We currently show the student-centric "Remember to chat responsibly" modal to teachers after this first viewing of the welcome modal, which [I don't think was the intended behavior per the ticket written up for this teacher-facing modal.](https://codedotorg.atlassian.net/browse/LABS-1051?atlOrigin=eyJpIjoiNzc4OTg1ZThkOWMxNDIwMWIwMjM5NWVhM2VlOTRjYTMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

![image](https://github.com/user-attachments/assets/3d157ab9-052d-4ae3-96af-38147bb753a8)

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1458

## Testing story

Tested manually.