### PR TITLE
fix(canonical): all localized paths are canonical pages

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/[[...paths]]/page.tsx
@@ -81,7 +81,12 @@ export async function generateMetadata({
   return {
     title: getPageHeading(experience),
     icons: getIcons(pageProps.brand),
-    ...getSeoMetadata(experience, pageProps.brand, pageProps.locale),
+    ...getSeoMetadata(
+      experience,
+      pageProps.brand,
+      pageProps.locale,
+      pageProps.slug,
+    ),
     verification: getSiteVerification(pageProps.brand),
   };
 }

--- a/frontend/apps/marketing/src/config/host.ts
+++ b/frontend/apps/marketing/src/config/host.ts
@@ -16,7 +16,7 @@ export function getLocalhostAddress() {
   return `http://${getLocalhostDomain()}`;
 }
 
-function getProductionCanonicalRootDomain(brand: Brand) {
+export function getProductionCanonicalRootDomain(brand: Brand | undefined) {
   switch (brand) {
     case Brand.CS_FOR_ALL:
       return `csforall.org`;

--- a/frontend/apps/marketing/src/metadata/__tests__/seo.test.ts
+++ b/frontend/apps/marketing/src/metadata/__tests__/seo.test.ts
@@ -57,14 +57,19 @@ describe('getSeoMetadata', () => {
 
   it('should return metadata when seoMetadata is defined', () => {
     const locale = 'en-US';
-    const result = getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, locale);
+    const result = getSeoMetadata(
+      mockExperience,
+      Brand.CODE_DOT_ORG,
+      locale,
+      'engineering/all-the-things',
+    );
 
     expect(result).toEqual<Metadata>({
       title: 'Test Title',
       description: 'Test Description',
       keywords: ['test', 'seo'],
       alternates: {
-        canonical: 'https://example.com',
+        canonical: 'https://code.org/en-US/engineering/all-the-things',
       },
       openGraph: {
         type: 'website',
@@ -84,7 +89,12 @@ describe('getSeoMetadata', () => {
   it('should return undefined when seoMetadata is undefined', () => {
     (getSeoMetadataFromExperience as jest.Mock).mockReturnValue(undefined);
 
-    const result = getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, 'en-US');
+    const result = getSeoMetadata(
+      mockExperience,
+      Brand.CODE_DOT_ORG,
+      'en-US',
+      '/engineering/all-the-things',
+    );
 
     expect(result).toBeUndefined();
   });
@@ -99,7 +109,12 @@ describe('getSeoMetadata', () => {
       seoMetadataWithoutImage,
     );
 
-    const result = getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, locale);
+    const result = getSeoMetadata(
+      mockExperience,
+      Brand.CODE_DOT_ORG,
+      locale,
+      '/engineering/all-the-things',
+    );
 
     expect(result?.openGraph?.images).toBe(
       'https://contentful-images.code.org/90t6bu6vlf76/6QAykNTAjFdgHya4lBchyF/539e119f045b74395ec9aca97bacf6ed/opengraph-default.png',
@@ -120,6 +135,7 @@ describe('getSeoMetadata', () => {
       mockExperience,
       'incorrect brand' as Brand,
       locale,
+      '/engineering/all-the-things',
     );
 
     expect(result?.openGraph?.images).toBeUndefined();
@@ -135,7 +151,12 @@ describe('getSeoMetadata', () => {
       seoMetadataWithoutRobots,
     );
 
-    const result = getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, 'en-US');
+    const result = getSeoMetadata(
+      mockExperience,
+      Brand.CODE_DOT_ORG,
+      'en-US',
+      '/engineering/all-the-things',
+    );
 
     expect(result?.robots).toEqual({
       index: true,
@@ -151,7 +172,12 @@ describe('getSeoMetadata', () => {
       'https://example.com/test-image.png',
     );
     const locale = 'en-US';
-    getSeoMetadata(mockExperience, Brand.CODE_DOT_ORG, locale);
+    getSeoMetadata(
+      mockExperience,
+      Brand.CODE_DOT_ORG,
+      locale,
+      '/engineering/all-the-things',
+    );
     expect(getAbsoluteImageUrl).toHaveBeenCalledWith(
       mockSeoMetadata.openGraphImage,
       {fm: 'webp'},

--- a/frontend/apps/marketing/src/metadata/seo.ts
+++ b/frontend/apps/marketing/src/metadata/seo.ts
@@ -2,6 +2,7 @@ import {Experience} from '@contentful/experiences-sdk-react';
 import {Metadata} from 'next';
 
 import {Brand} from '@/config/brand';
+import {getProductionCanonicalRootDomain} from '@/config/host';
 import {BRAND_OPENGRAPH_DEFAULT_IMAGE_URL} from '@/config/metadata/opengraph';
 import {getSeoMetadataFromExperience} from '@/selectors/contentful/getExperienceEntryFields';
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
@@ -11,6 +12,7 @@ export function getSeoMetadata(
   experience: Experience | undefined,
   brand: Brand | undefined,
   locale: string,
+  slug: string,
 ): Metadata | undefined {
   const seoMetadata = getSeoMetadataFromExperience(experience);
 
@@ -23,7 +25,7 @@ export function getSeoMetadata(
     description: seoMetadata.seoDescription,
     keywords: seoMetadata.keywords,
     alternates: {
-      canonical: seoMetadata.canonicalUrl,
+      canonical: `https://${getProductionCanonicalRootDomain(brand)}/${locale}/${slug}`,
     },
     openGraph: getOpenGraph(seoMetadata, brand, locale),
     robots: getRobots(seoMetadata),


### PR DESCRIPTION
Previously, the canonical tag was set on Contentful. However, canonical pages (pages that are unique in content but de-duplicated if the content is the same) are all our localized pages because they should have localized content and therefore not be duplicates. This changes the logic to automatically calculate the canonical path without having to require content editors to define it.