### PR TITLE
Extend MySQL client Timeout Outside Web Application Servers

### DIFF
--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -73,6 +73,11 @@ environment_defaults: &environment_defaults
   primary_reporting:
     replica: true
     <<: *mysql_defaults
+    <% if !CDO.running_web_application?
+    # Set the MySQL client timeout to 10 minutes for reporting queries that are not executing within a web application server
+    # such as queries executing in an ActiveJob worker, a cron job, or irb (dashboard-console).
+    read_timeout: 600
+    %>
     host: <%= CDO.db_endpoint_proxy_reporting %>
     port: <%= CDO.db_endpoint_proxy_reporting_port %>
     username: <%= CDO.db_credential_reader['username'] %>

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -78,7 +78,7 @@ environment_defaults: &environment_defaults
   primary_reporting:
     replica: true
     <<: *mysql_defaults
-    <% if !CDO.running_web_application? %>
+    <% unless CDO.running_web_application? %>
     # Set the MySQL client timeout to 10 minutes for reporting queries that are not executing within a web application server
     # such as queries executing in an ActiveJob worker, a cron job, or irb (dashboard-console).
     read_timeout: 600

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -42,7 +42,12 @@ mysql_defaults: &mysql_defaults
   # You can set the value so that a lost connection can be detected earlier than the TCP/IP Close_Wait_Timeout value of 10 minutes.
   #
   # NOTE: mysql2 reuses this variable as a query timeout without retry, so set it to the maximum query execution time.
-  read_timeout: 30
+  #
+  # Set the MySQL client timeout to 2 minutes for SQL statements that are not executing within a web application server
+  # such as queries executing in an ActiveJob worker, a cron job, or irb (dashboard-console). This is particularly
+  # important for database migrations (DDL) or database seeding SQL statements that can take longer than 30 seconds
+  # to complete and are executed by the aws/ci_build cron job.
+  read_timeout: <%= CDO.running_web_application? ? 30 : 120 %>
 
   # `MYSQL_OPT_WRITE_TIMEOUT`: The timeout in seconds for each attempt to write to the server.
   # There is a retry if necessary, so the total effective timeout value is two times the option value.
@@ -60,13 +65,6 @@ environment_defaults: &environment_defaults
   primary_replica:
     replica: true
     <<: *mysql_defaults
-    <% if !CDO.running_web_application?
-    # Set the MySQL client timeout to 2 minutes for SQL statements that are not executing within a web application server
-    # such as queries executing in an ActiveJob worker, a cron job, or irb (dashboard-console). This is particularly
-    # important for database migrations (DDL) or database seeding SQL statements that can take longer than 30 seconds
-    # to complete and are executed by the aws/ci_build cron job.
-    read_timeout: 120
-    %>
     database: <%= reader.path.sub(%r{^/},"") %>
     host: <%= reader.host %>
     password: <%= reader.password %>
@@ -80,11 +78,11 @@ environment_defaults: &environment_defaults
   primary_reporting:
     replica: true
     <<: *mysql_defaults
-    <% if !CDO.running_web_application?
+    <% if !CDO.running_web_application? %>
     # Set the MySQL client timeout to 10 minutes for reporting queries that are not executing within a web application server
     # such as queries executing in an ActiveJob worker, a cron job, or irb (dashboard-console).
     read_timeout: 600
-    %>
+    <% end %>
     host: <%= CDO.db_endpoint_proxy_reporting %>
     port: <%= CDO.db_endpoint_proxy_reporting_port %>
     username: <%= CDO.db_credential_reader['username'] %>

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -60,6 +60,13 @@ environment_defaults: &environment_defaults
   primary_replica:
     replica: true
     <<: *mysql_defaults
