### PR TITLE
Update Certs scripts date logic flaw, refusing to update

### DIFF
--- a/aws/cloudformation/update_certs
+++ b/aws/cloudformation/update_certs
@@ -35,7 +35,7 @@ def get_certificate_expiration(common_name)
   # Run the Acmesmith command using Ruby's system-level command execution and capture its output
   certificate_info = `acmesmith show-certificate #{common_name}`
   not_after_line = certificate_info.split("\n").find {|line| line.include?('Not After')}
-  not_after = Date.parse(not_after_line.split(': ').last)
+  not_after = DateTime.parse(not_after_line.split(': ').last)
   return not_after
 end
 
@@ -52,7 +52,7 @@ begin
 
   CDO.log.info "Existing certificate found, checking expiration..."
   expiration_date = get_certificate_expiration(common_name)
-  raise 'cert expired' if expiration_date < Date.today
+  raise 'cert expired' if expiration_date < DateTime.now
   CDO.log.info "Existing certificate for #{common_name} is valid until #{expiration_date}."
 rescue => exception
   case exception.message


### PR DESCRIPTION
## Fix certificate expiration check in update_certs script


**Problem**: The `update_certs` script was incorrectly determining that expired certificates were still valid. The script was using `Date.today` to compare against certificate expiration dates, which only compares the date part without considering the time component. This caused certificates that expired earlier in the day to be incorrectly identified as still valid.

**Example**: A certificate expiring on 2025-07-09 at 12:00 AM would be incorrectly considered valid when checked on 2025-07-09 at 4:00 PM, even though it had expired 16 hours earlier.

**Solution**: 
- Changed `Date.parse` to `DateTime.parse` to capture full timestamps including time
- Changed `Date.today` to `DateTime.now` to compare full current timestamp against expiration timestamp

## Testing story

I ran this to update the cert for the BugCrowd target adhoc, and it worked!

## PR Checklist:

- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
