### PR TITLE
fix(sitemap): use canonical hostname

### DIFF
--- a/frontend/apps/marketing/src/app/sitemap.xml/route.ts
+++ b/frontend/apps/marketing/src/app/sitemap.xml/route.ts
@@ -2,7 +2,10 @@ import {eTag} from '@tinyhttp/etag';
 import {EmptySitemap, SitemapStream, streamToPromise} from 'sitemap';
 
 import {STALE_WHILE_REVALIDATE_ONE_DAY} from '@/cache/constants';
+import {getBrandFromHostname} from '@/config/brand';
+import {getCanonicalHostname} from '@/config/host';
 import {SUPPORTED_LOCALE_CODES} from '@/config/locale';
+import {getStage} from '@/config/stage';
 import {getContentfulClient} from '@/contentful/client';
 import {getAllEntriesForContentType} from '@/contentful/get-entries';
 import {SeoMetadataEntry} from '@/types/contentful/entries/SeoMetadata';
@@ -31,7 +34,11 @@ export async function GET(request: Request) {
     return new Response();
   }
 
-  const hostname = `https://${request.headers.get('host')}`;
+  const host = request.headers.get('host');
+  const brand = getBrandFromHostname(host);
+  const stage = getStage();
+
+  const hostname = `https://${getCanonicalHostname(brand, stage)}`;
 
   const experienceEntries = await getAllEntriesForContentType<
     Entry<SitemapEntry>

--- a/frontend/apps/marketing/src/config/__tests__/host.test.ts
+++ b/frontend/apps/marketing/src/config/__tests__/host.test.ts
@@ -1,4 +1,9 @@
-import {getLocalhostDomain, getLocalhostAddress} from '../host';
+import {Brand} from '../brand';
+import {
+  getLocalhostDomain,
+  getLocalhostAddress,
+  getCanonicalHostname,
+} from '../host';
 
 describe('getLocalhostDomain', () => {
   const OLD_ENV = process.env;
@@ -41,5 +46,55 @@ describe('getLocalhostAddress', () => {
   it('returns http://localhost:<PORT> if PORT is set', () => {
     process.env.PORT = '5000';
     expect(getLocalhostAddress()).toBe('http://localhost:5000');
+  });
+});
+
+describe('getCanonicalHostname', () => {
+  const brands = [
+    {
+      brand: Brand.CODE_DOT_ORG,
+      name: 'CODE_DOT_ORG',
+      expected: {
+        development: 'code.marketing-sites.localhost',
+        pr: 'code.marketing-sites.localhost',
+        test: 'code.marketing-sites.test-code.org',
+        production: 'code.org',
+      },
+    },
+    {
+      brand: Brand.HOUR_OF_CODE,
+      name: 'HOUR_OF_CODE',
+      expected: {
+        development: 'hourofcode.marketing-sites.localhost',
+        pr: 'hourofcode.marketing-sites.localhost',
+        test: 'hourofcode.marketing-sites.test-code.org',
+        production: 'hourofcode.com',
+      },
+    },
+    {
+      brand: Brand.CS_FOR_ALL,
+      name: 'CS_FOR_ALL',
+      expected: {
+        development: 'csforall.marketing-sites.localhost',
+        pr: 'csforall.marketing-sites.localhost',
+        test: 'csforall.marketing-sites.test-code.org',
+        production: 'csforall.org',
+      },
+    },
+  ];
+
+  const stages: Array<'development' | 'pr' | 'test' | 'production'> = [
+    'development',
+    'pr',
+    'test',
+    'production',
+  ];
+
+  brands.forEach(({brand, name, expected}) => {
+    stages.forEach(stage => {
+      it(`returns correct hostname for brand ${name} and stage ${stage}`, () => {
+        expect(getCanonicalHostname(brand, stage)).toBe(expected[stage]);
+      });
+    });
   });
 });

--- a/frontend/apps/marketing/src/config/host.ts
+++ b/frontend/apps/marketing/src/config/host.ts
@@ -1,3 +1,6 @@
+import {Brand} from '@/config/brand';
+import {Stage} from '@/config/stage';
+
 /**
  * Returns the localhost domain
  */
@@ -11,4 +14,41 @@ export function getLocalhostDomain() {
  */
 export function getLocalhostAddress() {
   return `http://${getLocalhostDomain()}`;
+}
+
+function getProductionCanonicalRootDomain(brand: Brand) {
+  switch (brand) {
+    case Brand.CS_FOR_ALL:
+      return `csforall.org`;
+    case Brand.HOUR_OF_CODE:
+      return `hourofcode.com`;
+    case Brand.CODE_DOT_ORG:
+    default:
+      return `code.org`;
+  }
+}
+
+function getPreproductionTopLevelSubdomain(brand: Brand) {
+  switch (brand) {
+    case Brand.CS_FOR_ALL:
+      return `csforall`;
+    case Brand.HOUR_OF_CODE:
+      return `hourofcode`;
+    default:
+    case Brand.CODE_DOT_ORG:
+      return `code`;
+  }
+}
+
+export function getCanonicalHostname(brand: Brand, stage: Stage) {
+  switch (stage) {
+    default:
+    case 'development':
+    case 'pr':
+      return `${getPreproductionTopLevelSubdomain(brand)}.marketing-sites.localhost`;
+    case 'test':
+      return `${getPreproductionTopLevelSubdomain(brand)}.marketing-sites.test-code.org`;
+    case 'production':
+      return getProductionCanonicalRootDomain(brand);
+  }
 }


### PR DESCRIPTION
The current sitemap.xml implementation simply reads the `Host` header and replies it back on sitemap.xml. Unfortunately, due to the rewrite logic in the lambda @ edge, `code.org` will actually receive the value `code.marketing-sites.code.org`, and therefore some special logic to detect the canonical hostname from the stage and brand is needed.