### PR TITLE
AI Tutor: fix code layout

### DIFF
--- a/apps/src/lab2/views/components/AiTutor2ResponseShrink.module.scss
+++ b/apps/src/lab2/views/components/AiTutor2ResponseShrink.module.scss
@@ -26,10 +26,6 @@
   p:not(:last-child) {
     margin-bottom: 10px;
   }
-
-  code {
-    white-space: initial;
-  }
 }
 
 .waitingAnimation {


### PR DESCRIPTION
This fixes the code layout, removing a CSS override that prevented the underlying `white-space: pre-wrap` from applying.

### before

<img width="269" alt="Screenshot 2025-06-16 at 6 44 45 PM" src="https://github.com/user-attachments/assets/047b2834-4bd1-400c-9dbb-a98c44cbd792" />

### after

<img width="269" alt="Screenshot 2025-06-16 at 6 45 01 PM" src="https://github.com/user-attachments/assets/4820b48b-70fc-4a71-9f42-f55f671af82d" />
