### PR TITLE
feat(marketing): add Double the Donation search form component

### DIFF
--- a/frontend/apps/marketing/.env.example
+++ b/frontend/apps/marketing/.env.example
@@ -59,15 +59,6 @@ STATSIG_CLIENT_KEY=
 # See: https://docs.statsig.com/sdk-keys/api-keys/
 STATSIG_SERVER_KEY=
 
-##################################################
-# Double the Donation Employee Match Search Form #
-##################################################
-
-# The public API key for Double the Donation
-# Used for the Double the Donation integration on code.org/donate
-# See: https://support.doublethedonation.com/knowledge/getting-started-understanding-api-keys
-NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY=
-
 ############################################
 # OpenTelemetry Environment Variables      #
 # Disabled by default, uncomment to enable #

--- a/frontend/apps/marketing/.env.example
+++ b/frontend/apps/marketing/.env.example
@@ -59,6 +59,15 @@ STATSIG_CLIENT_KEY=
 # See: https://docs.statsig.com/sdk-keys/api-keys/
 STATSIG_SERVER_KEY=
 
+##################################################
+# Double the Donation Employee Match Search Form #
+##################################################
+
+# The public API key for Double the Donation
+# Used for the Double the Donation integration on code.org/donate
+# See: https://support.doublethedonation.com/knowledge/getting-started-understanding-api-keys
+NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY=
+
 ############################################
 # OpenTelemetry Environment Variables      #
 # Disabled by default, uncomment to enable #

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -327,7 +327,7 @@ Resources:
             - Name: NEXT_PUBLIC_STAGE
               Value: !Ref EnvironmentType
             - Name: NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY
-              Value: !Ref EnvironmentType
+              Value: 4RoxGGsUoWBRMUfj
             - Name: NEXT_PUBLIC_INSTRUMENTATION_ENABLED
               Value: "true"
             - Name: OTEL_SERVICE_NAME

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -326,8 +326,6 @@ Resources:
               Value: experience
             - Name: NEXT_PUBLIC_STAGE
               Value: !Ref EnvironmentType
-            - Name: NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY
-              Value: 4RoxGGsUoWBRMUfj
             - Name: NEXT_PUBLIC_INSTRUMENTATION_ENABLED
               Value: "true"
             - Name: OTEL_SERVICE_NAME

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -326,6 +326,8 @@ Resources:
               Value: experience
             - Name: NEXT_PUBLIC_STAGE
               Value: !Ref EnvironmentType
+            - Name: NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY
+              ValueFrom: !Sub "${WebApplicationServerSecretsARN}:NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY::"
             - Name: NEXT_PUBLIC_INSTRUMENTATION_ENABLED
               Value: "true"
             - Name: OTEL_SERVICE_NAME

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -327,7 +327,7 @@ Resources:
             - Name: NEXT_PUBLIC_STAGE
               Value: !Ref EnvironmentType
             - Name: NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY
-              ValueFrom: !Sub "${WebApplicationServerSecretsARN}:NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY::"
+              Value: !Ref EnvironmentType
             - Name: NEXT_PUBLIC_INSTRUMENTATION_ENABLED
               Value: "true"
             - Name: OTEL_SERVICE_NAME

