### PR TITLE
Evaluate Student Learning: remove "on run" evaluations in Applab

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -11,7 +11,6 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 
 import applabMsg from '@cdo/applab/locale';
-import {evaluateStudentWork} from '@cdo/apps/aiEvaluation/aiEvaluationApi';
 import autogenerateML from '@cdo/apps/applab/ai';
 import * as aiConfig from '@cdo/apps/applab/ai/dropletConfig';
 import SmallFooter from '@cdo/apps/code-studio/components/SmallFooter';
@@ -1126,31 +1125,6 @@ Applab.runButtonClick = function () {
     scriptId: analyticsData.scriptId,
     interaction: UserLevelInteractions.click_run,
   });
-
-  const config = studioApp().config;
-  const levelUrl = config.currentScriptLevelUrl;
-  // These are the hand-selected levels that are eligible for AI code analysis
-  // as part of the initial Evaluate Student Learning pilot. We want to tightly
-  // scope which levels we run AI code analysis on in for early testing. If we
-  // gain confidence in the approach and accuracy of AI evaluations, we'll expand,
-  // and ultimately likely store this information as a property of the level itself.
-  const aiEvaluationLevels = [
-    '/s/csp4-2024/lessons/3/levels/2',
-    '/s/csp4-2024/lessons/3/levels/6',
-  ];
-  const shouldEvaluateStudentCode = aiEvaluationLevels.includes(levelUrl);
-  if (shouldEvaluateStudentCode) {
-    evaluateStudentWork(
-      {
-        studentId: config.userId,
-        studentDisplayName: config.codeOwnersName,
-        studentWork: config.getCode(),
-        codeVersion: project.getCurrentSourceVersionId(),
-      },
-      analyticsData.levelId,
-      analyticsData.scriptId
-    );
-  }
 
   // Enable the Finish button if is present:
   var shareCell = document.getElementById('share-cell');


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/TEACH-2046

We have enough data - so much 
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdzI3OTZtZW1yMGl6emU4c3Vlcm9qcnZrY2UzbHMwbnN1dm94ODQwNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/fQoIDlLW6A6BAhyev8/giphy.gif) 

from our "canary" coding levels to do the analysis we need to for the next phase of the Evaluate project. No need to waste additional storage resources right now. So, we can turn off "behind-the-scenes" evaluation on run click from AppLab. 
 
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2c4MGw5MnNyZGs3N3FpampycmpxZGptb2JwZHZvNnpibGY0NXFxeSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/JOGIzSOusla3M5fI3m/giphy.gif)

The hypothetical plan is to bulk evaluate internally when we need this data in the future. 
![](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3OGxteWhzYWIxNzB1ZWRsa2VlM3dsZ2ttaG51eHJpOGkzMXFzOGY4dCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/2vofyIUx66r9qWOvtZ/giphy.gif)