### PR TITLE
Ensure new Lambda Version is published if source has changed

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -433,6 +433,13 @@ Resources:
     Properties:
       FunctionName: !Ref MarketingRouterLambda
       Description: "Code hash: <%= marketing_router_package[:content_hash] %>"
+  # Create an Alias to make it easier to monitor Metrics in CloudWatch.
+  MarketingRouterAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Ref MarketingRouterLambda
+      FunctionVersion: !GetAtt MarketingRouterVersion.Version
+      Name: LIVE
   MarketingRouterLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -426,6 +426,7 @@ Resources:
     Type: AWS::Lambda::Version
     Properties:
       FunctionName: !Ref MarketingRouterLambda
+      CodeSha256: !GetAtt MarketingRouterLambda.CodeSha256
   MarketingRouterLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -410,12 +410,18 @@ Resources:
 
 <%   if cdn_enabled && app == 'Pegasus' -%>
 <%=    component 'www_redirect', app: app -%>
+<%
+       marketing_router_package = zip_directory(
+         'marketing-router',
+         environment_variables: {marketingDomain: INTERNAL_MARKETING_DOMAIN_NAME}
+       )
+%>
   MarketingRouterLambda:
     Type: AWS::Lambda::Function
     Properties:
-      Description: 'Lambda for dynamically routing marketing traffic to different origins based on the URL path'
+      Description: 'Lambda for dynamically routing Corporate website traffic to new NextJS/Contentful system based on the URL path.'
       FunctionName: !Sub "${AWS::StackName}-marketing-router"
-      Code: <%=zip_directory('marketing-router', environment_variables: {marketingDomain: INTERNAL_MARKETING_DOMAIN_NAME}) %>
+      Code: <%= marketing_router_package[:s3_location].to_json %>
       Handler: index.handler
       Runtime: nodejs22.x
       Role: !GetAtt MarketingRouterLambdaRole.Arn
@@ -426,6 +432,7 @@ Resources:
     Type: AWS::Lambda::Version
     Properties:
       FunctionName: !Ref MarketingRouterLambda
+      Description: "Code hash: <%= marketing_router_package[:content_hash] %>"
   MarketingRouterLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -426,7 +426,6 @@ Resources:
     Type: AWS::Lambda::Version
     Properties:
       FunctionName: !Ref MarketingRouterLambda
