### PR TITLE
feat(LinkButton): add an analyticsCallback prop to LinkButton

### DIFF
--- a/frontend/packages/component-library/src/button/_BaseButton.tsx
+++ b/frontend/packages/component-library/src/button/_BaseButton.tsx
@@ -70,6 +70,9 @@ export interface LinkButtonSpecificProps {
   /** (\<a> specific prop)
    * Button title */
   title?: string;
+  /** (\<a> specific prop)
+   * Analytics event handler (only use to send analytics events) */
+  analyticsCallback?: () => void;
 }
 
 export interface ButtonSpecificProps {
@@ -211,6 +214,7 @@ const BaseButton: React.FunctionComponent<_BaseButtonProps> = ({
   target,
   download,
   title,
+  analyticsCallback,
   /** <button> specific props */
   onClick,
   value,
@@ -234,6 +238,7 @@ const BaseButton: React.FunctionComponent<_BaseButtonProps> = ({
           rel: target === '_blank' ? 'noopener noreferrer' : undefined,
           download,
           title,
+          onClick: analyticsCallback,
         }
       : {type: buttonTagTypeAttribute, onClick, value, name};
 

--- a/frontend/packages/component-library/src/button/stories/LinkButton.story.tsx
+++ b/frontend/packages/component-library/src/button/stories/LinkButton.story.tsx
@@ -82,6 +82,14 @@ IconLinkButton.args = {
   size: 'm',
 };
 
+export const AnalyticsCallbackLinkButton = SingleTemplate.bind({});
+AnalyticsCallbackLinkButton.args = {
+  text: 'Button',
+  href: 'https://www.google.com',
+  size: 'm',
+  analyticsCallback: () => alert('Sending analytics event...'),
+};
+
 export const GroupOfColorsOfLinkButtons = MultipleTemplate.bind({});
 GroupOfColorsOfLinkButtons.args = {
   components: [


### PR DESCRIPTION
often we need to send an analytics event when a user clicks a link. LinkButton does not allow a onClick prop to discourage navigating programmatically. this adds an `analyticsCallback` prop that is passed to the anchor element's onClick handler, so it's called right before navigation


https://github.com/user-attachments/assets/b1d72c0b-5690-4b61-ad42-732ee72aa26d



<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3388

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
