### PR TITLE
alter dashboard database to use utf8mb4 by default

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -71,10 +71,8 @@ You can do Code.org development using macOS, Ubuntu, or Windows (running Ubuntu 
         <code>bundle exec rake install</code> must always be called from the local project's root directory, or it won't work.
     </details>
 
-1. fix your database charset, collation, and timezone to match our servers
+1. fix your database timezone to match our servers
     - `bin/mysql-client-admin`
-    - `ALTER DATABASE dashboard_development CHARACTER SET utf8 COLLATE utf8_unicode_ci;`
-    - `ALTER DATABASE dashboard_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;`
     - `SET GLOBAL time_zone = '+00:00';` Set time zone for all new database connections
     - `SET PERSIST time_zone = '+00:00';` Save the setting to the mysqld-auto.cnf file which is read on restart
     - `SELECT @@global.time_zone;` Verify the setting

--- a/TESTING.md
+++ b/TESTING.md
@@ -71,7 +71,7 @@ Dashboard tests commands below should be run from the `dashboard/` directory:
 Before running dashboard tests for the first time, run these commands to seed the required test data
 
 1. `RAILS_ENV=test bundle exec rake assets:precompile`
-2. `RAILS_ENV=test UTF8=1 bundle exec rake db:reset db:test:prepare` : seed the DB with test data
+2. `RAILS_ENV=test bundle exec rake db:reset db:test:prepare` : seed the DB with test data
 3. `cd ../pegasus && RAILS_ENV=test bundle exec rake test:reset_dependencies && cd ../dashboard` : the pegasus test DB must be seeded as well.
 
 To run all dashboard tests, which takes about 15 mintues:
@@ -152,8 +152,7 @@ If you've made a change that caused an eyes failiure, log into Applitools and ch
       `spring stop` 
 
     3. recreate your local dashboard test db and reseed the data via:
-        * `UTF8=1 RAILS_ENV=test bundle exec rake db:reset db:test:prepare`
-        * if you forgot to specify `UTF8=1`, fix it by running: `echo "ALTER DATABASE dashboard_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;" | mysql -uroot`
+        * `RAILS_ENV=test bundle exec rake db:reset db:test:prepare`
 
 2. If you get an error about missing db fields, try migrating your test database:
 `RAILS_ENV=test rake db:migrate`

--- a/dashboard/db/migrate/20250624183835_alter_dashboard_utf8mb4.rb
+++ b/dashboard/db/migrate/20250624183835_alter_dashboard_utf8mb4.rb
@@ -1,0 +1,9 @@
+class AlterDashboardUtf8mb4 < ActiveRecord::Migration[6.1]
+  def up
+    execute "ALTER DATABASE #{CDO.dashboard_db_name} CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;"
+  end
+
+  def down
+    execute "ALTER DATABASE #{CDO.dashboard_db_name} CHARACTER SET = utf8 COLLATE = utf8_unicode_ci;"
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_18_223554) do
+ActiveRecord::Schema.define(version: 2025_06_24_183835) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"

--- a/dashboard/lib/tasks/seed_in_test.rake
+++ b/dashboard/lib/tasks/seed_in_test.rake
@@ -1,10 +1,5 @@
 Rake::Task['db:test:prepare'].enhance do
   ActiveRecord::Base.establish_connection(:test)
-  if ENV['UTF8']
-    ActiveRecord::Base.connection.execute(
-      "ALTER DATABASE #{ActiveRecord::Base.connection.current_database} CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
-    )
-  end
   Rake::Task['db:fixtures:load'].invoke
   require 'cdo/db_utils'
   DBUtils.reload_proxy_backends


### PR DESCRIPTION
Background: as a result of the new DB caching implementation on drone, we're now actually running migrations in drone. this has triggered an old check to start failing if running the migration in drone produces any diffs on schema.rb. because drone DB runs on utf8mb4 and developers with properly configured local databases run on utf8mb3, this now consistently causes drone runs to fail when developers write migrations which add new tables to dashboard DB. For more details, see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1750723048366829?thread_ts=1750698703.086529&cid=C0T0PNTM3).

Per discussion in eng meeting today with @Hamms @cat5inthecradle and @sureshc, rather than moving drone backward to utf8mb3, the plan is to move the DB default forward to utf8mb4 in all environments via database migration. This will affect any newly created tables but should not affect any existing tables in any environment.

Done in this PR:
* migrate dashboard DB to use utf8mb4 charset and collation
* update setup docs to no longer use workarounds to get local development databases into utf8mb3

This migration will reach the following places:
* dashboard_development and dashboard_test databases on local workstations
* dashboard database on staging, test, levelbuilder, and production

The following environments already use utf8mb4:
* unit test DB on the test machine
* drone

## Testing story

see [dashboard db utf8mb4 validation](https://docs.google.com/document/d/1a5rBWauH4EI6901dEAEHkwm8xTQ3K-X9cT2Nb52Y0sI/edit?tab=t.0) doc

## Deployment strategy

- [x] wait until ubuntu upgrade is complete in all chef-managed environments
- [x] merge this change to staging
- [x] notify developers that drone failures on schema diffs can no longer be ignored
- [x] as it reaches each environment, check that the DB charset and collation have been updated
  - [x] staging
  - [x] test
  - [x] levelbuilder
  - [x] production

## Follow-up work

* infra - consider further updating DB default collation from `utf8mb4_unicode_ci` to `utf8mb4_0900_ai_ci` (recommended for mysql 8+)
- [x] @davidsbailey - improve UX for existing `check_for_new_file_changes` check in drone (e.g. 5c6b162ab55eca4d6c073cbe58295fb41a2a5bb9)
