### PR TITLE
chore: remove CSP report-uri

### DIFF
--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -52,8 +52,7 @@ module Rack
             "img-src 'self' https: data: blob: https://*.code.org",
             "font-src 'self' https: data:",
             "connect-src 'self' https: https://api.pusherapp.com wss://ws.pusherapp.com http://localhost:8080 https://curriculum.code.org/ wss://*.code.org",
-            "media-src 'self' https: data: https://*.code.org http://vaas.acapela-group.com",
-            "report-uri #{CDO.code_org_url('https/mixed-content')}"
+            "media-src 'self' https: data: https://*.code.org http://vaas.acapela-group.com"
           ]
         end
 


### PR DESCRIPTION
We currently report CSP violations to /https/mixed/content but this endpoint is not in use, it only logs out the report in debug level. Since Pegasus is targeted for deprecation, remove the CSP report directive (as we would need to replace it with `report-to` anyway).