### PR TITLE
PII scrub service

### DIFF
--- a/dashboard/app/models/concerns/user/email_validations.rb
+++ b/dashboard/app/models/concerns/user/email_validations.rb
@@ -58,7 +58,7 @@ module User::EmailValidations
   def teacher_email_required?
     return false if Policies::Lti.lti? self
     # non-teachers are not relevant to this method.
-    return false unless teacher? && purged_at.nil?
+    return false unless teacher? && purged_at.nil? && pii_scrubbed_at.nil?
 
     # new teacher accounts should always require an email
     return true if created_at.blank?

--- a/dashboard/app/models/concerns/user/nameable.rb
+++ b/dashboard/app/models/concerns/user/nameable.rb
@@ -7,7 +7,7 @@ module User::Nameable
 
   included do
     ## Validation Macros
-    validates :name, presence: true, unless: -> {purged_at}
+    validates :name, presence: true, unless: -> {purged_at || pii_scrubbed_at}
     validates :name, length: {within: 1..70}, allow_blank: true
     validate :no_family_name_for_teachers
 

--- a/dashboard/app/models/user/data_retention_status.rb
+++ b/dashboard/app/models/user/data_retention_status.rb
@@ -16,5 +16,5 @@
 #  index_user_data_retention_statuses_on_user_id          (user_id)
 #
 class User::DataRetentionStatus < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, -> {with_deleted}
 end

--- a/dashboard/app/models/user_geo.rb
+++ b/dashboard/app/models/user_geo.rb
@@ -24,6 +24,8 @@
 class UserGeo < ApplicationRecord
   belongs_to :user, optional: true
 
+  PII_FIELDS = %w[ip_address city postal_code latitude longitude].freeze
+
   def clear_user_geo
     self.ip_address = nil
     self.city = nil
@@ -32,5 +34,9 @@ class UserGeo < ApplicationRecord
     self.longitude = nil
 
     save!
+  end
+
+  def cleared?
+    PII_FIELDS.all? {|field| send(field).nil?}
   end
 end

--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -14,16 +14,12 @@ module Services
     # Intended to be run on soft-deleted users after a 28-day grace period. Not for use on live users as it
     # renders the account unusuable.
     class PiiScrubber < Services::Base
-      attr_reader :user, :email, :delete_accounts_helper
+      attr_reader :user, :email
 
       def initialize(user:)
         raise ArgumentError, 'user must be a soft-deleted User' unless user.is_a?(::User) && user.deleted_at.present?
         @user = user
         @email = user.email.presence || user.read_attribute(:email)
-
-        # Legacy delete acccounts helper client for purging data from deprecated tables
-        # and Pegasus DB. After Pegasus DB is fully deprecated, we should remove this dependency.
-        @delete_accounts_helper = DeleteAccountsHelper.new(bypass_safety_constraints: true)
       end
 
       def call
@@ -80,6 +76,12 @@ module Services
         @user.last_sign_in_ip = nil
         @user.data_transfer_agreement_request_ip = nil
         @user.user_geos.each(&:clear_user_geo)
+      end
+
+      # Legacy delete acccounts helper client for purging data from deprecated tables
+      # and Pegasus DB. After Pegasus DB is fully deprecated, we should remove this dependency.
+      private def delete_accounts_helper
+        @delete_accounts_helper ||= DeleteAccountsHelper.new(bypass_safety_constraints: true)
       end
 
       # Deletes PII from deprecated tables that no longer have a corresponding ActiveRecord model.

--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -33,30 +33,30 @@ module Services
 
       private def scrub_user
         # Email and authentication
-        @user.authentication_options.with_deleted.each do |ao|
+        user.authentication_options.with_deleted.each do |ao|
           ao.destroy unless ao.destroyed?
           ao.assign_attributes(email: '', hashed_email: '', authentication_id: nil, data: nil)
           ao.save(validate: false) # Records may be invalid due to duplicate empty string emails
         end
