### PR TITLE
Add dark mode colors and support to ChatWorkspace and enable when within lab2 (AITutor)

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -60,14 +60,14 @@ $icon-overlay-padding-right: 8px;
 
 .message-user {
   @extend %message;
-  background-color: $user_color;
+  background-color: var(--background-neutral-tertiary);
   border-end-start-radius: $message-border-radius;
   border-end-end-radius: 0;
 }
 
 .message-assistant {
   @extend %message;
-  background-color: $assistant-color;
+  background-color: var(--background-brand-teal-extra-light);
   border-end-start-radius: 0;
   border-end-end-radius: $message-border-radius;
   overflow-x: auto;
@@ -109,7 +109,7 @@ $icon-overlay-padding-right: 8px;
   flex: 0 0 $bot-container-size;
   height: $bot-container-size;
   width: $bot-container-size;
-  background: $light-black;
+  background: var(--background-neutral-primary-inverse);
   border-radius: 20px;
   display: flex;
   justify-content: center;
@@ -127,6 +127,7 @@ $icon-overlay-padding-right: 8px;
 .footer {
   margin-left: $bot-container-size + $icon-message-gap;
 }
+
 
 .footerWithOverlay {
   margin-left: $bot-container-size + $icon-message-gap + $icon-overlay-padding-right;
@@ -166,9 +167,9 @@ $icon-overlay-padding-right: 8px;
 }
 
 .danger {
-  background-color: $light_negative_100;
+  background-color: var(--background-error-extra-light);
 }
 
 .warning {
-  background-color: $light_caution_100;
+  background-color: var(--background-warning-light);
 }

--- a/apps/src/aiComponentLibrary/copyButton/copy-button.module.scss
+++ b/apps/src/aiComponentLibrary/copyButton/copy-button.module.scss
@@ -2,7 +2,7 @@
 
 // Double class name is an approach (recommended by design team) to override Component Library specificity
 button.copy-button.copy-button {
-  @include icon-button(var(--background-neutral-quaternary), var(--text-neutral-tertiary), var(--text-neutral-secondary));
+  @include icon-button(transparent, var(--background-neutral-quaternary), var(--text-neutral-tertiary), var(--text-neutral-secondary));
 }
 
 @keyframes fade-in {

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -10,7 +10,7 @@ $tabs-default-spacing: 4px;
   height: 100%;
   display: flex;
   flex-direction: column;
-  background-color: $light_white;
+  background-color: var(--background-neutral-primary);
   overflow: hidden;
 }
 

--- a/apps/src/aichat/views/teacherFeedback/teacher-feedback-footer.module.scss
+++ b/apps/src/aichat/views/teacherFeedback/teacher-feedback-footer.module.scss
@@ -6,15 +6,15 @@
   justify-content: flex-end;
 
   button.icon-button-affirmative {
-    @include icon-button(var(--background-success-light), var(--text-success-primary), var(--text-success-secondary));
+    @include icon-button(transparent, var(--background-success-light), var(--text-success-primary), var(--text-success-secondary));
   }
 
   button.icon-button-negative {
-    @include icon-button(var(--background-error-light), var(--text-error-primary), var(--text-error-secondary));
+    @include icon-button(transparent, var(--background-error-light), var(--text-error-primary), var(--text-error-secondary));
   }
 
   button.icon-button-gray {
-    @include icon-button(var(--background-neutral-quaternary), var(--text-neutral-tertiary), var(--text-neutral-secondary));
+    @include icon-button(transparent, var(--background-neutral-quaternary), var(--text-neutral-tertiary), var(--text-neutral-secondary));
   }
 }
 
@@ -38,4 +38,3 @@
 .flaggedText {
   margin-right: 4px;
 }
-

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -95,6 +95,9 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
       document.body.classList.remove(`background-${oldTheme}`);
     }
     document.body.classList.add(`background-${themeDowncase}`);
+    // Set body's data-theme attribute to the current theme, as the copy button tooltip (DSCO Tooltip) is
+    // not a DOM descendant of its logical parent. Rather it is placed directly under body and thus is not
+    // affected by the data-theme attribute value set in ThemeProvider.
     document.body.setAttribute('data-theme', theme);
   }, [theme]);
 

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -95,6 +95,7 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
       document.body.classList.remove(`background-${oldTheme}`);
     }
     document.body.classList.add(`background-${themeDowncase}`);
+    document.body.setAttribute('data-theme', theme);
   }, [theme]);
 
   // Store the level ID provided by App Options in redux if necessary.

--- a/apps/src/mixins.scss
+++ b/apps/src/mixins.scss
@@ -32,20 +32,28 @@
   }
 }
 
-@mixin icon-button($background, $selected, $active) {
+@mixin icon-button(
+  $default-background-color,
+  $hover-background-color,
+  $selected-color,
+  $active-color
+  ) {
+
+   background-color: $default-background-color;
+
   i {
     color: var(--text-neutral-tertiary);
   }
 
   &.selected i, &:hover i {
-    color: $selected;
+    color: $selected-color;
   }
 
   &:hover {
-    background-color: $background;
+    background-color: $hover-background-color;
   }
 
   &:active i {
-    color: $active;
+    color: $active-color;
   }
 }


### PR DESCRIPTION
This is a quick first pass at adding dark mode support for AI Tutor's use of the `<ChatWorkspace>` component originally used for AI Chat.  Colors were chosen from DSCO colors either to match the original colors used in AI Chat or to get as close as possible.  I also attempted to chose the correct semantic color (as multiple semantic colors could use the same primitives) and if more than one was appropriate, I chose the one that led to the most logical dark-mode color.


https://github.com/user-attachments/assets/3047f10f-8604-47d1-beb2-b62c17fa287a



In the interest of time, we're hoping to get this merged pretty quickly for @samantha-code's student testing and then we can revisit.  The thought is that this quick first pass is better than Sam having to ensure students aren't in dark mode which takes time and distracts focus from the testing.  With that said, I think an important consideration is that this doesn't degrade the AI Chat experience, which was my main concern when throwing this together.

The few colors that were not perfectly matched in light mode (what AI Chat uses exclusively) are highlighted in this image with the blue arrow and oval to show slightly different before and after colors for message backgrounds (green arrow indicates color is the same).  Note: I couldn't figure out how to show a warning message in practice but the light mode color was also really close to what was used previously (I updated this for dark mode in case a warning ever pops up in AI Tutor).

<img width="1485" alt="before-after" src="https://github.com/user-attachments/assets/455c0713-ca0b-4f57-8770-1925a303542f" />

Finally, this is my first student facing frontend PR, so any guidance on how we think about UI tests for a change like this would be appreciated.