### PR TITLE
Adding hamburger button role

### DIFF
--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -3,7 +3,7 @@
   dashboard ||= false
   contents = Hamburger.get_hamburger_contents(options)
 
-#hamburger{class: contents[:visibility], tabindex: "0", 'aria-label': I18n.t('header_screen_reader_hamburger')}
+#hamburger{class: contents[:visibility], tabindex: "0", role: "button", 'aria-label': I18n.t('header_screen_reader_hamburger')}
   #hamburger-contents.hide-responsive-menu{class: request.path.include?('/global/fa') ? "farsi" : ""}
     -# Show the Sign in and Create account buttons if the user is not signed in
     - unless user_type


### PR DESCRIPTION
A one-liner (similar to https://github.com/code-dot-org/code-dot-org/pull/66755) that adds a role to the hamburger menu. We can only use aria-labels for valid html components. Because this is a clickable div, we need to ensure the browser knows this is operating as a button.

This does not impact the functionality (read: clickability) of the button.

WCAG violation before:

<img width="899" alt="Screenshot 2025-07-01 at 2 22 17 PM" src="https://github.com/user-attachments/assets/8f6a6afa-9538-4c2a-962b-ef88ec4b3c36" />


And after:


<img width="985" alt="Screenshot 2025-07-01 at 2 25 48 PM" src="https://github.com/user-attachments/assets/1c4afe12-b360-468d-b19a-ce469208946f" />


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1307

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
