### PR TITLE
chore(workshops): remove summary table columns that have been deprecated

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/reports/teacher_attendance_report.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/teacher_attendance_report.jsx
@@ -4,12 +4,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
-import {connect} from 'react-redux';
 
 import {RouterContext} from '@cdo/apps/code-studio/legacyDashboardRoutingCompatibility';
 
 import Spinner from '../../../../sharedComponents/Spinner';
-import {PermissionPropType} from '../permission';
 
 import {QUERY_BY_VALUES, COURSE_VALUES} from './report_constants';
 import ReportTable from './report_table';
@@ -18,7 +16,6 @@ const QUERY_URL = '/api/v1/pd/teacher_attendance_report';
 
 export class TeacherAttendanceReport extends React.Component {
   static propTypes = {
-    permission: PermissionPropType.isRequired,
     startDate: PropTypes.string.isRequired,
     endDate: PropTypes.string.isRequired,
     queryBy: PropTypes.oneOf(QUERY_BY_VALUES).isRequired,
@@ -162,14 +159,6 @@ export class TeacherAttendanceReport extends React.Component {
         header: {label: 'Workshop Name'},
       },
       {
-        property: 'on_map',
-        header: {label: 'Shown on Map'},
-      },
-      {
-        property: 'funded',
-        header: {label: 'Funded'},
-      },
-      {
         property: 'organizer_name',
         header: {label: 'Organizer Name'},
       },
@@ -190,33 +179,6 @@ export class TeacherAttendanceReport extends React.Component {
         header: {label: 'Days'},
       },
     ];
-
-    if (this.props.permission.hasWorkshopAdmin) {
-      columns.push(
-        {
-          property: `pay_period`,
-          header: {label: `Pay Period`},
-        },
-        {
-          property: `payment_type`,
-          header: {label: `Payment Type`},
-        },
-        {
-          property: `payment_rate`,
-          header: {label: `Payment Rate`},
-        },
-        {
-          property: `qualified`,
-          header: {label: `Qualified`},
-          cell: {format: this.formatYesNo},
-        },
-        {
-          property: `payment_amount`,
-          header: {label: `Payment Amount`},
-          cell: {format: this.formatCurrency},
-        }
-      );
-    }
 
     return columns;
   }
@@ -249,6 +211,4 @@ const styles = {
   link: {cursor: 'pointer'},
 };
 
-export default connect(state => ({
-  permission: state.workshopDashboard.permission,
-}))(TeacherAttendanceReport);
+export default TeacherAttendanceReport;

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
@@ -4,12 +4,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Checkbox, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
-import {connect} from 'react-redux';
 
 import {RouterContext} from '@cdo/apps/code-studio/legacyDashboardRoutingCompatibility';
 
 import Spinner from '../../../../sharedComponents/Spinner';
-import {PermissionPropType, WorkshopAdmin} from '../permission';
 
 import {QUERY_BY_VALUES, COURSE_VALUES} from './report_constants';
 import ReportTable from './report_table';
@@ -20,7 +18,6 @@ const QUERY_URL = '/api/v1/pd/workshop_summary_report';
 
 export class WorkshopSummaryReport extends React.Component {
   static propTypes = {
-    permission: PermissionPropType.isRequired,
     startDate: PropTypes.string.isRequired,
     endDate: PropTypes.string.isRequired,
     queryBy: PropTypes.oneOf(QUERY_BY_VALUES).isRequired,
@@ -140,10 +137,6 @@ export class WorkshopSummaryReport extends React.Component {
         header: {label: 'Workshop Total Hours'},
       },
       {
-        property: 'funded',
-        header: {label: 'Funded'},
-      },
-      {
         property: 'attendance_url',
         header: {label: 'Attendance URL'},
         cell: {format: this.formatUrl},
@@ -181,10 +174,6 @@ export class WorkshopSummaryReport extends React.Component {
       {
         property: 'workshop_name',
         header: {label: 'Workshop Name'},
-      },
-      {
-        property: 'on_map',
-        header: {label: 'Shown on Map'},
       },
       {
         property: 'workshop_id',
@@ -231,49 +220,6 @@ export class WorkshopSummaryReport extends React.Component {
       }
     );
 
-    if (this.props.permission.has(WorkshopAdmin)) {
-      columns.push(
-        {
-          property: `pay_period`,
-          header: {label: `Pay Period`},
-        },
-        {
-          property: `payment_type`,
-          header: {label: `Payment Type`},
-        },
-        {
-          property: `qualified`,
-          header: {label: `Qualified`},
-          cell: {format: this.formatYesNo},
-        },
-        {
-          property: `food_payment`,
-          header: {label: `Food Payment`},
-          cell: {format: this.formatCurrency},
-        },
-        {
-          property: `facilitator_payment`,
-          header: {label: `Facilitator Payment`},
-          cell: {format: this.formatCurrency},
-        },
-        {
-          property: `staffer_payment`,
-          header: {label: `Staffer Payment`},
-          cell: {format: this.formatCurrency},
-        },
-        {
-          property: `venue_payment`,
-          header: {label: `Venue Payment`},
-          cell: {format: this.formatCurrency},
-        },
-        {
-          property: `payment_total`,
-          header: {label: `Payment Total`},
-          cell: {format: this.formatCurrency},
-        }
-      );
-    }
-
     return columns;
   }
 
@@ -310,6 +256,4 @@ const styles = {
   link: {cursor: 'pointer'},
 };
 
-export default connect(state => ({
-  permission: state.workshopDashboard.permission,
-}))(WorkshopSummaryReport);
+export default WorkshopSummaryReport;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

cleans up the workshop summary and teacher summary tables by removing some deprecated columns. payment columns were shown to admins, but they've been removed for everyone now, so no need to connect these components to redux to get user permissions anymore

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3374

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