-      CodeSha256: !GetAtt MarketingRouterLambda.CodeSha256
   MarketingRouterLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -8,7 +8,6 @@ const marketingDomain = env.marketingDomain
 const marketingPaths = {
   // Add key-value pairs for each path that should be served by the CMS
   // e.g. '/videos': true,
-  '/test/lambda/version/remove/me',
   '/en-US/engineering/all-the-things': true,
   // P-0-1
   "/about/supporters/amazon": true,

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -8,6 +8,7 @@ const marketingDomain = env.marketingDomain
 const marketingPaths = {
   // Add key-value pairs for each path that should be served by the CMS
   // e.g. '/videos': true,
+  '/test/lambda/version/remove/me',
   '/en-US/engineering/all-the-things': true,
   // P-0-1
   "/about/supporters/amazon": true,

--- a/lib/cdo/cloud_formation/lambda.rb
+++ b/lib/cdo/cloud_formation/lambda.rb
@@ -66,7 +66,7 @@ module Cdo::CloudFormation
     # @param key_prefix [String] String to prefix on zip package filename (object key) before uploading to S3.
     # @return [String] JSON Deployment package https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html
     def zip_directory(relative_directory, environment_variables: {}, key_prefix: 'lambda')
-      absolute_directory = aws_dir('cloudformation/lambdas' + '//' + relative_directory)
+      absolute_directory = aws_dir(File.join('cloudformation/lambdas', relative_directory))
       raise "#{absolute_directory} is not a file system directory." unless File.directory?(absolute_directory)
 
       env_json_path = File.join(absolute_directory, 'env.json')
@@ -124,7 +124,8 @@ module Cdo::CloudFormation
           raise "Generated Lambda zip is empty! Directory: #{absolute_directory}"
         end
 
-        key = "#{key_prefix}-#{hash}.zip"
+        # Include relative_directory in the S3 key for better debugging
+        key = "#{key_prefix}-#{relative_directory}-#{hash}.zip"
 
         s3_client = Aws::S3::Client.new(http_read_timeout: 30)
         object_exists = begin

--- a/lib/cdo/cloud_formation/lambda.rb
+++ b/lib/cdo/cloud_formation/lambda.rb
@@ -57,14 +57,24 @@ module Cdo::CloudFormation
       RakeUtils.system("cd #{absolute_directory} && npm ci --only=prod")
     end
 
-    # Zip a directory containing a Lambda's source code and dependencies, upload to S3, and return the S3 location
-    # to assist in populating the `Code` Property of a CloudFormation template `AWS::Lambda::Function` Resource.
+    # Zip a directory containing a Lambda's source code and dependencies, upload to S3, and return both the S3 location
+    # and content hash to assist in populating CloudFormation template resources for AWS::Lambda::Function and AWS::Lambda::Version.
     # Assumes Lambdas are in `/aws/cloudformation/lambdas/`.
     # @param relative_directory [String] Name of Lambda directory relative to `/aws/cloudformation/lambdas`.
     # @param environment_variables [Hash] Environment variables to write to `env.json` in the zip package. This is intended
     # for use in Lambda@Edge functions greater than 4KB in size, which cannot be inlined and do not support Lambda environment variables.
     # @param key_prefix [String] String to prefix on zip package filename (object key) before uploading to S3.
-    # @return [String] JSON Deployment package https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html
+    # @return [Hash] Hash containing:
+    #   - :s3_location [Hash] S3 deployment package with :S3Bucket and :S3Key for CloudFormation Code property
+    #   - :content_hash [String] MD5 hash of directory contents for Lambda version tracking
+    # @example
+    #   result = zip_directory('my-lambda', environment_variables: {API_URL: 'https://api.example.com'})
+    #   # result[:s3_location] => {S3Bucket: 'cdo-dist', S3Key: 'lambda-my-lambda-abc123.zip'}
+    #   # result[:content_hash] => 'abc123def456...'
+    #
+    #   # Usage in CloudFormation template:
+    #   Code: <%= result[:s3_location].to_json %>
+    #   Description: "Code hash: <%= result[:content_hash] %>"
     def zip_directory(relative_directory, environment_variables: {}, key_prefix: 'lambda')
       absolute_directory = aws_dir(File.join('cloudformation/lambdas', relative_directory))
       raise "#{absolute_directory} is not a file system directory." unless File.directory?(absolute_directory)
@@ -139,10 +149,14 @@ module Cdo::CloudFormation
           s3_client.put_object({bucket: S3_LAMBDA_BUCKET, key: key, body: code_zip})
         end
 
+        # Return both S3 location and hash of source code.
         {
-          S3Bucket: S3_LAMBDA_BUCKET,
-          S3Key: key
-        }.to_json
+          s3_location: {
+            S3Bucket: S3_LAMBDA_BUCKET,
+            S3Key: key
+          },
+          content_hash: hash
+        }
       ensure
         # Clean up env.json file if we created it
         File.delete(env_json_path) if env_json_created && File.exist?(env_json_path)


### PR DESCRIPTION
Follow up to #66525
Ensure new Lambda Version is created when the source code of the Lambda changes.

## Testing story

`bundle exec rake adhoc:cdn:start RAILS_ENV=adhoc STACK_NAME=adhoc-lambda-version`

and then push a commit that changes the marketing sites router lambda source code. This successfully triggered publishing a new Lambda Version
<img width="999" alt="image" src="https://github.com/user-attachments/assets/b2126ffc-069b-4a2c-8653-7cfbb3713b1b" />


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
