### PR TITLE
fix(marketing): remove target-size override from .lighthouserc.js

### DIFF
--- a/frontend/apps/marketing/.lighthouserc.js
+++ b/frontend/apps/marketing/.lighthouserc.js
@@ -22,7 +22,6 @@ const assertions = {
   'network-dependency-tree-insight': 'off',
   'crawlable-anchors': ['error', {minScore: 0}], // Localizejs has invalid anchor tags
   'unsized-images': ['error', {maxLength: 6}],
-  'target-size': 'off',
 };
 
 if (process.env.STAGE !== 'production') {


### PR DESCRIPTION
Removes the Lighthouse `target-size` override on All The Things now that the fix in https://github.com/code-dot-org/code-dot-org/pull/66891 is merged.

## Links
Jira ticket: [CMS-845](https://codedotorg.atlassian.net/browse/CMS-845)
Related PRs: 
- https://github.com/code-dot-org/code-dot-org/pull/66881
- https://github.com/code-dot-org/code-dot-org/pull/66891