### PR TITLE
feat(sitemap): add sitemap support

### DIFF
--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -76,6 +76,7 @@
     "react-map-gl": "^8.0.4",
     "react-schemaorg": "^2.0.0",
     "redis": "^4.7.1",
+    "sitemap": "^8.0.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/frontend/apps/marketing/src/app/sitemap.xml/__tests__/route.test.ts
+++ b/frontend/apps/marketing/src/app/sitemap.xml/__tests__/route.test.ts
@@ -1,0 +1,147 @@
+import {STALE_WHILE_REVALIDATE_ONE_DAY} from '@/cache/constants';
+import {getContentfulClient} from '@/contentful/client';
+import {getAllEntriesForContentType} from '@/contentful/get-entries';
+
+import {GET} from '../route';
+
+jest.mock('@/contentful/client');
+jest.mock('@/contentful/get-entries');
+jest.mock('@tinyhttp/etag', () => ({
+  eTag: jest.fn(() => 'mock-etag'),
+}));
+jest.mock('@/cache/constants', () => ({
+  STALE_WHILE_REVALIDATE_ONE_DAY:
+    'public, max-age=0, stale-while-revalidate=86400',
+}));
+jest.mock('@/config/locale', () => ({
+  SUPPORTED_LOCALE_CODES: ['en', 'fr'],
+}));
+
+const mockRequest = (host = 'code.marketing-sites.localhost') =>
+  ({
+    headers: {
+      get: (key: string) => (key === 'host' ? host : undefined),
+    },
+  }) as unknown as Request;
+
+describe('GET /sitemap.xml', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID = 'test-content-type-id';
+  });
+
+  it('returns empty response if contentful client is not available', async () => {
+    (getContentfulClient as jest.Mock).mockReturnValue(undefined);
+
+    const response = await GET(mockRequest());
+    expect(response).toBeInstanceOf(Response);
+    const text = await response.text();
+    expect(text).toBe('');
+  });
+
+  it('returns sitemap xml with correct headers', async () => {
+    (getContentfulClient as jest.Mock).mockReturnValue({});
+    (getAllEntriesForContentType as jest.Mock).mockResolvedValue([
+      {
+        fields: {
+          slug: '/test',
+          seoMetadata: {fields: {}},
+        },
+        sys: {updatedAt: '2024-01-01T00:00:00Z'},
+      },
+    ]);
+
+    const response = await GET(mockRequest('mysite.com'));
+    expect(response.headers.get('Cache-Control')).toBe(
+      STALE_WHILE_REVALIDATE_ONE_DAY,
+    );
+    expect(response.headers.get('ETag')).toBe('mock-etag');
+    const body = await response.text();
+    expect(body).toContain('test');
+    expect(body).toContain('mysite.com');
+  });
+
+  it('skips entries with hidePageFromSearchEnginesNoindex', async () => {
+    (getContentfulClient as jest.Mock).mockReturnValue({});
+    (getAllEntriesForContentType as jest.Mock).mockResolvedValue([
+      {
+        fields: {
+          slug: '/hidden',
+          seoMetadata: {fields: {hidePageFromSearchEnginesNoindex: true}},
+        },
+        sys: {updatedAt: '2024-01-01T00:00:00Z'},
+      },
+    ]);
+
+    const response = await GET(mockRequest());
+    const body = await response.text();
+    expect(body).not.toContain('/hidden');
+  });
+
+  it('skips entries without a slug', async () => {
+    (getContentfulClient as jest.Mock).mockReturnValue({});
+    (getAllEntriesForContentType as jest.Mock).mockResolvedValue([
+      {
+        fields: {
+          slug: '',
+          seoMetadata: {fields: {}},
+        },
+        sys: {updatedAt: '2024-01-01T00:00:00Z'},
+      },
+    ]);
+
+    const response = await GET(mockRequest());
+    const body = await response.text();
+    expect(body).not.toContain('<url>');
+  });
+
+  it('handles root slug "/" correctly', async () => {
+    (getContentfulClient as jest.Mock).mockReturnValue({});
+    (getAllEntriesForContentType as jest.Mock).mockResolvedValue([
+      {
+        fields: {
+          slug: '/',
+          seoMetadata: {fields: {}},
+        },
+        sys: {updatedAt: '2024-01-01T00:00:00Z'},
+      },
+    ]);
+
+    const response = await GET(mockRequest());
+    const body = await response.text();
+    // Should not have double slash
+    expect(body).toContain(
+      '<loc>https://code.marketing-sites.localhost/en</loc>',
+    );
+    expect(body).toContain(
+      '<loc>https://code.marketing-sites.localhost/fr</loc>',
+    );
+  });
+
+  it('includes hreflang alternate links and x-default in sitemap entries', async () => {
+    (getContentfulClient as jest.Mock).mockReturnValue({});
+    (getAllEntriesForContentType as jest.Mock).mockResolvedValue([
+      {
+        fields: {
+          slug: '/hreftest',
+          seoMetadata: {fields: {}},
+        },
+        sys: {updatedAt: '2024-01-01T00:00:00Z'},
+      },
+    ]);
+
+    const response = await GET(mockRequest());
+    const body = await response.text();
+    // Check for alternate links for each supported locale
+    expect(body).toContain(
+      '<xhtml:link rel="alternate" hreflang="en" href="https://code.marketing-sites.localhost/en/hreftest"',
+    );
+    expect(body).toContain(
+      '<xhtml:link rel="alternate" hreflang="fr" href="https://code.marketing-sites.localhost/fr/hreftest"',
+    );
+    // Check for x-default which is the canonical URL
+    expect(body).toContain(
+      '<xhtml:link rel="alternate" hreflang="x-default" href="https://code.marketing-sites.localhost/en-US/hreftest"',
+    );
+  });
+});

