### PR TITLE
Revert "Enable ActiveRecord to Query Reporting Database"

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -7,20 +7,15 @@
   DATABASE_CONFIGURATION = {
     db_cluster_id: '!Ref AuroraCluster',
     db_endpoint_writer: '!GetAtt AuroraCluster.Endpoint.Address',
-    db_endpoint_writer_port: '!GetAtt AuroraCluster.Endpoint.Port',
     db_endpoint_proxy_writer: '!GetAtt DBProxy.Endpoint',
-    db_endpoint_proxy_writer_port: '3306', # RDS Proxy MySQL Endpoints only use 3306
     db_endpoint_proxy_reader: '!GetAtt ReaderDBProxyEndpoint.Endpoint',
-    db_endpoint_proxy_reader_port: '3306', # RDS Proxy MySQL Endpoints only use 3306
-    db_endpoint_proxy_reporting: '!GetAtt ReportingDBProxyEndpoint.Endpoint',
-    db_endpoint_proxy_reporting_port: '3306' # RDS Proxy MySQL Endpoints only use 3306
+    db_endpoint_proxy_reporting: '!GetAtt ReportingDBProxyEndpoint.Endpoint'
   }.tap do |hash|
     if rack_env?(:production)
       hash[:db_cluster_id] = PRODUCTION_DB_CLUSTER_ID
       # Use a placeholder string for production db cluster endpoint to avoid placing a slightly sensitive value
       # in source code. We set the value of the Secret manually in production.
       hash[:db_endpoint_writer] = 'PLACEHOLDER'
-      hash[:db_endpoint_writer_port] = '3306'
       # We haven't yet provisioned the Writer and Reader Proxy Endpoints in production.
       hash[:db_endpoint_proxy_writer] = 'PLACEHOLDER'
       hash[:db_endpoint_proxy_reader] = 'PLACEHOLDER'
@@ -96,48 +91,25 @@
       Description: 'Publish Database Cluster Writer Endpoint to application configuration setting CDO.db_endpoint_writer'
       Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_writer"
       SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_writer]%>
-  DBWriterEndpointPortConfig:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: 'Publish Database Cluster Writer Endpoint Port to application configuration setting CDO.db_endpoint_writer_port'
-      Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_writer_port"
-      SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_writer_port]%>
   DBProxyWriterEndpointConfig:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: 'Publish RDS Proxy Writer Endpoint to the application configuration setting CDO.db_endpoint_proxy_writer'
       Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_writer"
       SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_writer]%>
-  DBProxyWriterEndpointPortConfig:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: 'Publish RDS Proxy Writer Endpoint Port to the application configuration setting CDO.db_endpoint_proxy_writer_port'
-      Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_writer_port"
-      SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_writer_port]%>
   DBProxyReaderEndpointConfig:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: 'Publish RDS Proxy Reader Endpoint to the application configuration setting CDO.db_endpoint_proxy_reader'
       Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_reader"
       SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_reader]%>
-  DBProxyReaderEndpointPortConfig:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: 'Publish RDS Proxy Reader Endpoint Port to the application configuration setting CDO.db_endpoint_proxy_reader_port'
-      Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_reader_port"
-      SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_reader_port]%>
   DBProxyReportingEndpointConfig:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: 'Publish RDS Proxy Reporting Endpoint to the application configuration setting CDO.db_endpoint_proxy_reporting'
       Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_reporting"
       SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_reporting]%>
-  DBProxyReportingEndpointPortConfig:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: 'Publish RDS Proxy Reporting Endpoint Port to the application configuration setting CDO.db_endpoint_proxy_reporting_port'
-      Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_reporting_port"
-      SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_reporting_port]%>
+
 <% if database-%>
 # We don't yet provision the production database cluster/instances via CloudFormation, but we're incrementally
 # working towards that. Start with provisioning the DB Instance and Cluster ParameterGroups via this template.

--- a/bin/mysql-client-admin
+++ b/bin/mysql-client-admin
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_credential_admin' unless CDO.db_credential_admin
 credentials = CDO.db_credential_admin
+host = CDO.db_endpoint_writer.split(':')[0]
+port = CDO.db_endpoint_writer.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_writer,
-  port: CDO.db_endpoint_writer_port,
+  host: host,
+  port: port,
   path: '/'
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-dashboard-reader
+++ b/bin/mysql-client-dashboard-reader
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_proxy_reader' unless CDO.db_endpoint_proxy_reader
 credentials = CDO.db_credential_reader
+host = CDO.db_endpoint_proxy_reader.split(':')[0]
+port = CDO.db_endpoint_proxy_reader.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_proxy_reader,
-  port: CDO.db_endpoint_proxy_reader_port,
+  host: host,
+  port: port,
   path: '/' + CDO.dashboard_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-dashboard-reporting
