### PR TITLE
Simplify Workshop Catalog Card buttons to single Learn More button

### DIFF
--- a/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalog.jsx
+++ b/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalog.jsx
@@ -63,7 +63,7 @@ export default function RegionalWorkshopCatalog({
     } else {
       // Log page visit event with null info if there's no valid prepopulated zip
       analyticsReporter.sendEvent(
-        EVENTS.RP_LANDING_PAGE_VISITED_EVENT,
+        EVENTS.REGIONAL_WS_CATALOG_PAGE_VISITED,
         {
           'zip code': null,
           'regional partner': null,
@@ -134,8 +134,8 @@ export default function RegionalWorkshopCatalog({
           // or from a URL param), otherwise log the data as the zip enter event.
           analyticsReporter.sendEvent(
             prepopulatingZip
-              ? EVENTS.RP_LANDING_PAGE_VISITED_EVENT
-              : EVENTS.RP_LANDING_ZIP_ENTERED,
+              ? EVENTS.REGIONAL_WS_CATALOG_PAGE_VISITED
+              : EVENTS.REGIONAL_WS_CATALOG_ZIP_ENTERED,
             {
               'zip code': submittedZip,
               'regional partner': regionalPartner.name,
@@ -287,8 +287,6 @@ export default function RegionalWorkshopCatalog({
           location_name,
           fee,
           has_prereq,
-          description,
-          custom_registration_link,
         }) => (
           <RegionalWorkshopCatalogCard
             id={id}
@@ -304,8 +302,6 @@ export default function RegionalWorkshopCatalog({
             locationName={location_name}
             fee={fee || ''}
             hasPrereq={has_prereq}
-            description={description}
-            customRegistrationLink={custom_registration_link}
           />
         )
       )}

--- a/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalogCard.jsx
+++ b/apps/src/code-studio/pd/professional_learning/RegionalWorkshopCatalogCard.jsx
@@ -1,6 +1,5 @@
 import {Button} from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import Modal from '@code-dot-org/component-library/modal';
 import Tags from '@code-dot-org/component-library/tags';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import {
@@ -10,7 +9,7 @@ import {
 } from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {Fragment, useState} from 'react';
+import React, {Fragment} from 'react';
 
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -56,19 +55,13 @@ const RegionalWorkshopCatalogCard = ({
   locationName,
   fee,
   hasPrereq,
-  description,
-  customRegistrationLink,
 }) => {
-  const [showLearnMoreDialog, setShowLearnMoreDialog] = useState(false);
   const seatsRemaining = capacity - numEnrollments;
   const isFull = seatsRemaining <= 0;
-  const enrollButtonIconRight = customRegistrationLink
-    ? {iconName: 'up-right-from-square'}
-    : null;
 
-  const handleClickEnrollNow = () => {
+  const handleClickLearnMore = () => {
     analyticsReporter.sendEvent(
-      EVENTS.RP_LANDING_ENROLL_CLICKED,
+      EVENTS.REGIONAL_WS_CATALOG_LEARN_MORE_CLICK_EVENT,
       {
         workshop_id: id,
         workshop_course: course,
@@ -77,143 +70,109 @@ const RegionalWorkshopCatalogCard = ({
       },
       PLATFORMS.BOTH
     );
-    navigateToHref(
-      customRegistrationLink
-        ? customRegistrationLink
-        : `/pd/workshops/${id}/enroll`
-    );
+    navigateToHref(`/professional-learning/workshops/${id}`);
   };
 
   return (
-    <>
-      {showLearnMoreDialog && (
-        <Modal
-          title={name ? name : `${course}: ${subject}`}
-          description={description ? description : 'No description available.'}
-          primaryButtonProps={{
-            ariaLabel: 'enrollNow',
-            text: 'Enroll now',
-            target: '_blank',
-            iconRight: enrollButtonIconRight,
-            onClick: () => handleClickEnrollNow(),
-            disabled: isFull,
-          }}
-          secondaryButtonProps={{
-            ariaLabel: 'closeLearnMoreDialog',
-            text: 'Return to workshops',
-            onClick: () => setShowLearnMoreDialog(false),
-          }}
-        />
-      )}
-      <div className={style.workshopCatalogCard}>
-        <div className={style.workshopContent}>
-          <div className={style.titleBlock}>
-            <Tags
-              tagsList={[
-                {
-                  label: isFull ? 'Full' : `${seatsRemaining} Seats Remaining`,
-                  icon: {
-                    iconName: isFull ? 'users' : 'user-plus',
-                    iconStyle: 'solid',
-                    placement: 'left',
-                  },
+    <div className={style.workshopCatalogCard}>
+      <div className={style.workshopContent}>
+        <div className={style.titleBlock}>
+          <Tags
+            tagsList={[
+              {
+                label: isFull ? 'Full' : `${seatsRemaining} Seats Remaining`,
+                icon: {
+                  iconName: isFull ? 'users' : 'user-plus',
+                  iconStyle: 'solid',
+                  placement: 'left',
                 },
-              ]}
-              size="s"
-              className={classNames(
-                style.capacityTag,
-                isFull ? style.fullCapacityTag : style.spotsOpenCapacityTag
-              )}
-            />
-            <BodyOneText className={style.wsTitle}>
-              {name ? name : `${course}: ${subject}`}
-            </BodyOneText>
-            {supportedGradeLevels?.length > 0 && (
-              <div className={style.gradeContainer}>
-                <OverlineTwoText className={style.gradeNote}>
-                  FOR TEACHERS OF GRADES:
-                </OverlineTwoText>
-                <GradeLevelsBarDisplay
-                  supportedGradeLevels={supportedGradeLevels}
-                />
-              </div>
+              },
+            ]}
+            size="s"
+            className={classNames(
+              style.capacityTag,
+              isFull ? style.fullCapacityTag : style.spotsOpenCapacityTag
             )}
-          </div>
-          <div className={style.infoBlock}>
-            <WithTooltip
-              tooltipProps={{
-                tooltipId: sessions[0].start,
-                size: 'xs',
-                text: sessions.map(session => {
-                  const text = buildSessionDateAndTime(session);
-                  return (
-                    <Fragment key={text}>
-                      {text}
-                      <br />
-                    </Fragment>
-                  );
-                }),
-              }}
-            >
-              <span className={style.infoLine}>
-                <div className={style.infoLineIconContainer}>
-                  <FontAwesomeV6Icon iconName={'calendar'} />
-                </div>
-                <BodyTwoText>{buildWorkshopStartText(sessions)}</BodyTwoText>
-              </span>
-            </WithTooltip>
-            <span className={style.infoLine}>
-              <div className={style.infoLineIconContainer}>
-                <FontAwesomeV6Icon iconName={'screen-users'} />
-              </div>
-              <BodyTwoText>{`${format} workshop`}</BodyTwoText>
-            </span>
-            {locationName && (
-              <span className={style.infoLine}>
-                <div className={style.infoLineIconContainer}>
-                  <FontAwesomeV6Icon iconName={'building'} />
-                </div>
-                <BodyTwoText>{locationName}</BodyTwoText>
-              </span>
-            )}
-            <span className={style.infoLine}>
-              <div className={style.infoLineIconContainer}>
-                <FontAwesomeV6Icon iconName={'dollar-circle'} />
-              </div>
-              <BodyTwoText>{fee ? fee : 'Free'}</BodyTwoText>
-            </span>
-            <span className={style.infoLine}>
-              <div className={style.infoLineIconContainer}>
-                <FontAwesomeV6Icon iconName={'arrow-up-wide-short'} />
-              </div>
-              <BodyTwoText>
-                {hasPrereq ? 'Has prerequisites' : 'No prerequisites'}
-              </BodyTwoText>
-            </span>
-          </div>
+          />
+          <BodyOneText className={style.wsTitle}>
+            {name ? name : `${course}: ${subject}`}
+          </BodyOneText>
+          {supportedGradeLevels?.length > 0 && (
+            <div className={style.gradeContainer}>
+              <OverlineTwoText className={style.gradeNote}>
+                FOR TEACHERS OF GRADES:
+              </OverlineTwoText>
+              <GradeLevelsBarDisplay
+                supportedGradeLevels={supportedGradeLevels}
+              />
+            </div>
+          )}
         </div>
-        <div className={style.buttonContainer}>
-          <Button
-            aria-label="learnMore"
-            text="Learn more"
-            type="secondary"
-            color="black"
-            onClick={() => setShowLearnMoreDialog(true)}
-            className={style.wsCardButton}
-          />
-          <Button
-            aria-label="enrollNow"
-            text="Enroll now"
-            target="_blank"
-            color="purple"
-            iconRight={enrollButtonIconRight}
-            onClick={() => handleClickEnrollNow()}
-            className={style.wsCardButton}
-            disabled={isFull}
-          />
+        <div className={style.infoBlock}>
+          <WithTooltip
+            tooltipProps={{
+              tooltipId: sessions[0].start,
+              size: 'xs',
+              text: sessions.map(session => {
+                const text = buildSessionDateAndTime(session);
+                return (
+                  <Fragment key={text}>
+                    {text}
+                    <br />
+                  </Fragment>
+                );
+              }),
+            }}
+          >
+            <span className={style.infoLine}>
+              <div className={style.infoLineIconContainer}>
+                <FontAwesomeV6Icon iconName={'calendar'} />
+              </div>
+              <BodyTwoText>{buildWorkshopStartText(sessions)}</BodyTwoText>
+            </span>
+          </WithTooltip>
+          <span className={style.infoLine}>
+            <div className={style.infoLineIconContainer}>
+              <FontAwesomeV6Icon iconName={'screen-users'} />
+            </div>
+            <BodyTwoText>{`${format} workshop`}</BodyTwoText>
+          </span>
+          {locationName && (
+            <span className={style.infoLine}>
+              <div className={style.infoLineIconContainer}>
+                <FontAwesomeV6Icon iconName={'building'} />
+              </div>
+              <BodyTwoText>{locationName}</BodyTwoText>
+            </span>
+          )}
+          <span className={style.infoLine}>
+            <div className={style.infoLineIconContainer}>
+              <FontAwesomeV6Icon iconName={'dollar-circle'} />
+            </div>
+            <BodyTwoText>{fee ? fee : 'Free'}</BodyTwoText>
+          </span>
+          <span className={style.infoLine}>
+            <div className={style.infoLineIconContainer}>
+              <FontAwesomeV6Icon iconName={'arrow-up-wide-short'} />
+            </div>
+            <BodyTwoText>
+              {hasPrereq ? 'Has prerequisites' : 'No prerequisites'}
+            </BodyTwoText>
+          </span>
         </div>
       </div>
-    </>
+      <div className={style.buttonContainer}>
+        <Button
+          aria-label="learnMore"
+          text="Learn more"
+          target="_blank"
+          color="purple"
+          onClick={() => handleClickLearnMore()}
+          className={style.wsCardButton}
+          disabled={isFull}
+        />
+      </div>
+    </div>
   );
 };
 
@@ -237,8 +196,6 @@ RegionalWorkshopCatalogCard.propTypes = {
   locationName: PropTypes.string,
   fee: PropTypes.string,
   hasPrereq: PropTypes.bool.isRequired,
-  description: PropTypes.string,
-  customRegistrationLink: PropTypes.string,
 };
 
 export default RegionalWorkshopCatalogCard;

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -111,13 +111,17 @@ const EVENTS = {
   LESSON_OVERVIEW_PAGE_VISITED_EVENT: 'Lesson Overview Page Visited',
   LESSON_RESOURCE_LINK_VISITED_EVENT: 'Lesson Resource Link Visited',
 
+  // Regional Workshop Catalog
+  REGIONAL_WS_CATALOG_PAGE_VISITED: 'Regional Workshop Catalog Page Visited',
+  REGIONAL_WS_CATALOG_ZIP_ENTERED: 'Regional Workshop Catalog Zip Entered',
+  REGIONAL_WS_CATALOG_LEARN_MORE_CLICK_EVENT:
+    'Regional Workshop Catalog Learn More Button Clicked',
+
   // Workshop enrollment
   WORKSHOP_ENROLLMENT_PAGE_VISITED_EVENT: 'Workshop Enrollment Page Visited',
   WORKSHOP_ENROLLMENT_COMPLETED_EVENT: 'Workshop Enrollment Completed',
   WORKSHOP_ADD_SESSION_TO_CALENDAR_CLICK_EVENT:
     'Workshop Add Session to Calendar Clicked',
-  RP_LANDING_ZIP_ENTERED: 'Regional Partner Landing Zip Entered',
-  RP_LANDING_ENROLL_CLICKED: 'Regional Partner Landing Enroll Button Clicked',
 
   // Workshop session attendance
   WORKSHOP_ATTENDANCE_MARKED_EVENT: 'Workshop Attendance Marked',
@@ -133,7 +137,6 @@ const EVENTS = {
   APP_STATUS_CHANGE_EVENT: 'Application Status Changed',
   ADMIN_APPROVAL_RECEIVED_EVENT: 'Administrator Approval Received',
   SUBMIT_RP_CONTACT_FORM_EVENT: 'Submit Regional Partner Contact Form',
-  RP_LANDING_PAGE_VISITED_EVENT: 'Regional Partner Landing Page Visited',
 
   // Marketing site pages
   ADMIN_INTEREST_FORM_SUBMIT_EVENT: 'Administrator Interest Form Submitted',

--- a/apps/test/unit/code-studio/pd/professional_learning/RegionalWorkshopCatalogCardTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning/RegionalWorkshopCatalogCardTest.jsx
@@ -1,4 +1,4 @@
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 
@@ -35,8 +35,6 @@ const DEFAULT_PROPS = {
   locationName: 'Test University',
   fee: '$400',
   hasPrereq: true,
-  description: 'Test description',
-  customRegistrationLink: null,
 };
 
 const renderDefault = (overrideProps = {}) => {
@@ -45,20 +43,20 @@ const renderDefault = (overrideProps = {}) => {
 };
 
 describe('RegionalWorkshopCatalog', () => {
-  it('card states it is full and disables buttons if full', () => {
+  it('card states it is full and disables Learn More button if full', () => {
     renderDefault({capacity: 5, numEnrollments: 5});
 
     screen.getByText('Full');
-    expect(screen.queryByRole('button', {name: 'enrollNow'})).toBeDisabled();
+    expect(screen.queryByRole('button', {name: 'learnMore'})).toBeDisabled();
   });
 
-  it('card states how many spots are left and enables buttons if not full', () => {
+  it('card states how many spots are left and enables Learn More button if not full', () => {
     renderDefault();
 
     screen.getByText(
       `${DEFAULT_PROPS.capacity - DEFAULT_PROPS.numEnrollments} Seats Remaining`
     );
-    expect(screen.getByRole('button', {name: 'enrollNow'})).not.toBeDisabled();
+    expect(screen.getByRole('button', {name: 'learnMore'})).not.toBeDisabled();
   });
 
   it('card shows workshop name when available', () => {
@@ -109,42 +107,5 @@ describe('RegionalWorkshopCatalog', () => {
     });
 
     screen.getByText('04/22/25 (1:00PM-9:00PM) + 1 More');
-  });
-
-  it('card renders Learn More button that opens dialog with provided description', async () => {
-    renderDefault();
-
-    expect(screen.queryByText(DEFAULT_PROPS.description)).toBe(null);
-    expect(screen.queryByRole('button', {name: 'closeLearnMoreDialog'})).toBe(
-      null
-    );
-
-    fireEvent.click(screen.getByRole('button', {name: 'learnMore'}));
-
-    await waitFor(() => {
-      screen.getByText(DEFAULT_PROPS.description);
-      screen.getByRole('button', {name: 'closeLearnMoreDialog'});
-    });
-  });
-
-  it('card renders Learn More button that opens dialog with default description if none provided', async () => {
-    renderDefault({description: ''});
-
-    fireEvent.click(screen.getByRole('button', {name: 'learnMore'}));
-
-    await waitFor(() => {
-      screen.getByText('No description available.');
-      screen.getByRole('button', {name: 'closeLearnMoreDialog'});
-    });
-  });
-
-  it('card renders button to send user to registration link', () => {
-    renderDefault();
-
-    expect(
-      screen.getByRole('button', {
-        name: 'enrollNow',
-      })
-    ).not.toBeDisabled();
   });
 });

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -961,9 +961,6 @@ class Pd::Workshop < ApplicationRecord
       location_name: location_name,
       fee: fee,
       has_prereq: prereq.present?,
-      description: description,
-      custom_registration_link: registration_link,
-      regional_partner_name: regional_partner&.name,
     }
   end
 


### PR DESCRIPTION
Now that the Workshop Marketing page is set up, this PR updates the Regional Workshop Catalog cards to solely link to the marketing page with a "Learn More" button, rather than having an enroll button and a learn more modal. As part of this, I updated the naming of the Regional Workshop logging events to better reflect how/where they're used. Since these pages aren't being used by users yet, I imagine a rename is okay for events as we aren't currently monitoring those specific events.

https://github.com/user-attachments/assets/3c50affb-a2f9-4eef-9fa8-cc674ef28b26

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3274)

## Testing story
Local testing and updating unit tests.
