### PR TITLE
feat(Footer): hide powered by AWS temporarily

### DIFF
--- a/frontend/apps/marketing/src/components/footer/Footer.tsx
+++ b/frontend/apps/marketing/src/components/footer/Footer.tsx
@@ -6,7 +6,8 @@ import DSCOFooter, {
 } from '@code-dot-org/component-library/cms/footer';
 
 import {LOCALIZE_JS_CONFIG_MAP} from '@/config/locale';
-import awsLogo from '@public/images/powered-by-aws.png';
+// Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886
+// import awsLogo from '@public/images/powered-by-aws.png';
 
 import './onetrust.scss';
 
@@ -95,16 +96,17 @@ export const defaultProps: Omit<FooterProps, 'languages' | 'onLanguageChange'> =
         icon: {iconFamily: 'brands', iconName: 'medium'},
       },
     ],
-    imageLinks: [
-      {
-        key: 'poweredByAWS',
-        label: 'Powered by AWS Cloud Computing',
-        href: 'https://aws.amazon.com/what-is-cloud-computing',
-        image: {
-          src: awsLogo.src,
-        },
-      },
-    ],
+    // Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886
+    // imageLinks: [
+    //   {
+    //     key: 'poweredByAWS',
+    //     label: 'Powered by AWS Cloud Computing',
+    //     href: 'https://aws.amazon.com/what-is-cloud-computing',
+    //     image: {
+    //       src: awsLogo.src,
+    //     },
+    //   },
+    // ],
   };
 
 interface GlobalFooterProps {

--- a/frontend/packages/component-library/src/cms/footer/Footer.tsx
+++ b/frontend/packages/component-library/src/cms/footer/Footer.tsx
@@ -3,7 +3,8 @@ import {Key, HTMLAttributes, AnchorHTMLAttributes} from 'react';
 
 import {DefaultDropdown} from '@/dropdown/simpleDropdown/stories/SimpleDropdown.story';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
-import Image, {ImageProps} from '@/image';
+// Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886
+// import Image, {ImageProps} from '@/image';
 
 import moduleStyles from './footer.module.scss';
 
@@ -20,12 +21,13 @@ export interface SocialLink extends AnchorHTMLAttributes<HTMLAnchorElement> {
   icon: FontAwesomeV6IconProps;
 }
 
-export interface ImageLink extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  key: Key;
-  label: string;
-  href: string;
-  image: ImageProps;
-}
+// Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886
+// export interface ImageLink extends AnchorHTMLAttributes<HTMLAnchorElement> {
+//   key: Key;
+//   label: string;
+//   href: string;
+//   image: ImageProps;
+// }
 
 export interface LanguageOption {
   value: string;
@@ -37,8 +39,9 @@ export interface FooterProps extends HTMLAttributes<HTMLElement> {
   siteLinks: SiteLink[];
   /** Footer social links */
   socialLinks: SocialLink[];
-  /** Footer bottom image links */
-  imageLinks: ImageLink[];
+  // Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886
+  // /** Footer bottom image links */
+  // imageLinks: ImageLink[];
   /** Footer copyright notices */
   copyright: string;
   /** Footer language options */
@@ -70,7 +73,7 @@ const Footer: React.FC<FooterProps> = ({
   brand = 'Code.org',
   siteLinks,
   socialLinks,
-  imageLinks,
+  // imageLinks, // Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886
   copyright,
   className,
   languages,
@@ -130,7 +133,8 @@ const Footer: React.FC<FooterProps> = ({
         ))}
       </ul>
 
-      <ul className={moduleStyles.footerImageLinkList}>
+      {/* Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886 */}
+      {/* <ul className={moduleStyles.footerImageLinkList}>
         {imageLinks?.map(({key, label, href, image, ...link}) => (
           <li key={key}>
             <a href={href} aria-label={label} {...link}>
@@ -142,7 +146,7 @@ const Footer: React.FC<FooterProps> = ({
             </a>
           </li>
         ))}
-      </ul>
+      </ul> */}
     </div>
   </footer>
 );

--- a/frontend/packages/component-library/src/cms/footer/__tests__/Footer.test.tsx
+++ b/frontend/packages/component-library/src/cms/footer/__tests__/Footer.test.tsx
@@ -1,7 +1,7 @@
-import {render, screen, within} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import Footer, {FooterProps, SiteLink, SocialLink, ImageLink} from '../Footer';
+import Footer, {FooterProps, SiteLink, SocialLink} from '../Footer';
 
 describe('CMS Footer', () => {
   const title = 'Footer Title';
@@ -21,16 +21,17 @@ describe('CMS Footer', () => {
       icon: {iconName: 'facebook'},
     },
   ];
-  const imageLinks: ImageLink[] = [
-    {
-      key: 'imageLink',
-      label: 'Image Link Label',
-      href: '/image-link',
-      image: {
-        src: 'https://code.org/shared/images/Powered-By_logo-horiz_RGB_REV.png',
-      },
-    },
-  ];
+  // Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886
+  // const imageLinks: ImageLink[] = [
+  //   {
+  //     key: 'imageLink',
+  //     label: 'Image Link Label',
+  //     href: '/image-link',
+  //     image: {
+  //       src: 'https://code.org/shared/images/Powered-By_logo-horiz_RGB_REV.png',
+  //     },
+  //   },
+  // ];
   const languages = [
     {value: 'en', text: 'English'},
     {value: 'es', text: 'Spanish'},
@@ -41,7 +42,7 @@ describe('CMS Footer', () => {
     render(
       <Footer
         {...props}
-        {...{title, copyright, siteLinks, socialLinks, imageLinks}}
+        {...{title, copyright, siteLinks, socialLinks}}
         onLanguageChange={mockLanguageChange}
         languages={languages}
       />,
@@ -76,19 +77,21 @@ describe('CMS Footer', () => {
     expect(socialLink).toHaveAttribute('href', socialLinks[0].href);
   });
 
-  it('renders footer image links', () => {
-    renderFooterContainer();
+  // Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886
+  // eslint-disable-next-line
+  // it('renders footer image links', () => {
+  //   renderFooterContainer();
 
-    const imageLink = screen.getByRole('link', {name: imageLinks[0].label});
-    expect(imageLink).toBeVisible();
-    expect(imageLink).toHaveAttribute('href', imageLinks[0].href);
+  //   const imageLink = screen.getByRole('link', {name: imageLinks[0].label});
+  //   expect(imageLink).toBeVisible();
+  //   expect(imageLink).toHaveAttribute('href', imageLinks[0].href);
 
-    const imageLinkImg = within(imageLink).getByRole('img', {
-      name: imageLinks[0].label,
-    });
-    expect(imageLinkImg).toBeVisible();
-    expect(imageLinkImg).toHaveAttribute('src', imageLinks[0].image.src);
-  });
+  //   const imageLinkImg = within(imageLink).getByRole('img', {
+  //     name: imageLinks[0].label,
+  //   });
+  //   expect(imageLinkImg).toBeVisible();
+  //   expect(imageLinkImg).toHaveAttribute('src', imageLinks[0].image.src);
+  // });
 
   it('renders footer with provided className styles', () => {
     const className = 'customClass';

--- a/frontend/packages/component-library/src/cms/footer/index.ts
+++ b/frontend/packages/component-library/src/cms/footer/index.ts
@@ -1,4 +1,4 @@
 import './index.css';
 
-export type {FooterProps, SiteLink, SocialLink, ImageLink} from './Footer';
+export type {FooterProps, SiteLink, SocialLink} from './Footer';
 export {default as default} from './Footer';

--- a/frontend/packages/component-library/src/cms/footer/stories/Footer.story.tsx
+++ b/frontend/packages/component-library/src/cms/footer/stories/Footer.story.tsx
@@ -97,16 +97,17 @@ const defaultArgs: FooterProps = {
       icon: {iconFamily: 'brands', iconName: 'medium'},
     },
   ],
-  imageLinks: [
-    {
-      key: 'poweredByAWS',
-      label: 'Powered by AWS Cloud Computing',
-      href: 'https://aws.amazon.com/what-is-cloud-computing',
-      image: {
-        src: 'https://code.org/shared/images/Powered-By_logo-horiz_RGB_REV.png',
-      },
-    },
-  ],
+  // Hiding temporarily, see https://codedotorg.atlassian.net/browse/CMS-886
+  // imageLinks: [
+  //   {
+  //     key: 'poweredByAWS',
+  //     label: 'Powered by AWS Cloud Computing',
+  //     href: 'https://aws.amazon.com/what-is-cloud-computing',
+  //     image: {
+  //       src: 'https://code.org/shared/images/Powered-By_logo-horiz_RGB_REV.png',
+  //     },
+  //   },
+  // ],
   languages: [
     {value: 'en-US', text: 'English'},
     {value: 'es', text: 'Spanish'},


### PR DESCRIPTION
Temporarily hides "powered by AWS" in the CMS Footer. To undo this PR can be reverted.

## Links
Jira ticket: [CMS-886](https://codedotorg.atlassian.net/browse/CMS-886)
Slack convo: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1752069224786469)

## Testing story
Tested locally and updated unit tests. There will be Eyes diffs.

----

## Contentful
<img width="1773" alt="Screenshot 2025-07-09 at 8 58 52 AM" src="https://github.com/user-attachments/assets/dc0717a7-eba8-4cc6-90c6-11006cd37727" />
entful


## Storybook
<img width="1025" alt="Screenshot 2025-07-09 at 8 58 35 AM" src="https://github.com/user-attachments/assets/151d217c-6c4f-4a9f-b19f-d0528e6fef8f" />

