### PR TITLE
Fix CloudFormation Wildcard Certificate Lookup

### DIFF
--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -124,14 +124,18 @@ To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`."
     def certificate_arn
       acm = Aws::ACM::Client.new(region: ACM_REGION)
       wildcard = "*.#{domain}"
-      acm.
+
+      selected = acm.
         list_certificates(certificate_statuses: ['ISSUED']).
         certificate_summary_list.
         select {|cert| cert.domain_name == wildcard || cert.domain_name == domain}.
         map {|cert| acm.describe_certificate(certificate_arn: cert.certificate_arn).certificate}.
         select {|cert| cert.subject_alternative_names.include? wildcard}.
-        max_by(&:not_after).
-        certificate_arn
+        max_by(&:not_after)
+
+      raise "No valid ACM certificate found for domain #{domain}" unless selected
+
+      selected.certificate_arn
     end
 
     # S3 path to bootstrap script.

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -126,7 +126,7 @@ To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`."
       wildcard = "*.#{domain}"
 
       selected = acm.
-        list_certificates(certificate_statuses: ['ISSUED']).
+        list_certificates(certificate_statuses: ['ISSUED'], max_items: 200).
         certificate_summary_list.
         select {|cert| cert.domain_name == wildcard || cert.domain_name == domain}.
         map {|cert| acm.describe_certificate(certificate_arn: cert.certificate_arn).certificate}.

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -124,18 +124,30 @@ To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`."
     def certificate_arn
       acm = Aws::ACM::Client.new(region: ACM_REGION)
       wildcard = "*.#{domain}"
+      all_certificates = []
+      next_token = nil
 
-      selected = acm.
-        list_certificates(certificate_statuses: ['ISSUED'], max_items: 200).
-        certificate_summary_list.
+      # Paginate through all certificate pages
+      loop do
+        response = acm.list_certificates(
+          certificate_statuses: ['ISSUED'],
+          next_token: next_token
+        )
+
+        all_certificates.concat(response.certificate_summary_list)
+
+        # Break if there are no more pages
+        break unless response.next_token
+        next_token = response.next_token
+      end
+
+      # Process all certificates to find the best match
+      all_certificates.
         select {|cert| cert.domain_name == wildcard || cert.domain_name == domain}.
         map {|cert| acm.describe_certificate(certificate_arn: cert.certificate_arn).certificate}.
         select {|cert| cert.subject_alternative_names.include? wildcard}.
-        max_by(&:not_after)
-
-      raise "No valid ACM certificate found for domain #{domain}" unless selected
-
-      selected.certificate_arn
+        max_by(&:not_after).
+        certificate_arn
     end
 
     # S3 path to bootstrap script.

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -142,12 +142,15 @@ To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`."
       end
 
       # Process all certificates to find the best match
-      all_certificates.
+      selected = all_certificates.
         select {|cert| cert.domain_name == wildcard || cert.domain_name == domain}.
         map {|cert| acm.describe_certificate(certificate_arn: cert.certificate_arn).certificate}.
         select {|cert| cert.subject_alternative_names.include? wildcard}.
-        max_by(&:not_after).
-        certificate_arn
+        max_by(&:not_after)
+
+      raise "No valid ACM certificate found for domain #{domain}" unless selected
+
+      selected.certificate_arn
     end
 
     # S3 path to bootstrap script.


### PR DESCRIPTION
All Stacks are failing to build with this error when rendering the updated CloudFormation template:

```
rake aborted!
NoMethodError: undefined method `certificate_arn' for nil:NilClass

        certificate_arn
```

Root cause is that the wildcard certificate `*.code.org` is now in the 2nd page of results when getting a list of certificates and using a page size of 100 (default). Paginate the query.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
