### PR TITLE
feat(testing): isolate testing to development env per branch

### DIFF
--- a/.github/actions/frontend/marketing/ui-tests/action.yml
+++ b/.github/actions/frontend/marketing/ui-tests/action.yml
@@ -20,6 +20,13 @@ inputs:
   GITHUB_ENVIRONMENT_NAME:
     description: "The name of the GitHub environment to use for this action"
     required: false
+  BRANCHED_TESTING_ENABLED:
+    description: "Whether branched testing is enabled. Defaults to false"
+    default: "false"
+    required: false
+  PR_HEAD_REF:
+    description: "The head ref of the pull request."
+    required: false
 
 runs:
   using: composite
@@ -43,6 +50,8 @@ runs:
         STAGE: ${{ inputs.ENVIRONMENT_TYPE }}
         NEXT_PUBLIC_STAGE: ${{ inputs.ENVIRONMENT_TYPE }}
         APPLICATION_BASE_ADDRESS: ${{ inputs.APPLICATION_BASE_ADDRESS }}
+        BRANCHED_TESTING_ENABLED: ${{ inputs.BRANCHED_TESTING_ENABLED }}
+        PR_HEAD_REF: ${{ inputs.PR_HEAD_REF }}
       run: yarn workspace @code-dot-org/marketing test:ui:ci
       working-directory: ./frontend
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -40,6 +40,9 @@ jobs:
   marketing:
     needs: setup
     uses: ./.github/workflows/marketing-app-ci.yml
+    with:
+      BRANCHED_TESTING_ENABLED: ${{ contains( github.event.pull_request.labels.*.name, 'All The Things') }}
+      PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
     secrets: inherit
 
   # Start the component library CI workflow

--- a/.github/workflows/marketing-app-ci.yml
+++ b/.github/workflows/marketing-app-ci.yml
@@ -2,6 +2,16 @@ name: Marketing-CI
 
 on:
   workflow_call:
+    inputs:
+      BRANCHED_TESTING_ENABLED:
+        type: boolean
+        description: "Whether branched testing is enabled. Defaults to false"
+        default: false
+        required: false
+      PR_HEAD_REF:
+        type: string
+        description: "The head ref of the pull request."
+        required: false
 
 defaults:
   run:
@@ -82,7 +92,7 @@ jobs:
         shell: bash
         run: |
           echo "CONTENTFUL_SPACE_ID=${{ vars.CONTENTFUL_SPACE_ID }}
-          CONTENTFUL_ENV_ID=master
+          CONTENTFUL_ENV_ID=development
           CONTENTFUL_API_HOST=cdn.contentful.com
           CONTENTFUL_DELIVERY_TOKEN=${{ secrets.CONTENTFUL_DELIVERY_TOKEN }}
           CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID=experience
@@ -113,3 +123,5 @@ jobs:
           CONTENTFUL_DELIVERY_TOKEN: ${{ secrets.CONTENTFUL_DELIVERY_TOKEN}}
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY}}
           DRAFT_MODE_TOKEN: ci-draft-mode
+          BRANCHED_TESTING_ENABLED: ${{ inputs.BRANCHED_TESTING_ENABLED }}
+          PR_HEAD_REF: ${{ inputs.PR_HEAD_REF }}

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -105,6 +105,7 @@
     "playwright-core": "~1.49.1",
     "prettier": "3.4.2",
     "schema-dts": "^1.1.5",
+    "simple-git": "^3.28.0",
     "stylelint": "^16.14.1",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.3",

--- a/frontend/apps/marketing/tests/e2e/README.md
+++ b/frontend/apps/marketing/tests/e2e/README.md
@@ -99,43 +99,37 @@ yarn test:ui:fork
 - Any new content entries used in your component(s) should be prepended with "❌ [ENG]" to indicate they are for engineering/testing purposes only. These entries will be copied to Production in Step 9.
 - Make sure top level sections have a Fixed height in the Design sidebar in the Experiences editor, this can prevent page shifting in preparation to add Eyes tests in Step 11.
 
-3. Update the `development` snapshot with your forked version; the ID can be found at the end of the url on the forked experience in Contentful:
+3. Create a PR with the updates from steps 1-3. Label this PR with `All The Things` which will trigger the UI tests to test against the forked page.
 
