### PR TITLE
Add Automatic Expiration to Image Optimizer's Cache

### DIFF
--- a/lib/cdo/optimizer.rb
+++ b/lib/cdo/optimizer.rb
@@ -96,7 +96,11 @@ module Cdo
       cache_key = Optimizer.cache_key(data)
       cache.fetch(cache_key) do
         # Write `false` to cache to prevent concurrent image optimizations.
-        cache.write(cache_key, false)
+        #
+        # The expiry here is almost certainly unnecessary; adding it mostly to
+        # help debug some unexpected runaway growth by conclusively ruling this
+        # operation out as a culprit. Can be removed once we're done debugging.
+        cache.write(cache_key, false, expires_in: 1.day)
         IMAGE_OPTIM.optimize_image_data(data) || data
       end
     rescue => exception
@@ -106,7 +110,9 @@ module Cdo
           key: cache_key
         }
       )
-      cache.write(cache_key, data) if cache && cache_key
+      # Only cache results in the CDO shared cache for a short while; we mostly
+      # rely on CloudFront to cache this content.
+      cache.write(cache_key, data, expires_in: 1.day) if cache && cache_key
       data
     end
   end


### PR DESCRIPTION
We're seeing increased consumption of our `CDO.shared_cache` memcached cluster since the update to Ubuntu 22, and we're not yet sure why.

One theory is that [the new version of ImageMagick](https://github.com/code-dot-org/code-dot-org/blob/4d9c7c3095f4a278156a84a15beedc91fba956d1/bin/oneoff/update_ubuntu/02-postupdate.sh#L13-L17) that got installed as part of that update has resulted in inconsistent behavior when generating cache keys from optimized image data, causing us to repeatedly cache duplicate data.

To help diagnose, and because we feel comfortable relying on CloudFront to cache this content, this PR proposes we add an explicit expiration to these cache entries.

## Links

See thread at https://codedotorg.slack.com/archives/C03CK49G9/p1752029298057709 for more context.

## Testing story

Literally none; both image optimization and local memcached are difficult to get working locally, and this is a somewhat time-sensitive problem.

Mostly relying on this change being minor to verify correctness. Will plan to closely monitor as it gets deployed.

## Follow-up work

24 hours after this change gets deployed, we can check to see whether our increased rate of usage has begun to plateau or not.

Whether this or something else ends up being the root cause, we may also need to invest some time in manually expiring some old entries.

## Caching

With this change, we are now caching our optimized image data much less aggressively, and should therefore expect our frontend web application servers to expend a bit more compute re-optimizing images that have already been optimized. Given the shared nature of the cache and our usage of CloudFront as a CDN, however, I think we can afford to do that once a day or so.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
