### PR TITLE
Expand Data Analyst Role to Monitor Queries in Redshift

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -532,6 +532,7 @@ roles.each do |name, config| %>
               - 'redshift:DescribeClusters'
               - 'redshift:DescribeQuery'
               - 'redshift:CancelQuery'
+              - 'redshift:GetClusterCredentialsWithIAM'
               - 'events:ListRules'
             Resource: '*'
 

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -232,7 +232,10 @@ Resources:
         - Key: sqlworkbench-team
           Value: codedotorg
 
-# TODO: Migrate to REDTeam_Analyst
+  # TODO: Migrate to REDTeam_Analyst
+  # These permissions also require applying the following SQL permissions on the Redshift cluster:
+  # GRANT ROLE sys:monitor TO "IAM:DataAnalyst";
+  # GRANT ROLE sys:operator TO "IAM:DataAnalyst";
   DataAnalystRole:
     Type: AWS::IAM::Role
     Properties:
@@ -526,6 +529,9 @@ roles.each do |name, config| %>
               - 'redshift:DescribeClusterSubnetGroups'
               - 'redshift:ViewQueriesInConsole'
               - 'redshift:ViewQueriesFromConsole'
+              - 'redshift:DescribeClusters'
+              - 'redshift:DescribeQuery'
+              - 'redshift:CancelQuery'
               - 'events:ListRules'
             Resource: '*'
 


### PR DESCRIPTION
Expand RED Team permissions to view/monitor/cancel Redshift Queries in the AWS web console monitoring tool.

## Testing story

```
bundle exec rake stack:iam:validate RAILS_ENV=production ADMIN=true

Pending update for stack `IAM`:
Modify DataAnalystRedshiftPolicy [AWS::IAM::ManagedPolicy] Properties (PolicyDocument)
Finished stack:iam:validate (less than a minute)
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