--- a/frontend/apps/marketing/src/app/sitemap.xml/route.ts
+++ b/frontend/apps/marketing/src/app/sitemap.xml/route.ts
@@ -1,0 +1,105 @@
+import {eTag} from '@tinyhttp/etag';
+import {EmptySitemap, SitemapStream, streamToPromise} from 'sitemap';
+
+import {STALE_WHILE_REVALIDATE_ONE_DAY} from '@/cache/constants';
+import {SUPPORTED_LOCALE_CODES} from '@/config/locale';
+import {getContentfulClient} from '@/contentful/client';
+import {getAllEntriesForContentType} from '@/contentful/get-entries';
+import {SeoMetadataEntry} from '@/types/contentful/entries/SeoMetadata';
+import {Entry} from '@/types/contentful/Entry';
+
+interface SitemapEntry {
+  slug: string;
+  seoMetadata: SeoMetadataEntry;
+}
+
+/**
+ * GET /sitemap.xml
+ * Returns a sitemap for the site by querying Contentful for all experience entries and filtering out ones that are
+ * excluded from indexing.
+ */
+export async function GET(request: Request) {
+  const deliveryClient = getContentfulClient();
+
+  if (!deliveryClient) {
+    console.warn(
+      '⚠️ Contentful delivery client is not available, no redirects will be available. Please check that frontend/apps/marketing/.env is populated.',
+    );
+    return new Response();
+  }
+
+  const hostname = `https://${request.headers.get('host')}`;
+
+  const experienceEntries = await getAllEntriesForContentType<
+    Entry<SitemapEntry>
+  >(deliveryClient, process.env.CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID!, {
+    'fields.slug[exists]': 'true',
+    // Only include deep links one level deep (specifically the SEO Metadata)
+    include: 1,
+    // contentful has a very strict type, so we need to cast this to any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    select: 'fields.slug,fields.seoMetadata,sys.updatedAt' as any,
+  });
+
+  const sitemapStream = new SitemapStream({
+    hostname,
+  });
+
+  for (const entry of experienceEntries) {
+    const sitemapEntry: SitemapEntry = entry.fields;
+
+    // Skip entries that are marked as noindex
+    if (sitemapEntry.seoMetadata?.fields?.hidePageFromSearchEnginesNoindex) {
+      continue;
+    }
+
+    // Skip entries without a slug
+    if (!sitemapEntry.slug) {
+      continue;
+    }
+
+    const slug = sitemapEntry.slug === '/' ? '' : sitemapEntry.slug;
+
+    SUPPORTED_LOCALE_CODES.forEach(outerLocaleCode => {
+      sitemapStream.write({
+        url: `${outerLocaleCode}${slug}`,
+        lastmod: entry.sys.updatedAt,
+        changefreq: 'daily',
+        links: [
+          ...SUPPORTED_LOCALE_CODES.map(localeCode => ({
+            lang: localeCode,
+            url: `/${localeCode}${slug}`,
+          })),
+          // Also indicate that English is the canonical version
+          {
+            lang: 'x-default',
+            url: `/en-US${slug}`,
+          },
+        ],
+      });
+    });
+  }
+
+  sitemapStream.end();
+
+  try {
+    const sitemap = await streamToPromise(sitemapStream);
+
+    return new Response(sitemap, {
+      headers: {
+        'Cache-Control': STALE_WHILE_REVALIDATE_ONE_DAY,
+        ETag: eTag(sitemap),
+      },
+    });
+  } catch (e) {
+    if (e instanceof EmptySitemap) {
+      // If the sitemap is empty, we return a 404
+      return new Response('Not Found', {
+        status: 404,
+      });
+    }
+
+    // Otherwise, rethrow the error
+    throw e;
+  }
+}

