### PR TITLE
Fix trailing '/' problem on Workshop Catalog page

### DIFF
--- a/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalog.jsx
+++ b/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalog.jsx
@@ -17,7 +17,6 @@ import {ZIP_REGEX} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import CalendarEmptyStateIllustration from '@cdo/apps/templates/teacherNavigation/images/CalendarEmptyStateIllustration.svg';
 import CalendarNotAvailable from '@cdo/apps/templates/teacherNavigation/images/CalendarNotAvailable.svg';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
-import {navigateToHref} from '@cdo/apps/utils';
 
 import RegionalWorkshopCatalogCard from './RegionalWorkshopCatalogCard';
 
@@ -56,13 +55,6 @@ export default function RegionalWorkshopCatalog({
 
   // Load workshops for the given zip if one is present in the URL or is passed in as a prop
   useEffect(() => {
-    // Clear trailing '/' if present in URL
-    const urlParts = window.location.href.split('?zip=');
-    if (urlParts[0].endsWith('/')) {
-      const zipParam = urlParts.length > 1 ? `?zip=${urlParts[1]}` : '';
-      navigateToHref(`/professional-learning/workshops${zipParam}`);
-    }
-
     const zipFromUrl = queryParams()['zip'];
     const prepopulatedZip = zipFromUrl ? zipFromUrl : zipFromSchoolInfo;
     if (prepopulatedZip && ZIP_REGEX.test(prepopulatedZip)) {
@@ -108,13 +100,16 @@ export default function RegionalWorkshopCatalog({
       setIsSubmitting(true);
       try {
         updateQueryParam('zip', submittedZip, true);
-        const response = await fetch(`regional_workshop_data/${submittedZip}`, {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-CSRF-Token': await getAuthenticityToken(),
-          },
-        });
+        const response = await fetch(
+          `/professional-learning/regional_workshop_data/${submittedZip}`,
+          {
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRF-Token': await getAuthenticityToken(),
+            },
+          }
+        );
 
         if (response.ok) {
           const jsonData = await response.json();

--- a/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalog.jsx
+++ b/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalog.jsx
@@ -17,6 +17,7 @@ import {ZIP_REGEX} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import CalendarEmptyStateIllustration from '@cdo/apps/templates/teacherNavigation/images/CalendarEmptyStateIllustration.svg';
 import CalendarNotAvailable from '@cdo/apps/templates/teacherNavigation/images/CalendarNotAvailable.svg';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
+import {navigateToHref} from '@cdo/apps/utils';
 
 import RegionalWorkshopCatalogCard from './RegionalWorkshopCatalogCard';
 
@@ -55,6 +56,12 @@ export default function RegionalWorkshopCatalog({
 
   // Load workshops for the given zip if one is present in the URL or is passed in as a prop
   useEffect(() => {
+    // Clear trailing '/' if present in URL
+    const urlParts = window.location.href.split('?zip=');
+    if (urlParts[0].endsWith('/')) {
+      navigateToHref(`/professional-learning/workshops?zip=${urlParts[1]}`);
+    }
+
     const zipFromUrl = queryParams()['zip'];
     const prepopulatedZip = zipFromUrl ? zipFromUrl : zipFromSchoolInfo;
     if (prepopulatedZip && ZIP_REGEX.test(prepopulatedZip)) {

--- a/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalog.jsx
+++ b/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalog.jsx
@@ -59,7 +59,8 @@ export default function RegionalWorkshopCatalog({
     // Clear trailing '/' if present in URL
     const urlParts = window.location.href.split('?zip=');
     if (urlParts[0].endsWith('/')) {
-      navigateToHref(`/professional-learning/workshops?zip=${urlParts[1]}`);
+      const zipParam = urlParts.length > 1 ? `?zip=${urlParts[1]}` : '';
+      navigateToHref(`/professional-learning/workshops${zipParam}`);
     }
 
     const zipFromUrl = queryParams()['zip'];

--- a/apps/test/unit/code-studio/pd/professional_learning/RegionalWorkshopCatalogTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning/RegionalWorkshopCatalogTest.jsx
@@ -137,13 +137,16 @@ describe('RegionalWorkshopCatalog', () => {
         '/professional-learning/contact-regional-partner?zip=11111'
       );
 
-      expect(fetchStub).toHaveBeenCalledWith(`regional_workshop_data/${zip}`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': 'authToken',
-        },
-        method: 'GET',
-      });
+      expect(fetchStub).toHaveBeenCalledWith(
+        `/professional-learning/regional_workshop_data/${zip}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': 'authToken',
+          },
+          method: 'GET',
+        }
+      );
 
       // Still shows National workshops
       expect(screen.getAllByText('National workshops').length).toBe(2);
@@ -196,13 +199,16 @@ describe('RegionalWorkshopCatalog', () => {
       );
       TEST_REGIONAL_WORKSHOPS.forEach(ws => screen.getByText(ws.name));
 
-      expect(fetchStub).toHaveBeenCalledWith(`regional_workshop_data/${zip}`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': 'authToken',
-        },
-        method: 'GET',
-      });
+      expect(fetchStub).toHaveBeenCalledWith(
+        `/professional-learning/regional_workshop_data/${zip}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': 'authToken',
+          },
+          method: 'GET',
+        }
+      );
 
       // Still shows National workshops
       expect(screen.getAllByText('National workshops').length).toBe(2);
@@ -296,13 +302,16 @@ describe('RegionalWorkshopCatalog', () => {
       // Regional workshop content is displayed
       TEST_REGIONAL_WORKSHOPS.forEach(ws => screen.getByText(ws.name));
 
-      expect(fetchStub).toHaveBeenCalledWith(`regional_workshop_data/${zip}`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': 'authToken',
-        },
-        method: 'GET',
-      });
+      expect(fetchStub).toHaveBeenCalledWith(
+        `/professional-learning/regional_workshop_data/${zip}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': 'authToken',
+          },
+          method: 'GET',
+        }
+      );
 
       // Still shows National workshops
       expect(screen.getAllByText('National workshops').length).toBe(2);
@@ -343,13 +352,16 @@ describe('RegionalWorkshopCatalog', () => {
       // Regional workshop content is displayed
       TEST_REGIONAL_WORKSHOPS.forEach(ws => screen.getByText(ws.name));
 
-      expect(fetchStub).toHaveBeenCalledWith(`regional_workshop_data/${zip}`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': 'authToken',
-        },
-        method: 'GET',
-      });
+      expect(fetchStub).toHaveBeenCalledWith(
+        `/professional-learning/regional_workshop_data/${zip}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': 'authToken',
+          },
+          method: 'GET',
+        }
+      );
 
       // Still shows National workshops
       expect(screen.getAllByText('National workshops').length).toBe(2);


### PR DESCRIPTION
Fix trailing '/' issue on Workshop Catalog page where a URL ending in `/?zip=[zip]` will cause the request to fail.

### Nothing trailing still works
![no zip still works](https://github.com/user-attachments/assets/582de4ba-2591-4fed-b7f0-95366e2768fd)

### Regular zip param still works
![regular zip still works](https://github.com/user-attachments/assets/22928f10-b6ad-446d-9657-fc2014b2b6f2)

### Trailing slash with no zip param works

https://github.com/user-attachments/assets/12f4e8c9-7611-4e05-ac92-a5ad108ad56f

### Trailing slash with zip param works

https://github.com/user-attachments/assets/d443e4db-c6a5-425d-9ea2-f7f504d32a1b

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3365)

## Testing story
Local testing.
