### PR TITLE
CMS-859: Remove Pegasus picture password images

### DIFF
--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -884,11 +884,7 @@ export const convertStudentServerData = (studentData, loginType, sectionId) => {
       gender: student.gender || '',
       genderTeacherInput: student.gender_teacher_input || '',
       secretWords: student.secret_words,
-
-      // @deprecated Use `secretPictureUrl` instead
-      secretPicturePath: student.secret_picture_path,
       secretPictureUrl: student.secret_picture_url,
-
       loginType: loginType,
       sectionId: sectionId,
       sharingDisabled: student.sharing_disabled,

--- a/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
@@ -218,11 +218,7 @@ export const studentFromServerStudent = (serverStudent, sectionId) => ({
   name: serverStudent.name,
   familyName: serverStudent.family_name,
   sharingDisabled: serverStudent.sharing_disabled,
-
-  // @deprecated Use `secretPictureUrl` instead
-  secretPicturePath: serverStudent.secret_picture_path,
   secretPictureUrl: serverStudent.secret_picture_url,
-
   secretPictureName: serverStudent.secret_picture_name,
   secretWords: serverStudent.secret_words,
   userType: serverStudent.user_type,

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -128,7 +128,6 @@ export interface ServerStudent {
   id: number;
   name: string;
   secret_picture_name: string;
-  secret_picture_path?: string; // @deprecated Use `secret_picture_url` instead
   secret_picture_url: string;
   secret_words: string;
   sectionId: number;

--- a/apps/src/types/redux.ts
+++ b/apps/src/types/redux.ts
@@ -74,7 +74,6 @@ export interface Student {
   gender?: string;
   genderTeacherInput?: string;
   secretWords: string;
-  secretPicturePath?: string; // @deprecated Use `secretPictureUrl` instead
   secretPictureUrl: string;
   loginType: string;
   sectionId?: number;

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1284,11 +1284,7 @@ class User < ApplicationRecord
       birthday: birthday,
       secret_words: secret_words,
       secret_picture_name: secret_picture&.name,
-
-      # DEPRECATED: +secret_picture_path+ will be removed in future releases. Use +secret_picture_url+ instead.
-      secret_picture_path: secret_picture&.path,
       secret_picture_url: secret_picture && ApplicationController.helpers.image_url(secret_picture.path),
-
       location: "/v2/users/#{id}",
       age: age,
       sharing_disabled: sharing_disabled?,

--- a/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
@@ -164,7 +164,6 @@ class Api::V1::SectionsStudentsControllerTest < ActionController::TestCase
     response = JSON.parse(@response.body)
 
     @student.reload
-    assert response['secret_picture_path'].present?
     assert response['secret_words'].present?
     refute_equal response['secret_picture_url'], ApplicationController.helpers.image_url(old_secret_picture_path)
     refute_equal response['secret_words'], old_secret_words
@@ -183,7 +182,6 @@ class Api::V1::SectionsStudentsControllerTest < ActionController::TestCase
     response = JSON.parse(@response.body)
 
     @student.reload
-    assert response['secret_picture_path'].present?
     assert response['secret_words'].present?
     assert_equal response['secret_picture_url'], ApplicationController.helpers.image_url(secret_picture_path)
     assert_equal response['secret_words'], secret_words

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3306,7 +3306,6 @@ class UserTest < ActiveSupport::TestCase
         birthday: @student.birthday,
         secret_words: @student.secret_words,
         secret_picture_name: secret_picture.name,
-        secret_picture_path: secret_picture.path,
         secret_picture_url: ApplicationController.helpers.image_url(secret_picture.path),
         location: "/v2/users/#{@student.id}",
         age: @student.age,

--- a/pegasus/sites.v3/code.org/public/images/password_images/alien_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/alien_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e292a0aec8a791b3396bc3de19fa166e27b67146cb30646f2cf0e98f3ad92f4b
-size 17700

--- a/pegasus/sites.v3/code.org/public/images/password_images/bat_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/bat_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e85263118a207db34353d8d551d3428fcbca46ea01794e3376e92dc78b31674
-size 18561

--- a/pegasus/sites.v3/code.org/public/images/password_images/bird_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/bird_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b3b3d68a824f0884cbaf52059a3b276c82ca8c8d4a3dd721dd9703c5e300e97
-size 17118

--- a/pegasus/sites.v3/code.org/public/images/password_images/cat_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/cat_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dce199beb76739086a06727af13733d35d2c80714f1efb3f848f6079355a5c24
-size 17056

--- a/pegasus/sites.v3/code.org/public/images/password_images/dinosaur_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/dinosaur_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:293748469fa4a76ef7030610c77b0ec7ee661a74d58bb65ac6012d189b317b27
-size 17365

--- a/pegasus/sites.v3/code.org/public/images/password_images/dog_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/dog_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a3bbb74d138953801fb1c5a10e64c603902a68eade0f3cdb744d1db29b016abf
-size 15713

--- a/pegasus/sites.v3/code.org/public/images/password_images/dragon_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/dragon_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69a9641c0183e837b868fdcd2eb414aba1ac3a7357d95fba1b5f660d0a217351
-size 17135

--- a/pegasus/sites.v3/code.org/public/images/password_images/ghost_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/ghost_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28997ab51c0f01543e6fa55fe9c056fab0cd4f8287184b47e98946b8ac4a96b4
-size 9999

--- a/pegasus/sites.v3/code.org/public/images/password_images/knight_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/knight_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7ade580fa87d790901de118bd15af28cc813da3dcbd38cfeee62afee84d1f7e
-size 17783

--- a/pegasus/sites.v3/code.org/public/images/password_images/monster_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/monster_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6016c9a78737d70c982fbeb07d66e98db97aaa7c3b4862894876640a8cd5c56b
-size 19194

--- a/pegasus/sites.v3/code.org/public/images/password_images/ninja2_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/ninja2_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d55bfd1330219ac05a11bec499ea535bfa21b2534fb2cd27f7e1c5f6fe451aaf
-size 16574

--- a/pegasus/sites.v3/code.org/public/images/password_images/ninja_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/ninja_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ee287cdde628683ef6f6d02f447169ddbbe1bee47e54c81dd17efab920b8929
-size 16535

--- a/pegasus/sites.v3/code.org/public/images/password_images/octopus_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/octopus_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70f0affc99ac3f6413ba9444cc92eb731c0b87875f2fedb8a31f486d868668a6
-size 19052

--- a/pegasus/sites.v3/code.org/public/images/password_images/penguin_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/penguin_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6543bbfcc2684a06b9b91109bb9d3dba85115730566ef0902c341e9dc107ad1
-size 16342

--- a/pegasus/sites.v3/code.org/public/images/password_images/pirate_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/pirate_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4243880ffd89644d6726e8fc7b054eda31825d92ca0c8c0545bce6a47149fdd
-size 19027

--- a/pegasus/sites.v3/code.org/public/images/password_images/princess_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/princess_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e041c61be505b3a431adecd81b7f87cfd7f535c3be5470a2a55717b9d1628b0a
-size 15307

--- a/pegasus/sites.v3/code.org/public/images/password_images/robot_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/robot_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:013cd64385e97f1dd16d59ac744c879bc26017e3f8e11d74472cc013ff948980
-size 15132

--- a/pegasus/sites.v3/code.org/public/images/password_images/spacebot_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/spacebot_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dde0218c36748235a6d2cd312beac40e0a68d5b904fb2747fd6128b17fd7b80b
-size 17395

--- a/pegasus/sites.v3/code.org/public/images/password_images/squirrel_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/squirrel_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd6534a67483e2553c2b86d2448937bbb320bc3a825a22b79cd73ab4c9eac8ff
-size 18366

--- a/pegasus/sites.v3/code.org/public/images/password_images/unicorn_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/unicorn_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c62e5dee8d8fea07e5ccde42fad879db7b8c953ac4be6e436227eb7189953aa
-size 14391

--- a/pegasus/sites.v3/code.org/public/images/password_images/witch_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/witch_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb198e54bbdbd2ef74b37bd05fb197ff63837854f180d2b3d34d1895ff8ae1cd
-size 21927

--- a/pegasus/sites.v3/code.org/public/images/password_images/wizard_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/wizard_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6bfeb8e2c8ebcba2162918640ee4c3b77ca1360a58938b1dd25ba9cd41953fc2
-size 22072

--- a/pegasus/sites.v3/code.org/public/images/password_images/zombie_thumb@2x.png
+++ b/pegasus/sites.v3/code.org/public/images/password_images/zombie_thumb@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29d940180af690aa8391a0cc3fba0a146f7cefcd34c3c9772f03f72d5eabdd1d
-size 15811


### PR DESCRIPTION
## Links
- JIRA task: [CMS-859](https://codedotorg.atlassian.net/browse/CMS-859)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66929
- Dashboard password images: https://github.com/code-dot-org/code-dot-org/tree/CMS-859/pegasus-password-images-migration/dashboard/app/assets/images/password_images