### PR TITLE
fix(header): increase css specificity of caret in header

### DIFF
--- a/apps/src/code-studio/components/header/header-popup.module.scss
+++ b/apps/src/code-studio/components/header/header-popup.module.scss
@@ -18,7 +18,7 @@
   padding: 2px;
 }
 
-.caret {
+button .caret {
   font-size: 40px;
   line-height: 20px;
 }


### PR DESCRIPTION
The caret is being overridden by `fontawesome.css` now that it is loaded async and has higher speficity. Making the selector more spefcic fixes the ordering issue.

Before:

![image](https://github.com/user-attachments/assets/ddf6aca6-4631-4f41-b752-296d94f38848)

After: 

![image](https://github.com/user-attachments/assets/a81fc395-f5be-45af-9e46-f2d5e27b7443)
