### PR TITLE
Fix Self-Paced PL Catalog course offerings passed in

### DIFF
--- a/dashboard/app/controllers/pd/professional_learning_controller.rb
+++ b/dashboard/app/controllers/pd/professional_learning_controller.rb
@@ -32,7 +32,7 @@ class Pd::ProfessionalLearningController < ApplicationController
 
   # GET professional-learning/courses
   def courses
-    @self_paced_pl_course_offerings = CourseOffering.self_paced_course_offerings_for_catalog
+    @self_paced_pl_course_offerings = CourseOffering.professional_learning_and_self_paced_course_offerings.map(&:summarize_for_catalog)
     view_options(full_width: true, no_padding_container: true)
     render :self_paced_pl_catalog
   end

--- a/dashboard/app/controllers/pd/professional_learning_controller.rb
+++ b/dashboard/app/controllers/pd/professional_learning_controller.rb
@@ -32,7 +32,7 @@ class Pd::ProfessionalLearningController < ApplicationController
 
   # GET professional-learning/courses
   def courses
-    @self_paced_pl_course_offerings = CourseOffering.professional_learning_and_self_paced_course_offerings.map(&:summarize_for_catalog)
+    @self_paced_pl_course_offerings = CourseOffering.self_paced_course_offerings_for_catalog
     view_options(full_width: true, no_padding_container: true)
     render :self_paced_pl_catalog
   end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -224,12 +224,6 @@ class CourseOffering < ApplicationRecord
     end
   end
 
-  def self.self_paced_course_offerings_for_catalog
-    professional_learning_and_self_paced_course_offerings.
-      map(&:summarize_for_catalog).
-      filter {|co| co[:self_paced_pl_course_offering_path].present?}
-  end
-
   def summarize_for_unit_selector(unit_ids)
     {
       display_name: any_versions_launched? ? localized_display_name : localized_display_name + ' *',

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -224,6 +224,15 @@ class CourseOffering < ApplicationRecord
     end
   end
 
+  def self.self_paced_course_offerings_for_catalog
+    all_course_offerings.select do |co|
+      co.get_participant_audience == 'teacher' &&
+        co.instruction_type == 'self_paced' &&
+        co.assignable? &&
+        co.any_version_is_in_published_state?
+    end.map(&:summarize_for_catalog)
+  end
+
   def summarize_for_unit_selector(unit_ids)
     {
       display_name: any_versions_launched? ? localized_display_name : localized_display_name + ' *',

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -523,6 +523,37 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert_includes(filtered_course_offerings, all_co)
   end
 
+  test 'self_paced_course_offerings_for_catalog filters only for assignable published self-paced teacher course offerings' do
+    # Course offering that doesn't satisfy any of the conditions
+    none_unit = create(:script, name: 'unit1', family_name: 'none', version_year: '1991', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    none_co = CourseOffering.add_course_offering(none_unit)
+    none_co.update!(assignable: false)
+
+    # Course offering that only satisfies the 'assignable' condition
+    assignable_unit = create(:script, name: 'unit2', family_name: 'assignable', version_year: '1992', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    CourseOffering.add_course_offering(assignable_unit)
+
+    # Course offering that only satisfies the 'published' condition
+    published_unit = create(:script, name: 'unit3', family_name: 'published', version_year: '1993', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    published_co = CourseOffering.add_course_offering(published_unit)
+    published_co.update!(assignable: false)
+
+    # Course offering that only satisfies the 'for teacher' condition
+    for_teacher_unit = create(:script, name: 'unit4', family_name: 'for-teacher', version_year: '1994', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
+    for_teacher_co = CourseOffering.add_course_offering(for_teacher_unit)
+    for_teacher_co.update!(assignable: false)
+
+    # Course offering that is a NON-self-paced assignable published teacher course offerings
+    non_self_paced_unit = create(:script, name: 'unit5', family_name: 'non-self-paced', version_year: '1998', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
+    CourseOffering.add_course_offering(non_self_paced_unit)
+
+    # Course offering that satisfies all conditions
+    self_paced_unit = create(:script, name: 'unit6', family_name: 'all', version_year: '1998', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', instruction_type: 'self_paced', participant_audience: 'teacher')
+    self_paced_co = CourseOffering.add_course_offering(self_paced_unit)
+
+    assert_equal [self_paced_co.key], CourseOffering.self_paced_course_offerings_for_catalog.pluck(:key)
+  end
+
   test 'can_be_assigned? is false if its an unassignable course' do
     unassignable_course_offering = create :course_offering
     refute unassignable_course_offering.can_be_assigned?(@student)


### PR DESCRIPTION
Currently, the wrong course offerings are being passed into the Self-Paced PL Catalog: only course offerings with a valid self-paced PL course version path (which would get the courses themselves which have an associated self-paced PL course, so it was acquiring the wrong ones). Since this was meant to catch whether it had a valid path, a better way would be to check if the course is assignable and published (signifying it's ready to be shown).

To reflect this, this PR adjusts the filtering for which course offerings are passed to the Self-Paced PL Catalog to match that of the Curriculum Catalog (but with an `instruction_type` of `self_paced` and a `participant_audience` of `teacher` instead) as discussed in Slack [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1750293066252399?thread_ts=1750272055.885609&cid=C0453TUMLE7). I also added a unit test which I missed adding last time.

Shows more courses now:
![localhost-studio code org_3000_professional-learning_courses](https://github.com/user-attachments/assets/eb127874-fbbd-4c2c-81ac-9a7b69ea0a50)

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1750293066252399?thread_ts=1750272055.885609&cid=C0453TUMLE7)

## Testing story
Local testing and added a unit test for coverage.
