### PR TITLE
feat(workshops): decouple payment from workshop summary

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
@@ -157,6 +157,10 @@ export class WorkshopSummaryReport extends React.Component {
         header: {label: 'Num Registered'},
       },
       {
+        property: 'num_teachers_attending_all_sessions',
+        header: {label: 'Num Attending'},
+      },
+      {
         property: 'num_scholarship_teachers_attending_all_sessions',
         header: {label: 'Num Scholarship Attending'},
       },

--- a/dashboard/app/controllers/api/v1/pd/teacher_attendance_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/teacher_attendance_report_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Pd::TeacherAttendanceReportController < Api::V1::Pd::ReportContro
 
     report = @workshops.flat_map do |workshop|
       workshop.enrollments.map do |enrollment|
-        ::Pd::Payment::TeacherSummary.new(enrollment: enrollment).generate_teacher_summary_line_item
+        ::Pd::Summary::TeacherSummary.new(enrollment: enrollment).generate_teacher_summary_line_item
       end
     end
 

--- a/dashboard/app/controllers/api/v1/pd/teacher_attendance_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/teacher_attendance_report_controller.rb
@@ -3,8 +3,8 @@ class Api::V1::Pd::TeacherAttendanceReportController < Api::V1::Pd::ReportContro
 
   authorize_resource class: :pd_teacher_attendance_report
 
-  # GET /api/v1/pd/teacher_progress_report
-  # GET /api/v1/pd/teacher_progress_report.csv
+  # GET /api/v1/pd/teacher_attendance_report
+  # GET /api/v1/pd/teacher_attendance.csv
   def index
     @workshops = load_filtered_ended_workshops
 
@@ -23,7 +23,7 @@ class Api::V1::Pd::TeacherAttendanceReportController < Api::V1::Pd::ReportContro
         render json: report
       end
       format.csv do
-        send_as_csv_attachment report, 'teacher_progress_report.csv'
+        send_as_csv_attachment report, 'teacher_attendance_report.csv'
       end
     end
   end

--- a/dashboard/app/controllers/api/v1/pd/teacher_attendance_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/teacher_attendance_report_controller.rb
@@ -8,15 +8,11 @@ class Api::V1::Pd::TeacherAttendanceReportController < Api::V1::Pd::ReportContro
   def index
     @workshops = load_filtered_ended_workshops
 
-    report = @workshops.filter_map do |workshop|
-      ::Pd::Payment::PaymentFactory.get_payment(workshop).try do |workshop_summary|
-        workshop_summary.teacher_summaries.map do |teacher_summary|
-          teacher_summary.generate_teacher_progress_report_line_item(
-            with_payment: current_user.permission?(UserPermission::WORKSHOP_ADMIN)
-          )
-        end
+    report = @workshops.flat_map do |workshop|
+      workshop.enrollments.map do |enrollment|
+        ::Pd::Payment::TeacherSummary.new(enrollment: enrollment).generate_teacher_summary_line_item
       end
-    end.flatten
+    end
 
     respond_to do |format|
       format.json do

--- a/dashboard/app/controllers/api/v1/pd/workshop_summary_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_summary_report_controller.rb
@@ -2,8 +2,8 @@ class Api::V1::Pd::WorkshopSummaryReportController < Api::V1::Pd::ReportControll
   authorize_resource class: :pd_workshop_summary_report
   include Pd::WorkshopFilters
 
-  # GET /api/v1/pd/workshop_organizer_report
-  # GET /api/v1/pd/workshop_organizer_report.csv
+  # GET /api/v1/pd/workshop_summary_report
+  # GET /api/v1/pd/workshop_summary_report.csv
   def index
     @workshops = load_filtered_ended_workshops
 
@@ -18,7 +18,7 @@ class Api::V1::Pd::WorkshopSummaryReportController < Api::V1::Pd::ReportControll
         render json: report
       end
       format.csv do
-        send_as_csv_attachment report, 'workshop_organizer_report.csv'
+        send_as_csv_attachment report, 'workshop_summary_report.csv'
       end
     end
   end

--- a/dashboard/app/controllers/api/v1/pd/workshop_summary_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_summary_report_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Pd::WorkshopSummaryReportController < Api::V1::Pd::ReportControll
     @workshops = load_filtered_ended_workshops
 
     report = @workshops.map do |workshop|
-      ::Pd::Payment::WorkshopSummary.new(workshop: workshop).generate_workshop_summary_line_item
+      ::Pd::Summary::WorkshopSummary.new(workshop: workshop).generate_workshop_summary_line_item
     end
 
     respond_to do |format|

--- a/dashboard/app/controllers/api/v1/pd/workshop_summary_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_summary_report_controller.rb
@@ -7,10 +7,8 @@ class Api::V1::Pd::WorkshopSummaryReportController < Api::V1::Pd::ReportControll
   def index
     @workshops = load_filtered_ended_workshops
 
-    report = @workshops.filter_map do |workshop|
-      ::Pd::Payment::PaymentFactory.get_payment(workshop).try do |workshop_summary|
-        workshop_summary.generate_organizer_report_line_item(with_payment: current_user.permission?(UserPermission::WORKSHOP_ADMIN))
-      end
+    report = @workshops.map do |workshop|
+      ::Pd::Payment::WorkshopSummary.new(workshop: workshop).generate_workshop_summary_line_item
     end
 
     respond_to do |format|

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -793,14 +793,6 @@ class Pd::Workshop < ApplicationRecord
       state != Pd::Workshop::STATE_ENDED
   end
 
-  # deprecated
-  def funding_summary
-    # funded is no longer a required field
-    # new workshops will not have a funding_summary
-    return '' if funded.nil?
-    (funded ? 'Yes' : 'No') + (funding_type.present? ? ": #{funding_type}" : '')
-  end
-
   # Get all enrollments for this workshop with no associated attendances
   def unattended_enrollments
     enrollments.left_outer_joins(:attendances).where(pd_attendances: {id: nil})

--- a/dashboard/lib/pd/payment/teacher_summary.rb
+++ b/dashboard/lib/pd/payment/teacher_summary.rb
@@ -62,8 +62,6 @@ module Pd::Payment
         workshop_id: workshop.id,
         workshop_dates: workshop.sessions.map(&:formatted_date).join(' '),
         workshop_name: workshop.friendly_name,
-        on_map: workshop.on_map,
-        funded: workshop.funding_summary,
         organizer_name: workshop.organizer.name,
         organizer_email: workshop.organizer.email,
         year: workshop.year,

--- a/dashboard/lib/pd/payment/teacher_summary.rb
+++ b/dashboard/lib/pd/payment/teacher_summary.rb
@@ -1,24 +1,36 @@
 module Pd::Payment
   class TeacherSummary
-    TeacherAttendanceTotal = Struct.new(:days, :hours) do
-      def initialize(days = 0, hours = 0)
-        super(days, hours)
-      end
-
-      def add_session(hours)
-        self.days += 1
-        self.hours += hours
-      end
-    end
-
-    def initialize(enrollment:)
-      @teacher = enrollment&.user
+    def initialize(
+      workshop_summary:,
+      teacher:,
+      enrollment: nil,
+      raw_days:,
+      raw_hours:,
+      days:,
+      hours:
+    )
+      @workshop_summary = workshop_summary
+      @teacher = teacher
       @enrollment = enrollment
+      @raw_days = raw_days
+      @raw_hours = raw_hours
+      @days = days
+      @hours = hours
     end
 
-    attr_reader(:enrollment, :teacher)
+    attr_reader(
+      :workshop_summary,
+      :teacher, :enrollment,
+      :raw_days, :raw_hours,
+      :days, :hours
+    )
 
