### PR TITLE
Data retention status table migration

### DIFF
--- a/dashboard/db/migrate/20250617212412_create_data_retention_status.rb
+++ b/dashboard/db/migrate/20250617212412_create_data_retention_status.rb
@@ -1,0 +1,10 @@
+class CreateDataRetentionStatus < ActiveRecord::Migration[6.1]
+  def change
+    create_table :data_retention_statuses do |t|
+      t.belongs_to :user, type: :integer, null: false, foreign_key: true, index: true
+      t.datetime :pii_scrubbed_at, null: true, index: true
+      t.datetime :anonymized_at, null: true, index: true
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_05_30_162508) do
+ActiveRecord::Schema.define(version: 2025_06_17_212412) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -553,6 +553,17 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["key"], name: "index_data_docs_on_key", unique: true
     t.index ["name"], name: "index_data_docs_on_name"
+  end
+
+  create_table "data_retention_statuses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.datetime "pii_scrubbed_at"
+    t.datetime "anonymized_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["anonymized_at"], name: "index_data_retention_statuses_on_anonymized_at"
+    t.index ["pii_scrubbed_at"], name: "index_data_retention_statuses_on_pii_scrubbed_at"
+    t.index ["user_id"], name: "index_data_retention_statuses_on_user_id"
   end
 
   create_table "datablock_storage_kvps", primary_key: ["project_id", "key"], charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
@@ -2617,6 +2628,7 @@ ActiveRecord::Schema.define(version: 2025_05_30_162508) do
   add_foreign_key "cap_user_events", "users"
   add_foreign_key "census_submission_form_maps", "census_submissions"
   add_foreign_key "census_summaries", "schools"
+  add_foreign_key "data_retention_statuses", "users"
   add_foreign_key "hint_view_requests", "users"
   add_foreign_key "learning_goal_ai_evaluations", "learning_goals"
   add_foreign_key "learning_goal_ai_evaluations", "rubric_ai_evaluations"


### PR DESCRIPTION
Migration to create the data retention status table. The timestamps in this table will serve the same role as the `purged_at` timestamp in the user table, but for the new data retention processes that are planned for deployment this summer. The new system has two phases: an initial PII scrub and then a full in-place anonymization.

This was brought up during the Platform dev discussion, and the team opted to do a new table instead of adding new fields to the User model.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1543)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Create the model file and delegation relationship in the User model. Create the service that will eventually save data into this table.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
