### PR TITLE
Enable ECS Exec Command on non-Production Containers

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -1003,7 +1003,7 @@ roles.each do |name, config| %>
             Resource:
               - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/ecs/*<%=hyphenated_base_domain%>*"
               - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/ecs/*<%=hyphenated_base_domain%>*:log-stream:*"
-<% if environment_type == 'test' %>
+<% if environment_type != 'production' %>
           - Sid: AllowSSMMessagesForECSExec
             Effect: Allow
             Action:

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -306,18 +306,33 @@ Resources:
       VpcId:
         Ref: Vpc
 
-  FargateServiceTaskDefTaskRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: !Sub "marketing-sites-${EnvironmentType}-${SubdomainName}-task-role"
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-        Version: "2012-10-17"
-      PermissionsBoundary: !Ref RoleBoundary
+FargateServiceTaskDefTaskRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: !Sub "marketing-sites-${EnvironmentType}-${SubdomainName}-task-role"
+    AssumeRolePolicyDocument:
+      Statement:
+        - Action: sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service: ecs-tasks.amazonaws.com
+      Version: "2012-10-17"
+    PermissionsBoundary: !Ref RoleBoundary
+    Policies:
+      - !If
+        - IsProductionEnvironment
+        - !Ref AWS::NoValue
+        - PolicyName: ECSExecPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssmmessages:CreateControlChannel
+                  - ssmmessages:CreateDataChannel
+                  - ssmmessages:OpenControlChannel
+                  - ssmmessages:OpenDataChannel
+                Resource: "*"
 
   FargateServiceTaskDef:
     Type: AWS::ECS::TaskDefinition

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -307,33 +307,33 @@ Resources:
       VpcId:
         Ref: Vpc
 
-FargateServiceTaskDefTaskRole:
-  Type: AWS::IAM::Role
-  Properties:
-    RoleName: !Sub "marketing-sites-${EnvironmentType}-${SubdomainName}-task-role"
-    AssumeRolePolicyDocument:
-      Statement:
-        - Action: sts:AssumeRole
-          Effect: Allow
-          Principal:
-            Service: ecs-tasks.amazonaws.com
-      Version: "2012-10-17"
-    PermissionsBoundary: !Ref RoleBoundary
-    Policies:
-      - !If
-        - IsProductionEnvironment
-        - !Ref AWS::NoValue
-        - PolicyName: ECSExecPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - ssmmessages:CreateControlChannel
-                  - ssmmessages:CreateDataChannel
-                  - ssmmessages:OpenControlChannel
-                  - ssmmessages:OpenDataChannel
-                Resource: "*"
+  FargateServiceTaskDefTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "marketing-sites-${EnvironmentType}-${SubdomainName}-task-role"
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: "2012-10-17"
+      PermissionsBoundary: !Ref RoleBoundary
+      Policies:
+        - !If
+          - IsProductionEnvironment
+          - !Ref AWS::NoValue
+          - PolicyName: ECSExecPolicy
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - ssmmessages:CreateControlChannel
+                    - ssmmessages:CreateDataChannel
+                    - ssmmessages:OpenControlChannel
+                    - ssmmessages:OpenDataChannel
+                  Resource: "*"
 
   FargateServiceTaskDef:
     Type: AWS::ECS::TaskDefinition

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -215,6 +215,8 @@ Resources:
         # Delete the load balancer if the CloudFormation stack is deleted
         - Key: deletion_protection.enabled
           Value: "false"
+      # Note for idle_timeout.timeout_seconds: The default is 60 seconds, which is is appropriate for this application.
+      # If changing from the default, the KEEP_ALIVE_TIMEOUT in the Dockerfile must also be updated to be greater than this value.
       Scheme: internet-facing
       SecurityGroups:
         - !GetAtt FargateServiceLBSecurityGroup.GroupId
@@ -915,69 +917,6 @@ Resources:
       ReplicationGroupDescription: Marketing Sites redis full router page and internal data cache replication group
       Engine: redis
       ReplicationGroupId: !Sub "marketing-sites-${SubdomainName}-${EnvironmentType}"
-      CacheParameterGroupName: !Ref RedisParameterGroup
-      EngineVersion: 7.1
-      CacheNodeType:
-        Fn::If:
-          - IsProductionEnvironment
-          - cache.r7g.xlarge
-          - cache.t3.medium
-      NumNodeGroups: 1
-      ReplicasPerNodeGroup: 1
-      SecurityGroupIds:
-        - !Ref RedisSecurityGroup
-      CacheSubnetGroupName: !Ref RedisSubnetGroup
-      MultiAZEnabled: true
-      TransitEncryptionEnabled: true
-      AtRestEncryptionEnabled: true
-      AutomaticFailoverEnabled: true
-      AutoMinorVersionUpgrade: true
-      PreferredMaintenanceWindow: "sun:05:00-sun:06:00"
-
-  #######################
-  # End Redis Resources #
-  #######################
-
-  #########################
-  # Start Redis Resources #
-  #########################
-
-  RedisSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Redis access from ECS
-      VpcId: !Ref Vpc
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 6379
-          ToPort: 6379
-          SourceSecurityGroupId: !Ref FargateServiceSecurityGroup
-
-  RedisSubnetGroup:
-    Type: AWS::ElastiCache::SubnetGroup
-    Properties:
-      Description: Marketing Sites Redis Cache Subnet Group
-      SubnetIds:
-<% MarketingSites::Configuration::REGIONS[options[:region].to_sym][:vpc][:private_subnets].each_with_index do |_, index| %>
-        - Ref: VpcPrivateSubnet<%= index %>
-<% end %>
-
-  # This enables keyspace notifications for Redis, which is required for the Next.js caching.
-  # See: https://github.com/trieb-work/nextjs-turbo-redis-cache
-  RedisParameterGroup:
-    Type: AWS::ElastiCache::ParameterGroup
-    Properties:
-      CacheParameterGroupFamily: redis7
-      Description: Enable keyspace notifications
-      Properties:
-        notify-keyspace-events: Exe
-
-  RedisCluster:
-    Type: AWS::ElastiCache::ReplicationGroup
-    Properties:
-      ReplicationGroupDescription: Marketing Sites Redis Cache Replication Group
-      Engine: redis
-      ReplicationGroupId: !Sub "marketing-sites-page-cache-${SubdomainName}-${EnvironmentType}"
       CacheParameterGroupName: !Ref RedisParameterGroup
       EngineVersion: 7.1
       CacheNodeType:

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -29,6 +29,7 @@ Parameters:
     Type: String
     Description: The IAM Policy that any Role created by this template must apply as a Permissions Boundary.
 
+    
 Conditions:
   IsProductionEnvironment:
     Fn::Equals:

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -215,8 +215,8 @@ Resources:
         # Delete the load balancer if the CloudFormation stack is deleted
         - Key: deletion_protection.enabled
           Value: "false"
-      # Note for idle_timeout.timeout_seconds: The default is 60 seconds, which is is appropriate for this application.
-      # If changing from the default, the KEEP_ALIVE_TIMEOUT in the Dockerfile must also be updated to be greater than this value.
+        # Note for idle_timeout.timeout_seconds: The default is 60 seconds, which is is appropriate for this application.
+        # If changing from the default, the KEEP_ALIVE_TIMEOUT in the Dockerfile must also be updated to be greater than this value.
       Scheme: internet-facing
       SecurityGroups:
         - !GetAtt FargateServiceLBSecurityGroup.GroupId

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -216,8 +216,6 @@ Resources:
         # Delete the load balancer if the CloudFormation stack is deleted
         - Key: deletion_protection.enabled
           Value: "false"
-        # Note for idle_timeout.timeout_seconds: The default is 60 seconds, which is is appropriate for this application.
-        # If changing from the default, the KEEP_ALIVE_TIMEOUT in the Dockerfile must also be updated to be greater than this value.
       Scheme: internet-facing
       SecurityGroups:
         - !GetAtt FargateServiceLBSecurityGroup.GroupId
@@ -918,6 +916,69 @@ Resources:
       ReplicationGroupDescription: Marketing Sites redis full router page and internal data cache replication group
       Engine: redis
       ReplicationGroupId: !Sub "marketing-sites-${SubdomainName}-${EnvironmentType}"
+      CacheParameterGroupName: !Ref RedisParameterGroup
+      EngineVersion: 7.1
+      CacheNodeType:
+        Fn::If:
+          - IsProductionEnvironment
+          - cache.r7g.xlarge
+          - cache.t3.medium
+      NumNodeGroups: 1
+      ReplicasPerNodeGroup: 1
+      SecurityGroupIds:
+        - !Ref RedisSecurityGroup
+      CacheSubnetGroupName: !Ref RedisSubnetGroup
+      MultiAZEnabled: true
+      TransitEncryptionEnabled: true
+      AtRestEncryptionEnabled: true
+      AutomaticFailoverEnabled: true
+      AutoMinorVersionUpgrade: true
+      PreferredMaintenanceWindow: "sun:05:00-sun:06:00"
+
+  #######################
+  # End Redis Resources #
+  #######################
+
+  #########################
+  # Start Redis Resources #
+  #########################
+
+  RedisSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Redis access from ECS
+      VpcId: !Ref Vpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 6379
+          ToPort: 6379
+          SourceSecurityGroupId: !Ref FargateServiceSecurityGroup
+
+  RedisSubnetGroup:
+    Type: AWS::ElastiCache::SubnetGroup
+    Properties:
+      Description: Marketing Sites Redis Cache Subnet Group
+      SubnetIds:
+<% MarketingSites::Configuration::REGIONS[options[:region].to_sym][:vpc][:private_subnets].each_with_index do |_, index| %>
+        - Ref: VpcPrivateSubnet<%= index %>
+<% end %>
+
+  # This enables keyspace notifications for Redis, which is required for the Next.js caching.
+  # See: https://github.com/trieb-work/nextjs-turbo-redis-cache
+  RedisParameterGroup:
+    Type: AWS::ElastiCache::ParameterGroup
+    Properties:
+      CacheParameterGroupFamily: redis7
+      Description: Enable keyspace notifications
+      Properties:
+        notify-keyspace-events: Exe
+
+  RedisCluster:
+    Type: AWS::ElastiCache::ReplicationGroup
+    Properties:
+      ReplicationGroupDescription: Marketing Sites Redis Cache Replication Group
+      Engine: redis
+      ReplicationGroupId: !Sub "marketing-sites-page-cache-${SubdomainName}-${EnvironmentType}"
       CacheParameterGroupName: !Ref RedisParameterGroup
       EngineVersion: 7.1
       CacheNodeType:

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -29,7 +29,6 @@ Parameters:
     Type: String
     Description: The IAM Policy that any Role created by this template must apply as a Permissions Boundary.
 
-    
 Conditions:
   IsProductionEnvironment:
     Fn::Equals:


### PR DESCRIPTION
Change marketing site ECS Task Role to enable AWS Systems Manager on non-production containers to permit engineers to better debug issues with the Next.js web application server.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

1. Merge this Pull Request to apply the change to all Marketing Sites Stacks
2. `bundle exec rake stack:iam:start RAILS_ENV=production ADMIN=true` to update the Marketing Sites Deployer IAM Role

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  3.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
