### PR TITLE
Codebridge: remove unused prop in instructions

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -84,7 +84,6 @@ function initializeCodeMirror(target, mode, options = {}) {
             React.createElement(MainInstructionsPreview, {
               instructionsText: editor.getValue(),
               theme: 'Dark',
-              hasPassed: false,
             }),
             previewElement
           );

--- a/apps/src/codebridge/InfoPanel/MainInstructionsContent.tsx
+++ b/apps/src/codebridge/InfoPanel/MainInstructionsContent.tsx
@@ -7,7 +7,6 @@ import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.mo
 interface MainInstructionsContentProps {
   instructionsText: string;
   handleInstructionsTextClick?: (id: string) => void;
-  hasPassed: boolean;
 }
 
 /**
@@ -17,7 +16,7 @@ interface MainInstructionsContentProps {
  */
 const MainInstructionsContent: React.FunctionComponent<
   MainInstructionsContentProps
-> = ({instructionsText, handleInstructionsTextClick, hasPassed}) => {
+> = ({instructionsText, handleInstructionsTextClick}) => {
   return (
     <div className={moduleStyles.mainInstructions}>
       <EnhancedSafeMarkdown

--- a/apps/src/codebridge/InfoPanel/MainInstructionsPreview.tsx
+++ b/apps/src/codebridge/InfoPanel/MainInstructionsPreview.tsx
@@ -11,7 +11,6 @@ interface MainInstructionsPreviewProps {
   instructionsText: string;
   handleInstructionsTextClick?: (id: string) => void;
   theme: Theme;
-  hasPassed: boolean;
 }
 
 /**
@@ -20,7 +19,7 @@ interface MainInstructionsPreviewProps {
  */
 const MainInstructionsPreview: React.FunctionComponent<
   MainInstructionsPreviewProps
-> = ({instructionsText, handleInstructionsTextClick, theme, hasPassed}) => {
+> = ({instructionsText, handleInstructionsTextClick, theme}) => {
   return (
     <div
       key={instructionsText}
@@ -31,7 +30,6 @@ const MainInstructionsPreview: React.FunctionComponent<
       <MainInstructionsContent
         instructionsText={instructionsText}
         handleInstructionsTextClick={handleInstructionsTextClick}
-        hasPassed={hasPassed}
       />
     </div>
   );

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -358,7 +358,6 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
               <MainInstructionsContent
                 instructionsText={instructionsText}
                 handleInstructionsTextClick={handleInstructionsTextClick}
-                hasPassed={hasPassed}
               />
               <PredictQuestion
                 predictSettings={predictSettings}


### PR DESCRIPTION
We used to show a green bubble/checkmark in the codebridge instructions to indicate if the level had passed. We removed it in #65643. I missed removing a `hasPassed` prop from the main instructions component; this PR removes this unused prop. No visual change!

## Links

- Jira: part of the prep for [SL-1294](https://codedotorg.atlassian.net/browse/SL-1294)

## Testing story
Tested locally that the instructions still render correctly.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
