### PR TITLE
CMS-784: Move YourSchool Success Notice modal to top-level container to resolve z-index stacking issue

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/yourSchool/formSection/YourSchoolForm.tsx
+++ b/frontend/apps/marketing/src/components/contentful/yourSchool/formSection/YourSchoolForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {useCallback, useEffect, useState, useMemo} from 'react';
+import {createPortal} from 'react-dom';
 
 import Button, {LinkButton} from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
@@ -196,6 +197,13 @@ const YourSchoolForm: React.FC<YourSchoolFormProps> = ({
   }, [formData, formErrors]);
 
   if (isFormSubmitted) {
+    // Because the modal's z-index is scoped to its parent's stacking context,
+    // it cannot visually overlap sibling containers that have a higher stacking context.
+    // Therefore, moving the modal to a top-level container (e.g., directly under <body>)
+    // ensures it can render above all other page content.
+    const successNoticeContainer = document.createElement('div');
+    document.body.appendChild(successNoticeContainer);
+
     return (
       <>
         <Heading3
@@ -210,54 +218,56 @@ const YourSchoolForm: React.FC<YourSchoolFormProps> = ({
           We've received your submission!
         </Heading3>
 
-        {showSuccessNotice && (
-          <Modal
-            title="Thank you for telling us about your school!"
-            imageUrl={yourSchoolImg.src}
-            imagePlacement="inline"
-            className={styles.yourSchoolNotice}
-            onClose={handleSuccessNoticeClose}
-            primaryButtonProps={{
-              text: 'Return to page',
-              type: 'secondary',
-              color: 'black',
-              onClick: handleSuccessNoticeClose,
-            }}
-            customContent={
-              <div className={styles.yourSchoolNoticeContent}>
-                <BodyTwoText
-                  id="dsco-dialog-description"
-                  className={styles.yourSchoolNoticeDesc}
-                >
-                  The information you shared helps us track our progress as we
-                  work to bring CS to every school! Share this survey with
-                  friends and coworkers and encourage them to join too!
-                </BodyTwoText>
+        {showSuccessNotice &&
+          createPortal(
+            <Modal
+              title="Thank you for telling us about your school!"
+              imageUrl={yourSchoolImg.src}
+              imagePlacement="inline"
+              className={styles.yourSchoolNotice}
+              onClose={handleSuccessNoticeClose}
+              primaryButtonProps={{
+                text: 'Return to page',
+                type: 'secondary',
+                color: 'black',
+                onClick: handleSuccessNoticeClose,
+              }}
+              customContent={
+                <div className={styles.yourSchoolNoticeContent}>
+                  <BodyTwoText
+                    id="dsco-dialog-description"
+                    className={styles.yourSchoolNoticeDesc}
+                  >
+                    The information you shared helps us track our progress as we
+                    work to bring CS to every school! Share this survey with
+                    friends and coworkers and encourage them to join too!
+                  </BodyTwoText>
 
-                <div className={styles.yourSchoolNoticeButtons}>
-                  <LinkButton
-                    text="Share on Twitter"
-                    href={shareOnTwitterURL}
-                    size="s"
-                    iconLeft={{
-                      iconFamily: 'brands',
-                      iconName: 'x-twitter',
-                    }}
-                  />
-                  <LinkButton
-                    text="Share on Facebook"
-                    href={shareOnFacebookURL}
-                    size="s"
-                    iconLeft={{
-                      iconFamily: 'brands',
-                      iconName: 'facebook',
-                    }}
-                  />
+                  <div className={styles.yourSchoolNoticeButtons}>
+                    <LinkButton
+                      text="Share on Twitter"
+                      href={shareOnTwitterURL}
+                      size="s"
+                      iconLeft={{
+                        iconFamily: 'brands',
+                        iconName: 'x-twitter',
+                      }}
+                    />
+                    <LinkButton
+                      text="Share on Facebook"
+                      href={shareOnFacebookURL}
+                      size="s"
+                      iconLeft={{
+                        iconFamily: 'brands',
+                        iconName: 'facebook',
+                      }}
+                    />
+                  </div>
                 </div>
-              </div>
-            }
-          />
-        )}
+              }
+            />,
+            successNoticeContainer,
+          )}
       </>
     );
   }

--- a/frontend/apps/marketing/src/components/contentful/yourSchool/yourSchool.module.scss
+++ b/frontend/apps/marketing/src/components/contentful/yourSchool/yourSchool.module.scss
@@ -37,33 +37,6 @@
     text-align: center;
   }
 
-  .yourSchoolNotice {
-    max-width: 43rem;
-    padding: 1.5rem 2rem;
-
-    img {
-      background: none;
-      height: auto;
-    }
-
-    .yourSchoolNoticeContent {
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-
-      .yourSchoolNoticeDesc {
-        color: var(--text-neutral-tertiary);
-      }
-
-      .yourSchoolNoticeButtons {
-        display: flex;
-        width: 100%;
-        justify-content: space-between;
-        gap: 0.75rem;
-      }
-    }
-  }
-
   .yourSchoolMapSection {
     .yourSchoolMapHeading,
     .yourSchoolMapParagraph {
@@ -253,6 +226,33 @@
       .yourSchoolFormBottomText {
         margin: 0;
       }
+    }
+  }
+}
+
+.yourSchoolNotice {
+  max-width: 43rem;
+  padding: 1.5rem 2rem;
+
+  img {
+    background: none;
+    height: auto;
+  }
+
+  .yourSchoolNoticeContent {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    .yourSchoolNoticeDesc {
+      color: var(--text-neutral-tertiary);
+    }
+
+    .yourSchoolNoticeButtons {
+      display: flex;
+      width: 100%;
+      justify-content: space-between;
+      gap: 0.75rem;
     }
   }
 }


### PR DESCRIPTION
## Issue
Because the modal's z-index is scoped to its parent's stacking context, it cannot visually overlap sibling containers that have a higher stacking context. Therefore, moving the modal to a top-level container (e.g., directly under `<body>`) ensures it can render above all other page content.

## Before
<img width="100%" alt="before" src="https://github.com/user-attachments/assets/12d591ca-42bf-441a-8e9b-f6c5de47ced5" />

## After
<img width="100%" alt="after" src="https://github.com/user-attachments/assets/4586d05f-a827-4c0e-85ce-0d6bb0401cf2" />

## Links
- JIRA task: [CMS-784](https://codedotorg.atlassian.net/browse/CMS-784)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66663