### PR TITLE
Evaluate Student Learning: use key to identify skill in student dataset maker

### DIFF
--- a/apps/src/aiEvaluation/aiEvaluationApi.ts
+++ b/apps/src/aiEvaluation/aiEvaluationApi.ts
@@ -23,6 +23,7 @@ export interface AIResponse {
 
 export interface SkillBasedAIResponse extends AIResponse {
   skillId: number;
+  skillKey: string;
 }
 
 export interface StudentWorkEvaluation extends StudentAnswer, AIResponse {

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -13,7 +13,7 @@ import {fetchStudentCodeSamples} from './StudentWorkSamplesApi';
 
 type EvaluatedCodeSample = StudentAnswer &
   AIResponse & {
-    [key in `skill${number}${
+    [key in `skill-${string}${
       | 'evaluationCriteria'
       | 'aiEvaluation'
       | 'aiReasoning'}`]?: string;
@@ -91,12 +91,13 @@ const StudentCodeDatasetMaker: React.FC = () => {
     if (aiResponse.skillEvaluations) {
       for (let i = 0; i < aiResponse.skillEvaluations.length; i++) {
         const skillEvaluation = aiResponse.skillEvaluations[i];
-        const skillId = skillEvaluation.skillId;
-        evaluation[`skill${skillId}evaluationCriteria`] =
+        const skillKey = skillEvaluation.skillKey;
+        evaluation[`skill-${skillKey}-evaluationCriteria`] =
           skillEvaluation.evaluationCriteria;
-        evaluation[`skill${skillId}aiEvaluation`] =
+        evaluation[`skill-${skillKey}-aiEvaluation`] =
           skillEvaluation.aiEvaluation;
-        evaluation[`skill${skillId}aiReasoning`] = skillEvaluation.aiReasoning;
+        evaluation[`skill-${skillKey}-aiReasoning`] =
+          skillEvaluation.aiReasoning;
       }
     }
     setEvaluatedSamples(prevSamples => [...prevSamples, evaluation]);

--- a/dashboard/app/helpers/ai_system_prompts/evaluate_system_prompt_helper.rb
+++ b/dashboard/app/helpers/ai_system_prompts/evaluate_system_prompt_helper.rb
@@ -40,7 +40,7 @@ module AiSystemPrompts::EvaluateSystemPromptHelper
     if skills.any?
       skills.each do |skill|
         skill_evaluations << {
-          skilKey: skill.key,
+          skillKey: skill.key,
           evaluationCriteria: skill.evaluation_criteria
         }
       end

--- a/dashboard/app/helpers/ai_system_prompts/evaluate_system_prompt_helper.rb
+++ b/dashboard/app/helpers/ai_system_prompts/evaluate_system_prompt_helper.rb
@@ -3,7 +3,6 @@ module AiSystemPrompts::EvaluateSystemPromptHelper
     evaluation_criteria = get_evaluation_criteria(level)
     evaluation_summary = get_evaluation_criteria_summary(level)
     skill_evaluations = get_skill_evaluations(level)
-    # TODO figure out how to handle skills id
     skills = level.skills
     structure_with_skills = <<~TEXT
       Review the student's work. Respond in correctly formatted JSON.
@@ -30,7 +29,7 @@ module AiSystemPrompts::EvaluateSystemPromptHelper
     if skills.empty? && level.upper_grades_programming_level?
       summary << "/n Evaluated for general code quality."
     elsif skills.any?
-      summary << "/n Evaluated for #{skills.length} programming concept skills."
+      summary << "/n Evaluated for #{skills.length} skills."
     end
     summary
   end
@@ -41,7 +40,7 @@ module AiSystemPrompts::EvaluateSystemPromptHelper
     if skills.any?
       skills.each do |skill|
         skill_evaluations << {
-          skillId: skill.id,
+          skilKey: skill.key,
           evaluationCriteria: skill.evaluation_criteria
         }
       end


### PR DESCRIPTION
A little clean up to reference skillKey instead of skillId in the Student Dataset Maker
