### PR TITLE
Simplify enrollment creation to only need user_id

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
@@ -68,15 +68,7 @@ const WorkshopJoin: React.FunctionComponent<{
   );
 
   const handleSubmitEnrollment = async () => {
-    const result = await submitEnrollment(
-      user_info && {
-        user_id: user_info.id,
-        email: user_info.email,
-        first_name: user_info.given_name,
-        last_name: user_info.family_name,
-        school_info: user_info.school_info,
-      }
-    );
+    const result = await submitEnrollment(user_info.id);
 
     if (result?.workshop_enrollment_status === SUBMISSION_STATUSES.SUCCESS) {
       navigateOnEnrollSuccess();
@@ -121,6 +113,7 @@ const WorkshopJoin: React.FunctionComponent<{
             time in your account settings.
           </BodyThreeText>
           <Button
+            id="joinWorkshop"
             name="joinWorkshop"
             text="Join this workshop"
             color="purple"

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.tsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.tsx
@@ -15,7 +15,6 @@ import {DATA_SHARING_NOTICE} from '@cdo/apps/code-studio/pd/constants';
 import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
 import {useSchoolInfo} from '@cdo/apps/schoolInfo/hooks/useSchoolInfo';
-import {buildSchoolData} from '@cdo/apps/schoolInfo/utils/buildSchoolData';
 import {schoolInfoInvalid} from '@cdo/apps/schoolInfo/utils/schoolInfoInvalid';
 import SchoolDataInputs from '@cdo/apps/templates/SchoolDataInputs.jsx';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
@@ -235,99 +234,10 @@ export default function EnrollForm(props: EnrollFormProps) {
     return errors;
   };
 
-  const getRole = () => {
-    if (!formState.role) {
-      return null;
-    }
-    let roleWithDescription = formState.role;
-    if (formState.describe_role) {
-      roleWithDescription += `: ${formState.describe_role}`;
-    }
-    return roleWithDescription;
-  };
-
-  const getCsfCoursesPlanned = () => {
-    if (!formState.csf_courses_planned) {
-      return undefined;
-    }
-    const processedCourses: string[] = [];
-    formState.csf_courses_planned.forEach(course => {
-      if (course === `${OTHER} ${EXPLAIN}`) {
-        if (formState.explain_csf_course_other) {
-          processedCourses.push(
-            `${OTHER}: ${formState.explain_csf_course_other}`
-          );
-        } else {
-          processedCourses.push(OTHER);
-        }
-      } else {
-        processedCourses.push(course);
-      }
-    });
-    return processedCourses;
-  };
-
-  const getGradesTeaching = () => {
-    if (!formState.grades_teaching) {
-      return null;
-    }
-    const processedGrades: string[] = [];
-    formState.grades_teaching.forEach(grade => {
-      if (grade === `${OTHER} ${EXPLAIN}`) {
-        if (formState.explain_teaching_other) {
-          processedGrades.push(`${OTHER}: ${formState.explain_teaching_other}`);
-        } else {
-          processedGrades.push(OTHER);
-        }
-      } else if (grade === `${NOT_TEACHING} ${EXPLAIN}`) {
-        if (formState.explain_not_teaching) {
-          processedGrades.push(
-            `${NOT_TEACHING}: ${formState.explain_not_teaching}`
-          );
-        } else {
-          processedGrades.push(NOT_TEACHING);
-        }
-      } else {
-        processedGrades.push(grade);
-      }
-    });
-    return processedGrades;
-  };
-
   const submit = async () => {
     setFormErrors({});
     setSubmissionErrorMessage('');
     setIsSubmitting(true);
-
-    const params = {
-      user_id: props.user_id,
-      first_name: formState.first_name,
-      last_name: formState.last_name,
-      email: formState.email,
-      school_info: buildSchoolData({
-        schoolId: schoolInfo.schoolId,
-        country: schoolInfo.country,
-        schoolName: schoolInfo.schoolName,
-        schoolZip: schoolInfo.schoolZip,
-      }),
-      role: getRole(),
-      describe_role: formState.describe_role,
-      grades_teaching: getGradesTeaching(),
-      explain_teaching_other: formState.explain_teaching_other,
-      explain_not_teaching: formState.explain_not_teaching,
-      csf_course_experience: formState.csf_course_experience,
-      csf_courses_planned: getCsfCoursesPlanned(),
-      explain_csf_course_other: formState.explain_csf_course_other,
-      attended_csf_intro_workshop:
-        ATTENDED_CSF_COURSES_OPTIONS[formState.attended_csf_intro_workshop],
-      previous_courses: formState.previous_courses,
-      csf_intro_intent: formState.csf_intro_intent,
-      csf_intro_other_factors: formState.csf_intro_other_factors,
-      years_teaching: formState.years_teaching,
-      years_teaching_cs: formState.years_teaching_cs,
-      taught_ap_before: formState.taught_ap_before,
-      planning_to_teach_ap: formState.planning_to_teach_ap,
-    };
 
     try {
       const response = await fetch(
@@ -338,7 +248,7 @@ export default function EnrollForm(props: EnrollFormProps) {
             'Content-Type': 'application/json',
             'X-CSRF-Token': await getAuthenticityToken(),
           },
-          body: JSON.stringify(params),
+          body: JSON.stringify({user_id: props.user_id}),
         }
       );
       setIsSubmitting(false);

--- a/apps/src/code-studio/pd/workshops/WorkshopMarketingPage.tsx
+++ b/apps/src/code-studio/pd/workshops/WorkshopMarketingPage.tsx
@@ -7,10 +7,7 @@ import EnrollInWorkshop from './components/EnrollInWorkshop';
 import OrganizerInformation from './components/OrganizerInformation';
 import WorkshopDetails from './components/WorkshopDetails';
 import WorkshopEventJsonLdData from './components/WorkshopEventJsonLdData';
-import {
-  GetUserInfoForWorkshopResponse,
-  GetWorkshopInfoScriptDataResponse,
-} from './types';
+import {GetWorkshopInfoScriptDataResponse} from './types';
 
 import moduleStyles from './workshopMarketingPage.module.scss';
 
@@ -25,12 +22,8 @@ const workshopMarketingBreadcrumbs: LinkWithText[] = [
   },
 ];
 
-interface WorkshopMarketingPageProps
-  extends GetWorkshopInfoScriptDataResponse,
-    GetUserInfoForWorkshopResponse {}
-
 const WorkshopMarketingPage: React.FunctionComponent<
-  WorkshopMarketingPageProps
+  GetWorkshopInfoScriptDataResponse & {user_id?: number; is_student: boolean}
 > = props => {
   const {
     id,
@@ -51,7 +44,8 @@ const WorkshopMarketingPage: React.FunctionComponent<
     regional_partner_name,
     organizer,
     facilitators,
-    userInfo,
+    user_id,
+    is_student,
   } = props;
 
   return (
@@ -87,12 +81,13 @@ const WorkshopMarketingPage: React.FunctionComponent<
               capacity={capacity}
               num_enrollments={num_enrollments}
               regional_partner_name={regional_partner_name}
-              userInfo={userInfo}
               course={course}
               subject={subject}
               name={name}
               format={format}
               sessions={sessions}
+              user_id={user_id}
+              is_student={is_student}
             />
 
             <OrganizerInformation

--- a/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
+++ b/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
@@ -7,50 +7,70 @@ import {
 } from '@code-dot-org/component-library/typography';
 import React from 'react';
 
-import {
-  GetUserInfoForWorkshopResponse,
-  GetWorkshopInfoScriptDataResponse,
-} from '@cdo/apps/code-studio/pd/workshops/types';
+import {GetWorkshopInfoScriptDataResponse} from '@cdo/apps/code-studio/pd/workshops/types';
 
 import {useWorkshopEnrollment} from './../hooks/useWorkshopEnrollment';
 
 import moduleStyles from './../workshopMarketingPage.module.scss';
 
-const WORKSHOP_ENROLL_SOURCE_PAGE = 'workshop enroll';
+type WorkshopProps = Pick<
+  GetWorkshopInfoScriptDataResponse,
+  | 'custom_registration_link'
+  | 'num_enrollments'
+  | 'capacity'
+  | 'id'
+  | 'regional_partner_name'
+  | 'course'
+  | 'sessions'
+  | 'name'
+  | 'format'
+  | 'subject'
+>;
 
-interface EnrollInWorkshopProps
-  extends Pick<
-      GetWorkshopInfoScriptDataResponse,
-      | 'custom_registration_link'
-      | 'num_enrollments'
-      | 'capacity'
-      | 'id'
-      | 'regional_partner_name'
-      | 'course'
-      | 'sessions'
-      | 'name'
-      | 'format'
-      | 'subject'
-    >,
-    GetUserInfoForWorkshopResponse {}
-/** Component to display the enrollment information for a workshop. */
-const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
+// Dipslay for users that cannot enroll in workshops: signed-out users or students.
+const EnrollInWorkshopForNonTeachers: React.FC<{
+  workshop_id: number;
+  is_student: boolean;
+}> = ({workshop_id, is_student}) => {
+  const accountUpdateTypePath = is_student
+    ? 'teacher_account_required'
+    : 'logged_out';
+  const needTeacherAccountLink = `/${accountUpdateTypePath}?source_page=${encodeURIComponent(
+    'workshop enroll'
+  )}&return_to=/professional-learning/workshops/${workshop_id}`;
+
+  return (
+    <LinkButton
+      className={moduleStyles.fullWidthButton}
+      type="primary"
+      size="m"
+      href={needTeacherAccountLink}
+      text={is_student ? 'Switch to teacher account' : 'Sign-in to enroll'}
+      iconRight={{iconName: 'right-to-bracket'}}
+    />
+  );
+};
+
+// Display for users that can enroll in workshops: teachers.
+const EnrollInWorkshopForTeachers: React.FC<
+  WorkshopProps & {user_id: number}
+> = ({
   id,
   custom_registration_link,
   num_enrollments,
   capacity,
   sessions,
-  userInfo,
   regional_partner_name,
   course,
   format,
   name,
   subject,
+  user_id,
 }) => {
   const {handleClick, isSubmitting, alertState, setAlertState} =
     useWorkshopEnrollment({
       workshopId: id,
-      userInfo,
+      userId: user_id,
       regional_partner_name,
       course,
       format,
@@ -58,26 +78,7 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
       subject,
       sessions,
     });
-
-  const is_student = userInfo?.is_student || false;
-  const is_signed_out = !userInfo;
   const isFull = num_enrollments >= capacity;
-
-  const buildEnrollButtonLink = (enrollLink: string) => {
-    if (is_signed_out) {
-      return `/logged_out?source_page=${encodeURIComponent(
-        WORKSHOP_ENROLL_SOURCE_PAGE
-      )}&return_to=${encodeURIComponent(enrollLink)}`;
-    }
-
-    if (is_student) {
-      return `/teacher_account_required?source_page=${encodeURIComponent(
-        WORKSHOP_ENROLL_SOURCE_PAGE
-      )}&return_to=${encodeURIComponent(enrollLink)}`;
-    }
-
-    return enrollLink;
-  };
 
   const renderEnrollmentAction = () => {
     if (isFull) {
@@ -96,11 +97,11 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
       return (
         <>
           <BodyThreeText>
-            This workshop’s registration is managed externally by the regional
+            This workshop's registration is managed externally by the regional
             partner.
           </BodyThreeText>
           <LinkButton
-            href={buildEnrollButtonLink(custom_registration_link)}
+            href={custom_registration_link}
             className={moduleStyles.fullWidthButton}
             type="primary"
             size="m"
@@ -108,19 +109,6 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
             iconRight={{iconName: 'up-right-from-square'}}
           />
         </>
-      );
-    }
-
-    if (is_student || is_signed_out) {
-      return (
-        <LinkButton
-          className={moduleStyles.fullWidthButton}
-          type="primary"
-          size="m"
-          href={buildEnrollButtonLink(`/professional-learning/workshops/${id}`)}
-          text={is_student ? 'Switch to teacher account' : 'Sign-in to enroll'}
-          iconRight={{iconName: 'right-to-bracket'}}
-        />
       );
     }
 
@@ -154,6 +142,42 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
         Click to see data sharing notice
       </Link>
     </div>
+  );
+};
+
+/** Component to display the enrollment information for a workshop. */
+const EnrollInWorkshop: React.FC<
+  WorkshopProps & {user_id?: number; is_student: boolean}
+> = ({
+  id,
+  custom_registration_link,
+  num_enrollments,
+  capacity,
+  sessions,
+  regional_partner_name,
+  course,
+  format,
+  name,
+  subject,
+  user_id,
+  is_student,
+}) => {
+  return !user_id || is_student ? (
+    <EnrollInWorkshopForNonTeachers workshop_id={id} is_student={is_student} />
+  ) : (
+    <EnrollInWorkshopForTeachers
+      id={id}
+      custom_registration_link={custom_registration_link}
+      num_enrollments={num_enrollments}
+      capacity={capacity}
+      sessions={sessions}
+      regional_partner_name={regional_partner_name}
+      course={course}
+      format={format}
+      name={name}
+      subject={subject}
+      user_id={user_id}
+    />
   );
 };
 

--- a/apps/src/code-studio/pd/workshops/hooks/useWorkshopEnrollment.ts
+++ b/apps/src/code-studio/pd/workshops/hooks/useWorkshopEnrollment.ts
@@ -2,10 +2,7 @@ import {LinkProps} from '@code-dot-org/component-library/link';
 import {useState} from 'react';
 
 import {SUBMISSION_STATUSES} from '@cdo/apps/code-studio/pd/workshop_enrollment/constants';
-import {
-  GetUserInfoForWorkshopResponse,
-  GetWorkshopInfoScriptDataResponse,
-} from '@cdo/apps/code-studio/pd/workshops/types';
+import {GetWorkshopInfoScriptDataResponse} from '@cdo/apps/code-studio/pd/workshops/types';
 import {navigateToHref} from '@cdo/apps/utils';
 
 import {useWorkshopEnrollmentApi} from './useWorkshopEnrollmentApi';
@@ -20,7 +17,7 @@ type WorkshopEnrollmentHandlerProps = Pick<
   | 'sessions'
 > & {
   workshopId: number;
-  userInfo: GetUserInfoForWorkshopResponse['userInfo'];
+  userId: number;
 };
 
 /**
@@ -28,7 +25,7 @@ type WorkshopEnrollmentHandlerProps = Pick<
  * */
 export function useWorkshopEnrollment({
   workshopId,
-  userInfo,
+  userId,
   regional_partner_name,
   course,
   format,
@@ -45,20 +42,7 @@ export function useWorkshopEnrollment({
   }>({show: false, text: ''});
 
   const handleClick = async () => {
-    const result = await submitEnrollment(
-      userInfo && {
-        user_id: userInfo.id,
-        email: userInfo.email,
-        first_name: userInfo.first_name,
-        last_name: userInfo.last_name,
-        school_info: {
-          school_id: userInfo.school_info?.school_id,
-          country: userInfo.school_info?.country,
-          school_name: userInfo.school_info?.school_name,
-          school_zip: userInfo.school_info?.school_zip,
-        },
-      }
-    );
+    const result = await submitEnrollment(userId);
 
     switch (result?.workshop_enrollment_status) {
       case SUBMISSION_STATUSES.DUPLICATE:

--- a/apps/src/code-studio/pd/workshops/hooks/useWorkshopEnrollmentApi.ts
+++ b/apps/src/code-studio/pd/workshops/hooks/useWorkshopEnrollmentApi.ts
@@ -1,6 +1,5 @@
 import {useState} from 'react';
 
-import {WorkshopEnrollmentParams} from '@cdo/apps/code-studio/pd/workshops/types';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
 export type WorkshopEnrollmentResponse = {
@@ -17,7 +16,7 @@ export function useWorkshopEnrollmentApi(workshopId: number) {
   const [error, setError] = useState<string | null>(null);
 
   const submitEnrollment = async (
-    params: WorkshopEnrollmentParams | null
+    user_id: number
   ): Promise<WorkshopEnrollmentResponse | null> => {
     if (!isSubmitting) {
       setIsSubmitting(true);
@@ -32,7 +31,7 @@ export function useWorkshopEnrollmentApi(workshopId: number) {
               'Content-Type': 'application/json',
               'X-CSRF-Token': await getAuthenticityToken(),
             },
-            body: JSON.stringify(params),
+            body: JSON.stringify({user_id}),
           }
         );
 

--- a/apps/src/code-studio/pd/workshops/types.ts
+++ b/apps/src/code-studio/pd/workshops/types.ts
@@ -59,14 +59,3 @@ export type UserInfoForWorkshop = {
     school_zip?: string;
   };
 };
-
-export type WorkshopEnrollmentParams = Pick<
-  UserInfoForWorkshop,
-  'email' | 'first_name' | 'last_name' | 'school_info'
-> & {
-  user_id: number;
-};
-
-export interface GetUserInfoForWorkshopResponse {
-  userInfo: UserInfoForWorkshop | null;
-}

--- a/apps/src/sites/studio/pages/pd/professional_learning/workshops/index.js
+++ b/apps/src/sites/studio/pages/pd/professional_learning/workshops/index.js
@@ -28,7 +28,8 @@ document.addEventListener('DOMContentLoaded', function () {
       regional_partner_name={workshopInfo.regional_partner_name}
       organizer={workshopInfo.organizer}
       facilitators={workshopInfo.facilitators}
-      userInfo={getScriptData('userInfo')}
+      user_id={getScriptData('userId')}
+      is_student={getScriptData('isStudent')}
     />,
     document.getElementById('workshop-container')
   );

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import WorkshopLinks from '@cdo/apps/code-studio/pd/workshop_dashboard/WorkshopLinks';
 
-describe('EnrollInWorkshop', () => {
+describe('WorkshopLinks', () => {
   const renderDefault = (hasCustomRegistrationLink: boolean) => {
     render(
       <WorkshopLinks

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -40,11 +40,11 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
         status: :not_found
     end
 
-    enrollment_email = params[:email]
     user = User.find(params[:user_id])
 
     # See if a previous enrollment exists for this email
-    previous_enrollment = @workshop.enrollments.find_by(email: enrollment_email)
+    previous_enrollment = @workshop.enrollments.find_by(email: user.email)
+
     if previous_enrollment
       cancel_url = url_for action: :cancel, controller: '/pd/workshop_enrollment', code: previous_enrollment.code
       render_unsuccessful RESPONSE_MESSAGES[:DUPLICATE], {cancel_url: cancel_url}
@@ -57,14 +57,13 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
       render_unsuccessful RESPONSE_MESSAGES[:FULL]
     else
       ActiveRecord::Base.transaction do
-        enrollment = ::Pd::Enrollment.new workshop: @workshop
-
-        if @workshop.course == COURSE_BUILD_YOUR_OWN
-          enrollment.update!(enrollment_params)
-        else
-          enrollment.update!(enrollment_params.merge(school_info_attributes: school_info_params))
-          user&.update_school_info(enrollment.school_info)
-        end
+        enrollment = ::Pd::Enrollment.new(
+          workshop: @workshop,
+          first_name: user&.given_name&.strip_utf8mb4,
+          last_name: user&.family_name&.strip_utf8mb4,
+          email: user&.email,
+          school_info_id: user&.school_info_id
+        )
 
         Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
         Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
@@ -139,22 +138,6 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
     return head :forbidden unless current_user.workshop_admin?
     enrollment = Pd::Enrollment.find_by(id: params[:id])
     enrollment.update!(first_name: params[:first_name], last_name: params[:last_name], email: params[:email])
-  end
-
-  private def enrollment_params
-    params.require(:user_id)
-    params.permit(:user_id, :first_name, :last_name, :email).to_h.tap do |p|
-      p[:first_name] = p[:first_name]&.strip_utf8mb4
-      p[:last_name] = p[:last_name]&.strip_utf8mb4
-      p[:email] = p[:email]&.strip_utf8mb4
-    end
-  end
-
-  private def school_info_params
-    params.require(:school_info).
-      permit(:school_type, :zip, :school_id, :school_name, :country).to_h.tap do |p|
-        p[:school_name] = p[:school_name]&.strip_utf8mb4
-      end
   end
 
   private def render_unsuccessful(error_message, options = {})

--- a/dashboard/app/controllers/pd/professional_learning_controller.rb
+++ b/dashboard/app/controllers/pd/professional_learning_controller.rb
@@ -50,7 +50,8 @@ class Pd::ProfessionalLearningController < ApplicationController
   def workshop_marketing_page
     view_options(full_width: true, responsive_content: true, no_padding_container: true)
     @workshop_info = Pd::Workshop.find(params[:workshop_id])&.summarize_for_marketing_page
-    @user_info = current_user&.summarize_for_workshop
+    @user_id = current_user&.id
+    @is_student = current_user&.user_type == TYPE_STUDENT
     render 'pd/professional_learning/workshops/index'
   end
 

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -228,8 +228,13 @@ class Pd::WorkshopEnrollmentController < ApplicationController
 
   private def build_enrollment_from_params
     enrollment = get_workshop_user_enrollment
-    enrollment.assign_attributes enrollment_params.merge(user_id: current_user.id)
-    enrollment.school_info_attributes = school_info_params
+    enrollment.assign_attributes(
+      user_id: current_user.id,
+      first_name: current_user.given_name,
+      last_name: current_user.family_name,
+      email: current_user.email,
+      school_info_id: current_user.school_info_id
+    )
 
     enrollment
   end
@@ -266,34 +271,10 @@ class Pd::WorkshopEnrollmentController < ApplicationController
     Pd::Enrollment.new(
       pd_workshop_id: @workshop.id,
       user_id: current_user.id,
-      full_name: current_user.name,
-      email: current_user.email
-    )
-  end
-
-  private def enrollment_params
-    params.require(:pd_enrollment).permit(
-      :first_name,
-      :last_name,
-      :email,
-      :email_confirmation,
-      :school
-    )
-  end
-
-  private def school_info_params
-    params.require(:school_info).permit(
-      :country,
-      :school_type,
-      :school_state,
-      :school_zip,
-      :school_district_id,
-      :school_district_other,
-      :school_district_name,
-      :school_id,
-      :school_other,
-      :school_name,
-      :full_address,
+      first_name: current_user.given_name,
+      last_name: current_user.family_name,
+      email: current_user.email,
+      school_info_id: current_user.school_info_id
     )
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1297,17 +1297,6 @@ class User < ApplicationRecord
     }
   end
 
-  def summarize_for_workshop
-    {
-      id: id,
-      email: email,
-      is_student: user_type == TYPE_STUDENT,
-      first_name: given_name,
-      last_name: family_name,
-      school_info: Queries::SchoolInfo.current_school(self),
-    }
-  end
-
   def at_risk_age_gated_date
     Policies::ChildAccount::StatePolicies.state_policy(self)&.dig(:lockout_date) unless Policies::ChildAccount.compliant?(self, future: true)
   end

--- a/dashboard/app/views/pd/professional_learning/workshops/index.html.haml
+++ b/dashboard/app/views/pd/professional_learning/workshops/index.html.haml
@@ -1,7 +1,7 @@
 - content_for(:head) do
   = stylesheet_link_tag 'css/pd', media: 'all'
 
-%script{src: webpack_asset_path('js/pd/professional_learning/workshops/index.js'), data: {workshopInfo: @workshop_info.to_json,  userInfo: @user_info.to_json}}
+%script{src: webpack_asset_path('js/pd/professional_learning/workshops/index.js'), data: {workshopInfo: @workshop_info.to_json,  userId: @user_id.to_json, isStudent: @is_student.to_json}}
 
 #workshop-container
   -# populated by React


### PR DESCRIPTION
Simplify the enrollment creation process to only need the `user_id` (everything else it extrapolates based on that, such as the first name, email, school info, etc.). This ended up touching a lot of files due to the recent enrollment hooks Denys made and appeasing typescript's needs, but I think it'll put us in a much cleaner, easier-to-use spot.

- still works in all the places we use enrollment
- write tests

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3358)

## Testing story
Local testing and updating unit tests.
