### PR TITLE
P20/reenable global edition region switch UI tests

### DIFF
--- a/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
@@ -9,14 +9,12 @@ Feature: Global Edition - Region Switch Confirm Modal
     And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
     And I use a cookie to mock the DCDO key "global_edition_region_switch_confirm_enabled_in" as "["fa"]"
 
-  @skip
   Scenario: The modal is shown on studio.code.org (Studio) domain
     Given I am on "http://studio.code.org"
     And I am in Iran
     And I reload the page
     Then I wait until element "#global-edition-region-switch-confirm.fade.in[role='dialog']" is visible
 
-  @skip
   Scenario: The modal is not shown on hourofcode.com domain
     Given I am on "http://hourofcode.com/us"
     And I am in Iran

--- a/dashboard/test/ui/features/step_definitions/geolocation_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/geolocation_steps.rb
@@ -17,6 +17,6 @@ Given "I am in Europe" do
 end
 
 Given 'I am in Iran' do
-  iran_ip_address = '103.215.223.255'
+  iran_ip_address = '185.113.112.255'
   steps %Q[Given I use a cookie to mock my IP address as "#{iran_ip_address}"]
 end


### PR DESCRIPTION
Re-enables the global edition region switch UI tests. They were failing because Geocoder was reporting the Iranian IP as British in Drone's Geocoder endpoint. This switches to an Iranian registered university IP address, which should be more stable.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
