### PR TITLE
Lab2: revert adding data-theme attribute to body

### DIFF
--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -96,10 +96,6 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
       document.body.classList.remove(`background-${oldTheme}`);
     }
     document.body.classList.add(`background-${themeDowncase}`);
-    // Set body's data-theme attribute to the current theme, as the copy button tooltip (DSCO Tooltip) is
-    // not a DOM descendant of its logical parent. Rather it is placed directly under body and thus is not
-    // affected by the data-theme attribute value set in ThemeProvider.
-    document.body.setAttribute('data-theme', theme);
   }, [theme]);
 
   // Store the level ID provided by App Options in redux if necessary.


### PR DESCRIPTION
See https://codedotorg.slack.com/archives/C044AGTKW3D/p1752099182419489 - as an unintentional side-effect of https://github.com/code-dot-org/code-dot-org/pull/66859, the text color on the copyright footer and rubrics floating panel was changed to white and became unreadable since both components have a white background. As a quick fix, this reverts the addition of the `data-theme` attribute to the HTML body. This was originally done so that tooltips (which are rendered outside of the local component tree) would be themed correctly but due to these unintended side effects, I opted to revert this for now and we can revisit a more strategic solution for the tooltips theming.

Before:
<img width="1513" alt="Screenshot 2025-07-09 at 3 33 57 PM" src="https://github.com/user-attachments/assets/7f1d49c6-fa63-4cd7-915a-93d80b766b9b" />
<img width="1514" alt="Screenshot 2025-07-09 at 3 34 04 PM" src="https://github.com/user-attachments/assets/6c12060e-122a-48ef-9b9a-144510147fda" />

After:
<img width="1514" alt="Screenshot 2025-07-09 at 3 33 03 PM" src="https://github.com/user-attachments/assets/94f92452-6db8-4862-b5a6-a3f89a05c2c9" />
<img width="1514" alt="Screenshot 2025-07-09 at 3 33 10 PM" src="https://github.com/user-attachments/assets/43927bcd-d62f-4878-a6b9-cf4a41d833f0" />

## Testing story

Tested locally. Manually added a rubric to allthethings to verify.