### PR TITLE
feat(workshops): remove facilitators ability to create workshops

### DIFF
--- a/dashboard/app/controllers/api/v1/regional_partners_controller.rb
+++ b/dashboard/app/controllers/api/v1/regional_partners_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::RegionalPartnersController < ApplicationController
 
   # GET /api/v1/regional_partners
   def index
-    regional_partners = (current_user.facilitator? || current_user.workshop_admin?) ? RegionalPartner.all : current_user.regional_partners
+    regional_partners = current_user.workshop_admin? ? RegionalPartner.all : current_user.regional_partners
 
     render json: regional_partners.order(:name).map {|partner| {id: partner.id, name: partner.name}}
   end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -216,12 +216,6 @@ class Ability
         can [:read, :update], Pd::Workshop, organizer_id: user.id
         can :manage_attendance, Pd::Workshop, facilitators: {id: user.id}
         can :read, Pd::CourseFacilitator, facilitator_id: user.id
-
-        if Pd::CourseFacilitator.exists?(facilitator: user, course: Pd::Workshop::COURSE_CSF)
-          can :create, Pd::Workshop, course: Pd::Workshop::COURSE_CSF
-          can :update, Pd::Workshop, facilitators: {id: user.id}
-          can :destroy, Pd::Workshop, organizer_id: user.id
-        end
       end
 
       if user.workshop_organizer? || user.program_manager?

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -496,17 +496,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'facilitators can not delete a workshop where they are not the organizer' do
-    csp_facilitator_organizer = create(:pd_course_facilitator, course: Pd::Workshop::COURSE_CSP).facilitator
-    csp_facilitator_nonorganizer = create(:pd_course_facilitator, course: Pd::Workshop::COURSE_CSP).facilitator
-    workshop = create :pd_workshop, facilitators: [csp_facilitator_organizer, csp_facilitator_nonorganizer], organizer: csp_facilitator_organizer
-    sign_in csp_facilitator_nonorganizer
-    assert_does_not_destroy(Pd::Workshop) do
-      delete :destroy, params: {id: workshop.id}
-    end
-    assert_response :forbidden
-  end
-
   test_user_gets_response_for(
     :destroy,
     name: 'organizers cannot delete workshops they do not own',
@@ -586,19 +575,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     sign_in(@facilitator)
 
     workshop = create :workshop, organizer: @facilitator
-    put :update, params: {
-      id: workshop.id,
-      pd_workshop: workshop_params.merge({regional_partner_id: @regional_partner.id})
-    }
-    assert_response :success
-    workshop.reload
-    assert_nil workshop.regional_partner_id
-  end
-
-  test 'CSF Facilitators can update workshops they are assigned to' do
-    sign_in(@csf_facilitator)
-
-    workshop = create :workshop, facilitators: [@csf_facilitator]
     put :update, params: {
       id: workshop.id,
       pd_workshop: workshop_params.merge({regional_partner_id: @regional_partner.id})

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -302,6 +302,10 @@ class AbilityTest < ActiveSupport::TestCase
     refute ability.can?(:destroy, Level)
     refute ability.can?(:destroy, Activity)
 
+    refute ability.can?(:create, Pd::Workshop)
+    refute ability.can?(:destroy, Pd::Workshop)
+    assert ability.can?(:read, Pd::Workshop)
+
     assert ability.can?(:read, Section)
 
     assert ability.can?(:read, Unit.find_by_name('ECSPD'))


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This removes CSF course facilitators ability to create CSF workshops, and updates the api request for regional partners to remove the exception for csf course facilitators to fetch all regional partners that they could assign to workshops. I added some tests in ability_test to ensure the behavior is correct.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3355

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
