### PR TITLE
Remove Cached `image_optim` Entries Without Expiration

### DIFF
--- a/bin/oneoff/remove_no_ttl_optimized_images.rb
+++ b/bin/oneoff/remove_no_ttl_optimized_images.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# based on remove_no_ttl_partial_registrations
+
+require 'socket'
+require 'timeout'
+
+require_relative '../../dashboard/config/environment'
+
+# This script inspects all cache entries in the image optimization namespace for the presence of a TTL.
+# If no TTL is present, the cache entry is removed.
+DRY_RUN = true
+
+puts "Processing... DRYRUN=#{DRY_RUN}"
+
+IMAGE_OPTIM_PREFIX = /^optimize-3-/
+
+all_keys_without_expiration = []
+
+dalli_data = CDO.shared_cache.instance_variable_get(:@data)
+memcached_endpoints = dalli_data.instance_variable_get(:@servers)
+
+puts "Found endpoints #{memcached_endpoints}"
+
+memcached_endpoints.each do |endpoint|
+  hostname, port = endpoint.split(":")
+
+  puts "Checking #{hostname} #{port}"
+  sock = TCPSocket.new(hostname, 11211)
+
+  begin
+    # metadump doesn't return END in our version of memcached, wait 30 seconds for all output instead
+    # https://github.com/memcached/memcached/issues/667
+    Timeout.timeout(30) do
+      sock.write("lru_crawler metadump all\r\n")
+
+      # read keys until encountered an end (for memcached, this will be the Timeout)
+      loop do
+        data = sock.readline
+        break if !data || data.empty? || data == "END\r\n" || data == "ERROR\r\n"
+        matches = data.scan(/^key=(?<key>.*) exp=-1/)
+        next if matches.empty?
+        all_keys_without_expiration.concat(matches.flatten!)
+      end
+    end
+  rescue EOFError
+    puts "Connection closed by remote host."
+  rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Timeout::Error
+    puts "Timeout reached while waiting for data."
+  ensure
+    sock.close
+  end
+end
+
+# Filter strings that match any of the regexes
+partial_registration_keys = all_keys_without_expiration.grep(IMAGE_OPTIM_PREFIX)
+
+puts "Filtered keys:"
+puts partial_registration_keys
+
+unless DRY_RUN
+  partial_registration_keys.each do |key|
+    CDO.shared_cache.delete(key)
+    puts "Removed key #{key}"
+  end
+end


### PR DESCRIPTION
A direct copy of https://github.com/code-dot-org/code-dot-org/blob/staging/bin/oneoff/remove_no_ttl_partial_registrations.rb, which we used to clean up old cached entries without a TTL for the partial registration entries. This version does exactly the same thing, but for optimized images.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/66993, which added an expiration to these entries.