### PR TITLE
Share Filter: change street_address to address in PII Geocoder code 

### DIFF
--- a/lib/cdo/geocoder.rb
+++ b/lib/cdo/geocoder.rb
@@ -102,10 +102,6 @@ module Geocoder
     results = Geocoder.search(first_number_to_end)
     return nil if results.empty?
 
-    # Return nil if none of the results returned from Geocoder matched on a
-    # street address with relevance >= 0.8
-    return nil if results.none? {|r| r.relevance >= 0.8 && r.street_address}
-
     first_number_to_end
   end
 

--- a/lib/cdo/geocoder.rb
+++ b/lib/cdo/geocoder.rb
@@ -102,6 +102,10 @@ module Geocoder
     results = Geocoder.search(first_number_to_end)
     return nil if results.empty?
 
+    # Return nil if none of the results returned from Geocoder matched on a
+    # street address with relevance >= 0.8
+    return nil if results.none? {|r| r.relevance >= 0.8 && r.address}
+
     first_number_to_end
   end
 
@@ -147,7 +151,7 @@ module Geocoder
   # servers. Localhost lookups are usually because UI tests are making requests and we want our developer and CI
   # environments to behave similar to production and staging.
   # https://github.com/alexreisner/geocoder/blob/350cf0cc6a158d510aec3d91594d9b5718f877a9/lib/geocoder/lookups/freegeoip.rb#L41-L54
-  module LocahostOverride
+  module LocalhostOverride
     def search(query, options = {})
       ip = begin
         IPAddr.new(query)
@@ -167,7 +171,7 @@ module Geocoder
       end
     end
   end
-  singleton_class.prepend LocahostOverride
+  singleton_class.prepend LocalhostOverride
 end
 
 # We need to override some of the behavior of Geocoder::Lookup::Freegeoip in order for is to work with our self-hosted


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/TEACH-2005

In testing the PII filter on free response AI analysis, we hit and error when there is a street address in the student's response caught by the PII filter: 
<img width="750" alt="Screenshot 2025-06-12 at 9 04 36 AM" src="https://github.com/user-attachments/assets/8d713b2b-8f9d-45db-81a5-d6e6b53f9331" />

`SharingFilter.find_pii_failure` calls `Geocoder.find_potential_street_address(text)` which calls `Geocoder.search` which returns results like this when a street address is found: 
<img width="1217" alt="Screenshot 2025-06-12 at 9 10 26 AM" src="https://github.com/user-attachments/assets/cd8d7e01-ec67-4cf7-94c2-4440b2c6f999" />

which doesn't have a `street_address`, but does have an `address`. 
