### PR TITLE
CMS-65: Allow facilitators to update their bio via the Account Settings page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1367,6 +1367,7 @@
   "extraTopBlocks": "You have unattached blocks.",
   "extraTopBlocksWhenRun": "You have unattached blocks. Did you mean to attach these to the \"when run\" block?",
   "facilitatorLedWorkshops": "Facilitator led workshops",
+  "facilitatorBio": "Facilitator biography",
   "failedToGenerateBlocklyCode": "Uh oh! We can’t run your code. We are investigating this issue. In the meantime, you may need to start over or skip to another level.",
   "fallbackVideoClosedCaptioningLink": "Closed Captioning and Translations",
   "fallbackVideoClosedCaptioningDialogHeading": "Closed captioning and translations available on YouTube",

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -357,7 +357,6 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
             >
               <textarea
                 name="user[facilitator_bio]"
-                className={commonStyles.textarea}
                 value={facilitatorBio}
                 onChange={e => {
                   setFacilitatorBio(e.target.value);

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -1,6 +1,7 @@
 import Alert, {alertTypes} from '@code-dot-org/component-library/alert';
 import {Button} from '@code-dot-org/component-library/button';
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
+import FormFieldWrapper from '@code-dot-org/component-library/formFieldWrapper';
 import Link from '@code-dot-org/component-library/link';
 import TextField from '@code-dot-org/component-library/textField';
 import {Heading2} from '@code-dot-org/component-library/typography';
@@ -34,6 +35,7 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
   shouldSeeEditEmailLink,
   isPasswordRequired,
   isStudent,
+  isFacilitator,
   migrated,
   userType,
   userAge,
@@ -43,6 +45,7 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
   userFamilyName,
   userProperties,
   userEmail,
+  userFacilitatorBio,
   hashedEmail,
   encryptedPasswordPresent,
   canEditPassword,
@@ -59,6 +62,9 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
   const [givenName, setGivenName] = useState(userGivenName ?? '');
   const [familyName, setFamilyName] = useState(userFamilyName ?? '');
   const [email, setEmail] = useState(userEmail ?? '');
+  const [facilitatorBio, setFacilitatorBio] = useState(
+    userFacilitatorBio ?? ''
+  );
   const [gender, setGender] = useState(
     userProperties?.gender_student_input ?? ''
   );
@@ -124,6 +130,9 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
       gender_student_input: isStudent && gender ? gender : undefined,
       us_state: isStudent && isUSA ? usState : undefined,
       country_code: isStudent ? countryCode : undefined,
+      facilitator_info_attributes: isFacilitator
+        ? {bio: facilitatorBio}
+        : undefined,
     };
     const response = await fetch('/users', {
       method: 'PUT',
@@ -334,6 +343,28 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
               minLength={5}
               errorMessage={getError('username')}
             />
+          )}
+
+          {/* facilitator bio */}
+          {isFacilitator && (
+            <FormFieldWrapper
+              label={i18n.facilitatorBio()}
+              errorMessage={
+                getError('facilitator_info.bio') ||
+                getError('facilitator_info.base') ||
+                getError('facilitator_info.user')
+              }
+            >
+              <textarea
+                name="user[facilitator_bio]"
+                className={commonStyles.textarea}
+                value={facilitatorBio}
+                onChange={e => {
+                  setFacilitatorBio(e.target.value);
+                  clearError('facilitator_info.bio');
+                }}
+              />
+            </FormFieldWrapper>
           )}
 
           {/* email */}

--- a/apps/src/accounts/AccountInformation/style.module.scss
+++ b/apps/src/accounts/AccountInformation/style.module.scss
@@ -12,5 +12,13 @@
       color: var(--sentiment-success-50);
       margin: 0;
     }
+
+    textarea {
+      box-sizing: border-box;
+      min-width: 100%;
+      height: 6rem;
+      padding: 0.5rem 0.75rem;
+      margin: 0;
+    }
   }
 }

--- a/apps/src/accounts/AccountInformation/types.ts
+++ b/apps/src/accounts/AccountInformation/types.ts
@@ -11,6 +11,7 @@ export interface AccountInformationProps {
   shouldSeeEditEmailLink: boolean;
   isPasswordRequired: boolean;
   isStudent: boolean;
+  isFacilitator: boolean;
   migrated: boolean;
   encryptedPasswordPresent: boolean;
   canEditPassword: boolean;
@@ -30,4 +31,5 @@ export interface AccountInformationProps {
   userFamilyName?: string;
   userEmail?: string;
   userProperties?: UserProperties;
+  userFacilitatorBio?: string;
 }

--- a/apps/src/accounts/common/common.styles.module.scss
+++ b/apps/src/accounts/common/common.styles.module.scss
@@ -20,13 +20,6 @@
     margin: 1rem 0;
   }
 
-  .textarea {
-    box-sizing: border-box;
-    min-width: 100%;
-    height: 6rem;
-    padding: 0.5rem 0.75rem;
-  }
-
   input,
   select {
     height: unset;

--- a/apps/src/accounts/common/common.styles.module.scss
+++ b/apps/src/accounts/common/common.styles.module.scss
@@ -20,6 +20,13 @@
     margin: 1rem 0;
   }
 
+  .textarea {
+    box-sizing: border-box;
+    min-width: 100%;
+    height: 6rem;
+    padding: 0.5rem 0.75rem;
+  }
+
   input,
   select {
     height: unset;

--- a/apps/test/unit/accounts/AccountInformationTest.jsx
+++ b/apps/test/unit/accounts/AccountInformationTest.jsx
@@ -295,4 +295,30 @@ describe('AccountInformation', () => {
       screen.getByText(/account information successfully updated/i)
     ).toBeInTheDocument();
   });
+
+  it('renders no facilitator info fields when user is not facilitator', () => {
+    render(<AccountInformation {...defaultProps} isFacilitator={false} />);
+
+    expect(
+      screen.queryByRole('textbox', {name: /Facilitator biography/i})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders facilitator info fields when user is facilitator', () => {
+    const userFacilitatorBio = 'This is a facilitator bio';
+
+    render(
+      <AccountInformation
+        {...defaultProps}
+        isFacilitator={true}
+        userFacilitatorBio={userFacilitatorBio}
+      />
+    );
+
+    const facilitatorBioTextarea = screen.getByRole('textbox', {
+      name: /Facilitator biography/i,
+    });
+    expect(facilitatorBioTextarea).toBeInTheDocument();
+    expect(facilitatorBioTextarea.value).toBe(userFacilitatorBio);
+  });
 });

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -55,9 +55,8 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       session_dates = @workshop.sessions.map(&:formatted_date_with_start_and_end_times)
       session_info_for_calendar = @workshop.sessions.map(&:session_info_for_calendar)
 
-      facilitators = @workshop.facilitators.map do |facilitator|
+      facilitators = @workshop.facilitators.includes(:facilitator_info).map do |facilitator|
         # TODO [CMS-65]: Come up with more permanent solution that doesn't require cross-project file dependency.
-        bio_file = pegasus_dir("sites.v3/code.org/views/workshop_affiliates/#{facilitator.id}_bio.md")
         image_file = pegasus_dir("sites.v3/code.org/public/images/affiliate-images/#{facilitator.id}.jpg")
 
         {
@@ -65,7 +64,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
           name: facilitator.name,
           email: facilitator.email,
           image_path: File.exist?(image_file) ? CDO.code_org_url("/images/affiliate-images/fit-150/#{facilitator.id}.jpg") : nil,
-          bio: File.exist?(bio_file) ? File.read(bio_file) : nil
+          bio: facilitator.facilitator_bio,
         }
       end
 

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -564,6 +564,9 @@ class RegistrationsController < Devise::RegistrationsController
       :user_provided_us_state,
       :ai_rubrics_disabled,
       :lti_roster_sync_enabled,
