### PR TITLE
temporarily disable rake ci:sparse_checkout

### DIFF
--- a/docker/ci/scripts/prepare_tests_common.sh
+++ b/docker/ci/scripts/prepare_tests_common.sh
@@ -15,17 +15,18 @@ export DISABLE_SPRING=1
 export LD_LIBRARY_PATH=/usr/local/lib
 
 # Disable Pegasus content based on the exit code of the rake task.
-if bundle exec rake ci:sparse_checkout; then
-  echo "Full checkout – HAS_PEGASUS_CONTENT not set"
-else
-  # Nest this check inside the outer `if` block to ensure that a non-zero exit
-  # code from the rake task does not cause this script to exit immediately.
-  exit_code=$?
-  if [ "$exit_code" -eq 11 ]; then
-    export HAS_PEGASUS_CONTENT=false
-    echo "Sparse checkout – HAS_PEGASUS_CONTENT set to false"
-  else
-    echo "Unexpected exit code from ci:sparse_checkout: $exit_code"
-    exit 1
-  fi
-fi
+echo 'rake ci:sparse_checkout temporarily disabled - HAS_PEGASUS_CONTENT not set'
+#if bundle exec rake ci:sparse_checkout; then
+#  echo "Full checkout – HAS_PEGASUS_CONTENT not set"
+#else
+#  # Nest this check inside the outer `if` block to ensure that a non-zero exit
+#  # code from the rake task does not cause this script to exit immediately.
+#  exit_code=$?
+#  if [ "$exit_code" -eq 11 ]; then
+#    export HAS_PEGASUS_CONTENT=false
+#    echo "Sparse checkout – HAS_PEGASUS_CONTENT set to false"
+#  else
+#    echo "Unexpected exit code from ci:sparse_checkout: $exit_code"
+#    exit 1
+#  fi
+#fi


### PR DESCRIPTION
* See [slack](https://codedotorg.slack.com/archives/C03CK49G9/p1750353448562039?thread_ts=1750322268.109379&cid=C03CK49G9). temporary, speculative fix for drone cache issue. this essentially disables https://github.com/code-dot-org/code-dot-org/pull/65825 while a proper fix is validated.

## Testing story

* passing drone run indicates this doesn't break normal drone runs
* visual inspection of https://github.com/code-dot-org/code-dot-org/pull/65825 to confirm this PR disables all the drone setup code that was added in that PR
