### PR TITLE
Improve Database Instance Type Defaults

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -70,10 +70,10 @@ Parameters:
     MaxLength: 16
   DBInstanceType:
     Type: String
-    Default: db.r5.2xlarge
+    Default: <%= rack_env?(:adhoc) ? 'db.t4g.large' : 'db.r7i.xlarge' %>
   DBBackupRetention:
     Type: Number
-    Default: 5
+    Default: <%= rack_env?(:adhoc) ? 0 : 5 %>
 <% end -%>
 <% if frontends -%>
   DaemonInstanceType:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -70,6 +70,8 @@ Parameters:
     MaxLength: 16
   DBInstanceType:
     Type: String
+    # `t4g.large` is the largest `t` family database instance type that supports Aurora 3 / MySQL 8.
+    # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.SupportAurora.html
     Default: <%= rack_env?(:adhoc) ? 'db.t4g.large' : 'db.r7i.xlarge' %>
   DBBackupRetention:
     Type: Number

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -337,7 +337,9 @@
         - error
         - slowquery
       DeletionProtection: <%= rack_env?(:adhoc) ? false : true %>
+<%    unless rack_env?(:adhoc) -%>
       BackupRetentionPeriod: !Ref DBBackupRetention
+<%    end -%>
 <%    DB_INSTANCE_RANGE.each do |i| %>
   Aurora<%=i%>:
     Type: AWS::RDS::DBInstance


### PR DESCRIPTION
Set new default instance types for Aurora clusters (and also stop backing up adhoc databases).

## Testing story

`bundle exec rake adhoc:start RAILS_ENV=adhoc DATABASE=yes STACK_NAME=adhoc-default-db-instance-type`

## Deployment strategy
All long-lived Stacks have been manually updated (via Stack Parameter change) to use `r7i` database instance types:


- staging - `db.r7i.xlarge`
- test - `db.r7i.2xlarge`
- levelbuilder - `db.r7i.xlarge`
- bugcrowd - `db.r7i.2xlarge`
- production - `db.r7i.8xlarge`


## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
