### PR TITLE
Disable Distributed Tracing in NewRelic 8.0

### DIFF
--- a/cookbooks/cdo-apps/templates/default/newrelic.yml.erb
+++ b/cookbooks/cdo-apps/templates/default/newrelic.yml.erb
@@ -188,8 +188,8 @@ common: &default_settings
   # Distributed tracing is enabled by default as of version 8.0. Much as we'd
   # like to benefit from this functionality, we are already over budget on our
   # data ingestion; unfortunately, we need to turn this off for now.
-	distributed_tracing:
-		enabled: false
+  distributed_tracing:
+    enabled: false
 
 # Application Environments
 # ------------------------------------------

--- a/cookbooks/cdo-apps/templates/default/newrelic.yml.erb
+++ b/cookbooks/cdo-apps/templates/default/newrelic.yml.erb
@@ -185,6 +185,12 @@ common: &default_settings
   instrumentation:
     sinatra: chain
 
+  # Distributed tracing is enabled by default as of version 8.0. Much as we'd
+  # like to benefit from this functionality, we are already over budget on our
+  # data ingestion; unfortunately, we need to turn this off for now.
+	distributed_tracing:
+		enabled: false
+
 # Application Environments
 # ------------------------------------------
 # Environment-specific settings are in this section.


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/66428

The new version of the NewRelic gem we upgraded to [enables distributed tracing by default](https://docs.newrelic.com/docs/apm/agents/ruby-agent/getting-started/migration-8x-guide/#distributed_tracing), which unfortunately generates [more data than we have capacity to consume](https://one.newrelic.com/admin-portal/data-ingestion/home?account=501463&duration=2592000000&state=de8a76ed-bcc5-dba7-594b-b8261644ff55) in New Relic right now.

Huge thanks to @stephenliang for discovering the problem, and for reminding me about it when I forgot :upside_down_face: 

## Links

- Slack thread: https://codedotorg.slack.com/archives/C03CK49G9/p1749839400539909