### PR TITLE
 devise.rb: adapt to ruby 3.1 Module#prepend behavior change

### DIFF
--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -373,9 +373,7 @@ end
 
 Rails.application.config.to_prepare do
   # See lib/devise/models/custom_lockable.rb
-  Rails.application.config.to_prepare do
-    unless Devise::Models::Lockable.ancestors.include?(Devise::Models::CustomLockable)
-      Devise::Models::Lockable.prepend(Devise::Models::CustomLockable)
-    end
+  unless Devise::Models::Lockable.ancestors.include?(Devise::Models::CustomLockable)
+    Devise::Models::Lockable.prepend(Devise::Models::CustomLockable)
   end
 end

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -373,5 +373,9 @@ end
 
 Rails.application.config.to_prepare do
   # See lib/devise/models/custom_lockable.rb
-  Devise::Models::Lockable.prepend Devise::Models::CustomLockable
+  Rails.application.config.to_prepare do
+    unless Devise::Models::Lockable.ancestors.include?(Devise::Models::CustomLockable)
+      Devise::Models::Lockable.prepend(Devise::Models::CustomLockable)
+    end
+  end
 end


### PR DESCRIPTION
This PR dedupes repeated calls to `Devise::Models::Lockable.prepend Devise::Models::CustomLockable` during Rails code reloads to avoid crashes in ActiveJob workers. This accommodates behavior Module#prepend behavior changes in Ruby 3.1.

With the Ruby 3.1 upgrade a couple weeks ago, we started to see segfaults of the delayed_job (activejob) workers on levelbuilder. They would start, and then disappear 1-5 minutes later. The segfaults occurred during calls to `Rails.application.reloader.reload!`: i.e. reloading the application code.

Using gdb, we tracked the segfaults back to the line of code modified by this PR: `Devise::Models::Lockable.prepend(Devise::Models::CustomLockable)`. Reloading this code was causing segfaults.

Checking out Ruby 3.1 change notes we find a change in Module#prepend behavior: https://rubyreferences.github.io/rubychanges/3.1.html#moduleprepend-behavior-change

<img width="755" alt="image" src="https://github.com/user-attachments/assets/e4865135-49bb-4508-a5f3-d2242f22bc2b" />

In this PR, we avoid calling ``Devise::Models::Lockable.prepend(Devise::Models::CustomLockable)` if its already been called. As a result, we observe that levelbuilder delayed_job workers no longer segfault after startup.