### PR TITLE
Music: fix missing trigger buttons

### DIFF
--- a/apps/src/music/views/Controls.tsx
+++ b/apps/src/music/views/Controls.tsx
@@ -4,7 +4,7 @@ import React, {memo, useCallback} from 'react';
 import {useDispatch} from 'react-redux';
 
 import {submitPredictResponse} from '@cdo/apps/lab2/redux/predictLevelRedux';
-import {Triggers} from '@cdo/apps/music/constants';
+import {Trigger} from '@cdo/apps/music/constants';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -103,7 +103,7 @@ const SkipControls: React.FunctionComponent = () => {
 interface ControlsProps {
   setPlaying: (value: boolean) => void;
   playTrigger: (id: string) => void;
-  hasTrigger: (id: string) => boolean;
+  triggers: Trigger[];
   isPredictLevel?: boolean;
   enableSkipControls?: boolean;
 }
@@ -115,7 +115,7 @@ interface ControlsProps {
 const Controls: React.FunctionComponent<ControlsProps> = ({
   setPlaying,
   playTrigger,
-  hasTrigger,
+  triggers,
   isPredictLevel,
   enableSkipControls = false,
 }) => {
@@ -153,10 +153,7 @@ const Controls: React.FunctionComponent<ControlsProps> = ({
         </button>
         {enableSkipControls && <SkipControls />}
       </div>
-      <BeatPad
-        triggers={Triggers.filter(trigger => hasTrigger(trigger.id))}
-        playTrigger={playTrigger}
-      />
+      <BeatPad triggers={triggers} playTrigger={playTrigger} />
       <LoadingProgress />
     </div>
   );

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -31,6 +31,7 @@ import {
   installFunctionBlocks,
 } from '../blockly/blockUtils';
 import MusicBlocklyWorkspace from '../blockly/MusicBlocklyWorkspace';
+import {Trigger} from '../constants';
 import musicI18n from '../locale';
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
 import MusicPlayer from '../player/MusicPlayer';
@@ -64,7 +65,7 @@ interface MusicLabViewProps {
   blocklyDivId: string;
   setPlaying: (playing: boolean) => void;
   playTrigger: (id: string) => void;
-  hasTrigger: (id: string) => boolean;
+  triggers: Trigger[];
   getCurrentPlayheadPosition: () => number;
   updateHighlightedBlocks: () => void;
   undo: () => void;
@@ -86,7 +87,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   blocklyDivId,
   setPlaying,
   playTrigger,
-  hasTrigger,
+  triggers,
   getCurrentPlayheadPosition,
   updateHighlightedBlocks,
   undo,
@@ -448,7 +449,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
               <Controls
                 setPlaying={setPlaying}
                 playTrigger={playTrigger}
-                hasTrigger={hasTrigger}
+                triggers={triggers}
                 isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
                 enableSkipControls={
                   AppConfig.getValue('skip-controls-enabled') === 'true'

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -41,6 +41,7 @@ import {
   DEFAULT_LIBRARY,
   DEFAULT_PACK,
   DEFAULT_VALIDATION_TIMEOUT,
+  Triggers,
 } from '../constants';
 import {AnalyticsContext} from '../context';
 import MusicRegistry from '../MusicRegistry';
@@ -915,7 +916,9 @@ class UnconnectedMusicView extends React.Component {
           blocklyDivId={BLOCKLY_DIV_ID}
           setPlaying={this.setPlaying}
           playTrigger={this.playTrigger}
-          hasTrigger={this.hasTrigger}
+          triggers={Triggers.filter(trigger =>
+            this.musicBlocklyWorkspace.hasTrigger(trigger.id)
+          )}
           getCurrentPlayheadPosition={this.getCurrentPlayheadPosition}
           updateHighlightedBlocks={this.updateHighlightedBlocks}
           undo={this.undo}


### PR DESCRIPTION
Optimized too hard 🙂 as a consequence of https://github.com/code-dot-org/code-dot-org/pull/66852, we were no longer updating the UI to show the trigger buttons when trigger blocks were dragged into the workspace. This quick fix passes down the trigger list directly so we don't have to rely on a function changing to trigger the UI change.

(There are further optimizations that can be made, but this should unblock the build and avoid breaking projects in production).

## Testing story

Tested locally on a music lab project with triggers.