### PR TITLE
AI Tutor: hide hint

### DIFF
--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -85,11 +85,9 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
     predictSettings,
     submittable: isSubmittable,
     appName: appType,
-    aiTutor2Available,
   } = levelProperties;
 
-  const showAiTutor2 =
-    aiTutor2Available || queryParams('show-ai-tutor2') === 'true';
+  const showAiTutor2 = queryParams('show-ai-tutor2-hint') === 'true';
 
   const scriptId = useAppSelector(state => state.lab.scriptId);
   const hasNextLevel = useSelector(state => nextLevelId(state) !== undefined);

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -100,6 +100,8 @@ const PythonlabView: React.FunctionComponent<
     levelProperties.aiTutor2Available ||
     queryParams('show-ai-tutor2') === 'true';
 
+  const isAiTutor2HintEnabled = queryParams('show-ai-tutor2-hint') === 'true';
+
   const dispatch = useAppDispatch();
 
   const currentProjectType = useMemo(() => {
@@ -189,7 +191,7 @@ const PythonlabView: React.FunctionComponent<
   };
 
   const [askAiTutor2, AiTutor2Response] = useAiTutor2(
-    isAiTutor2Enabled,
+    isAiTutor2HintEnabled,
     getAiTutor2FullPrompt,
     'hint'
   );


### PR DESCRIPTION
With this change, the hint, which is a short Socratic question that appears under the instructions after pressing Run, no longer appears by default.  It can still be shown by adding `?show-ai-tutor2-hint=true` to the URL on a Python Lab level.