+++ b/bin/mysql-client-dashboard-reporting
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please set CDO.db_endpoint_proxy_reporting' unless CDO.db_endpoint_proxy_reporting
 credentials = CDO.db_credential_reader
+host = CDO.db_endpoint_proxy_reporting.split(':')[0]
+port = CDO.db_endpoint_proxy_reporting.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_proxy_reporting,
-  port: CDO.db_endpoint_proxy_reporting_port,
+  host: host,
+  port: port,
   path: '/' + CDO.dashboard_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-dashboard-writer
+++ b/bin/mysql-client-dashboard-writer
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_writer' unless CDO.db_endpoint_writer
 credentials = CDO.db_credential_writer
+host = CDO.db_endpoint_proxy_writer.split(':')[0]
+port = CDO.db_endpoint_proxy_writer.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_writer,
-  port: CDO.db_endpoint_writer_port,
+  host: host,
+  port: port,
   path: '/' + CDO.dashboard_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-pegasus-reader
+++ b/bin/mysql-client-pegasus-reader
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_proxy_reader' unless CDO.db_endpoint_proxy_reader
 credentials = CDO.db_credential_reader
+host = CDO.db_endpoint_proxy_reader.split(':')[0]
+port = CDO.db_endpoint_proxy_reader.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_proxy_reader,
-  port: CDO.db_endpoint_proxy_reader_port,
+  host: host,
+  port: port,
   path: '/' + CDO.pegasus_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-pegasus-reporting
+++ b/bin/mysql-client-pegasus-reporting
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_proxy_reporting' unless CDO.db_endpoint_proxy_reporting
 credentials = CDO.db_credential_reader
+host = CDO.db_endpoint_proxy_reporting.split(':')[0]
+port = CDO.db_endpoint_proxy_reporting.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_proxy_reporting,
-  port: CDO.db_endpoint_proxy_reporting_port,
+  host: host,
+  port: port,
   path: '/' + CDO.pegasus_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-pegasus-writer
+++ b/bin/mysql-client-pegasus-writer
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_writer' unless CDO.db_endpoint_writer
 credentials = CDO.db_credential_writer
+host = CDO.db_endpoint_proxy_writer.split(':')[0]
+port = CDO.db_endpoint_proxy_writer.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_writer,
-  port: CDO.db_endpoint_writer_port,
+  host: host,
+  port: port,
   path: '/' + CDO.pegasus_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -559,13 +559,9 @@ devinternal_db_writer: !Secret
 # Until we have a better configuration setting service, use AWS Secrets Manager to store these non-secret values.
 db_cluster_id: !StackSecret
 db_endpoint_writer: !StackSecret
-db_endpoint_writer_port: !StackSecret
 db_endpoint_proxy_writer: !StackSecret
-db_endpoint_proxy_writer_port: !StackSecret
 db_endpoint_proxy_reader: !StackSecret
-db_endpoint_proxy_reader_port: !StackSecret
 db_endpoint_proxy_reporting: !StackSecret
-db_endpoint_proxy_reporting_port: !StackSecret
 
 # Database credentials (username & password) are stored in an AWS Secret in a JSON format required by RDS Proxy:
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-setup.html#rds-proxy-secrets-arns
@@ -591,6 +587,8 @@ dashboard_db_reader:           '<%="#{db_reader}#{dashboard_db_name}"%>'
 dashboard_db_writer:           '<%="#{db_writer}#{dashboard_db_name}"%>'
 pegasus_db_reader:             '<%="#{db_reader}#{pegasus_db_name}"%>'
 pegasus_db_writer:             '<%="#{db_writer}#{pegasus_db_name}"%>'
+dashboard_reporting_db_reader: '<%="#{reporting_db_reader}#{dashboard_db_name}"%>'
+dashboard_reporting_db_writer: '<%="#{reporting_db_writer}#{dashboard_db_name}"%>'
 pegasus_reporting_db_reader:   '<%="#{reporting_db_reader}#{pegasus_db_name}"%>'
 pegasus_reporting_db_writer:   '<%="#{reporting_db_writer}#{pegasus_db_name}"%>'
 

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -5,13 +5,9 @@ dashboard_enable_pegasus: true
 
 db_cluster_id: localhost
 db_endpoint_writer: localhost
-db_endpoint_writer_port: 3306
 db_endpoint_proxy_writer: localhost
-db_endpoint_proxy_writer_port: 3306
 db_endpoint_proxy_reader: localhost
-db_endpoint_proxy_reader_port: 3306
 db_endpoint_proxy_reporting: localhost
