### PR TITLE
Disable test due to flakiness

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -104,6 +104,8 @@ Scenario: Check for Understanding summaries
   And element "p:contains('Sally')" does not exist
   And I wait until element "a:contains('Show hidden responses')" is visible
 
+@skip
+# Skipping 7-2-25 due to flakiness
 Scenario: Check free response AI
   Given I am on "http://studio.code.org"
 


### PR DESCRIPTION
Disables `level_summary.check_free_response_ai` test due to flakiness

## Links
Example test failures. [first](https://cucumber-logs.s3.amazonaws.com/circle/34957/Chrome_teacher_tools_level_summary_output.html?versionId=HfNxUocfyvfYSEN3VQ0PdbS5qqCWAIWf), [second](https://cucumber-logs.s3.amazonaws.com/circle/34973/Chrome_teacher_tools_level_summary_output.html?versionId=PNoVkYe1yylA0a0Az2aNyEg_GRMRTtdZ), [third](https://cucumber-logs.s3.amazonaws.com/circle/34972/Chrome_teacher_tools_level_summary_output.html?versionId=XB2.wl.dG5eCAG0yjWzHg0gI9zr8W.lh)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65/backlog?selectedIssue=TEACH-2072
