### PR TITLE
Revert "feat(marketing): refactor Overline component to use MUI and theme updates"

### DIFF
--- a/frontend/apps/marketing/src/components/common/constants/index.ts
+++ b/frontend/apps/marketing/src/components/common/constants/index.ts
@@ -6,11 +6,3 @@ export const externalLinkIconProps: FontAwesomeV6IconProps = {
   iconName: 'up-right-from-square',
   iconStyle: 'solid',
 };
-
-export const FONT_SIZE = {
-  xxs: '0.625rem', // 10px
-  xs: '0.75rem', // 12px
-  s: '0.875rem', // 14px
-  m: '1rem', // 16px
-  l: '1.25rem', // 20px
-};

--- a/frontend/apps/marketing/src/components/common/types/index.ts
+++ b/frontend/apps/marketing/src/components/common/types/index.ts
@@ -1,5 +1,3 @@
-export type ComponentSize = 'xs' | 's' | 'm' | 'l';
-
 export interface RemoveMarginBottomProps {
   /** Whether to remove the margin bottom */
   removeMarginBottom: boolean;

--- a/frontend/apps/marketing/src/components/contentful/collections/actionBlockCollection/ActionBlockCollection.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/actionBlockCollection/ActionBlockCollection.tsx
@@ -85,7 +85,7 @@ const ActionBlockCollection: React.FC<ActionBlockCollectionProps> = ({
 
   if (!blocks) {
     return (
-      <Typography variant="body2">
+      <Typography variant="body2" sx={{color: 'var(--text-neutral-primary)'}}>
         <em>
           <strong>📋 Action Block Collection placeholder.</strong> Please add a
           "List" content type entry in the Content sidebar.

--- a/frontend/apps/marketing/src/components/contentful/collections/logoCollection/LogoCollection.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/logoCollection/LogoCollection.tsx
@@ -58,7 +58,7 @@ const LogoCollection: React.FC<LogoCollectionProps> = ({
 }) => {
   if (!logos) {
     return (
-      <Typography variant="body2">
+      <Typography variant="body2" sx={{color: 'var(--text-neutral-primary)'}}>
         <em>
           <strong>📋 Logo Collection placeholder.</strong> Please add a "List"
           content type entry in the Content sidebar.

--- a/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/PeopleCollection.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/PeopleCollection.tsx
@@ -46,8 +46,13 @@ const styles = {
     borderRadius: '50%',
   },
   overline: {
+    // TODO: replace this w/ theme palette value
+    color: '#4C5661',
     marginTop: 1,
-    marginBottom: 1.25,
+    marginBottom: 1.5,
+  },
+  bio: {
+    textAlign: 'center',
   },
   personalLink: {
     display: 'inline-flex',
@@ -68,7 +73,7 @@ const PeopleCollection: React.FC<PeopleCollectionProps> = ({
 }) => {
   if (!people) {
     return (
-      <Typography variant="body2">
+      <Typography variant="body2" sx={{color: 'var(--text-neutral-primary)'}}>
         <em>
           <strong>📋 People Collection placeholder.</strong> Please add a "List"
           content type entry in the Content sidebar.
@@ -108,14 +113,13 @@ const PeopleCollection: React.FC<PeopleCollectionProps> = ({
               <Typography
                 variant="overline"
                 component="h4"
-                color="text.secondary"
                 sx={styles.overline}
               >
                 {title}
               </Typography>
             )}
             {bio && (
-              <Typography variant="body2" component="p" align="center">
+              <Typography variant="body2" component="p" sx={styles.bio}>
                 {bio}
               </Typography>
             )}
@@ -128,7 +132,7 @@ const PeopleCollection: React.FC<PeopleCollectionProps> = ({
                 sx={styles.personalLink}
               >
                 Visit personal page
-                <OpenInNew fontSize="small" color="secondary" />
+                <OpenInNew fontSize="small" color="primary" />
               </Link>
             )}
           </Box>

--- a/frontend/apps/marketing/src/components/contentful/overline/Overline.tsx
+++ b/frontend/apps/marketing/src/components/contentful/overline/Overline.tsx
@@ -1,32 +1,39 @@
-import Typography from '@mui/material/Typography';
+import classNames from 'classnames';
 import React, {ReactNode} from 'react';
 
-import {FONT_SIZE} from '@/components/common/constants';
+import {ComponentSizeXSToL} from '@code-dot-org/component-library/common/types';
 import {
-  ComponentSize,
-  RemoveMarginBottomProps,
-} from '@/components/common/types';
+  default as Typography,
+  VisualAppearance,
+} from '@code-dot-org/component-library/typography';
+
+import {RemoveMarginBottomProps} from '@/components/common/types';
+
+import moduleStyles from './overline.module.scss';
+
+type OverlineVisualAppearance = Extract<
+  VisualAppearance,
+  'overline-one' | 'overline-two' | 'overline-three'
+>;
 
 type OverlineProps = RemoveMarginBottomProps & {
   /** Overline content */
   children: ReactNode;
   /** Overline size */
-  size: Exclude<ComponentSize, 'xs'>;
+  size: Exclude<ComponentSizeXSToL, 'xs'>;
   /** Overline color */
   color: 'primary' | 'secondary';
   /** ClassName passed by Contentful to apply styles that are set through Contentful native editor*/
   className?: string;
 };
 
-// Define font sizes based on the existing Contentful Overline size values
-// that were set before using the MUI Typography component.
-//
-// The mapping below intentionally does not match the ComponentSize type one-to-one.
-// This is to provide clearer dropdown options in the Contentful editor.
-const overlineFontSizes: Record<Exclude<ComponentSize, 'xs'>, string> = {
-  s: FONT_SIZE.xxs,
-  m: FONT_SIZE.xs,
-  l: FONT_SIZE.s,
+const overlineSizeToVisualAppearance: Record<
+  Exclude<ComponentSizeXSToL, 'xs'>,
+  OverlineVisualAppearance
+> = {
+  s: 'overline-three',
+  m: 'overline-two',
+  l: 'overline-one',
 };
 
 const Overline: React.FunctionComponent<OverlineProps> = ({
@@ -38,12 +45,14 @@ const Overline: React.FunctionComponent<OverlineProps> = ({
 }) => {
   return (
     <Typography
-      className={className}
-      component="p"
-      variant="overline"
-      color={color === 'primary' ? 'primary.main' : 'text.secondary'}
-      fontSize={overlineFontSizes[size]}
-      gutterBottom={!removeMarginBottom}
+      className={classNames(
+        moduleStyles.overline,
+        moduleStyles[`overline-color-${color}`],
+        removeMarginBottom && moduleStyles['overline-removeMarginBottom'],
+        className,
+      )}
+      semanticTag="p"
+      visualAppearance={overlineSizeToVisualAppearance[size]}
     >
       {children}
     </Typography>

--- a/frontend/apps/marketing/src/components/contentful/overline/__tests__/Overline.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/overline/__tests__/Overline.test.tsx
@@ -1,11 +1,32 @@
 import {render, screen} from '@testing-library/react';
 
-import Overline from '../Overline';
+import Overline from '@/components/contentful/overline';
+
+type OverlineColorClassMap = [
+  'primary' | 'secondary',
+  `overline-color-${'primary' | 'secondary'}`,
+][];
+
+const colorClassMappings: OverlineColorClassMap = [
+  ['primary', 'overline-color-primary'],
+  ['secondary', 'overline-color-secondary'],
+];
+
+type OverlineSizeClassMap = [
+  's' | 'm' | 'l',
+  `overline-${'three' | 'two' | 'one'}`,
+][];
+
+const sizeClassMappings: OverlineSizeClassMap = [
+  ['s', 'overline-three'],
+  ['m', 'overline-two'],
+  ['l', 'overline-one'],
+];
 
 describe('Overline Component', () => {
   it('renders Overline with default props', () => {
     render(
-      <Overline size="m" color="primary" removeMarginBottom={false}>
+      <Overline size="m" color="primary">
         Test Overline
       </Overline>,
     );
@@ -16,14 +37,31 @@ describe('Overline Component', () => {
     expect(overlineElement.tagName.toLowerCase()).toBe('p'); // Ensures semanticTag="p"
   });
 
-  it('removes margin when removeMarginBottom is true', () => {
-    render(
-      <Overline size="m" color="primary" removeMarginBottom={true}>
-        Test Overline No Margin
-      </Overline>,
-    );
+  it.each(colorClassMappings)(
+    'applies the correct color class for color=%s',
+    (color, expectedClass) => {
+      render(
+        <Overline size="m" color={color}>
+          Test Overline
+        </Overline>,
+      );
 
-    const overlineElement = screen.getByText('Test Overline No Margin');
-    expect(window.getComputedStyle(overlineElement).marginBottom).toBe('0px');
-  });
+      const overlineElement = screen.getByText('Test Overline');
+      expect(overlineElement).toHaveClass(expectedClass);
+    },
+  );
+
+  it.each(sizeClassMappings)(
+    'sets correct visualAppearance for size=%s',
+    (size, expectedAppearance) => {
+      render(
+        <Overline size={size} color="primary">
+          Test Overline
+        </Overline>,
+      );
+
+      const overlineElement = screen.getByText('Test Overline');
+      expect(overlineElement.className.includes(expectedAppearance)).toBe(true);
+    },
+  );
 });

--- a/frontend/apps/marketing/src/components/contentful/overline/overline.module.scss
+++ b/frontend/apps/marketing/src/components/contentful/overline/overline.module.scss
@@ -1,0 +1,23 @@
+@use '@/components/common/styles/mixins' as mixins;
+
+// Overline common styles
+p {
+  &.overline {
+    margin-top: 0;
+  }
+
+  &.overline-removeMarginBottom {
+    @include mixins.common-margin-bottom-none;
+  }
+
+  // Overline colors
+  &.overline-color {
+    &-primary {
+      color: var(--text-brand-teal-primary);
+    }
+
+    &-secondary {
+      color: var(--text-neutral-quaternary);
+    }
+  }
+}

--- a/frontend/apps/marketing/src/themes/code.org/index.ts
+++ b/frontend/apps/marketing/src/themes/code.org/index.ts
@@ -10,49 +10,44 @@ const theme = createTheme({
   cssVariables: true,
   palette: {
     primary: {
-      main: '#0093A4', // Teal
-    },
-    secondary: {
-      main: '#8C52BA', // Purple
-    },
-    text: {
-      primary: '#292F36', // Dark Gray
+      main: '#000000',
     },
   },
   components: {
     MuiButton: {
       styleOverrides: {
-        root: ({theme}) => ({
+        root: {
           ['&.MuiButton-contained.MuiButton-colorPrimary']: {
-            backgroundColor: theme.palette.secondary.main,
+            backgroundColor: 'var(--brand-purple-50)',
           },
-        }),
+        },
       },
     },
     MuiLink: {
       styleOverrides: {
-        root: ({theme}) => ({
-          color: theme.palette.secondary.main,
+        root: {
+          color: 'var(--text-brand-purple-primary)',
           fontWeight: 500,
           textDecoration: 'underline',
           transition: 'color 0.2s ease-in-out',
           '&:hover': {
-            color: theme.palette.secondary.dark,
+            color: 'var(--text-brand-purple-secondary)',
             '& svg': {
-              color: theme.palette.secondary.dark,
+              color: 'var(--text-brand-purple-secondary)',
             },
           },
           ['& svg']: {
+            color: 'var(--text-brand-purple-primary)',
             transition: 'color 0.2s ease-in-out',
           },
-        }),
+        },
       },
     },
     MuiTypography: {
       styleOverrides: {
-        root: ({theme}) => ({
-          color: theme.palette.text.primary,
-        }),
+        root: {
+          color: 'var(--text-neutral-primary)',
+        },
         gutterBottom: {
           '&.MuiTypography-h1': {
             marginBottom: '1.5rem', // 24px
@@ -71,9 +66,6 @@ const theme = createTheme({
           },
           '&.MuiTypography-h6': {
             marginBottom: '0.5rem', // 8px
-          },
-          '&.MuiTypography-overline': {
-            marginBottom: '1rem', // 16px
           },
         },
       },
@@ -116,10 +108,8 @@ const theme = createTheme({
       lineHeight: 1.48,
     },
     overline: {
-      fontSize: '0.75rem', // 12px
-      fontWeight: 600,
       letterSpacing: '0.03rem', // 0.48px
-      lineHeight: 1.64,
+      lineHeight: 1.4,
     },
   },
 });


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#66991 — not working with Dark mode so caused a regression on the live site.