### PR TITLE
skip-bubble-choice-progress-test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -50,6 +50,7 @@ Feature: BubbleChoice
   # Mobile re-enable ticket: https://codedotorg.atlassian.net/browse/TEACH-1752
   @no_mobile
   @no_firefox
+  @no_safari
   @properties_encryption_key
   Scenario: Lab2 BubbleChoice progress
     Given I create a teacher-associated student named "Alice"


### PR DESCRIPTION
Skipping a very flaky test in safari.

Jira to re-enable: [TEACH-2077](https://codedotorg.atlassian.net/browse/TEACH-2077)