### PR TITLE
feat(workshops): update required fields for enrollment creation

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
@@ -83,6 +83,10 @@ export default class WorkshopEnroll extends React.Component {
         signUpUrl: result.sign_up_url,
         workshopUrl: result.workshop_url,
       });
+
+      if (result.workshop_enrollment_status === SUBMISSION_STATUSES.SUCCESS) {
+        this.handleSuccess();
+      }
     } else {
       this.setState({
         workshopEnrollmentStatus: SUBMISSION_STATUSES.UNKNOWN_ERROR,
@@ -153,7 +157,7 @@ export default class WorkshopEnroll extends React.Component {
     );
   }
 
-  renderSuccess() {
+  handleSuccess() {
     // Redirect to My PL landing page. The WORKSHOP_ENROLLMENT_COMPLETED_EVENT event will be logged
     // on that page since event logs immediately followed by redirects sometimes do not fire.
     sessionStorage.setItem(
@@ -188,8 +192,6 @@ export default class WorkshopEnroll extends React.Component {
         return this.renderFull();
       case SUBMISSION_STATUSES.NOT_FOUND:
         return this.renderNotFound();
-      case SUBMISSION_STATUSES.SUCCESS:
-        return this.renderSuccess();
       default:
         return (
           <div>

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -142,38 +142,19 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
   end
 
   private def enrollment_params
-    {
-      user_id: params[:user_id],
-      first_name: params[:first_name]&.strip_utf8mb4,
-      last_name: params[:last_name]&.strip_utf8mb4,
-      email: params[:email]&.strip_utf8mb4,
-      role: params[:role],
-      grades_teaching: params[:grades_teaching],
-      attended_csf_intro_workshop: params[:attended_csf_intro_workshop],
-      csf_course_experience: params[:csf_course_experience],
-      csf_courses_planned: params[:csf_courses_planned],
-      previous_courses: params[:previous_courses],
-      csf_intro_intent: params[:csf_intro_intent],
-      csf_intro_other_factors: params[:csf_intro_other_factors],
-      # params only collected in CSP returning teachers workshop
-      years_teaching: params[:years_teaching],
-      years_teaching_cs: params[:years_teaching_cs],
-      taught_ap_before: params[:taught_ap_before],
-      planning_to_teach_ap: params[:planning_to_teach_ap]
-    }
+    params.require(:user_id)
+    params.permit(:user_id, :first_name, :last_name, :email).to_h.tap do |p|
+      p[:first_name] = p[:first_name]&.strip_utf8mb4
+      p[:last_name] = p[:last_name]&.strip_utf8mb4
+      p[:email] = p[:email]&.strip_utf8mb4
+    end
   end
 
   private def school_info_params
-    {
-      school_type: params[:school_info][:school_type],
-      school_state: params[:school_info][:school_state],
-      school_zip: params[:school_info][:zip],
-      school_district_name: params[:school_info][:school_district_name]&.strip_utf8mb4,
-      school_district_other: params[:school_info][:school_district_other]&.strip_utf8mb4,
-      school_id: params[:school_info][:school_id],
-      school_name: params[:school_info][:school_name]&.strip_utf8mb4,
-      country: params[:school_info][:country]
-    }
+    params.require(:school_info).
+      permit(:school_type, :zip, :school_id, :school_name, :country).to_h.tap do |p|
+        p[:school_name] = p[:school_name]&.strip_utf8mb4
+      end
   end
 
   private def render_unsuccessful(error_message, options = {})

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -60,8 +60,6 @@ class Pd::Enrollment < ApplicationRecord
   validates_email_format_of :email, allow_blank: true
   validates :email, uniqueness: {scope: :pd_workshop_id, message: 'already enrolled in workshop', case_sensitive: false}, unless: :deleted?
 
-  validate :school_forbidden, if: -> {new_record? || school_changed?}
-
   before_validation :autoupdate_user_field
   before_save :set_application_id
   after_create :set_default_scholarship_info
@@ -104,18 +102,6 @@ class Pd::Enrollment < ApplicationRecord
   # School info (https://github.com/code-dot-org/code-dot-org/pull/9023) was deployed on 2016-08-30
   def created_before_school_info?
     persisted? && created_at < '2016-08-30'
-  end
-
-  def school_forbidden
-    errors.add(:school, 'is forbidden') if read_attribute(:school)
-  end
-
-  def school_info_country_required
-    errors.add(:school_info, 'must have a country') unless school_info.try(:country)
-  end
-
-  def self.for_school_district(school_district)
-    joins(:school_info).where(school_infos: {school_district_id: school_district.id})
   end
 
   scope :attended, -> {joins(:attendances).group('pd_enrollments.id')}

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -341,7 +341,6 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
         first_name: @enrollment.first_name,
         last_name: @enrollment.last_name,
         email: @enrollment.email,
-        confirmation_email: @enrollment.email,
       }
     )
     post :create, params: params.merge({workshop_id: @workshop.id})
@@ -355,7 +354,6 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
         user_id: @organizer.id,
         full_name: @organizer.name,
         email: @organizer.email,
-        confirmation_email: @organizer.email,
       }
     )
     post :create, params: params.merge({workshop_id: @organizer_workshop.id})
@@ -369,7 +367,6 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
         user_id: @program_manager.id,
         full_name: @program_manager.name,
         email: @program_manager.email,
-        confirmation_email: @program_manager.email,
       }
     )
     post :create, params: params.merge({workshop_id: @workshop.id})
@@ -383,7 +380,6 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
         user_id: @facilitator.id,
         full_name: @facilitator.name,
         email: @facilitator.email,
-        confirmation_email: @facilitator.email,
       }
     )
     post :create, params: params.merge({workshop_id: @workshop.id})
