### PR TITLE
Disable jotform sync (sync_jotforms)

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -97,7 +97,6 @@
       cronjob at:'0 16 * * *', do:dashboard_dir('bin','scheduled_pd_application_emails')
       cronjob at:'*/4 * * * *', do:dashboard_dir('bin', 'process_pd_workshop_ends')
       cronjob at:'*/5 * * * *', do:dashboard_dir('bin', 'fill_jotform_placeholders')
-      cronjob at:'*/30 * * * *', do:dashboard_dir('bin', 'sync_jotforms')
       cronjob at:'0 6 * * *', do:deploy_dir('bin', 'cron', 'process_foorm_data')
       cronjob at:'*/10 * * * *', do:deploy_dir('bin', 'cron', 'delete_twilio_data')
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'confirm_usage')

--- a/dashboard/bin/sync_jotforms
+++ b/dashboard/bin/sync_jotforms
@@ -1,4 +1,10 @@
 #!/usr/bin/env ruby
+
+# This script generates nothing but RestClient::RequestFailed errors when syncing.
+# It should not be run until these errors are fixed.
+# See: https://codedotorg.atlassian.net/browse/ACQ-3158
+exit
+
 # The current version of this script should be run periodically to sync certain
 # JotForm-based forms that don't have placeholders.  That is, it works for forms
 # filled out directly by end-users without seeing them embedded via our site.


### PR DESCRIPTION
These errors spawning from the `sync_jotforms` script are consistently one of the highest error rates every day. These are a bunch of errors that occur 100% of the time from the named script. There is some problem with the sync process that is unknown... but considering that nobody seems to have cared, maybe this is evidence for deprecation. Either way, turning off the script reduces the alert burden on Honeybadger and based on the evidence, will not cause any further disruption.

## Links

- Jira: [ACQ-3158](https://codedotorg.atlassian.net/browse/ACQ-3158)

## Other thoughts

The error rate is 66 errors per half hour (3,168 errors per day). The script runs at that cadence. The script goes through and calls an offending function exactly 66 times, no more no less. 51 for each `Pd::SurveyQuestion` already in the production database and another 15 times for each hard-coded form id. Therefore, the script does nothing but generate Honeybadger errors.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