--- a/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonation.tsx
+++ b/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonation.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React, {useEffect, useState} from 'react';
+
+import {BodyOneText} from '@code-dot-org/component-library/typography';
+
+import {getEnv} from '@/providers/environment';
+
+declare global {
+  interface Window {
+    DDCONF?: {API_KEY: string};
+  }
+}
+
+const DoubleTheDonationSearch: React.FC = () => {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+
+    if (typeof window !== 'undefined') {
+      window.DDCONF = {
+        API_KEY: getEnv('NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY') ?? '',
+      };
+
+      const script = document.createElement('script');
+      script.src = 'https://doublethedonation.com/api/js/ddplugin.js';
+      script.async = true;
+      document.body.appendChild(script);
+
+      return () => {
+        if (document.body.contains(script)) {
+          document.body.removeChild(script);
+        }
+      };
+    }
+  }, []);
+
+  if (!isClient) {
+    return (
+      <div id="dd-container">
+        <BodyOneText>
+          Loading Double the Donation employee match search form...
+        </BodyOneText>
+      </div>
+    );
+  }
+
+  return (
+    <div id="dd-container">
+      <a href="https://doublethedonation.com/matching-grant-resources/matching-gift-basics/">
+        Matching Gift
+      </a>
+      {' and '}
+      <a href="https://doublethedonation.com/matching-grant-resources/volunteer-grant-basics/">
+        Volunteer Grant
+      </a>
+      {' information provided by '}
+      <br />
+      <a href="https://doublethedonation.com">
+        <img
+          alt="Powered by Double the Donation"
+          src="https://doublethedonation.com/api/img/powered-by.png"
+        />
+      </a>
+    </div>
+  );
+};
+
+export default DoubleTheDonationSearch;

--- a/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonation.tsx
+++ b/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 
 import {BodyOneText} from '@code-dot-org/component-library/typography';
 
