### PR TITLE
Add jquery load to prevent test flake

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -38,6 +38,7 @@ Feature: BubbleChoice
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/40/levels/1"
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
+    And I wait for jquery to load
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
     Then I select the "New Section" option in dropdown with class "uitest-sectionselect"
     And I wait for 5 seconds


### PR DESCRIPTION
Test failure from `bubble_choice.feature` was:
`Failed: A JavaScript exception occured: Can't find variable: $`

This is a jquery exception when it fails to load. Adding a wait for jquery.

## Links

Test failures [first](https://cucumber-logs.s3.amazonaws.com/test/test/Safari_teacher_tools_level_types_bubble_choice_output.html?versionId=a1fuoWGPtqLoAKYMbOVuUQXXsviDqOPY), [second](https://app.saucelabs.com/tests/1e3a84219a584a1688a03c632018810a#133)
![image](https://github.com/user-attachments/assets/bdc35d0b-6dc1-4ffd-a156-52434c5c2b9e)

[Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1751471906828789)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 