+      facilitator_info_attributes: [
+        :bio,
+      ],
       school_info_attributes: [
         :country,
         :school_type,

--- a/dashboard/app/models/concerns/user/facilitator.rb
+++ b/dashboard/app/models/concerns/user/facilitator.rb
@@ -4,9 +4,11 @@ module User::Facilitator
   extend ActiveSupport::Concern
 
   included do
-    has_one :facilitator_info, dependent: :destroy
+    has_one :facilitator_info, inverse_of: :user
 
     # Defines +facilitator_bio+ method to access the bio of the facilitator info
     delegate :bio, to: :facilitator_info, prefix: :facilitator, allow_nil: true
+
+    accepts_nested_attributes_for :facilitator_info, update_only: true
   end
 end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -949,16 +949,14 @@ class Pd::Workshop < ApplicationRecord
   end
 
   def summarize_for_marketing_page
-    facilitators_info = facilitators.map do |facilitator|
+    facilitators_info = facilitators.includes(:facilitator_info).map do |facilitator|
       # TODO [CMS-65]: Come up with more permanent solution that doesn't require cross-project file dependency.
-
-      bio_file = pegasus_dir("sites.v3/code.org/views/workshop_affiliates/#{facilitator.id}_bio.md")
       image_file = pegasus_dir("sites.v3/code.org/public/images/affiliate-images/#{facilitator.id}.jpg")
 
       {
         name: facilitator.name,
         email: facilitator.email,
-        bio: File.exist?(bio_file) ? File.read(bio_file) : nil,
+        bio: facilitator.facilitator_bio,
         image_path: File.exist?(image_file) ? CDO.code_org_url("/images/affiliate-images/fit-150/#{facilitator.id}.jpg") : nil
       }
     end

--- a/dashboard/app/models/user/facilitator_info.rb
+++ b/dashboard/app/models/user/facilitator_info.rb
@@ -15,11 +15,23 @@
 #  index_user_facilitator_infos_on_user_id  (user_id)
 #
 class User::FacilitatorInfo < ApplicationRecord
-  belongs_to :user
+  BIO_MIN_LENGTH = 24
+  BIO_MAX_LENGTH = 500
 
-  validate :validate_user_is_facilitator, if: :user_id_changed?
+  belongs_to :user, inverse_of: :facilitator_info
 
-  private def validate_user_is_facilitator
+  auto_strip_attributes :bio
+
+  validates :bio, length: BIO_MIN_LENGTH..BIO_MAX_LENGTH, allow_blank: true, if: :bio_changed?
+  validate :user_is_facilitator, if: :user_id_changed?
+  validate :bio_has_no_profanity, if: :bio_changed?
+
+  private def user_is_facilitator
     errors.add(:user, :not_facilitator) unless user&.facilitator?
+  end
+
+  private def bio_has_no_profanity
+    return if bio.blank? || errors.present?
+    errors.add(:bio, :has_profanity) if ProfanityFilter.find_potential_profanity(bio, I18n.locale.to_s)
   end
 end

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -228,6 +228,8 @@
       userEmail: current_user.email,
       userProperties: current_user.properties,
       userUsState: current_user.us_state,
+      userFacilitatorBio: current_user.facilitator? ? current_user.facilitator_bio : nil,
+      isFacilitator: current_user.facilitator?,
       isAdmin: current_user.admin,
       isOauth: current_user.oauth?,
       isPasswordRequired: current_user.encrypted_password.present?,

--- a/dashboard/config/locales/base/en.yml
+++ b/dashboard/config/locales/base/en.yml
@@ -48,8 +48,10 @@ en:
             lockout_flow: "cannot be updated because you need parent or guardian permission first."
         user/facilitator_info:
           attributes:
+            bio:
+              has_profanity: contains profanity
             user:
-              not_facilitator: "must have the facilitator permission"
+              not_facilitator: must have the facilitator permission
       messages:
         blank: "is required"
         blank_plural: "are required"
@@ -90,7 +92,8 @@ en:
         us_state: 'State'
         ai_rubrics_disabled: 'Disable AI Rubric Feature'
       user/facilitator_info:
-        user: 'User'
+        user: User
+        bio: Biography
   beta: "beta"
   hello: "Hello world"
   welcome_back: "Welcome back, %{name}"

--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -52,6 +52,7 @@ module Services
         user.secret_picture_id = nil
         user.secret_words = nil
         user.studio_person&.destroy # Studio person record may contain emails
+        user.facilitator_info&.destroy
 
         # Users might have multiple accounts with the same email address.
         # If there is a live user with the same email, these data points will not be scrubbed.

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -770,7 +770,7 @@ FactoryBot.define do
 
   factory :user_facilitator_info, class: User::FacilitatorInfo do
     association :user, factory: :facilitator
-    bio {Faker::Lorem.paragraph}
+    bio {Faker::Lorem.paragraph(sentence_count: 5).truncate(User::FacilitatorInfo::BIO_MAX_LENGTH)}
   end
 
   factory :authentication_option do

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -15,15 +15,40 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
       given_name: 'John',
       family_name: 'Doe',
       full_address: '123 Main St, Springfield, USA',
-    ).destroy
+    )
   end
   let(:described_instance) {described_class.new(user: user)}
 
   describe '#call' do
     subject(:scrub_pii) {described_instance.call}
 
