### PR TITLE
Send user to custom registration link on the Workshop Marketing page regardless of signed-in state

### DIFF
--- a/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
+++ b/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
@@ -101,7 +101,7 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
             partner.
           </BodyThreeText>
           <LinkButton
-            href={buildEnrollButtonLink(custom_registration_link)}
+            href={custom_registration_link}
             className={moduleStyles.fullWidthButton}
             type="primary"
             size="m"

--- a/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
+++ b/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
@@ -97,7 +97,7 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
       return (
         <>
           <BodyThreeText>
-            This workshop’s registration is managed externally by the regional
+            This workshop's registration is managed externally by the regional
             partner.
           </BodyThreeText>
           <LinkButton

--- a/apps/test/unit/code-studio/pd/workshops/components/EnrollInWorkshopTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshops/components/EnrollInWorkshopTest.tsx
@@ -60,70 +60,6 @@ describe('EnrollInWorkshop', () => {
     expect(fullButton).toBeDisabled();
   });
 
-  it('enroll button sends logged out users to logged out gate', () => {
-    render(<EnrollInWorkshop {...baseProps} userInfo={null} />);
-    const linkButton = screen.getByRole('link', {
-      name: /Sign-in to enroll/i,
-    });
-    expect(linkButton).toHaveAttribute(
-      'href',
-      `/logged_out?source_page=${encodeURIComponent(
-        'workshop enroll'
-      )}&return_to=${encodeURIComponent('/professional-learning/workshops/1')}`
-    );
-  });
-
-  it('enroll button sends students to update account type gate', () => {
-    render(
-      <EnrollInWorkshop
-        {...baseProps}
-        userInfo={{...baseUserInfo, is_student: true}}
-      />
-    );
-    const linkButton = screen.getByRole('link', {
-      name: /Switch to teacher account/i,
-    });
-    expect(linkButton).toHaveAttribute(
-      'href',
-      `/teacher_account_required?source_page=${encodeURIComponent(
-        'workshop enroll'
-      )}&return_to=${encodeURIComponent('/professional-learning/workshops/1')}`
-    );
-  });
-
-  it('shows partner registration link if custom_registration_link is present', () => {
-    const customLink = 'https://partner.org/enroll';
-    render(
-      <EnrollInWorkshop {...baseProps} custom_registration_link={customLink} />
-    );
-
-    expect(
-      screen.getByText(/This workshop’s registration is managed externally/i)
-    ).toBeInTheDocument();
-
-    const linkButton = screen.getByRole('link', {
-      name: /Go to partner enrollment/i,
-    });
-    expect(linkButton).toHaveAttribute('href', customLink);
-  });
-
-  it('shows internal enrollment button if user is signed in and not a student', () => {
-    render(<EnrollInWorkshop {...baseProps} />);
-    const enrollButton = screen.getByRole('button', {
-      name: /Enroll in this workshop/i,
-    });
-    expect(enrollButton).toBeInTheDocument();
-    expect(enrollButton).toBeEnabled();
-  });
-
-  it('always shows "Click to see data sharing notice" link', () => {
-    render(<EnrollInWorkshop {...baseProps} />);
-    const link = screen.getByRole('link', {
-      name: /Click to see data sharing notice/i,
-    });
-    expect(link).toHaveAttribute('href', '#data-sharing-notice');
-  });
-
   it('enroll button is disabled if user information is missing', () => {
     const missingFirstNameUserInfo = {...baseUserInfo, first_name: ''};
     render(
@@ -143,5 +79,109 @@ describe('EnrollInWorkshop', () => {
     });
     expect(enrollButton).toBeInTheDocument();
     expect(enrollButton).toBeEnabled();
+  });
+
+  it('enroll button sends logged out users to logged out gate if workshop has no custom_registration_link', () => {
+    render(<EnrollInWorkshop {...baseProps} userInfo={null} />);
+    const linkButton = screen.getByRole('link', {
+      name: /Sign-in to enroll/i,
+    });
+    expect(linkButton).toHaveAttribute(
+      'href',
+      `/logged_out?source_page=${encodeURIComponent(
+        'workshop enroll'
+      )}&return_to=${encodeURIComponent('/professional-learning/workshops/1')}`
+    );
+  });
+
+  it('enroll button sends students to update account type gate if workshop has no custom_registration_link', () => {
+    render(
+      <EnrollInWorkshop
+        {...baseProps}
+        userInfo={{...baseUserInfo, is_student: true}}
+      />
+    );
+    const linkButton = screen.getByRole('link', {
+      name: /Switch to teacher account/i,
+    });
+    expect(linkButton).toHaveAttribute(
+      'href',
+      `/teacher_account_required?source_page=${encodeURIComponent(
+        'workshop enroll'
+      )}&return_to=${encodeURIComponent('/professional-learning/workshops/1')}`
+    );
+  });
+
+  it('shows internal enrollment button to teachers if workshop has no custom_registration_link', () => {
+    render(<EnrollInWorkshop {...baseProps} />);
+    const enrollButton = screen.getByRole('button', {
+      name: /Enroll in this workshop/i,
+    });
+    expect(enrollButton).toBeInTheDocument();
+    expect(enrollButton).toBeEnabled();
+  });
+
+  it('enroll button sends signed-out users to partner registration link if custom_registration_link is present', () => {
+    const customLink = 'https://partner.org/enroll';
+    render(
+      <EnrollInWorkshop
+        {...baseProps}
+        userInfo={null}
+        custom_registration_link={customLink}
+      />
+    );
+
+    expect(
+      screen.getByText(/This workshop's registration is managed externally/i)
+    ).toBeInTheDocument();
+
+    const linkButton = screen.getByRole('link', {
+      name: /Go to partner enrollment/i,
+    });
+    expect(linkButton).toHaveAttribute('href', customLink);
+  });
+
+  it('enroll button sends student users to partner registration link if custom_registration_link is present', () => {
+    const customLink = 'https://partner.org/enroll';
+    render(
+      <EnrollInWorkshop
+        {...baseProps}
+        userInfo={{...baseUserInfo, is_student: true}}
+        custom_registration_link={customLink}
+      />
+    );
+
+    expect(
+      screen.getByText(/This workshop's registration is managed externally/i)
+    ).toBeInTheDocument();
+
+    const linkButton = screen.getByRole('link', {
+      name: /Go to partner enrollment/i,
+    });
+    expect(linkButton).toHaveAttribute('href', customLink);
+  });
+
+  it('enroll button sends teachers users to partner registration link if custom_registration_link is present', () => {
+    const customLink = 'https://partner.org/enroll';
+    render(
+      <EnrollInWorkshop {...baseProps} custom_registration_link={customLink} />
+    );
+
+    expect(
+      screen.getByText(/This workshop's registration is managed externally/i)
+    ).toBeInTheDocument();
+
+    const linkButton = screen.getByRole('link', {
+      name: /Go to partner enrollment/i,
+    });
+    expect(linkButton).toHaveAttribute('href', customLink);
+  });
+
+  it('always shows "Click to see data sharing notice" link', () => {
+    render(<EnrollInWorkshop {...baseProps} />);
+    const link = screen.getByRole('link', {
+      name: /Click to see data sharing notice/i,
+    });
+    expect(link).toHaveAttribute('href', '#data-sharing-notice');
   });
 });


### PR DESCRIPTION
Sends user to the workshop's custom registration link (if present) on the Workshop Marketing page regardless of if they're signed-in, a student, or a teacher. Signed-out and student users will eventually hit a sign-in/upgrade gate once they finish their external registration and are directed to the /join page.

### Sends signed-out users to custom registration link
I arbitrarily chose the curriculum catalog as the custom registration link.

https://github.com/user-attachments/assets/91411c7b-7287-4e8d-8ba2-2c04b5355109

### Sends students to custom registration link
I arbitrarily chose the curriculum catalog as the custom registration link.

https://github.com/user-attachments/assets/1b8b22d1-7258-4f97-9a01-3e1e570c8269

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3381)

## Testing story
Local testing and updating unit tests.
