### PR TITLE
Fix text to speech and lesson extras not showing in advanced settings when creating a section

### DIFF
--- a/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
@@ -115,17 +115,11 @@ function updateSectionCourse(updateCourse, course) {
   }
 
   const courseVersion = courseVersions[courseVersionId];
-  const isStandaloneUnit = courseVersion.type === 'Unit';
 
-  let hasLessonExtras;
-  let hasTextToSpeech;
-
-  if (isStandaloneUnit) {
-    hasLessonExtras = Object.values(courseVersion.units)[0]
-      .lesson_extras_available;
-    hasTextToSpeech = Object.values(courseVersion.units)[0]
-      .text_to_speech_enabled;
-  }
+  const hasLessonExtras = Object.values(courseVersion.units)[0]
+    .lesson_extras_available;
+  const hasTextToSpeech = Object.values(courseVersion.units)[0]
+    .text_to_speech_enabled;
 
   updateCourse({
     displayName: course.display_name,

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -36,9 +36,10 @@ const SECTIONS_API = '/api/v1/sections';
 const NEW = 'New';
 
 // Custom hook to update the list of sections to create
-// Currently, this hook returns two things:
+// Currently, this hook returns three things:
 //   - sections: list of objects that represent the sections to create
 //   - updateSection: function to update the section at the given index
+//   - batchUpdateSection: function to update multiple section properties at once
 const useSections = section => {
   // added "default properties" for any new section
   const [sections, setSections] = useState(


### PR DESCRIPTION
There was an error preventing two advanced section options (text to speech and lesson extras) from showing on the section edit page when creating a new section. This was because the booleans that determine whether to display these options would only be set if the course selected was a standalone unit. This update removes the standalone unit check so that the options will display for any course that allows for text to speech or includes lesson extras.

## Links
[TEACH-1917](https://codedotorg.atlassian.net/browse/TEACH-1917)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
