### PR TITLE
AI Tutor: fix more code layout

### DIFF
--- a/apps/src/lab2/views/components/AiTutor2ResponseShrink.module.scss
+++ b/apps/src/lab2/views/components/AiTutor2ResponseShrink.module.scss
@@ -26,6 +26,10 @@
   p:not(:last-child) {
     margin-bottom: 10px;
   }
+
+  code {
+    white-space: pre-wrap;
+  }
 }
 
 .waitingAnimation {


### PR DESCRIPTION
The fix in https://github.com/code-dot-org/code-dot-org/pull/66565 worked for code blocks, but not for inline code.  This change fixes the latter.

### before

<img width="277" alt="Screenshot 2025-06-17 at 10 21 44 AM" src="https://github.com/user-attachments/assets/4933aa80-75dd-4c5f-85d8-6d73def36dd1" />

### after

<img width="277" alt="Screenshot 2025-06-17 at 10 21 33 AM" src="https://github.com/user-attachments/assets/9549a408-dd76-44bf-a4a5-08f5124a98a5" />
