### PR TITLE
CMS-840: Fix "Lab share page logo" ui tests

### DIFF
--- a/dashboard/test/ui/features/star_labs/sharepage_logo.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage_logo.feature
@@ -62,7 +62,7 @@ Feature: Lab share page logo
     And I sign out
     And I navigate to the last shared URL
     And element "div:contains('STUDIO')" does not exist
-    And I click "#logo-img" to load a new page
+    And I click "#logo-img img" once it exists to load a new page
     And check that the URL contains "http://code.org"
 
   @no_mobile
@@ -77,7 +77,7 @@ Feature: Lab share page logo
     And I sign out
     And I navigate to the last shared URL
     And element "div:contains('STUDIO')" does not exist
-    And I click "#logo-img" to load a new page
+    And I click "#logo-img img" once it exists to load a new page
     And check that the URL contains "http://code.org"
 
   @only_mobile


### PR DESCRIPTION
```
And I click "#logo-img" to load a new page

 (Selenium::WebDriver::Error::ElementNotInteractableError)
 
./utils/selenium_browser.rb:51:in `create_response'
./features/step_definitions/steps.rb:574:in `block (2 levels) in '
./features/step_definitions/steps.rb:54:in `page_load'
./features/step_definitions/steps.rb:574:in `/^I click "([^"]*)"( once it exists)?(?: to load a new (page|tab))?$/'
./features/support/hooks.rb:28:in `block in '
features/star_labs/sharepage_logo.feature:65:in `And I click "#logo-img" to load a new page'
```

## Links
- JIRA task: [CMS-840](https://codedotorg.atlassian.net/browse/CMS-840)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66625
- Test run: https://cucumber-logs.s3.amazonaws.com/test/test/Safari_star_labs_sharepage_logo_output.html?versionId=vLyjOdxKp7ppWrqOyv8N4gs8Jh1bmX4l