-    delegate :workshop, to: :enrollment
+    # @return [TeacherPayment] payment information for this teacher in this workshop
+    attr_accessor :payment
+
+    def qualified?
+      !payment.nil?
+    end
 
     def school_district
       enrollment.try(&:school_info).try(&:school_district)
@@ -32,27 +44,15 @@ module Pd::Payment
       enrollment.try(&:school_name)
     end
 
-    def calculate_teacher_attendance
-      teacher_attendance = TeacherAttendanceTotal.new
-      session_ids = workshop.sessions.pluck(:id)
-      attendances = Pd::Attendance.where(pd_session_id: session_ids, teacher_id: teacher.id)
+    delegate :workshop, to: :workshop_summary
 
-      attendances.each do |attendance|
-        session = workshop.sessions.find {|s| s.id == attendance.pd_session_id}
-        teacher_attendance.add_session(session.hours) if session
-      end
-
-      teacher_attendance
-    end
-
-    def generate_teacher_summary_line_item
-      attendance = calculate_teacher_attendance
+    def generate_teacher_progress_report_line_item(with_payment: false)
       line_item = {
         teacher_first_name: enrollment.first_name,
         teacher_last_name: enrollment.last_name,
         teacher_id: teacher.try(&:id),
         teacher_email: enrollment.email,
-        plp_name: workshop.regional_partner.try(&:name),
+        plp_name: workshop_summary.plp.try(&:name),
         state: state,
         district_name: school_district.try(&:name),
         district_id: school_district.try(&:id),
@@ -62,12 +62,27 @@ module Pd::Payment
         workshop_id: workshop.id,
         workshop_dates: workshop.sessions.map(&:formatted_date).join(' '),
         workshop_name: workshop.friendly_name,
-        organizer_name: workshop.organizer.try(&:name),
-        organizer_email: workshop.organizer.try(&:email),
+        on_map: workshop.on_map,
+        funded: workshop.funding_summary,
+        organizer_name: workshop.organizer.name,
+        organizer_email: workshop.organizer.email,
         year: workshop.year,
-        hours: attendance.hours,
-        days: attendance.days,
+        hours: hours,
+        days: days
       }
+
+      if with_payment
+        line_item.merge!(
+          {
+            pay_period: workshop_summary.pay_period,
+            payment_type: payment.try(&:type),
+            payment_rate: payment.try(&:rate),
+            qualified: qualified?,
+            payment_amount: payment.try(&:amount)
+          }
+        )
+      end
+
       line_item
     end
   end

--- a/dashboard/lib/pd/payment/teacher_summary.rb
+++ b/dashboard/lib/pd/payment/teacher_summary.rb
@@ -1,36 +1,22 @@
 module Pd::Payment
   class TeacherSummary
-    def initialize(
-      workshop_summary:,
-      teacher:,
-      enrollment: nil,
-      raw_days:,
-      raw_hours:,
-      days:,
-      hours:
-    )
-      @workshop_summary = workshop_summary
-      @teacher = teacher
+    TeacherAttendanceTotal = Struct.new(:days, :hours) do
+      def initialize(days = 0, hours = 0)
+        super(days, hours)
+      end
+
+      def add_session(hours)
+        self.days += 1
+        self.hours += hours
+      end
+    end
+
+    def initialize(enrollment:)
+      @teacher = enrollment&.user
       @enrollment = enrollment
-      @raw_days = raw_days
-      @raw_hours = raw_hours
-      @days = days
-      @hours = hours
     end
 
-    attr_reader(
-      :workshop_summary,
-      :teacher, :enrollment,
-      :raw_days, :raw_hours,
-      :days, :hours
-    )
-
-    # @return [TeacherPayment] payment information for this teacher in this workshop
-    attr_accessor :payment
-
-    def qualified?
-      !payment.nil?
-    end
+    attr_reader(:enrollment, :teacher)
 
     def school_district
       enrollment.try(&:school_info).try(&:school_district)
@@ -44,15 +30,29 @@ module Pd::Payment
       enrollment.try(&:school_name)
     end
 
-    delegate :workshop, to: :workshop_summary
+    delegate :workshop, to: :enrollment
 
-    def generate_teacher_progress_report_line_item(with_payment: false)
+    def calculate_teacher_attendance
+      teacher_attendance = TeacherAttendanceTotal.new
+      session_ids = workshop.sessions.pluck(:id)
+      attendances = Pd::Attendance.where(pd_session_id: session_ids, teacher_id: teacher.id)
+
+      attendances.each do |attendance|
+        session = workshop.sessions.find {|s| s.id == attendance.pd_session_id}
+        teacher_attendance.add_session(session.hours) if session
+      end
+
+      teacher_attendance
+    end
+
+    def generate_teacher_summary_line_item
+      attendance = calculate_teacher_attendance
       line_item = {
         teacher_first_name: enrollment.first_name,
         teacher_last_name: enrollment.last_name,
         teacher_id: teacher.try(&:id),
         teacher_email: enrollment.email,
-        plp_name: workshop_summary.plp.try(&:name),
+        plp_name: workshop.regional_partner.try(&:name),
         state: state,
         district_name: school_district.try(&:name),
         district_id: school_district.try(&:id),
@@ -62,27 +62,12 @@ module Pd::Payment
         workshop_id: workshop.id,
         workshop_dates: workshop.sessions.map(&:formatted_date).join(' '),
         workshop_name: workshop.friendly_name,
-        on_map: workshop.on_map,
-        funded: workshop.funding_summary,
         organizer_name: workshop.organizer.name,
         organizer_email: workshop.organizer.email,
         year: workshop.year,
-        hours: hours,
-        days: days
+        hours: attendance.hours,
+        days: attendance.days,
       }
-
-      if with_payment
-        line_item.merge!(
-          {
-            pay_period: workshop_summary.pay_period,
-            payment_type: payment.try(&:type),
-            payment_rate: payment.try(&:rate),
-            qualified: qualified?,
-            payment_amount: payment.try(&:amount)
-          }
-        )
-      end
-
       line_item
     end
   end

--- a/dashboard/lib/pd/payment/teacher_summary.rb
+++ b/dashboard/lib/pd/payment/teacher_summary.rb
@@ -18,6 +18,8 @@ module Pd::Payment
 
     attr_reader(:enrollment, :teacher)
 
+    delegate :workshop, to: :enrollment
+
     def school_district
       enrollment.try(&:school_info).try(&:school_district)
     end
@@ -29,8 +31,6 @@ module Pd::Payment
     def school
       enrollment.try(&:school_name)
     end
-
-    delegate :workshop, to: :enrollment
 
     def calculate_teacher_attendance
       teacher_attendance = TeacherAttendanceTotal.new
@@ -62,8 +62,8 @@ module Pd::Payment
         workshop_id: workshop.id,
         workshop_dates: workshop.sessions.map(&:formatted_date).join(' '),
         workshop_name: workshop.friendly_name,
-        organizer_name: workshop.organizer.name,
-        organizer_email: workshop.organizer.email,
+        organizer_name: workshop.organizer.try(&:name),
+        organizer_email: workshop.organizer.try(&:email),
         year: workshop.year,
         hours: attendance.hours,
         days: attendance.days,

--- a/dashboard/lib/pd/payment/workshop_summary.rb
+++ b/dashboard/lib/pd/payment/workshop_summary.rb
@@ -85,7 +85,6 @@ module Pd::Payment
         regional_partner_name: workshop.regional_partner.try(:name),
         workshop_dates: workshop.sessions.map(&:formatted_date).join(' '),
         num_hours: num_hours,
-        funded: workshop.funding_summary,
         attendance_url: attendance_url,
         num_facilitators: workshop.facilitators.count,
         num_registered: workshop.enrollments.count,

