### PR TITLE
Added new dates and certificate links fir Korean partner event

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -67,8 +67,8 @@ export default function Congrats(props) {
    */
   const getExtraLinkData = (language, tutorial, currentDate) => {
     // https://codedotorg.atlassian.net/browse/P20-1144
-    const codingPartyStart = new Date('2024-10-07:00:00+09:00');
-    const codingPartyEnd = new Date('2024-11-17:00:00+09:00');
+    const codingPartyStart = new Date('2025-06-16:00:00+09:00');
+    const codingPartyEnd = new Date('2025-07-27:00:00+09:00');
     const codingPartyActive =
       codingPartyStart <= currentDate && currentDate < codingPartyEnd;
     if (language === 'ko' && codingPartyActive) {
@@ -76,17 +76,22 @@ export default function Congrats(props) {
         '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
       if (/oceans/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2024-2-oceans.png'),
+          extraLinkUrl: pegasus('/files/online-coding-party-2025-1-oceans.png'),
           extraLinkText: extraLinkText,
         };
       } else if (/hero/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2024-2-hero.png'),
+          extraLinkUrl: pegasus('/files/online-coding-party-2025-1-hero.png'),
           extraLinkText: extraLinkText,
         };
-      } else if (/dance/.test(tutorial)) {
+      } else if (/dance-ai/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2024-2-dance.png'),
+          extraLinkUrl: pegasus('/files/online-coding-party-2025-1-dance.png'),
+          extraLinkText: extraLinkText,
+        };
+      } else if (/music-jam/.test(tutorial)) {
+        return {
+          extraLinkUrl: pegasus('/files/online-coding-party-2025-1-music.png'),
           extraLinkText: extraLinkText,
         };
       }


### PR DESCRIPTION
Our Korean partners would like us to show a custom certificate for Korean students. This PR adds a link to a certificate provided by our partner when the language is in Korean. The links will be removed once their campaign is over.
What's different from the last request: We added Music Lab:Jam Session and kept 3 HoC activities - AI for Oceans, Minecraft Hero's Journey, and Dance Party AI Edition. Thus, in total 4 activities.

1. AI for Oceans
2. Minecraft Hero's Journey
3. Dance Party AI Edition
3. Music Lab:Jam Session (updated): 

Certificates uploaded on Dropbox: Below are the uploaded certificate file names. The Korean-linked text will remain the same.
/files/online-coding-party-2025-1-oceans.png 
/files/online-coding-party-2025-1-hero.png
/files/online-coding-party-2025-1-dance.png
/files/online-coding-party-2025-1-music.png

Due Date: Friday, June 13, 2025

Campaign Start and End Dates 
Start date: Monday, June 16, 2025, Korea Time (UTC/GMT +9) 
End Date: Sunday, July 27, 2025, Korea Time (UTC/GMT +9)

## Links

- Jira: [P20-1533](https://codedotorg.atlassian.net/browse/P20-1533)

## Testing story

### Testing links:
- /courses/oceans/units/1/lessons/1/levels/8
- /courses/hero/units/1/lessons/1/levels/12
- /courses/dance-ai-2023/units/1/lessons/1/levels/10
- /courses/music-jam-2024/units/1/lessons/1/levels/17

### Screenshots (date of events modified for testing):
<img width="1161" alt="Screenshot 2025-06-13 at 10 42 46" src="https://github.com/user-attachments/assets/d43f8184-4a35-4f06-87f4-57ded3848937" />
<img width="1161" alt="Screenshot 2025-06-13 at 10 42 21" src="https://github.com/user-attachments/assets/2100e15a-384d-42d3-a77d-3ed841b7677f" />
<img width="1161" alt="Screenshot 2025-06-13 at 10 42 01" src="https://github.com/user-attachments/assets/a44d04f6-c9b6-4e5c-98a7-2857547e7647" />
<img width="1161" alt="Screenshot 2025-06-13 at 10 51 07" src="https://github.com/user-attachments/assets/ba74fb25-fd3f-4730-a3e2-3bd4a190d021" />


### Other tutorials don't have links:
<img width="1066" alt="Screenshot 2025-06-13 at 10 41 09" src="https://github.com/user-attachments/assets/3197a8d6-e150-4314-a395-85e9f25ef99b" />

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
