### PR TITLE
Music: rendering optimizations

### DIFF
--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -1,5 +1,5 @@
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
-import React from 'react';
+import React, {useCallback} from 'react';
 import {useSelector} from 'react-redux';
 
 import {nextLevelId} from '@cdo/apps/code-studio/progressReduxSelectors';
@@ -54,8 +54,12 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
 }) => {
   const levelProperties = useAppSelector(state => state.lab.levelProperties);
   const hasNextLevel = useSelector(state => nextLevelId(state) !== undefined);
-  const {hasConditions, message, satisfied, index} = useAppSelector(
-    state => state.lab.validationState
+  const message = useAppSelector(state => state.lab.validationState.message);
+  const messageIndex = useAppSelector(state => state.lab.validationState.index);
+  const passingValidation = useAppSelector(
+    state =>
+      !state.lab.validationState.hasConditions ||
+      state.lab.validationState.satisfied
   );
   const predictSettings = useAppSelector(
     state => state.lab.levelProperties?.predictSettings
@@ -75,6 +79,13 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
 
   const dispatch = useAppDispatch();
 
+  const setPredictResponseCallback = useCallback(
+    (response: string) => {
+      dispatch(setPredictResponse(response));
+    },
+    [dispatch]
+  );
+
   const {theme} = useTheme();
 
   // Don't render anything if we don't have any instructions.
@@ -87,18 +98,18 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
 
   const canShowNextButton =
     manageNavigation &&
-    (!hasConditions || satisfied) &&
+    passingValidation &&
     (!predictSettings?.isPredictLevel || predictResponseSubmitted);
 
   return (
     <InstructionsPanel
       text={levelProperties.longInstructions}
       message={message || undefined}
-      messageIndex={index}
+      messageIndex={messageIndex}
       theme={theme}
       predictSettings={predictSettings}
       predictResponse={predictResponse}
-      setPredictResponse={response => dispatch(setPredictResponse(response))}
+      setPredictResponse={setPredictResponseCallback}
       predictAnswerLocked={predictAnswerLocked}
       layout={layout}
       handleInstructionsTextClick={handleInstructionsTextClick}

--- a/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
+++ b/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
@@ -77,8 +77,10 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
   const hasSubmittedPredictResponse = useAppSelector(
     isPredictResponseSubmitted
   );
-  const {hasConditions, satisfied} = useAppSelector(
-    state => state.lab.validationState
+  const passingValidation = useAppSelector(
+    state =>
+      !state.lab.validationState.hasConditions ||
+      state.lab.validationState.satisfied
   );
   const useSecondaryFinishButton =
     useAppSelector(
@@ -86,8 +88,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
     ) || queryParams('use-secondary-finish-button') === 'true';
 
   const canShow =
-    (!isPredictLevel || hasSubmittedPredictResponse) &&
-    (!hasConditions || satisfied);
+    (!isPredictLevel || hasSubmittedPredictResponse) && passingValidation;
 
   const text = hasNextLevel ? commonI18n.continue() : commonI18n.finish();
 

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -23,7 +23,6 @@ const registerReducers = require('@cdo/apps/redux').registerReducers;
  */
 
 export enum InstructionsPosition {
-  TOP = 'TOP',
   LEFT = 'LEFT',
   RIGHT = 'RIGHT',
 }
@@ -61,10 +60,8 @@ export interface MusicState {
   soundLoadingProgress: number;
   /** The 1-based playhead position to start playback from, scaled to measures */
   startingPlayheadPosition: number;
-  undoStatus: {
-    canUndo: boolean;
-    canRedo: boolean;
-  };
+  canUndo: boolean;
+  canRedo: boolean;
   /** A callout that's currently being shown.  The index lets the same callout be
    * reshown multiple times in a row.
    */
@@ -99,10 +96,8 @@ const initialState: MusicState = {
   // This is to prevent the progress bar from showing if there are no sounds to load initially.
   soundLoadingProgress: 1,
   startingPlayheadPosition: 1,
-  undoStatus: {
-    canUndo: false,
-    canRedo: false,
-  },
+  canUndo: false,
+  canRedo: false,
   currentCallout: {
     id: undefined,
     index: 0,
@@ -224,7 +219,8 @@ const musicSlice = createSlice({
       state,
       action: PayloadAction<{canUndo: boolean; canRedo: boolean}>
     ) => {
-      state.undoStatus = action.payload;
+      state.canUndo = action.payload.canUndo;
+      state.canRedo = action.payload.canRedo;
     },
     showCallout: (state, action: PayloadAction<string>) => {
       state.currentCallout.id = action.payload;

--- a/apps/src/music/views/Controls.tsx
+++ b/apps/src/music/views/Controls.tsx
@@ -1,6 +1,6 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import classNames from 'classnames';
-import React, {useCallback} from 'react';
+import React, {memo, useCallback} from 'react';
 import {useDispatch} from 'react-redux';
 
 import {submitPredictResponse} from '@cdo/apps/lab2/redux/predictLevelRedux';
@@ -14,12 +14,11 @@ import {
 } from '../redux/musicRedux';
 
 import BeatPad from './BeatPad';
-import {useMusicSelector} from './types';
 
 import moduleStyles from './controls.module.scss';
 
 const LoadingProgress: React.FunctionComponent = () => {
-  const progressValue = useMusicSelector(
+  const progressValue = useAppSelector(
     state => state.music.soundLoadingProgress
   );
 
@@ -47,7 +46,7 @@ const LoadingProgress: React.FunctionComponent = () => {
 };
 
 const SkipControls: React.FunctionComponent = () => {
-  const isPlaying = useMusicSelector(state => state.music.isPlaying);
+  const isPlaying = useAppSelector(state => state.music.isPlaying);
   const dispatch = useDispatch();
 
   const onClickSkip = useCallback(
@@ -121,7 +120,7 @@ const Controls: React.FunctionComponent<ControlsProps> = ({
   enableSkipControls = false,
 }) => {
   const dispatch = useAppDispatch();
-  const isPlaying = useMusicSelector(state => state.music.isPlaying);
+  const isPlaying = useAppSelector(state => state.music.isPlaying);
   const disableRun = useAppSelector(({predictLevel, music}) => {
     const hasPredictResponse = !!predictLevel.response;
     const isLoading = music.soundLoadingProgress < 1;
@@ -163,4 +162,4 @@ const Controls: React.FunctionComponent<ControlsProps> = ({
   );
 };
 
-export default Controls;
+export default memo(Controls);

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, {useCallback, useContext} from 'react';
+import React, {memo, useCallback, useContext} from 'react';
 import {useSelector} from 'react-redux';
 
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
@@ -12,7 +12,6 @@ import {getBaseAssetUrl} from '../appConfig';
 import {AnalyticsContext} from '../context';
 import musicI18n from '../locale';
 import MusicLibrary, {SoundFolder} from '../player/MusicLibrary';
-import {MusicState} from '../redux/musicRedux';
 
 import moduleStyles from './HeaderButtons.module.scss';
 
@@ -80,9 +79,8 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
   hideChaff,
 }) => {
   const readOnlyWorkspace: boolean = useSelector(isReadOnlyWorkspace);
-  const {canUndo, canRedo} = useSelector(
-    (state: {music: MusicState}) => state.music.undoStatus
-  );
+  const canUndo = useAppSelector(state => state.music.canUndo);
+  const canRedo = useAppSelector(state => state.music.canRedo);
   const currentPackId = useAppSelector(state => state.music.packId);
   const analyticsReporter = useContext(AnalyticsContext);
   const dialogControl = useDialogControl();
@@ -240,4 +238,4 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
   );
 };
 
-export default HeaderButtons;
+export default memo(HeaderButtons);

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -1,6 +1,6 @@
 import {javascript} from '@codemirror/lang-javascript';
 import classNames from 'classnames';
-import React, {useCallback, useContext, useEffect} from 'react';
+import React, {memo, useCallback, useContext, useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
 import header from '@cdo/apps/code-studio/header';
@@ -56,6 +56,9 @@ import PackDialog from './PackDialog';
 import Timeline from './Timeline';
 
 import moduleStyles from './music-view.module.scss';
+
+const exemplarPlayerInsideInstructions =
+  AppConfig.getValue('exemplar-player-bottom') !== 'true';
 
 interface MusicLabViewProps {
   blocklyDivId: string;
@@ -130,13 +133,6 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   const validationStateCallout = useAppSelector(
     state => state.lab.validationState.callout
   );
-  const currentPlayheadPosition = useAppSelector(
-    state => state.music.currentPlayheadPosition
-  );
-  const startingPlayheadPosition = useAppSelector(
-    state => state.music.startingPlayheadPosition
-  );
-  const lastMeasure = useAppSelector(state => state.music.lastMeasure);
 
   const progressManager = useContext(ProgressManagerContext);
 
@@ -239,16 +235,9 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     progressManager,
   ]);
 
-  // Stop the song if the playhead is past the desired end.
-  useEffect(() => {
-    if (!isPlaying) {
-      return;
-    }
-
-    if (lastMeasure === undefined) {
-      return;
-    }
-
+  const playheadPastEnd = useAppSelector(state => {
+    const {startingPlayheadPosition, lastMeasure, currentPlayheadPosition} =
+      state.music;
     // We are done playing once the playhead reaches the end of the last scheduled sound.
     // But if the starting playhead position has been set beyond that point, we'll use that
     // instead, so that at least a bit of playback can be shown.
@@ -258,17 +247,19 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     // the user wants to trigger another sound.
     const extraMeasures = blocklyWorkspace.hasAnyTriggers() ? 4 : 2;
 
-    if (currentPlayheadPosition >= stopMeasure + extraMeasures) {
+    return currentPlayheadPosition >= stopMeasure + extraMeasures;
+  });
+
+  // Stop the song if the playhead is past the desired end.
+  useEffect(() => {
+    if (!isPlaying) {
+      return;
+    }
+
+    if (playheadPastEnd) {
       setPlaying(false);
     }
-  }, [
-    blocklyWorkspace,
-    currentPlayheadPosition,
-    isPlaying,
-    lastMeasure,
-    setPlaying,
-    startingPlayheadPosition,
-  ]);
+  }, [isPlaying, setPlaying, playheadPastEnd]);
 
   const resetValidation = useCallback(
     () => progressManager?.resetValidation(),
@@ -294,126 +285,19 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     [blocklyWorkspace]
   );
 
-  // TODO: Rendering instructions with a function causes frequent re-renders.
-  // Pull this out into a component and/or drop support for "top" position
-  const renderInstructions = useCallback(
-    (position: InstructionsPosition) => {
-      const exemplarPlayerInsideInstructions =
-        AppConfig.getValue('exemplar-player-bottom') !== 'true';
+  const showExemplarPlayer =
+    exemplarSettings?.playerEnabled && exemplarSources && !isEditingExemplar;
 
-      const exemplarPlayer = exemplarSettings?.playerEnabled &&
-        exemplarSources &&
-        !isEditingExemplar && (
-          <ExemplarPlayerView
-            playbackEvents={exemplarPlaybackEvents}
-            title={exemplarSettings.playerTitle!}
-            player={player}
-            insideInstructions={exemplarPlayerInsideInstructions}
-          />
-        );
-
-      return (
-        <div
-          id="instructions-area"
-          className={classNames(
-            moduleStyles.instructionsArea,
-            position === InstructionsPosition.TOP
-              ? moduleStyles.instructionsTop
-              : moduleStyles.instructionsSide
-          )}
-        >
-          <PanelContainer
-            id="instructions-panel"
-            headerContent={musicI18n.panelHeaderInstructions()}
-            hideHeaders={hideHeaders}
-          >
-            <Instructions
-              isRunning={isPlaying}
-              layout={
-                position !== InstructionsPosition.TOP
-                  ? 'vertical'
-                  : 'horizontal'
-              }
-              handleInstructionsTextClick={onInstructionsTextClick}
-              bottomComponent={
-                exemplarPlayerInsideInstructions && exemplarPlayer
-              }
-              hasRun={hasRun}
-              hasEdited={hasEdited}
-            />
-            {!exemplarPlayerInsideInstructions && exemplarPlayer}
-          </PanelContainer>
-        </div>
-      );
-    },
-    [
-      hasRun,
-      hasEdited,
-      hideHeaders,
-      exemplarSettings,
-      exemplarSources,
-      isEditingExemplar,
-      onInstructionsTextClick,
-      exemplarPlaybackEvents,
-      player,
-      isPlaying,
-    ]
-  );
-
-  const renderPlayArea = useCallback(
-    (timelineAtTop: boolean) => {
-      return (
-        <div
-          id="play-area"
-          className={classNames(
-            moduleStyles.playArea,
-            timelineAtTop
-              ? moduleStyles.playAreaTop
-              : moduleStyles.playAreaBottom
-          )}
-        >
-          <div id="controls-area" className={moduleStyles.controlsArea}>
-            <PanelContainer
-              id="controls-panel"
-              headerContent={musicI18n.panelHeaderControls()}
-              hideHeaders={hideHeaders}
-            >
-              <Controls
-                setPlaying={setPlaying}
-                playTrigger={playTrigger}
-                hasTrigger={hasTrigger}
-                isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
-                enableSkipControls={
-                  AppConfig.getValue('skip-controls-enabled') === 'true'
-                }
-              />
-            </PanelContainer>
-          </div>
-
-          <div
-            dir="ltr"
-            id="timeline-area"
-            className={moduleStyles.timelineArea}
-          >
-            <PanelContainer
-              id="timeline-panel"
-              headerContent={musicI18n.panelHeaderTimeline()}
-              hideHeaders={hideHeaders}
-            >
-              <Timeline
-                allowChangeStartingPlayheadPosition={
-                  (levelProperties.levelData as MusicLevelData | undefined)
-                    ?.allowChangeStartingPlayheadPosition
-                }
-                isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
-              />
-            </PanelContainer>
-          </div>
-        </div>
-      );
-    },
-    [setPlaying, playTrigger, hasTrigger, hideHeaders, levelProperties]
-  );
+  const ExemplarPlayer = ({title}: {title: string}) => {
+    return (
+      <ExemplarPlayerView
+        playbackEvents={exemplarPlaybackEvents}
+        title={title}
+        player={player}
+        insideInstructions={exemplarPlayerInsideInstructions}
+      />
+    );
+  };
 
   const showAdvancedControls =
     AppConfig.getValue('player') === 'tonejs' &&
@@ -435,25 +319,54 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   );
 
   return (
-    <div id="music-lab" className={moduleStyles.musicLab}>
+    <div
+      id="music-lab"
+      className={classNames(
+        moduleStyles.musicLab,
+        timelineAtTop && moduleStyles.reverse
+      )}
+    >
       {allowPackSelection && <PackDialog player={player} />}
-
-      {showInstructions &&
-        instructionsPosition === InstructionsPosition.TOP &&
-        renderInstructions(InstructionsPosition.TOP)}
-
-      {timelineAtTop && !isToolboxMode && renderPlayArea(true)}
-
       <div
         id="work-area"
         className={classNames(moduleStyles.workArea, {
           // Allow full height when the play area is hidden.
           [moduleStyles.toolboxMode]: isToolboxMode,
+          [moduleStyles.reverse]:
+            instructionsPosition === InstructionsPosition.RIGHT,
         })}
       >
-        {showInstructions &&
-          instructionsPosition === InstructionsPosition.LEFT &&
-          renderInstructions(InstructionsPosition.LEFT)}
+        {showInstructions && (
+          <div
+            id="instructions-area"
+            className={classNames(
+              moduleStyles.instructionsArea,
+              moduleStyles.instructionsSide
+            )}
+          >
+            <PanelContainer
+              id="instructions-panel"
+              headerContent={musicI18n.panelHeaderInstructions()}
+              hideHeaders={hideHeaders}
+            >
+              <Instructions
+                isRunning={isPlaying}
+                handleInstructionsTextClick={onInstructionsTextClick}
+                bottomComponent={
+                  exemplarPlayerInsideInstructions &&
+                  showExemplarPlayer && (
+                    <ExemplarPlayer title={exemplarSettings.playerTitle!} />
+                  )
+                }
+                hasRun={hasRun}
+                hasEdited={hasEdited}
+              />
+              {!exemplarPlayerInsideInstructions && showExemplarPlayer && (
+                <ExemplarPlayer title={exemplarSettings.playerTitle!} />
+              )}
+            </PanelContainer>
+          </div>
+        )}
 
         <div id="blockly-area" className={moduleStyles.blocklyArea}>
           <PanelContainer
@@ -522,15 +435,51 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
             )}
           </PanelContainer>
         </div>
-
-        {showInstructions &&
-          instructionsPosition === InstructionsPosition.RIGHT &&
-          renderInstructions(InstructionsPosition.RIGHT)}
       </div>
 
-      {!timelineAtTop && !isToolboxMode && renderPlayArea(false)}
+      {!isToolboxMode && (
+        <div id="play-area" className={classNames(moduleStyles.playArea)}>
+          <div id="controls-area" className={moduleStyles.controlsArea}>
+            <PanelContainer
+              id="controls-panel"
+              headerContent={musicI18n.panelHeaderControls()}
+              hideHeaders={hideHeaders}
+            >
+              <Controls
+                setPlaying={setPlaying}
+                playTrigger={playTrigger}
+                hasTrigger={hasTrigger}
+                isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
+                enableSkipControls={
+                  AppConfig.getValue('skip-controls-enabled') === 'true'
+                }
+              />
+            </PanelContainer>
+          </div>
+
+          <div
+            dir="ltr"
+            id="timeline-area"
+            className={moduleStyles.timelineArea}
+          >
+            <PanelContainer
+              id="timeline-panel"
+              headerContent={musicI18n.panelHeaderTimeline()}
+              hideHeaders={hideHeaders}
+            >
+              <Timeline
+                allowChangeStartingPlayheadPosition={
+                  (levelProperties.levelData as MusicLevelData | undefined)
+                    ?.allowChangeStartingPlayheadPosition
+                }
+                isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
+              />
+            </PanelContainer>
+          </div>
+        </div>
+      )}
     </div>
   );
 };
 
-export default MusicLabView;
+export default memo(MusicLabView);

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -108,7 +108,7 @@ class UnconnectedMusicView extends React.Component {
     clearSelectedBlockId: PropTypes.func,
     clearSelectedTriggerId: PropTypes.func,
     setInstructionsPosition: PropTypes.func,
-    currentlyPlayingBlockIds: PropTypes.array,
+    currentlyPlayingBlockIdsString: PropTypes.string,
     setIsLoading: PropTypes.func,
     setPageError: PropTypes.func,
     lastMeasure: PropTypes.number,
@@ -123,6 +123,8 @@ class UnconnectedMusicView extends React.Component {
     blockMode: PropTypes.string,
     playbackEvents: PropTypes.array,
     validationState: PropTypes.object,
+    canUndo: PropTypes.bool,
+    canRedo: PropTypes.bool,
   };
 
   constructor(props) {
@@ -169,6 +171,7 @@ class UnconnectedMusicView extends React.Component {
     };
 
     this.isLevelLoadInProgress = false;
+    this.exemplarPlaybackEvents = [];
 
     MusicBlocklyWorkspace.setupBlocklyEnvironment(this.props.blockMode);
   }
@@ -243,10 +246,9 @@ class UnconnectedMusicView extends React.Component {
       );
     }
 
-    // Using stringified JSON for deep comparison
     if (
-      JSON.stringify(prevProps.currentlyPlayingBlockIds) !==
-      JSON.stringify(this.props.currentlyPlayingBlockIds)
+      prevProps.currentlyPlayingBlockIdsString !==
+      this.props.currentlyPlayingBlockIdsString
     ) {
       this.updateHighlightedBlocks();
     }
@@ -311,7 +313,7 @@ class UnconnectedMusicView extends React.Component {
     }
     this.library.setCurrentPackId(packId);
     this.props.setPackId(packId);
-    this.setExemplarPlaybackEvents();
+    this.exemplarPlaybackEvents = this.generateExemplarPlaybackEvents();
 
     if (AppConfig.getValue('js-editor') !== 'true') {
       const isSubmittable = this.props.levelProperties.submittable;
@@ -494,7 +496,7 @@ class UnconnectedMusicView extends React.Component {
 
   updateHighlightedBlocks = () => {
     this.musicBlocklyWorkspace.updateHighlightedBlocks(
-      this.props.currentlyPlayingBlockIds
+      JSON.parse(this.props.currentlyPlayingBlockIdsString)
     );
   };
 
@@ -562,10 +564,10 @@ class UnconnectedMusicView extends React.Component {
   };
 
   getExemplarPlaybackEvents = () => {
-    return this.exemplarPlaybackEvents || [];
+    return this.exemplarPlaybackEvents;
   };
 
-  setExemplarPlaybackEvents = () => {
+  generateExemplarPlaybackEvents = () => {
     const exemplarSources = this.getExemplarSources();
     if (!exemplarSources) {
       return [];
@@ -575,8 +577,8 @@ class UnconnectedMusicView extends React.Component {
     workspace.loadCode(exemplarSources);
     workspace.compileSong(BlockMode.SIMPLE2);
     const {playbackEvents} = workspace.executeCompiledSong();
-    this.exemplarPlaybackEvents = playbackEvents;
     workspace.dispose();
+    return playbackEvents;
   };
 
   onBlockSpaceChange = e => {
@@ -647,10 +649,11 @@ class UnconnectedMusicView extends React.Component {
       workspace.cleanUp(true);
     }
     // Update undo status when blocks change.
-    this.props.setUndoStatus({
-      canUndo: this.musicBlocklyWorkspace.canUndo(),
-      canRedo: this.musicBlocklyWorkspace.canRedo(),
-    });
+    const canUndo = this.musicBlocklyWorkspace.canUndo();
+    const canRedo = this.musicBlocklyWorkspace.canRedo();
+    if (this.props.canUndo !== canUndo || this.props.canRedo !== canRedo) {
+      this.props.setUndoStatus({canUndo, canRedo});
+    }
 
     if (e.type === Blockly.Events.SELECTED) {
       if (
@@ -893,6 +896,10 @@ class UnconnectedMusicView extends React.Component {
     this.musicBlocklyWorkspace.redo();
   };
 
+  hasTrigger = id => {
+    return this.musicBlocklyWorkspace.hasTrigger(id);
+  };
+
   render() {
     return (
       <AnalyticsContext.Provider value={this.analyticsReporter}>
@@ -908,7 +915,7 @@ class UnconnectedMusicView extends React.Component {
           blocklyDivId={BLOCKLY_DIV_ID}
           setPlaying={this.setPlaying}
           playTrigger={this.playTrigger}
-          hasTrigger={id => this.musicBlocklyWorkspace.hasTrigger(id)}
+          hasTrigger={this.hasTrigger}
           getCurrentPlayheadPosition={this.getCurrentPlayheadPosition}
           updateHighlightedBlocks={this.updateHighlightedBlocks}
           undo={this.undo}
@@ -923,7 +930,7 @@ class UnconnectedMusicView extends React.Component {
           }
           analyticsReporter={this.analyticsReporter}
           blocklyWorkspace={this.musicBlocklyWorkspace}
-          exemplarPlaybackEvents={this.getExemplarPlaybackEvents()}
+          exemplarPlaybackEvents={this.exemplarPlaybackEvents}
           executeCode={
             AppConfig.getValue('js-editor') === 'true' &&
             (code => {
@@ -954,13 +961,18 @@ const MusicView = connect(
     blockMode: getBlockMode(state),
     isPlaying: state.music.isPlaying,
     selectedBlockId: state.music.selectedBlockId,
-    currentlyPlayingBlockIds: getCurrentlyPlayingBlockIds(state),
+    // Stringify the value to prevent unnecessary re-renders when the array is the same.
+    currentlyPlayingBlockIdsString: JSON.stringify(
+      getCurrentlyPlayingBlockIds(state)
+    ),
     isReadOnlyWorkspace: isReadOnlyWorkspace(state),
     startingPlayheadPosition: state.music.startingPlayheadPosition,
     isPlayView: state.lab.isShareView,
     playbackEvents: state.music.playbackEvents,
     validationState: state.lab.validationState,
     lastMeasure: state.music.lastMeasure,
+    canUndo: state.music.canUndo,
+    canRedo: state.music.canRedo,
   }),
   dispatch => ({
     setPackId: packId => dispatch(setPackId(packId)),

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, {
+  memo,
   MouseEvent,
   useCallback,
   useEffect,
@@ -84,28 +85,31 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
   const [availableHeight, setAvailableHeight] = useState(0);
 
   // Get the height that each event should occupy.  This is inclusive of empty vertical space at the bottom.
-  const getEventHeight = (numUniqueRows: number) => {
-    // While we might not actually have this many rows to show,
-    // we will limit each row's height to the size that would allow
-    // this many to be shown at once.
-    const minVisible = 5;
+  const getEventHeight = useCallback(
+    (numUniqueRows: number) => {
+      // While we might not actually have this many rows to show,
+      // we will limit each row's height to the size that would allow
+      // this many to be shown at once.
+      const minVisible = 5;
 
-    const maxVisible = 45;
+      const maxVisible = 45;
 
-    // We might not actually have this many rows to show, but
-    // we will size the bars so that this many rows would show.
-    const numSoundsToShow = Math.max(
-      Math.min(numUniqueRows, maxVisible),
-      minVisible
-    );
+      // We might not actually have this many rows to show, but
+      // we will size the bars so that this many rows would show.
+      const numSoundsToShow = Math.max(
+        Math.min(numUniqueRows, maxVisible),
+        minVisible
+      );
 
-    return Math.floor(availableHeight / numSoundsToShow);
-  };
+      return Math.floor(availableHeight / numSoundsToShow);
+    },
+    [availableHeight]
+  );
 
   // How how much of the event height should be left as empty vertical space at the bottom.
-  const getEventVerticalSpace = (eventHeight: number) => {
+  const getEventVerticalSpace = useCallback((eventHeight: number) => {
     return eventHeight > 8 ? 3 : eventHeight > 6 ? 2 : 1;
-  };
+  }, []);
 
   const timelineElementProps = {
     paddingOffset,
@@ -308,4 +312,4 @@ const LoopMarkers: React.FunctionComponent<{
   );
 };
 
-export default Timeline;
+export default memo(Timeline);

--- a/apps/src/music/views/TimelineElement.tsx
+++ b/apps/src/music/views/TimelineElement.tsx
@@ -2,14 +2,14 @@ import classNames from 'classnames';
 import React from 'react';
 import {useDispatch} from 'react-redux';
 
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
 import {isChordEvent} from '../player/interfaces/ChordEvent';
 import {isInstrumentEvent} from '../player/interfaces/InstrumentEvent';
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
 import {isSoundEvent} from '../player/interfaces/SoundEvent';
 import {selectBlockId} from '../redux/musicRedux';
 import SoundStyle from '../utils/SoundStyle';
-
-import {useMusicSelector} from './types';
 
 import moduleStyles from './timeline.module.scss';
 
@@ -31,24 +31,23 @@ const TimelineElement: React.FunctionComponent<TimelineElementProps> = ({
   top,
   left,
 }) => {
-  const isPlaying = useMusicSelector(state => state.music.isPlaying);
-  const selectedBlockId = useMusicSelector(
-    state => state.music.selectedBlockId
-  );
+  const isPlaying = useAppSelector(state => state.music.isPlaying);
+  const selectedBlockId = useAppSelector(state => state.music.selectedBlockId);
   const dispatch = useDispatch();
-  const currentPlayheadPosition = useMusicSelector(
-    state => state.music.currentPlayheadPosition
-  );
   const isInsideRandom = eventData.skipContext?.insideRandom;
   const isSkipSound = isPlaying && eventData.skipContext?.skipSound;
   const isThinBorder = height <= 4;
 
-  const isCurrentlyPlaying =
-    isPlaying &&
-    !isSkipSound &&
-    currentPlayheadPosition !== 0 &&
-    currentPlayheadPosition >= eventData.when &&
-    currentPlayheadPosition < eventData.when + eventData.length;
+  const isCurrentlyPlaying = useAppSelector(state => {
+    const currentPlayheadPosition = state.music.currentPlayheadPosition;
+    return (
+      isPlaying &&
+      !isSkipSound &&
+      currentPlayheadPosition !== 0 &&
+      currentPlayheadPosition >= eventData.when &&
+      currentPlayheadPosition < eventData.when + eventData.length
+    );
+  });
 
   const isBlockSelected = eventData.blockId === selectedBlockId;
 

--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -19,6 +19,11 @@ $default-spacing: 2px;
   display: flex;
   flex-direction: column;
   gap: $default-spacing;
+
+
+  &.reverse {
+    flex-direction: column-reverse;
+  }
 }
 
 .workArea {
@@ -30,6 +35,9 @@ $default-spacing: 2px;
   overflow: hidden;
   &.toolboxMode {
     max-height: 100%; // Allow the work area to take full height
+  }
+  &.reverse {
+    flex-direction: row-reverse;
   }
 }
 


### PR DESCRIPTION
## Overview

While working on a previous issue with React dev tools turned on, I noticed that we were doing a bunch of unexpected extra re-renders in Music Lab. This introduces various small refactors, fixes, and optimizations that significantly cut down on those re-renders and aims to clean up related code where relevant. 

Music Lab was already quite fast on my machine so I didn't really notice a substantial performance speedup, but I do think this will be beneficial for low power machines running complex projects. (Seeing the number of re-renders go down is also just kind of addictive 😄)

Though there are various fixes across different files, generally they fall into the following categories:
1. **Replacing JSX-producing functions with functional components, or inline JSX**
This was mostly happening in `MusicLabView`; because we wanted to support optionally rendering various UI components in different places on the screen based on URL overrides (holdovers from early UI experimentation), we broke out those pieces of JSX into functions. The issue is that on each render pass, these functions re-evaluate and return new values which reacts treats as new components, causing a chain of re-renders. Instead, we can just move these to functional components where applicable; elsewhere, I opted to just render them inline, and instead use CSS to reverse direction to keep the UI affordances from before (for example, rendering instructions on the right or rendering the timeline above the workspace).

2. **Optimizing redux selectors**
React components re-render when the value computed by a redux selector changes. This can trip us up in sneaky ways when we extract data that is changing frequently but only use it to compute a new value that isn't changing nearly as often. Because the selector-extracted value is changing frequently, we get frequent re-renders, even though the information we actually care about hasn't changed. A few examples:
- `currentPlayheadPosition` changes on every tick when playback is in progress. This value is used by a bunch of different components, but only the timeline playhead really needs tick-accurate position information. In contrast, we also use this value to determine if a given timeline element should be highlight (if the playhead is currently within its bounds). Instead of selecting `currentPlayheadPosition`, which causes the element to re-render constantly, a more optimal approach is to move the logic of determining whether the playhead is in its bounds into the selector function. This produces a boolean value (`isCurrentlyPlaying`) that stays true while the playhead is within its bounds, and false otherwise, which means that the timeline element now only re-renders when this flag changes.
- similarly, it's more optimal to only extract the relevant state values from a given slice, rather than extracting the full slice and picking out specific values after the fact (`const {isPlaying, selectedBlockId} = useAppSelector(state => state.music)` vs `const isPlaying = useAppSelector(state => state.music.isPlaying); const selectedBlockId = ... `). The former results in re-renders when any part of the relevant slice changes, including values that are not relevant to the component.

3. **React.memo**
This one may be a bit overkill; I had added a bunch of these initially to try and optimize as much as possible, and subsequently tried to remove where they weren't having any impact. By default, React will re-render a component when its parent re-renders. Using `memo` tells React to skip re-rendering a component if its props haven't changed. For example, this did have an immediate impact on sub-components like `Controls` and `Timeline`.

#### Screen recordings with React Devtools

Before:

https://github.com/user-attachments/assets/5424c9b1-a65d-4ea8-83f2-315257766289

After:

https://github.com/user-attachments/assets/1b947ce0-045b-44e6-8494-2fe9cbf27c02


### Testing story
Tested locally with React devtools on various Music Lab projects.