### PR TITLE
Filter to only one evaluation per code version

### DIFF
--- a/dashboard/app/helpers/openai_evaluate_helper.rb
+++ b/dashboard/app/helpers/openai_evaluate_helper.rb
@@ -92,7 +92,6 @@ module OpenaiEvaluateHelper
 
     response = evaluate(
       user_level.level,
-      unit,
       student_work: student_work,
       evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]
     )
@@ -105,7 +104,7 @@ module OpenaiEvaluateHelper
     student_code = helper.get_student_code(user_level.user.id, user_level.level, unit.id)
 
     unless student_code.nil? || student_code[:student_code].nil?
-      response = evaluate(user_level.level, unit, student_work: student_code[:student_code], evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT])
+      response = evaluate(user_level.level, student_work: student_code[:student_code], evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT])
 
       create_ai_evaluations_from_ai_response(user_level.user, user_level, unit, response, code_version: student_code[:code_version])
     end

--- a/dashboard/app/helpers/skills_helper.rb
+++ b/dashboard/app/helpers/skills_helper.rb
@@ -9,9 +9,9 @@ module SkillsHelper
       student_id: student_ids,
       unit_id: unit.id,
       skill_id: skill_ids
-    ).pluck(:student_id, :skill_id, :evaluation)
+    ).pluck(:student_id, :skill_id, :evaluation, :level_id, :created_at, :code_version)
 
-    evaluation_records = evaluations_data.map do |student_id, skill_id, evaluation|
+    evaluation_records = filter_evaluations(evaluations_data).map do |student_id, skill_id, evaluation|
       {
         student_id: student_id,
         skill_id: skill_id,
@@ -40,6 +40,17 @@ module SkillsHelper
     result
   end
 
+  # Only keep the most recent evaluation for each unique combination of student_id, skill_id, level_id, and code_version
+  def self.filter_evaluations(evaluations_data)
+    grouped_evaluations = evaluations_data.group_by do |student_id, skill_id, _evaluation, level_id, _created_at, code_version|
+      [student_id, skill_id, level_id, code_version]
+    end
+
+    grouped_evaluations.map do |_key, group|
+      group.max_by {|_student_id, _skill_id, _evaluation, _level_id, created_at, _code_version| created_at}
+    end
+  end
+
   def self.determine_mastery_level_for_student(evaluations)
     return "Not seen" if evaluations.empty?
 
@@ -50,5 +61,5 @@ module SkillsHelper
     "Not seen"
   end
 
-  private_class_method :determine_mastery_level_for_student
+  private_class_method :determine_mastery_level_for_student, :filter_evaluations
 end

--- a/dashboard/app/helpers/skills_helper.rb
+++ b/dashboard/app/helpers/skills_helper.rb
@@ -51,6 +51,7 @@ module SkillsHelper
     end
   end
 
+  # A basic method as an example of how we could determine mastery.
   def self.determine_mastery_level_for_student(evaluations)
     return "Not seen" if evaluations.empty?
 

--- a/dashboard/test/helpers/openai_evaluate_helper_test.rb
+++ b/dashboard/test/helpers/openai_evaluate_helper_test.rb
@@ -41,7 +41,6 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
 
     OpenaiEvaluateHelper.expects(:evaluate).with(
       @free_response_level,
-      @unit,
       student_work: "This is my free response answer",
       evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]
     ).returns(mock_response)
@@ -87,7 +86,6 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
 
     OpenaiEvaluateHelper.expects(:evaluate).with(
       @code_level1,
-      @unit,
       student_work: "console.log('Hello')",
       evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]
     ).returns(mock_response)

--- a/dashboard/test/helpers/skills_helper_test.rb
+++ b/dashboard/test/helpers/skills_helper_test.rb
@@ -193,4 +193,65 @@ class SkillsHelperTest < ActiveSupport::TestCase
 
     assert_equal 'Shown', result[@student1.id][@skill1.id][:mastery_level]
   end
+
+  test "filter_evaluations keeps most recent evaluation for each unique combination" do
+    evaluations_data = [
+      [@student1.id, @skill1.id, 'Ok', @level1.id, 1.day.ago, nil],
+      [@student1.id, @skill1.id, 'Great', @level1.id, Time.current, nil],
+      [@student1.id, @skill1.id, 'Needs revision', @level2.id, 2.days.ago, 'CODE_VERSION_HASH_1'],
+      [@student1.id, @skill1.id, 'Ok', @level2.id, 1.day.ago, 'CODE_VERSION_HASH_1'],
+      [@student1.id, @skill1.id, 'Great', @level2.id, Time.current, 'CODE_VERSION_HASH_2']
+    ]
+
+    result = SkillsHelper.send(:filter_evaluations, evaluations_data)
+
+    assert_equal 3, result.length
+
+    most_recent_level1_nil = result.find {|r| r[3] == @level1.id && r[5].nil?}
+    assert_equal 'Great', most_recent_level1_nil[2]
+
+    most_recent_level2_v1 = result.find {|r| r[3] == @level2.id && r[5] == 'CODE_VERSION_HASH_1'}
+    assert_equal 'Ok', most_recent_level2_v1[2]
+
+    most_recent_level2_v2 = result.find {|r| r[3] == @level2.id && r[5] == 'CODE_VERSION_HASH_2'}
+    assert_equal 'Great', most_recent_level2_v2[2]
+  end
+
+  test "filter_evaluations handles empty array" do
+    result = SkillsHelper.send(:filter_evaluations, [])
+    assert_equal [], result
+  end
+
+  test "filter_evaluations handles single evaluation" do
+    evaluations_data = [
+      [@student1.id, @skill1.id, 'Great', @level1.id, Time.current, nil]
+    ]
+
+    result = SkillsHelper.send(:filter_evaluations, evaluations_data)
+
+    assert_equal 1, result.length
+    assert_equal evaluations_data.first, result.first
+  end
+
+  test "filter_evaluations handles different students and skills" do
+    evaluations_data = [
+      [@student1.id, @skill1.id, 'Ok', @level1.id, 1.day.ago, nil],
+      [@student1.id, @skill1.id, 'Great', @level1.id, Time.current, nil],
+      [@student2.id, @skill1.id, 'Needs revision', @level1.id, 2.days.ago, nil],
+      [@student1.id, @skill2.id, 'Ok', @level1.id, Time.current, nil]
+    ]
+
+    result = SkillsHelper.send(:filter_evaluations, evaluations_data)
+
+    assert_equal 3, result.length
+
+    student1_skill1 = result.find {|r| r[0] == @student1.id && r[1] == @skill1.id}
+    assert_equal 'Great', student1_skill1[2]
+
+    student2_skill1 = result.find {|r| r[0] == @student2.id && r[1] == @skill1.id}
+    assert_equal 'Needs revision', student2_skill1[2]
+
+    student1_skill2 = result.find {|r| r[0] == @student1.id && r[1] == @skill2.id}
+    assert_equal 'Ok', student1_skill2[2]
+  end
 end


### PR DESCRIPTION
Filter evaluations used for the eventual skills dashboard to only include one evaluation per student per code version or level.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/TEACH-1984

## Testing story
Added unit tests and called manually.