### PR TITLE
Evaluate Student Learning: handle when unit or level is not found for ULI 

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -287,17 +287,21 @@ function handleExecutionError(err, lineNumber, outputString, libraryName) {
   outputError(outputString, lineNumber, libraryName);
   Applab.executionError = {err: err, lineNumber: lineNumber};
   const analyticsData = studioApp().analyticsData();
-  logUserLevelInteraction({
-    levelId: analyticsData.levelId,
-    scriptId: analyticsData.scriptId,
-    interaction: UserLevelInteractions.code_execution_error,
-    metadata: JSON.stringify({
-      error: err,
-      lineNumber: lineNumber,
-      outputString: outputString,
-      libraryName: libraryName,
-    }),
-  });
+  // We don't want to log a User Level Interaction if we don't have a scriptId, which is the case
+  // for users working on App Lab standalone projects outside of the curriculum.
+  if (analyticsData.scriptId) {
+    logUserLevelInteraction({
+      levelId: analyticsData.levelId,
+      scriptId: analyticsData.scriptId,
+      interaction: UserLevelInteractions.code_execution_error,
+      metadata: JSON.stringify({
+        error: err,
+        lineNumber: lineNumber,
+        outputString: outputString,
+        libraryName: libraryName,
+      }),
+    });
+  }
   // prevent further execution
   Applab.clearEventHandlersKillTickLoop();
 
@@ -1120,11 +1124,15 @@ Applab.runButtonClick = function () {
   }
   Applab.execute();
   const analyticsData = studioApp().analyticsData();
-  logUserLevelInteraction({
-    levelId: analyticsData.levelId,
-    scriptId: analyticsData.scriptId,
-    interaction: UserLevelInteractions.click_run,
-  });
+  // We don't want to log a User Level Interaction if we don't have a scriptId, which is the case
+  // for users working on App Lab standalone projects outside of the curriculum.
+  if (analyticsData.scriptId) {
+    logUserLevelInteraction({
+      levelId: analyticsData.levelId,
+      scriptId: analyticsData.scriptId,
+      interaction: UserLevelInteractions.click_run,
+    });
+  }
 
   // Enable the Finish button if is present:
   var shareCell = document.getElementById('share-cell');
@@ -1310,11 +1318,15 @@ function onInterfaceModeChange(mode) {
 
 Applab.onPuzzleFinish = function () {
   const analyticsData = studioApp().analyticsData();
-  logUserLevelInteraction({
-    levelId: analyticsData.levelId,
-    scriptId: analyticsData.scriptId,
-    interaction: UserLevelInteractions.click_finish,
-  });
+  // We don't want to log a User Level Interaction if we don't have a scriptId, which is the case
+  // for users working on App Lab standalone projects outside of the curriculum.
+  if (analyticsData.scriptId) {
+    logUserLevelInteraction({
+      levelId: analyticsData.levelId,
+      scriptId: analyticsData.scriptId,
+      interaction: UserLevelInteractions.click_finish,
+    });
+  }
   Applab.onPuzzleComplete(false); // complete without submitting
 };
 

--- a/apps/src/userLevelInteractionsLogger/userLevelInteractionsApi.ts
+++ b/apps/src/userLevelInteractionsLogger/userLevelInteractionsApi.ts
@@ -7,27 +7,29 @@ import {UserLevelInteraction} from './types';
 export async function logUserLevelInteraction(
   interactionData: UserLevelInteraction
 ) {
-  try {
-    const response = await fetch('/user_level_interactions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': await getAuthenticityToken(),
-      },
-      body: JSON.stringify(interactionData),
-    });
-    if (response.status === 400) {
-      console.log('Bad request: likely the script is not 2024+');
-    } else if (!response.ok) {
-      throw new Error('Failed to save User Level interaction');
+  if (interactionData && interactionData.scriptId) {
+    try {
+      const response = await fetch('/user_level_interactions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': await getAuthenticityToken(),
+        },
+        body: JSON.stringify(interactionData),
+      });
+      if (response.status === 400) {
+        console.log('Bad request: likely the script is not 2024+');
+      } else if (!response.ok) {
+        throw new Error('Failed to save User Level interaction');
+      }
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      MetricsReporter.logError({
+        event: MetricEvent.USER_LEVEL_INTERACTION_SAVE_FAIL,
+        errorMessage:
+          (error as Error).message || 'Failed to save User Level interaction',
+      });
     }
-    const data = await response.json();
-    return data;
-  } catch (error) {
-    MetricsReporter.logError({
-      event: MetricEvent.USER_LEVEL_INTERACTION_SAVE_FAIL,
-      errorMessage:
-        (error as Error).message || 'Failed to save User Level interaction',
-    });
   }
 }

--- a/dashboard/app/controllers/user_level_interactions_controller.rb
+++ b/dashboard/app/controllers/user_level_interactions_controller.rb
@@ -8,16 +8,50 @@ class UserLevelInteractionsController < ApplicationController
 
   # POST /user_level_interactions
   def create