-db_endpoint_proxy_reporting_port: 3306
 
 db_credential_admin: {"username":"root", "password":""}
 db_credential_writer: {"username":"root", "password":""}

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -24,20 +24,6 @@ channels_api_secret: not a real secret
 dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
 google_maps_api_key: boguskey
-
-db_cluster_id: localhost
-db_endpoint_writer: localhost
-db_endpoint_writer_port: 3306
-db_endpoint_proxy_writer: localhost
-db_endpoint_proxy_writer_port: 3306
-db_endpoint_proxy_reader: localhost
-db_endpoint_proxy_reader_port: 3306
-db_endpoint_proxy_reporting: localhost
-db_endpoint_proxy_reporting_port: 3306
-
-db_credential_admin: {"username":"root", "password":""}
-db_credential_writer: {"username":"root", "password":""}
-db_credential_reader: {"username":"root", "password":""}
 db_writer: 'mysql://root@localhost/'
 
 # Number of workers to start when running `rake build:start_active_job_workers`:

--- a/dashboard/app/models/application_record.rb
+++ b/dashboard/app/models/application_record.rb
@@ -3,7 +3,6 @@ class ApplicationRecord < ActiveRecord::Base
 
   connects_to database: {
     writing: Policies::ActiveRecordRoles.get_writing_role_name,
-    reading: Policies::ActiveRecordRoles.get_reading_role_name,
-    reporting: Policies::ActiveRecordRoles.get_reporting_role_name,
+    reading: Policies::ActiveRecordRoles.get_reading_role_name
   }
 end

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -66,18 +66,6 @@ environment_defaults: &environment_defaults
     port: <%= reader.port || 3306 %>
     username: <%= reader.user %>
   <% end %>
-  # Always provision a reporting replica database connection pool, even in environments that do not have an Aurora
-  # cluster with a "reporting" RDS Proxy, such as local development environments and continuous integration
-  # builds. In those non-AWS environments, CDO.db_endpoint_proxy_reporting is set to the same servername as the writer
-  # (typically 'localhost').
-  primary_reporting:
-    replica: true
-    <<: *mysql_defaults
-    host: <%= CDO.db_endpoint_proxy_reporting %>
-    port: <%= CDO.db_endpoint_proxy_reporting_port %>
-    username: <%= CDO.db_credential_reader['username'] %>
-    password: <%= CDO.db_credential_reader['password'] %>
-    database: <%= CDO.dashboard_db_name %>
 
 development:
   <<: *environment_defaults

--- a/dashboard/lib/policies/active_record_roles.rb
+++ b/dashboard/lib/policies/active_record_roles.rb
@@ -16,12 +16,4 @@ module Policies::ActiveRecordRoles
     configurations = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, include_replicas: true)
     configurations.find(&:replica?)&.spec_name&.to_sym || get_writing_role_name
   end
-
-  # Get the name of the ActiveRecord "role" used for connecting to the reporting
-  # database which is a clone of our primary database meant for large / long
-  # queries usually used for data analysis. This role should not be used when
-  # handling web requests.
-  def self.get_reporting_role_name
-    :primary_reporting
-  end
 end

--- a/dashboard/test/lib/policies/active_record_roles_test.rb
+++ b/dashboard/test/lib/policies/active_record_roles_test.rb
@@ -44,8 +44,4 @@ class Policies::ActiveRecordRolesTest < ActiveSupport::TestCase
     ActiveRecord::Base.stubs(:configurations).returns(test_config)
     assert_equal Policies::ActiveRecordRoles.get_reading_role_name, :secondary
   end
-
-  test 'get_reporting_role_name' do
-    assert_equal Policies::ActiveRecordRoles.get_reporting_role_name, :primary_reporting
-  end
 end

--- a/lib/cdo/db.rb
+++ b/lib/cdo/db.rb
@@ -1,4 +1,3 @@
-require 'uri'
 require 'cdo/sequel'
 require 'sequel'
 require 'cdo/cache'
@@ -13,3 +12,4 @@ PEGASUS_DB.singleton_class.prepend StaticModels
 # rubocop:enable CustomCops/PegasusDbUsage
 
 DASHBOARD_DB = Cdo::Sequel.database_connection_pool CDO.dashboard_db_writer, CDO.dashboard_db_reader
+DASHBOARD_REPORTING_DB_READER = Cdo::Sequel.database_connection_pool CDO.dashboard_reporting_db_reader, CDO.dashboard_reporting_db_reader


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#63351

This Pull Request declared new `CDO.` configuration settings AND it included CloudFormation logic to provision/populate AWS Secrets that set the values of the `CDO.` keys, but that doesn't take place until much later in the build process so some build components fail to execute.  I forgot to test applying this change to an existing Stack.

I'll split this up into two separate Pull Requests.