@@ -13,11 +13,7 @@ declare global {
 }
 
 const DoubleTheDonationSearch: React.FC = () => {
-  const [isClient, setIsClient] = useState(false);
-
   useEffect(() => {
-    setIsClient(true);
-
     if (typeof window !== 'undefined') {
       window.DDCONF = {
         API_KEY: DOUBLE_THE_DONATION_PUBLIC_KEY,
@@ -36,7 +32,7 @@ const DoubleTheDonationSearch: React.FC = () => {
     }
   }, []);
 
-  if (!isClient) {
+  if (typeof window === 'undefined') {
     return (
       <div id="dd-container">
         <BodyOneText>

--- a/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonation.tsx
+++ b/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonation.tsx
@@ -4,7 +4,7 @@ import React, {useEffect, useState} from 'react';
 
 import {BodyOneText} from '@code-dot-org/component-library/typography';
 
-import {getEnv} from '@/providers/environment';
+import {DOUBLE_THE_DONATION_PUBLIC_KEY} from '@/config/doubleTheDonation';
 
 declare global {
   interface Window {
@@ -20,7 +20,7 @@ const DoubleTheDonationSearch: React.FC = () => {
 
     if (typeof window !== 'undefined') {
       window.DDCONF = {
-        API_KEY: getEnv('NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY') ?? '',
+        API_KEY: DOUBLE_THE_DONATION_PUBLIC_KEY,
       };
 
       const script = document.createElement('script');

--- a/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonationContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonationContentfulDefinition.ts
@@ -6,12 +6,12 @@ export const DoubleTheDonationContentfulComponentDefinition: ComponentDefinition
     name: 'Double the Donation',
     category: '08: Advanced',
     thumbnailUrl:
-      'https://contentful-images.code.org/90t6bu6vlf76/1KBqVuN3E8F9xCfpqm9mDh/1a0aaa4e1580355e7b696b0512303155/component_afe_icon.png',
+      'https://contentful-images.code.org/90t6bu6vlf76/74ExwNwZ0rUACiixPFxPKE/3d911e35a139d451127228c2f78ce12f/component_double_the_donation_icon.png',
     tooltip: {
       description:
         'Embeds the Double the Donation employee match search form. This component is case-specific and intended for use on a specific page only.',
       imageUrl:
-        'https://contentful-images.code.org/90t6bu6vlf76/45xOdiOzDWKEs3AZDL8fSe/c79d09ed7bd7a82488fb7e75e83db715/component_afe_tooltip.png',
+        'https://contentful-images.code.org/90t6bu6vlf76/1yEmxilfATc6AqePRADl2h/23ffdc94ca3f7d1c86e9d7f51a9e6286/component_double_the_donation_tooltip.png',
     },
     variables: {},
   };

--- a/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonationContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/doubleTheDonation/DoubleTheDonationContentfulDefinition.ts
@@ -1,0 +1,17 @@
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+export const DoubleTheDonationContentfulComponentDefinition: ComponentDefinition =
+  {
+    id: 'doubleTheDonation',
+    name: 'Double the Donation',
+    category: '08: Advanced',
+    thumbnailUrl:
+      'https://contentful-images.code.org/90t6bu6vlf76/1KBqVuN3E8F9xCfpqm9mDh/1a0aaa4e1580355e7b696b0512303155/component_afe_icon.png',
+    tooltip: {
+      description:
+        'Embeds the Double the Donation employee match search form. This component is case-specific and intended for use on a specific page only.',
+      imageUrl:
+        'https://contentful-images.code.org/90t6bu6vlf76/45xOdiOzDWKEs3AZDL8fSe/c79d09ed7bd7a82488fb7e75e83db715/component_afe_tooltip.png',
+    },
+    variables: {},
+  };

--- a/frontend/apps/marketing/src/components/contentful/doubleTheDonation/__tests__/DoubleTheDonation.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/doubleTheDonation/__tests__/DoubleTheDonation.test.tsx
@@ -1,9 +1,11 @@
 import {render, waitFor, cleanup} from '@testing-library/react';
 
+import {DOUBLE_THE_DONATION_PUBLIC_KEY} from '@/config/doubleTheDonation';
+
 import DoubleTheDonationSearch from '../DoubleTheDonation';
 
 jest.mock('@/providers/environment', () => ({
-  getEnv: jest.fn(() => 'test-api-key'),
+  getEnv: jest.fn(() => DOUBLE_THE_DONATION_PUBLIC_KEY),
 }));
 
 describe('DoubleTheDonationSearch', () => {
@@ -18,7 +20,7 @@ describe('DoubleTheDonationSearch', () => {
     render(<DoubleTheDonationSearch />);
     await waitFor(() => {
       expect(window.DDCONF).toBeDefined();
-      expect(window.DDCONF?.API_KEY).toBe('test-api-key');
+      expect(window.DDCONF?.API_KEY).toBe(DOUBLE_THE_DONATION_PUBLIC_KEY);
       const script = Array.from(document.getElementsByTagName('script')).find(
         s => s.src === 'https://doublethedonation.com/api/js/ddplugin.js',
       );

--- a/frontend/apps/marketing/src/components/contentful/doubleTheDonation/__tests__/DoubleTheDonation.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/doubleTheDonation/__tests__/DoubleTheDonation.test.tsx
@@ -1,0 +1,46 @@
+import {render, waitFor, cleanup} from '@testing-library/react';
+
+import DoubleTheDonationSearch from '../DoubleTheDonation';
+
+jest.mock('@/providers/environment', () => ({
+  getEnv: jest.fn(() => 'test-api-key'),
+}));
+
+describe('DoubleTheDonationSearch', () => {
+  beforeEach(() => {
+    // Remove any previously injected script
+    cleanup();
+    // Reset global DDCONF
+    delete window.DDCONF;
+  });
+
+  it('sets window.DDCONF and injects script after mount', async () => {
+    render(<DoubleTheDonationSearch />);
+    await waitFor(() => {
+      expect(window.DDCONF).toBeDefined();
+      expect(window.DDCONF?.API_KEY).toBe('test-api-key');
+      const script = Array.from(document.getElementsByTagName('script')).find(
+        s => s.src === 'https://doublethedonation.com/api/js/ddplugin.js',
+      );
+      expect(script).toBeTruthy();
+    });
+  });
+
+  it('removes the injected script on unmount', async () => {
+    const {unmount} = render(<DoubleTheDonationSearch />);
+    let script: HTMLScriptElement | undefined;
+    await waitFor(() => {
+      script = Array.from(document.getElementsByTagName('script')).find(
+        s => s.src === 'https://doublethedonation.com/api/js/ddplugin.js',
+      );
+      expect(script).toBeTruthy();
+    });
+    unmount();
+    await waitFor(() => {
+      script = Array.from(document.getElementsByTagName('script')).find(
+        s => s.src === 'https://doublethedonation.com/api/js/ddplugin.js',
+      );
+      expect(script).toBeFalsy();
+    });
+  });
+});

--- a/frontend/apps/marketing/src/components/contentful/doubleTheDonation/index.ts
+++ b/frontend/apps/marketing/src/components/contentful/doubleTheDonation/index.ts
@@ -1,0 +1,3 @@
+// Export the Component Definition for use in Contentful Studio
+export {DoubleTheDonationContentfulComponentDefinition} from './DoubleTheDonationContentfulDefinition';
+export {default as default} from './DoubleTheDonation';

--- a/frontend/apps/marketing/src/config/doubleTheDonation.ts
+++ b/frontend/apps/marketing/src/config/doubleTheDonation.ts
@@ -1,0 +1,4 @@
+// The public API key for Double the Donation
+// Used for the Double the Donation integration on code.org/donate
+// See: https://support.doublethedonation.com/knowledge/getting-started-understanding-api-keys
+export const DOUBLE_THE_DONATION_PUBLIC_KEY = '4RoxGGsUoWBRMUfj';

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -29,6 +29,8 @@ import VideoCarousel, {
 import Divider, {
   DividerContentfulComponentDefinition,
 } from '@/components/contentful/divider';
+import {DoubleTheDonationContentfulComponentDefinition} from '@/components/contentful/doubleTheDonation';
+import DoubleTheDonation from '@/components/contentful/doubleTheDonation/DoubleTheDonation';
 import EditorialCard, {
   EditorialCardContentfulComponentDefinition,
 } from '@/components/contentful/editorialCard';
@@ -119,6 +121,11 @@ defineComponents(
         wrapContainerWidth: '100%',
       },
     },
+    {
+      component: DoubleTheDonation,
+      definition: DoubleTheDonationContentfulComponentDefinition,
+    },
+
     {
       component: EditorialCard,
       definition: EditorialCardContentfulComponentDefinition,

--- a/frontend/apps/marketing/src/providers/environment/EnvironmentLoader.tsx
+++ b/frontend/apps/marketing/src/providers/environment/EnvironmentLoader.tsx
@@ -5,8 +5,6 @@ import {PUBLIC_ENV_KEY} from '@/providers/environment/constants';
 const EnvironmentLoader = () => {
   const publicEnvironmentVariables = {
     NEXT_PUBLIC_STAGE: process.env.NEXT_PUBLIC_STAGE,
-    NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY:
-      process.env.NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY,
   };
 
   return (

--- a/frontend/apps/marketing/src/providers/environment/EnvironmentLoader.tsx
+++ b/frontend/apps/marketing/src/providers/environment/EnvironmentLoader.tsx
@@ -5,6 +5,8 @@ import {PUBLIC_ENV_KEY} from '@/providers/environment/constants';
 const EnvironmentLoader = () => {
   const publicEnvironmentVariables = {
     NEXT_PUBLIC_STAGE: process.env.NEXT_PUBLIC_STAGE,
+    NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY:
+      process.env.NEXT_PUBLIC_DOUBLE_THE_DONATION_KEY,
   };
 
   return (


### PR DESCRIPTION
Adds a custom component for the Double the Donation employee match form on Contentful. This component will be used on the code.org/donate page. 

## Links
Jira ticket: [CMS-707](https://codedotorg.atlassian.net/browse/CMS-707)
Slack convo re: API key: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1750093941503399)
Plugin instructions: [here](https://doublethedonation.com/members/#/setup/plugin-settings)

## Testing story
Tested locally on Contentful and added unit tests

----
 

https://github.com/user-attachments/assets/d6181c49-e991-4093-9499-0756a0b17500

<img width="546" alt="Screenshot 2025-06-16 at 11 45 29 AM" src="https://github.com/user-attachments/assets/41023e4d-819f-4ae5-b8b0-65aa73b62077" />


