### PR TITLE
AI Tutor: Allow access for chat history related apis for aitutor2

### DIFF
--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -10,6 +10,10 @@ class AichatEventsController < ApplicationController
       return render status: :bad_request, json: {}
     end
 
+    unless can_log_aichat_events?(params[:aichatContext][:currentLevelId])
+      return render status: :forbidden, json: {user_type: current_user.user_type}
+    end
+
     context = params[:aichatContext]
     event = params[:newChatEvent]
 
@@ -101,8 +105,12 @@ class AichatEventsController < ApplicationController
     render status: :ok, json: {}
   end
 
+  private def can_log_aichat_events?(level_id)
+    current_user.has_aichat_access? || current_user.can_access_ai_tutor2?(level_id)
+  end
+
   private def can_view_chat_history?(user_id)
-    User.find_by_id(user_id)&.student_of?(current_user) || current_user.id == user_id
+    current_user.id == user_id || User.find_by_id(user_id)&.student_of?(current_user)
   end
 
   private def can_submit_feedback?(user_id)

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -27,8 +27,9 @@ class AichatRequestsController < ApplicationController
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
     end
-    return render status: :forbidden, json: {user_type: current_user.user_type} unless can_access_aichat? || can_access_ai_tutor2?(params[:aichatContext][:currentLevelId])
-
+    unless can_access_aichat_chat_completion? || can_access_ai_tutor2_chat_completion?(params[:aichatContext][:currentLevelId])
+      return render status: :forbidden, json: {user_type: current_user.user_type}
+    end
     return head :too_many_requests if should_throttle_request_count?
 
     model_id = params[:aichatModelCustomizations][:selectedModelId]
@@ -90,14 +91,14 @@ class AichatRequestsController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
-  private def can_access_ai_tutor2?(level_id)
-    # AiTutor2 requests only come from python lab levels.
-    return false if level_id.nil? || DCDO.get("block_ai_tutor2_chat_completion", false)
-    Level.find(level_id).is_a? Pythonlab
+  private def can_access_ai_tutor2_chat_completion?(level_id)
+    return false if DCDO.get("block_ai_tutor2_chat_completion", false)
+    current_user.can_access_ai_tutor2?(level_id)
   end
 
-  private def can_access_aichat?
-    !DCDO.get("block_aichat_chat_completion", false) && current_user.has_aichat_access?
+  private def can_access_aichat_chat_completion?
+    return false if DCDO.get("block_aichat_chat_completion", false)
+    current_user.has_aichat_access?
   end
 
   private def should_throttle_request_count?

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -173,7 +173,7 @@ class Ability
       # all signed in users can access the aichat_request and aichat_events endpoints
       # additional permission logic lives in the controllers themselves
       can [:start_chat_completion, :chat_request], :aichat_request
-      can [:log_chat_event, :chat_history], :aichat_event
+      can [:log_chat_event, :chat_history, :submit_teacher_feedback], :aichat_event
 
       if user.teacher?
         can :manage, Section do |s|
@@ -522,10 +522,6 @@ class Ability
 
       can :find_toxicity, :aichat do
         user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
-      end
-
-      can :submit_teacher_feedback, :aichat_event do
-        user.teacher?
       end
 
       can :user_has_access, :aichat

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -170,9 +170,10 @@ class Ability
 
       can :evaluate, :openai_evaluate
 
-      # all signed in users can access the aichat_request endpoint
-      # additional permission logic lives in the controller itself
+      # all signed in users can access the aichat_request and aichat_events endpoints
+      # additional permission logic lives in the controllers themselves
       can [:start_chat_completion, :chat_request], :aichat_request
+      can [:log_chat_event, :chat_history], :aichat_event
 
       if user.teacher?
         can :manage, Section do |s|
@@ -523,13 +524,8 @@ class Ability
         user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
       end
 
-      # Additional logic that confirms that a given teacher or student should have access
-      # to a given student (or their own, in the case of a student viewer) chat history is in aichat_events_controller.
-      can [:log_chat_event, :chat_history], :aichat_event do
-        user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
-      end
       can :submit_teacher_feedback, :aichat_event do
