### PR TITLE
chore: enable debug marketing router paths

### DIFF
--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -343,6 +343,7 @@ const marketingPaths = {
   "/blockchain": true,
   "/curriculum/music": true,
   "/security": true,
+  "/about/geocode_test": true,
 }
 
 const nextJsAssetsPath = '/_next/static/';


### PR DESCRIPTION
Enables `/about/geocode_test` and `/https/mixed-content`