### PR TITLE
AI Chat: move warning modal to AichatView

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -5,8 +5,10 @@ import ActionDropdown from '@code-dot-org/component-library/dropdown/actionDropd
 import SegmentedButtons, {
   SegmentedButtonsProps,
 } from '@code-dot-org/component-library/segmentedButtons';
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback, useEffect, useMemo} from 'react';
 
+import TeacherOnboardingModal from '@cdo/apps/aichat/views/TeacherOnboardingModal';
+import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarningModal';
 import {isProjectTemplateLevel} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {LabProps} from '@cdo/apps/lab2/types';
@@ -19,6 +21,7 @@ import ProjectTemplateWorkspaceIconV2 from '@cdo/apps/templates/ProjectTemplateW
 import {commonI18n} from '@cdo/apps/types/locale';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 
 import {getUserHasAichatAccess} from '../aichatApi';
 import {ModalTypes} from '../constants';
@@ -74,7 +77,7 @@ const AichatView: React.FunctionComponent<LabProps> = () => {
 
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
 
-  const {currentAiCustomizations, viewMode} = useAppSelector(
+  const {currentAiCustomizations, viewMode, showModalType} = useAppSelector(
     state => state.aichat
   );
 
@@ -139,6 +142,49 @@ const AichatView: React.FunctionComponent<LabProps> = () => {
         });
     }
   }, [dispatch, signInState]);
+
+  useEffect(() => {
+    const modalToShow = () => {
+      if (!isUserTeacher) {
+        return ModalTypes.WARNING;
+      }
+
+      const teacherSawAichatOnboardingModal = tryGetLocalStorage(
+        'teacherSawAichatOnboarding',
+        'no'
+      );
+
+      return teacherSawAichatOnboardingModal === 'yes'
+        ? undefined
+        : ModalTypes.TEACHER_ONBOARDING;
+    };
+
+    dispatch(setShowModalType(modalToShow()));
+  }, [isUserTeacher, dispatch]);
+
+  const onCloseModal = useCallback(() => {
+    // We only want to show the teacher onboarding modal the first time a teacher user
+    // interacts with the aichat tool. Thus, we store a value in local storage when
+    // closing the modal.
+    if (
+      isUserTeacher &&
+      showModalType === ModalTypes.TEACHER_ONBOARDING &&
+      tryGetLocalStorage('teacherSawAichatOnboarding', 'no') !== 'yes'
+    ) {
+      trySetLocalStorage('teacherSawAichatOnboarding', 'yes');
+    }
+    dispatch(setShowModalType(undefined));
+  }, [dispatch, isUserTeacher, showModalType]);
+
+  const ChatModal = useMemo(
+    () =>
+      showModalType === ModalTypes.TEACHER_ONBOARDING
+        ? TeacherOnboardingModal
+        : showModalType === ModalTypes.WARNING
+        ? ChatWarningModal
+        : undefined,
+    [showModalType]
+  );
 
   // Showing presentation view when:
   // 1) levelbuilder hasn't explicitly configured the toggle to be hidden, and
@@ -226,6 +272,7 @@ const AichatView: React.FunctionComponent<LabProps> = () => {
 
   return (
     <div id="aichat-lab" className={moduleStyles.aichatLab}>
+      {ChatModal && <ChatModal onClose={onCloseModal} />}
       {showPresentationToggle() && (
         <div
           id="uitest-view-mode-toggle-container"

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -4,12 +4,8 @@ import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 
-import TeacherOnboardingModal from '@cdo/apps/aichat/views/TeacherOnboardingModal';
-import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarningModal';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 
-import {ModalTypes} from '../constants';
 import aichatI18n from '../locale';
 import {
   clearChatMessages,
@@ -17,7 +13,6 @@ import {
   fetchUserChatHistory,
   selectAllVisibleMessages,
   selectMultimodalEnabled,
-  setShowModalType,
 } from '../redux';
 import {ChatButton} from '../types';
 import {getShortName} from '../utils';
@@ -56,11 +51,8 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   const [selectedTab, setSelectedTab] =
     useState<WorkspaceTeacherViewTab | null>(null);
 
-  const {showModalType, studentChatHistory} = useAppSelector(
-    state => state.aichat
-  );
+  const {studentChatHistory} = useAppSelector(state => state.aichat);
   const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
-  const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
   const visibleItems = useSelector(selectAllVisibleMessages);
   const currentUserId = useAppSelector(state => state.currentUser.userId);
 
@@ -101,25 +93,6 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     () => selectedTab !== WorkspaceTeacherViewTab.STUDENT_CHAT_HISTORY,
     [selectedTab]
   );
-
-  useEffect(() => {
-    const modalToShow = () => {
-      if (!isUserTeacher) {
-        return ModalTypes.WARNING;
-      }
-
-      const teacherSawAichatOnboardingModal = tryGetLocalStorage(
-        'teacherSawAichatOnboarding',
-        'no'
-      );
-
-      return teacherSawAichatOnboardingModal === 'yes'
-        ? undefined
-        : ModalTypes.TEACHER_ONBOARDING;
-    };
-
-    dispatch(setShowModalType(modalToShow()));
-  }, [isUserTeacher, dispatch]);
 
   useEffect(() => {
     // If we are viewing as a student, default to the student chat history tab if tab is not yet selected.
@@ -177,35 +150,10 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     tabPanelsContainerClassName: moduleStyles.tabPanelsContainer,
   };
 
-  const ChatModal = useMemo(
-    () =>
-      showModalType === ModalTypes.TEACHER_ONBOARDING
-        ? TeacherOnboardingModal
-        : showModalType === ModalTypes.WARNING
-        ? ChatWarningModal
-        : undefined,
-    [showModalType]
-  );
-
-  const onCloseModal = useCallback(() => {
-    // We only want to show the teacher onboarding modal the first time a teacher user
-    // interacts with the aichat tool. Thus, we store a value in local storage when
-    // closing the modal.
-    if (
-      isUserTeacher &&
-      showModalType === ModalTypes.TEACHER_ONBOARDING &&
-      tryGetLocalStorage('teacherSawAichatOnboarding', 'no') !== 'yes'
-    ) {
-      trySetLocalStorage('teacherSawAichatOnboarding', 'yes');
-    }
-    dispatch(setShowModalType(undefined));
-  }, [dispatch, isUserTeacher, showModalType]);
-
   const multimodalEnabled = useAppSelector(selectMultimodalEnabled);
 
   return (
     <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
-      {ChatModal && <ChatModal onClose={onCloseModal} />}
       {selectedStudent ? (
         <Tabs {...tabArgs} />
       ) : (


### PR DESCRIPTION
A first step in an attempt to make our `ChatWorkspace` component more generic / reusable for use cases beyond AI Chat (eg, AI Tutor) -- move the modal that students and teacher see on first view of the lab to the parent component that we use in AI Chat (`AichatView`).

There's no expected behavior change here, and really no changes other than moving things from one component to another.

## Links

- [Refactor discussion Slack thread](https://codedotorg.slack.com/archives/C08S29NDZ5E/p1750825065711549?thread_ts=1750747694.208079&cid=C08S29NDZ5E)

## Testing story

Tested manually in an incognito window that I saw the expected behavior (ie, the appropriate modal shows once for teachers and students respectively, and does not show up on subsequent bubble navigation to other levels).