### PR TITLE
fix(localize): use localizejs code from bcp 47 code

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
@@ -7,7 +7,7 @@ import Header from '@/components/header';
 import {Brand} from '@/config/brand';
 import {getGoogleAnalyticsMeasurementId} from '@/config/ga4';
 import OrganizationJsonLd from '@/config/jsonLd/OrganizationJsonLd';
-import {SUPPORTED_LOCALES_MAP} from '@/config/locale';
+import {SUPPORTED_LOCALES_MAP, SupportedLocale} from '@/config/locale';
 import {getStage} from '@/config/stage';
 import EnvironmentLoader from '@/providers/environment';
 import LocalizeLoader from '@/providers/localize/LocalizeLoader';
@@ -23,7 +23,7 @@ export default async function Layout({
   params,
 }: Readonly<{
   children: React.ReactNode;
-  params: Promise<{brand: Brand; locale: string}>;
+  params: Promise<{brand: Brand; locale: SupportedLocale}>;
 }>) {
   const syncParams = await params;
   const {brand, locale} = syncParams;

--- a/frontend/apps/marketing/src/components/footer/Footer.tsx
+++ b/frontend/apps/marketing/src/components/footer/Footer.tsx
@@ -5,7 +5,7 @@ import DSCOFooter, {
   FooterProps,
 } from '@code-dot-org/component-library/cms/footer';
 
-import {SUPPORTED_LOCALES} from '@/config/locale';
+import {LOCALIZE_JS_CONFIG_MAP} from '@/config/locale';
 import awsLogo from '@public/images/powered-by-aws.png';
 
 import './onetrust.scss';
@@ -129,7 +129,7 @@ const Footer = ({locale}: GlobalFooterProps) => {
       {...defaultProps}
       onLanguageChange={handleLanguageChange}
       selectedLocaleCode={locale}
-      languages={SUPPORTED_LOCALES}
+      languages={LOCALIZE_JS_CONFIG_MAP}
     />
   );
 };

