### PR TITLE
Re-own `.bundle` Directories on Servers

### DIFF
--- a/cookbooks/cdo-ruby/recipes/bundler.rb
+++ b/cookbooks/cdo-ruby/recipes/bundler.rb
@@ -4,13 +4,16 @@ apt_package 'git'
 
 # In preparation for no longer running `bundle install` as root, re-own the
 # existing root-owned .bundle directories on our persisitent managed servers.
+# See https://github.com/code-dot-org/code-dot-org/pull/66536
 #
 # TODO infra: remove this block once we've updated all servers
 root_dir = File.join(node[:home], node.chef_environment)
 ['dashboard', 'cookbooks'].each do |subdir|
+  bundle_dir = File.join(root_dir, subdir, '.bundle')
   execute "change ownership of #{subdir} bundle directory" do
-    command "chown -R #{node[:user]}:#{node[:user]} #{File.join(root_dir, subdir, '.bundle')}"
+    command "chown -R #{node[:user]}:#{node[:user]} #{bundle_dir}"
     user 'root'
+    only_if {Dir.exist?(bundle_dir)}
   end
 end
 

--- a/cookbooks/cdo-ruby/recipes/bundler.rb
+++ b/cookbooks/cdo-ruby/recipes/bundler.rb
@@ -2,6 +2,18 @@
 include_recipe 'apt'
 apt_package 'git'
 
+# In preparation for no longer running `bundle install` as root, re-own the
+# existing root-owned .bundle directories on our persisitent managed servers.
+#
+# TODO infra: remove this block once we've updated all servers
+root_dir = File.join(node[:home], node.chef_environment)
+['dashboard', 'cookbooks'].each do |subdir|
+  execute "change ownership of #{subdir} bundle directory" do
+    command "chown -R #{node[:user]}:#{node[:user]} #{File.join(root_dir, subdir, '.bundle')}"
+    user 'root'
+  end
+end
+
 gem_package 'bundler' do
   action :upgrade
   version node['cdo-ruby']['bundler_version']


### PR DESCRIPTION
Currently, all of our persistent managed servers will generate `.bundle` subdirectories owned by the root user within the `cookbooks` and `dashboard` directories as a side effect of the CI build:

```bash
ubuntu@test:~/test$ find . -name .bundle -type d
./cookbooks/.bundle
./.bundle
./dashboard/.bundle
ubuntu@test:~/test$ ll | grep bundle
drwxr-xr-x  2 ubuntu ubuntu   4096 Jul  2 17:52 .bundle/
ubuntu@test:~/test$ ll cookbooks | grep bundle
drwxr-xr-x  2 root   root     4096 Feb  3  2024 .bundle/
ubuntu@test:~/test$ ll dashboard | grep bundle
drwxr-xr-x  2 root   root    4096 Feb  3  2024 .bundle/
```

This behavior also manifests on adhocs, although the cookbooks subdir will only show up after a second full build following the first initial build.

Currently, this behavior is messy but not technically problematic, since we do indeed execute (most) of our `bundle install` operations as the root user. That is bad practice, however, and particularly with the [removal of the "auto-sudo" feature](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.4.0) in bundler v2.4 we intend to [start executing our `bundle install`s as the ubuntu user.](https://github.com/code-dot-org/code-dot-org/pull/66536)

In preparation for that, this PR adds some logic to chef which will re-own those directories appropriately.

## Testing story

To verify both that this change will apply cleanly to our existing persistent managed servers and that it will enable the desired switch, I followed this process:

1. Spin up an adhoc based off of staging
2. Trigger one additional `ci_build` after the adhoc has successfully spun up, which will create the root-owned `.bundle` directories as a side effect
3. Merge and push this branch to the adhoc branch; after the local chef cookbooks get updated, manually run `sudo chef-client -o cdo-apps` from `/var/chef` to execute the changes, then trigger another build with `start-build` and verify that it succeeds.
4. Repeat the previous step with the https://github.com/code-dot-org/code-dot-org/pull/66536 to the adhoc branch

## Follow-up work

Once this change has propagated to all appropriate servers, we can safely merge https://github.com/code-dot-org/code-dot-org/pull/66536

Note that because of the order in which we execute things during a CI build, we specifically need for a `chef-client` run which executes this change to fully complete on the server before a CI build including the next change can begin.