### PR TITLE
AI Chat: use level properties and sources from props

### DIFF
--- a/apps/src/aichat/levelPropertiesContext.ts
+++ b/apps/src/aichat/levelPropertiesContext.ts
@@ -1,0 +1,14 @@
+import {createContext, useContext} from 'react';
+
+import {AichatLevelProperties} from './types';
+
+export const LevelPropertiesContext =
+  createContext<AichatLevelProperties | null>(null);
+
+export const useLevelProperties = () => {
+  const context = useContext(LevelPropertiesContext);
+  if (context === null) {
+    throw new Error('Level properties have not been provided!');
+  }
+  return context;
+};

--- a/apps/src/aichat/redux/selectors/index.ts
+++ b/apps/src/aichat/redux/selectors/index.ts
@@ -3,7 +3,6 @@ import {createSelector} from '@reduxjs/toolkit';
 import type {RootState} from '@cdo/apps/types/redux';
 
 import {modelDescriptions} from '../../constants';
-import type {AichatLevelProperties} from '../../types';
 import {
   allFieldsHidden,
   anyFieldsChanged,
@@ -48,14 +47,12 @@ export const selectHavePropertiesChanged = (state: RootState) =>
     state.aichat.currentAiCustomizations
   ).length > 0;
 
-export const selectMultimodalEnabled = ({aichat, lab}: RootState) => {
-  const multimodalSupported = modelDescriptions.find(
-    model => model.id === aichat.savedAiCustomizations.selectedModelId
-  )?.multimodal;
+export const getSelectMultimodalAvailable =
+  (multimodalEnabled?: boolean) =>
+  ({aichat}: RootState) => {
+    const multimodalSupported = modelDescriptions.find(
+      model => model.id === aichat.savedAiCustomizations.selectedModelId
+    )?.multimodal;
 
-  const multimodalEnabled = (
-    lab.levelProperties as AichatLevelProperties | undefined
-  )?.aichatSettings?.multimodalEnabled;
-
-  return multimodalSupported && multimodalEnabled;
-};
+    return multimodalSupported && multimodalEnabled;
+  };

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -25,6 +25,7 @@ import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 
 import {getUserHasAichatAccess} from '../aichatApi';
 import {ModalTypes} from '../constants';
