### PR TITLE
refactor levelbuilder commit filtering

### DIFF
--- a/bin/content-push
+++ b/bin/content-push
@@ -1,16 +1,20 @@
 #!/usr/bin/env ruby
+#
+# This script serves as a command-line wrapper around the ContentPush module.
+# While most local code should use the ContentPush module directly, this wrapper
+# is maintained for:
+#
+# 1. Remote calls from other servers (e.g., from bin/dotd which runs commands on staging/levelbuilder)
+# 2. Backward compatibility with existing scripts and documentation
+# 3. Command-line usage by developers
+#
+# For programmatic use within Ruby code, prefer using the ContentPush module directly:
+#   require 'cdo/content_push'
+#   ContentPush.commit_and_push(name)
+#
 require 'optparse'
 require_relative '../deployment'
-require 'cdo/git_utils'
-require 'cdo/only_one'
-
-CONTENT_PATHS = 'dashboard pegasus aws/dms'.freeze
-
-# Revert any local changes to these files on levelbuilder
-LEVELBUILDER_OMISSIONS = [
-  'dashboard/db/schema_cache.yml',
-  'dashboard/db/schema.rb',
-]
+require 'cdo/content_push'
 
 def ask_for_name
   name = ''
@@ -20,66 +24,6 @@ def ask_for_name
   end
   puts "Hi #{name}!"
   name
-end
-
-def disallow_case_change
-  `git add -A #{CONTENT_PATHS}`
-  ignore_levelbuilder_omissions
-  `git status --porcelain --untracked-files=all #{CONTENT_PATHS}`.split("\n").each do |line|
-    next unless (%r{^R  ([^ ]+) -> ([^ ]+)}.match(line) || %r{^R  ("[^"]+") -> ("[^"]+")}.match(line)) && $1.casecmp($2) == 0
-    warn "\nAborting due to case-only rename:\n\n    #{line}\n\n"
-    warn "To fix this, run the following commands:\n\n"
-    warn "    git add #{$2}\n\n"
-    warn "    git mv #{$2} #{$2}.tmp\n\n"
-    warn "    git commit --only #{$1} #{$2}.tmp -m 'temporarily rename #{$1} -> #{$2}.tmp'\n\n"
-    warn "    git mv #{$2}.tmp #{$2}\n\n"
-    warn "    bin/content-push\n\n"
-    # unstage all changes so the above instructions can be followed
-    `git reset HEAD`
-    exit 1
-  end
-end
-
-def ignore_levelbuilder_omissions
-  if GitUtils.current_branch == 'levelbuilder'
-    system("git reset -q HEAD -- '#{LEVELBUILDER_OMISSIONS.join("' '")}'")
-    system("git checkout -q HEAD -- '#{LEVELBUILDER_OMISSIONS.join("' '")}'")
-  end
-end
-
-def has_changes?
-  !`git status --porcelain --untracked-files=all #{CONTENT_PATHS}`.empty?
-end
-
-def check_changes
-  unless has_changes?
-    puts "There are no unstaged or untracked files to commit."
-    return false
-  end
-
-  disallow_case_change
-
-  system("git status --untracked-files=all #{CONTENT_PATHS}")
-  print "Should I commit and push all of these unstaged and untracked files in pegasus and dashboard? [Y/n] "
-  input = gets.chomp
-  if input == '' || input[0].casecmp?('y')
-    puts "Cool!"
-    true
-  else
-    puts "Ok, not doing anything."
-    false
-  end
-end
-
-def commit_changes(name)
-  ignore_levelbuilder_omissions
-  exit 0 unless has_changes?
-
-  branchname = GitUtils.current_branch
-  exit 1 unless system("git add -A #{CONTENT_PATHS}")
-  exit 1 unless system("git commit -m '#{branchname} content changes (-#{name})'")
-  exit 1 unless system("git pull")
-  exit 1 unless system("git push")
 end
 
 options = {}
@@ -105,10 +49,22 @@ end.parse!
 
 raise OptionParser::MissingArgument, 'Name is required if forcing push' if options['force'] && options['name'].nil?
 
-Dir.chdir(deploy_dir) do
-  name = options['name'] || ask_for_name
+name = options['name'] || ask_for_name
 
