### PR TITLE
P20-1541/Handle LTI sync failing silently for users with multiple user identities

### DIFF
--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -8,8 +8,11 @@ class Queries::Lti
   end
 
   # Returns the LTI user id for a particular code.org user and LTI integration
-  def self.lti_user_id(user, lti_integration)
-    user.lti_user_identities.find_by(lti_integration_id: lti_integration.id)&.subject
+  def self.lti_user_ids(user, lti_integration)
+    user.lti_user_identities.
+        where(lti_integration_id: lti_integration.id).
+        pluck(:subject).
+        presence
   end
 
   def self.lti_user_identity(user, lti_integration)

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -83,11 +83,16 @@ module Services
     end
 
     def self.lti_user_type(current_user, lti_integration, nrps_section)
-      lti_user_id = Queries::Lti.lti_user_id(current_user, lti_integration)
-      member_roles = lti_user_roles(nrps_section, lti_user_id)
+      lti_user_ids = Queries::Lti.lti_user_ids(current_user, lti_integration)
 
-      if Policies::Lti.lti_teacher?(member_roles)
-        return ::User::TYPE_TEACHER
+      return ::User::TYPE_STUDENT unless lti_user_ids
+
+      # Check if any of the user's LTI IDs have teacher roles
+      lti_user_ids.each do |lti_user_id|
+        member_roles = lti_user_roles(nrps_section, lti_user_id)
+        if Policies::Lti.lti_teacher?(member_roles)
+          return ::User::TYPE_TEACHER
+        end
       end
 
       return ::User::TYPE_STUDENT

--- a/dashboard/test/lib/queries/lti_test.rb
+++ b/dashboard/test/lib/queries/lti_test.rb
@@ -75,19 +75,23 @@ class Services::LtiTest < ActiveSupport::TestCase
     assert_equal lti_course, Queries::Lti.find_or_create_lti_course(lti_integration_id: lti_integration.id, context_id: lti_course.context_id, deployment_id: 'deployment-id', nrps_url: 'http://some-nrps-url.com', resource_link_id: 'rlid')
   end
 
-  test 'lti_user_id should return the subject (user id) for a given user' do
+  test 'lti_user_ids should return the subjects (user id) for a given user' do
     lti_integration = create :lti_integration
     lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
 
-    assert_equal "subject", Queries::Lti.lti_user_id(lti_user_identity.user, lti_integration)
+    assert_equal ["subject"], Queries::Lti.lti_user_ids(lti_user_identity.user, lti_integration)
+
+    # Returns all subjects if a user has more than one with a matching lti_integration
+    create :lti_user_identity, lti_integration: lti_integration, user: lti_user_identity.user, subject: 'subject2'
+    assert_equal ["subject", "subject2"], Queries::Lti.lti_user_ids(lti_user_identity.user, lti_integration)
   end
 
-  test 'lti_user_id should return nil if there are no matching identities' do
+  test 'lti_user_ids should return nil if there are no matching identities' do
     lti_integration = create :lti_integration
     other_lti_integration = create :lti_integration
     lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
 
-    assert_nil Queries::Lti.lti_user_id(lti_user_identity.user, other_lti_integration)
+    assert_nil Queries::Lti.lti_user_ids(lti_user_identity.user, other_lti_integration)
   end
 
   test 'lti_user_identity should return the lti_user_identity for a given user' do

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -704,6 +704,30 @@ class Services::LtiTest < ActiveSupport::TestCase
     assert lti_course.reload.sections.length, 2
   end
 
+  test 'should sync if user has multiple LTI identities with one that is the instructor' do
+    teacher = create :teacher
+    lti_user_id1 = create :lti_user_identity, lti_integration: @lti_integration, user: teacher, subject: 'student-0'
+    lti_user_id2 = create :lti_user_identity, lti_integration: @lti_integration, user: teacher, subject: 'user-id-1'
+    auth_id1 = @lti_integration.issuer + "|" + @lti_integration.client_id + "|" + lti_user_id1.subject
+    auth_id2 = @lti_integration.issuer + "|" + @lti_integration.client_id + "|" + lti_user_id2.subject
+    teacher.authentication_options << build(:lti_authentication_option, authentication_id: auth_id1, user: teacher)
+    teacher.authentication_options << build(:lti_authentication_option, authentication_id: auth_id2, user: teacher)
+    teacher.save
+    Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
+
+    lti_course = create :lti_course, lti_integration: @lti_integration
+    create :lti_section, lti_course: lti_course
+    parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
+
+    Services::Lti.sync_course_roster(lti_integration: @lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
+    assert lti_course.reload.sections.length, 3
+
+    # Make changes and sync again
+    parsed_response.delete(@lms_section_ids.first.to_s)
+    Services::Lti.sync_course_roster(lti_integration: @lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
+    assert lti_course.reload.sections.length, 2
+  end
+
   test 'should add or remove sections when syncing a course' do
     teacher = create :teacher
     lti_integration = create :lti_integration
@@ -786,5 +810,15 @@ class Services::LtiTest < ActiveSupport::TestCase
     user_type = Services::Lti.lti_user_type(teacher, lti_integration, @nrps_full_response)
 
     assert_equal User::TYPE_STUDENT, user_type
+  end
+
+  test 'lti_user_type should return teacher if any LTI user role is instructor' do
+    teacher = create :teacher
+    lti_integration = create :lti_integration
+    create :lti_user_identity, lti_integration: lti_integration, user: teacher, subject: 'student-0'
+    create :lti_user_identity, lti_integration: lti_integration, user: teacher, subject: 'user-id-1'
+    user_type = Services::Lti.lti_user_type(teacher, lti_integration, @nrps_full_response)
+
+    assert_equal User::TYPE_TEACHER, user_type
   end
 end


### PR DESCRIPTION
The LTI roster sync feature only syncs sections when we determine the current user to be the owner of the LTI course being synced. The responsible query assumes a user will only have a single LTI user identity for a given LTI integration, so it used `find_by`, which will return the first matching record. If a user has multiple matching LTI user identities, records other than the first were never returned. Even if a subsequent record matches the subject that owns the course, the system would erroneously determine that the user does not own the course, and will not sync it.

This PR changes the underlying query to use `where` instead and updates the method to handle an array of subjects.

## Links
- Jira: [P20-1541](https://codedotorg.atlassian.net/browse/P20-1541)

## Testing story
Added and modified unit tests as well as manually verified:

- [x] A teacher with one LTI user identity is still **able** to sync
- [x] A student is still **unable** to sync
- [x] A teacher with multiple LTI user identities where the first LTI user identity is NOT the instructor identity, but a subsequent LTI user identity is
