### PR TITLE
Refine project share filtering of user inputs / add Star Wars to filtered list

### DIFF
--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -203,4 +203,9 @@ export const OPEN_ENDED_LEGACY_PROJECT_TYPES = [
 
 export const OPEN_ENDED_LAB2_PROJECT_TYPES = ['pythonlab', 'weblab2'];
 
-export const OPEN_ENDED_PROJECTS_YOUNG_AGE = ['spritelab', 'poetry', 'playlab'];
+export const OPEN_ENDED_PROJECTS_YOUNG_AGE = [
+  'spritelab',
+  'poetry',
+  'playlab',
+  'starwarsblocks',
+];

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -39,7 +39,7 @@ module ShareFiltering
     PROFANITY = 'profanity'.freeze
   end
 
-  USER_ENTERED_TEXT_INDICATORS = ['COMMENT', 'SPEECH', 'TEXT', 'TITLE', 'title name\=\"VAL\"'].freeze
+  USER_ENTERED_TEXT_INDICATORS = ['AUTHOR', 'COMMENT',  'LINE', 'QUESTION', 'SPEECH', 'TEXT', 'TEXT1', 'TEXT2', 'TITLE', 'title name\=\"VAL\"'].freeze
   FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
 

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -39,8 +39,8 @@ module ShareFiltering
     PROFANITY = 'profanity'.freeze
   end
 
-  USER_ENTERED_TEXT_INDICATORS = ['TITLE', 'TEXT', 'title name\=\"VAL\"'].freeze
-  FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry'].freeze
+  USER_ENTERED_TEXT_INDICATORS = ['COMMENT', 'SPEECH', 'TEXT', 'TITLE', 'title name\=\"VAL\"'].freeze
+  FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
 
   # Searches for a sharing failure given a program and locale.
@@ -126,18 +126,14 @@ module ShareFiltering
   def self.traverse_block(block, texts)
     return unless block.is_a?(Hash)
 
-    type = block["type"]
     fields = block["fields"] || {}
     inputs = block["inputs"] || {}
 
-    if type == "gamelab_comment"
-      comment = clean_text_value(fields["COMMENT"])
-      texts << comment if comment && !comment.strip.empty?
-    end
-
-    fields.each_value do |value|
-      cleaned = clean_text_value(value)
-      texts << cleaned if cleaned && !cleaned.strip.empty?
+    fields.each do |key, value|
+      if USER_ENTERED_TEXT_INDICATORS.include?(key)
+        cleaned = clean_text_value(value)
+        texts << cleaned if cleaned && !cleaned.strip.empty?
+      end
     end
 
     inputs.each_value do |input|
@@ -154,11 +150,8 @@ module ShareFiltering
     return false unless Gatekeeper.allows('webpurify', default: true)
     return false unless FILTERED_PROJECT_TYPES.include?(project_type)
 
-    # For Playlab projects, only filter if program contains user-entered indicators.
-    if project_type == 'playlab'
-      return program.match?(/(?:#{USER_ENTERED_TEXT_INDICATORS.join('|')})/)
-    end
-    true
+    # Only filter if program contains user-entered indicators.
+    return program.match?(/(?:#{USER_ENTERED_TEXT_INDICATORS.join('|')})/)
   end
 
   # Searches for a sharing failure given a program name and locale.

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -39,7 +39,7 @@ module ShareFiltering
     PROFANITY = 'profanity'.freeze
   end
 
-  USER_ENTERED_TEXT_INDICATORS = ['AUTHOR', 'COMMENT',  'LINE', 'QUESTION', 'SPEECH', 'TEXT', 'TEXT1', 'TEXT2', 'TITLE', 'title name\=\"VAL\"'].freeze
+  USER_ENTERED_TEXT_INDICATORS = ['A', 'B', 'C', 'COMMENT', 'SPEECH', 'TEXT', 'TEXT1', 'TITLE', 'title name\=\"VAL\"'].freeze
   FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
 

--- a/lib/test/cdo/test_share_filtering.rb
+++ b/lib/test/cdo/test_share_filtering.rb
@@ -280,9 +280,11 @@ class ShareFilteringTest < Minitest::Test
 
   def test_should_filter_program_check_project_type
     Gatekeeper.stubs(:allows).with('webpurify', default: true).returns(true)
+    indicator = ShareFiltering::USER_ENTERED_TEXT_INDICATORS.first
+    program_with_indicator = "<xml><field name=\"FNAME\">#{indicator}</field></xml>"
     # 'gamelab' is not in FILTERED_PROJECT_TYPES
-    assert_equal false, ShareFiltering.should_filter_program('<xml/>', 'gamelab')
-    assert_equal true, ShareFiltering.should_filter_program('<xml/>', 'poetry')
+    assert_equal false, ShareFiltering.should_filter_program(program_with_indicator, 'gamelab')
+    assert_equal true, ShareFiltering.should_filter_program(program_with_indicator, 'poetry')
   end
 
   def test_should_filter_program_playlab_only_with_indicator


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR refines our [filtering for K-5 'open-ended' projects](https://github.com/code-dot-org/code-dot-org/pull/66614) by only including input fields with keys that indicate user-generated text (excluding dropdown options). We recently received a [Zendesk report](https://codeorg.zendesk.com/agent/tickets/544982) that a project was blocked from sharing due to the animation name 'grasshopper_1'. Thus, we are updating the filtering logic to only include user-generated text.

We currently [only filter Play Lab projects](https://github.com/code-dot-org/code-dot-org/blob/aa2969aa9dfe7edaf68c4785a814878a66eb5b90/lib/cdo/share_filtering.rb#L158-L160) if they include a field name in [`USER_ENTERED_TEXT_INDICATORS`](https://github.com/code-dot-org/code-dot-org/blob/aa2969aa9dfe7edaf68c4785a814878a66eb5b90/lib/cdo/share_filtering.rb#L42) . When I first implemented filtering of other Blockly project types, I was unsure which field names mapped to user-generated text. When curriculum writers create Blockly blocks, they also determine the field names.  So currently we filter all text that is considered user input including dropdown options.

Therefore, @mikeharv and I audited all blocks (https://levelbuilder-studio.code.org/pools) to collect the list of field names that indicate open text (strings) as opposed to dropdown options across all Blockly project types (this took a bit of digging and testing).

While going through all the blocks, we realized that Star Wars's `setScore` block uses a string parameter that is displayed at the top of the visualization when the program is run. Thus we're adding Star Wars Blockly to list of programs to filter.

Example:
<img width="644" height="460" alt="Screenshot 2025-07-11 at 8 46 04 AM" src="https://github.com/user-attachments/assets/1fe913e3-afc8-4cb1-8758-3a4d09a709a1" />

This update is based on the fact that any block field that supports open text has a field name included in the list above. Thus, we follow up and warn/prevent curriculum writers from making new free-text blocks that break this convention. [Thanks Mike!](https://github.com/code-dot-org/code-dot-org/pull/67012).

## Before update
Sprite Lab project being flagged for 'grasshopper_1':
<img width="1352" height="616" alt="before-grasshopper" src="https://github.com/user-attachments/assets/565c453f-bd6d-4b4e-982e-c28613ea1ee6" />

Star Wars project that contains profanity not being flagged:
<img width="854" height="534" alt="before-starwars" src="https://github.com/user-attachments/assets/e687452c-9c89-4b26-8432-cd0bc3058036" />


## After update
Sprite Lab project with 'grasshopper_1' animation no longer being blocked from sharing:
<img width="804" height="491" alt="after-grasshopper" src="https://github.com/user-attachments/assets/c8784fef-17bd-4b1a-932b-84a2ebf9642c" />

Star Wars project that contains profanity blocked from sharing:
<img width="1320" height="459" alt="after-starwars" src="https://github.com/user-attachments/assets/bfdd2f9b-9fb8-4b70-bab6-35e62482ad3d" />

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/SL-1324
- [Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1752158450612129)

## Testing story
Tested locally on different project types (Sprite Lab, Poetry Lab, Play Lab, and Star Wars (blockly). See before/after updates above.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
- [Remove createTextArrow_ overrides in Google Blockly](https://github.com/code-dot-org/code-dot-org/pull/67009)
- [Validate text field names when editing blocks in pools](https://codedotorg.atlassian.net/browse/SL-1326)

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
