### PR TITLE
Fix Devise prepend order check

### DIFF
--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -373,7 +373,7 @@ end
 
 Rails.application.config.to_prepare do
   # See lib/devise/models/custom_lockable.rb
-  unless Devise::Models::CustomLockable <= Devise::Models::Lockable
+  unless Devise::Models::Lockable <= Devise::Models::CustomLockable
     Devise::Models::Lockable.prepend(Devise::Models::CustomLockable)
   end
 end


### PR DESCRIPTION
Noticed today that delayed_job processes on levelbuilder were no longer working. Looks like we accidentally flipped a condition in [a linting update](https://github.com/code-dot-org/code-dot-org/pull/66627) -- fixed that here.

## Links

- Slack: https://codedotorg.slack.com/archives/C0T0PNTM3/p1752165700306929?thread_ts=1750200043.880709&cid=C0T0PNTM3 

## Testing story

Tested manually in the levelbuilder Rails console that the reversed condition matched the returned value when this work was initially merged.