### PR TITLE
decouple AI Tutor v1 from AI Chat and AI Tutor v2

### DIFF
--- a/bin/cron/openai_pdf_processing_availability_check
+++ b/bin/cron/openai_pdf_processing_availability_check
@@ -41,7 +41,7 @@ def main
     }
   ]
 
-  client = OpenaiChatHelper::Client.new(
+  client = AichatOpenaiResponsesHelper::Client.new(
     CDO.openai_student_learning_api_key,
     'gpt-4o-mini-2024-07-18'
   )

--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -187,6 +187,6 @@ module AichatOpenaiHelper
   end
 
   def self.client
-    OpenaiChatHelper::Client.new(API_KEY, MODEL)
+    AichatOpenaiResponsesHelper::Client.new(API_KEY, MODEL)
   end
 end

--- a/dashboard/app/helpers/aichat_openai_responses_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_responses_helper.rb
@@ -1,0 +1,36 @@
+module AichatOpenaiResponsesHelper
+  class Client
+    attr_accessor :api_key, :model
+
+    OPEN_AI_URL = "https://api.openai.com/v1/chat/completions"
+    DEFAULT_TEMPERATURE = 0
+
+    def initialize(api_key, model)
+      @api_key = api_key
+      @model = model
+    end
+
+    # Optional "options" parameter is included to provide generic coverage for additional OpenAI parameters.
+    # Examples include "response_format" for JSON response formatting, and "tools" for function calling.
+    def request_chat_completion(messages, temperature = DEFAULT_TEMPERATURE, options: {})
+      headers = {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer #{api_key}"
+      }
+
+      data = {
+        model: model,
+        temperature: temperature,
+        messages: messages
+      }.merge(options)
+
+      HTTParty.post(
+        OPEN_AI_URL,
+        headers: headers,
+        body: data.to_json,
+        open_timeout: DCDO.get('openai_http_open_timeout', 5),
+        read_timeout: DCDO.get('openai_http_read_timeout', 30)
+      )
+    end
+  end
+end

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -94,7 +94,7 @@ module AichatSafetyHelper
     end
 
     private def client
-      OpenaiChatHelper::Client.new(API_KEY, MODEL)
+      AichatOpenaiResponsesHelper::Client.new(API_KEY, MODEL)
     end
 
     private def comprehend_enabled?(role)

--- a/dashboard/app/models/user_level_interaction.rb
+++ b/dashboard/app/models/user_level_interaction.rb
@@ -19,6 +19,9 @@
 #  index_user_level_interactions_on_level_id  (level_id)
 #  index_user_level_interactions_on_user_id   (user_id)
 #
+# Logs for user interactions with levels, such as clicking the run or finish buttons.
+# This contains additional information than just completion status or attempts.
+# These interactions are used to improve insights into student learning.
 class UserLevelInteraction < ApplicationRecord
   belongs_to :user
   belongs_to :level

--- a/dashboard/app/models/user_level_interaction.rb
+++ b/dashboard/app/models/user_level_interaction.rb
@@ -19,9 +19,6 @@
 #  index_user_level_interactions_on_level_id  (level_id)
 #  index_user_level_interactions_on_user_id   (user_id)
 #
-# Logs for user interactions with levels, such as clicking the run or finish buttons.
-# This contains additional information than just completion status or attempts.
-# These interactions are used to improve insights into student learning.
 class UserLevelInteraction < ApplicationRecord
   belongs_to :user
   belongs_to :level

--- a/dashboard/test/helpers/aichat_safety_helper_test.rb
+++ b/dashboard/test/helpers/aichat_safety_helper_test.rb
@@ -71,7 +71,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
     ShareFiltering.stubs(:find_profanity_failure).returns(ShareFailure.new(ShareFiltering::FailureType::PROFANITY, @webpurify_profanity))
     AichatComprehendHelper.stubs(:get_toxicity).returns(@comprehend_response)
     mock_response = create_stubbed_response(@openai_response_profanity_json)
-    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
+    AichatOpenaiResponsesHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
 
     @english_script = create(:script, :with_levels, name: 'customizing-llms-2024')
     @spanish_script = create(:script, :with_levels, name: 'customizing-llms-latm-pilot')
@@ -97,7 +97,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
     AichatComprehendHelper.stubs(:get_toxicity).returns(nil)
     ShareFiltering.stubs(:find_profanity_failure).returns(nil)
     mock_response = create_stubbed_response(@openai_response_safe_json)
-    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
+    AichatOpenaiResponsesHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
 
     DCDO.stubs(:get).with("aichat_safety_profane_word_blocklist", anything).returns([])
     ROLES.each do |role|
@@ -112,7 +112,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
   test "request_safety_check returns a valid response.body the first time it is called" do
     stub_safety_services('openai', 'user')
     mock_response = create_stubbed_response(@openai_response_safe_json)
-    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response).once
+    AichatOpenaiResponsesHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response).once
 
     AichatSafetyHelper.find_toxicity('user', 'clean message', 'en', nil)
   end
