### PR TITLE
Skip another test for 2018 curriculum

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v1.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v1.feature
@@ -81,6 +81,9 @@ Feature: Using the teacher dashboard homepage (v1)
     And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"
 
   @eyes
+  @skip
+  # Skipped while fixing issue with curriculum version
+  # https://codedotorg.atlassian.net/browse/TEACH-2080
   Scenario: Teacher can view more tiles when clicking on view more button
     When I open my eyes to test "teacher dashboard"
     Given I am a teacher and go home


### PR DESCRIPTION
2018 curriculum was recently set to sunsetting and therefore removed from curriculum lists on test. 5 teacher tools tests failed because they relied on them.

This PR skips the failing tests while I debug a fix

Links
[Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1751994757401739)

Jira: https://codedotorg.atlassian.net/browse/TEACH-2080

FLUP to https://github.com/code-dot-org/code-dot-org/pull/66945
