### PR TITLE
CMS-65: Add one-off script to backfill user facilitator bios from Pegasus markdown files

### DIFF
--- a/bin/oneoff/backfill_data/user_facilitator_bios.rb
+++ b/bin/oneoff/backfill_data/user_facilitator_bios.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script migrates facilitator bios from Pegasus markdown files to the dashboard database
+
+require 'redcarpet'
+require 'redcarpet/render_strip'
+require 'ruby-progressbar'
+
+require_relative '../../../dashboard/config/environment'
+
+facilitator_bio_paths = Dir[pegasus_dir('sites.v3/code.org/views/workshop_affiliates/*_bio.md')]
+progress_bar = ProgressBar.create(total: facilitator_bio_paths.size, format: 'Migrated[%c/%C]: |%W| %a')
+markdown_to_text_converter = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+
+facilitator_bio_paths.each do |facilitator_bio_path|
+  user_id = File.basename(facilitator_bio_path, '_bio.md').to_i
+  facilitator_info = User::FacilitatorInfo.find_or_initialize_by(user_id: user_id)
+  facilitator_info.bio = markdown_to_text_converter.render(File.read(facilitator_bio_path)).strip
+  facilitator_info.save!
+rescue StandardError => exception
+  progress_bar.log "Failed to migrate facilitator bio from #{facilitator_bio_path}: #{exception.inspect}".red
+ensure
+  progress_bar.increment
+end
+
+progress_bar.finish

--- a/dashboard/app/models/concerns/teacher/facilitatable.rb
+++ b/dashboard/app/models/concerns/teacher/facilitatable.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Teacher::Facilitatable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :facilitator_info, class_name: 'User::FacilitatorInfo', foreign_key: :user_id, dependent: :destroy
+
+    # Defines +facilitator_bio+ method to access the bio of the facilitator info
+    delegate :bio, to: :facilitator_info, prefix: :facilitator, allow_nil: true
+  end
+end

--- a/dashboard/app/models/concerns/user/facilitator.rb
+++ b/dashboard/app/models/concerns/user/facilitator.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-module Teacher::Facilitatable
+module User::Facilitator
   extend ActiveSupport::Concern
 
   included do
-    has_one :facilitator_info, class_name: 'User::FacilitatorInfo', foreign_key: :user_id, dependent: :destroy
+    has_one :facilitator_info, dependent: :destroy
 
     # Defines +facilitator_bio+ method to access the bio of the facilitator info
     delegate :bio, to: :facilitator_info, prefix: :facilitator, allow_nil: true

--- a/dashboard/app/models/teacher.rb
+++ b/dashboard/app/models/teacher.rb
@@ -74,8 +74,6 @@
 #  index_users_on_username_and_deleted_at              (username,deleted_at) UNIQUE
 #
 class Teacher < User
-  include Facilitatable
-
   def self.sti_name
     TYPE_TEACHER
   end

--- a/dashboard/app/models/teacher.rb
+++ b/dashboard/app/models/teacher.rb
@@ -74,6 +74,8 @@
 #  index_users_on_username_and_deleted_at              (username,deleted_at) UNIQUE
 #
 class Teacher < User
+  include Facilitatable
+
   def self.sti_name
     TYPE_TEACHER
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -106,6 +106,7 @@ class User < ApplicationRecord
   include SectionParticipation
   include PartialRegistration
   include Purgeable
+  include Facilitator
   include Rails.application.routes.url_helpers
 
   self.inheritance_column = :user_type

--- a/dashboard/app/models/user/facilitator_info.rb
+++ b/dashboard/app/models/user/facilitator_info.rb
@@ -15,5 +15,11 @@
 #  index_user_facilitator_infos_on_user_id  (user_id)
 #
 class User::FacilitatorInfo < ApplicationRecord
-  belongs_to :user, -> {with_deleted}
+  belongs_to :user
+
+  validate :validate_user_is_facilitator, if: :user_id_changed?
+
+  private def validate_user_is_facilitator
+    errors.add(:user, :not_facilitator) unless user&.facilitator?
+  end
 end

