### PR TITLE
Change background colors for design

### DIFF
--- a/apps/src/templates/sectionProgressV2/StudentColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/StudentColumn.jsx
@@ -23,14 +23,17 @@ const SECTION_PROGRESS_V2 = 'SectionProgressV2';
 
 const skeletonCell = index => (
   <div
-    className={classNames(styles.gridBox, styles.gridBoxStudent)}
+    className={classNames(
+      styles.gridBox,
+      styles.gridBoxStudent,
+      index % 2 === 0 ? styles.lighterBackground : styles.darkerBackground
+    )}
     key={index}
   >
     <span
       className={classNames(
         skeletonizeContent.skeletonizeContent,
-        styles.gridBoxSkeleton,
-        index % 2 === 0 ? styles.lighterBackground : styles.darkerBackground
+        styles.gridBoxSkeleton
       )}
       style={{width: _.random(30, 90) + '%'}}
       // eslint-disable-next-line react/forbid-dom-props

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -515,7 +515,7 @@ $level-cell-width: 52;
 }
 
 .darkerBackground {
-  background-color: var(--background-neutral-tertiary);
+  background-color: var(--background-neutral-secondary);
 }
 
 .lighterBackground {

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -95,7 +95,7 @@
 
   &.selected {
     border-left: 4px solid var(--borders-brand-teal-primary);
-    background-color: var(--background-neutral-tertiary);
+    background-color: var(--background-neutral-quaternary);
     padding-left: 28px;
     text-decoration: none;
     color: var(--text-neutral-primary);


### PR DESCRIPTION
Changes the alternating row darker background to secondary and the selected navigation page to quaternary per design request.

Also fixes a bug where skeleton cells were not showing the alternating colors

![image](https://github.com/user-attachments/assets/5c7a41bc-5794-4a91-bcbf-28378e488160)

