### PR TITLE
Teach-2039/final factory updates

### DIFF
--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -10,7 +10,7 @@ class LessonsControllerTest < ActionController::TestCase
     # stub writes so that we dont actually make updates to filesystem
     File.stubs(:write)
 
-    @script = create(:script, :in_unit_group, name: 'unit-1')
+    @script = create(:script, name: 'unit-1')
     @course = create(:single_unit_course, unit: @script)
     lesson_group = create :lesson_group, script: @script
     @lesson = create(
@@ -57,34 +57,34 @@ class LessonsControllerTest < ActionController::TestCase
 
     @levelbuilder = create :levelbuilder
 
-    @in_development_unit = create :script, :in_unit_group, :with_lessons, lessons_count: 1, name: 'in-development-unit', include_student_lesson_plans: true
+    @in_development_unit = create :script, :with_lessons, lessons_count: 1, name: 'in-development-unit', include_student_lesson_plans: true
     @in_development_course = create(:single_unit_course, unit: @in_development_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development)
     @in_development_unit.reload
 
     @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
-    @pilot_script = create :script, :in_unit_group, :with_lessons, lessons_count: 1, name: 'pilot-script', pilot_experiment: 'my-experiment', include_student_lesson_plans: true
+    @pilot_script = create :script, :with_lessons, lessons_count: 1, name: 'pilot-script', pilot_experiment: 'my-experiment', include_student_lesson_plans: true
     @pilot_course = create(:single_unit_course, unit: @pilot_script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, pilot_experiment: 'my-experiment')
     @pilot_script.reload
     @pilot_section = create :section, user: @pilot_teacher, script: @pilot_script
     @pilot_student = create(:follower, section: @pilot_section).student_user
 
     @pilot_instructor = create :teacher, pilot_experiment: 'pl-my-experiment'
-    @pilot_pl_script = create :script, :in_unit_group, :with_lessons, lessons_count: 1, name: 'pl-pilot-script', pilot_experiment: 'pl-my-experiment', include_student_lesson_plans: true
+    @pilot_pl_script = create :script, :with_lessons, lessons_count: 1, name: 'pl-pilot-script', pilot_experiment: 'pl-my-experiment', include_student_lesson_plans: true
     @pilot_pl_course = create(:single_unit_course, unit: @pilot_pl_script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, pilot_experiment: 'pl-my-experiment')
     @pilot_pl_script.reload
     @pilot_pl_section = create :section, user: @pilot_instructor, script: @pilot_pl_script
     @pilot_participant = create :teacher
     create(:follower, section: @pilot_pl_section, student_user: @pilot_participant)
 
-    @login_req_script = create :script, :in_unit_group, :with_lessons, lessons_count: 1, name: 'signed-in-script', include_student_lesson_plans: true, login_required: true
+    @login_req_script = create :script, :with_lessons, lessons_count: 1, name: 'signed-in-script', include_student_lesson_plans: true, login_required: true
     @login_req_course = create(:single_unit_course, unit: @login_req_script)
     @login_req_script.reload
 
-    @pl_login_req_script = create :script, :in_unit_group, :with_lessons, lessons_count: 1, name: 'signed-in-pl-script', include_student_lesson_plans: true, login_required: true
+    @pl_login_req_script = create :script, :with_lessons, lessons_count: 1, name: 'signed-in-pl-script', include_student_lesson_plans: true, login_required: true
     @pl_login_req_course = create(:single_unit_course, :pl_course, unit: @pl_login_req_script)
     @pl_login_req_script.reload
 
-    @pl_script = create :script, :in_unit_group, :with_lessons, lessons_count: 1, name: 'pl-unit-1'
+    @pl_script = create :script, :with_lessons, lessons_count: 1, name: 'pl-unit-1'
     @pl_course = create(:single_unit_course, :pl_course, unit: @pl_script)
     @pl_script.reload
   end

--- a/dashboard/test/controllers/openai_evaluate_controller_test.rb
+++ b/dashboard/test/controllers/openai_evaluate_controller_test.rb
@@ -45,8 +45,8 @@ class OpenaiEvaluateControllerTest < ActionController::TestCase
     ShareFiltering.stubs(:find_pii_failure).returns 'harry@hogwarts.edu'
     student = create(:student)
     sign_in(student)
-    csp_course_offering = create(:csp_course_offering, :with_units)
-    unit = csp_course_offering.course_versions.first.content_root
+    csp_course_offering = create(:csp_course_offering, :with_unit_group)
+    unit = csp_course_offering.course_versions.first.content_root.first_unit
     level = create(:free_response)
     create(:script_level, script: unit, levels: [level])
     get :evaluate, params: {level_id: level.id, student_work: "My email is harry@hogwarts.edu", evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]}

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -775,11 +775,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "show: redirect to latest stable script version in family for logged out user if one exists" do
-    courseg_2017 = create :script, :in_unit_group, name: 'courseg-2017', family_name: 'courseg'
+    courseg_2017 = create :script, name: 'courseg-2017', family_name: 'courseg'
     create :single_unit_course, unit: courseg_2017, family_name: 'courseg', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    courseg_2018 = create :script, :in_unit_group, name: 'courseg-2018', family_name: 'courseg'
