### PR TITLE
Music: use level properties and sources from props

### DIFF
--- a/apps/src/music/views/Controls.tsx
+++ b/apps/src/music/views/Controls.tsx
@@ -105,6 +105,7 @@ interface ControlsProps {
   setPlaying: (value: boolean) => void;
   playTrigger: (id: string) => void;
   hasTrigger: (id: string) => boolean;
+  isPredictLevel?: boolean;
   enableSkipControls?: boolean;
 }
 
@@ -116,12 +117,12 @@ const Controls: React.FunctionComponent<ControlsProps> = ({
   setPlaying,
   playTrigger,
   hasTrigger,
+  isPredictLevel,
   enableSkipControls = false,
 }) => {
   const dispatch = useAppDispatch();
   const isPlaying = useMusicSelector(state => state.music.isPlaying);
-  const disableRun = useAppSelector(({lab, predictLevel, music}) => {
-    const isPredictLevel = lab.levelProperties?.predictSettings?.isPredictLevel;
+  const disableRun = useAppSelector(({predictLevel, music}) => {
     const hasPredictResponse = !!predictLevel.response;
     const isLoading = music.soundLoadingProgress < 1;
     return isLoading || (isPredictLevel && !hasPredictResponse);

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -16,7 +16,7 @@ import {
   getAppOptionsEditingExemplar,
   getAppOptionsViewingExemplar,
 } from '@cdo/apps/lab2/projects/utils';
-import {BlocklySource} from '@cdo/apps/lab2/types';
+import {LevelProperties} from '@cdo/apps/lab2/types';
 import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
@@ -39,9 +39,10 @@ import {
   getBlockMode,
   InstructionsPosition,
   setCurrentPlayheadPosition,
+  setShowInstructions,
   showCallout,
 } from '../redux/musicRedux';
-import {MusicExemplarSettings} from '../types';
+import {MusicExemplarSettings, MusicLevelData} from '../types';
 
 import AdvancedControls from './AdvancedControls';
 import Controls from './Controls';
@@ -75,6 +76,7 @@ interface MusicLabViewProps {
   executeCode: (code: string) => void;
   hasRun: boolean;
   hasEdited: boolean;
+  levelProperties: LevelProperties;
 }
 
 const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
@@ -96,10 +98,14 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   executeCode,
   hasRun,
   hasEdited,
+  levelProperties,
 }) => {
   const dialogControl = useDialogControl();
   useUpdatePlayer(player);
-  useUpdateAnalytics(analyticsReporter);
+  useUpdateAnalytics(
+    analyticsReporter,
+    levelProperties.isProjectLevel || false
+  );
   const dispatch = useAppDispatch();
   const isPlaying = useAppSelector(state => state.music.isPlaying);
   const showInstructions = useAppSelector(
@@ -110,12 +116,16 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   );
   const timelineAtTop = useAppSelector(state => state.music.timelineAtTop);
   const hideHeaders = useAppSelector(state => state.music.hideHeaders);
-  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
-  const skipUrl = useAppSelector(state => state.lab.levelProperties?.skipUrl);
-
-  const levelData = useAppSelector(
-    state => state.lab.levelProperties?.levelData
-  );
+  const {
+    id: levelId,
+    appName,
+    skipUrl,
+    levelData,
+    exemplarSources,
+  } = levelProperties;
+  const exemplarSettings = levelProperties.exemplarSettings as
+    | MusicExemplarSettings
+    | undefined;
   const isPlayView = useAppSelector(state => state.lab.isShareView);
   const validationStateCallout = useAppSelector(
     state => state.lab.validationState.callout
@@ -128,13 +138,6 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   );
   const lastMeasure = useAppSelector(state => state.music.lastMeasure);
 
-  const exemplarSources = useAppSelector(
-    state => state.lab.levelProperties?.exemplarSources
-  ) as BlocklySource | undefined;
-  const exemplarSettings = useAppSelector(
-    state => state.lab.levelProperties?.exemplarSettings
-  ) as MusicExemplarSettings | undefined;
-
   const progressManager = useContext(ProgressManagerContext);
 
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
@@ -144,13 +147,16 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
   const blockMode = useSelector(getBlockMode);
 
-  const levelId = useAppSelector(state => state.lab.levelProperties?.id);
   // Pass music validator to Progress Manager
   useEffect(() => {
     if (progressManager && appName === 'music') {
       progressManager.setValidator(validator);
     }
   }, [progressManager, validator, appName]);
+
+  useEffect(() => {
+    dispatch(setShowInstructions(!!levelProperties.longInstructions));
+  }, [dispatch, levelProperties.longInstructions]);
 
   useEffect(() => {
     if (isStartMode) {
@@ -376,6 +382,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 setPlaying={setPlaying}
                 playTrigger={playTrigger}
                 hasTrigger={hasTrigger}
+                isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
                 enableSkipControls={
                   AppConfig.getValue('skip-controls-enabled') === 'true'
                 }
@@ -393,13 +400,19 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
               headerContent={musicI18n.panelHeaderTimeline()}
               hideHeaders={hideHeaders}
             >
-              <Timeline />
+              <Timeline
+                allowChangeStartingPlayheadPosition={
+                  (levelProperties.levelData as MusicLevelData | undefined)
+                    ?.allowChangeStartingPlayheadPosition
+                }
+                isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
+              />
             </PanelContainer>
           </div>
         </div>
       );
     },
-    [setPlaying, playTrigger, hasTrigger, hideHeaders]
+    [setPlaying, playTrigger, hasTrigger, hideHeaders, levelProperties]
   );
 
   const showAdvancedControls =

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -54,7 +54,6 @@ import {
   setStartingPlayheadPosition,
   clearSelectedBlockId,
   selectBlockId,
-  setShowInstructions,
   setInstructionsPosition,
   setLastMeasure,
   addOrderedFunctions,
@@ -88,6 +87,8 @@ const BLOCKLY_DIV_ID = 'blockly-div';
  */
 class UnconnectedMusicView extends React.Component {
   static propTypes = {
+    levelProperties: PropTypes.object.isRequired,
+    initialSources: PropTypes.object,
     // populated by Redux
     currentLevelId: PropTypes.string,
     userId: PropTypes.number,
@@ -106,20 +107,14 @@ class UnconnectedMusicView extends React.Component {
     setSelectedTriggerId: PropTypes.func,
     clearSelectedBlockId: PropTypes.func,
     clearSelectedTriggerId: PropTypes.func,
-    showInstructions: PropTypes.bool,
-    setShowInstructions: PropTypes.func,
     setInstructionsPosition: PropTypes.func,
     currentlyPlayingBlockIds: PropTypes.array,
     setIsLoading: PropTypes.func,
     setPageError: PropTypes.func,
-    initialSources: PropTypes.object,
-    levelProperties: PropTypes.object,
-    longInstructions: PropTypes.string,
     lastMeasure: PropTypes.number,
     clearTimeline: PropTypes.func,
     updateTimeline: PropTypes.func,
 
-    isProjectLevel: PropTypes.bool,
     isReadOnlyWorkspace: PropTypes.bool,
     updateLoadProgress: PropTypes.func,
     setUndoStatus: PropTypes.func,
@@ -127,7 +122,6 @@ class UnconnectedMusicView extends React.Component {
     isPlayView: PropTypes.bool,
     blockMode: PropTypes.string,
     playbackEvents: PropTypes.array,
-    exemplarPlaybackEvents: PropTypes.array,
     validationState: PropTypes.object,
   };
 
@@ -180,12 +174,10 @@ class UnconnectedMusicView extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.levelProperties?.appName === 'music') {
-      this.onLevelLoad(
-        this.props.levelProperties?.levelData,
-        this.props.initialSources
-      );
-    }
+    this.onLevelLoad(
+      this.props.levelProperties.levelData,
+      this.props.initialSources
+    );
     this.player.setUpdateLoadProgress(this.props.updateLoadProgress);
 
     Lab2Registry.getInstance()
@@ -337,7 +329,7 @@ class UnconnectedMusicView extends React.Component {
             this.props.isRtl,
             this.props.blockMode,
             localizedToolboxDefinition,
-            this.props.levelProperties?.enableBlocklyKeyboardNavigation
+            this.props.levelProperties.enableBlocklyKeyboardNavigation
           );
 
       if (
@@ -351,17 +343,13 @@ class UnconnectedMusicView extends React.Component {
       }
     }
 
-    this.props.setShowInstructions(
-      !!levelData?.text || !!this.props.longInstructions
-    );
-
     const startSources = this.getStartSources();
 
     // Check if the user has already made changes to the code on the project level.
     let codeChangedOnProjectLevel = false;
     if (isToolboxMode) {
       const blockMode = this.props.blockMode;
-      const levelData = this.props.levelProperties?.levelData;
+      const levelData = this.props.levelProperties.levelData;
       const levelToolbox = levelData?.toolbox;
       const levelToolboxDefinition = levelData?.toolboxDefinition;
       this.musicBlocklyWorkspace.initializeToolboxMode(
@@ -372,7 +360,7 @@ class UnconnectedMusicView extends React.Component {
     } else if (isEditingExemplar || isViewingExemplar) {
       this.loadCode(this.getExemplarSources() || startSources);
     } else if (startSources || initialSources) {
-      const predictSettings = this.props.levelProperties?.predictSettings;
+      const predictSettings = this.props.levelProperties.predictSettings;
       const isPredictLevel = !!predictSettings?.isPredictLevel;
       const codeEditableAfterSubmit = predictSettings?.codeEditableAfterSubmit;
       const isEditablePredictLevel = isPredictLevel && codeEditableAfterSubmit;
@@ -385,7 +373,7 @@ class UnconnectedMusicView extends React.Component {
       ) {
         codeToLoad = JSON.parse(initialSources.source);
         codeChangedOnProjectLevel =
-          this.props.isProjectLevel &&
+          this.props.levelProperties.isProjectLevel &&
           !isEqual(codeToLoad?.blocks, startSources?.blocks);
       }
       this.loadCode(codeToLoad);
@@ -485,11 +473,10 @@ class UnconnectedMusicView extends React.Component {
     // messages.
     // If no timeout is specified, then we can starting showing the non-success messages
     // at measure 2.
-    return this.props.levelProperties?.levelData?.validationTimeout
-      ? Math.min(
-          this.props.levelProperties?.levelData?.validationTimeout,
-          this.props.lastMeasure
-        )
+    const validationTimeout =
+      this.props.levelProperties.levelData?.validationTimeout;
+    return validationTimeout
+      ? Math.min(validationTimeout, this.props.lastMeasure)
       : DEFAULT_VALIDATION_TIMEOUT;
   };
 
@@ -516,7 +503,7 @@ class UnconnectedMusicView extends React.Component {
     const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
     const isEditingExemplar = getAppOptionsEditingExemplar();
 
-    let packId = this.props.levelProperties?.levelData?.packId;
+    let packId = this.props.levelProperties.levelData?.packId;
     // Prevent "Select a track" dialog from special mode.
     if (isToolboxMode || isStartMode || isEditingExemplar) {
       packId = packId || DEFAULT_PACK;
@@ -536,7 +523,7 @@ class UnconnectedMusicView extends React.Component {
     } else if (isToolboxMode) {
       const toolbox = getToolbox(
         this.props.blockMode,
-        this.props.levelProperties?.levelData?.toolbox
+        this.props.levelProperties.levelData?.toolbox
       );
       addToolboxBlocksToWorkspace(
         toolbox.contents,
@@ -551,8 +538,8 @@ class UnconnectedMusicView extends React.Component {
   };
 
   getStartSources = () => {
-    const templateSources = this.props.levelProperties?.templateSources;
-    const levelSources = this.props.levelProperties?.levelData?.startSources;
+    const templateSources = this.props.levelProperties.templateSources;
+    const levelSources = this.props.levelProperties.levelData?.startSources;
     const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
     if (templateSources && !isStartMode) {
       return templateSources;
@@ -566,12 +553,12 @@ class UnconnectedMusicView extends React.Component {
 
   getExemplarValidationMode = () => {
     return (
-      this.props.levelProperties?.exemplarSettings?.validationMode || 'default'
+      this.props.levelProperties.exemplarSettings?.validationMode || 'default'
     );
   };
 
   getExemplarSources = () => {
-    return this.props.levelProperties?.exemplarSources;
+    return this.props.levelProperties.exemplarSources;
   };
 
   getExemplarPlaybackEvents = () => {
@@ -915,10 +902,7 @@ class UnconnectedMusicView extends React.Component {
           uiShortcutsEnabled={
             AppConfig.getValue('ui-keyboard-shortcuts-enabled') === 'true'
           }
-          disabled={
-            this.props.levelProperties?.appName !== 'music' ||
-            this.props.isPlayView
-          }
+          disabled={this.props.isPlayView}
         />
         <MusicLabView
           blocklyDivId={BLOCKLY_DIV_ID}
@@ -934,7 +918,7 @@ class UnconnectedMusicView extends React.Component {
           player={this.player}
           allowPackSelection={
             this.library?.getHasRestrictedPacks() &&
-            !this.props.levelProperties?.levelData?.packId &&
+            !this.props.levelProperties.levelData?.packId &&
             !this.props.isReadOnlyWorkspace
           }
           analyticsReporter={this.analyticsReporter}
@@ -948,6 +932,7 @@ class UnconnectedMusicView extends React.Component {
           }
           hasRun={this.state.hasRun}
           hasEdited={this.state.hasEdited}
+          levelProperties={this.props.levelProperties}
         />
         <Callouts />
       </AnalyticsContext.Provider>
@@ -969,12 +954,7 @@ const MusicView = connect(
     blockMode: getBlockMode(state),
     isPlaying: state.music.isPlaying,
     selectedBlockId: state.music.selectedBlockId,
-    showInstructions: state.music.showInstructions,
     currentlyPlayingBlockIds: getCurrentlyPlayingBlockIds(state),
-    initialSources: state.lab.initialSources,
-    levelProperties: state.lab.levelProperties,
-    longInstructions: state.lab.levelProperties?.longInstructions,
-    isProjectLevel: state.lab.levelProperties?.isProjectLevel,
     isReadOnlyWorkspace: isReadOnlyWorkspace(state),
     startingPlayheadPosition: state.music.startingPlayheadPosition,
     isPlayView: state.lab.isShareView,
@@ -993,8 +973,6 @@ const MusicView = connect(
     setSelectedTriggerId: id => dispatch(setSelectedTriggerId(id)),
     clearSelectedTriggerId: () => dispatch(clearSelectedTriggerId()),
     clearSelectedBlockId: () => dispatch(clearSelectedBlockId()),
-    setShowInstructions: showInstructions =>
-      dispatch(setShowInstructions(showInstructions)),
     setInstructionsPosition: instructionsPosition =>
       dispatch(setInstructionsPosition(instructionsPosition)),
     addOrderedFunctions: orderedFunctions =>

--- a/apps/src/music/views/MusicViewWrapper.tsx
+++ b/apps/src/music/views/MusicViewWrapper.tsx
@@ -5,6 +5,6 @@ import {LabProps} from '@cdo/apps/lab2/types';
 import MusicView from './MusicView';
 
 /** Temporary functional/TS wrapper around MusicView that satisfies type constraints */
-const MusicViewWrapper: React.FC<LabProps> = () => <MusicView />;
+const MusicViewWrapper: React.FC<LabProps> = props => <MusicView {...props} />;
 
 export default MusicViewWrapper;

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -18,7 +18,6 @@ import {
   getBlockMode,
   setStartingPlayheadPosition,
 } from '../redux/musicRedux';
-import {MusicLevelData} from '../types';
 
 import usePlaybackUpdate from './hooks/usePlaybackUpdate';
 import TimelineSampleEvents from './TimelineSampleEvents';
@@ -36,10 +35,18 @@ const playheadScrollThreshold = 0.75;
 // How many extra measures to show at the end.
 const extraMeasures = 8;
 
+interface TimelineProps {
+  allowChangeStartingPlayheadPosition?: boolean;
+  isPredictLevel?: boolean;
+}
+
 /**
  * Renders the music playback timeline.
  */
-const Timeline: React.FunctionComponent = () => {
+const Timeline: React.FunctionComponent<TimelineProps> = ({
+  allowChangeStartingPlayheadPosition,
+  isPredictLevel,
+}) => {
   const isPlaying = useMusicSelector(state => state.music.isPlaying);
 
   const blockMode = useSelector(getBlockMode);
@@ -51,12 +58,8 @@ const Timeline: React.FunctionComponent = () => {
     state => state.music.startingPlayheadPosition
   );
 
-  const allowChangeStartingPlayheadPosition =
-    (useAppSelector(
-      state =>
-        (state.lab.levelProperties?.levelData as MusicLevelData | undefined)
-          ?.allowChangeStartingPlayheadPosition
-    ) ||
+  const canChangeStartingPlayheadPosition =
+    (allowChangeStartingPlayheadPosition ||
       appConfig.getValue('allow-change-starting-playhead-position') ===
         'true') &&
     !isPlaying;
@@ -117,12 +120,9 @@ const Timeline: React.FunctionComponent = () => {
     (_, i) => i + 1
   );
 
-  const currentlyAllowChangeStartingPlayheadPosition =
-    !isPlaying && allowChangeStartingPlayheadPosition;
-
   const onMeasuresBackgroundClick = useCallback(
     (event: MouseEvent) => {
-      if (!currentlyAllowChangeStartingPlayheadPosition) {
+      if (!canChangeStartingPlayheadPosition) {
         return;
       }
       const offset =
@@ -134,17 +134,17 @@ const Timeline: React.FunctionComponent = () => {
       const roundedMeasure = Math.round(exactMeasure * 4) / 4;
       dispatch(setStartingPlayheadPosition(roundedMeasure));
     },
-    [dispatch, currentlyAllowChangeStartingPlayheadPosition]
+    [dispatch, canChangeStartingPlayheadPosition]
   );
 
   const onMeasureNumberClick = useCallback(
     (measureNumber: number) => {
-      if (!currentlyAllowChangeStartingPlayheadPosition) {
+      if (!canChangeStartingPlayheadPosition) {
         return;
       }
       dispatch(setStartingPlayheadPosition(measureNumber));
     },
-    [dispatch, currentlyAllowChangeStartingPlayheadPosition]
+    [dispatch, canChangeStartingPlayheadPosition]
   );
 
   const onTimelineClick = useCallback(() => {
@@ -171,9 +171,6 @@ const Timeline: React.FunctionComponent = () => {
 
   usePlaybackUpdate(scrollPlayheadForward, scrollToPlayhead, scrollToPlayhead);
   const predictResponseSubmitted = useAppSelector(isPredictResponseSubmitted);
-  const isPredictLevel = useAppSelector(
-    state => state.lab.levelProperties?.predictSettings?.isPredictLevel
-  );
   const canPopulateTimeline = !isPredictLevel || predictResponseSubmitted;
 
   const firstBarLineRef = useRef<HTMLDivElement>(null);
@@ -208,7 +205,7 @@ const Timeline: React.FunctionComponent = () => {
         className={classNames(
           moduleStyles.measuresBackground,
           moduleStyles.fullWidthOverlay,
-          currentlyAllowChangeStartingPlayheadPosition &&
+          canChangeStartingPlayheadPosition &&
             moduleStyles.measuresBackgroundClickable
         )}
         style={{width: paddingOffset + measuresToDisplay * barWidth}}
@@ -229,7 +226,7 @@ const Timeline: React.FunctionComponent = () => {
                   moduleStyles.barNumber,
                   measure === Math.floor(currentPlayheadPosition) &&
                     moduleStyles.barNumberCurrent,
-                  currentlyAllowChangeStartingPlayheadPosition &&
+                  canChangeStartingPlayheadPosition &&
                     moduleStyles.barNumberClickable
                 )}
                 onClick={() => onMeasureNumberClick(measure)}

--- a/apps/src/music/views/hooks/useUpdateAnalytics.ts
+++ b/apps/src/music/views/hooks/useUpdateAnalytics.ts
@@ -13,7 +13,10 @@ import AnalyticsReporter from '../../analytics/AnalyticsReporter';
  * A hook for updating the {@link AnalyticsReporter} when relevant redux state changes and attaching callbacks
  * to browser and lifecycle events.
  */
-function useUpdateAnalytics(analyticsReporter: AnalyticsReporter) {
+function useUpdateAnalytics(
+  analyticsReporter: AnalyticsReporter,
+  isProjectLevel: boolean
+) {
   /**
    * Effect that runs on initial mount
    *   - Starts a new analytics session.
@@ -101,9 +104,7 @@ function useUpdateAnalytics(analyticsReporter: AnalyticsReporter) {
       analyticsReporter.setProjectProperty('channelId', channelId);
   }, [sessionInProgress, channelId, analyticsReporter]);
 
-  const levelType = useAppSelector(state =>
-    state.lab.levelProperties?.isProjectLevel ? 'Standalone Project' : 'Level'
-  );
+  const levelType = isProjectLevel ? 'Standalone Project' : 'Level';
   useEffect(() => {
     sessionInProgress &&
       analyticsReporter.setProjectProperty('levelType', levelType);


### PR DESCRIPTION
Converts Music Lab to use the new lab2 props (as introduced in https://github.com/code-dot-org/code-dot-org/pull/63974). As discussed in this [doc](https://docs.google.com/document/d/1fpyd88e-mXkyUQrE1ILRh-na6zz9glz9rpcQu80o34o/edit?tab=t.0), this will eventually allow us to simplify and streamline our lab loading lifecycle. There should be no functional changes.

## Testing story

Tested this on various Music Lab lessons, as well as the allthethings showcase and other lessons with multiple labs.