### PR TITLE
feat(iam): loosen github environment oidc permission

### DIFF
--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -39,7 +39,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: code-dot-org/marketing
-  GITHUB_ENVIRONMENT_NAME: marketing-sites-${{ input.ENVIRONMENT_TYPE }}-${{ input.SITE_TYPE }}
+  GITHUB_ENVIRONMENT_NAME: marketing-sites-${{ inputs.ENVIRONMENT_TYPE }}-${{ inputs.SITE_TYPE }}
 
 concurrency:
   # Deployments are grouped by logical environment stages. For example, a push to staging will initiate deployment waves:

--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -8,8 +8,12 @@ name: Marketing-App-Deploy-To-Environment
 on:
   workflow_dispatch:
     inputs:
-      GITHUB_ENVIRONMENT_NAME:
-        description: "The name of the Github environment to deploy to."
+      ENVIRONMENT_TYPE:
+        description: "The type of environment to deploy to, e.g. 'test' or 'production'."
+        required: true
+        type: string
+      SITE_TYPE:
+        description: "The type of site to deploy, e.g. 'csforall' or 'corporate'."
         required: true
         type: string
       CONTAINER_IMAGE_DIGEST:
@@ -18,8 +22,12 @@ on:
         type: string
   workflow_call:
     inputs:
-      GITHUB_ENVIRONMENT_NAME:
-        description: "The name of the Github environment to deploy to."
+      ENVIRONMENT_TYPE:
+        description: "The type of environment to deploy to, e.g. 'test' or 'production'."
+        required: true
+        type: string
+      SITE_TYPE:
+        description: "The type of site to deploy, e.g. 'csforall' or 'corporate'."
         required: true
         type: string
       CONTAINER_IMAGE_DIGEST:
@@ -31,6 +39,13 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: code-dot-org/marketing
+  GITHUB_ENVIRONMENT_NAME: marketing-sites-${{ matrix.ENVIRONMENT_TYPE }}-${{ matrix.SITE_TYPE }}
+
+concurrency:
+  # Deployments are grouped by logical environment stages. For example, a push to staging will initiate deployment waves:
+  # 1. Deploy to "test" CSForAll & Corporate Website concurrently
+  # 2. Deploy to "production" CSForAll & Corporate Website concurrently (only when all 'test' deployments are successful)
+  group: ${{ inputs.ENVIRONMENT_TYPE }}
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
@@ -40,7 +55,7 @@ jobs:
   # See: https://docs.github.com/en/actions/use-cases-and-examples/deploying/deploying-to-amazon-elastic-container-service
   deploy:
     runs-on: ubuntu-24.04
-    environment: ${{ inputs.GITHUB_ENVIRONMENT_NAME }}
+    environment: ${{ env.GITHUB_ENVIRONMENT_NAME }}
 
     permissions:
       # Allows Github to retrieve AWS credentials via OIDC
@@ -64,7 +79,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_DEPLOYER_IAM_ROLE_ARN }}
-          role-session-name: GithubActions-${{ inputs.GITHUB_ENVIRONMENT_NAME }}
+          role-session-name: GithubActions-${{ env.GITHUB_ENVIRONMENT_NAME }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: "Download Built Docker Image"
@@ -76,7 +91,7 @@ jobs:
         run: |
           docker cp temp:/app/apps/marketing/.next/static/ ./static
 
-      - name: "[${{ inputs.GITHUB_ENVIRONMENT_NAME }}] Upload Static Assets to S3"
+      - name: "[${{ env.GITHUB_ENVIRONMENT_NAME }}] Upload Static Assets to S3"
         env:
           BASE_DOMAIN: ${{ vars.APPLICATION_BASE_DOMAIN }}
           SUBDOMAIN_NAME: ${{ vars.APPLICATION_SUBDOMAIN_NAME }}
@@ -87,7 +102,7 @@ jobs:
 
           aws s3 sync static/ "s3://$BUCKET_NAME/_next/static" --quiet
 
-      - name: "[${{ inputs.GITHUB_ENVIRONMENT_NAME }}] Deploy Marketing App to AWS"
+      - name: "[${{ env.GITHUB_ENVIRONMENT_NAME }}] Deploy Marketing App to AWS"
         working-directory: ./frontend/apps/marketing/cicd/3-app
         run: |
           bundle exec ruby deploy.rb --environment_type ${{ vars.ENVIRONMENT_TYPE }} \
@@ -100,7 +115,7 @@ jobs:
             --web_application_server_secrets_arn ${{ secrets.APPLICATION_SERVER_SECRETS_ARN }} \
             --cloudformation_role_boundary ${{ secrets.CLOUDFORMATION_ROLE_BOUNDARY_ARN }}
 
-      - name: "[${{ inputs.GITHUB_ENVIRONMENT_NAME }}] Invalidate CloudFront Cache"
+      - name: "[${{ env.GITHUB_ENVIRONMENT_NAME }}] Invalidate CloudFront Cache"
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           STACK_NAME: "${{ vars.APPLICATION_SUBDOMAIN_NAME }}-${{ vars.APPLICATION_BASE_DOMAIN }}"
@@ -116,7 +131,8 @@ jobs:
 
   tests:
     runs-on: ubuntu-24.04
-    environment: ${{ inputs.GITHUB_ENVIRONMENT_NAME }}
+    environment: ${{ env.GITHUB_ENVIRONMENT_NAME }}
+    if: ${{ inputs.SITE_TYPE == 'corporate' }}
     needs:
       - deploy
 
@@ -143,4 +159,4 @@ jobs:
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY}}
           APPLICATION_BASE_ADDRESS: "${{ vars.APPLICATION_SUBDOMAIN_NAME }}.${{ vars.APPLICATION_BASE_DOMAIN }}"
           DRAFT_MODE_TOKEN: ${{ secrets.DRAFT_MODE_TOKEN }}