-        @user.lti_user_identities.with_deleted.order(deleted_at: :desc).each(&:really_destroy!)
-        @user.email = ''
-        @user.hashed_email = nil
-        @user.encrypted_password = nil
-        @user.reset_password_token = nil
-        @user.unlock_token = nil
-        @user.oauth_refresh_token = nil
-        @user.oauth_token = nil
-        @user.oauth_token_expiration = nil
-        @user.parent_email = nil
-        @user.secret_picture_id = nil
-        @user.secret_words = nil
-        @user.studio_person&.destroy # Studio person record may contain emails
+        user.lti_user_identities.with_deleted.order(deleted_at: :desc).each(&:really_destroy!)
+        user.email = ''
+        user.hashed_email = nil
+        user.encrypted_password = nil
+        user.reset_password_token = nil
+        user.unlock_token = nil
+        user.oauth_refresh_token = nil
+        user.oauth_token = nil
+        user.oauth_token_expiration = nil
+        user.parent_email = nil
+        user.secret_picture_id = nil
+        user.secret_words = nil
+        user.studio_person&.destroy # Studio person record may contain emails
 
         # Users might have multiple accounts with the same email address.
         # If there is a live user with the same email, these data points will not be scrubbed.
-        if @email.present? && ::User.find_by_email(@email).blank?
-          MailJet.delete_contact(@email) if @email.present? # Removes the contact from MailJet
-          EmailPreference.where(email: @email).destroy_all
+        if email.present? && ::User.find_by_email(email).blank?
+          MailJet.delete_contact(email) if email.present? # Removes the contact from MailJet
+          EmailPreference.where(email: email).destroy_all
           census_submissions = Census::CensusSubmission.where(submitter_email_address: email)
           csfms = Census::CensusSubmissionFormMap.where(census_submission_id: census_submissions.pluck(:id))
           csfms.destroy_all
@@ -64,18 +64,18 @@ module Services
         end
 
         # Names
-        @user.name = nil
-        @user.family_name = nil
-        @user.username = SecureRandom.alphanumeric(20)
-        @user.ops_first_name = nil
-        @user.ops_last_name = nil
+        user.name = nil
+        user.family_name = nil
+        user.username = SecureRandom.alphanumeric(20)
+        user.ops_first_name = nil
+        user.ops_last_name = nil
 
         # Address and location data
-        @user.full_address = nil
-        @user.current_sign_in_ip = nil
-        @user.last_sign_in_ip = nil
-        @user.data_transfer_agreement_request_ip = nil
-        @user.user_geos.each(&:clear_user_geo)
+        user.full_address = nil
+        user.current_sign_in_ip = nil
+        user.last_sign_in_ip = nil
+        user.data_transfer_agreement_request_ip = nil
+        user.user_geos.each(&:clear_user_geo)
       end
 
       # Legacy delete acccounts helper client for purging data from deprecated tables
@@ -93,17 +93,17 @@ module Services
       # - Location and email data in "forms" tables
       # - Email addresses in contact rollup tables
       private def scrub_legacy_data
-        if @email.present?
-          @delete_accounts_helper.clean_and_destroy_pd_content(@user.id, @email)
-          @delete_accounts_helper.remove_poste_data(@email)
-          @delete_accounts_helper.remove_census_submissions(@email)
-          @delete_accounts_helper.purge_contact_rollups(@email)
+        if email.present?
+          delete_accounts_helper.clean_and_destroy_pd_content(user.id, email)
+          delete_accounts_helper.remove_poste_data(email)
+          delete_accounts_helper.remove_census_submissions(email)
+          delete_accounts_helper.purge_contact_rollups(email)
         end
-        @delete_accounts_helper.clean_pegasus_forms_for_user(@user)
+        delete_accounts_helper.clean_pegasus_forms_for_user(user)
       end
 
       private def mark_scrubbed
-        user_data_retention_status = ::User::DataRetentionStatus.find_or_initialize_by(user_id: @user.id)
+        user_data_retention_status = ::User::DataRetentionStatus.find_or_initialize_by(user_id: user.id)
         user_data_retention_status.pii_scrubbed_at = Time.now
         user_data_retention_status.save!
       end

--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -23,7 +23,7 @@ module Services
       end
 
       def call
-        ActiveRecord::Base.transaction do
+        user.transaction do
           scrub_user
           scrub_legacy_data
           mark_scrubbed
@@ -105,7 +105,7 @@ module Services
       # Removes any third-party data that requires an API call. Called after
       # other methods since it is not reversible.
       private def scrub_external_data
-        MailJet.delete_contact(email) if email.present? && ::User.find_by_email(email).blank?
+        MailJet.delete_contact(email) if email.present? && !::User.exists?(email: email)
       end
 
       private def mark_scrubbed

--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -27,10 +27,12 @@ module Services
       end
 
       def call