-  if options['force'] || check_changes
-    commit_changes(name)
+# Handle interactive mode if not forcing
+if !options['force']
+  # Show status and ask for confirmation
+  status = ContentPush.get_status
+  puts status
+  
+  print "Should I commit and push all of these unstaged and untracked files in pegasus and dashboard? [Y/n] "
+  input = gets.chomp
+  if input != '' && !input[0].casecmp?('y')
+    puts "Ok, not doing anything."
+    exit(0)
   end
+  puts "Ok, pushing!"
 end
+
+success = ContentPush.commit_and_push(name)
+exit(success ? 0 : 1)

--- a/bin/cron/commit_content
+++ b/bin/cron/commit_content
@@ -8,6 +8,8 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 require_relative '../../deployment'
 require 'cdo/chat_client'
 require 'cdo/developers_topic'
+require 'cdo/levelbuilder_content_restrictions'
+require 'cdo/content_push'
 
 class ContentCommitter
   # @param [Symbol] env The environment the commit is being performed on.
@@ -58,13 +60,13 @@ class ContentCommitter
     false
   end
 
-  # Runs content-push, creating a new commit with any new content.
-  # @raise [RuntimeError] If the content-push was unsuccessful.
-  # TODO(asher): As we are now using content-push as a service rather than as an executable, we
-  # should convert it from an executable to a module.
+  # Commits content changes using the ContentPush module
+  # @raise [RuntimeError] If the content push was unsuccessful
   def commit_content
-    success = system "~/#{@env}/bin/content-push --force --name robo-commit"
-    raise "#{@env}/bin/content-push was unsuccessful" unless success
+    Dir.chdir(deploy_dir) do
+      success = ContentPush.commit_and_push('robo-commit', force: true)
+      raise "Content push was unsuccessful" unless success
+    end
   end
 
   def set_slack_failed

--- a/bin/cron/commit_content
+++ b/bin/cron/commit_content
@@ -64,7 +64,7 @@ class ContentCommitter
   # @raise [RuntimeError] If the content push was unsuccessful
   def commit_content
     Dir.chdir(deploy_dir) do
-      success = ContentPush.commit_and_push('robo-commit', force: true)
+      success = ContentPush.commit_and_push('robo-commit')
       raise "Content push was unsuccessful" unless success
     end
   end

--- a/bin/watch-and-test-levelbuilder
+++ b/bin/watch-and-test-levelbuilder
@@ -4,6 +4,7 @@ require 'cdo/only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
 require_relative '../tools/hooks/hooks_utils'
+require 'cdo/content_push'
 require 'time'
 
 REPO_DIR = File.expand_path('../../', __FILE__).freeze
@@ -51,5 +52,6 @@ system "echo #{Time.now} > #{LEVELBUILDER_CI_LAST_RUN_FILENAME}" if test_result
 puts "Ran tests, result was #{test_result}"
 
 if test_result
-  puts `./bin/content-push -n "Levelbuilder autocommits" -f`
+  success = ContentPush.commit_and_push('Levelbuilder autocommits')
+  puts "Content push result: #{success ? 'success' : 'failure'}"
 end