-        user.teacher_can_access_ai_chat?
+        user.teacher?
       end
 
       can :user_has_access, :aichat

--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -12,16 +12,12 @@ module User::AiAccessible
 
   def has_ai_tutor_access?
     return false if ai_tutor_access_denied || ai_tutor_feature_globally_disabled?
-    permission_for_ai_tutor? || in_ai_tutor_experiment_with_enabled_section?
+    ai_tutor_permission? || in_ai_tutor_experiment_with_enabled_section?
   end
 
   def can_enable_ai_tutor?
-    !DCDO.get('ai-tutor-disabled', false) && (ai_tutor_permission? ||
+    !ai_tutor_feature_globally_disabled? && (ai_tutor_permission? ||
       SingleUserExperiment.enabled?(user: self, experiment_name: AI_TUTOR_EXPERIMENT_NAME))
-  end
-
-  def ai_tutor_permission?
-    permission?(UserPermission::AI_TUTOR_ACCESS)
   end
 
   def can_use_ai_iteration_tools?
@@ -47,11 +43,18 @@ module User::AiAccessible
     teacher_can_access_ai_chat? || student_can_access_ai_chat?
   end
 
+  def can_access_ai_tutor2?(level_id)
+    # If the request is coming from a python lab level, trust the client to decide
+    # if it can access AiTutor2. This allows easy testing of AiTutor2 using a url param.
+    return false if level_id.nil?
+    Level.find(level_id).is_a? Pythonlab
+  end
+
   private def ai_tutor_feature_globally_disabled?
     DCDO.get('ai-tutor-disabled', false)
   end
 
-  private def permission_for_ai_tutor?
+  private def ai_tutor_permission?
     permission?(UserPermission::AI_TUTOR_ACCESS)
   end
 

--- a/dashboard/test/controllers/aichat_events_controller_test.rb
+++ b/dashboard/test/controllers/aichat_events_controller_test.rb
@@ -6,6 +6,8 @@ class AichatEventsControllerTest < ActionController::TestCase
   setup_all do
     @authorized_teacher1 = create :authorized_teacher
     @authorized_teacher2 = create :authorized_teacher
+    @unauthorized_student = create(:student)
+    @unauthorized_teacher = create(:teacher)
     unit_group = create :unit_group, name: 'exploring-gen-ai-2024'
     @section = create :section, user: @authorized_teacher1, unit_group: unit_group
     @authorized_student1 = create(:follower, section: @section).student_user
@@ -39,24 +41,34 @@ class AichatEventsControllerTest < ActionController::TestCase
     @controller.stubs(:storage_decrypt_channel_id).returns([123, 456])
   end
 
-  users = [:student, :teacher]
-  [
-    :log_chat_event,
-    :submit_teacher_feedback,
-    [:chat_history, :get]
-  ].each do |action, method = :post|
-    users.each do |user|
-      test_user_gets_response_for action,
-        name: "#{user}_no_access_#{action}_test",
-        user: user,
-        method: method,
-        response: :forbidden
-    end
-  end
-
   # *****
   # log_chat_event tests
   # *****
+
+  test 'log_chat_event returns forbidden if user is not signed in' do
+    post :log_chat_event, params: {}, as: :json
+    assert_response :forbidden
+  end
+
+  test 'teachers without access to log_chat_event get forbidden response' do
+    sign_in(@unauthorized_teacher)
+    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
+    assert_response :forbidden
+  end
+
+  test 'students without access to log_chat_event get forbidden response' do
+    sign_in(@unauthorized_student)
+    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
+    assert_response :forbidden
+  end
+
+  test 'unauthorized users can access log_chat_event from python lab levels' do
+    sign_in(@unauthorized_student)
+    python_lab_level = create :pythonlab
+    params_with_python_level = @valid_params_log_chat_event.merge(aichatContext: @valid_params_log_chat_event[:aichatContext].merge(currentLevelId: python_lab_level.id))
+    post :log_chat_event, params: params_with_python_level, as: :json
+    assert_response :success
+  end
 
   test 'authorized teacher has access to log_chat_event' do
     sign_in(@authorized_teacher1)
@@ -116,6 +128,11 @@ class AichatEventsControllerTest < ActionController::TestCase
   # chat_history tests
   # *****
 
+  test 'chat_history returns forbidden if user is not signed in' do
+    get :chat_history, params: {}, as: :json
+    assert_response :forbidden
+  end
+
   test 'Bad request if required params are not included for chat_history' do
     sign_in(@authorized_teacher1)
     get :chat_history, params: {studentId: @authorized_student1.id}, as: :json
@@ -168,6 +185,11 @@ class AichatEventsControllerTest < ActionController::TestCase
   # *****
   # submit_teacher_feedback tests
   # *****
+
+  test 'submit_teacher_feedback returns forbidden if user is not signed in' do
+    post :submit_teacher_feedback, params: {}, as: :json
+    assert_response :forbidden
+  end
 
   test 'submit_teacher_feedback returns bad request if eventId is missing' do
     sign_in(@authorized_teacher1)

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -969,13 +969,6 @@ class AbilityTest < ActiveSupport::TestCase
     refute Ability.new(student).can? :chat_completion, :openai_chat
   end
 
-  test 'teachers should be able to submit_teacher_feedback but not students' do
-    student = create :student
-    teacher = create :teacher
-    refute Ability.new(student).can? :submit_teacher_feedback, :aichat_event
-    assert Ability.new(teacher).can? :submit_teacher_feedback, :aichat_event
-  end
-
   # other :aichat_request and aichat_event actions are tested via respective controller tests.
 
   private def put_students_in_section_and_code_review_group(students, section)

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -969,37 +969,14 @@ class AbilityTest < ActiveSupport::TestCase
     refute Ability.new(student).can? :chat_completion, :openai_chat
   end
 
-  test 'teacher meeting AI Chat access requirements can perform AI Chat actions' do
-    teacher = create :teacher
-    teacher.stubs(:teacher_can_access_ai_chat?).returns(true)
-    # :aichat_request actions are tested via the aichat_requests_controller tests.
-    assert Ability.new(teacher).can? :log_chat_event, :aichat_event
-    assert Ability.new(teacher).can? :chat_history, :aichat_event
-  end
-
-  test 'teacher not meeting AI Chat access requirements cannot perform AI Chat actions' do
-    teacher = create :teacher
-    teacher.stubs(:teacher_can_access_ai_chat?).returns(false)
-    # :aichat_request actions are tested via the aichat_requests_controller tests.
-    refute Ability.new(teacher).can? :log_chat_event, :aichat_event
-    refute Ability.new(teacher).can? :chat_history, :aichat_event
-  end
-
-  test 'student meeting AI Chat access requirements can perform AI Chat actions' do
+  test 'teachers should be able to submit_teacher_feedback but not students' do
     student = create :student
-    student.stubs(:student_can_access_ai_chat?).returns(true)
-    # :aichat_request actions are tested via the aichat_requests_controller tests.
-    assert Ability.new(student).can? :log_chat_event, :aichat_event
-    assert Ability.new(student).can? :chat_history, :aichat_event
+    teacher = create :teacher
+    refute Ability.new(student).can? :submit_teacher_feedback, :aichat_event
+    assert Ability.new(teacher).can? :submit_teacher_feedback, :aichat_event
   end
 
-  test 'student not meeting AI Chat access requirements cannot perform AI Chat actions' do
-    student = create :student
-    student.stubs(:student_can_access_ai_chat?).returns(false)
-    # :aichat_request actions are tested via the aichat_requests_controller tests.
-    refute Ability.new(student).can? :log_chat_event, :aichat_event
-    refute Ability.new(student).can? :chat_history, :aichat_event
-  end
+  # other :aichat_request and aichat_event actions are tested via respective controller tests.
 
   private def put_students_in_section_and_code_review_group(students, section)
     code_review_group = create :code_review_group, section: section


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Given the changes in #66653 to use more ai chat components, we need to relax some of the restrictions on ai chat apis to allow for chat history to be visible and allow teacher feedback. This change is similar to  #66883 to allow access from python lab levels so the client can choose whether to allow Ai Tutor 2 on these levels. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1498

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

tested locally and updated UTs for coverage


