### PR TITLE
Revert "[Google Blockly] Disable cross-tab copy/paste when using keyboard navigation"

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -126,6 +126,14 @@ import {
   isDarkTheme,
 } from './utils';
 
+const options = {
+  contextMenu: true,
+  shortcut: true,
+};
+
+const plugin = new CrossTabCopyPaste();
+plugin.init(options);
+
 const MAX_GET_CODE_RETRIES = 2;
 const RETRY_GET_CODE_INTERVAL_MS = 500;
 
@@ -890,9 +898,6 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       )
     ) {
       initializeKeyboardNavigation(workspace, options.theme);
-    } else {
-      const plugin = new CrossTabCopyPaste();
-      plugin.init();
     }
 
     // Typically, we need to handle disabling blocks that are not connected to an


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#66617

It looks like this is causing errors when students switch levels.