-        scrub_user
-        scrub_legacy_data
-        mark_scrubbed
-        @user.save!
+        ActiveRecord::Base.transaction do
+          scrub_user
+          scrub_legacy_data
+          mark_scrubbed
+          @user.save!
+        end
       end
 
       private def scrub_user

--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -1,0 +1,108 @@
+require 'cdo/mailjet'
+require 'cdo/delete_accounts_helper'
+
+module Services
+  module User
+    # Scrubs personally identifiable information (PII) from a user. This class removes
+    # the following categories of information, deemed highest risk:
+    # - IP addresses
+    # - Latitude, longitude, and other geolocation data more specific than state or province
+    # - Names and usernames
+    # - Email addresses
+    # - Authentication tokens, secret words, secret pictures, and any other means of authenticating
+    # - Physical addresses
+    # Intended to be run on soft-deleted users after a 28-day grace period. Not for use on live users as it
+    # renders the account unusuable.
+    class PiiScrubber < Services::Base
+      attr_reader :user, :email, :delete_accounts_helper
+
+      def initialize(user:)
+        raise ArgumentError, 'user must be a soft-deleted User' unless user.is_a?(::User) && user.deleted_at.present?
+        @user = user
+        @email = user.email.presence || user.read_attribute(:email)
+
+        # Legacy delete acccounts helper client for purging data from deprecated tables
+        # and Pegasus DB. After Pegasus DB is fully deprecated, we should remove this dependency.
+        @delete_accounts_helper = DeleteAccountsHelper.new(bypass_safety_constraints: true)
+      end
+
+      def call
+        scrub_user
+        scrub_legacy_data
+        mark_scrubbed
+        @user.save!
+      end
+
+      private def scrub_user
+        # Email and authentication
+        @user.authentication_options.with_deleted.each do |ao|
+          ao.destroy unless ao.destroyed?
+          ao.assign_attributes(email: '', hashed_email: '', authentication_id: nil, data: nil)
+          ao.save(validate: false) # Records may be invalid due to duplicate empty string emails
+        end
+        @user.lti_user_identities.with_deleted.order(deleted_at: :desc).each(&:really_destroy!)
+        @user.email = ''
+        @user.hashed_email = nil
+        @user.encrypted_password = nil
+        @user.reset_password_token = nil
+        @user.unlock_token = nil
+        @user.oauth_refresh_token = nil
+        @user.oauth_token = nil
+        @user.oauth_token_expiration = nil
+        @user.parent_email = nil
+        @user.secret_picture_id = nil
+        @user.secret_words = nil
+        @user.studio_person&.destroy # Studio person record may contain emails
+
+        # Users might have multiple accounts with the same email address.
+        # If there is a live user with the same email, these data points will not be scrubbed.
+        if @email.present? && ::User.find_by_email(@email).blank?
+          MailJet.delete_contact(@email) if @email.present? # Removes the contact from MailJet
+          EmailPreference.where(email: @email).destroy_all
+          census_submissions = Census::CensusSubmission.where(submitter_email_address: email)
+          csfms = Census::CensusSubmissionFormMap.where(census_submission_id: census_submissions.pluck(:id))
+          csfms.destroy_all
+          census_submissions.destroy_all
+        end
+
+        # Names
+        @user.name = nil
+        @user.family_name = nil
+        @user.username = SecureRandom.alphanumeric(20)
+        @user.ops_first_name = nil
+        @user.ops_last_name = nil
+
+        # Address and location data
+        @user.full_address = nil
+        @user.current_sign_in_ip = nil
+        @user.last_sign_in_ip = nil
+        @user.data_transfer_agreement_request_ip = nil
+        @user.user_geos.each(&:clear_user_geo)
+      end
+
+      # Deletes PII from deprecated tables that no longer have a corresponding ActiveRecord model.
+      # Also deletes PII from Pegasus DB, which is planned to for deprecation and should not generally
+      # be accessed from Dashboard code. Pegasus DB is a separate database in the RDS cluster, and includes
+      # PII such as:
+      # - PD applications and forms with email addresses, names, addresses
+      # - Email addresses in Poste tables
+      # - Location and email data in "forms" tables
+      # - Email addresses in contact rollup tables
+      private def scrub_legacy_data
+        if @email.present?
+          @delete_accounts_helper.clean_and_destroy_pd_content(@user.id, @email)
+          @delete_accounts_helper.remove_poste_data(@email)
+          @delete_accounts_helper.remove_census_submissions(@email)
+          @delete_accounts_helper.purge_contact_rollups(@email)
+        end
+        @delete_accounts_helper.clean_pegasus_forms_for_user(@user)
+      end
+
+      private def mark_scrubbed
+        user_data_retention_status = ::User::DataRetentionStatus.find_or_initialize_by(user_id: @user.id)
+        user_data_retention_status.pii_scrubbed_at = Time.now
+        user_data_retention_status.save!
+      end
+    end
+  end
+end

