### PR TITLE
Add UserPassport to Workshop Marketing page

### DIFF
--- a/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
+++ b/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
@@ -13,6 +13,7 @@ import {
 } from '@cdo/apps/code-studio/pd/workshops/types';
 
 import {useWorkshopEnrollment} from './../hooks/useWorkshopEnrollment';
+import UserPassport from './UserPassport';
 
 import moduleStyles from './../workshopMarketingPage.module.scss';
 
@@ -124,31 +125,50 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
       );
     }
 
+    const isMissingRequiredUserField =
+      !userInfo.first_name ||
+      !userInfo.last_name ||
+      !userInfo.email ||
+      !userInfo.school_info?.school_name;
     return (
-      <Button
-        className={moduleStyles.fullWidthButton}
-        type="primary"
-        size="m"
-        isPending={isSubmitting}
-        onClick={handleClick}
-        text="Enroll in this workshop"
-      />
+      <div className={moduleStyles.internalEnrollButton}>
+        {userInfo && (
+          <UserPassport
+            displayName={userInfo.display_name}
+            givenName={userInfo.first_name}
+            familyName={userInfo.last_name}
+            email={userInfo.email}
+            schoolName={userInfo.school_info?.school_name}
+            returnToHref={`/professional-learning/workshops/${id}`}
+            className={moduleStyles.userPassport}
+          />
+        )}
+        {alertState.show && (
+          <Alert
+            type={'danger'}
+            text={alertState.text}
+            link={alertState.link}
+            onClose={() =>
+              setAlertState({show: false, text: '', link: undefined})
+            }
+          />
+        )}
+        <Button
+          className={moduleStyles.fullWidthButton}
+          type="primary"
+          size="m"
+          isPending={isSubmitting}
+          onClick={handleClick}
+          text="Enroll in this workshop"
+          disabled={isMissingRequiredUserField}
+        />
+      </div>
     );
   };
 
   return (
     <div className={moduleStyles.card}>
       <Heading3 visualAppearance="heading-xs">Enroll in this workshop</Heading3>
-      {alertState.show && (
-        <Alert
-          type={'danger'}
-          text={alertState.text}
-          link={alertState.link}
-          onClose={() =>
-            setAlertState({show: false, text: '', link: undefined})
-          }
-        />
-      )}
       {renderEnrollmentAction()}
       <Link type="secondary" size="xs" href="#data-sharing-notice">
         Click to see data sharing notice

--- a/apps/src/code-studio/pd/workshops/components/userPassport.module.scss
+++ b/apps/src/code-studio/pd/workshops/components/userPassport.module.scss
@@ -45,6 +45,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-around;
+    gap: 0.25rem;
     height: 100%;
     padding: 0.5rem 0.625rem;
 

--- a/apps/src/code-studio/pd/workshops/types.ts
+++ b/apps/src/code-studio/pd/workshops/types.ts
@@ -49,6 +49,7 @@ export interface GetWorkshopInfoScriptDataResponse {
 export type UserInfoForWorkshop = {
   id: number;
   email: string;
+  display_name: string;
   is_student?: boolean;
   first_name?: string;
   last_name?: string;

--- a/apps/src/code-studio/pd/workshops/workshopMarketingPage.module.scss
+++ b/apps/src/code-studio/pd/workshops/workshopMarketingPage.module.scss
@@ -106,6 +106,21 @@ $mobile-padding: 4rem;
           border: 1px solid var(--borders-neutral-primary);
           background: var(--background-neutral-secondary);
 
+          .internalEnrollButton {
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+
+            .userPassport {
+              width: 100%;
+
+              > div {
+                background-color: var(--neutral-base-white);
+              }
+            }
+          }
+
           .underCardHeadingDetails {
             display: flex;
             flex-direction: column;

--- a/apps/test/unit/code-studio/pd/workshops/components/EnrollInWorkshopTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshops/components/EnrollInWorkshopTest.tsx
@@ -9,6 +9,7 @@ const baseUserInfo = {
   is_student: false,
   id: 123,
   email: 'sample@google.com',
+  display_name: 'Mr. Doe',
   first_name: 'John',
   last_name: 'Doe',
   school_info: {

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1302,6 +1302,7 @@ class User < ApplicationRecord
       id: id,
       email: email,
       is_student: user_type == TYPE_STUDENT,
+      display_name: name,
       first_name: given_name,
       last_name: family_name,
       school_info: Queries::SchoolInfo.current_school(self),


### PR DESCRIPTION
As part of the bug bash today, we noted that the Workshop Marketing page was missing the `UserPassport` component that ensures a user has set their full name, email, and school info before enrolling.

### Shows `UserPassport` for workshops the user can enroll in
![shows user card if can enroll](https://github.com/user-attachments/assets/42c5969e-8616-4551-855e-1e1348e26b36)

### Enroll button is disabled if the user is missing any fields
![disabled if missing field](https://github.com/user-attachments/assets/d1d1e79e-896f-4441-b924-a9872a2d4828)

### Follows same pattern as Join page
User can edit missing fields, automatically return to the page, and then enroll.

https://github.com/user-attachments/assets/0ba18ff5-c0d1-4602-a7a4-3de6fe46fb81

## Links
Figma: [here](https://www.figma.com/design/Km9JCLNbayBlTrlnKenumq/New-PL-Program?node-id=4608-15624&t=UJrJQcmCBco7R8lG-0)
Jira: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3380)

## Testing story
Local testing and updating unit tests.