-```bash
-yarn test:ui:update-snapshot --source-entry-id <ID HERE> --environment development
-```
+4. Once the PR is merged, update your workspace with `staging`.
 
-4. Create a PR with the updates from steps 1-3.
-
-5. Once the PR is merged, update your workspace with `staging`.
-
-6. Publish the updated snapshot in the `development` environment:
+5. Publish the updated snapshot in the `development` environment:
 
 ```bash
 yarn test:ui:publish-snapshot --environment development
 ```
 
-7. Open the development output link in the terminal in Contentful, and Publish the experience.
+6. Open the development output link in the terminal in Contentful, and Publish the experience.
 
-8. Publish the updated snapshot in the `test` environment:
+7. Publish the updated snapshot in the `test` environment:
 
 ```bash
 yarn test:ui:publish-snapshot --environment test
 ```
 
-9. Publish the updated snapshot in the `production` environment:
+8. Publish the updated snapshot in the `production` environment:
 
 ```bash
 yarn test:ui:publish-snapshot --environment production
 ```
 
-10. Publish updated `production` version of the All The Things page in Contentful.
+9. Publish updated `production` version of the All The Things page in Contentful.
 
-11. **If you're adding a new component:** add the component to the Section Types on `/apps/marketing/tests/e2e/pom/all-the-things.ts` and add unit and Eyes tests to `/apps/marketing/tests/e2e/all-the-things.spec.ts`. Create/merge a PR with these tests.
+10. **If you're adding a new component:** add the component to the Section Types on `/apps/marketing/tests/e2e/pom/all-the-things.ts` and add unit and Eyes tests to `/apps/marketing/tests/e2e/all-the-things.spec.ts`. Create/merge a PR with these tests.
 
-12. Eyes diffs may show up in a Marketing-App-Deploy message in the _#infra-marketing-app-staging_ Slack channel.
+11. Eyes diffs may show up in a Marketing-App-Deploy message in the _#infra-marketing-app-staging_ Slack channel.
 