--- a/dashboard/lib/pd/payment/workshop_summary.rb
+++ b/dashboard/lib/pd/payment/workshop_summary.rb
@@ -8,43 +8,19 @@ module Pd::Payment
     # e.g. attendance_day_1
     REPORT_ATTENDANCE_DAY_COUNT = 5
 
-    def initialize(
-      workshop:,
-      pay_period:,
-      num_days:,
-      num_hours:,
-      min_attendance_days:,
-      calculator_class:,
-      attendance_count_per_session:
-    )
+    def initialize(workshop:)
       @workshop = workshop
-      @pay_period = pay_period
-      @num_days = num_days
-      @num_hours = num_hours
-      @min_attendance_days = min_attendance_days
-      @calculator_class = calculator_class
-      @attendance_count_per_session = attendance_count_per_session
-      @teacher_summaries = []
+      @num_days = workshop.sessions.count
+      @attendance_count_per_session = workshop.sessions.map {|s| s.attendances.count}
     end
 
-    attr_reader :workshop, :pay_period, :num_days, :num_hours, :min_attendance_days
-
-    # @return [Class] calculator class that was used to calculate this payment.
-    attr_reader :calculator_class
+    attr_reader :workshop, :num_days
 
     # @return [Array<Integer>] Number of teachers marked attended for each session.
-    # This does not take into account min attendance or max sessions.
     attr_reader :attendance_count_per_session
 
     # @return [Array<TeacherSummary>] teacher summaries for this workshop.
     attr_accessor :teacher_summaries
-
-    # @return [WorkshopPayment] payment information for this workshop.
-    attr_accessor :payment
-
-    def qualified?
-      !payment.nil?
-    end
 
     def attendance_url
       return nil if workshop.sessions.empty?
@@ -56,20 +32,15 @@ module Pd::Payment
     end
 
     def num_teachers
-      teacher_summaries.count
-    end
-
-    def num_qualified_teachers
-      teacher_summaries.count(&:qualified?)
+      session_ids = workshop.sessions.pluck(:id)
+      Pd::Attendance.where(pd_session_id: session_ids).
+        pluck(:teacher_id).
+        uniq.
+        count
     end
 
     def plp
       workshop.regional_partner
-    end
-
-    # @return [Integer] Total adjusted days attended by all qualified teachers (one per teacher per day).
-    def total_teacher_attendance_days
-      teacher_summaries.select(&:qualified?).sum(&:days)
     end
 
     # Get number of teachers attending all sessions, except for admin and counselor PD where logging in
@@ -78,14 +49,13 @@ module Pd::Payment
       workshop.account_required_for_attendance? ? workshop.teachers_attending_all_sessions(filter_by_cdo_scholarship: true).count : nil
     end
 
-    def generate_organizer_report_line_item(with_payment: false)
+    def generate_workshop_summary_line_item
       line_item = {
         organizer_name: workshop.organizer&.name,
         organizer_email: workshop.organizer&.email,
         regional_partner_name: workshop.regional_partner.try(:name),
         workshop_dates: workshop.sessions.map(&:formatted_date).join(' '),
-        num_hours: num_hours,
-        funded: workshop.funding_summary,
+        num_hours: workshop.sessions.sum(&:hours),
         attendance_url: attendance_url,
         num_facilitators: workshop.facilitators.count,
         num_registered: workshop.enrollments.count,
@@ -102,13 +72,12 @@ module Pd::Payment
       line_item.merge!(
         {
           organizer_id: workshop.organizer&.id,
-          on_map: workshop.on_map,
           facilitators: workshop.facilitators.pluck(:name).join(', '),
           workshop_id: workshop.id,
           workshop_name: workshop.friendly_name,
           course: workshop.course,
           subject: workshop.subject,
-          num_qualified_teachers: num_qualified_teachers,
+          num_qualified_teachers: num_teachers,
           days: num_days,
         }
       )
@@ -117,22 +86,6 @@ module Pd::Payment
       (1..REPORT_FACILITATOR_DETAILS_COUNT).each do |n|
         line_item[:"facilitator_name_#{n}"] = workshop.facilitators[n - 1].try(&:name)
         line_item[:"facilitator_email_#{n}"] = workshop.facilitators[n - 1].try(&:email)
-      end
-
-      if with_payment
-        line_item.merge!(
-          {
-            pay_period: pay_period,
-            payment_type: payment.try(&:type),
-            qualified: qualified?,
-            teacher_attendance_days: total_teacher_attendance_days,
-            food_payment: payment.try {|p| p.amounts[:food]},
-            facilitator_payment: payment.try {|p| p.amounts[:facilitator]},
-            staffer_payment: payment.try {|p| p.amounts[:staffer]},
-            venue_payment: payment.try {|p| p.amounts[:venue]},
-            payment_total: payment.try(&:total)
-          }
-        )
       end
 
       line_item

--- a/dashboard/lib/pd/payment/workshop_summary.rb
+++ b/dashboard/lib/pd/payment/workshop_summary.rb
@@ -45,8 +45,12 @@ module Pd::Payment
 
     # Get number of teachers attending all sessions, except for admin and counselor PD where logging in
     # to attend is not required.
+    def num_teachers_attending_all_sessions(filter_by_cdo_scholarship: false)
+      workshop.account_required_for_attendance? ? workshop.teachers_attending_all_sessions(filter_by_cdo_scholarship: filter_by_cdo_scholarship).count : nil
+    end
+
     def num_scholarship_teachers_attending_all_sessions
-      workshop.account_required_for_attendance? ? workshop.teachers_attending_all_sessions(filter_by_cdo_scholarship: true).count : nil
+      num_teachers_attending_all_sessions(filter_by_cdo_scholarship: true)
     end
 
     def generate_workshop_summary_line_item
@@ -59,7 +63,8 @@ module Pd::Payment
         attendance_url: attendance_url,
         num_facilitators: workshop.facilitators.count,
         num_registered: workshop.enrollments.count,
-        num_scholarship_teachers_attending_all_sessions: num_scholarship_teachers_attending_all_sessions
+        num_scholarship_teachers_attending_all_sessions: num_scholarship_teachers_attending_all_sessions,
+        num_teachers_attending_all_sessions: num_teachers_attending_all_sessions
       }
 
       # Attendance days 1-5

--- a/dashboard/lib/pd/summary/teacher_summary.rb
+++ b/dashboard/lib/pd/summary/teacher_summary.rb
@@ -1,0 +1,74 @@
+module Pd::Summary
+  class TeacherSummary
+    TeacherAttendanceTotal = Struct.new(:days, :hours) do
+      def initialize(days = 0, hours = 0)
+        super(days, hours)
+      end
+
+      def add_session(hours)
+        self.days += 1
+        self.hours += hours
+      end
+    end
+
+    def initialize(enrollment:)
+      @teacher = enrollment&.user
+      @enrollment = enrollment
+    end
+
+    attr_reader(:enrollment, :teacher)
+
+    delegate :workshop, to: :enrollment
+
+    def school_district
+      enrollment.try(&:school_info).try(&:school_district)
+    end
+
+    def state
+      enrollment.try(&:school_info).try(&:state)
+    end
+
+    def school
+      enrollment.try(&:school_name)
+    end
+
+    def calculate_teacher_attendance
+      teacher_attendance = TeacherAttendanceTotal.new
+      session_ids = workshop.sessions.pluck(:id)
+      attendances = Pd::Attendance.where(pd_session_id: session_ids, teacher_id: teacher.id)
+
+      attendances.each do |attendance|
+        session = workshop.sessions.find {|s| s.id == attendance.pd_session_id}
+        teacher_attendance.add_session(session.hours) if session
+      end
+
+      teacher_attendance
+    end
+
+    def generate_teacher_summary_line_item
+      attendance = calculate_teacher_attendance
+      line_item = {
+        teacher_first_name: enrollment.first_name,
+        teacher_last_name: enrollment.last_name,
+        teacher_id: teacher.try(&:id),
+        teacher_email: enrollment.email,
+        plp_name: workshop.regional_partner.try(&:name),
+        state: state,
+        district_name: school_district.try(&:name),
+        district_id: school_district.try(&:id),
+        school: school,
+        course: workshop.course,
+        subject: workshop.subject,
+        workshop_id: workshop.id,
+        workshop_dates: workshop.sessions.map(&:formatted_date).join(' '),
+        workshop_name: workshop.friendly_name,
+        organizer_name: workshop.organizer.try(&:name),
+        organizer_email: workshop.organizer.try(&:email),
+        year: workshop.year,
+        hours: attendance.hours,
+        days: attendance.days,
+      }
+      line_item
+    end
+  end
+end

