### PR TITLE
[Google Blockly] remove createTextArrow_ overrides

### DIFF
--- a/apps/src/blockly/addons/cdoFieldDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldDropdown.ts
@@ -151,57 +151,6 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
   }
 
   /**
-   * We override createTextArrow_ to skip creating the arrow for uneditable blocks.
-   *
-   * Additionally, we need fix the arrow position on Safari, but only until
-   * upgrading to Blockly v11. After this, we should be able to just call
-   * super.createTextArrow_() after the early return.
-   *  @override */
-  createTextArrow_() {
-    /**
-     * Begin CDO customization
-     */
-    if (!this.getSourceBlock()?.isEditable()) {
-      return;
-    }
-    /**
-     * End CDO customization
-     */
-
-    // Once we are on v11, we should be able to use the parent class method
-    // for everything below this point.
-    const arrow = Blockly.utils.dom.createSvgElement(
-      Blockly.utils.Svg.TSPAN,
-      {},
-      this.textElement_
-    );
-    arrow.appendChild(
-      document.createTextNode(
-        this.getSourceBlock()?.RTL
-          ? Blockly.FieldDropdown.ARROW_CHAR + ' '
-          : ' ' + Blockly.FieldDropdown.ARROW_CHAR
-      )
-    );
-
-    /**
-     * Begin CDO customization
-     */
-    arrow.setAttribute('dominant-baseline', 'central');
-    /**
-     * End CDO customization
-     */
-
-    if (this.getSourceBlock()?.RTL) {
-      this.getTextElement().insertBefore(arrow, this.textContent_);
-    } else {
-      this.getTextElement().appendChild(arrow);
-    }
-    // this.arrow is private in the parent.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (this as any).arrow = arrow;
-  }
-
-  /**
    * Get the text from this field to display on the block. May differ from
    * `getText` due to ellipsis, and other formatting.
    * @override Handling of text for RTL blocks is customized.

--- a/apps/src/blockly/addons/cdoFieldParameter.ts
+++ b/apps/src/blockly/addons/cdoFieldParameter.ts
@@ -202,54 +202,6 @@ export default class CdoFieldParameter extends GoogleBlockly.FieldVariable {
     }
     return {definitionBlock, workspace};
   }
-  /**
-   * We override createTextArrow_ to skip creating the arrow for uneditable blocks.
-   *
-   * Additionally, we need fix the arrow position on Safari, but only until
-   * upgrading to Blockly v11. After this, we should be able to just call
-   * super.createTextArrow_() after the early return.
-   *  @override */
-  createTextArrow_() {
-    /**
-     * Begin CDO customization
-     */
-    if (!this.getSourceBlock()?.isEditable()) {
-      return;
-    }
-    /**
-     * End CDO customization
-     */
-
-    const arrow = Blockly.utils.dom.createSvgElement(
-      Blockly.utils.Svg.TSPAN,
-      {},
-      this.textElement_
-    );
-    arrow.appendChild(
-      document.createTextNode(
-        this.getSourceBlock()?.RTL
-          ? Blockly.FieldDropdown.ARROW_CHAR + ' '
-          : ' ' + Blockly.FieldDropdown.ARROW_CHAR
-      )
-    );
-
-    /**
-     * Begin CDO customization
-     */
-    arrow.setAttribute('dominant-baseline', 'central');
-    /**
-     * End CDO customization
-     */
-
-    if (this.getSourceBlock()?.RTL) {
-      this.getTextElement().insertBefore(arrow, this.textContent_);
-    } else {
-      this.getTextElement().appendChild(arrow);
-    }
-    // this.arrow is private in the parent.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (this as any).arrow = arrow;
-  }
 
   menuGenerator_ = function (
     this: GoogleBlockly.FieldDropdown

--- a/apps/src/blockly/addons/cdoFieldVariable.ts
+++ b/apps/src/blockly/addons/cdoFieldVariable.ts
@@ -64,58 +64,6 @@ export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
   }
 
   /**
-   * We override createTextArrow_ to skip creating the arrow for uneditable blocks.
-   *
-   * Additionally, we need fix the arrow position on Safari, but only until
-   * upgrading to Blockly v11. After this, we should be able to just call
-   * super.createTextArrow_() after the early return.
-   *  @override */
-  createTextArrow_() {
-    /**
-     * Begin CDO customization
-     */
-    if (
-      Blockly.disableVariableEditing ||
-      !this.getSourceBlock()?.isEditable()
-    ) {
-      return;
-    }
-    /**
-     * End CDO customization
-     */
-
-    const arrow = Blockly.utils.dom.createSvgElement(
-      Blockly.utils.Svg.TSPAN,
-      {},
-      this.textElement_
-    );
-    arrow.appendChild(
-      document.createTextNode(
-        this.getSourceBlock()?.RTL
-          ? Blockly.FieldDropdown.ARROW_CHAR + ' '
-          : ' ' + Blockly.FieldDropdown.ARROW_CHAR
-      )
-    );
-
-    /**
-     * Begin CDO customization
-     */
-    arrow.setAttribute('dominant-baseline', 'central');
-    /**
-     * End CDO customization
-     */
-
-    if (this.getSourceBlock()?.RTL) {
-      this.getTextElement().insertBefore(arrow, this.textContent_);
-    } else {
-      this.getTextElement().appendChild(arrow);
-    }
-    // this.arrow is private in the parent.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (this as any).arrow = arrow;
-  }
-
-  /**
    * Create a dropdown menu under the text.
    *
    * @param e Optional mouse event that triggered the field to open, or


### PR DESCRIPTION
This removes an override from three of our field classes. There were two reasons for these overrides to exist:
1. To fix a placement bug affecting Safari users
2. To hide the dropdown arrow for all uneditable blocks.

I actually fixed the but in Blockly core last year (https://github.com/google/blockly/pull/8017) but we needed to duplicate it here until we were on v11. 
We started hiding dropdown arrows for uneditable blocks last year (https://github.com/code-dot-org/code-dot-org/pull/58446). The theory was that the arrow was too suggestive that the block was editable even if it wasn't. However in practice, removing the arrow just makes the field look like a text field instead of a dropdown field. 

Before:
<img width="236" height="311" alt="image" src="https://github.com/user-attachments/assets/d47b96c5-24d5-43a9-8d8c-78e70218b269" /><img width="214" height="358" alt="image" src="https://github.com/user-attachments/assets/ddac5410-b071-4359-8745-1e64070a4b7b" />

After:
<img width="241" height="315" alt="image" src="https://github.com/user-attachments/assets/47b18697-5d09-4380-ac4b-dc70722d9fb8" /><img width="215" height="349" alt="image" src="https://github.com/user-attachments/assets/6e4b5f32-d518-4f87-a083-adb970a74ddf" />

You'll note that in the latter set of screenshots, it's much easier to spot the actual text field in each column.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
