### PR TITLE
Lab2Redux: Refactor selectors

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -9,8 +9,8 @@ import React, {useCallback, useEffect, useMemo} from 'react';
 
 import TeacherOnboardingModal from '@cdo/apps/aichat/views/TeacherOnboardingModal';
 import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarningModal';
-import {isProjectTemplateLevel} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LabProps} from '@cdo/apps/lab2/types';
 import InstructionsV2 from '@cdo/apps/lab2/views/components/Instructions/InstructionsV2';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';

--- a/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
+++ b/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
@@ -3,7 +3,7 @@ import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import React, {useCallback, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useLevelProperties} from '../levelPropertiesContext';

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -11,7 +11,7 @@ import {
   selectHasFilledOutModelCard,
   selectHavePropertiesChanged,
 } from '@cdo/apps/aichat/redux';
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import aichatI18n from '../../locale';

--- a/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback} from 'react';
 import {useSelector} from 'react-redux';
 
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import aichatI18n from '../../locale';

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -6,7 +6,7 @@ import React, {useState, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
 import {ModelDescription} from '@cdo/apps/aichat/types';
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {modelDescriptions} from '../../constants';

--- a/apps/src/codebridge/FileBrowser/FileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowser.tsx
@@ -20,7 +20,7 @@ import classNames from 'classnames';
 import React, {useMemo, useState} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 

--- a/apps/src/codebridge/FileBrowser/InnerFileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/InnerFileBrowser.tsx
@@ -5,8 +5,8 @@ import classNames from 'classnames';
 import React from 'react';
 
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 

--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -9,9 +9,9 @@ import React, {useEffect, useRef} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {START_SOURCES, WARNING_BANNER_MESSAGES} from '@cdo/apps/lab2/constants';
-import {isProjectTemplateLevel} from '@cdo/apps/lab2/lab2Redux';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {setRestoredOldVersion} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
+import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import i18n from '@cdo/apps/pythonlab/locale';
 import ProjectTemplateWorkspaceIconV2 from '@cdo/apps/templates/ProjectTemplateWorkspaceIconV2';

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -8,7 +8,6 @@ import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
 import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {TestResults} from '@cdo/apps/constants';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {
   getAppOptionsEditBlocks,
@@ -19,6 +18,7 @@ import {
   setHasEdited,
   setProjectSource,
 } from '@cdo/apps/lab2/redux/lab2ProjectRedux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -23,10 +23,8 @@ import {
   setUserRoleInCourse,
   CourseRoles,
 } from '@cdo/apps/templates/currentUserRedux';
-import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import {setLevel} from '../aiTutor/redux/aiTutorRedux';
-import {getCurrentLevel} from '../code-studio/progressReduxSelectors';
 import {
   setProjectUpdatedAt,
   setProjectUpdatedError,
@@ -47,6 +45,7 @@ import ProjectManager from './projects/ProjectManager';
 import ProjectManagerFactory from './projects/ProjectManagerFactory';
 import {getPredictResponse} from './projects/userLevelsApi';
 import {setProjectTooLarge} from './redux/lab2ProjectRedux';
+import {isReadOnlyWorkspace} from './redux/lab2ReduxSelectors';
 import {LevelPropertiesValidator} from './responseValidators';
 import {
   Channel,
@@ -296,42 +295,6 @@ export const isLabLoading = (state: {lab: LabState}) =>
   state.lab.isLoadingProjectOrLevel ||
   state.lab.isLoading ||
   state.lab.isLoadingTheme;
-
-// This may depend on more factors, such as share.
-export const isReadOnlyWorkspace = (state: RootState) => {
-  const isEditMode = !!getAppOptionsEditBlocks();
-  const isEditingExemplar = getAppOptionsEditingExemplar();
-  const isViewingExemplar = getAppOptionsViewingExemplar();
-  const isWidgetView = !!state.lab.levelProperties?.widgetView;
-
-  // Exemplar and block edit modes do not have a channel.
-  if (isEditMode || isEditingExemplar) {
-    return false;
-  } else if (isViewingExemplar) {
-    return true;
-  }
-  // Otherwise, we are in read only mode if we are not the owner of the channel,
-  // the level is frozen, the level is a read only predict level, the level has been submitted.
-  // or this is a lab that should be read only while running and the code is currently running.
-  const isOwner = state.lab.channel?.isOwner;
-  const isFrozen = !!state.lab.channel?.frozen;
-  const readonlyPredictLevel = isReadonlyPredictLevel(state);
-  const hasSubmitted = getCurrentLevel(state)?.status === LevelStatus.submitted;
-  const isViewingOldVersion = state.lab2Project.viewingOldVersion;
-  const isRunningAndReadonly =
-    (state.lab2System.isRunning || state.lab2System.isValidating) &&
-    shouldBeReadonlyWhileRunning(state);
-
-  return (
-    !isOwner ||
-    isFrozen ||
-    readonlyPredictLevel ||
-    hasSubmitted ||
-    isRunningAndReadonly ||
-    isViewingOldVersion ||
-    isWidgetView
-  );
-};
 
 // If there is an error present on the page.
 export const hasPageError = (state: {lab: LabState}) => {
@@ -588,31 +551,6 @@ async function cleanUpProjectManager() {
   // saves from the existing project manager.
   await existingProjectManager?.cleanUp();
   Lab2Registry.getInstance().clearProjectManager();
-}
-
-// Returns if the current state represents a predict level that should be read only.
-// If the predict level code is not editable after submit or the user has not submitted a response,
-// the predict level is read only.
-function isReadonlyPredictLevel(state: RootState) {
-  const isPredictLevel =
-    state.lab.levelProperties?.predictSettings?.isPredictLevel || false;
-  let isReadonlyPredictLevel = isPredictLevel;
-  if (isPredictLevel) {
-    const isEditableAfterSubmit =
-      state.lab.levelProperties?.predictSettings?.codeEditableAfterSubmit ||
-      false;
-    const hasSubmittedPredictResponse = state.predictLevel.hasSubmittedResponse;
-    // If the predict level code is not editable after submit or the user has not submitted a response,
-    // the predict level is read only.
-    isReadonlyPredictLevel =
-      !isEditableAfterSubmit || !hasSubmittedPredictResponse;
-  }
-  return isReadonlyPredictLevel;
-}
-
-// Currently only Python Lab disables editing while code is running.
-function shouldBeReadonlyWhileRunning(state: RootState) {
-  return state.lab.levelProperties?.appName === 'pythonlab';
 }
 
 // This is an action that other reducers (specifically predictLevelRedux) can respond to.

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -288,29 +288,6 @@ export const setUpWithLevel = createAsyncThunk<
   }
 });
 
-// Selectors
-
-// If any load is currently in progress.
-export const isLabLoading = (state: {lab: LabState}) =>
-  state.lab.isLoadingProjectOrLevel ||
-  state.lab.isLoading ||
-  state.lab.isLoadingTheme;
-
-// If there is an error present on the page.
-export const hasPageError = (state: {lab: LabState}) => {
-  return state.lab.pageError !== undefined;
-};
-
-// If the share and remix buttons should be hidden for the lab. Defaults to true (hidden)
-// if not specified.
-export const shouldHideShareAndRemix = (state: {lab: LabState}): boolean => {
-  const hideShareAndRemix = state.lab.levelProperties?.hideShareAndRemix;
-  return hideShareAndRemix === undefined ? true : hideShareAndRemix;
-};
-
-export const isProjectTemplateLevel = (state: {lab: LabState}) =>
-  !!state.lab.levelProperties?.projectTemplateLevelName;
-
 // SLICE
 
 const labSlice = createSlice({

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -16,12 +16,12 @@ import {
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {
-  isReadOnlyWorkspace,
   setUpWithLevel,
   shouldHideShareAndRemix,
 } from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {resetProjectMetadata} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {AppName} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -15,13 +15,13 @@ import {
   getUserAppOptionsPath,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
-import {
-  setUpWithLevel,
-  shouldHideShareAndRemix,
-} from '@cdo/apps/lab2/lab2Redux';
+import {setUpWithLevel} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {resetProjectMetadata} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {
+  isReadOnlyWorkspace,
+  shouldHideShareAndRemix,
+} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {AppName} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';

--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -12,6 +12,8 @@ import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import Lab2Registry from '../Lab2Registry';
 
+import {isReadOnlyWorkspace} from './lab2ReduxSelectors';
+
 export interface Lab2ProjectState {
   projectSources: ProjectSources | undefined;
   viewingOldVersion: boolean;

--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -12,8 +12,6 @@ import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import Lab2Registry from '../Lab2Registry';
 
-import {isReadOnlyWorkspace} from './lab2ReduxSelectors';
-
 export interface Lab2ProjectState {
   projectSources: ProjectSources | undefined;
   viewingOldVersion: boolean;

--- a/apps/src/lab2/redux/lab2ReduxSelectors.ts
+++ b/apps/src/lab2/redux/lab2ReduxSelectors.ts
@@ -67,6 +67,8 @@ export const isReadOnlyWorkspace = (state: RootState) => {
   );
 };
 
+// Helper functions
+
 // Returns if the current state represents a predict level that should be read only.
 // If the predict level code is not editable after submit or the user has not submitted a response,
 // the predict level is read only.

--- a/apps/src/lab2/redux/lab2ReduxSelectors.ts
+++ b/apps/src/lab2/redux/lab2ReduxSelectors.ts
@@ -1,4 +1,5 @@
 import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {LabState} from '@cdo/apps/lab2/lab2Redux';
 import {
   getAppOptionsEditBlocks,
   getAppOptionsEditingExemplar,
@@ -6,6 +7,29 @@ import {
 } from '@cdo/apps/lab2/projects/utils';
 import {RootState} from '@cdo/apps/types/redux';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
+
+// Redux selectors for lab2 state.
+
+// If any load is currently in progress.
+export const isLabLoading = (state: {lab: LabState}) =>
+  state.lab.isLoadingProjectOrLevel ||
+  state.lab.isLoading ||
+  state.lab.isLoadingTheme;
+
+// If there is an error present on the page.
+export const hasPageError = (state: {lab: LabState}) => {
+  return state.lab.pageError !== undefined;
+};
+
+// If the share and remix buttons should be hidden for the lab. Defaults to true (hidden)
+// if not specified.
+export const shouldHideShareAndRemix = (state: {lab: LabState}): boolean => {
+  const hideShareAndRemix = state.lab.levelProperties?.hideShareAndRemix;
+  return hideShareAndRemix === undefined ? true : hideShareAndRemix;
+};
+
+export const isProjectTemplateLevel = (state: {lab: LabState}) =>
+  !!state.lab.levelProperties?.projectTemplateLevelName;
 
 // This may depend on more factors, such as share.
 export const isReadOnlyWorkspace = (state: RootState) => {

--- a/apps/src/lab2/redux/lab2ReduxSelectors.ts
+++ b/apps/src/lab2/redux/lab2ReduxSelectors.ts
@@ -1,0 +1,69 @@
+import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {
+  getAppOptionsEditBlocks,
+  getAppOptionsEditingExemplar,
+  getAppOptionsViewingExemplar,
+} from '@cdo/apps/lab2/projects/utils';
+import {RootState} from '@cdo/apps/types/redux';
+import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
+
+// This may depend on more factors, such as share.
+export const isReadOnlyWorkspace = (state: RootState) => {
+  const isEditMode = !!getAppOptionsEditBlocks();
+  const isEditingExemplar = getAppOptionsEditingExemplar();
+  const isViewingExemplar = getAppOptionsViewingExemplar();
+  const isWidgetView = !!state.lab.levelProperties?.widgetView;
+
+  // Exemplar and block edit modes do not have a channel.
+  if (isEditMode || isEditingExemplar) {
+    return false;
+  } else if (isViewingExemplar) {
+    return true;
+  }
+  // Otherwise, we are in read only mode if we are not the owner of the channel,
+  // the level is frozen, the level is a read only predict level, the level has been submitted.
+  // or this is a lab that should be read only while running and the code is currently running.
+  const isOwner = state.lab.channel?.isOwner;
+  const isFrozen = !!state.lab.channel?.frozen;
+  const readonlyPredictLevel = isReadonlyPredictLevel(state);
+  const hasSubmitted = getCurrentLevel(state)?.status === LevelStatus.submitted;
+  const isViewingOldVersion = state.lab2Project.viewingOldVersion;
+  const isRunningAndReadonly =
+    (state.lab2System.isRunning || state.lab2System.isValidating) &&
+    shouldBeReadonlyWhileRunning(state);
+
+  return (
+    !isOwner ||
+    isFrozen ||
+    readonlyPredictLevel ||
+    hasSubmitted ||
+    isRunningAndReadonly ||
+    isViewingOldVersion ||
+    isWidgetView
+  );
+};
+
+// Returns if the current state represents a predict level that should be read only.
+// If the predict level code is not editable after submit or the user has not submitted a response,
+// the predict level is read only.
+function isReadonlyPredictLevel(state: RootState) {
+  const isPredictLevel =
+    state.lab.levelProperties?.predictSettings?.isPredictLevel || false;
+  let isReadonlyPredictLevel = isPredictLevel;
+  if (isPredictLevel) {
+    const isEditableAfterSubmit =
+      state.lab.levelProperties?.predictSettings?.codeEditableAfterSubmit ||
+      false;
+    const hasSubmittedPredictResponse = state.predictLevel.hasSubmittedResponse;
+    // If the predict level code is not editable after submit or the user has not submitted a response,
+    // the predict level is read only.
+    isReadonlyPredictLevel =
+      !isEditableAfterSubmit || !hasSubmittedPredictResponse;
+  }
+  return isReadonlyPredictLevel;
+}
+
+// Currently only Python Lab disables editing while code is running.
+function shouldBeReadonlyWhileRunning(state: RootState) {
+  return state.lab.levelProperties?.appName === 'pythonlab';
+}

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -17,6 +17,10 @@ import {
   getAppOptionsTheme,
   getIsShareView,
 } from '@cdo/apps/lab2/projects/utils';
+import {
+  isLabLoading,
+  hasPageError,
+} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import fetchPermissions from '@cdo/apps/lab2/utils/fetchPermissions';
 import {useBrowserTextToSpeech} from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
 import {capitalizeFirstLetter} from '@cdo/apps/util/capitalizeFirstLetter';
@@ -25,13 +29,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {PERMISSIONS} from '../constants';
 import ErrorBoundary from '../ErrorBoundary';
 import useLifecycleNotifier from '../hooks/useLifecycleNotifier';
-import {
-  LabState,
-  isLabLoading,
-  hasPageError,
-  setIsShareView,
-  setPermissions,
-} from '../lab2Redux';
+import {LabState, setIsShareView, setPermissions} from '../lab2Redux';
 import Lab2Registry from '../Lab2Registry';
 import {LifecycleEvent} from '../utils';
 

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {FontSize} from '@cdo/apps/lab2/constants';
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {
   fetchAndSaveEditorFontSize,
   setEditorFontSizeLoaded,

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
@@ -6,8 +6,8 @@ import {
 } from '@code-dot-org/component-library/tooltip';
 import React, {useCallback, useRef, useState} from 'react';
 
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {ProjectSources, ProjectVersion} from '@cdo/apps/lab2/types';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React, {memo, useCallback, useContext} from 'react';
 import {useSelector} from 'react-redux';
 
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {commonI18n} from '@cdo/apps/types/locale';

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -9,13 +9,13 @@ import {
   TOOLBOX_BLOCKS,
   WARNING_BANNER_MESSAGES,
 } from '@cdo/apps/lab2/constants';
-import {isProjectTemplateLevel} from '@cdo/apps/lab2/lab2Redux';
 import {ProgressManagerContext} from '@cdo/apps/lab2/progress/ProgressContainer';
 import {
   getAppOptionsEditBlocks,
   getAppOptionsEditingExemplar,
   getAppOptionsViewingExemplar,
 } from '@cdo/apps/lab2/projects/utils';
+import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -10,17 +10,14 @@ import './small-footer-music-overrides.scss';
 
 import DCDO from '@cdo/apps/dcdo';
 import {START_SOURCES, TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
-import {
-  isReadOnlyWorkspace,
-  setIsLoading,
-  setPageError,
-} from '@cdo/apps/lab2/lab2Redux';
+import {setIsLoading, setPageError} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {
   getAppOptionsEditBlocks,
   getAppOptionsEditingExemplar,
   getAppOptionsViewingExemplar,
 } from '@cdo/apps/lab2/projects/utils';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {setExtraCopyrightContent} from '@cdo/apps/sharedComponents/footer/CopyrightDialog/index';

--- a/apps/src/music/views/hooks/useUpdateAnalytics.ts
+++ b/apps/src/music/views/hooks/useUpdateAnalytics.ts
@@ -1,8 +1,8 @@
 import {useEffect} from 'react';
 
 import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {Channel, LevelProperties} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';


### PR DESCRIPTION
This PR just moves the lab2Redux selectors into their own file, and updates imports accordingly. The reason I wanted to do this was to enable `lab2ProjectRedux` to use the `isReadOnlyWorkspace` selector; right now this causes a new circular dependency. There should be no functionality change here.


## Testing story
Tested that Python Lab, AI Chat, and Music Lab still behave as before.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