--- a/dashboard/lib/pd/summary/workshop_summary.rb
+++ b/dashboard/lib/pd/summary/workshop_summary.rb
@@ -1,4 +1,4 @@
-module Pd::Payment
+module Pd::Summary
   class WorkshopSummary
     # Number of columns for facilitator details, name and email
     # e.g. facilitator_name_1 and facilitator_email_1
@@ -8,43 +8,19 @@ module Pd::Payment
     # e.g. attendance_day_1
     REPORT_ATTENDANCE_DAY_COUNT = 5
 
-    def initialize(
-      workshop:,
-      pay_period:,
-      num_days:,
-      num_hours:,
-      min_attendance_days:,
-      calculator_class:,
-      attendance_count_per_session:
-    )
+    def initialize(workshop:)
       @workshop = workshop
-      @pay_period = pay_period
-      @num_days = num_days
-      @num_hours = num_hours
-      @min_attendance_days = min_attendance_days
-      @calculator_class = calculator_class
-      @attendance_count_per_session = attendance_count_per_session
-      @teacher_summaries = []
+      @num_days = workshop.sessions.count
+      @attendance_count_per_session = workshop.sessions.map {|s| s.attendances.count}
     end
 
-    attr_reader :workshop, :pay_period, :num_days, :num_hours, :min_attendance_days
-
-    # @return [Class] calculator class that was used to calculate this payment.
-    attr_reader :calculator_class
+    attr_reader :workshop, :num_days
 
     # @return [Array<Integer>] Number of teachers marked attended for each session.
-    # This does not take into account min attendance or max sessions.
     attr_reader :attendance_count_per_session
 
     # @return [Array<TeacherSummary>] teacher summaries for this workshop.
     attr_accessor :teacher_summaries
-
-    # @return [WorkshopPayment] payment information for this workshop.
-    attr_accessor :payment
-
-    def qualified?
-      !payment.nil?
-    end
 
     def attendance_url
       return nil if workshop.sessions.empty?
@@ -56,40 +32,39 @@ module Pd::Payment
     end
 
     def num_teachers
-      teacher_summaries.count
-    end
-
-    def num_qualified_teachers
-      teacher_summaries.count(&:qualified?)
+      session_ids = workshop.sessions.pluck(:id)
+      Pd::Attendance.where(pd_session_id: session_ids).
+        pluck(:teacher_id).
+        uniq.
+        count
     end
 
     def plp
       workshop.regional_partner
     end
 
-    # @return [Integer] Total adjusted days attended by all qualified teachers (one per teacher per day).
-    def total_teacher_attendance_days
-      teacher_summaries.select(&:qualified?).sum(&:days)
-    end
-
     # Get number of teachers attending all sessions, except for admin and counselor PD where logging in
     # to attend is not required.
-    def num_scholarship_teachers_attending_all_sessions
-      workshop.account_required_for_attendance? ? workshop.teachers_attending_all_sessions(filter_by_cdo_scholarship: true).count : nil
+    def num_teachers_attending_all_sessions(filter_by_cdo_scholarship: false)
+      workshop.account_required_for_attendance? ? workshop.teachers_attending_all_sessions(filter_by_cdo_scholarship: filter_by_cdo_scholarship).count : nil
     end
 
-    def generate_organizer_report_line_item(with_payment: false)
+    def num_scholarship_teachers_attending_all_sessions
+      num_teachers_attending_all_sessions(filter_by_cdo_scholarship: true)
+    end
+
+    def generate_workshop_summary_line_item
       line_item = {
         organizer_name: workshop.organizer&.name,
         organizer_email: workshop.organizer&.email,
         regional_partner_name: workshop.regional_partner.try(:name),
         workshop_dates: workshop.sessions.map(&:formatted_date).join(' '),
-        num_hours: num_hours,
-        funded: workshop.funding_summary,
+        num_hours: workshop.sessions.sum(&:hours),
         attendance_url: attendance_url,
         num_facilitators: workshop.facilitators.count,
         num_registered: workshop.enrollments.count,
-        num_scholarship_teachers_attending_all_sessions: num_scholarship_teachers_attending_all_sessions
+        num_scholarship_teachers_attending_all_sessions: num_scholarship_teachers_attending_all_sessions,
+        num_teachers_attending_all_sessions: num_teachers_attending_all_sessions
       }
 
       # Attendance days 1-5
@@ -102,13 +77,12 @@ module Pd::Payment
       line_item.merge!(
         {
           organizer_id: workshop.organizer&.id,
-          on_map: workshop.on_map,
           facilitators: workshop.facilitators.pluck(:name).join(', '),
           workshop_id: workshop.id,
           workshop_name: workshop.friendly_name,
           course: workshop.course,
           subject: workshop.subject,
-          num_qualified_teachers: num_qualified_teachers,
+          num_qualified_teachers: num_teachers,
           days: num_days,
         }
       )
@@ -117,22 +91,6 @@ module Pd::Payment
       (1..REPORT_FACILITATOR_DETAILS_COUNT).each do |n|
         line_item[:"facilitator_name_#{n}"] = workshop.facilitators[n - 1].try(&:name)
         line_item[:"facilitator_email_#{n}"] = workshop.facilitators[n - 1].try(&:email)
-      end
-
-      if with_payment
-        line_item.merge!(
-          {
-            pay_period: pay_period,
-            payment_type: payment.try(&:type),
-            qualified: qualified?,
-            teacher_attendance_days: total_teacher_attendance_days,
-            food_payment: payment.try {|p| p.amounts[:food]},
-            facilitator_payment: payment.try {|p| p.amounts[:facilitator]},
-            staffer_payment: payment.try {|p| p.amounts[:staffer]},
-            venue_payment: payment.try {|p| p.amounts[:venue]},
-            payment_total: payment.try(&:total)
-          }
-        )
       end
 
       line_item

--- a/dashboard/lib/pd/summary/workshop_summary.rb
+++ b/dashboard/lib/pd/summary/workshop_summary.rb
@@ -64,7 +64,15 @@ module Pd::Summary
         num_facilitators: workshop.facilitators.count,
         num_registered: workshop.enrollments.count,
         num_scholarship_teachers_attending_all_sessions: num_scholarship_teachers_attending_all_sessions,
-        num_teachers_attending_all_sessions: num_teachers_attending_all_sessions
+        num_teachers_attending_all_sessions: num_teachers_attending_all_sessions,
+        organizer_id: workshop.organizer&.id,
+        facilitators: workshop.facilitators.pluck(:name).join(', '),
+        workshop_id: workshop.id,
+        workshop_name: workshop.friendly_name,
+        course: workshop.course,
+        subject: workshop.subject,
+        num_qualified_teachers: num_teachers,
+        days: num_days,
       }
 
       # Attendance days 1-5
@@ -72,20 +80,6 @@ module Pd::Summary
       (1..REPORT_ATTENDANCE_DAY_COUNT).each do |n|
         line_item[:"attendance_day_#{n}"] = session_attendance_counts[n - 1]
       end
