### PR TITLE
[Blockly] Adding keydown listener to Shortcuts Modal

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -915,6 +915,25 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       }
 
       blocklyWrapper.KeyboardNavigation = new KeyboardNavigation(workspace);
+
+      // Now that the shortcutModal is initialized, we can add a keydown
+      // event listener to the modal to close it when the Escape key is pressed.
+      const shortcutModal = document.querySelector('.shortcut-modal');
+      if (shortcutModal) {
+        shortcutModal.addEventListener('keydown', event => {
+          const keyboardEvent = event as KeyboardEvent;
+          if (keyboardEvent.key === 'Escape') {
+            keyboardEvent.stopPropagation();
+            // Simulate a click on the close button to mimic the behavior
+            const closeButton = document.querySelector(
+              '.close-modal'
+            ) as HTMLElement;
+            if (closeButton) {
+              closeButton.click();
+            }
+          }
+        });
+      }
       // Rerun user theme after Keyboard Experiment bug introduces incorrect theme
       const theme = cdoUtils.getUserTheme(options.theme as GoogleBlockly.Theme);
       workspace.setTheme(theme);


### PR DESCRIPTION
This is a bit of a hack: Ideally their modal would already have this functionality, but it does not. They are relying on default browser functionality to enable their esc close logic, which in our case is not working or is being intercepted. This, however verbose, ensures keyboard users will always be able to close this menu regardless of browser defaults. 

Before: Can't quite capture because 'esc' just *doesn't do anything.

After: (Showed that it still appears correctly after, focus management is smooth, and you can still use the button to close)


https://github.com/user-attachments/assets/ce8ad073-5d29-482a-b842-0bbac1dd58a7



## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1477

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