+    courseg_2018 = create :script, name: 'courseg-2018', family_name: 'courseg'
     create :single_unit_course, unit: courseg_2018, family_name: 'courseg', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    courseg_2019 = create :script, :in_unit_group, name: 'courseg-2019', family_name: 'courseg'
+    courseg_2019 = create :script, name: 'courseg-2019', family_name: 'courseg'
     create :single_unit_course, unit: courseg_2019, family_name: 'courseg', version_year: '2019', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
 
     courseg_2017_lesson_group_1 = create :lesson_group, script: courseg_2017
@@ -799,11 +799,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test "show: redirect to latest assigned script version in family for student if one exists" do
     sign_in @student
 
-    courseg_2017 = create :script, :in_unit_group, name: 'courseg-2017', family_name: 'courseg'
+    courseg_2017 = create :script, name: 'courseg-2017', family_name: 'courseg'
     create :single_unit_course, unit: courseg_2017, family_name: 'courseg', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    courseg_2018 = create :script, :in_unit_group, name: 'courseg-2018', family_name: 'courseg'
+    courseg_2018 = create :script, name: 'courseg-2018', family_name: 'courseg'
     create :single_unit_course, unit: courseg_2018, family_name: 'courseg', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    courseg_2019 = create :script, :in_unit_group, name: 'courseg-2019', family_name: 'courseg'
+    courseg_2019 = create :script, name: 'courseg-2019', family_name: 'courseg'
     create :single_unit_course, unit: courseg_2019, family_name: 'courseg', version_year: '2019', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
 
     courseg_2017_lesson_group_1 = create :lesson_group, script: courseg_2017
@@ -832,11 +832,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test "show: redirect to latest assigned script version in family for participant if one exists" do
     sign_in @student
 
-    pl_courseg_2017 = create :script, :in_unit_group, name: 'pl-courseg-2017', family_name: 'pl-courseg'
+    pl_courseg_2017 = create :script, name: 'pl-courseg-2017', family_name: 'pl-courseg'
     create :single_unit_course, unit: pl_courseg_2017, family_name: 'pl-courseg', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    pl_courseg_2018 = create :script, :in_unit_group,  name: 'pl-courseg-2018', family_name: 'pl-courseg'
+    pl_courseg_2018 = create :script,  name: 'pl-courseg-2018', family_name: 'pl-courseg'
     create :single_unit_course, unit: pl_courseg_2018, family_name: 'pl-courseg', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    pl_courseg_2019 = create :script, :in_unit_group, name: 'pl-courseg-2019', family_name: 'pl-courseg'
+    pl_courseg_2019 = create :script, name: 'pl-courseg-2019', family_name: 'pl-courseg'
     create :single_unit_course, unit: pl_courseg_2019, family_name: 'pl-courseg', version_year: '2019', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
 
     pl_courseg_2017_lesson_group_1 = create :lesson_group, script: pl_courseg_2017
@@ -2119,7 +2119,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'should redirect to 2017 version in script family' do
-    cats1 = create :script, :in_unit_group, :with_levels, name: 'cats1', family_name: 'cats', version_year: '2017'
+    cats1 = create :script, :with_levels, name: 'cats1', family_name: 'cats', version_year: '2017'
     cats1_course = create :single_unit_course, unit: cats1, name: 'cats1', family_name: 'cats', version_year: '2017'
     CourseOffering.add_course_offering(cats1_course)
     Unit.stubs(:family_names).returns(['cats'])
