### PR TITLE
fix(marketing): minor fixes on PeopleCollection component

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/PeopleCollection.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/PeopleCollection.tsx
@@ -46,6 +46,7 @@ const styles = {
     borderRadius: '50%',
   },
   overline: {
+    // TODO: replace this w/ theme palette value
     color: '#4C5661',
     marginTop: 1,
     marginBottom: 1.5,

--- a/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/PeopleCollection.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/PeopleCollection.tsx
@@ -46,7 +46,7 @@ const styles = {
     borderRadius: '50%',
   },
   overline: {
-    color: 'var(---neutral-gray-90)',
+    color: '#4C5661',
     marginTop: 1,
     marginBottom: 1.5,
   },
@@ -142,7 +142,7 @@ const PeopleCollection: React.FC<PeopleCollectionProps> = ({
             ),
           };
         })
-        .sort((a, b) => a.id.localeCompare(b.id)), // Sort alphabetically
+        .sort((a, b) => a?.id?.localeCompare(b?.id)), // Sort alphabetically
     [people, imageVisibility],
   );
 

--- a/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/__tests__/PeopleCollection.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/__tests__/PeopleCollection.test.tsx
@@ -88,4 +88,38 @@ describe('PeopleCollection', () => {
     expect(headings[1]).toHaveTextContent('Bob');
     expect(headings[2]).toHaveTextContent('Clarissa');
   });
+
+  it('handles people with missing or undefined name fields when sorting', () => {
+    const peopleWithMissingFields: PeopleCollectionProps['people'] = [
+      {
+        fields: {
+          name: null,
+          title: null,
+          bio: null,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      {
+        fields: {
+          name: undefined,
+          title: undefined,
+          bio: undefined,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    ];
+
+    render(
+      <PeopleCollection people={[...mockPeople, ...peopleWithMissingFields]} />,
+    );
+    const headings = screen.getAllByRole('heading', {level: 3});
+    expect(headings[0]).toHaveTextContent('Alex');
+    expect(headings[1]).toHaveTextContent('Bob');
+    expect(headings[2]).toHaveTextContent('Clarissa');
+  });
+
+  it('does not render images when imageVisibility is "hide"', () => {
+    render(<PeopleCollection people={mockPeople} imageVisibility="hide" />);
+    expect(document.querySelector('img')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Fixes for the PeopleCollection component:
- Adds optional chaining to `localeCompare` method
  - Fixes an error when there is an unpublished content entry in the List content type
- Updates the Title (Overline) color
  - Using a CSS variable doesn't work here (see [comment](https://github.com/code-dot-org/code-dot-org/pull/66745#discussion_r2172301999))

## Links
Jira ticket: [CMS-861](https://codedotorg.atlassian.net/browse/CMS-861)

----

## Error fix
| Before | After |
| ---- | ---- |
| <img width="1768" alt="Before" src="https://github.com/user-attachments/assets/efcbe44b-b323-41e3-820b-d7e99d72fdfa" /> | <img width="1768" alt="After" src="https://github.com/user-attachments/assets/29c1c8ac-52e7-43b5-abd4-a9f6df32ef8d" /> |


### Title color
| Before | After |
| ---- | ---- |
| <img width="360" alt="Screenshot 2025-06-27 at 2 50 50 PM" src="https://github.com/user-attachments/assets/6ad0fb94-cb92-48a6-9b66-5cf239db76b2" /> | <img width="360" alt="Screenshot 2025-06-27 at 2 49 05 PM" src="https://github.com/user-attachments/assets/89694ff2-2ee4-4c33-a33b-c5f362567f71" /> |