--- a/lib/cdo/content_push.rb
+++ b/lib/cdo/content_push.rb
@@ -1,0 +1,140 @@
+require_relative '../deployment'
+require 'cdo/git_utils'
+require 'cdo/levelbuilder_content_restrictions'
+
+# This module provides functionality for committing content changes
+# to the repository. It encapsulates the logic previously contained in
+# the bin/content-push executable script.
+#
+# This module is used by:
+# 1. The bin/content-push wrapper script (for command-line and remote usage)
+# 2. The bin/cron/commit_content script (for automated content commits)
+# 3. The bin/watch-and-test-levelbuilder script (for automated testing and commits)
+# 4. Any other Ruby code that needs to programmatically commit content changes
+#
+# For the levelbuilder environment, this module also handles filtering files
+# to ensure only allowed paths are committed, using the LevelbuilderContentRestrictions module.
+#
+# Usage:
+#   require 'cdo/content_push'
+#   ContentPush.commit_and_push('Your Name')
+#
+module ContentPush
+  CONTENT_PATHS = 'dashboard pegasus aws/dms'.freeze
+  SCHEMA_FILES = [
+    'dashboard/db/schema_cache.yml',
+    'dashboard/db/schema.rb',
+  ].freeze
+
+  # Check for case-only renames, which can cause issues
+  # @return [Boolean] true if no case-only renames were found, false otherwise
+  def self.disallow_case_change
+    `git add -A #{CONTENT_PATHS}`
+    ignore_levelbuilder_schema_changes
+    
+    case_changes = []
+    `git status --porcelain --untracked-files=all #{CONTENT_PATHS}`.split("\n").each do |line|
+      if (%r{^R  ([^ ]+) -> ([^ ]+)}.match(line) || %r{^R  ("[^"]+") -> ("[^"]+")}.match(line)) && $1.casecmp($2) == 0
+        case_changes << line
+      end
+    end
+    
+    unless case_changes.empty?
+      case_changes.each do |line|
+        warn "\nCase-only rename detected:\n\n    #{line}\n\n"
+      end
+      
+      warn "To fix this, run the following commands for each file:\n\n"
+      warn "    git add NEW_FILENAME\n\n"
+      warn "    git mv NEW_FILENAME NEW_FILENAME.tmp\n\n"
+      warn "    git commit --only OLD_FILENAME NEW_FILENAME.tmp -m 'temporarily rename OLD_FILENAME -> NEW_FILENAME.tmp'\n\n"
+      warn "    git mv NEW_FILENAME.tmp NEW_FILENAME\n\n"
+      warn "    bin/content-push\n\n"
+      
+      # unstage all changes so the above instructions can be followed
+      `git reset HEAD`
+      return false
+    end
+    
+    true
+  end
+
+  # Ignore levelbuilder omissions (schema files)
+  def self.ignore_levelbuilder_schema_changes
+    if GitUtils.current_branch == 'levelbuilder'
+      system("git reset -q HEAD -- '#{SCHEMA_FILES.join("' '")}'")
+      system("git checkout -q HEAD -- '#{SCHEMA_FILES.join("' '")}'")
+    end
+  end
+
+  # Filter out files that aren't allowed on levelbuilder
+  # @return [Boolean] true if filtering was performed, false otherwise
+  def self.filter_levelbuilder_files
+    return false unless GitUtils.current_branch == 'levelbuilder'
+    
+    # Get all modified/untracked files
+    all_files = `git status --porcelain --untracked-files=all #{CONTENT_PATHS}`.split("\n")
+      .map { |line| line.sub(/^.. /, '') }  # Remove git status prefix
+      .map { |path| File.join(deploy_dir, path) }  # Convert to full paths
+    
+    # Filter out files that aren't allowed
+    allowed_files = all_files.select { |file| LevelbuilderContentRestrictions.file_allowed?(file) }
+    skipped_files = all_files - allowed_files
+    
+    # Log skipped files
+    unless skipped_files.empty?
+      puts "Skipping files not allowed on levelbuilder:"
+      skipped_files.each { |file| puts "  #{file}" }
+    end
+    
+    # Stage only allowed files
+    allowed_files.each do |file|
+      relative_path = file.sub(deploy_dir + '/', '')
+      system("git add '#{relative_path}'")
+    end
+    
+    return true
+  end
+
+  # Check if there are any changes to commit
+  # @return [Boolean] true if there are changes, false otherwise
+  def self.has_changes?
+    !`git status --porcelain --untracked-files=all #{CONTENT_PATHS}`.empty?
+  end
+
+  # Get the status of content changes
+  # @return [String] The git status output for content paths
+  def self.get_status
+    Dir.chdir(deploy_dir) do
+      `git status --untracked-files=all #{CONTENT_PATHS}`
+    end
+  end
+
+  # Commit and push content changes
+  # @param name [String] The name to include in the commit message
+  # @return [Boolean] true if successful, false otherwise
+  def self.commit_and_push(name)
+    Dir.chdir(deploy_dir) do
+      ignore_levelbuilder_schema_changes
+      return true unless has_changes?
+
+      # Check for case-only renames
+      return false unless disallow_case_change
+
+      branchname = GitUtils.current_branch
+      
+      # For levelbuilder, only add allowed files
+      if branchname == 'levelbuilder'
+        filter_levelbuilder_files
+      else
+        return false unless system("git add -A #{CONTENT_PATHS}")
+      end
+      
+      return false unless system("git commit -m '#{branchname} content changes (-#{name})'")
+      return false unless system("git pull")
+      return false unless system("git push")
+      
+      return true
+    end
+  end
+end

