### PR TITLE
Include ugu for all course offerings cache

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -188,9 +188,21 @@ class CourseOffering < ApplicationRecord
 
   def self.all_course_offerings
     if should_cache?
-      @@course_offerings ||= CourseOffering.all.includes(course_versions: :content_root)
+      @@course_offerings ||= CourseOffering.all.includes(
+        course_versions: {
+          content_root: {
+            default_unit_group_units: {}
+          }
+        }
+      )
     else
-      CourseOffering.all.includes(course_versions: :content_root)
+      CourseOffering.all.includes(
+        course_versions: {
+          content_root: {
+            default_unit_group_units: {}
+          }
+        }
+      )
     end
   end
 

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -605,11 +605,11 @@ class CourseOfferingTest < ActiveSupport::TestCase
   test 'query count for assignable_course_offerings' do
     Unit.stubs(:should_cache?).returns true
 
-    assert_cached_queries(16) do
+    assert_cached_queries(0) do
       CourseOffering.assignable_course_offerings_info(@teacher)
     end
 
-    assert_cached_queries(18) do
+    assert_cached_queries(0) do
       CourseOffering.assignable_course_offerings_info(@facilitator)
     end
 


### PR DESCRIPTION
Since the standalone unit migration, users have experienced extended loading times on the My Courses table:
<img width="1039" height="652" alt="image" src="https://github.com/user-attachments/assets/91309771-9f8c-4378-9b3b-8cf6ac935ece" />

While updating tests to remove references to standalone units, we discovered that the query count for `assignable_course_offerings_info` increased substantially (#66714 and #65961). This PR now includes unit group units when it loads the course offering cache. 

## Links
- Jira: [TEACH-2067](https://codedotorg.atlassian.net/browse/TEACH-2067)

## Testing story
Loaded the cache change to an adhoc to compare timings of a few key calls:
`quick_assign_course_offerings`: load the course offerings when creating a section
`valid_course_offerings`: load the course in the owned section table

|                                 | Production | Adhoc - Before | Adhoc - After |
|---------------------------------|------------|----------------|---------------|
| `quick_assign_course_offerings` | 1.83s      | 4.2s           | ~1.5s         |
| `valid_course_offerings`        | 2.11s      | 12s            | ~1.5s         |


## Follow-up work
Once this change makes it into production, I will see if the timing improves at all. If not, then we will need to open another ticket to re-investigate.
