### PR TITLE
AI Chat: remove model card updated notification

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -11,7 +11,7 @@ import {chatHistoryValidator} from './api/validators';
 import {
   AiCustomizations,
   AichatContext,
-  AichatModelCustomizations,
+  ModelParameters,
   ChatEvent,
   DetectToxicityResponse,
   FeedbackValue,
@@ -51,22 +51,15 @@ interface UserHasAichatAccessResponse {
 export async function postAichatCompletionMessage(
   newMessage: PendingChatMessage,
   storedMessages: CompletedChatMessage[],
-  aiCustomizations: AiCustomizations,
+  modelParameters: ModelParameters,
   aichatContext: AichatContext,
   // Configurable for testing.
   maxPollingTimeMs = MAX_POLLING_TIME_MS
 ): Promise<CompletedChatMessage[]> {
-  const aichatModelCustomizations: AichatModelCustomizations = {
-    selectedModelId: aiCustomizations.selectedModelId,
-    temperature: aiCustomizations.temperature,
-    retrievalContexts: aiCustomizations.retrievalContexts,
-    systemPrompt: aiCustomizations.systemPrompt,
-  };
-
   return postChatCompletionAsyncPolling(
     newMessage,
     storedMessages,
-    aichatModelCustomizations,
+    modelParameters,
     aichatContext,
     maxPollingTimeMs
   );
@@ -182,14 +175,14 @@ export interface GetChatRequestResponse {
 async function postChatCompletionAsyncPolling(
   newMessage: PendingChatMessage,
   storedMessages: CompletedChatMessage[],
-  aichatModelCustomizations: AichatModelCustomizations,
+  modelParameters: ModelParameters,
   aichatContext: AichatContext,
   maxPollingTimeMs = MAX_POLLING_TIME_MS
 ): Promise<CompletedChatMessage[]> {
   const payload = {
     newMessage,
     storedMessages,
-    aichatModelCustomizations,
+    modelParameters,
     aichatContext,
   };
 

--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -182,7 +182,7 @@ async function postChatCompletionAsyncPolling(
   const payload = {
     newMessage,
     storedMessages,
-    modelParameters,
+    aichatModelCustomizations: modelParameters,
     aichatContext,
   };
 

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -272,6 +272,7 @@ const aichatSlice = createSlice({
         [property]: value,
       };
       state.currentAiCustomizations.modelCardInfo = updatedModelCardInfo;
+      state.showResetMessage = false;
     },
     startSave(state, action: PayloadAction<SaveType>) {
       state.saveInProgress = true;

--- a/apps/src/aichat/redux/thunks/helpers/saveAiCustomization.ts
+++ b/apps/src/aichat/redux/thunks/helpers/saveAiCustomization.ts
@@ -10,7 +10,7 @@ import {AI_CUSTOMIZATIONS_LABELS} from '@cdo/apps/aichat/views/modelCustomizatio
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 
-import {setModelCardProperty, startSave} from '../../slice';
+import {startSave} from '../../slice';
 
 import {dispatchSaveFailNotification} from './dispatchSaveFailNotification';
 import {handleToxicityRequestError} from './handleToxicityRequestError';
@@ -23,26 +23,6 @@ export const saveAiCustomization = async (
   dispatch: AppDispatch,
   levelId: number | null
 ) => {
-  // Remove any empty example topics on save
-  const trimmedExampleTopics =
-    currentAiCustomizations.modelCardInfo.exampleTopics.filter(
-      topic => topic.length
-    );
-  dispatch(
-    setModelCardProperty({
-      property: 'exampleTopics',
-      value: trimmedExampleTopics,
-    })
-  );
-
-  const trimmedCurrentAiCustomizations = {
-    ...currentAiCustomizations,
-    modelCardInfo: {
-      ...currentAiCustomizations.modelCardInfo,
-      exampleTopics: trimmedExampleTopics,
-    },
-  };
-
   // Notify the UI that a save is in progress.
   dispatch(startSave(saveType));
   Lab2Registry.getInstance()
@@ -53,7 +33,7 @@ export const saveAiCustomization = async (
   let toxicity: DetectToxicityResponse;
   try {
     toxicity = await detectToxicityInCustomizations(
-      trimmedCurrentAiCustomizations,
+      currentAiCustomizations,
       levelId
     );
   } catch (error) {
@@ -70,7 +50,7 @@ export const saveAiCustomization = async (
         message: 'Toxicity detected in AI customizations',
         flaggedFields: toxicity.flaggedFields,
         customizations: extractFieldsToCheckForToxicity(
-          trimmedCurrentAiCustomizations
+          currentAiCustomizations
         ),
       });
     Lab2Registry.getInstance()
@@ -87,7 +67,7 @@ export const saveAiCustomization = async (
 
   await Lab2Registry.getInstance()
     .getProjectManager()
-    ?.save({source: JSON.stringify(trimmedCurrentAiCustomizations)}, true);
+    ?.save({source: JSON.stringify(currentAiCustomizations)}, true);
 };
 
 const getToxicityErrorMessage = (flaggedFields: FlaggedField[]) => {

--- a/apps/src/aichat/redux/thunks/onSaveComplete.ts
+++ b/apps/src/aichat/redux/thunks/onSaveComplete.ts
@@ -7,7 +7,7 @@ import {
   saveTypeToAnalyticsEvent,
   RESET_CONVERSATION_CUSTOMIZATION_UPDATES,
 } from '../../constants';
-import {AiCustomizations, ViewMode} from '../../types';
+import {ViewMode} from '../../types';
 import {
   endSave,
   setNewChatSession,
@@ -39,22 +39,24 @@ export const onSaveComplete =
     }
 
     changedProperties.forEach(property => {
-      const typedProperty = property as keyof AiCustomizations;
-      const modelUpdate = {
-        removeId: getNewRemoveId(),
-        updatedField: typedProperty,
-        updatedValue: currentAiCustomizations[typedProperty],
-        timestamp: Date.now(),
-      };
-      dispatch(addChatEvent(modelUpdate));
+      if (property !== 'modelCardInfo') {
+        dispatch(
+          addChatEvent({
+            removeId: getNewRemoveId(),
+            updatedField: property,
+            updatedValue: currentAiCustomizations[property],
+            timestamp: Date.now(),
+          })
+        );
+      }
 
       // Report to analytics the changed value for only selected model id and temperature properties.
       // Do not include the free text changes (system prompt and retrieval contexts).
       const propertiesChangedValueToReport = ['selectedModelId', 'temperature'];
       const propertyChangedTo = propertiesChangedValueToReport.includes(
-        typedProperty
+        property
       )
-        ? currentAiCustomizations[typedProperty]
+        ? currentAiCustomizations[property]
         : 'NULL';
       if (currentSaveType) {
         dispatch(

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -78,7 +78,12 @@ export const submitChatContents = createAsyncThunk(
       messages = await postAichatCompletionMessage(
         newUserMessage,
         chatEventsCurrent.filter(isCompletedChatMessage),
-        aiCustomizations,
+        {
+          selectedModelId: aiCustomizations.selectedModelId,
+          systemPrompt: aiCustomizations.systemPrompt,
+          retrievalContexts: aiCustomizations.retrievalContexts,
+          temperature: aiCustomizations.temperature,
+        },
         aichatContext
       );
 

--- a/apps/src/aichat/redux/utils.ts
+++ b/apps/src/aichat/redux/utils.ts
@@ -46,19 +46,11 @@ export const findChangedProperties = (
   previous: AiCustomizations | undefined,
   next: AiCustomizations
 ) => {
+  const allKeys = getTypedKeys(next);
   if (!previous) {
-    return Object.keys(next);
+    return allKeys;
   }
-
-  const changedProperties: string[] = [];
-  Object.keys(next).forEach(key => {
-    const typedKey = key as keyof AiCustomizations;
-    if (haveDifferentValues(previous[typedKey], next[typedKey])) {
-      changedProperties.push(key);
-    }
-  });
-
-  return changedProperties;
+  return allKeys.filter(key => haveDifferentValues(previous[key], next[key]));
 };
 
 // Used to decide whether to unpublish a project based on whether

--- a/apps/src/aichat/types/chatEvents.ts
+++ b/apps/src/aichat/types/chatEvents.ts
@@ -3,7 +3,7 @@ import {ValueOf} from '@cdo/apps/types/utils';
 import {AiInteractionStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import {ChatAsset} from './assets';
-import {AiCustomizations} from './customizations';
+import {ModelParameters} from './customizations';
 import {FeedbackValue} from './toxicity';
 
 export type ChatEventDescriptionKey = 'CLEAR_CHAT' | 'LOAD_LEVEL';
@@ -63,8 +63,8 @@ export interface UserActionEvent extends BaseChatEvent {
 export interface ModelUpdate extends BaseChatEvent {
   /** ID used for removing from this event from the student's chat workspace. */
   removeId: number;
-  updatedField: keyof AiCustomizations;
-  updatedValue: AiCustomizations[keyof AiCustomizations];
+  updatedField: keyof ModelParameters;
+  updatedValue: ModelParameters[keyof ModelParameters];
 }
 
 /** Any other general type of notification in the chat workspace. */

--- a/apps/src/aichat/types/customizations.ts
+++ b/apps/src/aichat/types/customizations.ts
@@ -2,19 +2,23 @@ import {ValueOf} from '@cdo/apps/types/utils';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 import modelsJson from '@cdo/static/aichat/modelDescriptions.json';
 
-/** Model customizations and model card information for aichat levels.
- *  selectedModelId is a foreign key to ModelDescription.id */
-export interface AiCustomizations {
+/**
+ * Model parameters provided to the LLM chat endpoint.
+ */
+export interface ModelParameters {
   selectedModelId: ValueOf<typeof AiChatModelIds>;
   temperature: number;
   systemPrompt: string;
   retrievalContexts: string[];
-  modelCardInfo: ModelCardInfo;
 }
 
-// Model customizations sent to backend for aichat levels - excludes modelCardInfo.
-// The customizations will be included in request to LLM endpoint.
-export type AichatModelCustomizations = Omit<AiCustomizations, 'modelCardInfo'>;
+/**
+ * Model customizations a student can make on an AI Chat Lab level.
+ * These include model parameters and model card information.
+ */
+export interface AiCustomizations extends ModelParameters {
+  modelCardInfo: ModelCardInfo;
+}
 
 export type FieldVisibilities = {[key in keyof AiCustomizations]: Visibility};
 

--- a/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
+++ b/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
@@ -26,7 +26,7 @@ const ExampleTopicsInputs: React.FunctionComponent<{
       dispatch(
         setModelCardProperty({
           property: 'exampleTopics',
-          value: updatedItems,
+          value: updatedItems.filter(topic => topic.trim().length > 0), // Remove empty topics
         })
       );
     },

--- a/apps/src/aichat/views/modelCustomization/MultiInputCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/MultiInputCustomization.tsx
@@ -74,7 +74,7 @@ const MultiInputCustomization: React.FunctionComponent<{
               size="s"
               onClick={onAdd}
               iconLeft={{iconName: 'plus'}}
-              disabled={!newItem || isReadOnly}
+              disabled={!newItem.trim() || isReadOnly}
             />
           </div>
         </>

--- a/apps/src/aichat/views/modelCustomization/SaveChangesAlerts.tsx
+++ b/apps/src/aichat/views/modelCustomization/SaveChangesAlerts.tsx
@@ -78,7 +78,12 @@ const SaveChangesAlerts: React.FunctionComponent<{isReadOnly: boolean}> = ({
   return !isReadOnly ? (
     <div className={styles.saveAlertContainer}>
       {alert && !saveInProgress && (
-        <Alert {...alert} size="s" className={styles.saveAlert} />
+        <Alert
+          id="uitest-aichat-save-alert"
+          {...alert}
+          size="s"
+          className={styles.saveAlert}
+        />
       )}
     </div>
   ) : null;

--- a/apps/test/unit/aichat/aichatApiTest.ts
+++ b/apps/test/unit/aichat/aichatApiTest.ts
@@ -5,11 +5,9 @@ import {
 import {
   AichatContext,
   ModelParameters,
-  AiCustomizations,
   CompletedChatMessage,
   PendingChatMessage,
 } from '@cdo/apps/aichat/types';
-import {EMPTY_MODEL_CARD_INFO} from '@cdo/apps/aichat/views/modelCustomization/constants';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {
@@ -25,8 +23,7 @@ import {
 describe('aichatApi', () => {
   let chatMessage: PendingChatMessage,
     storedMessages: CompletedChatMessage[],
-    aiCustomizations: AiCustomizations,
-    aichatModelCustomizations: ModelParameters,
+    modelParameters: ModelParameters,
     aichatContext: AichatContext,
     post: jest.MockedFunction<typeof HttpClient.post>,
     fetchJson: jest.MockedFunction<typeof HttpClient.fetchJson>;
@@ -54,19 +51,12 @@ describe('aichatApi', () => {
         requestId: 1,
       },
     ];
-    aiCustomizations = {
+
+    modelParameters = {
       selectedModelId: AiChatModelIds.ARITHMO,
       temperature: 0.5,
       retrievalContexts: ['123'],
       systemPrompt: 'hello',
-      modelCardInfo: EMPTY_MODEL_CARD_INFO,
-    };
-
-    aichatModelCustomizations = {
-      selectedModelId: aiCustomizations.selectedModelId,
-      temperature: aiCustomizations.temperature,
-      retrievalContexts: aiCustomizations.retrievalContexts,
-      systemPrompt: aiCustomizations.systemPrompt,
     };
 
     aichatContext = {
@@ -120,7 +110,7 @@ describe('aichatApi', () => {
       return await postAichatCompletionMessage(
         chatMessage,
         storedMessages,
-        aiCustomizations,
+        modelParameters,
         aichatContext,
         maxPollingTime
       );
@@ -151,7 +141,7 @@ describe('aichatApi', () => {
         JSON.stringify({
           newMessage: chatMessage,
           storedMessages,
-          aichatModelCustomizations,
+          aichatModelCustomizations: modelParameters,
           aichatContext,
         })
       );

--- a/apps/test/unit/aichat/aichatApiTest.ts
+++ b/apps/test/unit/aichat/aichatApiTest.ts
@@ -4,7 +4,7 @@ import {
 } from '@cdo/apps/aichat/aichatApi';
 import {
   AichatContext,
-  AichatModelCustomizations,
+  ModelParameters,
   AiCustomizations,
   CompletedChatMessage,
   PendingChatMessage,
@@ -26,7 +26,7 @@ describe('aichatApi', () => {
   let chatMessage: PendingChatMessage,
     storedMessages: CompletedChatMessage[],
     aiCustomizations: AiCustomizations,
-    aichatModelCustomizations: AichatModelCustomizations,
+    aichatModelCustomizations: ModelParameters,
     aichatContext: AichatContext,
     post: jest.MockedFunction<typeof HttpClient.post>,
     fetchJson: jest.MockedFunction<typeof HttpClient.fetchJson>;

--- a/dashboard/test/ui/features/star_labs/aichat/chat.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/chat.feature
@@ -49,7 +49,7 @@ Feature: Model customizations and interactions in AI Chat Lab
     And I click selector "#uitest-add-example-topic"
     And I wait until element "#uitest-publish-notes-save" is enabled
     And I click selector "#uitest-publish-notes-save"
-    Then I wait until element ".uitest-aichat-chat-alert" contains text "Model card information has been updated"
+    Then I wait until element "#uitest-aichat-save-alert" contains text "Saved"
 
     Given element "#uitest-view-mode-toggle-container" is not visible
     And element "#uitest-presentation-view-container" is not visible


### PR DESCRIPTION
Follow-up to: https://github.com/code-dot-org/code-dot-org/pull/66949. In the same vein, this removes the "Model card updated" notification from the chat window since it technically only pertains to the model customization workspace, and not the chat parameters themselves. Architecturally speaking, this breaks the dependency of the `ModelUpdate` notification event on `AiCustomizations`, which is an AI Chat Lab-specific construct, so that model updates can be purely concerned with updates that affect the LLM. Later on when the chat workspace is broken out, this will be helpful since the chat workspace won't be able to know what a "model card update" means or when to display it.

This also cleans up some behavior related to displaying the reset message under the Save/Publish buttons for the model card information (related to the extra dispatch we were doing when trimming empty "Example Topics" - we instead now filter before saving and try to prevent empty topics from being added in the first place).

Discussed on Slack here: https://codedotorg.slack.com/archives/C06FELVTV0Q/p1752170743723769?thread_ts=1751919606.568549&cid=C06FELVTV0Q

After (no notification in workspace):
<img width="1512" height="823" alt="Screenshot 2025-07-10 at 11 02 51 AM" src="https://github.com/user-attachments/assets/a19b6b1b-cf32-4a17-9fec-8bc68f16f56a" /> 

## Testing story

Tested locally.