### PR TITLE
Lab2 Instructions: update continue logic and add unit tests

### DIFF
--- a/apps/src/codebridge/InfoPanel/InfoPanel.tsx
+++ b/apps/src/codebridge/InfoPanel/InfoPanel.tsx
@@ -218,6 +218,7 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
             AiTutor2ResponseView={AiTutor2ResponseView}
             className={moduleStyles.instructionsContainer}
             levelProperties={levelProperties}
+            requireRun={true}
           />
         ) : (
           <ForTeachersOnly />

--- a/apps/src/lab2/redux/predictLevelRedux.ts
+++ b/apps/src/lab2/redux/predictLevelRedux.ts
@@ -94,6 +94,10 @@ const predictSlice = createSlice({
     setPredictResponse(state, action: PayloadAction<string>) {
       state.response = action.payload;
     },
+    setHasSubmittedResponse(state, action: PayloadAction<boolean>) {
+      // Should only be used by unit tests.
+      state.hasSubmittedResponse = action.payload;
+    },
   },
   extraReducers: builder => {
     builder.addCase(sendPredictLevelReport.fulfilled, state => {
@@ -119,6 +123,7 @@ const predictSlice = createSlice({
   },
 });
 
-export const {setPredictResponse} = predictSlice.actions;
+export const {setPredictResponse, setHasSubmittedResponse} =
+  predictSlice.actions;
 
 export default predictSlice.reducer;

--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -1,6 +1,6 @@
 import {Theme, useTheme} from '@code-dot-org/component-library/common/contexts';
 import classNames from 'classnames';
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useMemo, useRef} from 'react';
 import {useSelector} from 'react-redux';
 
 import InstructorsOnly from '@cdo/apps/code-studio/components/InstructorsOnly';
@@ -131,6 +131,25 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
     }
   }, [validationState?.validationResults]);
 
+  const canShowNextButton = useMemo(() => {
+    if (levelProperties?.submittable) {
+      return true;
+    } else if (predictSettings?.isPredictLevel) {
+      return predictResponseSubmitted;
+    } else if (validationState?.hasConditions) {
+      return validationState?.satisfied;
+    } else {
+      return hasRun;
+    }
+  }, [
+    hasRun,
+    levelProperties?.submittable,
+    predictResponseSubmitted,
+    predictSettings?.isPredictLevel,
+    validationState?.hasConditions,
+    validationState?.satisfied,
+  ]);
+
   // Don't render anything if we don't have any instructions.
   if (
     levelProperties === undefined ||
@@ -138,10 +157,6 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   ) {
     return null;
   }
-
-  const canShowNextButton =
-    (!validationState?.hasConditions || validationState?.satisfied) &&
-    (!predictSettings?.isPredictLevel || predictResponseSubmitted);
 
   const vertical = layout === 'vertical';
   const showSecondaryFinishButton = useSecondaryFinishButton && !hasNextLevel;

--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -52,6 +52,9 @@ interface InstructionsProps {
   /** Component to use for AI Tutor responses, if any. */
   AiTutor2ResponseView?: React.ReactNode;
   overrideTheme?: Theme;
+  /** If the lab requires the user to click run in order to continue.
+   * Only applies to non-validated levels. */
+  requireRun?: boolean;
 }
 
 interface ValidationSettings {
@@ -82,6 +85,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   fixedDarkBackground,
   AiTutor2ResponseView,
   overrideTheme,
+  requireRun,
 }) => {
   const hasNextLevel = useSelector(state => nextLevelId(state) !== undefined);
   const validationState = useAppSelector(state => state.lab.validationState);
@@ -139,7 +143,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
     } else if (validationState?.hasConditions) {
       return validationState?.satisfied;
     } else {
-      return hasRun;
+      return !requireRun || hasRun;
     }
   }, [
     hasRun,
@@ -148,6 +152,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
     predictSettings?.isPredictLevel,
     validationState?.hasConditions,
     validationState?.satisfied,
+    requireRun,
   ]);
 
   // Don't render anything if we don't have any instructions.

