### PR TITLE
feat(marketing): add support for home page

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -692,12 +692,13 @@ Resources:
               - next-url
               - Accept
               - x-prerender-revalidate
-              - Host
+              - Host # Used in the withBrand middleware to determine tenant in multi-tenant setup
+              - Accept-Language # Used in the withLocale middleware to determine the user's locale
           CookiesConfig:
             CookieBehavior: whitelist
             Cookies:
               - __prerender_bypass # Next.js Draft mode
-              - location_ # Code.org user locale
+              - language_ # Used in the withLocale middleware to determine the user's locale and shared with studio.code.org
           QueryStringsConfig:
             QueryStringBehavior: none
         Comment: Cache policy for the marketing app

--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
@@ -9,6 +9,7 @@ import {notFound} from 'next/navigation';
 import Bootstrap from '@/bootstrap';
 import ContentEditorHelper from '@/components/contentEditorHelper';
 import {Brand} from '@/config/brand';
+import {SUPPORTED_LOCALE_CODES} from '@/config/locale';
 import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
 import {getExperience} from '@/contentful/get-experience';
 import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
@@ -36,14 +37,21 @@ type ExperiencePageProps = {
 
 /**
  * Activates incremental static regeneration (ISR) for this page.
- * Currently, no pages are generated at build time. Pages are rather generated using on-demand ISR.
+ * Pages in this array are pulled from Contentful at build time and will be available even if Contentful were to go down.
+ *
+ * Other pages are generated using on-demand ISR.
  */
 export async function generateStaticParams() {
-  return [];
+  return SUPPORTED_LOCALE_CODES.map(locale => ({
+    brand: Brand.CODE_DOT_ORG,
+    // '' is home page because `/` is prepended when making a request to Contentful.
+    paths: [''],
+    locale,
+  }));
 }
 
 async function getPageProps({params, searchParams}: ExperiencePageProps) {
-  const {locale = 'en-US', paths = ['home']} = (await params) || {};
+  const {locale = 'en-US', paths = ['']} = (await params) || {};
   const isDraftModeEnabled = (await draftMode()).isEnabled;
 
   const slug = getContentfulSlug(paths);

--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
@@ -9,7 +9,6 @@ import {notFound} from 'next/navigation';
 import Bootstrap from '@/bootstrap';
 import ContentEditorHelper from '@/components/contentEditorHelper';
 import {Brand} from '@/config/brand';
-import {SUPPORTED_LOCALE_CODES} from '@/config/locale';
 import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
 import {getExperience} from '@/contentful/get-experience';
 import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
@@ -37,17 +36,10 @@ type ExperiencePageProps = {
 
 /**
  * Activates incremental static regeneration (ISR) for this page.
- * Pages in this array are pulled from Contentful at build time and will be available even if Contentful were to go down.
- *
- * Other pages are generated using on-demand ISR.
+ * Currently, no pages are generated at build time. Pages are rather generated using on-demand ISR.
  */
 export async function generateStaticParams() {
-  return SUPPORTED_LOCALE_CODES.map(locale => ({
-    brand: Brand.CODE_DOT_ORG,
-    // '' is home page because `/` is prepended when making a request to Contentful.
-    paths: [''],
-    locale,
-  }));
+  return [];
 }
 
 async function getPageProps({params, searchParams}: ExperiencePageProps) {

--- a/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
@@ -87,6 +87,9 @@ describe('withLocale middleware', () => {
     expect(response?.headers.get('location')).toBe(
       'https://test.code.org/zh-TW/home',
     );
+    expect(response?.headers.get('Cache-Control')).toEqual(
+      's-maxage=3600, stale-while-revalidate=31535100',
+    );
   });
 
   it('should redirect to the locale path if no locale is present in the path but has accept-language haeder', async () => {
@@ -107,6 +110,9 @@ describe('withLocale middleware', () => {
     expect(response).toBeInstanceOf(NextResponse);
     expect(response?.headers.get('location')).toBe(
       'https://test.code.org/zh-TW/home',
+    );
+    expect(response?.headers.get('Cache-Control')).toEqual(
+      's-maxage=3600, stale-while-revalidate=31535100',
     );
   });
 
@@ -163,6 +169,9 @@ describe('withLocale middleware', () => {
 
     expect(response).toBeInstanceOf(NextResponse);
     expect(response?.headers.get('location')).toContain('studio.code.org');
+    expect(response?.headers.get('Cache-Control')).toEqual(
+      's-maxage=3600, stale-while-revalidate=31535100',
+    );
   });
 
   it('should handle paths with multiple segments correctly', async () => {

--- a/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
@@ -151,7 +151,7 @@ describe('withLocale middleware', () => {
 
     expect(response).toBeInstanceOf(NextResponse);
     expect(response?.headers.get('location')).toBe(
-      'https://code.marketing-sites.local/zh-TW/',
+      'https://code.marketing-sites.local/zh-TW',
     );
   });
 

--- a/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
@@ -14,6 +14,10 @@ jest.mock('@/config/stage', () => ({
   getStage: jest.fn(),
 }));
 
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockReturnValue({get: jest.fn()}),
+}));
+
 describe('withLocale middleware', () => {
   const cookieMock = {
     set: jest.fn(),
@@ -141,7 +145,7 @@ describe('withLocale middleware', () => {
 
     expect(response).toBeInstanceOf(NextResponse);
     expect(response?.headers.get('location')).toBe(
-      'https://code.marketing-sites.local/zh-TW/home',
+      'https://code.marketing-sites.local/zh-TW/',
     );
   });
 

--- a/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
@@ -149,6 +149,22 @@ describe('withLocale middleware', () => {
     );
   });
 
+  it('should redirect to dashboard if _user_type is set', async () => {
+    const request = {
+      nextUrl: {pathname: ''},
+      cookies: {get: jest.fn().mockReturnValue({value: '_user_type=student'})},
+      headers: {
+        get: jest.fn(),
+      },
+      url: 'https://code.marketing-sites.local',
+    } as unknown as NextRequest;
+
+    const response = await withLocale(next)(request, mockEvent);
+
+    expect(response).toBeInstanceOf(NextResponse);
+    expect(response?.headers.get('location')).toContain('studio.code.org');
+  });
+
   it('should handle paths with multiple segments correctly', async () => {
     const request = {
       url: 'https://test.code.org',

--- a/frontend/apps/marketing/src/middleware/utils/__tests__/getCachedRedirectResponse.test.ts
+++ b/frontend/apps/marketing/src/middleware/utils/__tests__/getCachedRedirectResponse.test.ts
@@ -1,0 +1,45 @@
+import {NextResponse} from 'next/server';
+
+import {getCachedRedirectResponse} from '../getCachedRedirectResponse';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    redirect: jest.fn(() => ({
+      headers: {
+        set: jest.fn(),
+      },
+    })),
+  },
+}));
+
+describe('getCachedRedirectResponse', () => {
+  it('should create a redirect response with the correct URL', () => {
+    const url = 'https://code.marketing-sites.localhost';
+    const response = getCachedRedirectResponse(url);
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(url);
+    expect(response.headers.set).toHaveBeenCalledWith(
+      'Cache-Control',
+      's-maxage=3600, stale-while-revalidate=31535100',
+    );
+  });
+
+  it('should handle URL objects correctly', () => {
+    const url = new URL('https://code.marketing-sites.localhost');
+    const response = getCachedRedirectResponse(url);
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(url);
+    expect(response.headers.set).toHaveBeenCalledWith(
+      'Cache-Control',
+      's-maxage=3600, stale-while-revalidate=31535100',
+    );
+  });
+
+  it('should return a response object', () => {
+    const url = 'https://code.marketing-sites.localhost';
+    const response = getCachedRedirectResponse(url);
+
+    expect(response).toBeDefined();
+    expect(typeof response).toBe('object');
+  });
+});

--- a/frontend/apps/marketing/src/middleware/utils/getCachedRedirectResponse.ts
+++ b/frontend/apps/marketing/src/middleware/utils/getCachedRedirectResponse.ts
@@ -1,0 +1,17 @@
+import {NextResponse} from 'next/server';
+
+/**
+ * Sets the Cache-Control header on a redirect response to cache the redirect on the CDN.
+ * @param url The URL to redirect to.
+ */
+export function getCachedRedirectResponse(url: string | URL) {
+  const response = NextResponse.redirect(url);
+
+  // Cache the redirect on Cloudfront
+  response.headers.set(
+    'Cache-Control',
+    's-maxage=3600, stale-while-revalidate=31535100',
+  );
+
+  return response;
+}

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -60,8 +60,9 @@ export const withLocale: MiddlewareFactory = next => {
       return response;
     }
 
-    // If pathParts is empty, then it is a request to / which should resolve to the /home slug
-    const slug = pathParts.length === 0 ? 'home' : getContentfulSlug(pathParts);
+    // If pathParts is empty, then it is a request to / which should resolve to the / slug
+    // It is an empty string here because when a call is made to Contentful, `/` is automatically prepended
+    const slug = pathParts.length === 0 ? '' : getContentfulSlug(pathParts);
 
     const cookieLocale = getLanguageFromCookie(request);
     const browserPreferredLocale = getLanguageFromAcceptLanguageHeader(request);

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -89,7 +89,8 @@ export const withLocale: MiddlewareFactory = next => {
      */
     const locale = cookieLocale || browserPreferredLocale || 'en-US';
 
-    const redirectUrl = new URL(`/${locale}/${slug}`, request.url);
+    const localizedPath = isRootRoute ? `/${locale}` : `/${locale}/${slug}`;
+    const redirectUrl = new URL(localizedPath, request.url);
     const response = getCachedRedirectResponse(redirectUrl);
 
     // Set the language cookie if discovered via Accept-Language header

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -1,5 +1,5 @@
 import Negotiator from 'negotiator';
-import {NextFetchEvent, NextRequest, NextResponse} from 'next/server';
+import {NextFetchEvent, NextRequest} from 'next/server';
 
 import {
   getLocalizeJsLocale,
@@ -10,6 +10,7 @@ import {
 import {getStage} from '@/config/stage';
 import {getStudioBaseUrl} from '@/config/studio';
 import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
+import {getCachedRedirectResponse} from '@/middleware/utils/getCachedRedirectResponse';
 
 import {MiddlewareFactory} from './types';
 
@@ -71,7 +72,7 @@ export const withLocale: MiddlewareFactory = next => {
       const userTypeCookie = request.cookies.get('_user_type');
 
       if (userTypeCookie?.value) {
-        return NextResponse.redirect(getStudioBaseUrl());
+        return getCachedRedirectResponse(getStudioBaseUrl());
       }
     }
 
@@ -89,7 +90,7 @@ export const withLocale: MiddlewareFactory = next => {
     const locale = cookieLocale || browserPreferredLocale || 'en-US';
 
     const redirectUrl = new URL(`/${locale}/${slug}`, request.url);
-    const response = NextResponse.redirect(redirectUrl);
+    const response = getCachedRedirectResponse(redirectUrl);
 
     // Set the language cookie if discovered via Accept-Language header
     response.cookies.set('language_', getPegasusLocale(locale), {

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -67,8 +67,9 @@ export const withLocale: MiddlewareFactory = next => {
     const isRootRoute = pathParts.length === 0;
 
     if (isRootRoute) {
-      // If the _short_name cookie is set, then Dashboard successfully logged in the user which is an early indicator
+      // If the _user_type cookie is set, then Dashboard successfully logged in the user which is an early indicator
       // that the user is logged in right now. Therefore, send the user to Code Studio
+      // See: https://github.com/code-dot-org/code-dot-org/blob/3fad8bce055846378ae3da343da93a32acd4df8c/dashboard/config/initializers/devise.rb#L331
       const userTypeCookie = request.cookies.get('_user_type');
 
       if (userTypeCookie?.value) {

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -1,5 +1,4 @@
 import Negotiator from 'negotiator';
-import {cookies} from 'next/headers';
 import {NextFetchEvent, NextRequest, NextResponse} from 'next/server';
 
 import {
@@ -69,7 +68,7 @@ export const withLocale: MiddlewareFactory = next => {
     if (isRootRoute) {
       // If the _short_name cookie is set, then Dashboard successfully logged in the user which is an early indicator
       // that the user is logged in right now. Therefore, send the user to Code Studio
-      const userTypeCookie = (await cookies()).get('_user_type');
+      const userTypeCookie = request.cookies.get('_user_type');
 
       if (userTypeCookie?.value) {
         return NextResponse.redirect(getStudioBaseUrl());

--- a/frontend/apps/marketing/tests/e2e/home.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/home.spec.ts
@@ -84,8 +84,6 @@ test.describe('Home Page', () => {
 
     await marketingPage.goto('/');
 
-    await expect
-      .poll(() => page.evaluate(() => window.location.href), {timeout: 30_000})
-      .toContain('studio.code.org');
+    await expect(page.getByText('Mocked Code Studio')).toBeVisible();
   });
 });

--- a/frontend/apps/marketing/tests/e2e/home.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/home.spec.ts
@@ -1,8 +1,10 @@
+import {expect} from '@playwright/test';
+
 import {test} from './fixtures/base';
 import {MarketingPage} from './pom/marketing';
 
 test.describe('Home Page', () => {
-  test('should redirect / to the localized /home', async ({
+  test('should redirect / to the localized path', async ({
     page,
     browserName,
   }) => {
@@ -11,6 +13,79 @@ test.describe('Home Page', () => {
     const marketingPage = new MarketingPage(page);
     await marketingPage.goto('/');
 
-    await page.waitForURL('**/en-US/home');
+    await page.waitForURL('**/en-US');
+  });
+
+  test('should redirect / to dashboard if the _user_type cookie is set', async ({
+    page,
+    browserName,
+    context,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+    const redirects: string[] = [];
+
+    // Capture all requests to track redirects
+    page.on('request', request => {
+      console.log('push request url', request.url());
+      redirects.push(request.url());
+    });
+
+    await page.route('**://**studio.code.org**/', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>Mocked Code Studio</body></html>',
+      });
+    });
+
+    const marketingPage = new MarketingPage(page);
+
+    await context.addCookies([
+      {
+        name: '_user_type',
+        path: '/',
+        domain: `.${marketingPage.getCookieDomain()}`,
+        value: 'student',
+      },
+    ]);
+
+    try {
+      await marketingPage.goto('/');
+    } catch {
+      // It's ok if an error occurs as dashboard may not be running
+    }
+
+    await expect.poll(() => redirects[1]).toContain('studio.code.org');
+  });
+
+  test('should redirect / to dashboard if the user is signed in (no cookies set)', async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+
+    const marketingPage = new MarketingPage(page);
+
+    await page.route('**/api/v1/users/signed_in', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({is_signed_in: true}),
+      }),
+    );
+
+    await page.route('**://**studio.code.org**/', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>Mocked Code Studio</body></html>',
+      });
+    });
+
+    await marketingPage.goto('/');
+
+    await expect
+      .poll(() => page.evaluate(() => window.location.href), {timeout: 30_000})
+      .toContain('studio.code.org');
   });
 });

--- a/frontend/packages/component-library/src/cms/header/Header.tsx
+++ b/frontend/packages/component-library/src/cms/header/Header.tsx
@@ -130,7 +130,20 @@ const Header: React.FC<HeaderProps> = ({
       try {
         const data = await fetchUserSignedInStatus(studioBaseUrl);
         if (data) {
-          const renderState = data.is_signed_in ? 'signedIn' : 'signedOut';
+          const isSignedIn = data.is_signed_in;
+
+          if (isSignedIn) {
+            const paths = window.location.pathname?.split('/').filter(Boolean);
+
+            if (paths.length === 0 || paths.length === 1) {
+              // If the user is signed in and on the home page, redirect to dashboard
+              // If parts.length === 0, then they are on code.org
+              // If parts.length === 1, then they are on a localized home page path like code.org/en-US
+              window.location.href = `${studioBaseUrl}`;
+            }
+          }
+
+          const renderState = isSignedIn ? 'signedIn' : 'signedOut';
           setRenderState(renderState);
         } else {
           setRenderState('error');


### PR DESCRIPTION
This PR adds support for the code.org home page on Contentful. To support this, the following features were added:

1. Support caching the `withLocale` middleware (which returns a 307/308 from a non-localized to localized path) at the CDN level. This helps to ensure if Code.org is DDoSed on `/` it will simply return a cache result to the cached localized path rather than hitting the middleware and affecting the server. To support this, the `Accept-Language` header and the `language_` cookie is added to the page cache key.
2. Changing the home page slug from `/home` to `/`
3. Logic to support signed in user redirect to studio.code.org:
  a. If someone is signed in with the` _user_type` cookie, we will send you straight to studio.code.org
  b. If someone is signed in via our "is signed in" check, we will send you to studio.code.org
  c. When someone goes to code.org we will check the language_ cookie, then their browser's preferred language, and redirect to `/[locale]`

Followups needed to enable home page:

1. Support Redis full router page cache
2. Enable home page on marketing router lambda