### PR TITLE
Fix flaky signing_in ui test 

### DIFF
--- a/dashboard/test/ui/features/platform/signing_in.feature
+++ b/dashboard/test/ui/features/platform/signing_in.feature
@@ -12,7 +12,7 @@ Scenario: Student sign in from code.org
   Then I click "#header_user_signin"
   And I wait to see "#signin"
   And I fill in username and password for "Bob"
-  And I click "#signin-button" to load a new page
+  And I click the sign-in button to load a new page
   Then I wait until I am on "http://studio.code.org/home"
   Then I wait to see "#header_user_menu"
   And I wait until element ".display_name" is visible
@@ -49,7 +49,7 @@ Scenario: Teacher sign in from studio.code.org
   Given I am on "http://studio.code.org/users/sign_in"
   And I wait to see "#signin"
   And I fill in username and password for "Casey"
-  And I click the sign-in button to load a new page
+  And I click "#signin-button" to load a new page
   Then I wait until I am on "http://studio.code.org/home"
   Then I wait to see "#header_user_menu"
   And I wait until element ".display_name" is visible

--- a/dashboard/test/ui/features/platform/signing_in.feature
+++ b/dashboard/test/ui/features/platform/signing_in.feature
@@ -2,7 +2,6 @@
 @single_session
 Feature: Signing in and signing out
 
-@skip
 @pegasus_content
 Scenario: Student sign in from code.org
   Given I create a student named "Bob"
@@ -50,7 +49,7 @@ Scenario: Teacher sign in from studio.code.org
   Given I am on "http://studio.code.org/users/sign_in"
   And I wait to see "#signin"
   And I fill in username and password for "Casey"
-  And I click "#signin-button" to load a new page
+  And I click the sign-in button to load a new page
   Then I wait until I am on "http://studio.code.org/home"
   Then I wait to see "#header_user_menu"
   And I wait until element ".display_name" is visible

--- a/dashboard/test/ui/features/platform/signing_in.feature
+++ b/dashboard/test/ui/features/platform/signing_in.feature
@@ -12,7 +12,7 @@ Scenario: Student sign in from code.org
   Then I click "#header_user_signin"
   And I wait to see "#signin"
   And I fill in username and password for "Bob"
-  And I click the sign-in button to load a new page
+  And I press the first "#signin-button" element to load a new page
   Then I wait until I am on "http://studio.code.org/home"
   Then I wait to see "#header_user_menu"
   And I wait until element ".display_name" is visible

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -584,6 +584,7 @@ When "I click the sign-in button to load a new page" do
     break # Success
   rescue JSON.ParserError => exception
     if attempt < max_retries
+      puts "Session Id: #{@browser.session_id}"
       puts "JSON parser error on sign-in click (attempt #{attempt}): #{exception.message}"
       sleep 2
       next

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -574,6 +574,26 @@ When /^I click "([^"]*)"( once it exists)?(?: to load a new (page|tab))?$/ do |s
   page_load(load) {element.click}
 end
 
+When "I click the sign-in button to load a new page" do
+  selector = "#signin-button"
+  max_retries = 3
+
+  (1..max_retries).each do |attempt|
+    element = @browser.find_element(:css, selector)
+    page_load("page") {element.click}
+    break # Success
+  rescue JSON.ParserError => exception
+    if attempt < max_retries
+      puts "JSON parser error on sign-in click (attempt #{attempt}): #{exception.message}"
+      sleep 2
+      next
+    else
+      puts "Sign in failed after retries: #{exception.message}"
+      raise
+    end
+  end
+end
+
 When /^I click "([^"]*)" if it is visible$/ do |selector|
   if @browser.execute_script(jquery_is_element_visible(selector))
     find = -> {@browser.find_element(:css, selector)}

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -574,27 +574,6 @@ When /^I click "([^"]*)"( once it exists)?(?: to load a new (page|tab))?$/ do |s
   page_load(load) {element.click}
 end
 
-When "I click the sign-in button to load a new page" do
-  selector = "#signin-button"
-  max_retries = 3
-
-  (1..max_retries).each do |attempt|
-    element = @browser.find_element(:css, selector)
-    page_load("page") {element.click}
-    break # Success
-  rescue JSON.ParserError => exception
-    if attempt < max_retries
-      puts "Session Id: #{@browser.session_id}"
-      puts "JSON parser error on sign-in click (attempt #{attempt}): #{exception.message}"
-      sleep 2
-      next
-    else
-      puts "Sign in failed after retries: #{exception.message}"
-      raise
-    end
-  end
-end
-
 When /^I click "([^"]*)" if it is visible$/ do |selector|
   if @browser.execute_script(jquery_is_element_visible(selector))
     find = -> {@browser.find_element(:css, selector)}


### PR DESCRIPTION
The iPhone test `Scenario: Student sign in from code.org` flaked on Tue 3/18/25 with `unexpected token at 'dbf54315b9544c8e19aa2305' (JSON::ParserError)`. It seems like a rather common error with iPhone tests that are often caught on retries ([example](https://codedotorg.slack.com/archives/C03CM903Y/p1746497273791229)).

After running this test locally over a dozen times, I have been unable to repro. In order to reduce the chances of this test flaking in the future, I added a new step that retries clicking the sign-in button. 

## Links
- Jira: [P20-1441](https://codedotorg.atlassian.net/browse/P20-1441)

## Testing story
Verified the changes don't affect a successful test run. Unable to repro the initial issue that caused the flake.

## Follow-up work
I will watch the DTT for a while to see how this test does and if it flakes again.