--- a/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
+++ b/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
@@ -27,6 +27,7 @@ interface NavigationButtonProps {
   hasEdited: boolean;
   className?: string;
   size?: ComponentSizeXSToL;
+  requireRun?: boolean;
 }
 
 const NavigationButton: React.FC<NavigationButtonProps> = ({
@@ -35,6 +36,7 @@ const NavigationButton: React.FC<NavigationButtonProps> = ({
   hasEdited,
   className,
   size,
+  requireRun,
 }) => {
   if (levelProperties.submittable) {
     return (
@@ -54,6 +56,7 @@ const NavigationButton: React.FC<NavigationButtonProps> = ({
       size={size}
       hasRun={hasRun}
       isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
+      requireRun={requireRun}
     />
   );
 };
@@ -63,6 +66,7 @@ interface ContinueButtonProps {
   size?: ComponentSizeXSToL;
   isPredictLevel?: boolean;
   hasRun?: boolean;
+  requireRun?: boolean;
 }
 
 /**
@@ -73,6 +77,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
   size,
   isPredictLevel,
   hasRun,
+  requireRun,
 }) => {
   const dispatch = useAppDispatch();
   const hasNextLevel = useAppSelector(
@@ -98,7 +103,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
     } else if (hasConditions) {
       return validationSatisfied;
     } else {
-      return hasRun;
+      return !requireRun || hasRun;
     }
   }, [
     hasRun,
@@ -106,6 +111,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
     isPredictLevel,
     hasSubmittedPredictResponse,
     validationSatisfied,
+    requireRun,
   ]);
 
   const text = hasNextLevel ? commonI18n.continue() : commonI18n.finish();

--- a/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
+++ b/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
@@ -1,7 +1,7 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {ComponentSizeXSToL} from '@code-dot-org/component-library/common/types';
 import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import {sendSubmitReport} from '@cdo/apps/code-studio/progressRedux';
 import {
@@ -52,6 +52,7 @@ const NavigationButton: React.FC<NavigationButtonProps> = ({
     <ContinueButton
       className={className}
       size={size}
+      hasRun={hasRun}
       isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
     />
   );
@@ -61,6 +62,7 @@ interface ContinueButtonProps {
   className?: string;
   size?: ComponentSizeXSToL;
   isPredictLevel?: boolean;
+  hasRun?: boolean;
 }
 
 /**
@@ -70,6 +72,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
   className,
   size,
   isPredictLevel,
+  hasRun,
 }) => {
   const dispatch = useAppDispatch();
   const hasNextLevel = useAppSelector(
@@ -78,18 +81,32 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
   const hasSubmittedPredictResponse = useAppSelector(
     isPredictResponseSubmitted
   );
-  const passingValidation = useAppSelector(
-    state =>
-      !state.lab.validationState.hasConditions ||
-      state.lab.validationState.satisfied
+  const hasConditions = useAppSelector(
+    state => state.lab.validationState.hasConditions
+  );
+  const validationSatisfied = useAppSelector(
+    state => state.lab.validationState.satisfied
   );
   const useSecondaryFinishButton =
     useAppSelector(
       state => state.lab.levelProperties?.useSecondaryFinishButton
     ) || queryParams('use-secondary-finish-button') === 'true';
 
-  const canShow =
-    (!isPredictLevel || hasSubmittedPredictResponse) && passingValidation;
+  const canShow = useMemo(() => {
+    if (isPredictLevel) {
+      return hasSubmittedPredictResponse;
+    } else if (hasConditions) {
+      return validationSatisfied;
+    } else {
+      return hasRun;
+    }
+  }, [
+    hasRun,
+    hasConditions,
+    isPredictLevel,
+    hasSubmittedPredictResponse,
+    validationSatisfied,
+  ]);
 
   const text = hasNextLevel ? commonI18n.continue() : commonI18n.finish();
 

--- a/apps/test/unit/lab2/views/components/Instructions/NavigationButtonTest.tsx
+++ b/apps/test/unit/lab2/views/components/Instructions/NavigationButtonTest.tsx
@@ -25,31 +25,6 @@ import {
 import {InitProgressPayload, UnitProgress} from '@cdo/apps/types/progressTypes';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
-// Mock external dependencies
-jest.mock('@cdo/apps/lab2/progress/continueOrFinishLesson', () =>
-  jest.fn(() => ({type: 'MOCK_CONTINUE_OR_FINISH_LESSON'}))
-);
-
-jest.mock('@cdo/apps/lab2/views/dialogs', () => ({
-  DialogType: {
-    GenericConfirmation: 'GenericConfirmation',
-  },
-  useDialogControl: jest.fn(() => ({
-    showDialog: jest.fn(),
-  })),
-}));
-
-jest.mock(
-  '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi',
-  () => ({
-    logUserLevelInteraction: jest.fn(),
-  })
-);
-
-jest.mock('@cdo/apps/code-studio/utils', () => ({
-  queryParams: jest.fn(() => null),
-}));
-
 describe('NavigationButton', () => {
   let store: Store;
 
@@ -59,7 +34,6 @@ describe('NavigationButton', () => {
     appName: 'pythonlab',
     submittable: false,
     predictSettings: undefined,
-    useSecondaryFinishButton: false,
   };
 
   const submittableLevelProperties: LevelProperties = {
@@ -207,7 +181,7 @@ describe('NavigationButton', () => {
   }
 
   describe('Submit Button', () => {
-    it('button says "Submit" when level is not submitted and is enabled when hasRun and hasEdited are true', () => {
+    it('displays "Submit" when level is not submitted and is enabled when hasRun and hasEdited are true', () => {
       renderNavigationButton({
         levelProperties: submittableLevelProperties,
         hasRun: true,
@@ -217,7 +191,7 @@ describe('NavigationButton', () => {
       expect(submitButton).toBeEnabled();
     });
 
-    it('displays "Unsubmit" text and is enabled when level has been submitted', () => {
+    it('displays "Unsubmit" and is enabled when level has been submitted', () => {
       // Set up state for submitted level
       const submittedProgressState: InitProgressPayload = {
         ...initialProgress,
@@ -261,7 +235,7 @@ describe('NavigationButton', () => {
       expect(unsubmitButton).toBeEnabled();
     });
 
-    it('is disabled when hasRun is false or hasEdited is false for unsubmitted level', () => {
+    it('is disabled when hasRun is false or hasEdited is false for an unsubmitted level', () => {
       renderNavigationButton({
         levelProperties: submittableLevelProperties,
         hasRun: false,

--- a/apps/test/unit/lab2/views/components/Instructions/NavigationButtonTest.tsx
+++ b/apps/test/unit/lab2/views/components/Instructions/NavigationButtonTest.tsx
@@ -7,11 +7,13 @@ import {Store} from 'redux';
 import '@testing-library/jest-dom';
 import progress, {
   initProgress,
-  mergeResults,
+  setCurrentLevelId,
   setScriptProgress,
 } from '@cdo/apps/code-studio/progressRedux';
-import {TestResults} from '@cdo/apps/constants';
-import lab from '@cdo/apps/lab2/lab2Redux';
+import lab, {setValidationState} from '@cdo/apps/lab2/lab2Redux';
+import predictLevel, {
+  setHasSubmittedResponse,
+} from '@cdo/apps/lab2/redux/predictLevelRedux';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import NavigationButton from '@cdo/apps/lab2/views/components/Instructions/NavigationButton';
 import {
@@ -65,6 +67,13 @@ describe('NavigationButton', () => {
     submittable: true,
   };
 
+  const predictLevelProperties: LevelProperties = {
+    ...defaultLevelProperties,
+    predictSettings: {
+      isPredictLevel: true,
+    },
+  };
+
   const initialProgress: InitProgressPayload = {
     currentLevelId: '123',
     scriptId: 456,
@@ -85,8 +94,29 @@ describe('NavigationButton', () => {
             inactiveIds: [],
             is_concept_level: false,
             kind: '',
-            levelNumber: 0,
-            position: 0,
+            levelNumber: 1,
+            position: 1,
+            title: 0,
+            url: '',
+            path: '',
+            scriptLevelId: '',
+            usesLab2: false,
+          },
+          {
+            id: '234',
+            status: LevelStatus.not_tried,
+            activeId: '',
+            app: '',
+            bonus: false,
+            display_as_unplugged: false,
+            freePlay: false,
+            icon: null,
+            ids: ['234'],
+            inactiveIds: [],
+            is_concept_level: false,
+            kind: '',
+            levelNumber: 2,
+            position: 2,
             title: 0,
             url: '',
             path: '',
@@ -139,6 +169,7 @@ describe('NavigationButton', () => {
     registerReducers({
       progress,
       lab,
+      predictLevel,
     });
     store = getStore();
     store.dispatch(initProgress(initialProgress));
@@ -176,15 +207,15 @@ describe('NavigationButton', () => {
   }
 
   describe('Submit Button', () => {
-    // it('button says "Submit" when level is not submitted and is enabled when hasRun and hasEdited are true', () => {
-    //   renderNavigationButton({
-    //     levelProperties: submittableLevelProperties,
-    //     hasRun: true,
-    //     hasEdited: true,
-    //   });
-    //   const submitButton = screen.getByRole('button', {name: 'Submit'});
-    //   expect(submitButton).toBeEnabled();
-    // });
+    it('button says "Submit" when level is not submitted and is enabled when hasRun and hasEdited are true', () => {
+      renderNavigationButton({
+        levelProperties: submittableLevelProperties,
+        hasRun: true,
+        hasEdited: true,
+      });
+      const submitButton = screen.getByRole('button', {name: 'Submit'});
+      expect(submitButton).toBeEnabled();
+    });
 
     it('displays "Unsubmit" text and is enabled when level has been submitted', () => {
       // Set up state for submitted level
@@ -226,153 +257,114 @@ describe('NavigationButton', () => {
         hasEdited: true,
       });
 
-      screen.getByRole('button', {name: 'Unsubmit'});
+      const unsubmitButton = screen.getByRole('button', {name: 'Unsubmit'});
+      expect(unsubmitButton).toBeEnabled();
     });
 
-    // it('is enabled when level has been submitted', () => {
-    //   store.dispatch({
-    //     type: 'SET_LEVEL',
-    //     level: {
-    //       id: 123,
-    //       status: LevelStatus.submitted,
-    //     },
-    //   });
+    it('is disabled when hasRun is false or hasEdited is false for unsubmitted level', () => {
+      renderNavigationButton({
+        levelProperties: submittableLevelProperties,
+        hasRun: false,
+        hasEdited: true,
+      });
 
-    //   renderNavigationButton({
-    //     levelProperties: submittableLevelProperties,
-    //     hasRun: false,
-    //     hasEdited: false,
-    //   });
-
-    //   expect(screen.getByRole('button')).not.toBeDisabled();
-    // });
-
-    // it('is enabled when hasRun and hasEdited are true', () => {
-    //   renderNavigationButton({
-    //     levelProperties: submittableLevelProperties,
-    //     hasRun: true,
-    //     hasEdited: true,
-    //   });
-
-    //   expect(screen.getByRole('button')).not.toBeDisabled();
-    // });
-
-    // it('is disabled when hasRun is false or hasEdited is false for unsubmitted level', () => {
-    //   renderNavigationButton({
-    //     levelProperties: submittableLevelProperties,
-    //     hasRun: false,
-    //     hasEdited: true,
-    //   });
-
-    //   expect(screen.getByRole('button')).toBeDisabled();
-
-    //   // Re-render with hasRun true but hasEdited false
-    //   renderNavigationButton({
-    //     levelProperties: submittableLevelProperties,
-    //     hasRun: true,
-    //     hasEdited: false,
-    //   });
-
-    //   expect(screen.getByRole('button')).toBeDisabled();
-    // });
+      expect(screen.getByRole('button', {name: 'Submit'})).toBeDisabled();
+    });
   });
 
-  // describe('ContinueButton (non-submittable levels)', () => {
-  //   it('displays "Continue" text when there is a next level', () => {
-  //     // Mock that there is a next level
-  //     store.dispatch({
-  //       type: 'SET_NEXT_LEVEL_ID',
-  //       nextLevelId: 456,
-  //     });
+  describe('Continue Button', () => {
+    it('displays "Continue" when there is a next level', () => {
+      renderNavigationButton({
+        hasRun: true,
+      });
+      screen.getByRole('button', {name: 'Continue'});
+    });
 
-  //     renderNavigationButton({
-  //       hasRun: true,
-  //     });
+    it('displays "Finish" when there is no next level', () => {
+      store.dispatch(setCurrentLevelId('234'));
+      renderNavigationButton({
+        hasRun: true,
+      });
+      screen.getByRole('button', {name: 'Finish'});
+    });
 
-  //     expect(screen.getByText('Continue')).toBeInTheDocument();
-  //     expect(screen.getByRole('button')).toHaveAttribute(
-  //       'id',
-  //       'instructions-continue-button'
-  //     );
-  //   });
+    it('is hidden when requireRun is true but hasRun is false', () => {
+      renderNavigationButton({
+        hasRun: false,
+        requireRun: true,
+      });
+      expect(
+        screen.queryByRole('button', {name: 'Continue'})
+      ).not.toBeInTheDocument();
+    });
 
-  //   it('displays "Finish" text when there is no next level', () => {
-  //     // Ensure no next level
-  //     store.dispatch({
-  //       type: 'SET_NEXT_LEVEL_ID',
-  //       nextLevelId: undefined,
-  //     });
+    it('is shown when requireRun is true and hasRun is true', () => {
+      renderNavigationButton({
+        hasRun: true,
+        requireRun: true,
+      });
+      screen.getByRole('button', {name: 'Continue'});
+    });
 
-  //     renderNavigationButton({
-  //       hasRun: true,
-  //     });
+    it('is shown when requireRun is false regardless of hasRun', () => {
+      renderNavigationButton({
+        hasRun: false,
+        requireRun: false,
+      });
+      screen.getByRole('button', {name: 'Continue'});
+    });
 
-  //     expect(screen.getByText('Finish')).toBeInTheDocument();
-  //   });
+    it('is hidden when validation conditions exist but are not satisfied', () => {
+      store.dispatch(
+        setValidationState({
+          hasConditions: true,
+          satisfied: false,
+          message: null,
+          index: 0,
+        })
+      );
+      renderNavigationButton({
+        hasRun: true,
+      });
+      expect(
+        screen.queryByRole('button', {name: 'Continue'})
+      ).not.toBeInTheDocument();
+    });
 
-  //   it('is hidden when requireRun is true but hasRun is false', () => {
-  //     renderNavigationButton({
-  //       hasRun: false,
-  //       requireRun: true,
-  //     });
+    it('is shown when validation conditions exist and are satisfied', () => {
+      store.dispatch(
+        setValidationState({
+          hasConditions: true,
+          satisfied: true,
+          message: null,
+          index: 0,
+        })
+      );
+      renderNavigationButton({
+        hasRun: true,
+      });
+      screen.getByRole('button', {name: 'Continue'});
+    });
 
-  //     expect(screen.queryByRole('button')).not.toBeInTheDocument();
-  //   });
+    it('is hidden if predict response is not submitted', () => {
+      renderNavigationButton({
+        hasRun: true,
+        levelProperties: predictLevelProperties,
+      });
 
-  //   it('is shown when requireRun is true and hasRun is true', () => {
-  //     renderNavigationButton({
-  //       hasRun: true,
-  //       requireRun: true,
-  //     });
+      expect(
+        screen.queryByRole('button', {name: 'Continue'})
+      ).not.toBeInTheDocument();
+    });
 
-  //     expect(screen.getByRole('button')).toBeInTheDocument();
-  //   });
+    it('is shown if predict response is submitted', () => {
+      store.dispatch(setHasSubmittedResponse(true));
+      renderNavigationButton({
+        hasRun: true,
+        levelProperties: predictLevelProperties,
+      });
 
-  //   it('is shown when requireRun is false regardless of hasRun', () => {
-  //     renderNavigationButton({
-  //       hasRun: false,
-  //       requireRun: false,
-  //     });
-
-  //     expect(screen.getByRole('button')).toBeInTheDocument();
-  //   });
-
-  //   it('is hidden when validation conditions exist but are not satisfied', () => {
-  //     store.dispatch({
-  //       type: 'SET_LAB_STATE',
-  //       lab: {
-  //         validationState: {
-  //           hasConditions: true,
-  //           satisfied: false,
-  //         },
-  //         levelProperties: defaultLevelProperties,
-  //       },
-  //     });
-
-  //     renderNavigationButton({
-  //       hasRun: true,
-  //     });
-
-  //     expect(screen.queryByRole('button')).not.toBeInTheDocument();
-  //   });
-
-  //   it('is shown when validation conditions exist and are satisfied', () => {
-  //     store.dispatch({
-  //       type: 'SET_LAB_STATE',
-  //       lab: {
-  //         validationState: {
-  //           hasConditions: true,
-  //           satisfied: true,
-  //         },
-  //         levelProperties: defaultLevelProperties,
-  //       },
-  //     });
-
-  //     renderNavigationButton({
-  //       hasRun: true,
-  //     });
-
-  //     expect(screen.getByRole('button')).toBeInTheDocument();
-  //   });
-  // });
+      screen.getByRole('button', {name: 'Continue'});
+    });
+  });
 });

--- a/apps/test/unit/lab2/views/components/Instructions/NavigationButtonTest.tsx
+++ b/apps/test/unit/lab2/views/components/Instructions/NavigationButtonTest.tsx
@@ -1,0 +1,378 @@
+import {ThemeProvider} from '@code-dot-org/component-library/common/contexts';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+import {Provider} from 'react-redux';
+import {Store} from 'redux';
+
+import '@testing-library/jest-dom';
+import progress, {
+  initProgress,
+  mergeResults,
+  setScriptProgress,
+} from '@cdo/apps/code-studio/progressRedux';
+import {TestResults} from '@cdo/apps/constants';
+import lab from '@cdo/apps/lab2/lab2Redux';
+import {LevelProperties} from '@cdo/apps/lab2/types';
+import NavigationButton from '@cdo/apps/lab2/views/components/Instructions/NavigationButton';
+import {
+  getStore,
+  registerReducers,
+  restoreRedux,
+  stubRedux,
+} from '@cdo/apps/redux';
+import {InitProgressPayload, UnitProgress} from '@cdo/apps/types/progressTypes';
+import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
+
+// Mock external dependencies
+jest.mock('@cdo/apps/lab2/progress/continueOrFinishLesson', () =>
+  jest.fn(() => ({type: 'MOCK_CONTINUE_OR_FINISH_LESSON'}))
+);
+
+jest.mock('@cdo/apps/lab2/views/dialogs', () => ({
+  DialogType: {
+    GenericConfirmation: 'GenericConfirmation',
+  },
+  useDialogControl: jest.fn(() => ({
+    showDialog: jest.fn(),
+  })),
+}));
+
+jest.mock(
+  '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi',
+  () => ({
+    logUserLevelInteraction: jest.fn(),
+  })
+);
+
+jest.mock('@cdo/apps/code-studio/utils', () => ({
+  queryParams: jest.fn(() => null),
+}));
+
+describe('NavigationButton', () => {
+  let store: Store;
+
+  const defaultLevelProperties: LevelProperties = {
+    id: 123,
+    name: 'Test Level',
+    appName: 'pythonlab',
+    submittable: false,
+    predictSettings: undefined,
+    useSecondaryFinishButton: false,
+  };
+
+  const submittableLevelProperties: LevelProperties = {
+    ...defaultLevelProperties,
+    submittable: true,
+  };
+
+  const initialProgress: InitProgressPayload = {
+    currentLevelId: '123',
+    scriptId: 456,
+    lessons: [
+      {
+        id: 1,
+        levels: [
+          {
+            id: '123',
+            status: LevelStatus.not_tried,
+            activeId: '',
+            app: '',
+            bonus: false,
+            display_as_unplugged: false,
+            freePlay: false,
+            icon: null,
+            ids: ['123'],
+            inactiveIds: [],
+            is_concept_level: false,
+            kind: '',
+            levelNumber: 0,
+            position: 0,
+            title: 0,
+            url: '',
+            path: '',
+            scriptLevelId: '',
+            usesLab2: false,
+          },
+        ],
+        assessment: false,
+        description_student: '',
+        description_teacher: '',
+        hasLessonPlan: false,
+        key: '',
+        lessonEditPath: '',
+        lessonNumber: undefined,
+        lessonStartUrl: '',
+        lesson_extras_level_url: '',
+        lesson_group_display_name: '',
+        lockable: false,
+        name: '',
+        num_script_lessons: 0,
+        numberedLesson: false,
+        position: 0,
+        relative_position: 0,
+        script_id: 0,
+        script_name: '',
+        title: '',
+        unplugged: null,
+        background: null,
+      },
+    ],
+    deeperLearningCourse: false,
+    saveAnswersBeforeNavigation: null,
+    lessonGroups: null,
+    scriptName: null,
+    scriptDisplayName: undefined,
+    unitTitle: null,
+    unitDescription: undefined,
+    unitStudentDescription: undefined,
+    unitHasUnnumberedLessons: false,
+    courseId: null,
+    courseVersionId: undefined,
+    isLessonExtras: false,
+    peerReviewLessonInfo: null,
+    isFullProgress: false,
+    currentPageNumber: 0,
+  };
+
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({
+      progress,
+      lab,
+    });
+    store = getStore();
+    store.dispatch(initProgress(initialProgress));
+  });
+
+  afterEach(() => {
+    restoreRedux();
+    jest.clearAllMocks();
+  });
+
+  function renderNavigationButton(
+    props: {
+      levelProperties?: LevelProperties;
+      hasRun?: boolean;
+      hasEdited?: boolean;
+      className?: string;
+      requireRun?: boolean;
+    } = {}
+  ) {
+    const mergedProps = {
+      levelProperties: defaultLevelProperties,
+      hasRun: false,
+      hasEdited: false,
+      requireRun: false,
+      ...props,
+    };
+
+    return render(
+      <Provider store={store}>
+        <ThemeProvider>
+          <NavigationButton {...mergedProps} />
+        </ThemeProvider>
+      </Provider>
+    );
+  }
+
+  describe('Submit Button', () => {
+    // it('button says "Submit" when level is not submitted and is enabled when hasRun and hasEdited are true', () => {
+    //   renderNavigationButton({
+    //     levelProperties: submittableLevelProperties,
+    //     hasRun: true,
+    //     hasEdited: true,
+    //   });
+    //   const submitButton = screen.getByRole('button', {name: 'Submit'});
+    //   expect(submitButton).toBeEnabled();
+    // });
+
+    it('displays "Unsubmit" text and is enabled when level has been submitted', () => {
+      // Set up state for submitted level
+      const submittedProgressState: InitProgressPayload = {
+        ...initialProgress,
+        lessons: [
+          {
+            ...initialProgress.lessons[0],
+            levels: [
+              {
+                ...initialProgress.lessons[0].levels[0],
+                status: LevelStatus.submitted,
+              },
+            ],
+          },
+        ],
+      };
+      store.dispatch(initProgress(submittedProgressState));
+      const unitProgress: UnitProgress = {
+        status: LevelStatus.submitted,
+        lastTimestamp: undefined,
+        locked: false,
+        pages: null,
+        paired: false,
+        result: 0,
+        teacherFeedbackReviewState: undefined,
+        teacherFeedbackNew: false,
+        timeSpent: undefined,
+      };
+      store.dispatch(
+        setScriptProgress({
+          [submittableLevelProperties.id]: unitProgress,
+        })
+      );
+
+      renderNavigationButton({
+        levelProperties: submittableLevelProperties,
+        hasRun: true,
+        hasEdited: true,
+      });
+
+      screen.getByRole('button', {name: 'Unsubmit'});
+    });
+
+    // it('is enabled when level has been submitted', () => {
+    //   store.dispatch({
+    //     type: 'SET_LEVEL',
+    //     level: {
+    //       id: 123,
+    //       status: LevelStatus.submitted,
+    //     },
+    //   });
+
+    //   renderNavigationButton({
+    //     levelProperties: submittableLevelProperties,
+    //     hasRun: false,
+    //     hasEdited: false,
+    //   });
+
+    //   expect(screen.getByRole('button')).not.toBeDisabled();
+    // });
+
+    // it('is enabled when hasRun and hasEdited are true', () => {
+    //   renderNavigationButton({
+    //     levelProperties: submittableLevelProperties,
+    //     hasRun: true,
+    //     hasEdited: true,
+    //   });
+
+    //   expect(screen.getByRole('button')).not.toBeDisabled();
+    // });
+
+    // it('is disabled when hasRun is false or hasEdited is false for unsubmitted level', () => {
+    //   renderNavigationButton({
+    //     levelProperties: submittableLevelProperties,
+    //     hasRun: false,
+    //     hasEdited: true,
+    //   });
+
+    //   expect(screen.getByRole('button')).toBeDisabled();
+
+    //   // Re-render with hasRun true but hasEdited false
+    //   renderNavigationButton({
+    //     levelProperties: submittableLevelProperties,
+    //     hasRun: true,
+    //     hasEdited: false,
+    //   });
+
+    //   expect(screen.getByRole('button')).toBeDisabled();
+    // });
+  });
+
+  // describe('ContinueButton (non-submittable levels)', () => {
+  //   it('displays "Continue" text when there is a next level', () => {
+  //     // Mock that there is a next level
+  //     store.dispatch({
+  //       type: 'SET_NEXT_LEVEL_ID',
+  //       nextLevelId: 456,
+  //     });
+
+  //     renderNavigationButton({
+  //       hasRun: true,
+  //     });
+
+  //     expect(screen.getByText('Continue')).toBeInTheDocument();
+  //     expect(screen.getByRole('button')).toHaveAttribute(
+  //       'id',
+  //       'instructions-continue-button'
+  //     );
+  //   });
+
+  //   it('displays "Finish" text when there is no next level', () => {
+  //     // Ensure no next level
+  //     store.dispatch({
+  //       type: 'SET_NEXT_LEVEL_ID',
+  //       nextLevelId: undefined,
+  //     });
+
+  //     renderNavigationButton({
+  //       hasRun: true,
+  //     });
+
+  //     expect(screen.getByText('Finish')).toBeInTheDocument();
+  //   });
+
+  //   it('is hidden when requireRun is true but hasRun is false', () => {
+  //     renderNavigationButton({
+  //       hasRun: false,
+  //       requireRun: true,
+  //     });
+
+  //     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  //   });
+
+  //   it('is shown when requireRun is true and hasRun is true', () => {
+  //     renderNavigationButton({
+  //       hasRun: true,
+  //       requireRun: true,
+  //     });
+
+  //     expect(screen.getByRole('button')).toBeInTheDocument();
+  //   });
+
+  //   it('is shown when requireRun is false regardless of hasRun', () => {
+  //     renderNavigationButton({
+  //       hasRun: false,
+  //       requireRun: false,
+  //     });
+
+  //     expect(screen.getByRole('button')).toBeInTheDocument();
+  //   });
+
+  //   it('is hidden when validation conditions exist but are not satisfied', () => {
+  //     store.dispatch({
+  //       type: 'SET_LAB_STATE',
+  //       lab: {
+  //         validationState: {
+  //           hasConditions: true,
+  //           satisfied: false,
+  //         },
+  //         levelProperties: defaultLevelProperties,
+  //       },
+  //     });
+
+  //     renderNavigationButton({
+  //       hasRun: true,
+  //     });
+
+  //     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  //   });
+
+  //   it('is shown when validation conditions exist and are satisfied', () => {
+  //     store.dispatch({
+  //       type: 'SET_LAB_STATE',
+  //       lab: {
+  //         validationState: {
+  //           hasConditions: true,
+  //           satisfied: true,
+  //         },
+  //         levelProperties: defaultLevelProperties,
+  //       },
+  //     });
+
+  //     renderNavigationButton({
+  //       hasRun: true,
+  //     });
+
+  //     expect(screen.getByRole('button')).toBeInTheDocument();
+  //   });
+  // });
+});


### PR DESCRIPTION
This updates the continue logic to allow for Python Lab's previous logic, which was for non-submittable, non-validated levels to only show "continue" after the user has run their program. I considered making this a requirement for all users of `NavigationButton`, but Music Lab has some levels that rely on the continue button always being there [thread](https://codedotorg.slack.com/archives/C04TH8400AU/p1751991683264599). Therefore, I added a flag to `InstructionsV2` and `NavigationButton`, `requireRun`, which indicates if this feature should be enabled.

I also added unit tests for `NavigationButton`, which is most of the line changes here.

## Links

- Jira: [SL-1310](https://codedotorg.atlassian.net/browse/SL-1310)

## Testing story
Tested locally. Now on Python Lab you need to click run to see continue, but on Music Lab (for non-validated levels) you do not.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
