### PR TITLE
add given_name to PII scrubber service

### DIFF
--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -65,6 +65,7 @@ module Services
 
         # Names
         user.name = nil
+        user.given_name = nil
         user.family_name = nil
         user.username = SecureRandom.alphanumeric(20)
         user.ops_first_name = nil

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -11,6 +11,10 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
       :within_united_states,
       email: email,
       current_sign_in_ip: '192.168.0.1',
+      name: 'John Doe',
+      given_name: 'John',
+      family_name: 'Doe',
+      full_address: '123 Main St, Springfield, USA',
     ).destroy
   end
   let(:described_instance) {described_class.new(user: user)}
@@ -44,6 +48,9 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
       end
 
       it 'removes user email and authentication data' do
+        _(user.read_attribute(:email)).must_be :present?
+        _(user.read_attribute(:hashed_email)).must_be :present?
+        _(user.authentication_options.with_deleted).must_be :present?
         scrub_pii
         user.reload
         _(user.email).must_equal ''
@@ -54,6 +61,9 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
       end
 
       it 'removes names and assigns a UUID username' do
+        _(user.name).must_be :present?
+        _(user.given_name).must_be :present?
+        _(user.family_name).must_be :present?
         original_username = user.username
         scrub_pii
         user.reload
@@ -65,6 +75,8 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
       end
 
       it 'removes address and location data' do
+        _(user.full_address).must_be :present?
+        _(user.current_sign_in_ip).must_be :present?
         scrub_pii
         user.reload
         _(user.full_address).must_be_nil
@@ -102,6 +114,9 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
       end
 
       it 'removes legacy oauth fields' do
+        _(user.oauth_token).must_be :present?
+        _(user.oauth_refresh_token).must_be :present?
+        _(user.oauth_token_expiration).must_be :present?
         scrub_pii
         user.reload
         _(user.oauth_token).must_be_nil

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -58,6 +58,7 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
         scrub_pii
         user.reload
         _(user.name).must_be_nil
+        _(user.given_name).must_be_nil
         _(user.family_name).must_be_nil
         _(user.username).wont_equal original_username
         _(user.username).wont_be_nil


### PR DESCRIPTION
`given_name` is a new addition to the user model, representing a user's first name. Since names are considered high risk PII, this field needs to be added to the PII scrubber service.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1555)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
