### PR TITLE
Remove Temp Chef Resource

### DIFF
--- a/cookbooks/cdo-ruby/recipes/rubygems.rb
+++ b/cookbooks/cdo-ruby/recipes/rubygems.rb
@@ -1,10 +1,3 @@
-# Clean up configuration file for our old, apt-installed rubygems if it's still
-# around. TODO: remove this block once all environments have been cleaned up
-file '/etc/gemrc' do
-  action :delete
-  only_if {File.exist? '/etc/gemrc'}
-end
-
 directory '/usr/local/etc' do
   recursive true
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/50661, which added a temporary Chef resource to remove the unused `/etc/gemrc` file from all of our persistent managed servers.

It's been a little over two full years since it was first merged, so I'm pretty sure it should be safe to remove by now :crossed_fingers: