### PR TITLE
fix(opengraph): use webp for og:image

### DIFF
--- a/frontend/apps/marketing/src/metadata/__tests__/seo.test.ts
+++ b/frontend/apps/marketing/src/metadata/__tests__/seo.test.ts
@@ -142,4 +142,19 @@ describe('getSeoMetadata', () => {
       follow: true,
     });
   });
+
+  it('should call getAbsoluteImageUrl with fm=png for openGraphImage', () => {
+    (getSeoMetadataFromExperience as jest.Mock).mockReturnValue(
+      mockSeoMetadata,
+    );
+    (getAbsoluteImageUrl as jest.Mock).mockReturnValue(
+      'https://example.com/test-image.png',
+    );
+    const locale = 'en-US';
+    getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, locale);
+    expect(getAbsoluteImageUrl).toHaveBeenCalledWith(
+      mockSeoMetadata.openGraphImage,
+      {fm: 'webp'},
+    );
+  });
 });

--- a/frontend/apps/marketing/src/metadata/seo.ts
+++ b/frontend/apps/marketing/src/metadata/seo.ts
@@ -36,7 +36,9 @@ function getOpenGraph(
   locale: string,
 ) {
   const openGraphImage = seoMetadata.openGraphImage;
-  const openGraphImageUrl = getAbsoluteImageUrl(openGraphImage);
+  // As of July 2025, all open graph providers support JPEG & PNG but there is only partial support for AVIF.
+  // Use webp for compatibility.
+  const openGraphImageUrl = getAbsoluteImageUrl(openGraphImage, {fm: 'webp'});
 
   return {
     type: 'website',

--- a/frontend/apps/marketing/src/selectors/contentful/getImage.ts
+++ b/frontend/apps/marketing/src/selectors/contentful/getImage.ts
@@ -6,7 +6,7 @@ export function getRelativeImageUrl(asset: ExperienceAsset | undefined) {
 
 export function getAbsoluteImageUrl(
   asset: ExperienceAsset | string | undefined,
-  additionalParams?: string,
+  additionalParams?: ConstructorParameters<typeof URLSearchParams>[0],
 ) {
   const imgUrl =
     typeof asset === 'string' ? asset : getRelativeImageUrl(asset) || undefined;

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -166,7 +166,7 @@ test.describe('All the things UI e2e test', () => {
       'OpenGraph Description',
     );
     expect(await allTheThingsPage.getOpenGraph('image')).toBe(
-      'https://contentful-images.code.org/90t6bu6vlf76/4hXiOPiRlCXpmtypRNOZqc/9ebe430094c1ae1faf742e1de3f8aa8b/engineering-only-opengraph-default.png?fm=avif',
+      'https://contentful-images.code.org/90t6bu6vlf76/4hXiOPiRlCXpmtypRNOZqc/9ebe430094c1ae1faf742e1de3f8aa8b/engineering-only-opengraph-default.png?fm=webp',
     );
     expect(await allTheThingsPage.getOpenGraph('type')).toBe('website');
   });


### PR DESCRIPTION
OpenGraph images were using AVIF as part of the effort to reduce bandwidth consumption. However, most social media sites do not support AVIF and therefore, opengraph does not work there. Most providers do support webp though which is a reasonable compromise between file size and quality.[1]

[1] https://darekkay.com/blog/open-graph-image-formats/