-          GITHUB_ENVIRONMENT_NAME: ${{ inputs.GITHUB_ENVIRONMENT_NAME }}
+          GITHUB_ENVIRONMENT_NAME: ${{ env.GITHUB_ENVIRONMENT_NAME }}

--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -55,7 +55,7 @@ jobs:
   # See: https://docs.github.com/en/actions/use-cases-and-examples/deploying/deploying-to-amazon-elastic-container-service
   deploy:
     runs-on: ubuntu-24.04
-    environment: ${{ env.GITHUB_ENVIRONMENT_NAME }}
+    environment: marketing-sites-${{ inputs.ENVIRONMENT_TYPE }}-${{ inputs.SITE_TYPE }}
 
     permissions:
       # Allows Github to retrieve AWS credentials via OIDC

--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -39,7 +39,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: code-dot-org/marketing
-  GITHUB_ENVIRONMENT_NAME: marketing-sites-${{ matrix.ENVIRONMENT_TYPE }}-${{ matrix.SITE_TYPE }}
+  GITHUB_ENVIRONMENT_NAME: marketing-sites-${{ input.ENVIRONMENT_TYPE }}-${{ input.SITE_TYPE }}
 
 concurrency:
   # Deployments are grouped by logical environment stages. For example, a push to staging will initiate deployment waves:

--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -131,7 +131,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-24.04
-    environment: ${{ env.GITHUB_ENVIRONMENT_NAME }}
+    environment: marketing-sites-${{ inputs.ENVIRONMENT_TYPE }}-${{ inputs.SITE_TYPE }}
     if: ${{ inputs.SITE_TYPE == 'corporate' }}
     needs:
       - deploy

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -119,7 +119,6 @@ jobs:
       CONTAINER_IMAGE_DIGEST: ${{ needs.build-and-push-image.outputs.digest }}
     strategy:
       fail-fast: true
-      max-parallel: 1
       matrix:
         SITE_TYPE: [ corporate ]
         ENVIRONMENT_TYPE: [ test, production ]

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -22,7 +22,7 @@ env:
 concurrency:
   # For pushes to staging, requests are grouped into the "deploy-marketing" concurrency group to queue them up
   # For pull requests, there are no limits to concurrency
-  group: ${{ github.event_name == 'push' && 'deploy-marketing' || github.run_id }}
+  group: ${{ github.run_id }}
   # For pushes to staging, multiple pushes are queued
   # For pull requests, multiple pushes to the same PR cancels previous executions
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -114,10 +114,12 @@ jobs:
     uses: ./.github/workflows/marketing-app-deploy-to-environment.yml
     secrets: inherit
     with:
-      GITHUB_ENVIRONMENT_NAME: ${{ matrix.GITHUB_ENVIRONMENT_NAME }}
+      ENVIRONMENT_TYPE: ${{ matrix.ENVIRONMENT_TYPE }}
+      SITE_TYPE: ${{ matrix.SITE_TYPE }}
       CONTAINER_IMAGE_DIGEST: ${{ needs.build-and-push-image.outputs.digest }}
     strategy:
       fail-fast: true
       max-parallel: 1
       matrix:
-        GITHUB_ENVIRONMENT_NAME: [ marketing-sites-test-corporate, marketing-sites-production-corporate ]
+        SITE_TYPE: [ corporate ]
+        ENVIRONMENT_TYPE: [ test, production ]

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -120,4 +120,4 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        GITHUB_ENVIRONMENT_NAME: [ marketing-sites-test, marketing-sites-production ]
+        GITHUB_ENVIRONMENT_NAME: [ marketing-sites-test-code, marketing-sites-production-code ]

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -120,4 +120,4 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        GITHUB_ENVIRONMENT_NAME: [ marketing-sites-test-code, marketing-sites-production-code ]
+        GITHUB_ENVIRONMENT_NAME: [ marketing-sites-test-corporate, marketing-sites-production-corporate ]

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -105,20 +105,30 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
-  # Job: deploy
-  # This job pulls the task definition for the current task running in the cluster and updates the docker image tag with the one built in the previous job
-  # Then, the task definition is deployed to the ECS service
-  # See: https://docs.github.com/en/actions/use-cases-and-examples/deploying/deploying-to-amazon-elastic-container-service
-  deploy:
+  # Deploy test environments in parallel
+  deploy-test:
     needs: build-and-push-image
     uses: ./.github/workflows/marketing-app-deploy-to-environment.yml
     secrets: inherit
     with:
-      ENVIRONMENT_TYPE: ${{ matrix.ENVIRONMENT_TYPE }}
-      SITE_TYPE: ${{ matrix.SITE_TYPE }}
       CONTAINER_IMAGE_DIGEST: ${{ needs.build-and-push-image.outputs.digest }}
+      ENVIRONMENT_TYPE: test
+      SITE_TYPE: ${{ matrix.SITE_TYPE }}
     strategy:
       fail-fast: true
       matrix:
         SITE_TYPE: [ corporate, csforall ]
-        ENVIRONMENT_TYPE: [ test, production ]
+
+  # Deploy production environments in parallel, after test environments completes successfully
+  deploy-production:
+    needs: deploy-test
+    uses: ./.github/workflows/marketing-app-deploy-to-environment.yml
+    secrets: inherit
+    with:
+      CONTAINER_IMAGE_DIGEST: ${{ needs.build-and-push-image.outputs.digest }}
+      ENVIRONMENT_TYPE: production
+      SITE_TYPE: ${{ matrix.SITE_TYPE }}
+    strategy:
+      fail-fast: true
+      matrix:
+        SITE_TYPE: [ corporate, csforall ]

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -120,5 +120,5 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        SITE_TYPE: [ corporate ]
+        SITE_TYPE: [ corporate, csforall ]
         ENVIRONMENT_TYPE: [ test, production ]

--- a/frontend/apps/marketing/cicd/1-setup/account-resources.yml.erb
+++ b/frontend/apps/marketing/cicd/1-setup/account-resources.yml.erb
@@ -277,7 +277,8 @@ Resources:
               StringEquals:
                 # See: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#configuring-the-role-and-trust-policy
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
-                token.actions.githubusercontent.com:sub: 'repo:code-dot-org/code-dot-org:environment:marketing-sites-<%=environment_type%>'
+              StringLike:
+                token.actions.githubusercontent.com:sub: 'repo:code-dot-org/code-dot-org:environment:marketing-sites-<%=environment_type%>-*'
       Policies:
         - PolicyName: github-actions-cloudformation-policy
           PolicyDocument:

--- a/frontend/apps/marketing/cicd/README.md
+++ b/frontend/apps/marketing/cicd/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. Execute `1-setup/deploy.rb` to create Global resources (`per-account.yml.erb` and `per-region.yml.erb`) that support all Marketing Sites deployed to the current AWS Account and Region. This defaults to setting up Region resources in `us-east-1`. Use `setup.rb --region [region id]` to prepare a different Region to support Marketing Sites.
+1. Execute `1-setup/deploy.rb` (as AWS admin) to create Global resources (`per-account.yml.erb` and `per-region.yml.erb`) that support all Marketing Sites deployed to the current AWS Account and Region. This defaults to setting up Region resources in `us-east-1`. Use `setup.rb --region [region id]` to prepare a different Region to support Marketing Sites.
 1. Create an AWS Secrets Manager Secret in the same Account and Region where the marketing site Stack will be provisioned and with the naming convention `marketing-sites/[environment type]/[base domain name of the marketing site]/[subdomain of the site]` and populate it with the following keys
    - CONTENTFUL_DELIVERY_TOKEN
    - CONTENTFUL_PREVIEW_TOKEN


### PR DESCRIPTION
Allows all marketing site github environments in the same environment type to be deployed by the OIDC deployer.

For example, in the `test` environment, the following environments can be deployed by the `test` role:

- marketing-sites-test-code
- marketing-sites-test-csforall