-13. Approve Eyes diffs and rerun failed tests if needed.
+12. Approve Eyes diffs and rerun failed tests if needed.
 
 #### ⛔️ Troubleshooting
 

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -165,8 +165,8 @@ test.describe('All the things UI e2e test', () => {
     expect(await allTheThingsPage.getOpenGraph('description')).toBe(
       'OpenGraph Description',
     );
-    expect(await allTheThingsPage.getOpenGraph('image')).toBe(
-      'https://contentful-images.code.org/90t6bu6vlf76/4hXiOPiRlCXpmtypRNOZqc/9ebe430094c1ae1faf742e1de3f8aa8b/engineering-only-opengraph-default.png?fm=webp',
+    expect(await allTheThingsPage.getOpenGraph('image')).toMatch(
+      /https:\/\/contentful-images\.code\.org\/90t6bu6vlf76\/4hXiOPiRlCXpmtypRNOZqc\/(.*)\/engineering-only-opengraph-default\.png\?fm=webp/,
     );
     expect(await allTheThingsPage.getOpenGraph('type')).toBe('website');
   });

--- a/frontend/apps/marketing/tests/e2e/config/path.ts
+++ b/frontend/apps/marketing/tests/e2e/config/path.ts
@@ -1,0 +1,14 @@
+import {simpleGit} from 'simple-git';
+
+export async function getAllTheThingsPagePath() {
+  if (process.env.BRANCHED_TESTING_ENABLED === 'true') {
+    const maybeBranchName: string =
+      process.env.PR_HEAD_REF ?? (await simpleGit().branch()).current;
+
+    const branchName = maybeBranchName.replaceAll('/', '-');
+
+    return `/engineering/all-the-things-${branchName}`;
+  }
+
+  return `/engineering/all-the-things`;
+}

--- a/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/all-the-things.ts
@@ -1,5 +1,7 @@
 import {type Locator, type Page} from '@playwright/test';
 
+import {getAllTheThingsPagePath} from '../config/path';
+
 import {MarketingPage, MarketingPageOptions} from './marketing';
 
 export type Section =
@@ -54,7 +56,7 @@ export class AllTheThingsPage extends MarketingPage {
 
   async goto(path?: string) {
     if (!path) {
-      return await super.goto('/engineering/all-the-things?otgeo=us');
+      return await super.goto(`${await getAllTheThingsPagePath()}?otgeo=us`);
     }
 
     return await super.goto(path);

--- a/frontend/apps/marketing/tests/e2e/scripts/commands/fork.ts
+++ b/frontend/apps/marketing/tests/e2e/scripts/commands/fork.ts
@@ -1,5 +1,5 @@
 import {readJSON} from 'fs-extra';
-import os from 'node:os';
+import {simpleGit} from 'simple-git';
 
 import {SNAPSHOT_DIR, ALL_THE_THINGS_ENTRY_ID} from '../config';
 import {CreateOrUpdateEntryType, SerializedComponent} from '../types';
@@ -10,12 +10,14 @@ export async function fork(createOrUpdateEntry: CreateOrUpdateEntryType) {
   const snapshotData = serializedComponent.entryContent;
 
   // Change the slug and title for clarity
-  const username = os.userInfo().username;
-  const title = `[${username}] All The Things - ${new Date().toISOString()}`;
-  const slug = `/engineering/all-the-things-${username}-${Date.now()}`;
+  const branchName = (await simpleGit().branch()).current.replaceAll('/', '-');
+
+  const title = `[Fork] All The Things - ${branchName}`;
+  const slug = `/engineering/all-the-things-${branchName}`;
 
   snapshotData.fields.slug['en-US'] = slug;
   snapshotData.fields.title['en-US'] = title;
+  snapshotData.fields.pageHeading['en-US'] = title;
 
   const createdEntry = await createOrUpdateEntry({
     contentType: serializedComponent.contentType,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1248,6 +1248,7 @@ __metadata:
     react-schemaorg: "npm:^2.0.0"
     redis: "npm:^4.7.1"
     schema-dts: "npm:^1.1.5"
+    simple-git: "npm:^3.28.0"
     sitemap: "npm:^8.0.0"
     stylelint: "npm:^16.14.1"
     ts-node: "npm:^10.9.2"
@@ -3711,6 +3712,22 @@ __metadata:
   dependencies:
     buffer: "npm:^6.0.3"
   checksum: 10c0/24a257870b0548cfe430680c2ae1641751e6a6ec90c573eaf51bfe956839b6cfa462b4d2827157363b6d620872d32d69fa2f37210a864ba488f8ec7158436398
+  languageName: node
+  linkType: hard
+
+"@kwsites/file-exists@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/file-exists@npm:1.1.1"
+  dependencies:
+    debug: "npm:^4.1.1"
+  checksum: 10c0/39e693239a72ccd8408bb618a0200e4a8d61682057ca7ae2c87668d7e69196e8d7e2c9cde73db6b23b3b0230169a15e5f1bfe086539f4be43e767b2db68e8ee4
+  languageName: node
+  linkType: hard
+
+"@kwsites/promise-deferred@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/promise-deferred@npm:1.1.1"
+  checksum: 10c0/ef1ad3f1f50991e3bed352b175986d8b4bc684521698514a2ed63c1d1fc9848843da4f2bc2df961c9b148c94e1c34bf33f0da8a90ba2234e452481f2cc9937b1
   languageName: node
   linkType: hard
 
@@ -20244,6 +20261,17 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
+  languageName: node
+  linkType: hard
+
+"simple-git@npm:^3.28.0":
+  version: 3.28.0
+  resolution: "simple-git@npm:3.28.0"
+  dependencies:
+    "@kwsites/file-exists": "npm:^1.1.1"
+    "@kwsites/promise-deferred": "npm:^1.1.1"
+    debug: "npm:^4.4.0"
+  checksum: 10c0/d78b8f5884967513efa3d3ee419be421207367c65b680ee45f4c9571f909ba89933ffa27d6d7972fbb759bb30b00e435e35ade2b9e788661feb996da6f461932
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR implements branched testing for the "All The Things" e2e test page, allowing tests to be isolated to development environments on a per-branch basis.

This enables multiple developers to run tests concurrently without interfering with each other.
    
When contributors add the label "All the Things", the UI tests will execute against a fork of "All The Things" that is named the branch. This allows UI and lighthouse testing that are isolated and does not affect the test and production stages.