@@ -2132,7 +2132,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     get :show, params: {script_id: 'cats', lesson_position: 1, id: 1}
     assert_redirected_to "/s/cats1/lessons/1/levels/1"
 
-    cats2 = create :script, :in_unit_group, :with_levels, name: 'cats2', family_name: 'cats', version_year: '2018'
+    cats2 = create :script, :with_levels, name: 'cats2', family_name: 'cats', version_year: '2018'
     cats2_course = create :single_unit_course, unit: cats2, family_name: 'cats', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
     CourseOffering.add_course_offering(cats2_course)
     get :show, params: {script_id: 'cats', lesson_position: 1, id: 1}

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -192,18 +192,20 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test "should use unit name as param where unit name is words but looks like a number" do
-    unit = create(:script, name: '15-16')
+    unit = create(:script, :in_single_unit_course, name: '15-16')
     get :show, params: {id: "15-16"}
 
-    assert_response :success
+    assert_response :redirect
+    assert_redirected_to "/courses/#{unit.original_unit_group.name}/units/1"
     assert_equal unit, assigns(:script)
   end
 
   test "should use unit name as param where unit name is words" do
-    unit = create(:script, name: 'Heure de Code', skip_name_format_validation: true)
+    unit = create(:script, :in_single_unit_course, name: 'Heure de Code', skip_name_format_validation: true)
     get :show, params: {id: "Heure de Code"}
 
