### PR TITLE
Music: fix constant reloading in ExemplarPlayerView

### DIFF
--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -48,8 +48,9 @@ export interface Lab2WrapperProps {
 const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   const isLoading: boolean = useSelector(isLabLoading);
   const isPageError: boolean = useSelector(hasPageError);
-  const {isBlockedAbuse, projectSharingDisabled} = useAppSelector(
-    state => state.lab
+  const isBlockedAbuse = useAppSelector(state => state.lab.isBlockedAbuse);
+  const projectSharingDisabled = useAppSelector(
+    state => state.lab.projectSharingDisabled
   );
   const dispatch = useAppDispatch();
   const isProjectValidator = useAppSelector(state =>

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -32,8 +32,9 @@ const LabViewsRenderer: React.FunctionComponent = () => {
   const levelId = levelProperties?.id;
   const scriptLevelId = useAppSelector(getCurrentScriptLevelId);
 
-  const {isBlockedAbuse, projectSharingDisabled} = useAppSelector(
-    state => state.lab
+  const isBlockedAbuse = useAppSelector(state => state.lab.isBlockedAbuse);
+  const projectSharingDisabled = useAppSelector(
+    state => state.lab.projectSharingDisabled
   );
   const isProjectValidator = useAppSelector(state =>
     state.lab.permissions?.includes(PERMISSIONS.PROJECT_VALIDATOR)

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -294,17 +294,6 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   const showExemplarPlayer =
     exemplarSettings?.playerEnabled && exemplarSources && !isEditingExemplar;
 
-  const ExemplarPlayer = ({title}: {title: string}) => {
-    return (
-      <ExemplarPlayerView
-        playbackEvents={exemplarPlaybackEvents}
-        title={title}
-        player={player}
-        insideInstructions={exemplarPlayerInsideInstructions}
-      />
-    );
-  };
-
   const showAdvancedControls =
     AppConfig.getValue('player') === 'tonejs' &&
     AppConfig.getValue('advanced-controls-enabled') === 'true';
@@ -362,7 +351,12 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                   bottomComponent={
                     exemplarPlayerInsideInstructions &&
                     showExemplarPlayer && (
-                      <ExemplarPlayer title={exemplarSettings.playerTitle!} />
+                      <ExemplarPlayerView
+                        playbackEvents={exemplarPlaybackEvents}
+                        title={exemplarSettings.playerTitle!}
+                        player={player}
+                        insideInstructions={exemplarPlayerInsideInstructions}
+                      />
                     )
                   }
                   hasRun={hasRun}
@@ -378,7 +372,12 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                   bottomComponent={
                     exemplarPlayerInsideInstructions &&
                     showExemplarPlayer && (
-                      <ExemplarPlayer title={exemplarSettings.playerTitle!} />
+                      <ExemplarPlayerView
+                        playbackEvents={exemplarPlaybackEvents}
+                        title={exemplarSettings.playerTitle!}
+                        player={player}
+                        insideInstructions={exemplarPlayerInsideInstructions}
+                      />
                     )
                   }
                   hasRun={hasRun}
@@ -386,7 +385,12 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 />
               )}
               {!exemplarPlayerInsideInstructions && showExemplarPlayer && (
-                <ExemplarPlayer title={exemplarSettings.playerTitle!} />
+                <ExemplarPlayerView
+                  playbackEvents={exemplarPlaybackEvents}
+                  title={exemplarSettings.playerTitle!}
+                  player={player}
+                  insideInstructions={exemplarPlayerInsideInstructions}
+                />
               )}
             </PanelContainer>
           </div>

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -173,6 +173,7 @@ class UnconnectedMusicView extends React.Component {
 
     this.isLevelLoadInProgress = false;
     this.exemplarPlaybackEvents = [];
+    this.triggers = [];
 
     MusicBlocklyWorkspace.setupBlocklyEnvironment(this.props.blockMode);
   }
@@ -735,7 +736,14 @@ class UnconnectedMusicView extends React.Component {
   };
 
   compileSong = () => {
-    return this.musicBlocklyWorkspace.compileSong(this.props.blockMode);
+    const codeChanged = this.musicBlocklyWorkspace.compileSong(
+      this.props.blockMode
+    );
+    // Update the list of triggers that are available in the workspace.
+    this.triggers = Triggers.filter(trigger =>
+      this.musicBlocklyWorkspace.hasTrigger(trigger.id)
+    );
+    return codeChanged;
   };
 
   // Execute a song that has already been compiled from Blockly sources.
@@ -916,9 +924,7 @@ class UnconnectedMusicView extends React.Component {
           blocklyDivId={BLOCKLY_DIV_ID}
           setPlaying={this.setPlaying}
           playTrigger={this.playTrigger}
-          triggers={Triggers.filter(trigger =>
-            this.musicBlocklyWorkspace.hasTrigger(trigger.id)
-          )}
+          triggers={this.triggers}
           getCurrentPlayheadPosition={this.getCurrentPlayheadPosition}
           updateHighlightedBlocks={this.updateHighlightedBlocks}
           undo={this.undo}


### PR DESCRIPTION
@molly-moen noticed some [strange loading behavior](https://codedotorg.slack.com/archives/C04TH8400AU/p1751905444196389) while running Music Lab locally on a level with an Exemplar Player. Because cloudfront credentials were not set (as is expected with most local setups), we'll fail to fetch signed cookies and can't play licensed songs, but due to a side effect of https://github.com/code-dot-org/code-dot-org/pull/66897 (I suspect this was the case from before as well), we were re-mounting the Exemplar Player constantly and constantly trying to reload signed cookies, flooding the network tab with 500s and creating confusing loading UI behavior.

Root cause is likely that the `triggers` array prop was being re-created on every playback tick and because React does a direct equality `===` check when comparing props, it considered the new array as a different prop even with the same contents. This re-rendered `MusicLabView`, which in turn re-rendered `ExemplarPlayerView` because it was being created by a function. When `ExemplarPlayerView` mounts, it attempts to pre-fetch all of the exemplar songs' sounds as an optimization, but these loads will fail without cloudfront credentials set.

The fix here is to only re-create the `triggers` array when compiling code (the only time it can actually change), and move the `ExemplarPlayerView` code to the component body. It means the code is a bit redundant (especially while we're supporting both versions of Instructions) but results in drastically fewer renders and the expected number of load failures.

I also included some semi-related Lab2 load optimizations I noticed while inspecting with React devtools.

### Before

https://github.com/user-attachments/assets/60169198-5db3-491a-873f-b04d8c9320c5

### After

https://github.com/user-attachments/assets/20fa5e1c-942e-4411-9b81-15a730c68af7

## Testing story

Tested locally on Music Lab CSD levels and standalone/freeplay levels.