--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -134,7 +134,7 @@ export function getLocalizeJsLocaleFromBCP47(bcp47Code: string) {
 }
 
 /**
- * Returns the Pegasus locale code for a given LocalizeJS locale code.
+ * Returns the Dashboard (studio.code.org) locale code for a given LocalizeJS locale code.
  * @param localizeJsLocale - The LocalizeJS locale code to convert.
  */
 export function getDashboardLocale(localizeJsLocale: string): string {

--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -142,8 +142,8 @@ export function getDashboardLocale(localizeJsLocale: string): string {
 }
 
 /**
- * Returns the LocalizeJS locale code for a given Pegasus locale code.
- * @param dashboardLocale - The Pegasus locale code to convert.
+ * Returns the LocalizeJS locale code for a given Dashboard (studio.code.org) locale code.
+ * @param dashboardLocale - The Dashboard (studio.code.org) locale code to convert.
  */
 export function getLocalizeJsLocaleFromDashboardLocale(
   dashboardLocale: string | undefined,

--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -1,29 +1,88 @@
+export enum SupportedLocale {
+  'en-US' = 'en-US',
+  es = 'es',
+  ar = 'ar',
+  de = 'de',
+  fa = 'fa',
+  fr = 'fr',
+  hi = 'hi',
+  id = 'id',
+  it = 'it',
+  ja = 'ja',
+  ko = 'ko',
+  mr = 'mr',
+  pl = 'pl',
+  'pt-BR' = 'pt-BR',
+  sk = 'sk',
+  th = 'th',
+  tr = 'tr',
+  uk = 'uk',
+  vi = 'vi',
+  'zh-TW' = 'zh-TW',
+  sq = 'sq',
+  tl = 'tl',
+  he = 'he',
+}
+
+type LocalizeJsConfig = {
+  value: SupportedLocale;
+  text: string;
+  isRTL: boolean;
+};
+
 // The following are LocalizeJS language codes and map 1:1. They are replicated here to ensure compatability in SSR.
-export const SUPPORTED_LOCALES = [
-  {value: 'en-US', text: 'English', isRTL: false},
-  {value: 'es', text: 'Español', isRTL: false},
-  {value: 'ar', text: 'العربية', isRTL: true},
-  {value: 'de', text: 'Deutsch', isRTL: false},
-  {value: 'fa', text: 'فارسی', isRTL: true},
-  {value: 'fr', text: 'Français', isRTL: false},
-  {value: 'hi', text: 'हिन्दी', isRTL: false},
-  {value: 'id', text: 'Bahasa Indonesia', isRTL: false},
-  {value: 'it', text: 'Italiano', isRTL: false},
-  {value: 'ja', text: '日本語', isRTL: false},
-  {value: 'ko', text: '한국어', isRTL: false},
-  {value: 'mr', text: 'मराठी', isRTL: false},
-  {value: 'pl', text: 'Polski', isRTL: false},
-  {value: 'pt-BR', text: 'Português (Brasil)', isRTL: false},
-  {value: 'sk', text: 'Slovenčina', isRTL: false},
-  {value: 'th', text: 'ภาษาไทย', isRTL: false},
-  {value: 'tr', text: 'Türkçe', isRTL: false},
-  {value: 'uk', text: 'Українська', isRTL: false},
-  {value: 'vi', text: 'Tiếng Việt', isRTL: false},
-  {value: 'zh-TW', text: '繁體字', isRTL: false},
-  {value: 'sq', text: 'Shqip', isRTL: false},
-  {value: 'tl', text: 'Tagalog', isRTL: false},
-  {value: 'he', text: 'עברית', isRTL: true},
+export const LOCALIZE_JS_CONFIG_MAP: LocalizeJsConfig[] = [
+  {value: SupportedLocale['en-US'], text: 'English', isRTL: false},
+  {value: SupportedLocale['es'], text: 'Español', isRTL: false},
+  {value: SupportedLocale['ar'], text: 'العربية', isRTL: true},
+  {value: SupportedLocale['de'], text: 'Deutsch', isRTL: false},
+  {value: SupportedLocale['fa'], text: 'فارسی', isRTL: true},
+  {value: SupportedLocale['fr'], text: 'Français', isRTL: false},
+  {value: SupportedLocale['hi'], text: 'हिन्दी', isRTL: false},
+  {value: SupportedLocale['id'], text: 'Bahasa Indonesia', isRTL: false},
+  {value: SupportedLocale['it'], text: 'Italiano', isRTL: false},
+  {value: SupportedLocale['ja'], text: '日本語', isRTL: false},
+  {value: SupportedLocale['ko'], text: '한국어', isRTL: false},
+  {value: SupportedLocale['mr'], text: 'मराठी', isRTL: false},
+  {value: SupportedLocale['pl'], text: 'Polski', isRTL: false},
+  {value: SupportedLocale['pt-BR'], text: 'Português (Brasil)', isRTL: false},
+  {value: SupportedLocale['sk'], text: 'Slovenčina', isRTL: false},
+  {value: SupportedLocale['th'], text: 'ภาษาไทย', isRTL: false},
+  {value: SupportedLocale['tr'], text: 'Türkçe', isRTL: false},
+  {value: SupportedLocale['uk'], text: 'Українська', isRTL: false},
+  {value: SupportedLocale['vi'], text: 'Tiếng Việt', isRTL: false},
+  {value: SupportedLocale['zh-TW'], text: '繁體字', isRTL: false},
+  {value: SupportedLocale['sq'], text: 'Shqip', isRTL: false},
+  {value: SupportedLocale['tl'], text: 'Tagalog', isRTL: false},
+  {value: SupportedLocale['he'], text: 'עברית', isRTL: true},
 ];
+
+// Map of supported BCP 47 locale codes to LocalizeJS locale codes
+const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
+  'en-US': 'en',
+  es: 'es',
+  ar: 'ar',
+  de: 'de',
+  fa: 'fa',
+  fr: 'fr',
+  hi: 'hi',
+  id: 'id',
+  it: 'it',
+  ja: 'ja',
+  ko: 'ko',
+  mr: 'mr',
+  pl: 'pl',
+  'pt-BR': 'pt-BR',
+  sk: 'sk',
+  th: 'th',
+  tr: 'tr',
+  uk: 'uk',
+  vi: 'vi',
+  'zh-TW': 'zh-TW',
+  sq: 'sq',
+  tl: 'tl',
+  he: 'he',
+};
 
 // Map of LocalizeJS locale codes to Pegasus locale codes
 const PEGASUS_LOCALE_MAP: Record<string, string | undefined> = {
@@ -52,27 +111,43 @@ const PEGASUS_LOCALE_MAP: Record<string, string | undefined> = {
   he: 'he-IL',
 };
 
-const LOCALIZEJS_LOCALE_MAP: Record<string, string | undefined> =
+const LOCALIZEJS_LOCALE_MAP: Record<string, SupportedLocale | undefined> =
   Object.fromEntries(
     Object.entries(PEGASUS_LOCALE_MAP).map(([key, value]) => [value, key]),
   );
 
-export const SUPPORTED_LOCALE_CODES = SUPPORTED_LOCALES.map(
+export const SUPPORTED_LOCALE_CODES = LOCALIZE_JS_CONFIG_MAP.map(
   locale => locale.value,
 );
 export const SUPPORTED_LOCALES_SET = new Set(SUPPORTED_LOCALE_CODES);
 
 export const SUPPORTED_LOCALES_MAP = new Map(
-  SUPPORTED_LOCALES.map(locale => [locale.value, locale]),
+  LOCALIZE_JS_CONFIG_MAP.map(locale => [locale.value, locale]),
 );
 
+/**
+ * Returns the LocalizeJS locale code for a given BCP 47 locale code.
+ * @param bcp47Code - The BCP 47 locale code to convert.
+ */
+export function getLocalizeJsLocaleFromBCP47(bcp47Code: string) {
+  return LOCALIZEJS_LOCALE[bcp47Code as SupportedLocale] || 'en';
+}
+
+/**
+ * Returns the Pegasus locale code for a given LocalizeJS locale code.
+ * @param localizeJsLocale - The LocalizeJS locale code to convert.
+ */
 export function getPegasusLocale(localizeJsLocale: string): string {
   return PEGASUS_LOCALE_MAP[localizeJsLocale] || 'en-US';
 }
 
-export function getLocalizeJsLocale(
+/**
+ * Returns the LocalizeJS locale code for a given Pegasus locale code.
+ * @param pegasusLocale - The Pegasus locale code to convert.
+ */
+export function getLocalizeJsLocaleFromPegasusLocale(
   pegasusLocale: string | undefined,
-): string | undefined {
+): SupportedLocale | undefined {
   if (!pegasusLocale) {
     return undefined;
   }

--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -85,7 +85,7 @@ const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
 };
 
 // Map of LocalizeJS locale codes to Pegasus locale codes
-const PEGASUS_LOCALE_MAP: Record<string, string | undefined> = {
+const DASHBOARD_LOCALE_MAP: Record<string, string | undefined> = {
   'en-US': 'en-US',
   es: 'es-MX',
   ar: 'ar-SA',
@@ -113,7 +113,7 @@ const PEGASUS_LOCALE_MAP: Record<string, string | undefined> = {
 
 const LOCALIZEJS_LOCALE_MAP: Record<string, SupportedLocale | undefined> =
   Object.fromEntries(
-    Object.entries(PEGASUS_LOCALE_MAP).map(([key, value]) => [value, key]),
+    Object.entries(DASHBOARD_LOCALE_MAP).map(([key, value]) => [value, key]),
   );
 
 export const SUPPORTED_LOCALE_CODES = LOCALIZE_JS_CONFIG_MAP.map(
@@ -137,20 +137,20 @@ export function getLocalizeJsLocaleFromBCP47(bcp47Code: string) {
  * Returns the Pegasus locale code for a given LocalizeJS locale code.
  * @param localizeJsLocale - The LocalizeJS locale code to convert.
  */
-export function getPegasusLocale(localizeJsLocale: string): string {
-  return PEGASUS_LOCALE_MAP[localizeJsLocale] || 'en-US';
+export function getDashboardLocale(localizeJsLocale: string): string {
+  return DASHBOARD_LOCALE_MAP[localizeJsLocale] || 'en-US';
 }
 
 /**
  * Returns the LocalizeJS locale code for a given Pegasus locale code.
- * @param pegasusLocale - The Pegasus locale code to convert.
+ * @param dashboardLocale - The Pegasus locale code to convert.
  */
-export function getLocalizeJsLocaleFromPegasusLocale(
-  pegasusLocale: string | undefined,
+export function getLocalizeJsLocaleFromDashboardLocale(
+  dashboardLocale: string | undefined,
 ): SupportedLocale | undefined {
-  if (!pegasusLocale) {
+  if (!dashboardLocale) {
     return undefined;
   }
 
-  return LOCALIZEJS_LOCALE_MAP[pegasusLocale];
+  return LOCALIZEJS_LOCALE_MAP[dashboardLocale];
 }

--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -84,7 +84,7 @@ const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
   he: 'he',
 };
 
-// Map of LocalizeJS locale codes to Pegasus locale codes
+// Map of LocalizeJS locale codes to Dashboard (studio.code.org) locale codes
 const DASHBOARD_LOCALE_MAP: Record<string, string | undefined> = {
   'en-US': 'en-US',
   es: 'es-MX',

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -2,10 +2,11 @@ import Negotiator from 'negotiator';
 import {NextFetchEvent, NextRequest} from 'next/server';
 
 import {
-  getLocalizeJsLocale,
+  getLocalizeJsLocaleFromPegasusLocale,
   getPegasusLocale,
   SUPPORTED_LOCALE_CODES,
   SUPPORTED_LOCALES_SET,
+  SupportedLocale,
 } from '@/config/locale';
 import {getStage} from '@/config/stage';
 import {getStudioBaseUrl} from '@/config/studio';
@@ -15,7 +16,7 @@ import {getCachedRedirectResponse} from '@/middleware/utils/getCachedRedirectRes
 import {MiddlewareFactory} from './types';
 
 function getLanguageFromCookie(request: NextRequest) {
-  const cookieLocale = getLocalizeJsLocale(
+  const cookieLocale = getLocalizeJsLocaleFromPegasusLocale(
     request.cookies.get('language_')?.value,
   );
   return cookieLocale !== undefined && SUPPORTED_LOCALES_SET.has(cookieLocale)
@@ -48,7 +49,7 @@ export const withLocale: MiddlewareFactory = next => {
     const {pathname} = request.nextUrl;
     const pathParts = pathname.split('/').filter(Boolean);
 
-    const maybeLocale = pathParts[0];
+    const maybeLocale = pathParts[0] as SupportedLocale;
 
     if (SUPPORTED_LOCALES_SET.has(maybeLocale)) {
       // If the first part of the path is a supported locale or there are no subpaths, we don't need to redirect

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -2,8 +2,8 @@ import Negotiator from 'negotiator';
 import {NextFetchEvent, NextRequest} from 'next/server';
 
 import {
-  getLocalizeJsLocaleFromPegasusLocale,
-  getPegasusLocale,
+  getLocalizeJsLocaleFromDashboardLocale,
+  getDashboardLocale,
   SUPPORTED_LOCALE_CODES,
   SUPPORTED_LOCALES_SET,
   SupportedLocale,
@@ -16,7 +16,7 @@ import {getCachedRedirectResponse} from '@/middleware/utils/getCachedRedirectRes
 import {MiddlewareFactory} from './types';
 
 function getLanguageFromCookie(request: NextRequest) {
-  const cookieLocale = getLocalizeJsLocaleFromPegasusLocale(
+  const cookieLocale = getLocalizeJsLocaleFromDashboardLocale(
     request.cookies.get('language_')?.value,
   );
   return cookieLocale !== undefined && SUPPORTED_LOCALES_SET.has(cookieLocale)
@@ -55,7 +55,7 @@ export const withLocale: MiddlewareFactory = next => {
       // If the first part of the path is a supported locale or there are no subpaths, we don't need to redirect
       const response = await next(request, event);
 
-      response.cookies.set('language_', getPegasusLocale(maybeLocale), {
+      response.cookies.set('language_', getDashboardLocale(maybeLocale), {
         path: '/',
         domain: getStage() === 'production' ? '.code.org' : undefined,
       });
@@ -96,7 +96,7 @@ export const withLocale: MiddlewareFactory = next => {
     const response = getCachedRedirectResponse(redirectUrl);
 
     // Set the language cookie if discovered via Accept-Language header
-    response.cookies.set('language_', getPegasusLocale(locale), {
+    response.cookies.set('language_', getDashboardLocale(locale), {
       path: '/',
       domain: getStage() === 'production' ? '.code.org' : undefined,
     });

--- a/frontend/apps/marketing/src/providers/localize/LocalizeLoader.tsx
+++ b/frontend/apps/marketing/src/providers/localize/LocalizeLoader.tsx
@@ -2,6 +2,7 @@
 import Script from 'next/script';
 
 import {Brand} from '@/config/brand';
+import {getLocalizeJsLocaleFromBCP47} from '@/config/locale';
 import {getLocalizePath, getProjectId} from '@/config/localize';
 
 /**
@@ -58,7 +59,7 @@ const LocalizeLoader = ({brand, locale}: {brand: Brand; locale: string}) => (
               key: projectId!,
               autodetectLanguage: true,
               rememberLanguage: false, // use the locale in the URL instead
-              defaultLanguage: locale,
+              defaultLanguage: getLocalizeJsLocaleFromBCP47(locale),
               disableWidget: true, // use our own language dropdown
               // Block classes that match developer mode Next.js overlays
               blockedClasses: [


### PR DESCRIPTION
The localizejs implementation for en-US passed `en-US` as the locale to the localizejs loader. However, this is not a "valid" language for localizejs, which then causes the localizejs to auto detect english again resulting in a flash of text.

Instead, pass in the correct code to localizejs to begin with which avoids the need to auto detect language.