### PR TITLE
improve UX for when drone detects schema.rb changes

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -93,6 +93,8 @@ namespace :ci do
       next
     end
 
+    check_for_new_file_changes
+
     if CI::Utils.tagged?(SKIP_UI_TESTS_TAG)
       ChatClient.log "Commit message: '#{CI::Utils.git_commit_message}' contains [#{SKIP_UI_TESTS_TAG}], skipping UI tests for this run."
       next
@@ -145,8 +147,6 @@ namespace :ci do
     end
     close_sauce_connect if use_saucelabs || test_eyes?
     RakeUtils.system_stream_output 'sleep 10'
-
-    check_for_new_file_changes
   end
 
   desc 'Checks for unexpected changes (for example, after a build step) and raises an exception if an unexpected change is found'
@@ -248,5 +248,7 @@ def check_for_new_file_changes
   if GitUtils.changed_in_branch_or_local?(GitUtils.current_branch, ['dashboard/db/schema.rb'])
     RakeUtils.system_stream_output('git diff -- dashboard/db/schema.rb | cat')
     raise 'Unexpected change to schema.rb - Make sure you run your migration locally and push those changes into your branch.'
+  else
+    ChatClient.log 'No changes to schema.rb detected.'
   end
 end

--- a/lib/rake/install.rake
+++ b/lib/rake/install.rake
@@ -53,7 +53,7 @@ namespace :install do
             # cache, prepare one from scratch by creating the database and loading
             # the schema. If we do, make sure it's up to date with the branch
             # being tested. Either way, seeding will be performed in a later step.
-            RakeUtils.rake 'db:setup_or_migrate'
+            RakeUtils.rake_stream_output 'db:setup_or_migrate'
           else
             raise "Unknown CI job: #{ENV['CI_JOB']}"
           end


### PR DESCRIPTION
* Follow-up from https://github.com/code-dot-org/code-dot-org/pull/66690 . See that PR for context.

## Testing story

A slight variation of the changes in this PR were previously tested in https://github.com/code-dot-org/code-dot-org/pull/66693. Search for "schema.rb" in the ui test drone runs on that PR for confirmation of the following observations:

Without any migration:
```
[test] No changes to schema.rb detected.
```

When PR contains a migration that has not been run:
```
274 | + bundle exec rake ci:run_ui_tests
275 | git diff -- dashboard/db/schema.rb \| cat
276 | diff --git a/dashboard/db/schema.rb b/dashboard/db/schema.rb
...
293 | +  create_table "validate_charsets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do \|t\|
294 | +    t.datetime "created_at", precision: 6, null: false
295 | +    t.datetime "updated_at", precision: 6, null: false
296 | +    t.boolean "flag"
297 | +  end
...
302 | rake aborted!
303 | Unexpected change to schema.rb - Make sure you run your migration locally and push those changes into your branch.
```

After running the migration locally and pushing schema.rb changes to the branch:
```
[test] No changes to schema.rb detected.
```
