### PR TITLE
validate placeholder text before eyes snapshot for not started warning

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -265,7 +265,7 @@ end
 When /^I wait until (?:element )?"([^"]*)" (?:has|contains) (placeholder )?text "([^"]*)"$/ do |selector, is_placeholder, text|
   wait_for_jquery
   getter = is_placeholder ? "attr('placeholder')" : "text()"
-  wait_until {@browser.execute_script("return $(#{selector.dump}).#{getter};").include? text}
+  wait_until {@browser.execute_script("return $(#{selector.dump}).#{getter};")&.include?(text)}
 end
 
 When /^I wait until (?:element )?"([^"]*)" does not (?:have|contain) text "([^"]*)"$/ do |selector, text|

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -262,9 +262,10 @@ Then /^I see "([.#])([^"]*)"$/ do |selector_symbol, name|
   @browser.find_element(selection_criteria)
 end
 
-When /^I wait until (?:element )?"([^"]*)" (?:has|contains) text "([^"]*)"$/ do |selector, text|
+When /^I wait until (?:element )?"([^"]*)" (?:has|contains) (placeholder )?text "([^"]*)"$/ do |selector, is_placeholder, text|
   wait_for_jquery
-  wait_until {@browser.execute_script("return $(#{selector.dump}).text();").include? text}
+  getter = is_placeholder ? "attr('placeholder')" : "text()"
+  wait_until {@browser.execute_script("return $(#{selector.dump}).#{getter};").include? text}
 end
 
 When /^I wait until (?:element )?"([^"]*)" does not (?:have|contain) text "([^"]*)"$/ do |selector, text|

--- a/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
@@ -17,7 +17,7 @@ Scenario: Game lab level where student has not started
   And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
-  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for this student here."
+  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for your student here."
   And I wait until element ".editor-column" contains text "This student has not started the level."
   Then I see no difference for "student not started warning"
   And I close my eyes
@@ -35,7 +35,7 @@ Scenario: Maze level where student has not started
   And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
-  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for this student here."
+  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for your student here."
   And I wait until element ".editor-column" contains text "This student has not started the level."
   Then I see no difference for "student not started warning"
   And I close my eyes
@@ -53,7 +53,7 @@ Scenario: Contained level
   And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
-  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for this student here."
+  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for your student here."
   And I wait until element ".editor-column" does not contain text "This student has not started the level."
   Then I see no difference for "no student not started warning"
   And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
@@ -2,7 +2,7 @@
 Feature: Student Has Not Started Level Warning
 
   Background:
-    Given I create a teacher-associated student named "Sally"
+    Given I create an authorized teacher-associated student named "Sally"
 
 Scenario: Game lab level where student has not started
   When I open my eyes to test "game lab student has not started"

--- a/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
@@ -35,7 +35,6 @@ Scenario: Maze level where student has not started
   And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
-  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for your student here."
   And I wait until element ".editor-column" contains text "This student has not started the level."
   Then I see no difference for "student not started warning"
   And I close my eyes
@@ -53,7 +52,6 @@ Scenario: Contained level
   And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
-  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for your student here."
   And I wait until element ".editor-column" does not contain text "This student has not started the level."
   Then I see no difference for "no student not started warning"
   And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
@@ -17,6 +17,7 @@ Scenario: Game lab level where student has not started
   And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
+  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for this student here."
   And I wait until element ".editor-column" contains text "This student has not started the level."
   Then I see no difference for "student not started warning"
   And I close my eyes
@@ -34,6 +35,7 @@ Scenario: Maze level where student has not started
   And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
+  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for this student here."
   And I wait until element ".editor-column" contains text "This student has not started the level."
   Then I see no difference for "student not started warning"
   And I close my eyes
@@ -51,6 +53,7 @@ Scenario: Contained level
   And I click selector "#teacher-panel-container tr:eq(1)" to load a new page
   And I wait for the lab page to fully load
 
+  And I wait until element "#ui-test-feedback-input" contains placeholder text "Please enter feedback for this student here."
   And I wait until element ".editor-column" does not contain text "This student has not started the level."
   Then I see no difference for "no student not started warning"
   And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
@@ -2,7 +2,7 @@
 Feature: Student Has Not Started Level Warning
 
   Background:
-    Given I create an authorized teacher-associated student named "Sally"
+    Given I create a teacher-associated student named "Sally"
 
 Scenario: Game lab level where student has not started
   When I open my eyes to test "game lab student has not started"


### PR DESCRIPTION
See [slack](https://codedotorg.slack.com/archives/C045UAX4WKH/p1749835387536669). deflake this eyes test by explicitly checking flaky for behavior using a UI test step, which we automatically retry on failure, rather than allowing it to cause an eyes mismatch, which we do not retry.

