### PR TITLE
Run `bundle install` from prepare_tests_common.sh

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -346,6 +346,48 @@ volumes:
     temp: {}
 
 trigger:
+  event:
+    - pull_request
+---
+# REMOVE ME BEFORE MERGING, JUST FOR TESTING THE PR
+kind: pipeline
+type: docker
+name: cache-staging-build-artifacts-test
+
+clone:
+  disable: true
+
+steps:
+  - name: clone
+    image: bitnami/git
+    commands:
+      - git lfs install
+      - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 
+
+  # Do all the work necessary to run UI tests so we can capture a complete
+  # snapshot of rbenv and the database, but don't actually run the tests.
+  - name: prepare-ui-tests
+    image: codedotorg/code-dot-org:1.16
+    pull: always
+    environment:
+      PROPERTIES_ENCRYPTION_KEY:
+        from_secret: PROPERTIES_ENCRYPTION_KEY
+    volumes:
+      - name: rbenv
+        path: /home/ci/.rbenv
+      - name: mysql
+        path: /var/lib/mysql
+    commands:
+      - sudo chown -R ci:ci .
+      - /entrypoint.sh docker/ci/scripts/prepare_ui_tests.sh
+
+volumes:
+  - name: rbenv
+    temp: {}
+  - name: mysql
+    temp: {}
+
+trigger:
   branch:
     - "staging"
     - "staging-next"
@@ -353,6 +395,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: d706a958430c49a672f3c7c5a42209f54dd4cc1aada7d68e2489307e2d98b275
+hmac: 9e5191ce147e55a9e49a480d1f843d6fb3f85e7f8a23bf2dd39cfc7a96950240
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -352,48 +352,7 @@ trigger:
   event:
     - push
 ---
-kind: pipeline
-type: docker
-name: cache-staging-build-artifacts-test
-
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: bitnami/git
-    commands:
-      - git lfs install
-      - git clone --branch $DRONE_SOURCE_BRANCH $DRONE_GIT_HTTP_URL . 
-
-  # Do all the work necessary to run UI tests so we can capture a complete
-  # snapshot of rbenv and the database, but don't actually run the tests.
-  - name: prepare-ui-tests
-    image: codedotorg/code-dot-org:1.16
-    pull: always
-    environment:
-      PROPERTIES_ENCRYPTION_KEY:
-        from_secret: PROPERTIES_ENCRYPTION_KEY
-    volumes:
-      - name: rbenv
-        path: /home/ci/.rbenv
-      - name: mysql
-        path: /var/lib/mysql
-    commands:
-      - sudo chown -R ci:ci .
-      - /entrypoint.sh docker/ci/scripts/prepare_ui_tests.sh
-
-volumes:
-  - name: rbenv
-    temp: {}
-  - name: mysql
-    temp: {}
-
-trigger:
-  event:
-    - pull_request
----
 kind: signature
-hmac: 3c505e0a490c1f0da8702467b059d39a611a4d64b801163cd92a015ac9361db9
+hmac: d706a958430c49a672f3c7c5a42209f54dd4cc1aada7d68e2489307e2d98b275
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -394,6 +394,6 @@ trigger:
     - pull_request
 ---
 kind: signature
-hmac: 786dff2afec9a56e09e28c65b7c0ff6f4756f09cbc23900c9b95aa2d45bb18f0
+hmac: 3c505e0a490c1f0da8702467b059d39a611a4d64b801163cd92a015ac9361db9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -346,10 +346,12 @@ volumes:
     temp: {}
 
 trigger:
+  branch:
+    - "staging"
+    - "staging-next"
   event:
-    - pull_request
+    - push
 ---
-# REMOVE ME BEFORE MERGING, JUST FOR TESTING THE PR
 kind: pipeline
 type: docker
 name: cache-staging-build-artifacts-test
@@ -388,13 +390,10 @@ volumes:
     temp: {}
 
 trigger:
-  branch:
-    - "staging"
-    - "staging-next"
   event:
-    - push
+    - pull_request
 ---
 kind: signature
-hmac: 9e5191ce147e55a9e49a480d1f843d6fb3f85e7f8a23bf2dd39cfc7a96950240
+hmac: 786dff2afec9a56e09e28c65b7c0ff6f4756f09cbc23900c9b95aa2d45bb18f0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -364,7 +364,7 @@ steps:
     image: bitnami/git
     commands:
       - git lfs install
-      - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 
+      - git clone --branch $DRONE_SOURCE_BRANCH $DRONE_GIT_HTTP_URL . 
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of rbenv and the database, but don't actually run the tests.

--- a/docker/ci/scripts/prepare_tests_common.sh
+++ b/docker/ci/scripts/prepare_tests_common.sh
@@ -14,6 +14,8 @@ export RACK_ENV=test
 export DISABLE_SPRING=1
 export LD_LIBRARY_PATH=/usr/local/lib
 
+bundle install --quiet
+
 # Disable Pegasus content based on the exit code of the rake task.
 if bundle exec rake ci:sparse_checkout; then
   echo "Full checkout – HAS_PEGASUS_CONTENT not set"

--- a/docker/ci/scripts/prepare_ui_tests.sh
+++ b/docker/ci/scripts/prepare_ui_tests.sh
@@ -54,7 +54,6 @@ echo "Wrote settings and secrets from env vars into locals.yml."
 
 set -x
 
-bundle install --quiet
 bundle exec rake install
 bundle exec rake build
 

--- a/docker/ci/scripts/prepare_unit_tests.sh
+++ b/docker/ci/scripts/prepare_unit_tests.sh
@@ -40,6 +40,5 @@ echo "Wrote settings and secrets from env vars into locals.yml."
 
 set -x
 
-bundle install --quiet
 bundle exec rake install
 bundle exec rake build


### PR DESCRIPTION
The `cache-staging-build-artifacts` drone pipeline was failing after merging #65825, because prepare_tests_common.sh was invoking rake before running `bundle install`.

This PR is one idea for fixing this: move the running of `bundle install` into prepare_tests_common.sh (previously was run later by both prepare_unit_tests.sh and prepare_ui_tests.sh).

Testing whether this approach resolves the issue by adding a temporary pipeline that mirrors cache-staging-build-artifacts but triggers on PR: https://drone.cdn-code.org/code-dot-org/code-dot-org/34045/3/1