+    let(:delete_accounts_helper_stub) {stub(:delete_accounts_helper)}
+    let(:soft_deleted_user) {true}
+
+    before do
+      delete_accounts_helper_stub.stubs(:remove_census_submissions)
+      delete_accounts_helper_stub.stubs(:clean_pegasus_forms_for_user)
+      delete_accounts_helper_stub.stubs(:remove_poste_data)
+      delete_accounts_helper_stub.stubs(:clean_and_destroy_pd_content)
+      delete_accounts_helper_stub.stubs(:purge_contact_rollups)
+      DeleteAccountsHelper.stubs(:new).with(bypass_safety_constraints: true).returns(delete_accounts_helper_stub)
+
+      user.destroy if soft_deleted_user
+    end
+
+    it 'removes data from deprecated tables' do
+      expect(delete_accounts_helper_stub).to receive(:remove_census_submissions).with(email)
+      expect(delete_accounts_helper_stub).to receive(:clean_pegasus_forms_for_user).with(user)
+      expect(delete_accounts_helper_stub).to receive(:remove_poste_data).with(email)
+      expect(delete_accounts_helper_stub).to receive(:clean_and_destroy_pd_content).with(user.id, email)
+      expect(delete_accounts_helper_stub).to receive(:purge_contact_rollups).with(email)
+      expect(described_instance).to receive(:scrub_external_data)
+      scrub_pii
+    end
+
     context 'when user is not soft-deleted' do
-      let(:user) {create(:teacher)}
+      let(:soft_deleted_user) {false}
+
       it 'raises an error' do
         _ {scrub_pii}.must_raise ArgumentError
       end
@@ -37,16 +62,6 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
     end
 
     context 'when migrated' do
