### PR TITLE
Fixing click to scroll for instrument grids

### DIFF
--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -285,6 +285,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
           scrollStart={scrollStart}
           scrollEnd={scrollEnd}
           className={classNames(styles[`sequence-editor-${interfaceMode}`])}
+          ariaLabel="Instrument Grid"
         >
           {allNotes.map(({note, name}) => {
             const {

--- a/apps/src/music/views/util/EaseIntoView.tsx
+++ b/apps/src/music/views/util/EaseIntoView.tsx
@@ -23,6 +23,8 @@ interface EaseIntoViewProps {
   scrollStart: number;
   /** Scroll position to stop scrolling at */
   scrollEnd?: number;
+  /** Aria label for the container */
+  ariaLabel?: string;
   children: React.ReactNode;
 }
 
@@ -34,6 +36,7 @@ const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
   frames,
   scrollStart,
   scrollEnd = 0,
+  ariaLabel = 'Scrollable content',
   children,
 }) => {
   const scrollStep = useRef<number | undefined>(0);
@@ -112,7 +115,14 @@ const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
   }, [delayFrames, scrollStart, scrollEnd, doEase, frames]);
 
   return (
-    <div id={id} className={className} ref={containerRefCallback}>
+    <div
+      id={id}
+      role="tablist"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      className={className}
+      ref={containerRefCallback}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
This is a followup to the [PR fixing click-to-scroll](https://github.com/code-dot-org/code-dot-org/pull/66871) in the soundPanel scroll region. 

The issue is the same- FocusLock does not recognize the scroll region as focusable, so restricts the movement and makes click to scroll jumpy. By adding a tab stop in the scroll region, the problem is fixed.

This is also an a11y improvement, as now there is a designated callout that users are entering the instrument grid region, giving the div a role and aria-label. 

This required adding a tab stop to all EaseIntoView uses (though there is just one now), and I made aria-label an optional param with 'scrollable content' as the default so any future cases will have baseline accessibility coverage.

Before:


https://github.com/user-attachments/assets/6142e25b-f51e-43ca-af9f-c37896989b4a



After:

https://github.com/user-attachments/assets/172ce98f-5a67-4c82-8d4a-ed7b62e93b76


After w/ voiceOver on:

https://github.com/user-attachments/assets/a9d980b3-1807-48d9-8be9-ffae77394711


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1315

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
