### PR TITLE
Fix for student courses not showing up on PL page

### DIFF
--- a/apps/src/templates/studioHomepages/JoinSectionArea.jsx
+++ b/apps/src/templates/studioHomepages/JoinSectionArea.jsx
@@ -80,15 +80,17 @@ export default function JoinSectionArea({
             updateSections={setJoinedStudentSections}
           />
         )}
-        {isPlSections && joinedPlSections?.length > 0 && isTeacher && (
-          <ParticipantSections
-            sections={joinedPlSections.concat(joinedStudentSections)}
-            isTeacher={isTeacher}
-            isPlSections={true}
-            updateSectionsResult={updateSectionsResult}
-            updateSections={setJoinedPlSections}
-          />
-        )}
+        {isPlSections &&
+          (joinedPlSections?.length > 0 || joinedStudentSections?.length > 0) &&
+          isTeacher && (
+            <ParticipantSections
+              sections={joinedPlSections.concat(joinedStudentSections)}
+              isTeacher={isTeacher}
+              isPlSections={true}
+              updateSectionsResult={updateSectionsResult}
+              updateSections={setJoinedPlSections}
+            />
+          )}
       </>
     );
   };

--- a/apps/test/unit/templates/studioHomepages/JoinSectionAreaTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/JoinSectionAreaTest.jsx
@@ -37,4 +37,17 @@ describe('JoinSectionArea', () => {
     expect(wrapper.find('ParticipantSections').length).toBe(1);
     expect(wrapper.find('ParticipantSections').props().isTeacher).toBe(true);
   });
+  it('shows student sections for pl if isPlSections is true and has joined student sections', () => {
+    const wrapper = shallow(
+      <JoinSectionArea
+        {...defaultProps}
+        isTeacher={true}
+        initialJoinedStudentSections={joinedSections}
+        isPlSections={true}
+      />
+    );
+    expect(wrapper.find('Connect(JoinSection)').length).toBe(1);
+    expect(wrapper.find('ParticipantSections').length).toBe(1);
+    expect(wrapper.find('ParticipantSections').props().isTeacher).toBe(true);
+  });
 });


### PR DESCRIPTION
We previously updated the Joined PL Sections table to include student sections the teacher has joined, since these will no longer be visible on the teacher homepage. This update fixes an error that prevented the table from displaying if there are student sections but no PL sections.

## Links
[TEACH-2087](https://codedotorg.atlassian.net/browse/TEACH-2087)

## Testing story
Added a unit test to confirm student sections will trigger table to display
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
