### PR TITLE
fix(marketing): add fix for Carousel flashing on page load

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
+++ b/frontend/apps/marketing/src/components/contentful/carousels/actionBlockCarousel/ActionBlockCarousel.tsx
@@ -15,6 +15,11 @@ import {LinkEntry} from '@/types/contentful/entries/Link';
 import {Entry} from '@/types/contentful/Entry';
 import {ExperienceAsset} from '@/types/contentful/ExperienceAsset';
 
+// This is a workaround to prevent carousel slidesPerView from flashing on page load
+// See: https://github.com/nolimits4web/swiper/discussions/6785#discussioncomment-9145384
+// eslint-disable-next-line
+localStorage?.getItem?.('theme') || 'light';
+
 type ActionBlockCarouselFields = {
   actionBlockOverline: EntryFields.Text;
   title: EntryFields.Text;


### PR DESCRIPTION
Fixes an issue where the `slidesPerView` prop on Swiper carousel components causes a content flicker on page load in Next.js apps. See https://github.com/nolimits4web/swiper/discussions/6785#discussioncomment-9145384 and https://github.com/nolimits4web/swiper/discussions/6785#discussioncomment-9145384. 

Curiously this works across all three carousel components when it's only applied to one so I added it to the ActionBlockCarousel component which is the most widely used. I tried adding it to [layout.tsx](https://github.com/code-dot-org/code-dot-org/blob/staging/frontend/apps/marketing/src/app/%5Bbrand%5D/%5Blocale%5D/layout.tsx) but it caused a build error. 

## Links
Jira ticket: [CMS-855](https://codedotorg.atlassian.net/browse/CMS-855)
Related PR comment: https://github.com/code-dot-org/code-dot-org/pull/66685#issuecomment-3006330537

## Testing story
Tested locally

----

## Action Block Carousel

### Before
https://github.com/user-attachments/assets/60a51e3b-f0b7-4f5a-86d0-4a9efa007d69

### After
https://github.com/user-attachments/assets/22861d37-6476-485d-a060-246fd2ae8f76


## Image Carousel

### Before

https://github.com/user-attachments/assets/31dec784-f6b1-4651-8a9d-23f0a75321af

### After

https://github.com/user-attachments/assets/27defdfd-056f-4c83-b9d0-c07a65480c90

## Video Carousel

### Before

https://github.com/user-attachments/assets/962db871-2496-4ca1-a9b7-9a790e8dc826

### After

https://github.com/user-attachments/assets/39ef6bdb-e553-48fa-a0e6-0559ecfb2bc7


