### PR TITLE
CMS-836: Open `HeroBanner` and `SkinnyBanner` external links in new tab

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBanner.tsx
+++ b/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBanner.tsx
@@ -104,6 +104,8 @@ const HeroBanner: React.FunctionComponent<HeroBannerProps> = ({
                     href: firstAnnouncementBannerLink.fields.primaryTarget,
                     external:
                       firstAnnouncementBannerLink.fields.isThisAnExternalLink,
+                    openInNewTab:
+                      firstAnnouncementBannerLink.fields.isThisAnExternalLink,
                   }
                 : undefined,
             }
@@ -129,6 +131,9 @@ const HeroBanner: React.FunctionComponent<HeroBannerProps> = ({
               ariaLabel: firstButtonLink.fields.ariaLabel,
               iconRight: firstButtonLink.fields.isThisAnExternalLink
                 ? externalLinkIconProps
+                : undefined,
+              target: firstButtonLink.fields.isThisAnExternalLink
+                ? '_blank'
                 : undefined,
             }
           : undefined

--- a/frontend/apps/marketing/src/components/contentful/heroBanner/__tests__/HeroBanner.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/heroBanner/__tests__/HeroBanner.test.tsx
@@ -1,0 +1,114 @@
+import {render, screen} from '@testing-library/react';
+
+import HeroBanner from '../HeroBanner';
+
+jest.mock('@/components/contentful/video', () => ({
+  __esModule: true,
+  default: ({videoTitle}: {videoTitle: string}) => (
+    <button aria-label={`Play video ${videoTitle}`}>Play</button>
+  ),
+}));
+
+describe('Hero Banner', () => {
+  const contentMode = 'Light';
+  const heading = 'Test Heading';
+  const imageSize = 'Small';
+
+  const renderComponent = (props = {}) =>
+    render(
+      <HeroBanner
+        heading={heading}
+        contentMode={contentMode}
+        imageSize={imageSize}
+        {...props}
+      />,
+    );
+
+  it('renders announcement banner internal link when props provided', () => {
+    const announcementBannerText = 'Test Announcement Banner';
+    const bannerLinkData = {
+      label: 'Internal Banner Link',
+      primaryTarget: '/test-link',
+      ariaLabel: 'Internal Banner Link Label',
+      isThisAnExternalLink: false,
+    };
+
+    renderComponent({
+      announcementBannerText,
+      announcementBannerLink: [{fields: bannerLinkData}],
+    });
+
+    const bannerLink = screen.getByRole('link', {
+      name: bannerLinkData.ariaLabel,
+    });
+    expect(bannerLink).toBeInTheDocument();
+    expect(bannerLink).toHaveTextContent(bannerLinkData.label);
+    expect(bannerLink).toHaveAttribute('href', bannerLinkData.primaryTarget);
+    expect(bannerLink).not.toHaveAttribute('rel');
+    expect(bannerLink).not.toHaveAttribute('target');
+  });
+
+  it('renders announcement banner external link when props provided', () => {
+    const announcementBannerText = 'Test Announcement Banner';
+    const bannerLinkData = {
+      label: 'External Banner Link',
+      primaryTarget: '/test-link',
+      ariaLabel: 'External Banner Link Label',
+      isThisAnExternalLink: true,
+    };
+
+    renderComponent({
+      announcementBannerText,
+      announcementBannerLink: [{fields: bannerLinkData}],
+    });
+
+    const bannerLink = screen.getByRole('link', {
+      name: bannerLinkData.ariaLabel,
+    });
+    expect(bannerLink).toBeInTheDocument();
+    expect(bannerLink).toHaveTextContent(bannerLinkData.label);
+    expect(bannerLink).toHaveAttribute('href', bannerLinkData.primaryTarget);
+    expect(bannerLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(bannerLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders internal button link when props provided', () => {
+    const buttonLinkData = {
+      label: 'Internal Button Link',
+      primaryTarget: '/test-link',
+      ariaLabel: 'Internal Button Link Label',
+      isThisAnExternalLink: false,
+    };
+
+    renderComponent({buttonLinks: [{fields: buttonLinkData}]});
+
+    const buttonLink = screen.getByRole('link', {
+      name: buttonLinkData.ariaLabel,
+    });
+    expect(buttonLink).toBeInTheDocument();
+    expect(buttonLink).toHaveTextContent(buttonLinkData.label);
+    expect(buttonLink).toHaveAttribute('href', buttonLinkData.primaryTarget);
+    expect(buttonLink).not.toHaveAttribute('rel');
+    expect(buttonLink).not.toHaveAttribute('target');
+  });
+
+  it('renders external button link when props provided', () => {
+    const buttonLinkData = {
+      label: 'External Button Link',
+      primaryTarget: '/test-link',
+      ariaLabel: 'External Button Link Label',
+      isThisAnExternalLink: true,
+    };
+
+    renderComponent({buttonLinks: [{fields: buttonLinkData}]});
+
+    const buttonLink = screen.getByRole('link', {
+      name: buttonLinkData.ariaLabel,
+    });
+    expect(buttonLink).toBeInTheDocument();
+    expect(buttonLink).toHaveTextContent(buttonLinkData.label);
+    expect(buttonLink).toHaveAttribute('href', buttonLinkData.primaryTarget);
+    expect(buttonLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(buttonLink).toHaveAttribute('target', '_blank');
+  });
+});

--- a/frontend/apps/marketing/src/components/contentful/skinnyBanner/SkinnyBanner.tsx
+++ b/frontend/apps/marketing/src/components/contentful/skinnyBanner/SkinnyBanner.tsx
@@ -73,6 +73,9 @@ const SkinnyBanner: React.FunctionComponent<SkinnyBannerProps> = ({
               iconRight: firstButtonLink.fields.isThisAnExternalLink
                 ? externalLinkIconProps
                 : undefined,
+              target: firstButtonLink.fields.isThisAnExternalLink
+                ? '_blank'
+                : undefined,
             }
           : undefined
       }

--- a/frontend/apps/marketing/src/components/contentful/skinnyBanner/__tests_/SkinnyBanner.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/skinnyBanner/__tests_/SkinnyBanner.test.tsx
@@ -1,0 +1,53 @@
+import {render, screen} from '@testing-library/react';
+
+import SkinnyBanner from '../SkinnyBanner';
+
+describe('Skinny Banner', () => {
+  const heading = 'Test Heading';
+  const contentMode = 'Light';
+
+  const renderComponent = (props = {}) =>
+    render(
+      <SkinnyBanner heading={heading} contentMode={contentMode} {...props} />,
+    );
+
+  it('renders internal button link when props provided', () => {
+    const buttonLinkData = {
+      label: 'Internal Button Link',
+      primaryTarget: '/test-link',
+      ariaLabel: 'Internal Button Link Label',
+      isThisAnExternalLink: false,
+    };
+
+    renderComponent({buttonLinks: [{fields: buttonLinkData}]});
+
+    const buttonLink = screen.getByRole('link', {
+      name: buttonLinkData.ariaLabel,
+    });
+    expect(buttonLink).toBeInTheDocument();
+    expect(buttonLink).toHaveTextContent(buttonLinkData.label);
+    expect(buttonLink).toHaveAttribute('href', buttonLinkData.primaryTarget);
+    expect(buttonLink).not.toHaveAttribute('rel');
+    expect(buttonLink).not.toHaveAttribute('target');
+  });
+
+  it('renders external button link when props provided', () => {
+    const buttonLinkData = {
+      label: 'External Button Link',
+      primaryTarget: '/test-link',
+      ariaLabel: 'External Button Link Label',
+      isThisAnExternalLink: true,
+    };
+
+    renderComponent({buttonLinks: [{fields: buttonLinkData}]});
+
+    const buttonLink = screen.getByRole('link', {
+      name: buttonLinkData.ariaLabel,
+    });
+    expect(buttonLink).toBeInTheDocument();
+    expect(buttonLink).toHaveTextContent(buttonLinkData.label);
+    expect(buttonLink).toHaveAttribute('href', buttonLinkData.primaryTarget);
+    expect(buttonLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(buttonLink).toHaveAttribute('target', '_blank');
+  });
+});


### PR DESCRIPTION
## Hero Banner
<img width="100%" alt="hero-banner-links" src="https://github.com/user-attachments/assets/89ca2377-8b42-4f78-a5f8-a511b67baf5e" />

## Skinny Banner
<img width="100%" alt="skinny-banner-link" src="https://github.com/user-attachments/assets/3a6c554f-5e62-49db-959a-525f32ce17f0" />

## Links
- JIRA task: [CMS-836](https://codedotorg.atlassian.net/browse/CMS-836)