### PR TITLE
fix(delayed_jobs): prevent worker crash on startup when code reloading

### DIFF
--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -371,6 +371,8 @@ Devise.setup do |config|
   # config.omniauth_path_prefix = "/my_engine/users/auth"
 end
 
+require 'devise/models/custom_lockable'
+
 Rails.application.config.to_prepare do
   # See lib/devise/models/custom_lockable.rb
   unless Devise::Models::Lockable <= Devise::Models::CustomLockable


### PR DESCRIPTION
On environments like `levelbuilder` and `staging`, where `config.cache_classes = false` but `config.eager_load = true`, Rails loads all application code at boot but also reloads app code between requests. This means constants are redefined as new objects after each reload, but any classes or modules that already included the old version keep a reference to the original object.
```ruby
[development] dashboard > Rails.application.config.cache_classes
=> false
[development] dashboard > Rails.application.config.eager_load
=> true
```
```ruby
[development] dashboard > Devise::Models::CustomLockable.object_id
=> 441220
[development] dashboard > Rails.application.reloader.reload!
=> true
[development] dashboard > Devise::Models::CustomLockable.object_id
=> 552720
```
```ruby
[development] dashboard > Devise::Models::Lockable.ancestors.index_by(&:object_id)
=> 
{552720=>Devise::Models::CustomLockable,
 441220=>Devise::Models::CustomLockable,
 211000=>Devise::Models::Lockable}
```

Using `require 'devise/models/custom_lockable'` to load the module `Devise::Models::CustomLockable` instead of relying on Rails autoloading avoids this issue, because Ruby's `require` only loads the file once, so the module's object identity remains the same throughout the process and identity checks always succeed.