### PR TITLE
Revert "Redirect old Workshop Enroll form to new Workshop Join page"

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
@@ -107,7 +107,6 @@ const WorkshopJoin: React.FunctionComponent<{
             time in your account settings.
           </BodyThreeText>
           <Button
-            id="joinWorkshop"
             name="joinWorkshop"
             text="Join this workshop"
             color="purple"

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -955,7 +955,7 @@ Dashboard::Application.routes.draw do
 
       delete 'fit_weekend_registration/:application_guid', to: 'fit_weekend_registration#destroy'
 
-      get 'workshops/:workshop_id/enroll', to: redirect("/pd/workshops/%{workshop_id}/join")
+      get 'workshops/:workshop_id/enroll', action: 'new', controller: 'workshop_enrollment'
       get 'workshops/:workshop_id/join', action: 'join', controller: 'workshop_enrollment'
       get 'workshop_enrollment/:code', action: 'show', controller: 'workshop_enrollment'
       get 'workshop_enrollment/:code/cancel', action: 'cancel', controller: 'workshop_enrollment'

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -23,6 +23,161 @@ class Pd::WorkshopEnrollmentControllerTest < ActionController::TestCase
     @organizer_workshop_existing_enrollment = create :pd_enrollment, workshop: @organizer_workshop
   end
 
+  test 'enroll get route' do
+    assert_routing(
+      {path: "http://#{CDO.dashboard_hostname}/pd/workshops/#{@workshop.id}/enroll", method: :get},
+      {controller: 'pd/workshop_enrollment', action: 'new', workshop_id: @workshop.id.to_s}
+    )
+  end
+
+  test 'non-logged-in users cannot enroll in csd workshop' do
+    workshop = create :workshop, course: Pd::Workshop::COURSE_CSD
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :redirect
+    assert_redirected_to "/logged_out?source_page=workshop%20enroll&return_to=%2Fpd%2Fworkshops%2F#{workshop.id}%2Fenroll"
+  end
+
+  test 'non-logged-in users cannot enroll in csp workshop' do
+    workshop = create :workshop, course: Pd::Workshop::COURSE_CSP
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :redirect
+    assert_redirected_to "/logged_out?source_page=workshop%20enroll&return_to=%2Fpd%2Fworkshops%2F#{workshop.id}%2Fenroll"
+  end
+
+  test 'logged-in users can enroll in csd workshop' do
+    sign_in @teacher
+    workshop = create :workshop, course: Pd::Workshop::COURSE_CSD
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :new
+  end
+
+  test 'logged-in users can enroll in csp workshop' do
+    sign_in @teacher
+    workshop = create :workshop, course: Pd::Workshop::COURSE_CSP
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :new
+  end
+
+  test 'students are sent to Teacher Acount Required page' do
+    student = create :student
+    sign_in student
+    workshop = create :workshop, course: Pd::Workshop::COURSE_CSD
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :redirect
+    assert_redirected_to "/teacher_account_required?source_page=workshop%20enroll&return_to=%2Fpd%2Fworkshops%2F#{workshop.id}%2Fenroll"
+  end
+
+  test 'teacher with missing application gets missing application view' do
+    teacher = create :teacher
+
+    # see Pd::Workshop#require_application? for the logic that determines whether a workshop requires an application
+    rp = create :regional_partner
+    workshop = create :summer_workshop, regional_partner: rp
+    assert workshop.require_application?
+
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :missing_application
+  end
+
+  test 'teacher with old application gets new view' do
+    teacher = create :teacher
+    old_year = Pd::SharedApplicationConstants::YEAR_18_19
+    create :pd_teacher_application, user: teacher, application_year: old_year
+
+    rp = create :regional_partner
+    workshop = create :summer_workshop, regional_partner: rp
+    assert workshop.require_application?
+
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :missing_application
+  end
+
+  test 'teacher with incomplete application gets missing application view' do
+    teacher = create :teacher
+    create :pd_teacher_application, user: teacher, status: 'incomplete'
+
+    rp = create :regional_partner
+    workshop = create :summer_workshop, regional_partner: rp
+    assert workshop.require_application?
+
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :missing_application
+  end
+
+  test 'teacher already enrolled in workshop cannot enroll again' do
+    teacher = create :teacher
+    application = create :pd_teacher_application, user: teacher, status: 'accepted'
+    workshop = create :workshop
+    create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :already_enrolled
+  end
+
+  test 'teacher with required application gets new view' do
+    teacher = create :teacher
+    create :pd_teacher_application, user: teacher, status: 'accepted'
+
+    rp = create :regional_partner
+    workshop = create :summer_workshop, regional_partner: rp
+    assert workshop.require_application?
+
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :new
+  end
+
+  # TODO: remove this test when workshop_organizer is deprecated
+  test 'workshop organizers can see enrollment form' do
+    # Note - organizers can see the form, but cannot enroll in their own workshops.
+    # This is tested in 'creating an enrollment with email match from organizer renders own view'
+    sign_in @workshop_organizer
+    get :new, params: {workshop_id: @organizer_workshop.id}
+    assert_template :new
+  end
+
+  test 'program manager workshop organizers can see enrollment form' do
+    # Note - organizers can see the form, but cannot enroll in their own workshops.
+    # This is tested in 'creating an enrollment with email match from organizer renders own view'
+    sign_in @organizer
+    get :new, params: {workshop_id: @workshop.id}
+    assert_template :new
+  end
+
+  test 'facilitators can see enrollment form' do
+    # Note - facilitators can see the form, but cannot enroll in their own workshops.
+    # This is tested in 'creating an enrollment with email match from facilitator renders own view'
+    sign_in @facilitator
+    get :new, params: {workshop_id: @workshop.id}
+    assert_template :new
+  end
+
+  test 'unrelated organizers and facilitators can enroll' do
+    unrelated_super_user = @teacher
+    unrelated_super_user.permission = UserPermission::WORKSHOP_ORGANIZER
+    unrelated_super_user.permission = UserPermission::FACILITATOR
+
+    sign_in unrelated_super_user
+    get :new, params: {workshop_id: @workshop.id}
+    assert_template :new
+  end
+
+  test 'unknown workshop id responds with 404' do
+    get :new, params: {workshop_id: 'nonsense'}
+    assert_response 404
+  end
+
   test 'join sends signed out users to sign in gate' do
     get :join, params: {workshop_id: @workshop.id}
     assert_redirected_to "/logged_out?source_page=workshop%20join&return_to=%2Fpd%2Fworkshops%2F#{@workshop.id}%2Fjoin"
@@ -230,6 +385,34 @@ class Pd::WorkshopEnrollmentControllerTest < ActionController::TestCase
     # Still a student
     assert student.reload.student?
     assert_redirected_to controller: 'pd/session_attendance', action: 'upgrade_account'
+  end
+
+  test 'demographic questions added (for teachers, without application, for local summer workshop)' do
+    sign_in @teacher
+    workshop = create :summer_workshop
+
+    get :new, params: {workshop_id: workshop.id}
+    assert_template :new
+    assert prop('collect_demographics')
+  end
+
+  test 'demographic questions not added (for teachers, with application, for local summer workshop)' do
+    sign_in @teacher
+    workshop = create :workshop
+    create Pd::Application::ActiveApplicationModels::TEACHER_APPLICATION_FACTORY, user: @teacher
+
+    get :new, params: {workshop_id: workshop.id}
+    assert_template :new
+    refute prop('collect_demographics')
+  end
+
+  test 'demographic questions not added (for teachers, without application, for non-local summer workshop)' do
+    sign_in @teacher
+    workshop = create :workshop
+
+    get :new, params: {workshop_id: workshop.id}
+    assert_template :new
+    refute prop('collect_demographics')
   end
 
   private def enrollment_test_params(teacher = nil)

--- a/dashboard/test/ui/features/acquisition_products/pd/workshop_enrollment.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/workshop_enrollment.feature
@@ -1,78 +1,69 @@
 @dashboard_db_access
 Feature: Workshop Enrollment
 
-Scenario: Visiting old workshop enroll form redirects to join page
-  Given I am a teacher
-  And I visit the old enroll form page of a workshop
-  And I wait until current URL contains "/join"
-
-  # test clean up
-  And I delete the workshop
-
-Scenario: Attempting to join workshop signed-out prompts user to sign in
-  Given I am a "signed_out" user enrolling in workshop with "unsubmitted" status
-  And I wait until element "span:contains('Create an account')" is visible
-
-  # test clean up
-  And I delete the workshop
-
-Scenario: Attempting to join workshop as a student prompts user to upgrade account
-  Given I am a "student" user enrolling in workshop with "unsubmitted" status
-  And I wait until element "span:contains('Exit and cancel')" is visible
-
-  # test clean up
-  And I delete the workshop
-
-Scenario: Attempting to join invalid workshop as a teacher states it cannot be found
-  Given I am a teacher
-  And I am on "http://studio.code.org/pd/workshops/0/join"
-  And I wait until element "h3:contains('Not found')" is visible
-
-Scenario: Attempting to join closed workshop as a teacher states it is closed
-  Given I am a "teacher" user enrolling in workshop with "closed" status
-  And I wait until element "h3:contains('Closed')" is visible
-
-  # test clean up
-  And I delete the workshop
-
-Scenario: Attempting to join full workshop as a teacher states it is full
-  Given I am a "teacher" user enrolling in workshop with "full" status
-  And I wait until element "h3:contains('Full')" is visible
-
-  # test clean up
-  And I delete the workshop
-
-Scenario: Attempting to join own workshop as a teacher states it is your own workshop
-  Given I am a "teacher" user enrolling in workshop with "own" status
-  And I wait until element "h3:contains('Your own workshop')" is visible
-
-  # test clean up
-  And I delete the workshop
-
-Scenario: Attempting to join workshop again as a teacher states you have already enrolled
-  Given I am a "teacher" user enrolling in workshop with "duplicate" status
-  And I wait until element "h3:contains('Duplicate enrollment')" is visible
-
-  # test clean up
-  And I delete the workshop
-
-Scenario: Attempting to join workshop as a teacher requires user info then allows enrolling and sends teacher to MyPL page
-  Given I am a "teacher" user enrolling in workshop with "unsubmitted" status
-  And I wait until element "p:contains('Add your full name')" is visible
-  And I wait until element "a:contains('Edit')" is visible
-  Then I click selector "a:contains('Edit')"
-
-  # add full name in account settings
-  And I wait until current URL contains "users/edit"
-  And I press keys "Reba" for element "input#given_name"
-  And I press keys "McEntire" for element "input#family_name"
-  And I scroll the "button:contains(Update account information)" element into view
-  Then I click selector "button:contains(Update account information)"
-
-  # join workshop
-  And I wait until current URL contains "pd/workshops"
-  Then I click selector "#joinWorkshop"
+Scenario: Enrolling in a new workshop with school info US nces school
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I select the "United States" option in dropdown "uitest-country-dropdown"
+  And I wait until element "#uitest-school-zip" is visible
+  And I press keys "31513" for element "#uitest-school-zip"
+  And I wait until element "#uitest-school-dropdown" is visible
+  And I select the "Appling County High School" option in dropdown "uitest-school-dropdown"
+  And I click "button#submit"
   And I wait until current URL contains "my-professional-learning"
 
   # test clean up
   And I delete the workshop
+
+Scenario: Enrolling in a new workshop with school info unknown school
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I select the "United States" option in dropdown "uitest-country-dropdown"
+  And I wait until element "#uitest-school-zip" is visible
+  And I press keys "31513" for element "#uitest-school-zip"
+  And I wait until element "#uitest-school-dropdown" is visible
+  And I select the "Not listed here - add my school" option in dropdown "uitest-school-dropdown"
+  And I wait until element "#uitest-school-name" is visible
+  And I press keys "New School" for element "#uitest-school-name"
+  And I click "button#submit"
+  And I wait until current URL contains "my-professional-learning"
+
+  # test clean up
+  And I delete the workshop
+
+Scenario: Enrolling in a new workshop with school info no school setting
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I select the "United States" option in dropdown "uitest-country-dropdown"
+  And I wait until element "#uitest-school-zip" is visible
+  And I press keys "31513" for element "#uitest-school-zip"
+  And I wait until element "#uitest-school-dropdown" is visible
+  And I select the "I don't teach CS in a school setting" option in dropdown "uitest-school-dropdown"
+  And I click "button#submit"
+  And I wait until current URL contains "my-professional-learning"
+
+  # test clean up
+  And I delete the workshop
+
+Scenario: Enrolling in a new workshop with school info non-US school
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I select the "Canada" option in dropdown "uitest-country-dropdown"
+  And I wait until element "#uitest-school-name" is visible
+  And I press keys "New School" for element "#uitest-school-name"
+  And I click "button#submit"
+  And I wait until current URL contains "my-professional-learning"
+
+  # test clean up
+  And I delete the workshop
+
+Scenario: Enrolling in a new workshop with invalid school info
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I click "button#submit"
+  And I wait until element "span:contains('School information is required')" is visible
+
+  # test clean up
+  And I delete the workshop
+
+

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -289,57 +289,14 @@ And(/^I am viewing a workshop with fake survey results$/) do
   steps "And I am on \"http://studio.code.org/pd/workshop_dashboard/daily_survey_results/#{workshop.id}\""
 end
 
-Given(/^I visit the old enroll form page of a workshop$/) do
-  require_rails_env
-
-  workshop = FactoryBot.create :workshop
+Given(/^I am a teacher enrolling in "([^"]*)"$/) do |course|
+  workshop = FactoryBot.create(:workshop, course: course)
   @workshop_id = workshop.id