-
-      # Waiting to add some columns until after attendance to make payment processing easier
-      line_item.merge!(
-        {
-          organizer_id: workshop.organizer&.id,
-          facilitators: workshop.facilitators.pluck(:name).join(', '),
-          workshop_id: workshop.id,
-          workshop_name: workshop.friendly_name,
-          course: workshop.course,
-          subject: workshop.subject,
-          num_qualified_teachers: num_teachers,
-          days: num_days,
-        }
-      )
 
       # Facilitator names and emails, 1-6
       (1..REPORT_FACILITATOR_DETAILS_COUNT).each do |n|

--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class Api::V1::Pd::TeacherAttendanceReportControllerTest < ActionController::TestCase
-  freeze_time
-
   EXPECTED_COMMON_FIELDS = %w(
     teacher_first_name
     teacher_last_name
@@ -26,6 +24,11 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ActionController::Tes
   ).freeze
 
   self.use_transactional_test_case = true
+
+  setup_all do
+    travel_to Time.zone.parse('2025-01-15 12:00:00')
+  end
+
   setup do
     @workshop_admin = create :workshop_admin
     @organizer = create :workshop_organizer
@@ -208,7 +211,6 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ActionController::Tes
     assert_equal EXPECTED_COMMON_FIELDS.count, response.first.count
 
     # Check that column 11 in the header row is workshop id
-    puts response.first.to_json
     assert_equal 'Workshop Id', response.first[11]
 
     # Check expected row counts for our test workshops

--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -18,8 +18,6 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ActionController::Tes
     workshop_id
     workshop_dates
     workshop_name
-    on_map
-    funded
     organizer_name
     organizer_email
     year
@@ -27,141 +25,100 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ActionController::Tes
     days
   ).freeze
 
-  EXPECTED_PAYMENT_FIELDS = %w(
-    pay_period
-    payment_type
-    payment_rate
-    qualified
-    payment_amount
-  ).freeze
-
   self.use_transactional_test_case = true
-  setup_all do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
+  setup do
     @workshop_admin = create :workshop_admin
     @organizer = create :workshop_organizer
     @program_manager = create :program_manager
 
-    # CSF workshop from this program manager with 10 teachers.
-    @pm_workshop = create :workshop, :ended,
-      organizer: @program_manager,
-      course: Pd::Workshop::COURSE_CSF,
-      started_at: 1.day.ago,
-      ended_at: 1.day.ago,
-      sessions_from: 1.day.ago
-    10.times do
-      create :pd_workshop_participant, workshop: @pm_workshop, enrolled: true, attended: true
-    end
+    # CSF workshop for this program manager with 10 teachers
+    @pm_workshop = build :workshop, :ended, organizer: @program_manager, course: Pd::Workshop::COURSE_CSF, enrolled_and_attending_users: 3
+    @pm_workshop.save(validate: false)
 
-    # CSF workshop from this organizer with 10 teachers.
-    @workshop = create :workshop, :ended,
-      organizer: @organizer,
-      course: Pd::Workshop::COURSE_CSF,
-      started_at: 1.day.ago,
-      ended_at: 1.day.ago,
-      sessions_from: 1.day.ago
-    10.times do
-      create :pd_workshop_participant, workshop: @workshop, enrolled: true, attended: true
-    end
+    # CSF workshop for this organizer with 2 teachers
+    @workshop = build :workshop, :ended, organizer: @organizer, course: Pd::Workshop::COURSE_CSF, enrolled_and_attending_users: 2
+    @workshop.save(validate: false)
 
-    # Non-CSF workshop from a different organizer, with 1 teacher.
-    @other_workshop = create :workshop, :ended,
-      course: Pd::Workshop::COURSE_ECS,
-      subject: Pd::Workshop::SUBJECT_ECS_PHASE_2,
-      started_at: 1.day.ago,
-      ended_at: 1.day.ago,
-      sessions_from: 1.day.ago
-    create :pd_workshop_participant, workshop: @other_workshop, enrolled: true, attended: true
+    # Non-CSF workshop from a different organizer, with 1 teacher
+    @other_workshop = create :byo_workshop, :ended, enrolled_and_attending_users: 1
   end
 
-  # -- SKIP -- Setup method fails 6 hours per day due to time zone differences
-  # test_user_gets_response_for :index, user: :workshop_admin
-  # test_user_gets_response_for :index, user: :workshop_organizer
-  # test_user_gets_response_for :index, user: :program_manager
-  # test_user_gets_response_for :index, response: :forbidden, user: :teacher
+  [:admin, :workshop_organizer, :program_manager].each do |user_type|
+    test_user_gets_response_for :index, user: user_type
+  end
 
-  test 'workshop admins get payment info' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
+  test_user_gets_response_for :index, response: :forbidden, user: :teacher
+
+  test 'workshop admins get teacher attendance info' do
     sign_in @workshop_admin
 
     get :index
     assert_response :success
     response = JSON.parse(@response.body)
 
+    assert response.first
     assert_common_fields response.first
-    assert_payment_fields response.first
   end
 
-  test 'organizers do not get payment info' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
+  test 'organizers get teacher attendance info' do
     sign_in @organizer
 
     get :index
     assert_response :success
     response = JSON.parse(@response.body)
 
+    assert response.first
     assert_common_fields response.first
-    refute_payment_fields response.first
   end
 
-  test 'program managers do not get payment info' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
+  test 'program managers get teacher attendance info' do
     sign_in @program_manager
 
     get :index
     assert_response :success
     response = JSON.parse(@response.body)
 
+    assert response.first
     assert_common_fields response.first
-    refute_payment_fields response.first
   end
 
-  test 'workshop admins see all workshops' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
+  test 'workshop admins see all teacher attendance info' do
     sign_in @workshop_admin
 
     get :index
     assert_response :success
     response = JSON.parse(@response.body)
-
-    assert_equal 21, response.count
+    # 3 + 2 + 1 teachers
+    assert_equal 6, response.count
     assert_equal [@pm_workshop.id, @workshop.id, @other_workshop.id].sort, response.map {|r| r['workshop_id']}.uniq.sort
   end
 
-  test 'organizers only see their own workshops' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
+  test 'organizers only see their own teachers attendance info' do
     sign_in @organizer
 
     get :index
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal 10, response.count
+    assert_equal 2, response.count
     assert_equal [@workshop.id], response.map {|r| r['workshop_id']}.uniq
   end
 
-  test 'program managers only see their own workshops' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
+  test 'program managers only see their own teachers attendance info' do
     sign_in @program_manager
 
     get :index
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal 10, response.count
+    assert_equal 3, response.count
     assert_equal [@pm_workshop.id], response.map {|r| r['workshop_id']}.uniq
   end
 
-  test 'Returns only workshops that have ended and have teachers' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
-    # Workshop, not ended, with teachers
-    # This workshop should not be returned
-    workshop_in_progress = create :workshop
+  test 'returns only workshops that have ended and have teachers' do
+    # Workshop, not ended, with teachers (should not be returned)
+    workshop_in_progress = create :workshop, enrolled_and_attending_users: 2
     workshop_in_progress.start!
-    5.times do
-      create :pd_workshop_participant, workshop: workshop_in_progress, enrolled: true, attended: true
-    end
 
-    # Workshop, ended, with no teachers
-    # This workshop should not be returned
+    # Workshop, ended, with no teachers (should not be returned)
     teacherless_workshop = create :workshop, :ended
 
     sign_in @workshop_admin
@@ -170,18 +127,14 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ActionController::Tes
     response = JSON.parse(@response.body)
     workshops_returned = response.map {|r| r['workshop_id']}.uniq
 
