### PR TITLE
fix(middleware): do not match tenant id

### DIFF
--- a/frontend/apps/marketing/src/middleware.ts
+++ b/frontend/apps/marketing/src/middleware.ts
@@ -11,8 +11,9 @@ export const config = {
      * 3. /_static (inside /public)
      * 4. /onetrust (OneTrust cookie consent)
      * 4. all root files inside /public (e.g. /favicon.ico)
+     * 5. /robots.txt
      */
-    '/((?!api/|_next/|onetrust/|_static/|_vercel).*)',
+    '/((?!api/|_next/|onetrust/|_static/|_vercel|robots.txt).*)',
   ],
 };
 

--- a/frontend/apps/marketing/src/middleware.ts
+++ b/frontend/apps/marketing/src/middleware.ts
@@ -12,7 +12,7 @@ export const config = {
      * 4. /onetrust (OneTrust cookie consent)
      * 4. all root files inside /public (e.g. /favicon.ico)
      */
-    '/((?!api/|_next/|onetrust/|_static/|_vercel|[\\w-]+\\.\\w+).*)',
+    '/((?!api/|_next/|onetrust/|_static/|_vercel).*)',
   ],
 };
 


### PR DESCRIPTION
The middleware was copied from the vercel multi-tenant example which includes a tenant id matcher. However, it appears the example has a bug which matches paths such as `/a.b.c/xyz` which causes the locale not to be rendered and sets the locale as `a.b.c` which ends up throwing an error. Rather, the multi-tenancy works as expected without this Regex because we use `NextResponse.rewrite` which proxies[1] the branded request while preserving the original URL. In other words, currently a request to `/code.org/en-US/engineering/all-the-things` works (when it shouldn't), but the middleware using the rewrite proxy `/en-US/engineering/all-the-things` also works because it proxies the request internally.

This should fix some security robots throwing 500s in production.

[1] https://nextjs.org/docs/app/api-reference/functions/next-response#rewrite