--- a/dashboard/app/models/user/facilitator_info.rb
+++ b/dashboard/app/models/user/facilitator_info.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_facilitator_infos
+#
+#  id         :bigint           not null, primary key
+#  user_id    :integer          not null
+#  bio        :text(65535)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_user_facilitator_infos_on_user_id  (user_id)
+#
+class User::FacilitatorInfo < ApplicationRecord
+  belongs_to :user, -> {with_deleted}
+end

--- a/dashboard/config/locales/base/en.yml
+++ b/dashboard/config/locales/base/en.yml
@@ -46,6 +46,10 @@ en:
             unlock_token:
               invalid: "is invalid or expired, possibly because your account has already been unlocked."
             lockout_flow: "cannot be updated because you need parent or guardian permission first."
+        user/facilitator_info:
+          attributes:
+            user:
+              not_facilitator: "must have the facilitator permission"
       messages:
         blank: "is required"
         blank_plural: "are required"
@@ -85,7 +89,8 @@ en:
         user_type: 'Account Type'
         us_state: 'State'
         ai_rubrics_disabled: 'Disable AI Rubric Feature'
-
+      user/facilitator_info:
+        user: 'User'
   beta: "beta"
   hello: "Hello world"
   welcome_back: "Welcome back, %{name}"

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -768,6 +768,11 @@ FactoryBot.define do
     end
   end
 
+  factory :user_facilitator_info, class: User::FacilitatorInfo do
+    association :user, factory: :facilitator
+    bio {Faker::Lorem.paragraph}
+  end
+
   factory :authentication_option do
     association :user
     sequence(:email) {|n| "testuser#{n}@example.com.xx"}

--- a/dashboard/test/models/user/facilitator_info_test.rb
+++ b/dashboard/test/models/user/facilitator_info_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class User::FacilitatorInfoTest < ActiveSupport::TestCase
+  describe 'validations' do
+    subject(:user_facilitator_info) {build(:user_facilitator_info, user: user)}
+
+    let(:user) {create(:facilitator)}
+
+    it 'is valid' do
+      _user_facilitator_info.must_be :valid?
+    end
+
+    context 'when associated user has no facilitator permission' do
+      before do
+        user.delete_permission(UserPermission::FACILITATOR)
+      end
+
+      it 'is invalid' do
+        _(user).wont_be :facilitator?
+        _user_facilitator_info.wont_be :valid?
+      end
+    end
+  end
+end

--- a/dashboard/test/models/user/facilitator_info_test.rb
+++ b/dashboard/test/models/user/facilitator_info_test.rb
@@ -18,6 +18,7 @@ class User::FacilitatorInfoTest < ActiveSupport::TestCase
       it 'is invalid' do
         _(user).wont_be :facilitator?
         _user_facilitator_info.wont_be :valid?
+        _(user_facilitator_info.errors.messages).must_equal({user: ['must have the facilitator permission']})
       end
     end
   end

--- a/dashboard/test/models/user/facilitator_info_test.rb
+++ b/dashboard/test/models/user/facilitator_info_test.rb
@@ -18,7 +18,7 @@ class User::FacilitatorInfoTest < ActiveSupport::TestCase
       it 'is invalid' do
         _(user).wont_be :facilitator?
         _user_facilitator_info.wont_be :valid?
-        _(user_facilitator_info.errors.messages).must_equal({user: ['must have the facilitator permission']})
+        _(user_facilitator_info.errors.full_messages).must_equal ['User must have the facilitator permission']
       end
     end
   end


### PR DESCRIPTION
## Links
- JIRA task: [CMS-65](https://codedotorg.atlassian.net/browse/CMS-65)
- Data sources: [/pegasus/sites.v3/code.org/views/workshop_affiliates/](https://github.com/code-dot-org/code-dot-org/tree/CMS-65/pegasus-facilitator-data-migration/pegasus/sites.v3/code.org/views/workshop_affiliates)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66968