-    # Ensure we see responses for the eligible workshops (see setup_all)
     assert_includes workshops_returned, @pm_workshop.id
     assert_includes workshops_returned, @workshop.id
     assert_includes workshops_returned, @other_workshop.id
-
-    # Ensure we do not see responses for the ineligible workshops
     refute_includes workshops_returned, workshop_in_progress.id
     refute_includes workshops_returned, teacherless_workshop.id
   end
 
   test 'filter by schedule' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
     start_date = Time.zone.today - 6.months
     end_date = start_date + 1.month
 
@@ -206,7 +159,6 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ActionController::Tes
   end
 
   test 'filter by end date' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
     start_date = Time.zone.today - 6.months
     end_date = start_date + 1.month
 
@@ -231,57 +183,43 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ActionController::Tes
   end
 
   test 'filter by course' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @workshop_admin
 
     # @pm_workshop and @workshop are CSF; @other_workshop is not
     {
-      'csf' => {workshop_id: [@pm_workshop.id, @workshop.id], teacher_count: 20},
-      '-csf' => {workshop_id: [@other_workshop.id], teacher_count: 1}
+      'csf' => [@pm_workshop.id, @workshop.id],
+      '-csf' => [@other_workshop.id]
     }.each do |course_param, expected|
       get :index, params: {course: course_param}
       assert_response :success
       response = JSON.parse(@response.body)
-      assert_equal expected[:teacher_count], response.count
-      assert_equal expected[:workshop_id], response.map {|r| r['workshop_id']}.uniq.sort
+      assert_equal expected, response.map {|r| r['workshop_id']}.uniq.sort
     end
   end
 
   test 'csv' do
-    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @workshop_admin
     get :index, format: :csv
     assert_response :success
     response = CSV.parse(@response.body)
 
-    # Check that we have the expected number of columns in the header row
-    assert_equal EXPECTED_COMMON_FIELDS.count + EXPECTED_PAYMENT_FIELDS.count, response.first.count
+    # 6 teacher attendances + 1 header row
+    assert_equal 7, response.count
+    assert_equal EXPECTED_COMMON_FIELDS.count, response.first.count
 
     # Check that column 11 in the header row is workshop id
+    puts response.first.to_json
     assert_equal 'Workshop Id', response.first[11]
 
     # Check expected row counts for our test workshops
-    # (We don't count all rows to insulate this test against existing state)
-    assert_equal(10, response.count {|row| row[11] == @pm_workshop.id.to_s})
-    assert_equal(10, response.count {|row| row[11] == @workshop.id.to_s})
+    assert_equal(3, response.count {|row| row[11] == @pm_workshop.id.to_s})
+    assert_equal(2, response.count {|row| row[11] == @workshop.id.to_s})
     assert_equal(1, response.count {|row| row[11] == @other_workshop.id.to_s})
   end
 
   private def assert_common_fields(line)
     EXPECTED_COMMON_FIELDS.each do |field_name|
       assert line.key?(field_name), "Expected common field #{field_name} not found in report line: #{line}"
-    end
-  end
-
-  private def assert_payment_fields(line)
-    EXPECTED_PAYMENT_FIELDS.each do |field_name|
-      assert line.key?(field_name), "Expected payment field #{field_name} not found in report line: #{line}"
-    end
-  end
-
-  private def refute_payment_fields(line)
-    EXPECTED_PAYMENT_FIELDS.each do |field_name|
-      refute line.key?(field_name), "Unexpected payment field #{field_name} found in report line: #{line}"
     end
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -447,7 +447,7 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
 
   test 'move' do
     origin_workshop = create :pd_workshop, num_sessions: 1, enrolled_and_attending_users: 1,
-      enrolled_unattending_users: 1
+      enrolled_absent_users: 1
     attendance = Pd::Attendance.for_workshop(origin_workshop).first
     attendance.update(pd_enrollment_id: origin_workshop.enrollments.first.id)
     destination_workshop = create :pd_workshop

--- a/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
@@ -9,8 +9,6 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
     organizer_email
     regional_partner_name
     workshop_dates
-    on_map
-    funded
     attendance_url
     facilitators
     num_facilitators
@@ -32,18 +30,6 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
       fields << "attendance_day_#{n}"
     end
   end.freeze
-
-  EXPECTED_PAYMENT_FIELDS = %w(
-    pay_period
-    payment_type
-    qualified
-    teacher_attendance_days
-    food_payment
-    facilitator_payment
-    staffer_payment
-    venue_payment
-    payment_total
-  ).freeze
 
   self.use_transactional_test_case = true
   setup do
@@ -71,7 +57,7 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
 
   test_user_gets_response_for :index, response: :forbidden, user: :teacher
 
-  test 'workshop admins get payment info' do
+  test 'workshop admins get summary info' do
     sign_in @workshop_admin
 
     get :index
@@ -80,10 +66,9 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
 
     assert response.first
     assert_common_fields response.first
-    assert_payment_fields response.first
   end
 
-  test 'organizers do not get payment info' do
+  test 'organizers get summary info' do
     sign_in @organizer
 
     get :index
@@ -92,10 +77,9 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
 
     assert response.first
     assert_common_fields response.first
-    refute_payment_fields response.first
   end
 
-  test 'program managers do not get payment info' do
+  test 'program managers get summary info' do
     sign_in @program_manager
 
     get :index
@@ -104,7 +88,6 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
 
     assert response.first
     assert_common_fields response.first
-    refute_payment_fields response.first
   end
 
   test 'workshop admins see all workshops' do
@@ -190,6 +173,7 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
     sign_in @workshop_admin
 
     # @workshop and @organizer_workshop are CSF; @other_workshop is not
+    # despite csf being deprecated, the workshop filters only apply to csf presently
     {
       'csf' => [@workshop.id, @organizer_workshop.id],
       '-csf' => [@other_workshop.id]
@@ -209,39 +193,12 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
 
     # 4 rows (header + workshop rows)
     assert_equal 4, response.count
-    assert_equal EXPECTED_COMMON_FIELDS.count + EXPECTED_PAYMENT_FIELDS.count, response.first.count
-  end
-
-  test 'includes unpaid workshops' do
-    unpaid_workshop = create :workshop, :ended, organizer: @program_manager, course: Pd::Workshop::COURSE_CSD
-    create :pd_workshop_participant, workshop: @workshop, enrolled: true, attended: true
-
-    sign_in @workshop_admin
-    get :index
-    assert_response :success
-    response = JSON.parse(@response.body)
-    assert_equal 4, response.count
-    unpaid_report = response.find {|row| row['workshop_id'] == unpaid_workshop.id}
-    refute_nil unpaid_report
-    refute unpaid_report['qualified']
-    assert_nil unpaid_report['payment_total']
+    assert_equal EXPECTED_COMMON_FIELDS.count, response.first.count
   end
 
   private def assert_common_fields(line)
     EXPECTED_COMMON_FIELDS.each do |field_name|
       assert line.key?(field_name), "Expected common field #{field_name} not found in report line: #{line}"
-    end
-  end
-
-  private def assert_payment_fields(line)
-    EXPECTED_PAYMENT_FIELDS.each do |field_name|
-      assert line.key?(field_name), "Expected payment field #{field_name} not found in report line: #{line}"
-    end
-  end
-
-  private def refute_payment_fields(line)
-    EXPECTED_PAYMENT_FIELDS.each do |field_name|
-      refute line.key?(field_name), "Unexpected payment field #{field_name} found in report line: #{line}"
     end
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
@@ -21,6 +21,7 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
     days
     num_hours
     num_scholarship_teachers_attending_all_sessions
+    num_teachers_attending_all_sessions
   ).tap do |fields|
     (1..Pd::Payment::WorkshopSummary::REPORT_FACILITATOR_DETAILS_COUNT).each do |n|
       fields << "facilitator_name_#{n}"

