### PR TITLE
add skills to helpful_links

### DIFF
--- a/dashboard/app/views/helpful_links/index.html.haml
+++ b/dashboard/app/views/helpful_links/index.html.haml
@@ -22,3 +22,4 @@
   %li= link_to 'Documentation Homepage', '/docs/ide'
   %li= link_to 'Videos', '/videos'
   %li= link_to 'Levels', '/levels'
+  %li= link_to 'Skills', '/skills'


### PR DESCRIPTION
This adds `Skills` to the `Helpful_links` page.

<img width="1083" alt="Screenshot 2025-06-26 at 11 12 26 AM" src="https://github.com/user-attachments/assets/e8eb4ec6-ee4a-4b21-846a-7e115e1ca3ea" />

