### PR TITLE
Fixing regression to experiment flag string and cleaning up

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -8,7 +8,6 @@ import {
   removeIdsFromBlocks,
 } from '@cdo/apps/blockly/addons/cdoXml';
 import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
-import experiments from '@cdo/apps/util/experiments';
 
 import * as blockUtils from '../../block_utils';
 import {parseElement as parseXmlElement} from '../../xml';
@@ -425,20 +424,6 @@ export function getUserTheme(themeOption: GoogleBlockly.Theme | undefined) {
       cdoTheme
     );
   }
-}
-
-/**
- * Returns a cursor type, based on the presence of an option in the browser's localStorage.
- * @param {string} type
- * @returns {string} one of 'default', 'basic', or 'line'
- */
-export function getUserCursorType() {
-  const defaultCursorType = experiments.isEnabled(
-    experiments.KEYBOARD_NAVIGATION
-  )
-    ? 'line'
-    : 'default';
-  return localStorage.blocklyCursor || defaultCursorType;
 }
 
 /**

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -885,7 +885,9 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
 
     if (
       options.enableKeyboardNavigation ||
-      experiments.isEnabledAllowingQueryString(experiments.KEYBOARD_NAVIGATION)
+      experiments.isEnabledAllowingQueryString(
+        experiments.BLOCKLY_KEYBOARD_NAVIGATION
+      )
     ) {
       initializeKeyboardNavigation(workspace, options.theme);
     } else {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -46,8 +46,6 @@ experiments.AI_DIFFERENTIATION = 'ai-differentiation';
 experiments.AI_TUTOR_ACCESS = 'ai-tutor';
 // Adds a "Get help with this block" option to block context menus if docs exist (e.g. Sprite Lab)
 experiments.BLOCKLY_DOCS = 'blockly_docs';
-// Adds a keyboard navigation toggle to the workspace header in Google Blockly labs
-experiments.KEYBOARD_NAVIGATION = 'blockly_keyboard';
 // Adds the ability to toggle between v1 and v2 of the section progress page of the teacher dashboard
 experiments.SECTION_PROGRESS_V2 = 'section_progress_v2';
 // Allows the playspace to be dragged to take up a larger portion of the screen


### PR DESCRIPTION
We merged a minor regression with this PR [here](https://github.com/code-dot-org/code-dot-org/pull/66590/files#diff-545d5d128a60289cdade31db5f86e54c592eb943fa0d9213a4530647a973b02aR894) that changed the experiment called for keyboard navigation. This meant we can no longer use the url param. I looked into this old experiment and it is no longer relevant (keyboard navigation will never be toggled on and off- it will just exist), so I removed the experiment flag and the one function that called it (nothing calls that function). 

Then I updated the call from googleBlocklyWrapper back to the correct experiment flag.

## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1286

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