+import {LevelPropertiesContext} from '../levelPropertiesContext';
 import aichatI18n from '../locale';
 import {
   addChatEvent,
@@ -59,22 +60,16 @@ const getResetModelNotification = (): Notification => ({
   includeInChatHistory: true,
 });
 
-const AichatView: React.FunctionComponent<LabProps> = () => {
+const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
+  levelProperties,
+  initialSources,
+}) => {
   const dispatch = useAppDispatch();
 
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
 
-  const levelAichatSettings = useAppSelector(
-    state =>
-      (state.lab.levelProperties as AichatLevelProperties | undefined)
-        ?.aichatSettings
-  );
-
-  const initialSources = useAppSelector(
-    state => (state.lab.initialSources?.source as string) || '{}'
-  );
-
+  const levelAichatSettings = levelProperties.aichatSettings;
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
 
   const {currentAiCustomizations, viewMode, showModalType} = useAppSelector(
@@ -112,7 +107,9 @@ const AichatView: React.FunctionComponent<LabProps> = () => {
   }, [projectManager, dispatch]);
 
   useEffect(() => {
-    const studentAiCustomizations = JSON.parse(initialSources);
+    const studentAiCustomizations = JSON.parse(
+      (initialSources?.source as string) || '{}'
+    );
     dispatch(
       setStartingAiCustomizations({
         levelAichatSettings,
@@ -271,93 +268,95 @@ const AichatView: React.FunctionComponent<LabProps> = () => {
   }, [dispatch]);
 
   return (
-    <div id="aichat-lab" className={moduleStyles.aichatLab}>
-      {ChatModal && <ChatModal onClose={onCloseModal} />}
-      {showPresentationToggle() && (
-        <div
-          id="uitest-view-mode-toggle-container"
-          className={moduleStyles.viewModeButtons}
-        >
-          <SegmentedButtons {...viewModeButtonsProps} />
-        </div>
-      )}
-      <div className={moduleStyles.labCoreContainer}>
-        {viewMode === ViewMode.EDIT && (
-          <>
-            <div className={moduleStyles.instructionsArea}>
-              <PanelContainer
-                id="aichat-instructions-panel"
-                headerContent={commonI18n.instructions()}
-                className={moduleStyles.panelContainer}
-                headerClassName={moduleStyles.panelHeader}
-                rightHeaderContent={renderInstructionsHeaderRight(
-                  isUserTeacher,
-                  () => {
-                    dispatch(setShowModalType(ModalTypes.TEACHER_ONBOARDING));
-                  }
-                )}
-              >
-                <Instructions
-                  className={moduleStyles.instructions}
-                  /** AI Chat doesn't have a traditional "run" state, so this is always false. */
-                  isRunning={false}
-                  hasRun={hasSentMessage}
-                  hasEdited={hasUpdatedCustomizations}
-                />
-              </PanelContainer>
-            </div>
-            {!allFieldsHidden && (
-              <div className={moduleStyles.customizationArea}>
+    <LevelPropertiesContext.Provider value={levelProperties}>
+      <div id="aichat-lab" className={moduleStyles.aichatLab}>
+        {ChatModal && <ChatModal onClose={onCloseModal} />}
+        {showPresentationToggle() && (
+          <div
+            id="uitest-view-mode-toggle-container"
+            className={moduleStyles.viewModeButtons}
+          >
+            <SegmentedButtons {...viewModeButtonsProps} />
+          </div>
+        )}
+        <div className={moduleStyles.labCoreContainer}>
+          {viewMode === ViewMode.EDIT && (
+            <>
+              <div className={moduleStyles.instructionsArea}>
                 <PanelContainer
-                  id="aichat-model-customization-panel"
-                  headerContent={aichatI18n.modelCustomizationHeader()}
+                  id="aichat-instructions-panel"
+                  headerContent={commonI18n.instructions()}
                   className={moduleStyles.panelContainer}
                   headerClassName={moduleStyles.panelHeader}
-                  rightHeaderContent={
-                    !viewAsUserId &&
-                    renderModelCustomizationHeaderRight(() => {
-                      onClickStartOver();
-                      dispatch(
-                        sendAnalytics(EVENTS.AICHAT_START_OVER, {
-                          levelPath: window.location.pathname,
-                        })
-                      );
-                    })
-                  }
+                  rightHeaderContent={renderInstructionsHeaderRight(
+                    isUserTeacher,
+                    () => {
+                      dispatch(setShowModalType(ModalTypes.TEACHER_ONBOARDING));
+                    }
+                  )}
                 >
-                  <ModelCustomizationWorkspace />
+                  <Instructions
+                    className={moduleStyles.instructions}
+                    /** AI Chat doesn't have a traditional "run" state, so this is always false. */
+                    isRunning={false}
+                    hasRun={hasSentMessage}
+                    hasEdited={hasUpdatedCustomizations}
+                  />
                 </PanelContainer>
               </div>
-            )}
-          </>
-        )}
-        {viewMode === ViewMode.PRESENTATION && (
-          <div
-            id="uitest-presentation-view-container"
-            className={moduleStyles.presentationArea}
-          >
+              {!allFieldsHidden && (
+                <div className={moduleStyles.customizationArea}>
+                  <PanelContainer
+                    id="aichat-model-customization-panel"
+                    headerContent={aichatI18n.modelCustomizationHeader()}
+                    className={moduleStyles.panelContainer}
+                    headerClassName={moduleStyles.panelHeader}
+                    rightHeaderContent={
+                      !viewAsUserId &&
+                      renderModelCustomizationHeaderRight(() => {
+                        onClickStartOver();
+                        dispatch(
+                          sendAnalytics(EVENTS.AICHAT_START_OVER, {
+                            levelPath: window.location.pathname,
+                          })
+                        );
+                      })
+                    }
+                  >
+                    <ModelCustomizationWorkspace />
+                  </PanelContainer>
+                </div>
+              )}
+            </>
+          )}
+          {viewMode === ViewMode.PRESENTATION && (
+            <div
+              id="uitest-presentation-view-container"
+              className={moduleStyles.presentationArea}
+            >
+              <PanelContainer
+                id="aichat-presentation-panel"
+                headerContent={aichatI18n.modelCardPanelHeader()}
+                className={moduleStyles.panelContainer}
+                headerClassName={moduleStyles.panelHeader}
+              >
+                <PresentationView />
+              </PanelContainer>
+            </div>
+          )}
+          <div className={moduleStyles.chatWorkspaceArea}>
             <PanelContainer
-              id="aichat-presentation-panel"
-              headerContent={aichatI18n.modelCardPanelHeader()}
+              id="aichat-workspace-panel"
+              headerContent={chatWorkspaceHeader}
               className={moduleStyles.panelContainer}
               headerClassName={moduleStyles.panelHeader}
             >
-              <PresentationView />
+              <ChatWorkspace onClear={onClear} />
             </PanelContainer>
           </div>
-        )}
-        <div className={moduleStyles.chatWorkspaceArea}>
-          <PanelContainer
-            id="aichat-workspace-panel"
-            headerContent={chatWorkspaceHeader}
-            className={moduleStyles.panelContainer}
-            headerClassName={moduleStyles.panelHeader}
-          >
-            <ChatWorkspace onClear={onClear} />
-          </PanelContainer>
         </div>
       </div>
-    </div>
+    </LevelPropertiesContext.Provider>
   );
 };
 

--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -8,6 +8,7 @@ import {ValueOf} from '@cdo/apps/types/utils';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
+import {useLevelProperties} from '../levelPropertiesContext';
 import {
   type ChatMessage as ChatMessageType,
   isCompletedChatMessage,
@@ -33,7 +34,7 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
   const [showProfaneUserMessage, setShowProfaneUserMessage] = useState(false);
   const {status, role, chatMessageText, assets} = chatMessage;
   const currentChannelId = useAppSelector(state => state.lab.channel?.id);
-  const levelName = useAppSelector(state => state.lab.levelProperties?.name);
+  const levelName = useLevelProperties().name;
 
   const displayText = getChatMessageDisplayText(
     status,

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -6,13 +6,14 @@ import {useSelector} from 'react-redux';
 
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {useLevelProperties} from '../levelPropertiesContext';
 import aichatI18n from '../locale';
 import {
   clearChatMessages,
   clearStagedFiles,
   fetchUserChatHistory,
+  getSelectMultimodalAvailable,
   selectAllVisibleMessages,
-  selectMultimodalEnabled,
 } from '../redux';
 import {ChatButton} from '../types';
 import {getShortName} from '../utils';
@@ -150,7 +151,11 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     tabPanelsContainerClassName: moduleStyles.tabPanelsContainer,
   };
 
-  const multimodalEnabled = useAppSelector(selectMultimodalEnabled);
+  const multimodalEnabled = useAppSelector(
+    getSelectMultimodalAvailable(
+      useLevelProperties().aichatSettings?.multimodalEnabled
+    )
+  );
 
   return (
     <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>

--- a/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
+++ b/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
@@ -3,10 +3,10 @@ import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import React, {useCallback, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 
-import {AichatLevelProperties} from '@cdo/apps/aichat/types';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {useLevelProperties} from '../levelPropertiesContext';
 import aichatI18n from '../locale';
 
 import PublishNotes from './modelCustomization/PublishNotes';
@@ -28,11 +28,8 @@ const ModelCustomizationWorkspace: React.FunctionComponent = () => {
 
   const isReadOnly = useSelector(isReadOnlyWorkspace);
 
-  const hidePresentationPanel = useAppSelector(
-    state =>
-      (state.lab.levelProperties as AichatLevelProperties | undefined)
-        ?.aichatSettings?.hidePresentationPanel
-  );
+  const hidePresentationPanel =
+    useLevelProperties().aichatSettings?.hidePresentationPanel;
 
   const showSetupCustomization =
     isVisible(temperature) ||

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -4,7 +4,8 @@ import React, {useCallback, useEffect, useRef} from 'react';
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {selectMultimodalEnabled, submitChatContents} from '../redux';
+import {useLevelProperties} from '../levelPropertiesContext';
+import {getSelectMultimodalAvailable, submitChatContents} from '../redux';
 import {ChatButton} from '../types';
 
 import moduleStyles from './UserChatMessageEditor.module.scss';
@@ -22,7 +23,11 @@ const UserChatMessageEditor: React.FunctionComponent<{
   );
 
   const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
-  const multimodalEnabled = useAppSelector(selectMultimodalEnabled);
+  const multimodalEnabled = useAppSelector(
+    getSelectMultimodalAvailable(
+      useLevelProperties().aichatSettings?.multimodalEnabled
+    )
+  );
   const chatAssets = useAppSelector(state =>
     state.aichat.stagedFiles.map(file => file.asset)
   );

--- a/apps/src/aichat/views/assets/StagedFilesPreview.tsx
+++ b/apps/src/aichat/views/assets/StagedFilesPreview.tsx
@@ -5,6 +5,7 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {MAX_FILE_SIZE_MB, MAX_NUM_FILES} from '../../constants';
+import {useLevelProperties} from '../../levelPropertiesContext';
 import aichatI18n from '../../locale';
 import {
   clearStagedFilesAlert,
@@ -33,7 +34,7 @@ const StagedFilesPreview: React.FC = () => {
   const dispatch = useAppDispatch();
   const stagedFiles = useAppSelector(state => state.aichat.stagedFiles);
   const currentChannelId = useAppSelector(state => state.lab.channel?.id);
-  const levelName = useAppSelector(state => state.lab.levelProperties?.name);
+  const levelName = useLevelProperties().name;
 
   const [alertMessage, style] = useAppSelector(state => {
     if (!state.aichat.stagedFilesAlert) {

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -16,6 +16,7 @@ import {
   MAX_FILE_SIZE_MB,
   MAX_NUM_FILES,
 } from '../../constants';
+import {useLevelProperties} from '../../levelPropertiesContext';
 import aichatI18n from '../../locale';
 import {
   addStagedFile,
@@ -35,11 +36,9 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
     state => state.aichat.stagedFiles.length
   );
   const numAllowedFiles = MAX_NUM_FILES - numStagedFiles;
-  const levelName = useAppSelector(state => state.lab.levelProperties?.name);
-  const hasStarterAssets = useAppSelector(state => {
-    const starterAssets = state.lab.levelProperties?.starterAssets;
-    return starterAssets && Object.keys(starterAssets).length > 0;
-  });
+  const {name: levelName, starterAssets} = useLevelProperties();
+  const hasStarterAssets =
+    starterAssets && Object.keys(starterAssets).length > 0;
   const [showAssetManager, setShowAssetManager] = useState(false);
 
   const onUploadFiles = async (event: ChangeEvent<HTMLInputElement>) => {

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -5,11 +5,12 @@ import classNames from 'classnames';
 import React, {useState, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
-import {AichatLevelProperties, ModelDescription} from '@cdo/apps/aichat/types';
+import {ModelDescription} from '@cdo/apps/aichat/types';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {modelDescriptions} from '../../constants';
+import {useLevelProperties} from '../../levelPropertiesContext';
 import aichatI18n from '../../locale';
 import {setAiCustomizationProperty} from '../../redux';
 
@@ -43,11 +44,8 @@ const SetupCustomization: React.FunctionComponent = () => {
     state => state.aichat.currentAiCustomizations
   );
 
-  const availableModelIds = useAppSelector(
-    state =>
-      (state.lab.levelProperties as AichatLevelProperties | undefined)
-        ?.aichatSettings?.availableModelIds
-  );
+  const availableModelIds =
+    useLevelProperties().aichatSettings?.availableModelIds;
 
   // Handle the possibility that modelDescription can change but levels
   // may be using outdated model ids. Fall back to first modelDescription.


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/66820. Level properties are exposed to sub-components using react context.

All lab2 labs should now be getting level properties and sources from props instead of redux.

## Testing story

Tested locally on AI Chat levels. No functional changes.

## Follow-up work

Now that all labs have been converted over, we'll need to tackle the remaining usages in shared components and redux files.