### PR TITLE
fix(workshops): workshop filter query unknown column

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -163,7 +163,6 @@ export default class WorkshopTable extends React.Component {
         property: 'regional_partner_name',
         header: {
           label: 'Regional Partner',
-          transforms: [sortable],
         },
       },
       {

--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -129,8 +129,7 @@ module Pd::WorkshopFilters
         when 'subject'
           workshops = workshops.order("subject #{direction}".strip)
         when 'virtual'
-          workshops = workshops.
-          joins("INNER JOIN pd_sessions ON pd_sessions.pd_workshop_id = pd_workshops.id and pd_sessions.deleted_at is null").
+          workshops = workshops.joins_sessions.
           group("pd_workshops.id").
           select("pd_workshops.*, MAX(CASE WHEN pd_sessions.session_format = #{Pd::Session.session_formats[:virtual]} THEN 1 ELSE 0 END) as has_virtual").
           order(Arel.sql("has_virtual #{direction}"))

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -266,14 +266,18 @@ class Pd::Workshop < ApplicationRecord
 
   scope :group_by_id, -> {group('pd_workshops.id')}
 
+  def self.joins_sessions
+    joins("INNER JOIN pd_sessions ON pd_sessions.pd_workshop_id = pd_workshops.id")
+  end
+
   # Filters by scheduled start date (date of first session)
   def self.scheduled_start_on_or_before(date)
-    joins(:sessions).group_by_id.having('(DATE(MIN(pd_sessions.start)) <= ?)', date)
+    joins_sessions.group_by_id.having('(DATE(MIN(pd_sessions.start)) <= ?)', date)
   end
 
   # Filters by scheduled start date (date of first session)
   def self.scheduled_start_on_or_after(date)
-    joins(:sessions).group_by_id.having('(DATE(MIN(pd_sessions.start)) >= ?)', date)
+    joins_sessions.group_by_id.having('(DATE(MIN(pd_sessions.start)) >= ?)', date)
   end
 
   scope(
@@ -289,7 +293,7 @@ class Pd::Workshop < ApplicationRecord
   # Orders by the scheduled start date (date of the first session),
   # @param :desc [Boolean] optional - when true, sort descending
   def self.order_by_scheduled_start(desc: false)
-    joins("INNER JOIN pd_sessions ON pd_sessions.pd_workshop_id = pd_workshops.id").
+    joins_sessions.
       group_by_id.
       # This SQL string is not at risk for injection vulnerabilites because
       # it's not injesting arbitrary strings, but programmatically constructing
@@ -327,20 +331,20 @@ class Pd::Workshop < ApplicationRecord
 
   # Filters by scheduled end date (date of last session)
   def self.scheduled_end_on_or_before(date)
-    joins(:sessions).group_by_id.having("(DATE(MAX(end)) <= ?)", date)
+    joins_sessions.group_by_id.having("(DATE(MAX(pd_sessions.end)) <= ?)", date)
   end
 
   # Filters by scheduled end date (date of last session)
   def self.scheduled_end_on_or_after(date)
-    joins(:sessions).group_by_id.having("(DATE(MAX(end)) >= ?)", date)
+    joins_sessions.group_by_id.having("(DATE(MAX(pd_sessions.end)) >= ?)", date)
   end
 
   def self.scheduled_start_in_days(days)
-    Pd::Workshop.joins(:sessions).group_by_id.having("(DATE(MIN(start)) = ?)", Time.zone.today + days.days)
+    joins_sessions.group_by_id.having("(DATE(MIN(pd_sessions.start)) = ?)", Time.zone.today + days.days)
   end
 
   def self.scheduled_end_in_days(days)
-    Pd::Workshop.joins(:sessions).group_by_id.having("(DATE(MAX(end)) = ?)", Time.zone.today + days.days)
+    joins_sessions.group_by_id.having("(DATE(MAX(pd_sessions.end)) = ?)", Time.zone.today + days.days)
   end
 
   # Filters by date the workshop actually ended, regardless of scheduled session times.
@@ -362,7 +366,7 @@ class Pd::Workshop < ApplicationRecord
   # Find the workshop that is closest in time to today
   # @return [Pd::Workshop, nil]
   def self.nearest
-    joins(:sessions).
+    joins_sessions.
       select("pd_workshops.*, ABS(DATEDIFF(pd_sessions.start, '#{Time.zone.today}')) AS day_diff").
       order("day_diff ASC").
       first


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
the workshop filter/order query is built by active record depending on the request params passed in. some params require the pd_workshops table joins the pd_sessions table. using active record `joins(:sessions)` would sometimes create an alias, `pd_sessions as sessions` depending on the combination of params, seemingly without reason. to fix this, I created a method on the workshop model called `joins_sessions` that joins the tables using raw sql so active record cannot add an alias that conflicts with other raw sql further downstream that relies on `pd_sessions`. I use the `joins_sessions` method in all the methods that join the sessions table in the filter query

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3320
- Honeybadger: https://app.honeybadger.io/projects/3240/faults/120827938

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
