### PR TITLE
show student sections on PL page

### DIFF
--- a/apps/src/templates/studioHomepages/JoinSectionArea.jsx
+++ b/apps/src/templates/studioHomepages/JoinSectionArea.jsx
@@ -82,7 +82,7 @@ export default function JoinSectionArea({
         )}
         {isPlSections && joinedPlSections?.length > 0 && isTeacher && (
           <ParticipantSections
-            sections={joinedPlSections}
+            sections={joinedPlSections.concat(joinedStudentSections)}
             isTeacher={isTeacher}
             isPlSections={true}
             updateSectionsResult={updateSectionsResult}


### PR DESCRIPTION
This update displayed sections joined as a student on the professional learning landing page. This is in preparation for the new teacher homepage which will no longer display sections joined as a student.

## Links
[TEACH-2003](https://codedotorg.atlassian.net/browse/TEACH-2003)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
