### PR TITLE
Adds localize-js tags to links generated with SafeMarkdown.

### DIFF
--- a/apps/src/templates/SafeMarkdown.jsx
+++ b/apps/src/templates/SafeMarkdown.jsx
@@ -124,7 +124,7 @@ blocklyTags.forEach(tag => {
 const localizationComponentWrappers = {
   a: function (props) {
     // eslint-disable-next-line jsx-a11y/anchor-has-content
-    return <a {...props} data-lz-url data-localize="markdown-url" />;
+    return <a {...props} data-lz-url="true" data-localize="markdown-url" />;
   },
   p: function (props) {
     return <p {...props} data-isolate="true" />;

--- a/apps/src/templates/SafeMarkdown.jsx
+++ b/apps/src/templates/SafeMarkdown.jsx
@@ -118,6 +118,19 @@ blocklyTags.forEach(tag => {
     return <BlocklyElement is={tag} {...props} />;
   };
 });
+
+// These wrappers add context for Localize to better understand the markdown
+// output. This also will enable URL localization for all links.
+const localizationComponentWrappers = {
+  a: function (props) {
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
+    return <a {...props} data-lz-url data-localize="markdown-url" />;
+  },
+  p: function (props) {
+    return <p {...props} data-isolate="true" />;
+  },
+};
+
 const markdownToReact = unified()
   .use(Processor.getParser())
   // include custom plugins
@@ -142,7 +155,10 @@ const markdownToReact = unified()
     createElement: React.createElement,
     // Use React component wrappers for Blockly XML elements to prevent
     // React from warning us about invalid components.
-    components: blocklyComponentWrappers,
+    components: {
+      ...blocklyComponentWrappers,
+      ...localizationComponentWrappers,
+    },
   });
 
 const markdownToReactExternalLinks = markdownToReact().use(externalLinks, {

--- a/apps/test/unit/templates/SafeMarkdownTest.js
+++ b/apps/test/unit/templates/SafeMarkdownTest.js
@@ -9,15 +9,18 @@ describe('SafeMarkdown', () => {
       <SafeMarkdown markdown="**some** _basic_ [inline](markdown)" />
     );
 
-    expect(
-      wrapper.equals(
+    expect(wrapper.html()).toBe(
+      shallow(
         <div>
-          <p>
-            <strong>some</strong> <em>basic</em> <a href="markdown">inline</a>
+          <p data-isolate="true">
+            <strong>some</strong> <em>basic</em>{' '}
+            <a href="markdown" data-lz-url="true" data-localize="markdown-url">
+              inline
+            </a>
           </p>
         </div>
-      )
-    ).toBe(true);
+      ).html()
+    );
   });
 
   it('will render raw html', () => {
@@ -26,15 +29,18 @@ describe('SafeMarkdown', () => {
     );
 
     // inline html is rendered directly
-    expect(
-      basicWrapper.equals(
+    expect(basicWrapper.html()).toBe(
+      shallow(
         <div>
-          <p>
-            <strong>some</strong> <em>basic</em> <a href="markdown">inline</a>
+          <p data-isolate="true">
+            <strong>some</strong> <em>basic</em>{' '}
+            <a href="markdown" data-lz-url="true" data-localize="markdown-url">
+              inline
+            </a>
           </p>
         </div>
-      )
-    ).toBe(true);
+      ).html()
+    );
 
     const advancedWrapper = shallow(
       <SafeMarkdown markdown="<table><thead><th>Some advanced html</th><th><strong>not</strong> usually supported by markdown</th></thead></table>" />
@@ -71,7 +77,7 @@ describe('SafeMarkdown', () => {
     );
 
     expect(paragraphWrapper.html()).toBe(
-      '<p id="test-markdown"><strong>some</strong> <em>basic</em> <a href="markdown">inline</a></p>'
+      '<p id="test-markdown"><strong>some</strong> <em>basic</em> <a href="markdown" data-lz-url="true" data-localize="markdown-url">inline</a></p>'
     );
   });
 
@@ -80,16 +86,18 @@ describe('SafeMarkdown', () => {
       <SafeMarkdown markdown="![regular](http://example.com/img.jpg)" />
     );
 
+    // Enzyme doesn't like the data-url property when comparing equality
+    // directly, so we use .html() as a proxy for this test
     // regular images are rendered normally
-    expect(
-      regularImage.equals(
+    expect(regularImage.html()).toBe(
+      shallow(
         <div>
-          <p>
+          <p data-isolate="true">
             <img src="http://example.com/img.jpg" alt="regular" />
           </p>
         </div>
-      )
-    ).toBe(true);
+      ).html()
+    );
 
     const expandableImage = shallow(
       <SafeMarkdown markdown="![expandable](http://example.com/img.jpg)" />
@@ -101,7 +109,7 @@ describe('SafeMarkdown', () => {
     expect(expandableImage.html()).toBe(
       shallow(
         <div>
-          <p>
+          <p data-isolate="true">
             <span
               data-url="http://example.com/img.jpg"
               className="expandable-image"
@@ -118,25 +126,27 @@ describe('SafeMarkdown', () => {
     );
 
     // regular code blocks are rendered normally
-    expect(
-      regularCodeBlock.equals(
+    expect(regularCodeBlock.html()).toBe(
+      shallow(
         <div>
-          <p>
+          <p data-isolate="true">
             some markdown with a <code>regular</code> code block
           </p>
         </div>
-      )
-    ).toBe(true);
+      ).html()
+    );
 
     const visualCodeBlock = shallow(
       <SafeMarkdown markdown="some markdown with a `visual`(#c0ffee) code block" />
     );
 
+    // Enzyme doesn't like the data-url property when comparing equality
+    // directly, so we use .html() as a proxy for this test
     // visual code blocks are rendered with expected properties
-    expect(
-      visualCodeBlock.equals(
+    expect(visualCodeBlock.html()).toBe(
+      shallow(
         <div>
-          <p>
+          <p data-isolate="true">
             some markdown with a{' '}
             <code className="visual-block" style={{backgroundColor: '#c0ffee'}}>
               visual
@@ -144,8 +154,8 @@ describe('SafeMarkdown', () => {
             code block
           </p>
         </div>
-      )
-    ).toBe(true);
+      ).html()
+    );
   });
 
   it('renders XML as top level block when appropriate', () => {
@@ -155,7 +165,7 @@ describe('SafeMarkdown', () => {
 
     // inline xml blocks render within their containing paragraph
     expect(inlineXml.html()).toBe(
-      '<div><p>Text with <xml is="xml"><block is="block" type="xml"></block></xml> inline</p></div>'
+      '<div><p data-isolate="true">Text with <xml is="xml"><block is="block" type="xml"></block></xml> inline</p></div>'
     );
 
     // Need to use markdown={} rather than markdown="" here so React doesn't
@@ -172,7 +182,7 @@ describe('SafeMarkdown', () => {
     // still have to rely on rendered HTML comparison here
     // block xml blocks render as top-level elements (siblings to paragraphs)
     expect(blockXml.html()).toBe(
-      '<div><p>Text with</p>\n<xml is="xml"><block is="block" type="xml"></block></xml>\n<p>in its own block</p></div>'
+      '<div><p data-isolate="true">Text with</p>\n<xml is="xml"><block is="block" type="xml"></block></xml>\n<p data-isolate="true">in its own block</p></div>'
     );
   });
 
@@ -180,28 +190,36 @@ describe('SafeMarkdown', () => {
     const externalLink = shallow(
       <SafeMarkdown markdown="[external link](example.com)" />
     );
-    expect(
-      externalLink.equals(
+    expect(externalLink.html()).toBe(
+      shallow(
         <div>
-          <p>
-            <a href="example.com">external link</a>
+          <p data-isolate="true">
+            <a
+              href="example.com"
+              data-lz-url="true"
+              data-localize="markdown-url"
+            >
+              external link
+            </a>
           </p>
         </div>
-      )
-    ).toBe(true);
+      ).html()
+    );
 
     const internalLink = shallow(
       <SafeMarkdown markdown="[internal link](code.org)" />
     );
-    expect(
-      internalLink.equals(
+    expect(internalLink.html()).toBe(
+      shallow(
         <div>
-          <p>
-            <a href="code.org">internal link</a>
+          <p data-isolate="true">
+            <a href="code.org" data-lz-url="true" data-localize="markdown-url">
+              internal link
+            </a>
           </p>
         </div>
-      )
-    ).toBe(true);
+      ).html()
+    );
   });
 
   it('will open links in a new tab if specified', () => {
@@ -211,17 +229,23 @@ describe('SafeMarkdown', () => {
         markdown="[external link](example.com)"
       />
     );
-    expect(
-      externalLink.equals(
+    expect(externalLink.html()).toBe(
+      shallow(
         <div>
-          <p>
-            <a href="example.com" target="_blank" rel="noreferrer noopener">
+          <p data-isolate="true">
+            <a
+              href="example.com"
+              target="_blank"
+              rel="noreferrer noopener"
+              data-lz-url="true"
+              data-localize="markdown-url"
+            >
               external link
             </a>
           </p>
         </div>
-      )
-    ).toBe(true);
+      ).html()
+    );
 
     const internalLink = shallow(
       <SafeMarkdown
@@ -229,17 +253,23 @@ describe('SafeMarkdown', () => {
         markdown="[internal link](code.org)"
       />
     );
-    expect(
-      internalLink.equals(
+    expect(internalLink.html()).toBe(
+      shallow(
         <div>
-          <p>
-            <a href="code.org" target="_blank" rel="noreferrer noopener">
+          <p data-isolate="true">
+            <a
+              href="code.org"
+              target="_blank"
+              rel="noreferrer noopener"
+              data-lz-url="true"
+              data-localize="markdown-url"
+            >
               internal link
             </a>
           </p>
         </div>
-      )
-    ).toBe(true);
+      ).html()
+    );
   });
 
   it('is resistant to JS injection', () => {


### PR DESCRIPTION
Updates `SafeMarkdown` to add `data-lz-url` to `<a>` tags and `data-isolate` to `<p>` tags to allow better usage with LocalizeJS. This is generally to better support localization of level 'instructions'.

The `data-lz-url` allows URL substitution in the phrase editor. That is, we can supply a different URL for different locales, which is important for the `pdf` linking being done within the "AI Foundations" course.

The `data-isolate` just hints to LocalizeJS that it should treat the entire paragraph within the markdown as its own phrase when it can do so. This just makes sure there is more context for translation.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
