### PR TITLE
fix: remove extraneous characters to keep replication id <40 char

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -897,7 +897,7 @@ Resources:
   RedisCluster:
     Type: AWS::ElastiCache::ReplicationGroup
     Properties:
-      ReplicationGroupDescription: Marketing Sites Redis Cache Replication Group
+      ReplicationGroupDescription: Marketing Sites redis full router page and internal data cache replication group
       Engine: redis
       ReplicationGroupId: !Sub "marketing-sites-${SubdomainName}-${EnvironmentType}"
       CacheParameterGroupName: !Ref RedisParameterGroup

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -899,7 +899,7 @@ Resources:
     Properties:
       ReplicationGroupDescription: Marketing Sites Redis Cache Replication Group
       Engine: redis
-      ReplicationGroupId: !Sub "marketing-sites-page-cache-${SubdomainName}-${EnvironmentType}"
+      ReplicationGroupId: !Sub "marketing-sites-${SubdomainName}-${EnvironmentType}"
       CacheParameterGroupName: !Ref RedisParameterGroup
       EngineVersion: 7.1
       CacheNodeType:


### PR DESCRIPTION
```
Replication Group ID cannot be longer than 40 characters. (Service: AmazonElastiCache; Status Code: 400; Error Code: InvalidParameterValue; Request ID: 3497ef49-314c-41f4-aa05-1f75efd15a01; Proxy: null)
```

Failing string is 43 chars: `marketing-sites-page-cache-code-production`. Removing `page-cache-` saves 12 characters.