### PR TITLE
Show workshop meeting link and session info in Workshop Reminder emails

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_workshop_logistics.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_workshop_logistics.html.haml
@@ -11,7 +11,11 @@
         - else
           = session.start_date_with_start_and_end_times_us_format
         %br
-        = session.formatted_location_details
+        - if session.session_format == 'virtual' && session.meeting_link
+          Virtual meeting:
+          = link_to session.meeting_link, session.meeting_link
+        - else
+          = session.formatted_location_details
         %br
         %br
   %tr

--- a/dashboard/app/views/pd/workshop_mailer/_workshop_logistics.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_workshop_logistics.html.haml
@@ -3,7 +3,7 @@
 
 %table
   %tr
-    %td.heading= 'Date'.pluralize(@workshop.sessions.length) + ':'
+    %td.heading= 'Session'.pluralize(@workshop.sessions.length) + ':'
     %td
       - @workshop.sessions.each do |session|
         - if @workshop.subject == Pd::Workshop::SUBJECT_CSA_CAPSTONE
@@ -11,15 +11,9 @@
         - else
           = session.start_date_with_start_and_end_times_us_format
         %br
-  - unless @workshop.location_name.blank? || (@workshop.virtual? && @workshop.subject != Pd::Workshop::SUBJECT_CSA_CAPSTONE)
-    %tr
-      %td.heading
-        Location:
-      %td
-        = @workshop.location_name
-        - if @workshop.location_address.present?
-          %br
-          = @workshop.location_address
+        = session.formatted_location_details
+        %br
+        %br
   %tr
     %td.heading
       Organizer:


### PR DESCRIPTION
Shows the workshop meeting link and session info in the 3- and 10-day Workshop Reminder emails. The ticket was originally just requesting to add the meeting links, but the emails were outdated to before we tracked virtual/in-person by session rather than by workshop. So, I used the `formatted_location_details` helper function to just print the relevant location/link information and had it display info for each session regardless of the type of workshop.

### With 1 session (just in-person)
![Single session](https://github.com/user-attachments/assets/df4aa4ae-e6a5-42b7-8429-f2ccae9a6841)

### With multiple sessions (both virtual and in-person)
![zoom hyperlinked](https://github.com/user-attachments/assets/d7017f3c-3211-45bc-b938-ccf7214dcff8)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&isEligibleForUserSurvey=true&selectedIssue=ACQ-3379)

## Testing story
Local testing.
