### PR TITLE
fix(locale): fix pegasus locale mapping

### DIFF
--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -27,7 +27,7 @@ export const SUPPORTED_LOCALES = [
 
 // Map of LocalizeJS locale codes to Pegasus locale codes
 const PEGASUS_LOCALE_MAP: Record<string, string | undefined> = {
-  'en-US': 'en_US',
+  'en-US': 'en-US',
   es: 'es-MX',
   ar: 'ar-SA',
   de: 'de-DE',

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -33,11 +33,20 @@ test.describe('All the things UI e2e test', () => {
   test.describe('locale-less redirect', () => {
     test('should redirect from localeless paths to english localized paths when no language cookie is set', async ({
       page,
+      context,
     }) => {
       const allTheThingsPage = new MarketingPage(page);
       await allTheThingsPage.goto('/engineering/all-the-things');
 
       await page.waitForURL('**/en-US/engineering/all-the-things');
+
+      // Should set the language cookie to en-US
+      expect(await context.cookies()).toContainEqual(
+        expect.objectContaining({
+          name: 'language_',
+          value: 'en-US',
+        }),
+      );
     });
 
     // Re-enable when locales other than English are supported


### PR DESCRIPTION
The Pegasus equivalent of `en-US` is also `en-US` as per the [Pegasus language spreadsheet](https://github.com/code-dot-org/code-dot-org/blob/7cbc5a5934b278672ada161a71fb5729f2e079ef/pegasus/data/cdo-languages.csv#L15), updating the mapping to reflect that.