### PR TITLE
Fix to allow school info confirmation to trigger on new homepage

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -172,6 +172,9 @@ export const TeacherHomepageDrawer: React.FC = () => {
     setSchoolInfoInterstitialOpen(false);
     setSchoolInfoConfirmationOpen(false);
     setSuccess(false);
+    HttpClient.get('update_last_seen_school_info_interstitial').catch(error =>
+      console.error('Error updating last seen timestamp:', error)
+    );
   };
 
   return (

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -172,9 +172,6 @@ export const TeacherHomepageDrawer: React.FC = () => {
     setSchoolInfoInterstitialOpen(false);
     setSchoolInfoConfirmationOpen(false);
     setSuccess(false);
-    HttpClient.get('update_last_seen_school_info_interstitial').catch(error =>
-      console.error('Error updating last seen timestamp:', error)
-    );
   };
 
   return (

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -57,17 +57,14 @@ class TeacherDashboardController < ApplicationController
   def get_school_info_interstitial_data
     show_school_info_interstitial = SchoolInfoInterstitialHelper.show?(current_user)
     show_school_info_confirmation = SchoolInfoInterstitialHelper.show_confirmation_dialog?(current_user)
-
     school_info = Queries::SchoolInfo.current_school(current_user)
+
+    SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user)
+
     render json: {
       showSchoolInfoInterstitial: show_school_info_interstitial,
       showSchoolInfoConfirmation: show_school_info_confirmation,
       schoolInfo: school_info,
     }
-  end
-
-  def update_last_seen_school_info_interstitial
-    SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user)
-    render json: {success: true}
   end
 end

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -58,12 +58,16 @@ class TeacherDashboardController < ApplicationController
     show_school_info_interstitial = SchoolInfoInterstitialHelper.show?(current_user)
     show_school_info_confirmation = SchoolInfoInterstitialHelper.show_confirmation_dialog?(current_user)
 
-    SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user) if show_school_info_interstitial || show_school_info_confirmation
     school_info = Queries::SchoolInfo.current_school(current_user)
     render json: {
       showSchoolInfoInterstitial: show_school_info_interstitial,
-      showSchoolInfoConfirmationDialog: show_school_info_confirmation,
+      showSchoolInfoConfirmation: show_school_info_confirmation,
       schoolInfo: school_info,
     }
+  end
+
+  def update_last_seen_school_info_interstitial
+    SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user)
+    render json: {success: true}
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -35,7 +35,6 @@ Dashboard::Application.routes.draw do
     resource :teacher_dashboard, only: [] do
       get :home, controller: :teacher_dashboard, action: :show
       get :get_school_info_interstitial_data, controller: :teacher_dashboard, action: :get_school_info_interstitial_data
-      get :update_last_seen_school_info_interstitial, controller: :teacher_dashboard, action: :update_last_seen_school_info_interstitial
       resources :sections, only: %i[show], param: :section_id, controller: :teacher_dashboard do
         member do
           get :parent_letter

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -35,6 +35,7 @@ Dashboard::Application.routes.draw do
     resource :teacher_dashboard, only: [] do
       get :home, controller: :teacher_dashboard, action: :show
       get :get_school_info_interstitial_data, controller: :teacher_dashboard, action: :get_school_info_interstitial_data
+      get :update_last_seen_school_info_interstitial, controller: :teacher_dashboard, action: :update_last_seen_school_info_interstitial
       resources :sections, only: %i[show], param: :section_id, controller: :teacher_dashboard do
         member do
           get :parent_letter


### PR DESCRIPTION
This update fixes a variable mismatch that caused the school info confirmation drawer to not display.

## Links
[TEACH-2095](https://codedotorg.atlassian.net/browse/TEACH-2095)
## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
