### PR TITLE
Fix AI Tutor level properties dependency

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -351,7 +351,10 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
               className={moduleStyles.panelContainer}
               headerClassName={moduleStyles.panelHeader}
             >
-              <ChatWorkspace onClear={onClear} />
+              <ChatWorkspace
+                onClear={onClear}
+                levelProperties={levelProperties}
+              />
             </PanelContainer>
           </div>
         </div>

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -4,9 +4,10 @@ import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 
+import {LevelProperties} from '@cdo/apps/lab2/types';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {useLevelProperties} from '../levelPropertiesContext';
+import {LevelPropertiesContext} from '../levelPropertiesContext';
 import aichatI18n from '../locale';
 import {
   clearChatMessages,
@@ -15,7 +16,7 @@ import {
   getSelectMultimodalAvailable,
   selectAllVisibleMessages,
 } from '../redux';
-import {ChatButton} from '../types';
+import {AichatLevelProperties, ChatButton} from '../types';
 import {getShortName} from '../utils';
 
 import StagedFilesPreview from './assets/StagedFilesPreview';
@@ -27,6 +28,9 @@ import UserChatMessageEditor from './UserChatMessageEditor';
 import moduleStyles from './chatWorkspace.module.scss';
 
 interface ChatWorkspaceProps {
+  // TODO: Temporary passing through level properties again because sub-components depend on the level properties context.
+  // When fully modularizing this component, we will instead pass through necessary data through props.
+  levelProperties: LevelProperties;
   chatButtons?: ChatButton[];
   hiddenContext?: string;
   onClear: () => void;
@@ -45,6 +49,7 @@ const eraserIcon: FontAwesomeV6IconProps = {
  * Renders the AI Chat Lab main chat workspace component.
  */
 const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
+  levelProperties,
   chatButtons,
   hiddenContext,
   onClear,
@@ -153,44 +158,49 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
 
   const multimodalEnabled = useAppSelector(
     getSelectMultimodalAvailable(
-      useLevelProperties().aichatSettings?.multimodalEnabled
+      (levelProperties as AichatLevelProperties).aichatSettings
+        ?.multimodalEnabled
     )
   );
 
   return (
-    <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
-      {selectedStudent ? (
-        <Tabs {...tabArgs} />
-      ) : (
-        <ChatEventsList events={visibleItems} />
-      )}
-
-      <div className={moduleStyles.footer}>
-        {multimodalEnabled && <StagedFilesPreview />}
-        {canChatWithModel && (
-          <UserChatMessageEditor
-            editorContainerClassName={moduleStyles.messageEditorContainer}
-            chatButtons={chatButtons}
-            hiddenContext={hiddenContext}
-          />
+    <LevelPropertiesContext.Provider value={levelProperties}>
+      <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
+        {selectedStudent ? (
+          <Tabs {...tabArgs} />
+        ) : (
+          <ChatEventsList events={visibleItems} />
         )}
-        <div className={moduleStyles.buttonRow}>
-          {multimodalEnabled && (
-            <UploadButton isDisabled={!canChatWithModel || !!selectedStudent} />
+
+        <div className={moduleStyles.footer}>
+          {multimodalEnabled && <StagedFilesPreview />}
+          {canChatWithModel && (
+            <UserChatMessageEditor
+              editorContainerClassName={moduleStyles.messageEditorContainer}
+              chatButtons={chatButtons}
+              hiddenContext={hiddenContext}
+            />
           )}
-          <Button
-            text={aichatI18n.clearChatButtonText()}
-            disabled={!canChatWithModel}
-            iconLeft={eraserIcon}
-            size="s"
-            type="secondary"
-            color="gray"
-            onClick={onClear}
-          />
-          <CopyChatHistoryButton isDisabled={!canChatWithModel} />
+          <div className={moduleStyles.buttonRow}>
+            {multimodalEnabled && (
+              <UploadButton
+                isDisabled={!canChatWithModel || !!selectedStudent}
+              />
+            )}
+            <Button
+              text={aichatI18n.clearChatButtonText()}
+              disabled={!canChatWithModel}
+              iconLeft={eraserIcon}
+              size="s"
+              type="secondary"
+              color="gray"
+              onClick={onClear}
+            />
+            <CopyChatHistoryButton isDisabled={!canChatWithModel} />
+          </div>
         </div>
       </div>
-    </div>
+    </LevelPropertiesContext.Provider>
   );
 };
 

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -8,16 +8,19 @@ import ChatWorkspace from '@cdo/apps/aichat/views/ChatWorkspace';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import {aiTutorModelId} from '../../ai/AiTutorModelId';
+import {LevelProperties} from '../../types';
 
 import moduleStyles from './AiTutor2Chat.module.scss';
 
 interface AiTutor2ChatProps {
   hiddenContext: string;
+  levelProperties: LevelProperties;
 }
 
 // A free chat with lab-supplied context added to each question.
 const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
   hiddenContext,
+  levelProperties,
 }) => {
   const dispatch = useAppDispatch();
 
@@ -64,6 +67,7 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
         onClear={() => {
           dispatch(clearChatMessages());
         }}
+        levelProperties={levelProperties}
       />
     </div>
   );

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -30,13 +30,11 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
   const widgetViewShowCode = useAppSelector(
     state => state.codebridgeWorkspace.widgetViewShowCode
   );
-  const {
-    aiTutor2Context,
-    levelProperties: {aiTutor2Available},
-  } = useCodebridgeContext();
+  const {aiTutor2Context, levelProperties} = useCodebridgeContext();
 
   const showAiTutor2 =
-    aiTutor2Available || queryParams('show-ai-tutor2') === 'true';
+    levelProperties.aiTutor2Available ||
+    queryParams('show-ai-tutor2') === 'true';
 
   const {
     leftPanelWidth,
@@ -126,7 +124,10 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
               className={moduleStyles.rightmostColumn}
             >
               <div className={moduleStyles.inside}>
-                <AiTutor2Chat hiddenContext={aiTutor2Context} />
+                <AiTutor2Chat
+                  hiddenContext={aiTutor2Context}
+                  levelProperties={levelProperties}
+                />
               </div>
             </PanelContainer>
           </div>


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/66877 accidentally broke AI Tutor 2 because `ChatWorkspace` and sub-components now depend on a `LevelPropertiesContext` to retrieve level-specific information (rather than from redux like before). This is a targeted fix that just wraps the body of `ChatWorkspace` in its own `LevelPropertiesContext.Provider` so that sub-components can continue operating in the same way. `ChatWorkspace` now requires `levelProperties` but because the only other use currently is within PythonLab, these are readily available.

Note that ideally, once this component is more modularized, I'd like to instead pass down the relevant data as props into `ChatWorkspace` directly and remove the dependency on `LevelPropertiesContext`. But I wanted to get this targeted fix out first to fix the crash on PythonLab when AI Tutor is enabled 🙂

## Testing story

Tested locally on AI Chat and PythonLab levels with AI Tutor 2.