@@ -121,7 +121,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
     stub_safety_services('openai', 'user')
     mock_response_invalid = create_stubbed_response(@openai_response_invalid_json)
     mock_structured_response = create_stubbed_response(@openai_response_structured_json)
-    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).
+    AichatOpenaiResponsesHelper::Client.any_instance.stubs(:request_chat_completion).
       returns(mock_response_invalid).
       returns(mock_structured_response)
 
@@ -131,7 +131,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
   test "raises an error if request_safety_check returns a response.body other than INAPPROPRIATE or OK twice" do
     stub_safety_services('openai', 'user')
     mock_response = create_stubbed_response(@openai_response_invalid_json)
-    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
+    AichatOpenaiResponsesHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
 
     assert_raises do
       AichatSafetyHelper.find_toxicity('user', 'clean message', 'en', nil)
@@ -141,7 +141,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
   test "Open AI safety check uses American safety prompt if not in Spanish script" do
     stub_safety_services('openai', 'user')
 
-    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).with do |messages, _|
+    AichatOpenaiResponsesHelper::Client.any_instance.stubs(:request_chat_completion).with do |messages, _|
       assert_includes messages[0][:content], "American"
       return true
     end
@@ -152,7 +152,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
   test "Open AI safety check uses Spanish safety prompt if in Spanish script" do
     stub_safety_services('openai', 'user')
 
-    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).with do |messages, _|
+    AichatOpenaiResponsesHelper::Client.any_instance.stubs(:request_chat_completion).with do |messages, _|
       assert_includes messages[0][:content], "Spanish"
       return true
     end


### PR DESCRIPTION
As discussed in this [slack thread](https://codedotorg.slack.com/archives/C08S29NDZ5E/p1749746302768819), this PR is to decouple the code for legacy (v1) AI Tutor from AI Chat and the new AI Tutor (v2).

The primary motivation is to enable a move to the newer OpenAI [responses API ](https://platform.openai.com/docs/api-reference/responses)vs. the older [chat completions one](https://platform.openai.com/docs/api-reference/chat) as the newer API is recommended by OpenAI and the newer API seems to be at least a little more reliable as discussed in this [slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1749064505153089).

This diagram shows one of the shared code paths:
![Multiple Code Paths](https://github.com/user-attachments/assets/e5af3578-987b-4100-a3e2-a81509641c1f)

And this image shows the changes made in this PR:
<img width="814" alt="pr-changes" src="https://github.com/user-attachments/assets/f92853ba-6b7c-4042-8a60-a10e822d1502" />


I named the new file and module `aichat_openai_responses_helper.rb` and `AichatOpenaiResponsesHelper` respectively as this ties into the naming convention for AI Chat's ruby code and to the newer `https://api.openai.com/v1/responses` API that motivates this change.  While these names are also going to be out-of-date (since AI Tutor v2 is starting to share this code), this name will make it easier to keep track of and rename these as we move forward.

## Testing

I think we will rely on any existing tests as this change does not add any new functionality.  I did quickly pull up AI Tutor v1 and AI Chat to ensure they still ran:

<img width="1069" alt="ai-tutor-v1-test" src="https://github.com/user-attachments/assets/9a6e7f70-e3a7-4bf0-b1ab-320160be1974" />

<img width="1068" alt="ai-chat-test" src="https://github.com/user-attachments/assets/e5c5335c-324b-4a36-8654-a9452470d202" />

## Follow-up work

Follow up work is to make the change to the newer OpenAI API now that the old AI Tutor v1 won't need to be considered for this change.  Additionally, we will want to rename (and reorganize) these files since they no longer are limited to AI Chat.