--- a/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
@@ -23,11 +23,11 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ActionController::TestC
     num_scholarship_teachers_attending_all_sessions
     num_teachers_attending_all_sessions
   ).tap do |fields|
-    (1..Pd::Payment::WorkshopSummary::REPORT_FACILITATOR_DETAILS_COUNT).each do |n|
+    (1..Pd::Summary::WorkshopSummary::REPORT_FACILITATOR_DETAILS_COUNT).each do |n|
       fields << "facilitator_name_#{n}"
       fields << "facilitator_email_#{n}"
     end
-    (1..Pd::Payment::WorkshopSummary::REPORT_ATTENDANCE_DAY_COUNT).each do |n|
+    (1..Pd::Summary::WorkshopSummary::REPORT_ATTENDANCE_DAY_COUNT).each do |n|
       fields << "attendance_day_#{n}"
     end
   end.freeze

--- a/dashboard/test/controllers/api/v1/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/regional_partners_controller_test.rb
@@ -282,7 +282,7 @@ class Api::V1::RegionalPartnersControllerTest < ActionController::TestCase
       create :workshop,
         course: course,
         subject: subject,
-        enrolled_unattending_users: index,
+        enrolled_absent_users: index,
         sessions_from: application_year_start_date,
         regional_partner: @regional_partner
     end

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
       each_session_hours {6}
       num_enrollments {0}
       enrolled_and_attending_users {0}
-      enrolled_unattending_users {0}
+      enrolled_absent_users {0}
       assign_session_code {false}
     end
 
@@ -96,7 +96,7 @@ FactoryBot.define do
           session.attendances << build(:pd_attendance, session: session, teacher: teacher)
         end
       end
-      evaluator.enrolled_unattending_users.times do
+      evaluator.enrolled_absent_users.times do
         teacher = create :teacher
         workshop.enrollments << build(:pd_enrollment, workshop: workshop, user: teacher)
       end

--- a/dashboard/test/lib/pd/payment/teacher_summary_test.rb
+++ b/dashboard/test/lib/pd/payment/teacher_summary_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+module Pd::Payment
+  class TeacherSummaryTest < ActiveSupport::TestCase
+    setup do
+      @workshop = create :workshop, :ended, enrolled_and_attending_users: 1, enrolled_absent_users: 1, num_sessions: 2
+      @enrollment = @workshop.enrollments.first
+      @teacher_summary = TeacherSummary.new(enrollment: @enrollment)
+    end
+
+    test 'teacher attributes are set correctly' do
+      assert_equal @enrollment.user, @teacher_summary.teacher
+      assert_equal @enrollment, @teacher_summary.enrollment
+    end
+
+    test 'school, district, and state are returned correctly' do
+      assert_equal @enrollment.school_name, @teacher_summary.school
+      assert_equal @enrollment.school_info&.school_district, @teacher_summary.school_district
+      assert_equal @enrollment.school_info&.state, @teacher_summary.state
+    end
+
+    test 'calculate_teacher_attendance returns correct days and hours' do
+      attendance = @teacher_summary.calculate_teacher_attendance
+      assert_kind_of TeacherSummary::TeacherAttendanceTotal, attendance
+      assert_equal attendance.days, 2
+      assert_equal attendance.hours, 12
+    end
+
+    test 'generate_teacher_summary_line_item returns expected summary' do
+      line_item = @teacher_summary.generate_teacher_summary_line_item
+      assert_equal @enrollment.first_name, line_item[:teacher_first_name]
+      assert_equal @enrollment.last_name, line_item[:teacher_last_name]
+      assert_equal @enrollment.user&.id, line_item[:teacher_id]
+      assert_equal @enrollment.email, line_item[:teacher_email]
+      assert_equal @workshop.regional_partner.try(:name), line_item[:plp_name]
+      assert_equal @enrollment.school_info&.state, line_item[:state]
+      assert_equal @enrollment.school_info&.school_district&.name, line_item[:district_name]
+      assert_equal @enrollment.school_info&.school_district&.id, line_item[:district_id]
+      assert_equal @enrollment.school_name, line_item[:school]
+      assert_equal @workshop.course, line_item[:course]
+      assert_equal @workshop.subject, line_item[:subject]
+      assert_equal @workshop.id, line_item[:workshop_id]
+      assert_equal @workshop.friendly_name, line_item[:workshop_name]
+      assert_equal @workshop.organizer&.name, line_item[:organizer_name]
+      assert_equal @workshop.organizer&.email, line_item[:organizer_email]
+      assert_equal @workshop.year, line_item[:year]
+      assert_kind_of Numeric, line_item[:hours]
+      assert_kind_of Numeric, line_item[:days]
+      assert_kind_of String, line_item[:workshop_dates]
+      assert line_item[:workshop_dates].present?
+    end
+
+    test 'handles missing organizer gracefully' do
+      @workshop.organizer.destroy
+      @workshop.reload
+      teacher_summary = TeacherSummary.new(enrollment: @enrollment.reload)
+      line_item = teacher_summary.generate_teacher_summary_line_item
+      assert_nil line_item[:organizer_name]
+      assert_nil line_item[:organizer_email]
+    end
+  end
+end

--- a/dashboard/test/lib/pd/payment/workshop_summary_test.rb
+++ b/dashboard/test/lib/pd/payment/workshop_summary_test.rb
@@ -3,16 +3,8 @@ require 'test_helper'
 module Pd::Payment
   class WorkshopSummaryTest < ActiveSupport::TestCase
     setup do
-      @ended_workshop = create :workshop, :ended
-      @workshop_summary = WorkshopSummary.new(
-        workshop: @ended_workshop,
-        pay_period: 'a pay period',
-        num_days: 1,
-        num_hours: 6,
-        min_attendance_days: 1,
-        calculator_class: PaymentCalculatorBase,
-        attendance_count_per_session: [0]
-      )
+      @ended_workshop = create :workshop, :ended, enrolled_and_attending_users: 2, enrolled_absent_users: 2, num_sessions: 2
+      @workshop_summary = WorkshopSummary.new(workshop: @ended_workshop)
     end
 
     test 'attendance_url' do
@@ -23,46 +15,87 @@ module Pd::Payment
       )
     end
 
+    test 'workshop_url' do
+      refute_nil @workshop_summary.workshop_url
+      assert_includes(
+        @workshop_summary.workshop_url,
+        "/pd/workshop_dashboard/workshops/#{@ended_workshop.id}"
+      )
+    end
+
+    test 'num_teachers' do
+      refute_nil @workshop_summary.num_teachers
+      assert_equal(
+        2,
+        @workshop_summary.num_teachers
+      )
+    end
+
     test 'leaves out organizer info when organizer has been deleted' do
       @ended_workshop.organizer.destroy
       @ended_workshop.reload
 
-      report = @workshop_summary.generate_organizer_report_line_item
+      report = @workshop_summary.generate_workshop_summary_line_item
       assert_nil report[:organizer_email]
       assert_nil report[:organizer_name]
       assert_nil report[:organizer_id]
     end
 
+    test 'workshop summary reports attendance count for all sessions attendance for regular workshops' do
+      report = @workshop_summary.generate_workshop_summary_line_item
+      assert_equal 2, report[:num_scholarship_teachers_attending_all_sessions]
+    end
+
     test 'workshop summary reports nil for attendance count for all sessions attendance for admin workshop' do
-      @ended_admin_workshop = build :admin_workshop, :ended
+      @ended_admin_workshop = build :admin_workshop, :ended, enrolled_and_attending_users: 2, enrolled_absent_users: 2, num_sessions: 2
       @ended_admin_workshop.save(validate: false)
