### PR TITLE
feat(marketing): add sorting to LogoCollection component

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/collections/logoCollection/LogoCollection.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/logoCollection/LogoCollection.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Link from '@mui/material/Link';
 import {EntryFields} from 'contentful';
-import {useMemo} from 'react';
+import {useId, useMemo} from 'react';
 
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 import {LinkEntry} from '@/types/contentful/entries/Link';
@@ -23,7 +23,7 @@ export type LogoCollectionProps = {
 };
 
 const logoStyles = {
-  container: {
+  gridItem: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -62,42 +62,52 @@ const LogoCollection: React.FC<LogoCollectionProps> = ({logos}) => {
 
   const logosData = useMemo(
     () =>
-      logos.filter(Boolean).map(({fields}) => {
-        const {title, logoImage, primaryLinkRef} = fields;
-
-        return {
-          id: title,
-          item: (
+      logos
+        .filter(Boolean)
+        .map(({fields}) => {
+          const {title, logoImage, primaryLinkRef} = fields;
+          const url = primaryLinkRef?.fields?.primaryTarget || '';
+          const getImage = () => (
             <img
               src={getAbsoluteImageUrl(logoImage)}
               alt={logoImage?.fields?.title || title || 'Logo'}
               loading="lazy"
             />
-          ),
-          url: primaryLinkRef?.fields?.primaryTarget || '',
-        };
-      }),
+          );
+
+          return {
+            id: title,
+            item: (
+              <Box component="figure" sx={logoStyles.gridItem}>
+                {url ? (
+                  <Link
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={logoStyles.link}
+                  >
+                    {getImage()}
+                  </Link>
+                ) : (
+                  getImage()
+                )}
+              </Box>
+            ),
+            url: url,
+          };
+        })
+        .sort((a, b) => a?.id?.localeCompare(b?.id)), // Sort alphabetically
     [logos],
   );
 
   return (
     <Grid container spacing={7.5}>
       {logosData.map(logo => (
-        <Grid key={logo.id} size={{xs: 12, sm: 4, md: 3}}>
-          <Box key={logo.id} component="figure" sx={logoStyles.container}>
-            {logo.url ? (
-              <Link
-                href={logo.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                sx={logoStyles.link}
-              >
-                {logo.item}
-              </Link>
-            ) : (
-              logo.item
-            )}
-          </Box>
+        <Grid
+          key={`id-${useId().replaceAll(':', '')}`}
+          size={{xs: 12, sm: 4, md: 3}}
+        >
+          {logo.item}
         </Grid>
       ))}
     </Grid>

--- a/frontend/apps/marketing/src/components/contentful/collections/logoCollection/__tests__/LogoCollection.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/logoCollection/__tests__/LogoCollection.test.tsx
@@ -65,7 +65,9 @@ describe('LogoCollection', () => {
 
   it('renders logos with correct alt text', () => {
     render(<LogoCollection logos={mockLogos} />);
-    expect(screen.getAllByAltText('Microsoft Logo')[0]).toBeInTheDocument();
+    expect(screen.getByAltText('Microsoft Logo')).toBeInTheDocument();
+    expect(screen.getByAltText('Amazon Logo')).toBeInTheDocument();
+    expect(screen.getByAltText('Google Logo')).toBeInTheDocument();
   });
 
   it('renders links for logos with URLs', () => {

--- a/frontend/apps/marketing/src/components/contentful/collections/logoCollection/__tests__/LogoCollection.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/logoCollection/__tests__/LogoCollection.test.tsx
@@ -1,83 +1,124 @@
 import {render, screen} from '@testing-library/react';
 
-import LogoCollection from '../LogoCollection';
+import LogoCollection, {LogoCollectionProps} from '../LogoCollection';
 
 jest.mock('@/selectors/contentful/getImage', () => ({
   getAbsoluteImageUrl: jest.fn(() => 'https://example.com/logo.png'),
 }));
 
-const mockLogo = (overrides = {}) => ({
-  fields: {
-    title: 'First Logo',
-    logoImage: {
-      fields: {
-        title: 'First Brand',
+const mockLogos: LogoCollectionProps['logos'] = [
+  {
+    fields: {
+      title: 'Microsoft',
+      logoImage: {
+        fields: {
+          title: 'Microsoft Logo',
+        },
+      },
+      primaryLinkRef: {
+        fields: {
+          primaryTarget: 'https://microsoft.com',
+        },
       },
     },
-    primaryLinkRef: {
-      fields: {
-        primaryTarget: 'https://first.com',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any,
+  {
+    fields: {
+      title: 'Amazon',
+      logoImage: {
+        fields: {
+          title: 'Amazon Logo',
+        },
+      },
+      primaryLinkRef: {
+        fields: {
+          primaryTarget: 'https://amazon.com',
+        },
       },
     },
-    ...overrides,
-  },
-});
-
-const mockLogos = [
-  mockLogo(),
-  mockLogo({
-    title: 'Second Logo',
-    logoImage: {fields: {title: 'Second Brand'}},
-    primaryLinkRef: {fields: {primaryTarget: 'https://second.com'}},
-  }),
-  mockLogo({
-    title: 'Third Logo',
-    logoImage: {fields: {title: 'Third Brand'}},
-    primaryLinkRef: {fields: {primaryTarget: ''}},
-  }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any,
+  {
+    fields: {
+      title: 'Google',
+      logoImage: {
+        fields: {
+          title: 'Google Logo',
+        },
+      },
+      primaryLinkRef: {
+        fields: {
+          primaryTarget: '',
+        },
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any,
 ];
 
 describe('LogoCollection', () => {
   it('renders logos', () => {
-    const logos = mockLogos;
-    render(
-      <LogoCollection
-        logos={logos as Parameters<typeof LogoCollection>[0]['logos']}
-      />,
-    );
+    render(<LogoCollection logos={mockLogos} />);
     expect(screen.getAllByRole('img')).toHaveLength(3);
   });
 
   it('renders logos with correct alt text', () => {
-    const logos = mockLogos;
-    render(
-      <LogoCollection
-        logos={logos as Parameters<typeof LogoCollection>[0]['logos']}
-      />,
-    );
-    expect(screen.getAllByAltText('First Brand')[0]).toBeInTheDocument();
+    render(<LogoCollection logos={mockLogos} />);
+    expect(screen.getAllByAltText('Microsoft Logo')[0]).toBeInTheDocument();
   });
 
   it('renders links for logos with URLs', () => {
-    const logos = mockLogos;
-    render(
-      <LogoCollection
-        logos={logos as Parameters<typeof LogoCollection>[0]['logos']}
-      />,
-    );
+    render(<LogoCollection logos={mockLogos} />);
     const images = screen.getAllByRole('figure');
 
     // check that images with URLs have links
     expect(images[0].firstElementChild).toHaveAttribute(
       'href',
-      'https://first.com',
+      'https://amazon.com',
     );
-    expect(images[1].firstElementChild).toHaveAttribute(
-      'href',
-      'https://second.com',
-    );
+    expect(images[1].firstElementChild).not.toHaveAttribute('href');
 
     // check that images without URLs do not have links
-    expect(images[2].firstElementChild).not.toHaveAttribute('href');
+    expect(images[2].firstElementChild).toHaveAttribute(
+      'href',
+      'https://microsoft.com',
+    );
+  });
+
+  it('sorts logos alphabetically by brand title', () => {
+    render(<LogoCollection logos={mockLogos} />);
+    const images = screen.getAllByRole('img');
+    expect(images[0]).toHaveAttribute('alt', 'Amazon Logo');
+    expect(images[1]).toHaveAttribute('alt', 'Google Logo');
+    expect(images[2]).toHaveAttribute('alt', 'Microsoft Logo');
+  });
+
+  it('handles logos with missing or undefined fields when sorting', () => {
+    const logos = mockLogos;
+    const logosWithMissingFields: LogoCollectionProps['logos'] = [
+      {
+        fields: {
+          title: null,
+          logoImage: null,
+          primaryLinkRef: null,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      {
+        fields: {
+          title: undefined,
+          logoImage: undefined,
+          primaryLinkRef: undefined,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    ];
+
+    render(<LogoCollection logos={[...logos, ...logosWithMissingFields]} />);
+    const images = screen.getAllByRole('img');
+    expect(images[0]).toHaveAttribute('alt', 'Amazon Logo');
+    expect(images[1]).toHaveAttribute('alt', 'Google Logo');
+    expect(images[2]).toHaveAttribute('alt', 'Microsoft Logo');
   });
 });


### PR DESCRIPTION
Adds sorting to the LogoCollection component and:
- Updates the key id to use `useId` 
- Refactors the component to be easier to read

## Links
Jira ticket: [CMS-858](https://codedotorg.atlassian.net/browse/CMS-858)

## Testing story
Tested locally in Contenful

----

## Before
<img width="1247" alt="Before" src="https://github.com/user-attachments/assets/ea3a4a28-959b-4620-8a14-c95fdc40ef69" />

## After
<img width="1247" alt="After" src="https://github.com/user-attachments/assets/8dff601d-5a4d-41ce-9653-28df9bdf8094" />
