### PR TITLE
Evaluate Student Learning: delete skill

### DIFF
--- a/apps/src/levelbuilder/skills/SkillsByConceptTable.tsx
+++ b/apps/src/levelbuilder/skills/SkillsByConceptTable.tsx
@@ -73,6 +73,17 @@ export const columns = [
       props: {},
     },
   },
+  {
+    property: 'delete',
+    header: {
+      label: 'Delete',
+      props: {className: 'skills-table-header-cell'},
+    },
+    cell: {
+      formatters: [(del: string) => <span>{del}</span>],
+      props: {},
+    },
+  },
 ];
 
 const SkillsByConceptTable: React.FC<SkillsByConceptTableProps> = ({
@@ -93,6 +104,32 @@ const SkillsByConceptTable: React.FC<SkillsByConceptTableProps> = ({
   const handleEditClick = (skill: Skill) => {
     setIsModalOpen(true);
     setSkillToEdit(skill);
+  };
+
+  const handleDelete = async (skillId: number) => {
+    if (!window.confirm('Are you sure you want to delete this skill?')) return;
+    try {
+      const response = await fetch(`/skills/${skillId}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token':
+            (
+              document.querySelector(
+                'meta[name="csrf-token"]'
+              ) as HTMLMetaElement
+            )?.content || '',
+        },
+      });
+      if (response.ok) {
+        window.location.reload();
+      } else {
+        const data = await response.json();
+        alert(data.message || 'Failed to delete skill.');
+      }
+    } catch (err) {
+      alert('Failed to delete skill.');
+    }
   };
 
   return (
@@ -128,6 +165,15 @@ const SkillsByConceptTable: React.FC<SkillsByConceptTableProps> = ({
                 onClick={() => handleEditClick(skill)}
               >
                 <FontAwesomeV6Icon iconName="pencil-alt" />
+              </span>
+            ),
+            delete: (
+              <span
+                style={{cursor: 'pointer', color: 'red'}}
+                onClick={() => handleDelete(skill.id)}
+                title="Delete Skill"
+              >
+                <FontAwesomeV6Icon iconName="times" />
               </span>
             ),
           }))}

--- a/dashboard/app/controllers/skills_controller.rb
+++ b/dashboard/app/controllers/skills_controller.rb
@@ -39,6 +39,15 @@ class SkillsController < ApplicationController
     end
   end
 
+  def destroy
+    @skill = Skill.find(params[:id])
+    if @skill.destroy
+      render json: {status: 'success', message: 'Skill deleted successfully'}, status: :ok
+    else
+      render json: {status: 'error', message: @skill.errors.full_messages.to_sentence}, status: :bad_request
+    end
+  end
+
   private def skill_params
     params.permit(
       :key,

--- a/dashboard/app/models/skill.rb
+++ b/dashboard/app/models/skill.rb
@@ -19,7 +19,7 @@ class Skill < ApplicationRecord
 
   has_and_belongs_to_many :levels, join_table: 'levels_skills', dependent: :delete_all
 
-  before_destroy :delete_serialized_file
+  after_destroy :delete_serialized_file
 
   def serialize
     {

--- a/dashboard/app/models/skill.rb
+++ b/dashboard/app/models/skill.rb
@@ -17,7 +17,9 @@
 class Skill < ApplicationRecord
   validates :description, presence: true
 
-  has_and_belongs_to_many :levels, join_table: 'levels_skills'
+  has_and_belongs_to_many :levels, join_table: 'levels_skills', dependent: :delete_all
+
+  before_destroy :delete_serialized_file
 
   def serialize
     {
@@ -51,5 +53,11 @@ class Skill < ApplicationRecord
     skill = Skill.find_or_initialize_by(key: properties[:key])
     skill.update! properties
     skill.key
+  end
+
+  def delete_serialized_file
+    return unless Rails.application.config.levelbuilder_mode
+    file_path = Rails.root.join("config/skills/#{key}.json")
+    FileUtils.rm_f(file_path)
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -67,7 +67,7 @@ Dashboard::Application.routes.draw do
 
     resources :user_level_interactions, only: [:create]
 
-    resources :skills, only: [:create, :index, :update]
+    resources :skills, only: [:create, :index, :update, :destroy]
 
     patch '/api/v1/user_scripts/:script_id', to: 'api/v1/user_scripts#update'
 


### PR DESCRIPTION
Building off Erin's work on the skills page for levelbuilders, this PR allows level builders to delete skills from the skills table.  Additionally, when we delete a skill from the database this also deletes the serialized JSON file with the skill's key that is used for seeding.

https://github.com/user-attachments/assets/d15c15f0-ae53-4532-b9b6-aa06eca19de9


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-2034)

## Notes

Will wait until Erin merges in https://github.com/code-dot-org/code-dot-org/pull/66598 before merging this PR in.
