### PR TITLE
Music: tune color

### DIFF
--- a/apps/src/music/utils/Tunes.ts
+++ b/apps/src/music/utils/Tunes.ts
@@ -113,7 +113,7 @@ export function getInstruments(editorType: EditorType) {
 }
 
 const noteColorsSimple = [
-  '#ee0916',
+  '#ff0c86',
   '#ff7b00',
   '#ff0',
   '#0f0',
@@ -123,7 +123,7 @@ const noteColorsSimple = [
 ];
 
 const noteColorsSimpleKeys = [
-  '#bb0710',
+  '#e60073',
   '#bd5b00',
   '#7a7a00',
   '#008a00',


### PR DESCRIPTION
I also find that red on black is a [little difficult](https://github.com/code-dot-org/code-dot-org/pull/66211) to visually parse, especially in the block's small field preview, so here is an idea to adjust the root note's color away from red.

### before

<img width="640" height="398" alt="Screenshot 2025-07-10 at 10 11 02 AM" src="https://github.com/user-attachments/assets/828c52c3-7626-4df3-b3bf-f8be5e005ef4" />

### after

<img width="640" height="398" alt="Screenshot 2025-07-10 at 10 04 01 AM" src="https://github.com/user-attachments/assets/25449b68-ca1d-403d-8229-77407a2c56da" />
