### PR TITLE
Pass hours as the duration to the Self-Paced PL Catalog

### DIFF
--- a/apps/src/code-studio/pd/professional_learning/SelfPacedPLCatalog.tsx
+++ b/apps/src/code-studio/pd/professional_learning/SelfPacedPLCatalog.tsx
@@ -16,7 +16,7 @@ export interface SelfPacedPLCourseInfo {
   key: string;
   display_name: string;
   grade_levels: string;
-  duration: string;
+  duration_in_hours: number;
   cs_topic: string;
   description: string;
   image?: string;
@@ -61,7 +61,7 @@ const SelfPacedPLCatalog: React.FunctionComponent<{
               courseKey={courseOffering.key}
               displayName={courseOffering.display_name}
               gradeLevels={courseOffering.grade_levels}
-              duration={courseOffering.duration}
+              duration={courseOffering.duration_in_hours}
               csTopics={courseOffering.cs_topic}
               description={courseOffering.description}
               image={courseOffering.image || defaultImageSrc}

--- a/apps/src/code-studio/pd/professional_learning/SelfPacedPLCatalogCard.tsx
+++ b/apps/src/code-studio/pd/professional_learning/SelfPacedPLCatalogCard.tsx
@@ -17,7 +17,7 @@ interface SelfPacedPLCard {
   courseKey: string;
   displayName: string;
   gradeLevels: string;
-  duration: string;
+  duration: number;
   csTopics: string;
   description: string;
   image?: string;

--- a/apps/src/code-studio/pd/professional_learning/SelfPacedPLCatalogExpandedCard.tsx
+++ b/apps/src/code-studio/pd/professional_learning/SelfPacedPLCatalogExpandedCard.tsx
@@ -18,7 +18,7 @@ const SelfPacedPLCatalogExpandedCard: React.FunctionComponent<{
   courseKey: string;
   displayName: string;
   gradeLevels: string;
-  duration: string;
+  duration: number;
   csTopics: string;
   description: string;
   image?: string;

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -300,11 +300,20 @@ class CourseOffering < ApplicationRecord
     localized_name || display_name
   end
 
-  def duration
+  def duration_in_minutes
     return nil unless latest_published_version
     co_units = latest_published_version.units
-    co_duration_in_minutes = co_units.sum(&:duration_in_minutes)
-    DURATION_LABEL_TO_MINUTES_CAP.keys.find {|dur| co_duration_in_minutes <= DURATION_LABEL_TO_MINUTES_CAP[dur]}
+    co_units.sum(&:duration_in_minutes)
+  end
+
+  def duration_in_hours
+    return nil unless duration_in_minutes
+    duration_in_minutes > 60 ? duration_in_minutes / 60 : 1
+  end
+
+  def duration
+    return nil unless duration_in_minutes
+    DURATION_LABEL_TO_MINUTES_CAP.keys.find {|dur| duration_in_minutes <= DURATION_LABEL_TO_MINUTES_CAP[dur]}
   end
 
   def translated?(locale_code = 'en-us')
@@ -347,6 +356,7 @@ class CourseOffering < ApplicationRecord
       marketing_initiative: marketing_initiative,
       grade_levels: grade_levels,
       duration: duration,
+      duration_in_hours: duration_in_hours,
       image: image,
       cs_topic: cs_topic,
       school_subject: school_subject,

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -649,6 +649,63 @@ class CourseOfferingTest < ActiveSupport::TestCase
     refute(co.missing_required_device_compatibility?)
   end
 
+  test 'duration_in_minutes returns nil if latest_published_version does not exist' do
+    course = create(:single_unit_course, family_name: 'test-duration', version_year: '1997', published_state: 'in_development')
+    co = CourseOffering.add_course_offering(course)
+
+    assert_nil co.latest_published_version
+    assert_nil co.duration_in_minutes
+  end
+
+  test 'duration_in_minutes returns sum of units duration in minutes' do
+    unit = create(:single_unit_course, unit: unit, published_state: 'stable', version_year: '1997', family_name: 'test-duration').first_unit
+    lesson_group = create(:lesson_group, script: unit)
+
+    lesson1 = create(:lesson, script: unit, lesson_group: lesson_group)
+    create(:lesson_activity, lesson: lesson1, duration: 40)
+
+    lesson2 = create(:lesson, script: unit, lesson_group: lesson_group)
+    create(:lesson_activity, lesson: lesson2, duration: 40)
+    create(:lesson_activity, lesson: lesson2, duration: 40)
+
+    co = CourseOffering.add_course_offering(unit.original_unit_group)
+    assert_equal 120, co.duration_in_minutes
+  end
+
+  test 'duration_in_hours returns nil if latest_published_version does not exist' do
+    course = create(:single_unit_course, family_name: 'test-duration', version_year: '1997', published_state: 'in_development')
+    co = CourseOffering.add_course_offering(course)
+
+    assert_nil co.latest_published_version
+    assert_nil co.duration_in_hours
+  end
+
+  test 'duration_in_hours returns 1 hour as the minimum if latest_published_version exists' do
+    unit = create(:single_unit_course, unit: unit, published_state: 'stable', version_year: '1997', family_name: 'test-duration').first_unit
+    lesson_group = create(:lesson_group, script: unit)
+
+    lesson1 = create(:lesson, script: unit, lesson_group: lesson_group)
+    create(:lesson_activity, lesson: lesson1, duration: 20)
+
+    co = CourseOffering.add_course_offering(unit.original_unit_group)
+    assert_equal 1, co.duration_in_hours
+  end
+
+  test 'duration_in_hours returns sum of units duration in hours (rounded down using integer math)' do
+    unit = create(:single_unit_course, unit: unit, published_state: 'stable', version_year: '1997', family_name: 'test-duration').first_unit
+    lesson_group = create(:lesson_group, script: unit)
+
+    lesson1 = create(:lesson, script: unit, lesson_group: lesson_group)
+    create(:lesson_activity, lesson: lesson1, duration: 50)
+
+    lesson2 = create(:lesson, script: unit, lesson_group: lesson_group)
+    create(:lesson_activity, lesson: lesson2, duration: 50)
+    create(:lesson_activity, lesson: lesson2, duration: 50)
+
+    co = CourseOffering.add_course_offering(unit.original_unit_group)
+    assert_equal 2, co.duration_in_hours
+  end
+
   test 'duration returns nil if latest_published_version does not exist' do
     course = create(:single_unit_course, family_name: 'test-duration', version_year: '1997', published_state: 'in_development')
     co = CourseOffering.add_course_offering(course)


### PR DESCRIPTION
Pass in the number of hours a course offering is to the Self-Paced PL Catalog rather than the duration calculated for the Curriculum Catalog (e.g. "Week", "Month", etc.).

![duration in hours](https://github.com/user-attachments/assets/d2a28e97-a134-4c48-9635-4e5370562034)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3397)

## Testing story
Local testing and adding unit tests for coverage.
