### PR TITLE
feat: enable /about/team-pets page on marketing lambda

### DIFF
--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -331,6 +331,10 @@ const marketingPaths = {
   "/about/leadership": true,
   // CSAIF
   "/csaif": true,
+  // Post Launch 4
+  "/your-school": true,
+  "/yourschool": true,
+  "/yourschool/thankyou": true,
 }
 
 const nextJsAssetsPath = '/_next/static/';

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -335,6 +335,7 @@ const marketingPaths = {
   "/your-school": true,
   "/yourschool": true,
   "/yourschool/thankyou": true,
+  "/about/team-pets": true,
 }
 
 const nextJsAssetsPath = '/_next/static/';


### PR DESCRIPTION
Adds the code.org/about/team-pets page to the marketing lambda so it can go live.