-      @workshop_summary = WorkshopSummary.new(
-        workshop: @ended_admin_workshop,
-        pay_period: 'a pay period',
-        num_days: 1,
-        num_hours: 6,
-        min_attendance_days: 1,
-        calculator_class: PaymentCalculatorBase,
-        attendance_count_per_session: [1]
-      )
-      report = @workshop_summary.generate_organizer_report_line_item
+      @workshop_summary = WorkshopSummary.new(workshop: @ended_admin_workshop)
+      report = @workshop_summary.generate_workshop_summary_line_item
       assert_nil report[:num_scholarship_teachers_attending_all_sessions]
     end
 
     test 'workshop summary reports nil for attendance count for all sessions attendance for admin/counselor workshop' do
-      @ended_admin_counselor_workshop = create :admin_counselor_workshop, :ended
-      @workshop_summary = WorkshopSummary.new(
-        workshop: @ended_admin_counselor_workshop,
-        pay_period: 'a pay period',
-        num_days: 1,
-        num_hours: 6,
-        min_attendance_days: 1,
-        calculator_class: PaymentCalculatorBase,
-        attendance_count_per_session: [1]
-      )
-      report = @workshop_summary.generate_organizer_report_line_item
+      @ended_admin_counselor_workshop = create :admin_counselor_workshop, :ended, enrolled_and_attending_users: 2, enrolled_absent_users: 2, num_sessions: 2
+      @workshop_summary = WorkshopSummary.new(workshop: @ended_admin_counselor_workshop)
+      report = @workshop_summary.generate_workshop_summary_line_item
 
       assert_nil report[:num_scholarship_teachers_attending_all_sessions]
+    end
+
+    test 'generate_workshop_summary_line_item returns expected summary' do
+      report = @workshop_summary.generate_workshop_summary_line_item
+
+      assert_equal @ended_workshop.organizer&.name, report[:organizer_name]
+      assert_equal @ended_workshop.organizer&.email, report[:organizer_email]
+      assert_equal @ended_workshop.regional_partner.try(:name), report[:regional_partner_name]
+      assert_equal @ended_workshop.sessions.sum(&:hours), report[:num_hours]
+      assert_equal @workshop_summary.attendance_url, report[:attendance_url]
+      assert_equal @ended_workshop.facilitators.count, report[:num_facilitators]
+      assert_equal @ended_workshop.enrollments.count, report[:num_registered]
+      assert_equal @workshop_summary.num_scholarship_teachers_attending_all_sessions, report[:num_scholarship_teachers_attending_all_sessions]
+      assert_equal 2, report[:attendance_day_1]
+      assert_equal 2, report[:attendance_day_2]
+      assert_nil report[:attendance_day_3]
+      assert_nil report[:attendance_day_4]
+      assert_nil report[:attendance_day_5]
+      assert_equal @ended_workshop.organizer&.id, report[:organizer_id]
+      assert_equal "", report[:facilitators]
+      assert_equal @ended_workshop.id, report[:workshop_id]
+      assert_equal @ended_workshop.course, report[:course]
+      assert_equal @ended_workshop.subject, report[:subject]
+      assert_equal 2, report[:num_qualified_teachers]
+      assert_equal 2, report[:days]
+
+      (1..6).each do |i|
+        assert_nil report[:"facilitator_name_#{i}"]
+        assert_nil report[:"facilitator_email_#{i}"]
+      end
+
+      assert_kind_of String, report[:workshop_name]
+      assert report[:workshop_name].present?
+
+      assert_kind_of String, report[:workshop_dates]
+      assert report[:workshop_dates].present?
     end
   end
 end

--- a/dashboard/test/lib/pd/payment/workshop_summary_test.rb
+++ b/dashboard/test/lib/pd/payment/workshop_summary_test.rb
@@ -43,7 +43,8 @@ module Pd::Payment
 
     test 'workshop summary reports attendance count for all sessions attendance for regular workshops' do
       report = @workshop_summary.generate_workshop_summary_line_item
-      assert_equal 2, report[:num_scholarship_teachers_attending_all_sessions]
+      assert_equal 2, report[:num_teachers_attending_all_sessions]
+      assert_equal 0, report[:num_scholarship_teachers_attending_all_sessions]
     end
 
     test 'workshop summary reports nil for attendance count for all sessions attendance for admin workshop' do
@@ -51,6 +52,7 @@ module Pd::Payment
       @ended_admin_workshop.save(validate: false)
       @workshop_summary = WorkshopSummary.new(workshop: @ended_admin_workshop)
       report = @workshop_summary.generate_workshop_summary_line_item
+      assert_nil report[:num_teachers_attending_all_sessions]
       assert_nil report[:num_scholarship_teachers_attending_all_sessions]
     end
 
@@ -58,7 +60,7 @@ module Pd::Payment
       @ended_admin_counselor_workshop = create :admin_counselor_workshop, :ended, enrolled_and_attending_users: 2, enrolled_absent_users: 2, num_sessions: 2
       @workshop_summary = WorkshopSummary.new(workshop: @ended_admin_counselor_workshop)
       report = @workshop_summary.generate_workshop_summary_line_item
-
+      assert_nil report[:num_teachers_attending_all_sessions]
       assert_nil report[:num_scholarship_teachers_attending_all_sessions]
     end
 

--- a/dashboard/test/lib/pd/summary/teacher_summary_test.rb
+++ b/dashboard/test/lib/pd/summary/teacher_summary_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-module Pd::Payment
+module Pd::Summary
   class TeacherSummaryTest < ActiveSupport::TestCase
     setup do
       @workshop = create :workshop, :ended, enrolled_and_attending_users: 1, enrolled_absent_users: 1, num_sessions: 2

--- a/dashboard/test/lib/pd/summary/workshop_summary_test.rb
+++ b/dashboard/test/lib/pd/summary/workshop_summary_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-module Pd::Payment
+module Pd::Summary
   class WorkshopSummaryTest < ActiveSupport::TestCase
     setup do
       @ended_workshop = create :workshop, :ended, enrolled_and_attending_users: 2, enrolled_absent_users: 2, num_sessions: 2


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Workshop and teacher summaries were tightly coupled, to where you needed to calculate payment before you could create a workshop summary, and you needed the workshop summary before you could create teacher summaries. By deprecating workshop payment, the summaries could be generated independently from each other. This pr refactors summary modules to remove any payment related fields and cleans up the initializers, so a `WorkshopSummary` is initialized with just a workshop, and a `TeacherSummary` is initialized with just an enrollment. I decided to preserve the original `WorkshopSummary` and `TeacherSummary` under the `Pd::Payment` module and create a new` Pd::Summary` module for the refactored summary modules. See this [commit](https://github.com/code-dot-org/code-dot-org/pull/66844/commits/5e7696d3377d869c1035ec8a2c36e1d1e7878bbe) for the refactor diff. Teacher attendance calculations were largely copied over from `payment_calculator_base` and moved into the `TeacherSummary` module.

also in this pr:
- added a `num_teachers_attending_all_sessions` value since it seemed useful, and the closest other value was `num_scholarship_teachers_attending_all_sessions` and I'm unsure if the scholarship stuff can go away with the payment stuff
- de-flaked and un-skipped the `teacher_attendance_report_controller` tests
  - replaced `freeze_time` (set when tests are run) with `travel_to` (set a specific datetime)
- some renaming
  - comments in controllers were outdated and misleading
  - renamed a transient workshop factory attribute

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3372
- Jira: https://codedotorg.atlassian.net/browse/ACQ-3295 (de-flake and un-skip unit tests)

## Testing story
- adds new teacher_summary_test unit tests
- updates workshop_summary_test unit tests
- updates workshop_summary_report_controller_test unit tests
- updates teacher_attendance_report_controller_test unit tests

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3373 (delete payment module and tests)

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