@@ -521,7 +517,6 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
       first_name: first_name,
       last_name: last_name,
       email: email,
-      email_confirmation: email
     }
   end
 

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -479,31 +479,6 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert_equal 'effective school district name', enrollment.school_district_name
   end
 
-  test 'school is forbidden' do
-    enrollment = build :pd_enrollment, school: 'a school'
-    refute enrollment.valid?
-    assert_equal ['School is forbidden'], enrollment.errors.full_messages
-  end
-
-  test 'old enrollments with school are grandfathered in' do
-    old_enrollment = create :pd_enrollment
-    assert old_enrollment.valid?
-
-    # Enrollments that already have a school are allowed to do so,
-    old_enrollment.school = 'a school'
-    old_enrollment.save(validate: false)
-    assert old_enrollment.valid?
-
-    # but they can't be changed
-    old_enrollment.school = 'another school'
-    refute old_enrollment.valid?
-
-    # and new enrollments cannot be so created.
-    assert_raises ActiveRecord::RecordInvalid do
-      create :pd_enrollment, school: 'a school'
-    end
-  end
-
   test 'enrollment is deleted after clear_data for deleted owner' do
     enrollment = create :pd_enrollment, :from_user
     enrollment.user.destroy!

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -97,14 +97,6 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert Pd::Enrollment.with_deleted.exists? enrollment.id
   end
 
-  test 'for_school_district' do
-    school_info = create :school_info
-    enrollment_in_district = create :pd_enrollment, school_info: school_info
-    _enrollment_out_of_district = create :pd_enrollment
-
-    assert_equal [enrollment_in_district], Pd::Enrollment.for_school_district(school_info.school_district)
-  end
-
   test 'pre_workshop_survey_url' do
     csp_summer_workshop = build :csp_summer_workshop
     csp_summer_workshop_enrollment = build :pd_enrollment, workshop: csp_summer_workshop


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

removes unnecessary params from workshop enrollment creation endpoint. also using rails strong parameters. lays the groundwork for removing the enrollment form entirely. I also removed some school_info validation from the enrollment model since that should be handled already in school_info model instead. I also tweaked the `workshop_enroll` component even though it's going to be deleted soon to get rid of a react error that was bugging me. it was complaining that nothing was returned from the render function because instead we are navigating to a different page (so the renderSuccess function was returning undefined). moved the relevant code to the on submission complete handler instead.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3347

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
