### PR TITLE
chore(marketing): put shared RemoveMarginBottomProps back on Heading component

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/heading/Heading.tsx
+++ b/frontend/apps/marketing/src/components/contentful/heading/Heading.tsx
@@ -1,6 +1,8 @@
 import Typography from '@mui/material/Typography';
 import {ReactNode} from 'react';
 
+import {RemoveMarginBottomProps} from '@/components/common/types';
+
 type HeadingSemanticTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 // Existing Contentful Heading visualAppearance values that
@@ -13,13 +15,11 @@ type HeadingVisualAppearance =
   | 'heading-sm'
   | 'heading-xs';
 
-export type HeadingProps = {
+export type HeadingProps = RemoveMarginBottomProps & {
   /** Heading content */
   children: ReactNode;
   /** Heading visual appearance */
   visualAppearance: HeadingVisualAppearance;
-  /** Remove margin bottom */
-  removeMarginBottom?: boolean;
   /** ClassName passed by Contentful to apply styles
    * that are set through Contentful native editor */
   className?: string;

--- a/frontend/apps/marketing/src/components/contentful/heading/__tests__/Heading.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/heading/__tests__/Heading.test.tsx
@@ -6,12 +6,24 @@ describe('Heading Component', () => {
   it('should render out all headings', async () => {
     render(
       <div>
-        <Heading visualAppearance={'heading-xxl'}>xxl - h1</Heading>
-        <Heading visualAppearance={'heading-xl'}>xl - h2</Heading>
-        <Heading visualAppearance={'heading-lg'}>lg - h3</Heading>
-        <Heading visualAppearance={'heading-md'}>md - h4</Heading>
-        <Heading visualAppearance={'heading-sm'}>sm - h5</Heading>
-        <Heading visualAppearance={'heading-xs'}>xs - h6</Heading>
+        <Heading visualAppearance={'heading-xxl'} removeMarginBottom={false}>
+          xxl - h1
+        </Heading>
+        <Heading visualAppearance={'heading-xl'} removeMarginBottom={false}>
+          xl - h2
+        </Heading>
+        <Heading visualAppearance={'heading-lg'} removeMarginBottom={false}>
+          lg - h3
+        </Heading>
+        <Heading visualAppearance={'heading-md'} removeMarginBottom={false}>
+          md - h4
+        </Heading>
+        <Heading visualAppearance={'heading-sm'} removeMarginBottom={false}>
+          sm - h5
+        </Heading>
+        <Heading visualAppearance={'heading-xs'} removeMarginBottom={false}>
+          xs - h6
+        </Heading>
       </div>,
     );
 
@@ -37,7 +49,7 @@ describe('Heading Component', () => {
 
   it('removes margin when removeMarginBottom is true', () => {
     render(
-      <Heading visualAppearance={'heading-md'} removeMarginBottom>
+      <Heading visualAppearance={'heading-md'} removeMarginBottom={true}>
         No Margin
       </Heading>,
     );


### PR DESCRIPTION
Puts shared `RemoveMarginBottomProps` back on the Heading component. I removed this in https://github.com/code-dot-org/code-dot-org/pull/66947 because I thought it was a DSCO thing, but it's CMS-specific. 

## Links
Jira ticket: [CMS-891](https://codedotorg.atlassian.net/browse/CMS-891)

## Testing story
Tested locally and updated unit tests.

----


https://github.com/user-attachments/assets/9055182f-85ce-461a-aea2-60ccf1aa4b7a