--- a/frontend/apps/marketing/src/cache/constants.ts
+++ b/frontend/apps/marketing/src/cache/constants.ts
@@ -1,3 +1,7 @@
 // Stale while revalidate, fresh for an hour, continue serving stale up to one year
 export const STALE_WHILE_REVALIDATE_ONE_HOUR =
   's-maxage=3600, stale-while-revalidate=31535100';
+
+// Stale while revalidate, fresh for a day, continue serving stale up to one year
+export const STALE_WHILE_REVALIDATE_ONE_DAY =
+  's-maxage=86400, stale-while-revalidate=31535100';

--- a/frontend/apps/marketing/src/contentful/get-entries.ts
+++ b/frontend/apps/marketing/src/contentful/get-entries.ts
@@ -6,10 +6,15 @@ import logger from '@/logger/contentful';
  * Fetches all entries for a given content type from Contentful.
  * @param client - The Contentful client to use for fetching entries (preview or delivery)
  * @param contentType - The content type to fetch all entries for
+ * @param options - Optional options to pass to Contentful getEntries
  */
 export async function getAllEntriesForContentType<
   EntrySkeleton extends EntrySkeletonType = EntrySkeletonType,
->(client: ContentfulClientApi<undefined>, contentType: string) {
+>(
+  client: ContentfulClientApi<undefined>,
+  contentType: string,
+  options?: Parameters<typeof client.getEntries>[0],
+) {
   logger.info(`Fetching all entries for content type: ${contentType}`, {
     contentType,
   });
@@ -21,6 +26,7 @@ export async function getAllEntriesForContentType<
 
   do {
     const response = await client.getEntries<EntrySkeleton>({
+      ...options,
       content_type: contentType,
       skip,
       limit: pageSize,

--- a/frontend/apps/marketing/src/middleware.ts
+++ b/frontend/apps/marketing/src/middleware.ts
@@ -14,7 +14,7 @@ export const config = {
      * 4. all root files inside /public (e.g. /favicon.ico)
      * 5. /robots.txt
      */
-    '/((?!api/|_next/|onetrust/|_static/|_vercel|robots.txt).*)',
+    '/((?!api/|_next/|onetrust/|_static/|_vercel|robots.txt|sitemap.xml).*)',
   ],
 };
 

--- a/frontend/apps/marketing/tests/e2e/sitemap.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/sitemap.spec.ts
@@ -1,0 +1,33 @@
+import {expect} from '@playwright/test';
+
+import {STALE_WHILE_REVALIDATE_ONE_DAY} from '@/cache/constants';
+
+import {test} from './fixtures/base';
+import {MarketingPage} from './pom/marketing';
+
+test.describe('Sitemap Tests', () => {
+  test('should return a sitemap and exclude noindex pages', async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+
+    const marketingPage = new MarketingPage(page);
+    const response = await marketingPage.goto('/sitemap.xml');
+
+    expect(response?.status()).toEqual(200);
+
+    // Should cache the page
+    expect(response?.headers()?.['cache-control']).toEqual(
+      STALE_WHILE_REVALIDATE_ONE_DAY,
+    );
+    expect(response?.headers()?.['etag']).toBeDefined();
+
+    const body = await response?.text();
+    // Should have /en-US
+    expect(body).toContain('/en-US');
+
+    // Should not have all the things because it is noindex
+    expect(body).not.toContain('all-the-things');
+  });
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1247,6 +1247,7 @@ __metadata:
     react-schemaorg: "npm:^2.0.0"
     redis: "npm:^4.7.1"
     schema-dts: "npm:^1.1.5"
+    sitemap: "npm:^8.0.0"
     stylelint: "npm:^16.14.1"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.19.3"
@@ -7671,6 +7672,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^17.0.5":
+  version: 17.0.45
+  resolution: "@types/node@npm:17.0.45"
+  checksum: 10c0/0db377133d709b33a47892581a21a41cd7958f22723a3cc6c71d55ac018121382de42fbfc7970d5ae3e7819dbe5f40e1c6a5174aedf7e7964e9cb8fa72b580b0
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^18.0.0":
   version: 18.19.65
   resolution: "@types/node@npm:18.19.65"
@@ -7828,6 +7836,15 @@ __metadata:
   version: 0.12.0
   resolution: "@types/retry@npm:0.12.0"
   checksum: 10c0/7c5c9086369826f569b83a4683661557cab1361bac0897a1cefa1a915ff739acd10ca0d62b01071046fe3f5a3f7f2aec80785fe283b75602dc6726781ea3e328
+  languageName: node
+  linkType: hard
+
+"@types/sax@npm:^1.2.1":
+  version: 1.2.7
+  resolution: "@types/sax@npm:1.2.7"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/d077a761a0753b079bf8279b3993948030ca86ed9125437b9b29c1de40db9b2deb7fddc369f014b58861d450e8b8cc75f163aa29dc8cea81952efbfd859168cf
   languageName: node
   linkType: hard
 
@@ -8858,6 +8875,13 @@ __metadata:
   version: 4.1.3
   resolution: "arg@npm:4.1.3"
   checksum: 10c0/070ff801a9d236a6caa647507bdcc7034530604844d64408149a26b9e87c2f97650055c0f049abd1efc024b334635c01f29e0b632b371ac3f26130f4cf65997a
+  languageName: node
+  linkType: hard
+
+"arg@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "arg@npm:5.0.2"
+  checksum: 10c0/ccaf86f4e05d342af6666c569f844bec426595c567d32a8289715087825c2ca7edd8a3d204e4d2fb2aa4602e09a57d0c13ea8c9eea75aac3dbb4af5514e6800e
   languageName: node
   linkType: hard
 
@@ -19797,6 +19821,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:^1.2.4":
+  version: 1.4.1
+  resolution: "sax@npm:1.4.1"
+  checksum: 10c0/6bf86318a254c5d898ede6bd3ded15daf68ae08a5495a2739564eb265cd13bcc64a07ab466fb204f67ce472bb534eb8612dac587435515169593f4fffa11de7c
+  languageName: node
+  linkType: hard
+
 "saxes@npm:^6.0.0":
   version: 6.0.0
   resolution: "saxes@npm:6.0.0"
@@ -20121,6 +20152,20 @@ __metadata:
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
   checksum: 10c0/230ac975cca485b7f6fe2b96a711aa62a6a26ead3e6fb8ba17c5a00d61b8bed0d7adc21f5626b70d7c33c62ff4e63933017a6462942c719d1980bb0b1207ad46
+  languageName: node
+  linkType: hard
+
+"sitemap@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "sitemap@npm:8.0.0"
+  dependencies:
+    "@types/node": "npm:^17.0.5"
+    "@types/sax": "npm:^1.2.1"
+    arg: "npm:^5.0.0"
+    sax: "npm:^1.2.4"
+  bin:
+    sitemap: dist/cli.js
+  checksum: 10c0/adaabfb1f27e3c76ba25f9a16dcb02ff17dd2ecbd1b2dbe2608a6770eff37bd71f7d21c10df6824917453bc4da2c2790fd85ee6424d75699bd053e3422d2ef5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds support for a multi-tenant sitemap.xml support. To accomplish this, a query is made to Contentful to fetch all experience entries isolated to the slug and SEO Metadata. Sitemap eligible entries are ones where the page is not set to 'noindex'.

This API route is highly cacheable, and should refresh on a one day basis. It will be revalidated when any experience entry is published/unpublished.
