### PR TITLE
feat(google): add site verification

### DIFF
--- a/dashboard/public/google3799398f478c3974.html
+++ b/dashboard/public/google3799398f478c3974.html
@@ -1,0 +1,1 @@
+google-site-verification: google3799398f478c3974.html

--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
@@ -7,6 +7,7 @@ import Bootstrap from '@/bootstrap';
 import ContentEditorHelper from '@/components/contentEditorHelper';
 import {Brand} from '@/config/brand';
 import {getIcons} from '@/config/metadata/icons';
+import {getSiteVerification} from '@/config/metadata/siteVerification';
 import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
 import {getExperience} from '@/contentful/get-experience';
 import {registerContentfulComponents} from '@/contentful/registration';
@@ -81,6 +82,7 @@ export async function generateMetadata({
     title: getPageHeading(experience),
     icons: getIcons(pageProps.brand),
     ...getSeoMetadata(experience, pageProps.brand, pageProps.locale),
+    verification: getSiteVerification(pageProps.brand),
   };
 }
 export default async function ExperiencePage({

--- a/frontend/apps/marketing/src/config/metadata/siteVerification.ts
+++ b/frontend/apps/marketing/src/config/metadata/siteVerification.ts
@@ -1,0 +1,19 @@
+import {Metadata} from 'next';
+
+import {Brand} from '@/config/brand';
+
+export function getSiteVerification(
+  brand: Brand,
+): Metadata['verification'] | undefined {
+  switch (brand) {
+    case Brand.CODE_DOT_ORG:
+      // This was done to separate code.org from studio.code.org
+      // Other sites do not need this specific verification as they use domain verification.
+      return {
+        google: 'LX_oP5X8q2qzWY0u0Hsz9MT7Htdr-NYqJs1uqk1CiJ0',
+      };
+    case Brand.HOUR_OF_CODE:
+    case Brand.CS_FOR_ALL:
+      return undefined;
+  }
+}


### PR DESCRIPTION
This PR adds google site verifications that differentiate between studio.code.org and code.org. For marketing sites, since the application is multi-tenant, the meta header was chosen to allow for verification based on runtime brand detection. In the future, we can switch to the Domain TXT method to reduce page payload size if needed.