### PR TITLE
[MusicLab] Fixes click-to-scroll focus lock bug by adding tab stop in scrolling region

### DIFF
--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -414,7 +414,13 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
               })}
             </div>
           )}
-          <div id="sounds-panel-right" className={styles.rightColumn}>
+          <div
+            id="sounds-panel-right"
+            className={styles.rightColumn}
+            tabIndex={0}
+            role="tabpanel"
+            aria-label={'Sounds Panel, ' + selectedFolder.name}
+          >
             {rightColumnSoundEntries.map((soundEntry, soundIndex) => {
               return (
                 <SoundsPanelRow


### PR DESCRIPTION
The FocusLock plugin was causing issues with our click-to-scroll functionality in the sounds panel.

Specifically, if a sound was selected, the user would be unable to use the click-to-scroll if it meant the selected sound was no longer displayed. The interaction was jumpy, with the panel scrolling partway and then jumping back.

There are known issues between FocusLock and scrollbars. There is a way to disable scrolling altogether, but we want to make sure both can work simultaneously. It turns out that the solution is to add a tab stop to the scrolling panel so that FocusLock recognizes it as a focusable area and no longer restricts the scroll actions. It was apparently not enough for the panel to have focusable children. That is, the line that fixes the bug is the tabIndex={0} line. 

The rest are for accessibility: if you are going to have a tab stop you need a label for it, and if you are going to have a label (and you are working with a div instead of a native html element) you need to ensure the screenreader knows the role.

I selected the label to read out the folder name so it is obvious that the presented sounds on the right correspond to the selected folder on the left.

I was able to test this both in the simple sounds panel and the more complex one (with and without the top panel of tab options), and when the sounds are on the right and when they take over the full width.

Shoutout to Dan's daughter Eva who caught this bug!!

Before:

https://github.com/user-attachments/assets/8b0e8771-563b-4ef7-aaae-6aa4501d8b95



After:

https://github.com/user-attachments/assets/beb521a7-f897-49e4-b2f8-230e33644042


With screenreader on to view the new tab stop:



https://github.com/user-attachments/assets/73165a3f-366a-4ac9-88d6-31b4186cef57





## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1508
- Slack Discussion: https://codedotorg.slack.com/archives/C07UT279KM1/p1751390210462299

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
