### PR TITLE
fix(404): return 404 when an api route is not found

### DIFF
--- a/frontend/apps/marketing/src/app/api/[...notFound]/page.tsx
+++ b/frontend/apps/marketing/src/app/api/[...notFound]/page.tsx
@@ -1,0 +1,8 @@
+import {notFound} from 'next/navigation';
+
+/**
+ * Catch-all route for handling 404 since the /api route only has an allow list of API paths.
+ */
+export default function NotFoundCatchAll() {
+  return notFound();
+}

--- a/frontend/apps/marketing/src/app/not-found.tsx
+++ b/frontend/apps/marketing/src/app/not-found.tsx
@@ -1,0 +1,27 @@
+'use client';
+import {sendGAEvent} from '@next/third-parties/google';
+import {usePathname} from 'next/navigation';
+import {useEffect} from 'react';
+
+import Error from '@/components/error';
+
+export default function NotFound() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    sendGAEvent('event', 'page_not_found', {
+      path: pathname,
+    });
+  }, [pathname]);
+
+  return (
+    <>
+      {/*
+        No support for metadata in not-found.tsx yet
+        See: https://github.com/vercel/next.js/issues/45620
+      */}
+      <title>Page Not Found</title>
+      <Error statusCode={404} />
+    </>
+  );
+}

--- a/frontend/apps/marketing/tests/e2e/not-found-page.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/not-found-page.spec.ts
@@ -16,7 +16,33 @@ test.describe('404 Not Found Page', () => {
     );
 
     expect(response?.status()).toEqual(404);
-    expect(await page.title()).toBe('Page Not Found');
+    await page.waitForFunction(() => document.title === 'Page Not Found');
+
+    await expect(
+      page.getByRole('heading', {name: "We couldn't find this page"}),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "We couldn't find the page you were looking for, let's get you back on track.",
+      ),
+    ).toBeVisible();
+    await expect(page.getByText('Go to homepage')).toBeVisible();
+  });
+
+  test('should return a custom 404 page for unknown /api routes', async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+    test.skip(getStage() === 'production', 'Only runs in preprod');
+
+    const marketingPage = new MarketingPage(page);
+    const response = await marketingPage.goto(
+      '/api/custom-api-route-not-found-d4740fb9',
+    );
+
+    expect(response?.status()).toEqual(404);
+    await page.waitForFunction(() => document.title === 'Page Not Found');
     await expect(
       page.getByRole('heading', {name: "We couldn't find this page"}),
     ).toBeVisible();


### PR DESCRIPTION
When security scanners run through the /api/ routes, a 500 is generated by the application because of a Next.js bug[1]. This bug causes the 404 error to be interpreted as a 500 which leads to error pollution in the production logs.

To workaround the bug, a catch all route was added to catch unknown API routes and explicitly set that the pages are 404. This causes the routes to then show the sad bee page.

[1] https://github.com/vercel/next.js/issues/60477