-    assert_response :success
+    assert_response :redirect
+    assert_redirected_to "/courses/#{unit.original_unit_group.name}/units/1"
     assert_equal unit, assigns(:script)
   end
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -92,7 +92,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'canonical url is added if it is a single unit course' do
-    unit = create :script, :in_unit_group, family_name: 'my-script'
+    unit = create :script, family_name: 'my-script'
     course = create :single_unit_course, unit: unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
 
     get :show, params: {

--- a/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
@@ -45,7 +45,7 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
 
     assert_equal TeacherFeedback.all.count, 4
     sign_in student
-    assert_queries 21 do
+    assert_queries 24 do
       get :index
       assert_response :success
     end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -11,16 +11,6 @@ FactoryBot.define do
     sequence(:display_name, 'a') {|c| "bogus-course-offering-#{c}"}
     assignable {true}
 
-    # TODO: TEACH-1678 Remove this trait
-    trait :with_units do
-      after(:create) do |course_offering|
-        create(:course_version, :with_unit, course_offering: course_offering)
-        create(:course_version, :with_unit, course_offering: course_offering)
-        create(:course_version, :with_unit, course_offering: course_offering)
-        create(:course_version, :with_unit, course_offering: course_offering)
-      end
-    end
-
     trait :with_unit_groups do
       after(:create) do |course_offering|
         create(:course_version, :with_unit_group, course_offering: course_offering)
@@ -35,13 +25,6 @@ FactoryBot.define do
       sequence(:display_name, 'a') {|c| "csp-course-offering-#{c}"}
       assignable {true}
       grade_levels {"9,10,11,12"}
-
-      # TODO: TEACH-1678 Remove this trait
-      trait :with_units do
-        after(:create) do |csp_course_offering|
-          create(:course_version, :with_csp_unit, course_offering: csp_course_offering)
-        end
-      end
 
       trait :with_unit_group do
         after(:create) do |csp_course_offering|
@@ -59,15 +42,6 @@ FactoryBot.define do
 
     trait :with_unit_group do
       association(:content_root, factory: :unit_group)
-    end
-
-    # TODO: TEACH-1678 Remove these traits
-    trait :with_unit do
-      association(:content_root, factory: :script, is_course: true)
-    end
-
-    trait :with_csp_unit do
-      association(:content_root, factory: :csp_script, is_course: true)
     end
 
     trait :with_single_unit_course do
@@ -105,11 +79,10 @@ FactoryBot.define do
       transient do
         unit {nil}
       end
-      # TODO: TEACH-1678 We can clean this unit create up once we remove those fields from the unit factory
+
       after(:create) do |unit_group, evaluator|
-        unit = evaluator.unit || create(:unit, :in_unit_group)
+        unit = evaluator.unit || create(:unit)
         create :unit_group_unit, unit_group: unit_group, script: unit, position: 1
-        unit.update(published_state: nil, instruction_type: nil, participant_audience: nil, instructor_audience: nil)
         unit.reload
       end
 
@@ -145,17 +118,17 @@ FactoryBot.define do
       transient do
         unit {nil}
       end
-      # TODO: TEACH-1678 We can clean this unit create up once we remove those fields from the unit factory
+
       after(:create) do |unit_group, evaluator|
-        unit = evaluator.unit || create(:unit, :in_unit_group)
+        unit = evaluator.unit || create(:unit)
         create :unit_group_unit, unit_group: unit_group, script: unit, position: 1
         unit_group.reload
       end
     end
-    # TODO: TEACH-1678 We can clean this unit create up once we remove those fields from the unit factory
+
     trait :with_units do
       transient do
-        units {[create(:unit, :in_unit_group), create(:unit, :in_unit_group)]}
+        units {[create(:unit), create(:unit)]}
       end
       after(:create) do |unit_group, evaluator|
         evaluator.units.each_with_index do |unit, index|
@@ -1169,26 +1142,7 @@ FactoryBot.define do
   factory :unit, aliases: [:script] do
     sequence(:name) {|n| "bogus-script-#{n}"}
     is_migrated {true}
-    # TODO: TEACH-1678 Delete these fields
-    published_state {"beta"}
-    instruction_type {"teacher_led"}
-    participant_audience {"student"}
-    instructor_audience {"teacher"}
-
-    # TODO: TEACH-1678 Delete this trait once we have deleted the fields in the unit factory
-    trait :in_unit_group do
-      published_state {nil}
-      instruction_type {nil}
-      participant_audience {nil}
-      instructor_audience {nil}
-    end
-
-    # TODO: TEACH-1678 Delete this trait
-    trait :is_course do
-      sequence(:version_year) {|n| "bogus-version-year-#{n}"}
-      sequence(:family_name) {|n| "bogus-family-name-#{n}"}
-      is_course {true}
-    end
+    published_state {nil}
 
     trait :in_single_unit_course do
       published_state {nil}
@@ -1257,31 +1211,6 @@ FactoryBot.define do
         csa_script.curriculum_umbrella = Curriculum::SharedCourseConstants::CURRICULUM_UMBRELLA.CSA
         csa_script.save!
       end
-    end
-
-    # TODO: TEACH-1678 Delete this factory
-    factory :hoc_script do
-      is_course {true}
-      sequence(:version_year) {|n| "bogus-hoc-version-year-#{n}"}
-      sequence(:family_name) {|n| "bogus-hoc-family-name-#{n}"}
-      after(:create) do |hoc_script|
-        hoc_script.curriculum_umbrella = Curriculum::SharedCourseConstants::CURRICULUM_UMBRELLA.HOC
-        hoc_script.save!
-        course_offering = CourseOffering.add_course_offering(hoc_script)
-        course_offering.update!(marketing_initiative: 'HOC')
-      end
-    end
-    # TODO: TEACH-1678 Delete this factory
-    factory :standalone_unit do
-      after(:create) do |standalone_unit|
-        standalone_unit.is_course = true
-        standalone_unit.save!
-      end
-    end
-    # TODO: TEACH-1678 Delete this factory
-    factory :pl_unit do
-      participant_audience {"teacher"}
-      instructor_audience {"facilitator"}
     end
 
     factory :foundations_of_cs_script do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1267,7 +1267,7 @@ FactoryBot.define do
 
   factory :script_level do
     script do |script_level|
-      script_level.activity_section&.lesson&.script || script_level.lesson&.script || create(:script)
+      script_level.activity_section&.lesson&.script || script_level.lesson&.script || create(:script, :in_single_unit_course)
     end
 
     trait :assessment do
@@ -1358,7 +1358,7 @@ FactoryBot.define do
     sequence(:key) {|n| "Bogus-Lesson-#{n}"}
     has_lesson_plan {false}
     script do |lesson|
-      lesson.lesson_group&.script || create(:script)
+      lesson.lesson_group&.script || create(:script, :in_single_unit_course)
     end
 
     absolute_position do |lesson|

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1041,7 +1041,7 @@ FactoryBot.define do
 
     trait :with_example_solutions do
       after(:create) do |level|
-        level.examples = ['https://studio.code.org/s/csa-examples/lessons/1/levels/1/']
+        level.examples = ['https://studio.code.org/courses/csa-examples/units/1/lessons/1/levels/1/']
         level.save!
       end
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -126,7 +126,6 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     script = create(
       :script,
       :with_levels,
-      :in_unit_group,
       levels_count: 10
     )
     course = create(:single_unit_course, unit: script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, version_year: 'unversioned', family_name: 'hoc-family')

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -37,15 +37,15 @@ module Services
     end
 
     test 'get_pdf_enabled_scripts excludes unit in development published state' do
-      in_development = create :script, :in_unit_group, seeded_from: true
+      in_development = create :script, seeded_from: true
       create :single_unit_course, unit: in_development, published_state: PUBLISHED_STATE.in_development
-      pilot = create :script, :in_unit_group, seeded_from: true
+      pilot = create :script, seeded_from: true
       create :single_unit_course, unit: pilot, published_state: PUBLISHED_STATE.pilot
-      beta = create :script, :in_unit_group, seeded_from: true
+      beta = create :script, seeded_from: true
       create :single_unit_course, unit: beta, published_state: PUBLISHED_STATE.beta
-      preview = create :script, :in_unit_group, seeded_from: true
+      preview = create :script, seeded_from: true
       create :single_unit_course, unit: preview, published_state: PUBLISHED_STATE.preview
-      stable = create :script, :in_unit_group, seeded_from: true
+      stable = create :script, seeded_from: true
       create :single_unit_course, unit: stable, published_state: PUBLISHED_STATE.stable
 
       script_names = Services::CurriculumPdfs.get_pdf_enabled_scripts.map(&:name)

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -1162,7 +1162,7 @@ module Services
     test 'published state set to pilot when pilot_experiment is present' do
       unit = create :script
       assert_nil unit.pilot_experiment
-      assert_equal Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta, unit.get_published_state
+      assert_equal Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development, unit.get_published_state
 
       json = ScriptSeed.serialize_seeding_json(unit)
       unit_data = JSON.parse(json)

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -1370,7 +1370,6 @@ module Services
       # TODO: how can this be simplified and/or moved into factories.rb?
       script = create(
         :script,
-        :in_unit_group,
         name: "#{name_prefix}-script",
         curriculum_path: 'my_curriculum_path',
         is_migrated: true

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -431,31 +431,31 @@ class CourseOfferingTest < ActiveSupport::TestCase
 
   test 'self_paced_course_offerings_for_catalog filters only for assignable published self-paced teacher course offerings' do
     # Course offering that doesn't satisfy any of the conditions
-    none_unit = create(:script, name: 'unit1', family_name: 'none', version_year: '1991', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
-    none_co = CourseOffering.add_course_offering(none_unit)
+    none_course = create(:single_unit_course, family_name: 'none', version_year: '1991', published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    none_co = CourseOffering.add_course_offering(none_course)
     none_co.update!(assignable: false)
 
     # Course offering that only satisfies the 'assignable' condition
-    assignable_unit = create(:script, name: 'unit2', family_name: 'assignable', version_year: '1992', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
-    CourseOffering.add_course_offering(assignable_unit)
+    assignable_course = create(:single_unit_course, family_name: 'assignable', version_year: '1992', published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    CourseOffering.add_course_offering(assignable_course)
 
     # Course offering that only satisfies the 'published' condition
-    published_unit = create(:script, name: 'unit3', family_name: 'published', version_year: '1993', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'student')
-    published_co = CourseOffering.add_course_offering(published_unit)
+    published_course = create(:single_unit_course, family_name: 'published', version_year: '1993', published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    published_co = CourseOffering.add_course_offering(published_course)
     published_co.update!(assignable: false)
 
     # Course offering that only satisfies the 'for teacher' condition
-    for_teacher_unit = create(:script, name: 'unit4', family_name: 'for-teacher', version_year: '1994', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
-    for_teacher_co = CourseOffering.add_course_offering(for_teacher_unit)
+    for_teacher_course = create(:single_unit_course, family_name: 'for-teacher', version_year: '1994', published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
+    for_teacher_co = CourseOffering.add_course_offering(for_teacher_course)
     for_teacher_co.update!(assignable: false)
 
     # Course offering that is a NON-self-paced assignable published teacher course offerings
-    non_self_paced_unit = create(:script, name: 'unit5', family_name: 'non-self-paced', version_year: '1998', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
-    CourseOffering.add_course_offering(non_self_paced_unit)
+    non_self_paced_course = create(:single_unit_course, family_name: 'non-self-paced', version_year: '1998', published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
+    CourseOffering.add_course_offering(non_self_paced_course)
 
     # Course offering that satisfies all conditions
-    self_paced_unit = create(:script, name: 'unit6', family_name: 'all', version_year: '1998', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', instruction_type: 'self_paced', participant_audience: 'teacher')
-    self_paced_co = CourseOffering.add_course_offering(self_paced_unit)
+    self_paced_course = create(:single_unit_course, family_name: 'all', version_year: '1998', published_state: 'stable', instructor_audience: 'universal_instructor', instruction_type: 'self_paced', participant_audience: 'teacher')
+    self_paced_co = CourseOffering.add_course_offering(self_paced_course)
 
     assert_equal [self_paced_co.key], CourseOffering.self_paced_course_offerings_for_catalog.pluck(:key)
   end

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -13,17 +13,17 @@ class CourseVersionTest < ActiveSupport::TestCase
   end
 
   setup do
-    @unit_teacher_to_students = create(:script, :in_unit_group, name: 'unit-teacher-to-student22')
+    @unit_teacher_to_students = create(:script, name: 'unit-teacher-to-student22')
     create(:single_unit_course, :with_course_offering, unit: @unit_teacher_to_students, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, version_year: '1991', family_name: 'family-22')
-    @unit_teacher_to_students2 = create(:script, :in_unit_group, name: 'unit-teacher-to-student32')
+    @unit_teacher_to_students2 = create(:script, name: 'unit-teacher-to-student32')
     create(:single_unit_course, :with_course_offering, unit: @unit_teacher_to_students2, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, version_year: '1992', family_name: 'family-22')
-    @unit_facilitator_to_teacher = create(:script, :in_unit_group, name: 'unit-facilitator-to-teacher22')
+    @unit_facilitator_to_teacher = create(:script, name: 'unit-facilitator-to-teacher22')
     create(:single_unit_course, :pl_course, :with_course_offering, unit: @unit_facilitator_to_teacher, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, version_year: '1991', family_name: 'family-32')
 
-    @beta_unit = create(:script, :in_unit_group, name: 'beta-unit2')
+    @beta_unit = create(:script, name: 'beta-unit2')
     create(:single_unit_course, :with_course_offering, unit: @beta_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta, version_year: '1991', family_name: 'beta2')
 
-    @in_development_unit = create(:script, :in_unit_group, name: 'in-development-unit22')
+    @in_development_unit = create(:script, name: 'in-development-unit22')
     create(:single_unit_course, :with_course_offering, unit: @in_development_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development, version_year: '1991', family_name: 'development2')
 
     @unit_group = create(:unit_group, name: 'course-instructed-by-teacher22', family_name: 'family-12', version_year: '1991', published_state: 'stable')

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -102,8 +102,8 @@ class ScriptLevelTest < ActiveSupport::TestCase
       bubble_choice = create :bubble_choice_level, name: 'bubble_choices', display_name: 'Bubble Choices', description: 'Choose one or more!', sublevels: sublevels
       sl = create :script_level, levels: [bubble_choice]
 
-      assert_equal sl.get_example_solutions(sublevel1, @authorized_teacher), ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"]
-      assert_equal sl.get_example_solutions(sublevel2, @authorized_teacher), ["https://studio.code.org/projects/spritelab/example-1/view", "https://studio.code.org/projects/spritelab/example-2/view"]
+      assert_equal ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"], sl.get_example_solutions(sublevel1, @authorized_teacher)
+      assert_equal ["https://studio.code.org/projects/spritelab/example-1/view", "https://studio.code.org/projects/spritelab/example-2/view"], sl.get_example_solutions(sublevel2, @authorized_teacher)
     end
 
     test 'get_example_solutions returns empty array if not instructor of course' do
@@ -111,36 +111,36 @@ class ScriptLevelTest < ActiveSupport::TestCase
       level = create(:dance, :with_example_solutions)
       sl = create(:script_level, levels: [level], script: unit)
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher), []
-      assert_equal sl.get_example_solutions(level, @facilitator), ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"]
+      assert_equal [], sl.get_example_solutions(level, @authorized_teacher)
+      assert_equal ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"], sl.get_example_solutions(level, @facilitator)
     end
 
     test 'get_example_solutions for dance level' do
       level = create(:dance, :with_example_solutions)
       sl = create(:script_level, levels: [level])
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"]
+      assert_equal ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"], sl.get_example_solutions(level, @authorized_teacher)
     end
 
     test 'get_example_solutions for spritelab level' do
       level = create(:spritelab, :with_example_solutions)
       sl = create(:script_level, levels: [level])
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/projects/spritelab/example-1/view", "https://studio.code.org/projects/spritelab/example-2/view"]
+      assert_equal ["https://studio.code.org/projects/spritelab/example-1/view", "https://studio.code.org/projects/spritelab/example-2/view"], sl.get_example_solutions(level, @authorized_teacher)
     end
 
     test 'get_example_solutions for artist level' do
       level = create(:artist, :with_example_solutions)
       sl = create(:script_level, levels: [level])
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/projects/artist/example-1/view", "https://studio.code.org/projects/artist/example-2/view"]
+      assert_equal ["https://studio.code.org/projects/artist/example-1/view", "https://studio.code.org/projects/artist/example-2/view"], sl.get_example_solutions(level, @authorized_teacher)
     end
 
     test 'get_example_solutions for playlab level' do
       level = create(:playlab, :with_example_solutions)
       sl = create(:script_level, levels: [level])
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/projects/playlab/example-1/view", "https://studio.code.org/projects/playlab/example-2/view"]
+      assert_equal ["https://studio.code.org/projects/playlab/example-1/view", "https://studio.code.org/projects/playlab/example-2/view"], sl.get_example_solutions(level, @authorized_teacher)
     end
 
     test 'get_example_solutions for javalab level with exemplar' do
@@ -182,8 +182,8 @@ class ScriptLevelTest < ActiveSupport::TestCase
       level = create(:level, :blockly, :with_ideal_level_source)
       sl = create(:script_level, levels: [level], script: script)
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher, unit_group_unit: script.original_unit_group_unit),
-                   ["//test-studio.code.org/courses/#{script.original_unit_group.name}/units/1/lessons/1/levels/1?solution=true"]
+      assert_equal ["//test-studio.code.org/courses/#{script.original_unit_group.name}/units/1/lessons/1/levels/1?solution=true"],
+                   sl.get_example_solutions(level, @authorized_teacher, unit_group_unit: script.original_unit_group_unit)
     end
 
     test 'get_example_solutions for level with ideal level source and section_id' do
@@ -191,25 +191,25 @@ class ScriptLevelTest < ActiveSupport::TestCase
       level = create(:level, :blockly, :with_ideal_level_source)
       sl = create(:script_level, levels: [level], script: script)
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher, 5, unit_group_unit: script.original_unit_group_unit),
-                   ["//test-studio.code.org/courses/#{script.original_unit_group.name}/units/1/lessons/1/levels/1?section_id=5&solution=true"]
+      assert_equal ["//test-studio.code.org/courses/#{script.original_unit_group.name}/units/1/lessons/1/levels/1?section_id=5&solution=true"],
+                   sl.get_example_solutions(level, @authorized_teacher, 5, unit_group_unit: script.original_unit_group_unit)
     end
 
     test 'get_example_solutions returns empty array if no examples' do
       level = create(:level)
       sl = create(:script_level, levels: [level])
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher), []
+      assert_equal [], sl.get_example_solutions(level, @authorized_teacher)
     end
 
     test 'get_example_solutions returns empty array if not authorized teacher and not CSF course' do
-      script = create(:csp_script)
+      script = create(:csp_script, :in_single_unit_course)
       level = create(:applab, :with_example_solutions)
       sl = create(:script_level, levels: [level], script: script)
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/projects/applab/example-1/view", "https://studio.code.org/projects/applab/example-2/view"]
-      assert_equal sl.get_example_solutions(level, @not_authorized_teacher), []
-      assert_equal sl.get_example_solutions(level, @student), []
+      assert_equal ["https://studio.code.org/projects/applab/example-1/view", "https://studio.code.org/projects/applab/example-2/view"], sl.get_example_solutions(level, @authorized_teacher)
+      assert_equal [], sl.get_example_solutions(level, @not_authorized_teacher)
+      assert_equal [], sl.get_example_solutions(level, @student)
     end
 
     test 'get_example_solutions returns example if not authorized teacher but in CSF course' do
@@ -217,9 +217,9 @@ class ScriptLevelTest < ActiveSupport::TestCase
       level = create(:dance, :with_example_solutions)
       sl = create(:script_level, levels: [level], script: script)
 
-      assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"]
-      assert_equal sl.get_example_solutions(level, @not_authorized_teacher), ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"]
-      assert_equal sl.get_example_solutions(level, @student), []
+      assert_equal ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"], sl.get_example_solutions(level, @authorized_teacher)
+      assert_equal ["https://studio.code.org/projects/dance/example-1/view", "https://studio.code.org/projects/dance/example-2/view"], sl.get_example_solutions(level, @not_authorized_teacher)
+      assert_equal [], sl.get_example_solutions(level, @student)
     end
   end
 

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -862,14 +862,14 @@ class UnitTest < ActiveSupport::TestCase
       absolute_position: 4
     )
 
-    summary = unit.summarize_for_lesson_show
-    assert_equal '/s/my-script', summary[:link]
+    summary = unit.summarize_for_lesson_show(unit_group_unit: unit.original_unit_group_unit)
+    assert_equal "/courses/#{unit.original_unit_group.name}/units/1", summary[:link]
     # only includes lesson groups with lessons with lesson plans
     assert_equal 2, summary[:lessonGroups].count
     # only includes lessons with lesson plans
     assert_equal 1, summary[:lessonGroups][0][:lessons].count
     assert_equal 'lesson-1', summary[:lessonGroups][0][:lessons][0][:key]
-    assert_equal '/s/my-script/lessons/1', summary[:lessonGroups][0][:lessons][0][:link]
+    assert_equal "/courses/#{unit.original_unit_group.name}/units/1/lessons/1", summary[:lessonGroups][0][:lessons][0][:link]
   end
 
   test 'can summarize unit for student lesson plan' do
@@ -924,15 +924,15 @@ class UnitTest < ActiveSupport::TestCase
       absolute_position: 4
     )
 
-    summary = unit.summarize_for_lesson_show(true)
-    assert_equal '/s/my-script', summary[:link]
+    summary = unit.summarize_for_lesson_show(true, unit_group_unit: unit.original_unit_group_unit)
+    assert_equal "/courses/#{unit.original_unit_group.name}/units/1", summary[:link]
     # only includes lesson groups with lessons with lesson plans
     assert_equal 2, summary[:lessonGroups].count
     # only includes lessons with lesson plans
     assert_equal 1, summary[:lessonGroups][0][:lessons].count
     assert_equal 'lesson-1', summary[:lessonGroups][0][:lessons][0][:key]
     # lesson links end with /student
-    assert_equal '/s/my-script/lessons/1/student', summary[:lessonGroups][0][:lessons][0][:link]
+    assert_equal "/courses/#{unit.original_unit_group.name}/units/1/lessons/1/student", summary[:lessonGroups][0][:lessons][0][:link]
   end
 
   test 'should generate a shorter summary for header' do


### PR DESCRIPTION
After the standalone-unit migration and URL restructure, we need to update all unit tests to reference single-unit courses and the correct `/courses/.../units/...` URLs. This PR includes cleaning up `factories.rb` and all the test changes that requires.

In `factories.rb`, this PR removes the following traits and factories: 
- `course_offering :with_units`
- `csp_course_offering :with_units`
- `course_version :with_unit` and `:with_csp_unit`
- `unit :in_unit_group` and `:is_course`
- `hoc_script`
- `standalone_unit`
- `pl_unit`

This PR also removes the following fields from the `unit` factory:
- `published_state`
- `instruction_type`
- `participant_audience`
- `instructor_audience`

Finally, this PR also defaults any scripts created in the `lesson` or `script_level` factories to part of a single-unit course.

## Links
- Jira: [TEACH-1678](https://codedotorg.atlassian.net/browse/TEACH-1678) (the main task)
- Jira: [TEACH-2039](https://codedotorg.atlassian.net/browse/TEACH-2039) (the sub task)