### PR TITLE
fix admin panel on script levels

### DIFF
--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -72,7 +72,7 @@
             = link_to '[E]', edit_level_path(project_template_level)
 
       - elsif @script_level
-        %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level, **@extra_params)).to_s
+        %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level, **(@extra_params || {}))).to_s
     - if @level.is_a?(Blockly) && !@level.uses_droplet?
       %button{type: 'button', onclick: 'window.levelbuilder.copySelectedBlockToClipboard()', class: 'btn btn-default btn-sm'}
         Copy selected block


### PR DESCRIPTION
We had a Honeybadger error come in regarding a script level page not loading for users that can see the admin panel because `@extra_params` was `nil`. This PR handles that case.

## Links
- [Honeybadger](https://app.honeybadger.io/projects/3240/faults/121379525) 

## Testing story
Manually verified the link is working
