### PR TITLE
Skip failing New Workshop test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/workshop_dashboard.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/workshop_dashboard.feature
@@ -2,6 +2,7 @@
 @eyes
 Feature: Workshop Dashboard
 
+@skip
 Scenario: New workshop: BYOW
   Given I am a program manager named "Test BYO PM" for regional partner "Test Partner"
   Given there is a facilitator named "Test BYO Facilitator 1" for course "Build Your Own Workshop"


### PR DESCRIPTION
Skips failing eyes test with inconsistent spacing of URL (sometimes takes up one line, sometimes 2, etc.) based on [this discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1751401419200739). A ticket was made [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3375) to fix it.
