### PR TITLE
fix(redirect): return 200 when redirect not found

### DIFF
--- a/frontend/apps/marketing/src/app/api/private/redirects/[brand]/[pathname]/__tests__/route.test.ts
+++ b/frontend/apps/marketing/src/app/api/private/redirects/[brand]/[pathname]/__tests__/route.test.ts
@@ -62,13 +62,13 @@ describe('GET /api/private/redirects/[brand]/[pathname]', () => {
     expect(text).toMatch(/brand/);
   });
 
-  it('returns 404 if no redirect entry found', async () => {
+  it('returns 200 and redirect not found if no redirect entry found', async () => {
     mockGetRedirectEntry.mockResolvedValue(undefined);
     const req = makeRequest();
     const res = await GET(req, {params});
-    expect(res.status).toBe(404);
-    const text = await res.text();
-    expect(text).toMatch(/Not Found/);
+    expect(res.status).toBe(200);
+    const resJson = await res.json();
+    expect(resJson.redirectEntry).toBeNull();
   });
 
   it('returns 200 and the redirect entry with correct headers', async () => {
@@ -82,6 +82,8 @@ describe('GET /api/private/redirects/[brand]/[pathname]', () => {
     );
     expect(res.headers.get('ETag')).toBeDefined();
     const json = await res.json();
-    expect(json).toEqual(entry);
+    expect(json).toEqual({
+      redirectEntry: {destination: '/bar', permanent: true},
+    });
   });
 });

--- a/frontend/apps/marketing/src/app/api/private/redirects/[brand]/[pathname]/route.ts
+++ b/frontend/apps/marketing/src/app/api/private/redirects/[brand]/[pathname]/route.ts
@@ -39,18 +39,16 @@ export async function GET(
 
   const redirectEntry = await getRedirectEntry(pathname, brand);
 
-  if (redirectEntry) {
-    const responseBody = JSON.stringify(redirectEntry);
-    // This API uses Stale While Revalidate with an ETag for caching
-    return new Response(responseBody, {
-      headers: {
-        'Cache-Control': STALE_WHILE_REVALIDATE_ONE_HOUR,
-        ETag: eTag(responseBody),
-      },
-    });
-  }
+  const response = {
+    redirectEntry: redirectEntry ?? null,
+  };
 
-  return new Response('Not Found', {
-    status: 404,
+  const responseBody = JSON.stringify(response);
+  // This API uses Stale While Revalidate with an ETag for caching
+  return new Response(responseBody, {
+    headers: {
+      'Cache-Control': STALE_WHILE_REVALIDATE_ONE_HOUR,
+      ETag: eTag(responseBody),
+    },
   });
 }

--- a/frontend/apps/marketing/src/cache/redirects/types.ts
+++ b/frontend/apps/marketing/src/cache/redirects/types.ts
@@ -6,3 +6,7 @@ export interface RedirectEntry {
   destination: string;
   permanent: boolean;
 }
+
+export type RedirectEntryResponse = {
+  redirectEntry: RedirectEntry | null;
+};

--- a/frontend/apps/marketing/src/middleware/withRedirects.ts
+++ b/frontend/apps/marketing/src/middleware/withRedirects.ts
@@ -1,7 +1,7 @@
 import {NextFetchEvent, NextRequest, NextResponse} from 'next/server';
 
 import {STALE_WHILE_REVALIDATE_ONE_HOUR} from '@/cache/constants';
-import {RedirectEntry} from '@/cache/redirects/types';
+import {RedirectEntryResponse} from '@/cache/redirects/types';
 import {getBrandFromHostname} from '@/config/brand';
 import {getLocalhostAddress} from '@/config/host';
 
@@ -27,12 +27,14 @@ export const withRedirects: MiddlewareFactory = next => {
       method: 'GET',
     });
 
-    if (redirectCacheByBrandResponse.status === 404) {
+    const redirectEntryResponse: RedirectEntryResponse =
+      await redirectCacheByBrandResponse.json();
+
+    if (!redirectEntryResponse.redirectEntry) {
       return next(request, event);
     }
 
-    const redirectEntry: RedirectEntry =
-      await redirectCacheByBrandResponse.json();
+    const redirectEntry = redirectEntryResponse.redirectEntry;
 
     const redirectUrl = redirectEntry.destination.startsWith('/')
       ? `${request.nextUrl.origin}${redirectEntry.destination}`


### PR DESCRIPTION
Originally the redirect API returned 404 when a redirect entry was not found. However, this causes a lot of noise on New Relic where it detects the 404 as an 'error'. To mitigate this, the API now returns an OK response but when the `redirectEntry` as null if the entry is not found.
