### PR TITLE
fix(cookie): allow environment specific cookies

### DIFF
--- a/frontend/apps/marketing/src/cookies/__tests__/getCookie.test.ts
+++ b/frontend/apps/marketing/src/cookies/__tests__/getCookie.test.ts
@@ -1,0 +1,16 @@
+import {getCookieNameByStage} from '../getCookie';
+
+describe('getCookieNameByStage', () => {
+  it('returns the cookie name unchanged for production stage', () => {
+    expect(getCookieNameByStage('session', 'production')).toBe('session');
+    expect(getCookieNameByStage('user_id', 'production')).toBe('user_id');
+  });
+
+  it('appends the stage to the cookie name for non-production stages', () => {
+    expect(getCookieNameByStage('session', 'test')).toBe('session_test');
+    expect(getCookieNameByStage('user_id', 'development')).toBe(
+      'user_id_development',
+    );
+    expect(getCookieNameByStage('auth', 'test')).toBe('auth_test');
+  });
+});

--- a/frontend/apps/marketing/src/cookies/getCookie.ts
+++ b/frontend/apps/marketing/src/cookies/getCookie.ts
@@ -1,0 +1,14 @@
+import {Stage} from '@/config/stage';
+
+/**
+ * JS port of lib/cdo/cookie_helpers.rb
+ * @param cookieName The cookie to retrieve
+ * @param stage The stage to retrieve the cookie for
+ */
+export function getCookieNameByStage(cookieName: string, stage: Stage) {
+  if (stage === 'production') {
+    return cookieName;
+  }
+
+  return `${cookieName}_${stage}`;
+}

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -11,6 +11,7 @@ import {
 import {getStage} from '@/config/stage';
 import {getStudioBaseUrl} from '@/config/studio';
 import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
+import {getCookieNameByStage} from '@/cookies/getCookie';
 import {getCachedRedirectResponse} from '@/middleware/utils/getCachedRedirectResponse';
 
 import {MiddlewareFactory} from './types';
@@ -50,6 +51,7 @@ export const withLocale: MiddlewareFactory = next => {
     const pathParts = pathname.split('/').filter(Boolean);
 
     const maybeLocale = pathParts[0] as SupportedLocale;
+    const stage = getStage();
 
     if (SUPPORTED_LOCALES_SET.has(maybeLocale)) {
       // If the first part of the path is a supported locale or there are no subpaths, we don't need to redirect
@@ -57,7 +59,7 @@ export const withLocale: MiddlewareFactory = next => {
 
       response.cookies.set('language_', getDashboardLocale(maybeLocale), {
         path: '/',
-        domain: getStage() === 'production' ? '.code.org' : undefined,
+        domain: stage === 'production' ? '.code.org' : undefined,
       });
 
       return response;
@@ -71,7 +73,11 @@ export const withLocale: MiddlewareFactory = next => {
       // If the _user_type cookie is set, then Dashboard successfully logged in the user which is an early indicator
       // that the user is logged in right now. Therefore, send the user to Code Studio
       // See: https://github.com/code-dot-org/code-dot-org/blob/3fad8bce055846378ae3da343da93a32acd4df8c/dashboard/config/initializers/devise.rb#L331
-      const userTypeCookie = request.cookies.get('_user_type');
+      const userTypeCookie = request.cookies.get(
+        getCookieNameByStage('_user_type', stage),
+      );
+
+      console.log('cookie name:', getCookieNameByStage('_user_type', stage));
 
       if (userTypeCookie?.value) {
         return getCachedRedirectResponse(getStudioBaseUrl());

--- a/frontend/apps/marketing/tests/e2e/home.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/home.spec.ts
@@ -1,10 +1,10 @@
 import {expect} from '@playwright/test';
 
-import {getStage} from '@/config/stage';
 import {getCookieNameByStage} from '@/cookies/getCookie';
 
 import {test} from './fixtures/base';
 import {MarketingPage} from './pom/marketing';
+import {getAppStageFromTestStage} from './utils/stage';
 
 test.describe('Home Page', () => {
   test('should redirect / to the localized path', async ({
@@ -44,7 +44,7 @@ test.describe('Home Page', () => {
 
     await context.addCookies([
       {
-        name: getCookieNameByStage('_user_type', getStage()),
+        name: getCookieNameByStage('_user_type', getAppStageFromTestStage()),
         path: '/',
         domain: `.${marketingPage.getCookieDomain()}`,
         value: 'student',

--- a/frontend/apps/marketing/tests/e2e/home.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/home.spec.ts
@@ -1,5 +1,8 @@
 import {expect} from '@playwright/test';
 
+import {getStage} from '@/config/stage';
+import {getCookieNameByStage} from '@/cookies/getCookie';
+
 import {test} from './fixtures/base';
 import {MarketingPage} from './pom/marketing';
 
@@ -41,7 +44,7 @@ test.describe('Home Page', () => {
 
     await context.addCookies([
       {
-        name: '_user_type',
+        name: getCookieNameByStage('_user_type', getStage()),
         path: '/',
         domain: `.${marketingPage.getCookieDomain()}`,
         value: 'student',


### PR DESCRIPTION
The `_user_type` cookie is environment specific. This means that on test.code.org, it is `_user_type_test` which the home redirector did not read.

This PR updates the cookie name logic to grab the environment specific cookie from dashboard.