### PR TITLE
feat: enable marketing router lambda on /

### DIFF
--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -209,7 +209,8 @@ class HttpCache
             ),
             query: false,
             headers: ALLOWLISTED_HEADERS,
-            cookies: default_cookies
+            cookies: default_cookies,
+            include_marketing_router_lambda: true,
           },
         ],
         # Remaining Pegasus paths are cached, and vary only on language, country, and default cookies.


### PR DESCRIPTION
This PR adds the marketing router on the `/` behavior.

This was tested on adhoc here: https://adhoc-stephen-router-home-page.cdn-code.org/

This does not enable the CMS on `/`, a subsequent entry needs to be added to the lambda to enable the CMS there.