### PR TITLE
Music: AI drums focus fix

### DIFF
--- a/apps/src/music/views/PatternAiPanel.tsx
+++ b/apps/src/music/views/PatternAiPanel.tsx
@@ -552,7 +552,7 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
   const aiBotImage = getAiBotImage();
 
   return (
-    <FocusLock>
+    <FocusLock className={styles.focusContainer}>
       <div className={styles.patternPanel} dir="ltr">
         <LoadingOverlay show={isLoading} />
 

--- a/apps/src/music/views/patternAiPanel.module.scss
+++ b/apps/src/music/views/patternAiPanel.module.scss
@@ -41,6 +41,10 @@ $ai-rubric-cyan-hover: #37e1db;
   }
 }
 
+.focusContainer {
+  display: contents;
+}
+
 .patternPanel {
   font-size: 13px;
   user-select: none;


### PR DESCRIPTION
This fixes a small regression from https://github.com/code-dot-org/code-dot-org/pull/66499 in the AI drums panel.

### before

<img width="961" alt="Screenshot 2025-06-24 at 2 08 36 PM" src="https://github.com/user-attachments/assets/5222a02b-2eac-42c9-af2c-4d989105c972" />

### after

<img width="961" alt="Screenshot 2025-06-24 at 2 13 44 PM" src="https://github.com/user-attachments/assets/852defad-c8b4-4703-91df-df33bd211f5e" />