+    <% if !CDO.running_web_application?
+    # Set the MySQL client timeout to 2 minutes for SQL statements that are not executing within a web application server
+    # such as queries executing in an ActiveJob worker, a cron job, or irb (dashboard-console). This is particularly
+    # important for database migrations (DDL) or database seeding SQL statements that can take longer than 30 seconds
+    # to complete and are executed by the aws/ci_build cron job.
+    read_timeout: 120
+    %>
     database: <%= reader.path.sub(%r{^/},"") %>
     host: <%= reader.host %>
     password: <%= reader.password %>


### PR DESCRIPTION
Follow up to #66503 
Now that ActiveRecord can use the reporting database, enable a longer MySQL client timeout for long running SELECT statements when they're not being executed within a web application server.

Also extend MySQL client timeout for the `primary` Rails database when NOT executing within a web application server. This is particularly important for ensuring that SQL statements executed by the build process (`aws/ci_build` cron job) that carry out schema changes (DDL) or that seed the database do not inadvertently terminate the build when a statement takes longer than 30 seconds to complete. For example, we may be able to re-enable seeding of `level_skills` on adhocs when this is merged (see #66610).

## Testing story

`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-mysql-client-timeout`

in `/var/log/chef-bootstrap-debug.log` on the adhoc's EC2 Instance we see that seeding of `level_skills` completed successfully, when previously it was executing at least one SQL statement that took longer than 30 seconds to complete:
```
Finished seed:levels_skills (37 seconds)
```

In the Ruby irb (`dashboard-console`) on an adhoc provisioned with an RDS cluster we can confirm that reporting connections work as expected:
```
Loading adhoc environment (Rails 6.1.7.7)
[adhoc] dashboard *   variables = ActiveRecord::Base.connected_to(role: :reporting) do
[adhoc] dashboard "     ActiveRecord::Base.connection.exec_query(<<~SQL)
[adhoc] dashboard "       SELECT
[adhoc] dashboard "         @@max_execution_time as max_execution_time,
[adhoc] dashboard "         @@aurora_read_replica_read_committed as aurora_read_replica_read_committed,
[adhoc] dashboard "         @@read_only as read_only,
[adhoc] dashboard "         @@aurora_server_id as aurora_server_id,
[adhoc] dashboard "         SLEEP(35) as sleep_result,
[adhoc] dashboard "         NOW() as completion_time
[adhoc] dashboard *     SQL
[adhoc] dashboard >   end.first
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
=>
{"max_execution_time"=>0,
...
[adhoc] dashboard > variables
=>
{"max_execution_time"=>0,
 "aurora_read_replica_read_committed"=>1,
 "read_only"=>0,
 "aurora_server_id"=>"adhoc-mysql-client-timeout-rds2-1",
 "sleep_result"=>0,
 "completion_time"=>2025-06-24 20:14:09 UTC}
```

Writer Role can execute SQL statements that take up to 120 seconds when executing outside the web application server:
```
[adhoc] dashboard *   writer_mysql_variables = ActiveRecord::Base.connected_to(role: :writing) do
[adhoc] dashboard "     ActiveRecord::Base.connection.exec_query(<<~SQL)
[adhoc] dashboard "       SELECT
[adhoc] dashboard "         @@max_execution_time as max_execution_time,
[adhoc] dashboard "         @@aurora_read_replica_read_committed as aurora_read_replica_read_committed,
[adhoc] dashboard "         @@read_only as read_only,
[adhoc] dashboard "         @@aurora_server_id as aurora_server_id,
[adhoc] dashboard "         SLEEP(35) as sleep_result,
[adhoc] dashboard "         NOW() as completion_time
[adhoc] dashboard *     SQL
[adhoc] dashboard >   end.first
=>
{"max_execution_time"=>30000,
...
[adhoc] dashboard > writer_mysql_variables
=>
{"max_execution_time"=>30000,
 "aurora_read_replica_read_committed"=>0,
 "read_only"=>0,
 "aurora_server_id"=>"adhoc-mysql-client-timeout-rds2-0",
 "sleep_result"=>1,
 "completion_time"=>2025-06-24 20:28:31 UTC}
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