--- a/lib/cdo/levelbuilder_content_restrictions.rb
+++ b/lib/cdo/levelbuilder_content_restrictions.rb
@@ -1,0 +1,101 @@
+require_relative '../deployment'
+
+# This module provides shared functionality for restricting content changes
+# in the levelbuilder environment. It centralizes the path restriction logic
+# that was previously duplicated across multiple files.
+#
+# This module is used by:
+# 1. The pre-commit hook (tools/hooks/restrict_levelbuilder_changes.rb)
+# 2. The ContentPush module (lib/cdo/content_push.rb)
+# 3. Any other code that needs to validate files against levelbuilder restrictions
+#
+# The module defines which paths and files are allowed to be committed to the
+# levelbuilder branch, and provides methods to validate files against these
+# restrictions.
+#
+# Usage:
+#   require 'cdo/levelbuilder_content_restrictions'
+#   LevelbuilderContentRestrictions.file_allowed?(filename)
+#   # or
+#   result = LevelbuilderContentRestrictions.validate_files(files)
+#   unless result[:valid]
+#     puts result[:message]
+#   end
+#
+module LevelbuilderContentRestrictions
+  REPO_DIR = File.expand_path('../../../', __FILE__).freeze
+
+  # Define allowed paths for levelbuilder
+  ALLOWED_PATHS = [
+    File.join(REPO_DIR, 'dashboard/config/blocks'),
+    File.join(REPO_DIR, 'dashboard/config/shared_functions'),
+    File.join(REPO_DIR, 'dashboard/config/libraries'),
+    File.join(REPO_DIR, 'dashboard/config/scripts'),
+    File.join(REPO_DIR, 'dashboard/config/levels'),
+    File.join(REPO_DIR, 'dashboard/config/courses'),
+    File.join(REPO_DIR, 'dashboard/config/course_offerings'),
+    File.join(REPO_DIR, 'dashboard/config/data_docs'),
+    File.join(REPO_DIR, 'dashboard/config/reference_guides'),
+    File.join(REPO_DIR, 'dashboard/config/programming_classes'),
+    File.join(REPO_DIR, 'dashboard/config/programming_environments'),
+    File.join(REPO_DIR, 'dashboard/config/programming_expressions'),
+    File.join(REPO_DIR, 'dashboard/public/c/video_thumbnails'),
+    File.join(REPO_DIR, 'dashboard/config/foorm')
+  ].freeze
+  
+  ALLOWED_FILES = [
+    File.join(REPO_DIR, 'dashboard/config/locales/dsls/en.yml'),
+    File.join(REPO_DIR, 'dashboard/config/locales/scripts/en.yml'),
+    File.join(REPO_DIR, 'dashboard/config/locales/courses/en.yml'),
+    File.join(REPO_DIR, 'dashboard/config/locales/unplugged/en.yml'),
+    File.join(REPO_DIR, 'dashboard/config/locales/data/en.yml'),
+    File.join(REPO_DIR, 'dashboard/config/videos.csv')
+  ].freeze
+  
+  # Error message for levelbuilder restrictions
+  ERROR_MESSAGE = "Levelbuilder branch should only commit files in allowed directories and specific allowed files. See #{__FILE__} for details.".freeze
+
+  # Validate if a file is allowed for levelbuilder
+  def self.file_allowed?(filename)
+    ALLOWED_PATHS.any? { |path| filename.start_with?(path) } ||
+      ALLOWED_FILES.include?(filename)
+  end
+  
+  # Validate a list of files for levelbuilder
+  # @param files [Array<String>] List of file paths to validate
+  # @return [Hash] Result of validation with keys :valid, :invalid_files, and :message
+  def self.validate_files(files)
+    invalid_files = files.reject { |file| file_allowed?(file) }
+    
+    if invalid_files.empty?
+      { valid: true }
+    else
+      {
+        valid: false,
+        invalid_files: invalid_files,
+        message: "#{ERROR_MESSAGE}\nInvalid files: #{invalid_files.join(', ')}"
+      }
+    end
+  end
+  
+  # Get the current Git branch name
+  # @return [String] Current branch name
+  def self.current_branch
+    `git rev-parse --abbrev-ref HEAD`.strip
+  end
+  
+  # Check if current branch is levelbuilder
+  # @return [Boolean] True if current branch is levelbuilder
+  def self.levelbuilder_branch?
+    current_branch == 'levelbuilder'
+  end
+  
+  # Get staged files for the current Git repository
+  # @return [Array<String>] List of staged file paths
+  def self.get_staged_files
+    Dir.chdir(REPO_DIR)
+    `git diff --cached --name-only --diff-filter AMR`.split("\n").map do |path|
+      File.join(REPO_DIR, path)
+    end
+  end
+end

