### PR TITLE
[Google Blockly] Update positioning logic for workspace cleanUp

### DIFF
--- a/apps/src/blockly/addons/cdoSerializationHelpers.ts
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.ts
@@ -534,18 +534,10 @@ export function cleanUp(
     block.moveTo(new Blockly.utils.Coordinate(x, y));
     let collider = getCollider(block);
 
-    const {viewWidth} = workspace.getMetrics();
-    const maximumX = viewWidth - WORKSPACE_PADDING;
-    const blockOutOfBounds = workspace.RTL
-      ? collider.x - collider.width < 0
-      : collider.x + collider.width > maximumX;
-    if (blockOutOfBounds) {
-      x = workspace.RTL
-        ? Math.min(collider.width, maximumX)
-        : Math.max(maximumX - collider.width, WORKSPACE_PADDING);
-      block.moveTo(new Blockly.utils.Coordinate(x, y));
-      collider = getCollider(block);
-    }
+    // We constrain horizontal positioning to the width of the view area or block content,
+    // whichever is greater. This prevents blocks from being pushed too far to the right.
+    const {viewWidth, contentWidth} = workspace.getMetrics();
+    const maximumX = Math.max(viewWidth, contentWidth) - WORKSPACE_PADDING;
 
     orderedColliders.forEach(orderedCollider => {
       if (isOverlapping(collider, orderedCollider)) {
@@ -569,7 +561,7 @@ export function cleanUp(
             // If the workspace is RTL, we need to check if we can move left
             const potentialNewRight = orderedCollider.x - SPACE_BETWEEN_BLOCKS;
             const potentialNewLeft = potentialNewRight - collider.width;
-            // The block must be able to fit to the left without leaving the view area.
+            // The block must be able to fit to the left without pushing further out of the view area.
             if (potentialNewLeft >= 0) {
               canMoveHorizontally = true;
               candidateX = potentialNewRight;
@@ -578,7 +570,7 @@ export function cleanUp(
             const potentialNewLeft =
               orderedCollider.x + orderedCollider.width + SPACE_BETWEEN_BLOCKS;
             const potentialNewRight = potentialNewLeft + collider.width;
-            // The block must be able to fit to the right without leaving the view area.
+            // The block must be able to fit to the right without pushing further out of the view area.
             if (potentialNewRight < maximumX) {
               canMoveHorizontally = true;
               candidateX = potentialNewLeft;


### PR DESCRIPTION
This is an update/fix for a `cleanUp` function that is designed to prevent blocks from overlapping:
- https://github.com/code-dot-org/code-dot-org/pull/65913

Earlier this week, @dancodedotorg reported an issue:

> - I made some starter code with lots of functions for students to pre-populate
> - I ran out of room, so I made a decision to expand my workspace horizontally and save the start code. This meant some blocks were off my screen to the right when my window loaded.
> - When I reloaded the page, they repositioned awkwardly so they were on my screen

https://github.com/user-attachments/assets/d9f5eb14-fd6d-41c2-816d-22f914bcf861

As you can tell from Dan's video, the function does succeed in preventing blocks from overlapping, but it has the unwanted side effect of also moving several blocks left into the view area of the workspace. The current logic is essentially two steps for each block being moved:
1. If the block is out of the view area horizontally, move it back in
2. If the block is overlapping any blocks that have already been positioned, move it right or down as space allows.

Step 1 is particularly opinionated and proved to not be what is desired. This branch proposes simplifying this process. Now:
* We will no longer move blocks just because they are outside the view area.
* When moving overlapping blocks, we will consider the width of the workspace content (ie. rendered blocks) when determining the maximum x position. This means that overlapping blocks can be repositioned to the right, provided that still fit within the view area OR at least that they don't increase the total current content width.

This effectively means that the user (levelbuilder or student) regains control over the horizontal positioning of the blocks on the workspace.

## Before (levelbuilder)
![image (317)](https://github.com/user-attachments/assets/6d108ead-ba1c-4c55-96f4-75ce829416af)

## After (localhost)
![image (318)](https://github.com/user-attachments/assets/334780ec-e9b0-49fd-8f77-585640c0f8b6)

This change doesn't otherwise affect the algorithm used to handle overlapping blocks, but I did check that it still worked as expected for extra wide translations and over-crowded workspaces.


## Links

Slack discussion: https://codedotorg.slack.com/archives/C04TH8400AU/p1749599195166279
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
