### PR TITLE
fix: skip redirect test unless chrome

### DIFF
--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -34,7 +34,13 @@ test.describe('All the things UI e2e test', () => {
     test('should redirect from localeless paths to english localized paths when no language cookie is set', async ({
       page,
       context,
+      browserName,
     }) => {
+      test.skip(
+        browserName !== 'chromium',
+        'This test only needs to run once on Chromium',
+      );
+
       const allTheThingsPage = new MarketingPage(page);
       await allTheThingsPage.goto('/engineering/all-the-things');
 


### PR DESCRIPTION
Skips the redirect test unless chrome because the logic is the same for all browsers. On Safari, the test was acting flaky with the browser unexpectedly closing and the behavior is more or less equivalent across all browsers. This should also speed up the tests by skipping it on firefox/webkit.