+  random_teacher_name = "Test Teacher" + SecureRandom.hex[0..9]
   steps <<~GHERKIN
+    And I create a teacher named "#{random_teacher_name}"
     And I am on "http://studio.code.org/pd/workshops/#{@workshop_id}/enroll"
   GHERKIN
-end
-
-Given(/^I am a "([^"]*)" user enrolling in workshop with "([^"]*)" status$/) do |user_type, status|
-  require_rails_env
-
-  random_name = "TestFacilitator" + SecureRandom.hex[0..9]
-  user = case user_type
-         when "student"
-           steps <<~GHERKIN
-             And I create a student named "#{random_name}"
-             And I sign in as "#{random_name}"
-           GHERKIN
-           find_test_user_by_name(random_name)
-         when "teacher"
-           steps <<~GHERKIN
-             And I create a teacher named "#{random_name}"
-             And I sign in as "#{random_name}"
-           GHERKIN
-
-           school_info = FactoryBot.create :school_info
-           teacher = find_test_user_by_name(random_name)
-           teacher.update!(school_info: school_info)
-           teacher
-         else
-           nil
-         end
-
-  workshop = case status
-             when "closed"
-               FactoryBot.create :workshop, :ended
-             when "full"
-               FactoryBot.create :workshop, capacity: 1, num_enrollments: 1
-             when "own"
-               FactoryBot.create :workshop, organizer: user
-             else
-               FactoryBot.create :workshop
-             end
-  if status == "duplicate"
-    FactoryBot.create :pd_enrollment, workshop: workshop, user: user
-  end
-  @workshop_id = workshop.id
-
-  steps "Then I am on \"http://studio.code.org/pd/workshops/#{@workshop_id}/join\""
 end
 
 Given 'I start a self-paced PL course' do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#66862

Looks like this PR is causing [failing UI tests](https://codedotorg.slack.com/archives/C04540KNGDQ/p1752160808608599) on iPhone and iPad, so we're reverting to investigate.