### PR TITLE
fix(heroBanner): use gray alert type for announcement banner

### DIFF
--- a/frontend/packages/component-library-styles/colors.scss
+++ b/frontend/packages/component-library-styles/colors.scss
@@ -95,8 +95,8 @@
   --borders-warning-light: var(--sentiment-warning-10);
   --borders-warning-primary: var(--sentiment-warning-50);
   --borders-warning-strong: var(--sentiment-warning-70);
-  --text-brand-aqua-primary: var(--brand-aqua-50);
-  --text-brand-aqua-primary-fixed: var(--brand-aqua-50);
+  --text-brand-aqua-primary: var(--brand-aqua-60);
+  --text-brand-aqua-primary-fixed: var(--brand-aqua-60);
   --text-brand-aqua-secondary: var(--brand-aqua-70);
   --text-brand-purple-primary: var(--brand-purple-50);
   --text-brand-purple-primary-fixed: var(--brand-purple-50);
@@ -208,7 +208,7 @@
   --text-brand-aqua-primary-fixed: var(--brand-aqua-50);
   --text-brand-aqua-secondary: var(--text-neutral-primary);
   --text-brand-purple-primary: var(--text-neutral-primary);
-  --text-brand-purple-primary-fixed: var(--brand-purple-50);
+  --text-brand-purple-primary-fixed: var(--brand-purple-40);
   --text-brand-purple-secondary: var(--text-neutral-tertiary);
   --text-brand-teal-primary: var(--text-neutral-primary);
   --text-brand-teal-primary-fixed: var(--brand-teal-50);

--- a/frontend/packages/component-library/src/alert/Alert.tsx
+++ b/frontend/packages/component-library/src/alert/Alert.tsx
@@ -8,7 +8,7 @@ import Link, {LinkProps} from '@/link';
 
 import moduleStyles from './alert.module.scss';
 
-type AlertType = 'primary' | 'success' | 'danger' | 'warning' | 'info' | 'gray';
+type AlertType = 'primary' | 'success' | 'danger' | 'warning' | 'info' | 'gray' | 'aqua';
 
 export const alertTypes: {[key in AlertType]: AlertType} = {
   primary: 'primary',
@@ -17,6 +17,7 @@ export const alertTypes: {[key in AlertType]: AlertType} = {
   warning: 'warning',
   info: 'info',
   gray: 'gray',
+  aqua: 'aqua',
 };
 
 export interface AlertProps extends HTMLAttributes<HTMLDivElement> {

--- a/frontend/packages/component-library/src/alert/Alert.tsx
+++ b/frontend/packages/component-library/src/alert/Alert.tsx
@@ -8,7 +8,14 @@ import Link, {LinkProps} from '@/link';
 
 import moduleStyles from './alert.module.scss';
 
-type AlertType = 'primary' | 'success' | 'danger' | 'warning' | 'info' | 'gray' | 'aqua';
+type AlertType =
+  | 'primary'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'gray'
+  | 'aqua';
 
 export const alertTypes: {[key in AlertType]: AlertType} = {
   primary: 'primary',

--- a/frontend/packages/component-library/src/alert/alert.module.scss
+++ b/frontend/packages/component-library/src/alert/alert.module.scss
@@ -27,6 +27,10 @@ $alert-span-vertical-top-spacing: 2px;
 // Types (colors)
 .alert-primary {
   background-color: var(--background-brand-purple-light);
+
+  .alertContentContainer i {
+    color: var(--text-brand-purple-primary-fixed);
+  }
 }
 
 .alert-success {

--- a/frontend/packages/component-library/src/alert/alert.module.scss
+++ b/frontend/packages/component-library/src/alert/alert.module.scss
@@ -37,7 +37,7 @@ $alert-span-vertical-top-spacing: 2px;
   background-color: var(--background-success-extra-light);
 
   .alertContentContainer i {
-    color: var(--text-success-primary);
+    color: var(--text-success-primary-fixed);
   }
 }
 
@@ -45,7 +45,7 @@ $alert-span-vertical-top-spacing: 2px;
   background-color: var(--background-error-extra-light);
 
   .alertContentContainer i {
-    color: var(--text-error-primary);
+    color: var(--text-error-primary-fixed);
   }
 }
 
@@ -53,7 +53,7 @@ $alert-span-vertical-top-spacing: 2px;
   background-color: var(--background-warning-extra-light);
 
   .alertContentContainer i {
-    color: var(--text-warning-primary);
+    color: var(--text-warning-primary-fixed);
   }
 }
 
@@ -61,7 +61,7 @@ $alert-span-vertical-top-spacing: 2px;
   background-color: var(--background-info-extra-light);
 
   .alertContentContainer i {
-    color: var(--text-info-primary);
+    color: var(--text-info-primary-fixed);
   }
 }
 

--- a/frontend/packages/component-library/src/alert/alert.module.scss
+++ b/frontend/packages/component-library/src/alert/alert.module.scss
@@ -65,6 +65,14 @@ $alert-span-vertical-top-spacing: 2px;
   background-color: var(--background-neutral-tertiary);
 }
 
+.alert-aqua {
+  background-color: var(--background-brand-aqua-extra-light);
+
+  .alertContentContainer i {
+    color: var(--text-brand-aqua-primary-fixed);
+  }
+}
+
 // Sizes
 .alert-l {
   padding: 0.875rem 1.125rem;

--- a/frontend/packages/component-library/src/alert/stories/Alert.story.tsx
+++ b/frontend/packages/component-library/src/alert/stories/Alert.story.tsx
@@ -113,6 +113,11 @@ GroupOfTypesOfAlerts.args = {
       type: 'gray',
       size: 'm',
     },
+    {
+      text: 'Aqua Alert',
+      type: 'aqua',
+      size: 'm',
+    },
   ],
 };
 

--- a/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
+++ b/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
@@ -102,6 +102,7 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
         text={announcementBannerProps.text}
         icon={announcementBannerProps.icon}
         link={announcementBannerProps.link}
+        type="gray"
       />
     )}
     <div


### PR DESCRIPTION
## Summary
Fixes visual regression in HeroBanner component where announcement banners inherited purple icon colors from recent Alert component changes.

## Problem
The recent [Alert component improvements](https://github.com/code-dot-org/code-dot-org/pull/67025) introduced purple icons for `type="primary"` alerts. Since HeroBanner's announcement banner uses the default primary type, it unintentionally inherited the purple icon styling, which conflicts with the neutral/informational nature of announcement banners.

## Solution
- Changed Alert `type` from default `"primary"` to `"gray"` in HeroBanner announcement banner
- Gray type provides neutral styling appropriate for announcements
- Maintains semantic meaning while avoiding unwanted color inheritance

## Changes Made
- **HeroBanner.tsx**: Added `type="gray"` prop to Alert component in announcement banner

## Testing
- ✅ Verified in Storybook that announcement banners now display with neutral icons
- ✅ Confirmed no impact on other HeroBanner functionality
- ✅ Eyes tests should now pass

<img width="1214" height="325" alt="Screenshot 2025-07-11 at 10 59 40 AM" src="https://github.com/user-attachments/assets/c29ef4be-a2ae-4e38-b2e0-102f0c9878e0" />

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
