### PR TITLE
fix: set keep alive greater than ELB timeout

### DIFF
--- a/frontend/apps/marketing/Dockerfile
+++ b/frontend/apps/marketing/Dockerfile
@@ -87,6 +87,14 @@ RUN yarn turbo run build
 FROM base AS runner
 WORKDIR /app
 
+# When deploying Next.js behind a downstream proxy (e.g. a load-balancer like AWS ELB/ALB), it's important to configure
+# Next's underlying HTTP server with keep-alive timeouts that are larger than the downstream proxy's timeouts.
+# Otherwise, once a keep-alive timeout is reached for a given TCP connection, Node.js will immediately terminate that
+# connection without notifying the downstream proxy. This results in a proxy error whenever it attempts to reuse a
+# connection that Node.js has already terminated.
+# See: https://nextjs.org/docs/app/api-reference/cli/next#configuring-a-timeout-for-downstream-proxies
+ENV KEEP_ALIVE_TIMEOUT 70000
+
 # Don't run production as root
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -215,6 +215,8 @@ Resources:
         # Delete the load balancer if the CloudFormation stack is deleted
         - Key: deletion_protection.enabled
           Value: "false"
+        # Note for idle_timeout.timeout_seconds: The default is 60 seconds, which is is appropriate for this application.
+        # If changing from the default, the KEEP_ALIVE_TIMEOUT in the Dockerfile must also be updated to be greater than this value.
       Scheme: internet-facing
       SecurityGroups:
         - !GetAtt FargateServiceLBSecurityGroup.GroupId


### PR DESCRIPTION
The Node.js default keep alive is 5 seconds and the ELB default keep alive is 60 seconds. ELB has a feature where it will preconnect to the endpoint but has a race condition where if the endpoint is closed prior (due to the 5 second timeout), the ELB will try to connect to a closed endpoint. As documented in the Next.js server documentation[1], set the timeout greater than the ELB value.

[1] https://nextjs.org/docs/app/api-reference/cli/next#configuring-a-timeout-for-downstream-proxies