### PR TITLE
Lab2 instructions: add padding to exemplar player when in instructions

### DIFF
--- a/apps/src/music/views/ExemplarPlayer.module.scss
+++ b/apps/src/music/views/ExemplarPlayer.module.scss
@@ -11,7 +11,7 @@
 
   &InsideInstructions {
     background-color: $neutral_light;
-    padding: 8px 0 4px 0;
+    padding: 8px 10px 4px;
   }
 
   .entry {


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/66260 -- add some padding to exemplar player. Details in [this Slack thread](https://codedotorg.slack.com/archives/C07UT279KM1/p1749744334300589).