### PR TITLE
[Google Blockly] increase efficiency of variable filtering

### DIFF
--- a/apps/src/blockly/addons/cdoFieldVariable.ts
+++ b/apps/src/blockly/addons/cdoFieldVariable.ts
@@ -135,18 +135,19 @@ export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
       this as GoogleBlockly.FieldVariable
     );
 
+    const workspace = this.getSourceBlock()?.workspace;
+    // Embedded workspaces are read-only, so we don't need to modify the dropdown options.
+    if (!workspace || Blockly.embeddedWorkspaces.includes(workspace.id)) {
+      return options;
+    }
+
     // Remove the last two options (Delete and Rename)
     options.pop();
     options.pop();
 
+    // Filter out variables that are function parameters (Music Lab advanced functions)
+    const nonParamVarIds = getNonFunctionVariableIds(workspace);
     const filteredOptions = options.filter(option => {
-      const workspace = this.getSourceBlock()?.workspace;
-      // Embedded workspaces are read-only, so we don't need to modify the dropdown options.
-      if (!workspace || Blockly.embeddedWorkspaces.includes(workspace.id)) {
-        return true;
-      }
-
-      const nonParamVarIds = getNonFunctionVariableIds(workspace);
       const optionValue = option[1] as string;
       return nonParamVarIds.includes(optionValue);
     });


### PR DESCRIPTION
@wilkie reported slow loading at https://studio.code.org/courses/k5-ai-data-2024/units/1/lessons/1/levels/7/sublevel/2

I identified a major performance bottleneck during initial page load in, where the main thread was blocked for almost a minute. 
![image (328)](https://github.com/user-attachments/assets/23887c7b-d8f3-4829-b799-4dce8105e7f2)

Drilling into the bottom-up JavaScript call tree showed that a large portion of CPU time was consumed by Blockly’s variable dropdown generation, specifically within our customized `CdoFieldVariable` class. The `menuGenerator_` method was recomputing `getNonFunctionVariableIds(workspace)` many times for a given variable dropdown, resulting in significant redundant work when deserializing workspaces with many variables. (The level @wilkie reported has 43 variables.)

To address this, I moved the call to `getNonFunctionVariableIds()` out of the `filter()` function and ensured it is only evaluated once per `menuGenerator_` call. This reduces the number of expensive operations from hundreds or thousands to just one per dropdown, significantly improving page load performance.

## Links
https://codedotorg.slack.com/archives/C08AMQ869QX/p1750192661017459
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

When loading this level in my dev environment, it actually took over 3 minutes. With this change, it now takes less than 10 seconds. I suspect that production will be even faster, hopefully matching other levels that don't have excessive amounts of variables.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

- We could consider caching `getNonFunctionVariableIds(workspace)` during initial loading across multiple dropdowns to avoid recalculation within a single render pass.
- Given that this filtering is only useful in Music Lab's Advanced Mode (which is no longer in use), we could potentially disable it entirely. (https://github.com/code-dot-org/code-dot-org/pull/61567)


<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