--- a/tools/hooks/restrict_levelbuilder_changes.rb
+++ b/tools/hooks/restrict_levelbuilder_changes.rb
@@ -1,39 +1,14 @@
 require_relative 'hooks_utils'
+require_relative '../../lib/cdo/levelbuilder_content_restrictions'
 
-REPO_DIR = File.expand_path('../../../', __FILE__).freeze
-BLOCKS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/blocks', __FILE__).freeze
-SHARED_FUNCTIONS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/shared_functions', __FILE__).freeze
-LIBRARIES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/libraries', __FILE__).freeze
-# As written, SCRIPTS_DIR also covers dashboard/config/scripts_json
-SCRIPTS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/scripts', __FILE__).freeze
-LEVELS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/levels', __FILE__).freeze
-COURSES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/courses', __FILE__).freeze
-COURSE_OFFERINGS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/course_offerings', __FILE__).freeze
-DATA_DOCS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/data_docs', __FILE__).freeze
-REFERENCE_GUIDES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/reference_guides', __FILE__).freeze
-PROGRAMMING_CLASSES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/programming_classes', __FILE__).freeze
-PROGRAMMING_ENVIRONMENTS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/programming_environments', __FILE__).freeze
-PROGRAMMING_EXPRESSIONS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/programming_expressions', __FILE__).freeze
-VIDEO_THUMBNAILS_DIR = File.expand_path(REPO_DIR + '/dashboard/public/c/video_thumbnails', __FILE__).freeze
-FOORM_DIR = File.expand_path(REPO_DIR + '/dashboard/config/foorm', __FILE__).freeze
-ALLOWED_FILES = %w(
-  dashboard/config/locales/dsls/en.yml
-  dashboard/config/locales/scripts/en.yml
-  dashboard/config/locales/courses/en.yml
-  dashboard/config/locales/unplugged/en.yml
-  dashboard/config/locales/data/en.yml
-  dashboard/config/videos.csv
-).map {|f| File.join(REPO_DIR, f)}.freeze
-ERROR_MESSAGE = "Levelbuilder branch should only commit files in levels directory and specific allowed files. See #{__FILE__} for details.".freeze
+# Exit if not on levelbuilder branch
+exit(0) unless LevelbuilderContentRestrictions.levelbuilder_branch?
 
-Dir.chdir REPO_DIR
-branchname = `git rev-parse --abbrev-ref HEAD`.strip
-
-exit(0) unless branchname == 'levelbuilder'
+# Get staged files and validate them
 staged_files = HooksUtils.get_staged_files
+validation_result = LevelbuilderContentRestrictions.validate_files(staged_files)
 
-staged_files.each do |filename|
-  raise "#{ERROR_MESSAGE}\nFile blocked: #{filename}" unless filename.start_with?(
-    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, SCRIPTS_DIR, LEVELS_DIR, COURSES_DIR, COURSE_OFFERINGS_DIR, DATA_DOCS_DIR, REFERENCE_GUIDES_DIR, PROGRAMMING_CLASSES_DIR, PROGRAMMING_ENVIRONMENTS_DIR, PROGRAMMING_EXPRESSIONS_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
-  ) || ALLOWED_FILES.include?(filename)
+# Raise an error if any files are not allowed
+unless validation_result[:valid]
+  raise validation_result[:message]
 end


### PR DESCRIPTION
We recently had some code changes get committed automatically from the Levelbuilder `commit_content` cron job. We have logic in the form of a commit hook that defines the relevant paths, this PR extracts that to a module and uses it for the commit hook and the commit_content job.

This PR was also an experiment using Cline and Claude-3.7-sonnet

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