-      before do
-        delete_accounts_helper = described_instance.send(:delete_accounts_helper)
-        expect(delete_accounts_helper).to receive(:remove_census_submissions).with(email)
-        expect(delete_accounts_helper).to receive(:clean_pegasus_forms_for_user).with(user)
-        expect(delete_accounts_helper).to receive(:remove_poste_data).with(email)
-        expect(delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
-        expect(delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
-        expect(described_instance).to receive(:scrub_external_data)
-      end
-
       it 'removes user email and authentication data' do
         _(user.read_attribute(:email)).must_be :present?
         _(user.read_attribute(:hashed_email)).must_be :present?
@@ -92,16 +107,6 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
     end
 
     context 'when not migrated' do
-      before do
-        delete_accounts_helper = described_instance.send(:delete_accounts_helper)
-        expect(delete_accounts_helper).to receive(:remove_census_submissions).with(email)
-        expect(delete_accounts_helper).to receive(:clean_pegasus_forms_for_user).with(user)
-        expect(delete_accounts_helper).to receive(:remove_poste_data).with(email)
-        expect(delete_accounts_helper).to receive(:clean_and_destroy_pd_content).with(user.id, email)
-        expect(delete_accounts_helper).to receive(:purge_contact_rollups).with(email)
-        expect(described_instance).to receive(:scrub_external_data)
-      end
-
       let(:user) do
         create(
           :teacher,
@@ -129,6 +134,16 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
         user.reload
         _(user.email).must_equal ''
         _(user.hashed_email).must_be_nil
+      end
+    end
+
+    context 'when user is facilitator' do
+      let(:user) {user_facilitator_info.user}
+
+      let!(:user_facilitator_info) {create(:user_facilitator_info)}
+
+      it 'destroys associated facilitator info record' do
+        _ {scrub_pii}.must_change -> {user_facilitator_info.destroyed?}, from: false, to: true
       end
     end
   end

--- a/dashboard/test/models/user/facilitator_info_test.rb
+++ b/dashboard/test/models/user/facilitator_info_test.rb
@@ -2,9 +2,16 @@ require 'test_helper'
 
 class User::FacilitatorInfoTest < ActiveSupport::TestCase
   describe 'validations' do
-    subject(:user_facilitator_info) {build(:user_facilitator_info, user: user)}
+    subject(:user_facilitator_info) {build(:user_facilitator_info, user: user, bio: bio)}
 
     let(:user) {create(:facilitator)}
+    let(:bio) do
+      Faker::Lorem.
+        paragraph(sentence_count: User::FacilitatorInfo::BIO_MIN_LENGTH).
+        truncate(User::FacilitatorInfo::BIO_MAX_LENGTH)
+    end
+
+    let(:error_messages) {user_facilitator_info.errors.full_messages}
 
     it 'is valid' do
       _user_facilitator_info.must_be :valid?
@@ -15,10 +22,72 @@ class User::FacilitatorInfoTest < ActiveSupport::TestCase
         user.delete_permission(UserPermission::FACILITATOR)
       end
 
-      it 'is invalid' do
+      it 'contains user permission error' do
         _(user).wont_be :facilitator?
         _user_facilitator_info.wont_be :valid?
-        _(user_facilitator_info.errors.full_messages).must_equal ['User must have the facilitator permission']
+        _(error_messages).must_equal ['User must have the facilitator permission']
+      end
+    end
+
+    context 'when bio is too short' do
+      let(:bio) {Faker::Lorem.paragraph.truncate(User::FacilitatorInfo::BIO_MIN_LENGTH.pred)}
+
+      it 'contains bio too short error' do
+        _user_facilitator_info.wont_be :valid?
+        _(error_messages).must_equal [
+          "Biography is too short (minimum is #{User::FacilitatorInfo::BIO_MIN_LENGTH} characters)"
+        ]
+      end
+    end
+
+    context 'when bio is too long' do
+      let(:bio) {Faker::Lorem.paragraph(sentence_count: User::FacilitatorInfo::BIO_MAX_LENGTH.next)}
+
+      it 'contains bio too long error' do
+        _user_facilitator_info.wont_be :valid?
+        _(error_messages).must_equal [
+          "Biography is too long (maximum is #{User::FacilitatorInfo::BIO_MAX_LENGTH} characters)"
+        ]
+      end
+    end
+
+    context 'when bio has profanity' do
+      let(:profanity) {'profanity'}
+
+      let!(:locale) {I18n.locale = 'uk-UA'}
+
+      before do
+        ProfanityFilter.stubs(:find_potential_profanity).with(bio, locale).returns(profanity)
+      end
+
+      it 'contains bio profanity error' do
+        _user_facilitator_info.wont_be :valid?
+        _(error_messages).must_equal ['Biography contains profanity']
+      end
+
+      context 'when bio is blank' do
+        let(:bio) {''}
+
+        it 'does not validate bio for profanity' do
+          _user_facilitator_info.must_be :valid?
+          _(error_messages).wont_include 'Biography contains profanity'
+        end
+      end
+
+      context 'when has other errors' do
+        let(:other_error) {'some other error'}
+
+        before do
+          # Prevents the error from being cleared during validation
+          user_facilitator_info.errors.stubs(:clear)
+          user_facilitator_info.errors.add(:base, other_error)
+        end
+
+        it 'does not validate bio for profanity' do
+          ProfanityFilter.expects(:find_potential_profanity).never
+          _user_facilitator_info.wont_be :valid?
+          _(error_messages).must_equal [other_error]
+        end
       end
     end
   end


### PR DESCRIPTION
## Account Settings
<img width="100%" alt="bio-textarea" src="https://github.com/user-attachments/assets/12cbbf90-3efc-4df2-948f-4be6100225fc" />

## Workshop
<img width="100%" alt="bio-usage" src="https://github.com/user-attachments/assets/80921e0f-9d0a-4475-885a-5eba06063914" />

## Links
- JIRA task: [CMS-65](https://codedotorg.atlassian.net/browse/CMS-65)
- Data sources: [/pegasus/sites.v3/code.org/views/workshop_affiliates/](https://github.com/code-dot-org/code-dot-org/tree/CMS-65/pegasus-facilitator-data-migration/pegasus/sites.v3/code.org/views/workshop_affiliates)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66983