### PR TITLE
Lab2 Instructions: update details line height

### DIFF
--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -142,7 +142,7 @@
   }
 
   details {
-    line-height: 0;
+    line-height: 1.2;
     summary {
       line-height: 1.2;
       font-weight: bold;


### PR DESCRIPTION
Small fix to lab2 InstructionsV2. We needed to update the `line-height` to `1.2` rather than `0` for details blocks to avoid squished lines under details.

## Before
<img width="375" height="510" alt="Screenshot 2025-07-10 at 9 13 12 AM" src="https://github.com/user-attachments/assets/8a1498c0-ee5a-4e6f-8d5b-25d96b13e8ed" />

## After
<img width="375" height="510" alt="Screenshot 2025-07-10 at 9 12 58 AM" src="https://github.com/user-attachments/assets/764f8283-e24f-46f2-8585-14aa96d52430" />

## Links

- [Slack](https://codedotorg.slack.com/archives/C044AGTKW3D/p1752108084547789)

## Testing story
Tested locally.

## Follow-up work
There's a few other discrepancies in the markdown css between the old and new panels. I'll go through them as a follow-up and ensure we aren't missing any other important stylings. [Jira ticket](https://codedotorg.atlassian.net/browse/SL-1323)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