-    version_year = JSON.parse(user_level_interaction_params[:metadata])["version_year"]
+    unit_id = user_level_interaction_params[:script_id]
+    begin
+      unit = Unit.find(unit_id)
+    rescue ActiveRecord::RecordNotFound
+      return render status: :not_found, json: "Unit with id #{unit_id}"
+    end
+
+    level_id = user_level_interaction_params[:level_id]
+    begin
+      level = Level.find(level_id)
+    rescue ActiveRecord::RecordNotFound
+      return render status: :not_found, json: "Level with id #{level_id}"
+    end
+    
+    project_data = get_project_and_version_id(level_id, unit_id)
+    channel = get_channel_for(level, unit_id, current_user)
+    user_level_interaction_params[:code_version] = project_data[:version_id]
+
+    version_year = unit.get_course_version.key
+
+    metadata = {
+      course_offering: unit.properties["curriculum_umbrella"],
+      version_year: version_year,
+      unit: unit.name,
+      level_type: level.type,
+      user_type: current_user.user_type,
+      project_id: project_data[:project_id],
+      channel: channel,
+    }
+
+     new_uli_params = user_level_interaction_params.merge(
+      code_version: project_data[:version_id],
+      metadata: metadata.to_json,
+    )
+   
     if should_create_uli?(version_year)
-      @user_level_interaction = UserLevelInteraction.new(user_level_interaction_params)
+      @user_level_interaction = UserLevelInteraction.new(new_uli_params)
       if @user_level_interaction.save
         render(status: :created, json: {message: "Successfully created UserLevelInteraction.", id: @user_level_interaction.id})
       else
         render(status: :not_acceptable, json: {error: 'There was an error creating a new UserLevelInteraction.'})
       end
     else
-      render(status: :bad_request, json: {message: 'UserLevelInteraction not created because this level is not in a 2024+ script.'})
+      render(status: :bad_request, json: {message: 'UserLevelInteraction not created because this level is not in a 2024+ unit.'})
     end
   end
 
@@ -40,23 +74,7 @@ class UserLevelInteractionsController < ApplicationController
     )
     user_level_interaction_params[:user_id] = current_user.id
     user_level_interaction_params[:school_year] = school_year
-    script_id = user_level_interaction_params[:script_id]
-    unit = Unit.find(script_id)
-    level = Level.find(user_level_interaction_params[:level_id])
-    project_data = get_project_and_version_id(user_level_interaction_params[:level_id], user_level_interaction_params[:script_id])
-    channel = get_channel_for(level, script_id, current_user)
-    user_level_interaction_params[:code_version] = project_data[:version_id]
-    params_metadata = JSON.parse(user_level_interaction_params[:metadata] || '{}')
-    metadata = {
-      course_offering: unit.properties["curriculum_umbrella"],
-      version_year: unit.get_course_version.key,
-      unit: unit.name,
-      level_type: level.type,
-      user_type: current_user.user_type,
-      project_id: project_data[:project_id],
-      channel: channel,
-    }
-    user_level_interaction_params[:metadata] = metadata.merge(params_metadata).to_json
+
     user_level_interaction_params
   end
 end

--- a/dashboard/app/controllers/user_level_interactions_controller.rb
+++ b/dashboard/app/controllers/user_level_interactions_controller.rb
@@ -21,7 +21,7 @@ class UserLevelInteractionsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       return render status: :not_found, json: "Level with id #{level_id}"
     end
-    
+
     project_data = get_project_and_version_id(level_id, unit_id)
     channel = get_channel_for(level, unit_id, current_user)
     user_level_interaction_params[:code_version] = project_data[:version_id]
@@ -38,11 +38,11 @@ class UserLevelInteractionsController < ApplicationController
       channel: channel,
     }
 
-     new_uli_params = user_level_interaction_params.merge(
+    new_uli_params = user_level_interaction_params.merge(
       code_version: project_data[:version_id],
       metadata: metadata.to_json,
     )
-   
+
     if should_create_uli?(version_year)
       @user_level_interaction = UserLevelInteraction.new(new_uli_params)
       if @user_level_interaction.save


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/TEACH-2053

There are a high number of errors coming in to New Relic for cases when there isn't a Unit found associated with the script_id in UserLevelInteractions creation. [example](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/NTAxNDYzfEFQTXxBUFBMSUNBVElPTnwzNzg3MzY0?duration=604800000&filters=selectedInstance%20IN%20%28%29&state=39faae41-148d-9284-ffe4-bc950be5b233) 

To prevent this error, I've made two related changes: 

1.) When we create UserLevelInteractions from AppLab code, only do so if there is a `scriptId`. The primary case for when users hit the error is using App Lab as a standalone project outside of the curriculum when there isn't a unit or level. 🙃 

2.) Update there user_level_interactions_controller to better handle when a Level or Unit is not found. 
