### PR TITLE
CMS-784: Apply higher stacking context to YourSchool container to ensure proper modal layering

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/yourSchool/yourSchool.module.scss
+++ b/frontend/apps/marketing/src/components/contentful/yourSchool/yourSchool.module.scss
@@ -3,6 +3,7 @@
 
 .yourSchool {
   width: 100%;
+  z-index: 1000;
 
   label {
     width: 100%;

--- a/frontend/apps/marketing/src/components/contentful/yourSchool/yourSchool.module.scss
+++ b/frontend/apps/marketing/src/components/contentful/yourSchool/yourSchool.module.scss
@@ -1,9 +1,10 @@
 @use '@code-dot-org/component-library-styles/font.scss' as font;
+@use '@code-dot-org/component-library-styles/variables.scss' as variables;
 @use '@code-dot-org/component-library-styles/cms/variables.scss' as cmsVars;
 
 .yourSchool {
   width: 100%;
-  z-index: 1000;
+  z-index: variables.$zindex-fixed;
 
   label {
     width: 100%;


### PR DESCRIPTION
## Before
<img width="100%" alt="before" src="https://github.com/user-attachments/assets/12d591ca-42bf-441a-8e9b-f6c5de47ced5" />

## After
<img width="100%" alt="after" src="https://github.com/user-attachments/assets/4586d05f-a827-4c0e-85ce-0d6bb0401cf2" />

## Links
- JIRA task: [CMS-784](https://codedotorg.atlassian.net/browse/CMS-784)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66663