--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -28,6 +28,7 @@ module Services
           scrub_legacy_data
           mark_scrubbed
           @user.save!
+          scrub_external_data
         end
       end
 
@@ -55,7 +56,6 @@ module Services
         # Users might have multiple accounts with the same email address.
         # If there is a live user with the same email, these data points will not be scrubbed.
         if email.present? && ::User.find_by_email(email).blank?
-          MailJet.delete_contact(email) if email.present? # Removes the contact from MailJet
           EmailPreference.where(email: email).destroy_all
           census_submissions = Census::CensusSubmission.where(submitter_email_address: email)
           csfms = Census::CensusSubmissionFormMap.where(census_submission_id: census_submissions.pluck(:id))
@@ -100,6 +100,12 @@ module Services
           delete_accounts_helper.purge_contact_rollups(email)
         end
         delete_accounts_helper.clean_pegasus_forms_for_user(user)
+      end
+
+      # Removes any third-party data that requires an API call. Called after
+      # other methods since it is not reversible.
+      private def scrub_external_data
+        MailJet.delete_contact(email) if email.present? && ::User.find_by_email(email).blank?
       end
 
       private def mark_scrubbed

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -1,0 +1,115 @@
+require 'test_helper'
+require 'cdo/delete_accounts_helper'
+
+class Services::User::PiiScrubberTest < ActiveSupport::TestCase
+  include Minitest::RSpecMocks
+
+  let(:email) {Faker::Internet.unique.email}
+  let(:user) do
+    create(
+      :teacher,
+      :within_united_states,
+      email: email,
+      current_sign_in_ip: '192.168.0.1',
+    ).destroy
+  end
+  let(:described_instance) {described_class.new(user: user)}
+
+  describe '#call' do
+    subject(:scrub_pii) {described_instance.call}
+
+    context 'when user is not soft-deleted' do
+      let(:user) {create(:teacher)}
+      it 'raises an error' do
+        _ {scrub_pii}.must_raise ArgumentError
+      end
+    end
+
+    context 'when non-user object is passed in' do
+      let(:user) {create(:section)}
+      it 'raises an error' do
+        _ {scrub_pii}.must_raise ArgumentError
+      end
+    end
+
+    context 'when migrated' do
+      before do
+        expect(described_instance.delete_accounts_helper).to receive(:remove_census_submissions).with(email)
+        expect(described_instance.delete_accounts_helper).to receive(:clean_pegasus_forms_for_user).with(user)
+        expect(described_instance.delete_accounts_helper).to receive(:remove_poste_data).with(email)
+        expect(described_instance.delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
+        expect(described_instance.delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
+      end
+
+      it 'removes user email and authentication data' do
+        scrub_pii
+        user.reload
+        _(user.email).must_equal ''
+        _(user.hashed_email).must_equal ''
+        _(user.authentication_options.with_deleted.first.email).must_equal ''
+        _(user.authentication_options.with_deleted.first.data).must_be_nil
+        _(user.authentication_options.with_deleted.first.authentication_id).must_be_nil
+      end
+
+      it 'removes names and assigns a UUID username' do
+        original_username = user.username
+        scrub_pii
+        user.reload
+        _(user.name).must_be_nil
+        _(user.family_name).must_be_nil
+        _(user.username).wont_equal original_username
+        _(user.username).wont_be_nil
+      end
+
+      it 'removes address and location data' do
+        scrub_pii
+        user.reload
+        _(user.full_address).must_be_nil
+        _(user.current_sign_in_ip).must_be_nil
+        _(user.user_geos.first.cleared?).must_equal true
+      end
+
+      it 'sets pii_scrubbed_at' do
+        scrub_pii
+        user.reload
+        _(user.pii_scrubbed_at).wont_be_nil
+      end
+    end
+
+    context 'when not migrated' do
+      before do
+        expect(described_instance.delete_accounts_helper).to receive(:remove_census_submissions).with(email)
+        expect(described_instance.delete_accounts_helper).to receive(:clean_pegasus_forms_for_user).with(user)
+        expect(described_instance.delete_accounts_helper).to receive(:remove_poste_data).with(email)
+        expect(described_instance.delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
+        expect(described_instance.delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
+      end
+
+      let(:user) do
+        create(
+          :teacher,
+          :demigrated,
+          :within_united_states,
+          :google_sso_provider,
+          email: email,
+          current_sign_in_ip: '192.168.0.1',
+        ).destroy
+      end
+
+      it 'removes legacy oauth fields' do
+        scrub_pii
+        user.reload
+        _(user.oauth_token).must_be_nil
+        _(user.oauth_refresh_token).must_be_nil
+        _(user.oauth_token_expiration).must_be_nil
+      end
+
+      it 'removes email even without an auth option' do
+        scrub_pii
+        user.reload
+        _(user.email).must_equal ''
+        _(user.hashed_email).must_equal ''
+      end
+    end
+  end
+end

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -40,6 +40,7 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
         expect(delete_accounts_helper).to receive(:remove_poste_data).with(email)
         expect(delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
         expect(delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
+        expect(described_instance).to receive(:scrub_external_data)
       end
 
       it 'removes user email and authentication data' do
@@ -85,6 +86,7 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
         expect(delete_accounts_helper).to receive(:remove_poste_data).with(email)
         expect(delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
         expect(delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
+        expect(described_instance).to receive(:scrub_external_data)
       end
 
       let(:user) do

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -108,7 +108,7 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
         scrub_pii
         user.reload
         _(user.email).must_equal ''
-        _(user.hashed_email).must_equal ''
+        _(user.hashed_email).must_be_nil
       end
     end
   end

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -34,11 +34,12 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
 
     context 'when migrated' do
       before do
-        expect(described_instance.delete_accounts_helper).to receive(:remove_census_submissions).with(email)
-        expect(described_instance.delete_accounts_helper).to receive(:clean_pegasus_forms_for_user).with(user)
-        expect(described_instance.delete_accounts_helper).to receive(:remove_poste_data).with(email)
-        expect(described_instance.delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
-        expect(described_instance.delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
+        delete_accounts_helper = described_instance.send(:delete_accounts_helper)
+        expect(delete_accounts_helper).to receive(:remove_census_submissions).with(email)
+        expect(delete_accounts_helper).to receive(:clean_pegasus_forms_for_user).with(user)
+        expect(delete_accounts_helper).to receive(:remove_poste_data).with(email)
+        expect(delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
+        expect(delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
       end
 
       it 'removes user email and authentication data' do
@@ -78,11 +79,12 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
 
     context 'when not migrated' do
       before do
-        expect(described_instance.delete_accounts_helper).to receive(:remove_census_submissions).with(email)
-        expect(described_instance.delete_accounts_helper).to receive(:clean_pegasus_forms_for_user).with(user)
-        expect(described_instance.delete_accounts_helper).to receive(:remove_poste_data).with(email)
-        expect(described_instance.delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
-        expect(described_instance.delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
+        delete_accounts_helper = described_instance.send(:delete_accounts_helper)
+        expect(delete_accounts_helper).to receive(:remove_census_submissions).with(email)
+        expect(delete_accounts_helper).to receive(:clean_pegasus_forms_for_user).with(user)
+        expect(delete_accounts_helper).to receive(:remove_poste_data).with(email)
+        expect(delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
+        expect(delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
       end
 
       let(:user) do

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -510,7 +510,7 @@ class DeleteAccountsHelper
     clean_pegasus_forms_for_email(email)
   end
 
-  private def clean_pegasus_forms_for_user(user)
+  def clean_pegasus_forms_for_user(user)
     @log.puts "Cleaning pegasus forms for user"
     clean_pegasus_forms(@pegasus_db[:forms].where(user_id: user.id))
   end


### PR DESCRIPTION
Adds a new service to delete personally identifiable information (PII) from a user. This service will soon replace the existing nightly purge cronjob that runs for users 28 days after they have been soft-deleted. It mostly fills the same role as the purge job, except that it retains certain data that is valuable for analytics or other business purposes, but that isn't considered risky PII. The existing purge process deletes nearly everything from a user record, including data that isn't PII or personal data, rendering it useless for analytics. The intent of the service added in this PR is to continue deleting PII, but retain useful non-personal data.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1524)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
