### PR TITLE
skip flaky unit test for channel with no owner

### DIFF
--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4243,7 +4243,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'find_channel_owner returns nil for channel with no owner' do
-    skip
+    skip # flaky test. see https://github.com/code-dot-org/code-dot-org/pull/66713
     with_anonymous_channel do |project_id, storage_id|
       encrypted_channel_id = storage_encrypt_channel_id storage_id, project_id
       result = User.find_channel_owner encrypted_channel_id

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4243,6 +4243,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'find_channel_owner returns nil for channel with no owner' do
+    skip
     with_anonymous_channel do |project_id, storage_id|
       encrypted_channel_id = storage_encrypt_channel_id storage_id, project_id
       result = User.find_channel_owner encrypted_channel_id


### PR DESCRIPTION
example failure: https://drone.cdn-code.org/code-dot-org/code-dot-org/34332/1/6
```
=ERROR["test_find_channel_owner_returns_nil_for_channel_with_no_owner", "UserTest", 670.325951756]
740 | test_find_channel_owner_returns_nil_for_channel_with_no_owner#UserTest (670.33s)
741 | Minitest::UnexpectedError:         Sequel::DatabaseError: Mysql2::Error::TimeoutError: Timeout waiting for a response from the last query. (waited 30 seconds)
742 | test/testing/projects_test_utils.rb:31:in `with_storage_id_for'
743 | test/testing/projects_test_utils.rb:9:in `with_channel_for'
744 | test/testing/projects_test_utils.rb:35:in `with_anonymous_channel'
745 | test/models/user_test.rb:4246:in `block in <class:UserTest>'
746 | test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

there are many examples of this test being reported as flaky in slack over the past few years.

Jira ticket to track re enabling: https://codedotorg.atlassian.net/browse/P20-1549