### PR TITLE
Revert "Revert "Refine project share filtering of user inputs / add Star Wars to filtered list""

### DIFF
--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -203,4 +203,9 @@ export const OPEN_ENDED_LEGACY_PROJECT_TYPES = [
 
 export const OPEN_ENDED_LAB2_PROJECT_TYPES = ['pythonlab', 'weblab2'];
 
-export const OPEN_ENDED_PROJECTS_YOUNG_AGE = ['spritelab', 'poetry', 'playlab'];
+export const OPEN_ENDED_PROJECTS_YOUNG_AGE = [
+  'spritelab',
+  'poetry',
+  'playlab',
+  'starwarsblocks',
+];

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -58,6 +58,7 @@ class ActivitiesController < ApplicationController
       share_failure = nil
       # True if STUDIO game. The other open-ended 'game's geared for young users
       # are channel-backed and filtered in loadProjectBackedLevel_ in project.js.
+      # Note that STUDIO games also include Star Wars (droplet) which is not a Blockly lab.
       if @level.game.sharing_filtered?
         project_type = 'playlab'
         begin

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -39,8 +39,8 @@ module ShareFiltering
     PROFANITY = 'profanity'.freeze
   end
 
-  USER_ENTERED_TEXT_INDICATORS = ['TITLE', 'TEXT', 'title name\=\"VAL\"'].freeze
-  FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry'].freeze
+  USER_ENTERED_TEXT_INDICATORS = ['A', 'B', 'C', 'COMMENT', 'SPEECH', 'TEXT', 'TEXT1', 'TITLE', 'title name\=\"VAL\"'].freeze
+  FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
 
   # Searches for a sharing failure given a program and locale.
@@ -126,18 +126,14 @@ module ShareFiltering
   def self.traverse_block(block, texts)
     return unless block.is_a?(Hash)
 
-    type = block["type"]
     fields = block["fields"] || {}
     inputs = block["inputs"] || {}
 
-    if type == "gamelab_comment"
-      comment = clean_text_value(fields["COMMENT"])
-      texts << comment if comment && !comment.strip.empty?
-    end
-
-    fields.each_value do |value|
-      cleaned = clean_text_value(value)
-      texts << cleaned if cleaned && !cleaned.strip.empty?
+    fields.each do |key, value|
+      if USER_ENTERED_TEXT_INDICATORS.include?(key)
+        cleaned = clean_text_value(value)
+        texts << cleaned if cleaned && !cleaned.strip.empty?
+      end
     end
 
     inputs.each_value do |input|
@@ -154,11 +150,8 @@ module ShareFiltering
     return false unless Gatekeeper.allows('webpurify', default: true)
     return false unless FILTERED_PROJECT_TYPES.include?(project_type)
 
-    # For Playlab projects, only filter if program contains user-entered indicators.
-    if project_type == 'playlab'
-      return program.match?(/(?:#{USER_ENTERED_TEXT_INDICATORS.join('|')})/)
-    end
-    true
+    # Only filter if program contains user-entered indicators.
+    return program.match?(/(?:#{USER_ENTERED_TEXT_INDICATORS.join('|')})/)
   end
 
   # Searches for a sharing failure given a program name and locale.

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -40,8 +40,7 @@ module ShareFiltering
   end
 
   USER_ENTERED_TEXT_INDICATORS = ['COMMENT', 'SPEECH', 'TEXT', 'TEXT1', 'TITLE', 'procedures_def', 'title name\=\"VAL\"'].freeze
-  # poetry_setpromptwithchoices block has 4 text fields: 'TEXT', 'A', 'B', and 'C'. So A, B, C added in field names list.
-  USER_ENTERED_TEXT_FIELDS = %w(COMMENT SPEECH TEXT TEXT1 TITLE A B C)
+  USER_ENTERED_TEXT_FIELDS = %w(COMMENT SPEECH TEXT TEXT1 TITLE)
   FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
 

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -127,13 +127,13 @@ module ShareFiltering
     end
   end
 
-  # This function recursively traverses a Blockly “block”, extracting any user-entered text
-  # (comments, field values, etc.), 'cleans' the text value (strips XML tags & quotes), and
+  # This function recursively traverses a Blockly block, extracting any user-entered text
+  # (comments, field values), 'cleans' the text value (strips XML tags & quotes), and
   # adds the text value to the texts array.
   # For each block it:
-  #   1. Iterates through block fields, cleaning and collecting user-genereated string values.
+  #   1. Iterates through block fields, cleaning and collecting user-generated strings.
   #   2. Recurses into both normal and shadow inputs.
-  #   3. Follows the “next” chain to handle sequenced blocks.
+  #   3. Handles sequenced blocks by following the 'next' chain of connections.
   def self.traverse_block(block, texts)
     return unless block.is_a?(Hash)
 

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -39,7 +39,11 @@ module ShareFiltering
     PROFANITY = 'profanity'.freeze
   end
 
-  USER_ENTERED_TEXT_INDICATORS = ['A', 'B', 'C', 'COMMENT', 'SPEECH', 'TEXT', 'TEXT1', 'TITLE', 'title name\=\"VAL\"'].freeze
+  # We are omiting comments, procedures, and variables from the indicator list as they are not displayed in share mode.
+  # However, if the program possibly contains user-generated text, we will also filter comments and variable/procedure names.
+  # Note that 'A', 'B', and 'C' could possibly indicate user-entered strings in fields, but are also used for input options.
+  POSSIBLE_USER_ENTERED_TEXT_INDICATORS = ['SPEECH', 'TEXT', 'TEXT1', '\"A\":', '\"B\":', '\"C\":', 'TITLE', 'title name\=\"VAL\"'].freeze
+  USER_ENTERED_TEXT_FIELDS = %w(COMMENT SPEECH TEXT TEXT1 TITLE A B C)
   FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
 
@@ -93,6 +97,16 @@ module ShareFiltering
       end
     end
 
+    # Extract user-created procedure names and descriptions.
+    json.dig("blocks", "blocks")&.each do |block|
+      if block["type"].match?(/^procedures_def/)
+        name = clean_text_value(block.dig("fields", "NAME"))
+        description = clean_text_value(block.dig("fields", "DESCRIPTION"))
+        texts << name if name && !name.empty?
+        texts << description if description && !description.empty?
+      end
+    end
+
     # Traverse each block recursively extracting comments, field values, nested inputs via traverse_block.
     json.dig("blocks", "blocks")&.each do |block|
       traverse_block(block, texts)
@@ -130,7 +144,7 @@ module ShareFiltering
     inputs = block["inputs"] || {}
 
     fields.each do |key, value|
-      if USER_ENTERED_TEXT_INDICATORS.include?(key)
+      if USER_ENTERED_TEXT_FIELDS.include?(key)
         cleaned = clean_text_value(value)
         texts << cleaned if cleaned && !cleaned.strip.empty?
       end
@@ -151,7 +165,7 @@ module ShareFiltering
     return false unless FILTERED_PROJECT_TYPES.include?(project_type)
 
     # Only filter if program contains user-entered indicators.
-    return program.match?(/(?:#{USER_ENTERED_TEXT_INDICATORS.join('|')})/)
+    return program.match?(/(?:#{POSSIBLE_USER_ENTERED_TEXT_INDICATORS.join('|')})/)
   end
 
   # Searches for a sharing failure given a program name and locale.

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -40,7 +40,7 @@ module ShareFiltering
   end
 
   USER_ENTERED_TEXT_INDICATORS = ['COMMENT', 'SPEECH', 'TEXT', 'TEXT1', 'TITLE', 'procedures_def', 'title name\=\"VAL\"'].freeze
-  USER_ENTERED_TEXT_FIELDS = %w(COMMENT SPEECH TEXT TEXT1 TITLE)
+  USER_ENTERED_TEXT_FIELDS = %w(COMMENT SPEECH TEXT TEXT1 TITLE).freeze
   FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
 

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -39,10 +39,8 @@ module ShareFiltering
     PROFANITY = 'profanity'.freeze
   end
 
-  # We are omiting comments, procedures, and variables from the indicator list as they are not displayed in share mode.
-  # However, if the program possibly contains user-generated text, we will also filter comments and variable/procedure names.
-  # Note that 'A', 'B', and 'C' could possibly indicate user-entered strings in fields, but are also used for input options.
-  POSSIBLE_USER_ENTERED_TEXT_INDICATORS = ['SPEECH', 'TEXT', 'TEXT1', '\"A\":', '\"B\":', '\"C\":', 'TITLE', 'title name\=\"VAL\"'].freeze
+  USER_ENTERED_TEXT_INDICATORS = ['COMMENT', 'SPEECH', 'TEXT', 'TEXT1', 'TITLE', 'procedures_def', 'title name\=\"VAL\"'].freeze
+  # poetry_setpromptwithchoices block has 4 text fields: 'TEXT', 'A', 'B', and 'C'. So A, B, C added in field names list.
   USER_ENTERED_TEXT_FIELDS = %w(COMMENT SPEECH TEXT TEXT1 TITLE A B C)
   FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
@@ -80,7 +78,7 @@ module ShareFiltering
       return stripped.gsub(/<[^>]*>/, "\n").split("\n").map(&:strip).reject(&:empty?)
     end
 
-    # Texts will include field values, text values in block inputs, comments, and variable names.
+    # Texts will include user-generated block text field values including comments and variable/user-created procedure names.
     texts = []
     begin
       json = JSON.parse(stripped, max_nesting: DCDO.get('share_filtering_blockly_json_max_depth', JSON_MAX_DEPTH))
@@ -107,7 +105,7 @@ module ShareFiltering
       end
     end
 
-    # Traverse each block recursively extracting comments, field values, nested inputs via traverse_block.
+    # Traverse each block recursively extracting user-generated field string values via traverse_block.
     json.dig("blocks", "blocks")&.each do |block|
       traverse_block(block, texts)
     end
@@ -133,10 +131,9 @@ module ShareFiltering
   # (comments, field values, etc.), 'cleans' the text value (strips XML tags & quotes), and
   # adds the text value to the texts array.
   # For each block it:
-  #   1. Checks for a “gamelab_comment” type and adds its COMMENT field.
-  #   2. Iterates all other fields, cleaning and collecting string values.
-  #   3. Recurses into both normal and shadow inputs.
-  #   4. Follows the “next” chain to handle sequenced blocks.
+  #   1. Iterates through block fields, cleaning and collecting user-genereated string values.
+  #   2. Recurses into both normal and shadow inputs.
+  #   3. Follows the “next” chain to handle sequenced blocks.
   def self.traverse_block(block, texts)
     return unless block.is_a?(Hash)
 
@@ -165,7 +162,7 @@ module ShareFiltering
     return false unless FILTERED_PROJECT_TYPES.include?(project_type)
 
     # Only filter if program contains user-entered indicators.
-    return program.match?(/(?:#{POSSIBLE_USER_ENTERED_TEXT_INDICATORS.join('|')})/)
+    return program.match?(/(?:#{USER_ENTERED_TEXT_INDICATORS.join('|')})/)
   end
 
   # Searches for a sharing failure given a program name and locale.

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -39,8 +39,8 @@ module ShareFiltering
     PROFANITY = 'profanity'.freeze
   end
 
-  USER_ENTERED_TEXT_INDICATORS = ['COMMENT', 'SPEECH', 'TEXT', 'TEXT1', 'TITLE', 'procedures_def', 'title name\=\"VAL\"'].freeze
-  USER_ENTERED_TEXT_FIELDS = %w(COMMENT SPEECH TEXT TEXT1 TITLE).freeze
+  USER_ENTERED_TEXT_INDICATORS = ['SPEECH', 'TEXT', 'TEXT1', 'TITLE', 'title name\=\"VAL\"'].freeze
+  USER_ENTERED_TEXT_FIELDS = %w(SPEECH TEXT TEXT1 TITLE).freeze
   FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
 
@@ -77,31 +77,13 @@ module ShareFiltering
       return stripped.gsub(/<[^>]*>/, "\n").split("\n").map(&:strip).reject(&:empty?)
     end
 
-    # Texts will include user-generated block text field values including comments and variable/user-created procedure names.
+    # Texts will include user-generated block text field values.
     texts = []
     begin
       json = JSON.parse(stripped, max_nesting: DCDO.get('share_filtering_blockly_json_max_depth', JSON_MAX_DEPTH))
     rescue JSON::NestingError
       CDO.log.warn "ShareFiltering.extract_text_blockly: JSON too deep after #{JSON_MAX_DEPTH} levels"
       return texts
-    end
-
-    # Extract variable names.
-    if json["variables"].is_a?(Array)
-      json["variables"].each do |variable|
-        name = variable["name"]
-        texts << name if name.is_a?(String) && !name.strip.empty?
-      end
-    end
-
-    # Extract user-created procedure names and descriptions.
-    json.dig("blocks", "blocks")&.each do |block|
-      if block["type"].match?(/^procedures_def/)
-        name = clean_text_value(block.dig("fields", "NAME"))
-        description = clean_text_value(block.dig("fields", "DESCRIPTION"))
-        texts << name if name && !name.empty?
-        texts << description if description && !description.empty?
-      end
     end
 
     # Traverse each block recursively extracting user-generated field string values via traverse_block.
@@ -126,9 +108,9 @@ module ShareFiltering
     end
   end
 
-  # This function recursively traverses a Blockly block, extracting any user-entered text
-  # (comments, field values), 'cleans' the text value (strips XML tags & quotes), and
-  # adds the text value to the texts array.
+  # This function recursively traverses a Blockly block, extracting any user-entered text,
+  # 'cleans' the text value (strips XML tags & quotes), and then adds the text value
+  # to the texts array.
   # For each block it:
   #   1. Iterates through block fields, cleaning and collecting user-generated strings.
   #   2. Recurses into both normal and shadow inputs.

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -39,8 +39,7 @@ module ShareFiltering
     PROFANITY = 'profanity'.freeze
   end
 
-  USER_ENTERED_TEXT_INDICATORS = ['SPEECH', 'TEXT', 'TEXT1', 'TITLE', 'title name\=\"VAL\"'].freeze
-  USER_ENTERED_TEXT_FIELDS = %w(SPEECH TEXT TEXT1 TITLE).freeze
+  USER_ENTERED_TEXT_FIELDS = ['SPEECH', 'TEXT', 'TEXT1', 'TITLE'].freeze
   FILTERED_PROJECT_TYPES = ['spritelab', 'playlab', 'poetry', 'starwarsblocks'].freeze
   JSON_MAX_DEPTH = 999
 
@@ -142,8 +141,8 @@ module ShareFiltering
     return false unless Gatekeeper.allows('webpurify', default: true)
     return false unless FILTERED_PROJECT_TYPES.include?(project_type)
 
-    # Only filter if program contains user-entered indicators.
-    return program.match?(/(?:#{USER_ENTERED_TEXT_INDICATORS.join('|')})/)
+    # Only filter if program contains fields that accept user-entered strings.
+    return program.match?(/(?:#{USER_ENTERED_TEXT_FIELDS.join('|')})/)
   end
 
   # Searches for a sharing failure given a program name and locale.

--- a/lib/test/cdo/test_share_filtering.rb
+++ b/lib/test/cdo/test_share_filtering.rb
@@ -280,9 +280,11 @@ class ShareFilteringTest < Minitest::Test
 
   def test_should_filter_program_check_project_type
     Gatekeeper.stubs(:allows).with('webpurify', default: true).returns(true)
+    indicator = ShareFiltering::USER_ENTERED_TEXT_INDICATORS.first
+    program_with_indicator = "<xml><field name=\"FNAME\">#{indicator}</field></xml>"
     # 'gamelab' is not in FILTERED_PROJECT_TYPES
-    assert_equal false, ShareFiltering.should_filter_program('<xml/>', 'gamelab')
-    assert_equal true, ShareFiltering.should_filter_program('<xml/>', 'poetry')
+    assert_equal false, ShareFiltering.should_filter_program(program_with_indicator, 'gamelab')
+    assert_equal true, ShareFiltering.should_filter_program(program_with_indicator, 'poetry')
   end
 
   def test_should_filter_program_playlab_only_with_indicator

--- a/lib/test/cdo/test_share_filtering.rb
+++ b/lib/test/cdo/test_share_filtering.rb
@@ -265,31 +265,26 @@ class ShareFilteringTest < Minitest::Test
     json = generate_json_program
     texts = ShareFiltering.extract_text_blockly(json)
 
-    # should find the variable name
-    assert_includes texts, 'myVar'
-    # should find the comment text
-    assert_includes texts, 'nice comment'
     # should strip quotes around the TEXT fields
     assert_includes texts, 'some text'
     assert_includes texts, 'inner text'
     # no duplicates
     assert_equal texts.uniq, texts
-    # should have exactly four entries
-    assert_equal 4, texts.length
+    # should have exactly two entries
+    assert_equal 2, texts.length
   end
 
   def test_should_filter_program_check_project_type
     Gatekeeper.stubs(:allows).with('webpurify', default: true).returns(true)
-    indicator = ShareFiltering::USER_ENTERED_TEXT_INDICATORS.first
-    program_with_indicator = "<xml><field name=\"FNAME\">#{indicator}</field></xml>"
     # 'gamelab' is not in FILTERED_PROJECT_TYPES
-    assert_equal false, ShareFiltering.should_filter_program(program_with_indicator, 'gamelab')
-    assert_equal true, ShareFiltering.should_filter_program(program_with_indicator, 'poetry')
+    json_program_with_indicator = generate_json_program
+    assert_equal false, ShareFiltering.should_filter_program(json_program_with_indicator, 'gamelab')
+    assert_equal true, ShareFiltering.should_filter_program(json_program_with_indicator, 'poetry')
   end
 
   def test_should_filter_program_playlab_only_with_indicator
     Gatekeeper.stubs(:allows).with('webpurify', default: true).returns(true)
-    indicator = ShareFiltering::USER_ENTERED_TEXT_INDICATORS.first
+    indicator = ShareFiltering::USER_ENTERED_TEXT_FIELDS.first
 
     # no indicator in program
     no_indicator = "<xml><block type=\"studio_showTitleScreen\"/></xml>"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67059
This PR re-implements the updates proposed in https://github.com/code-dot-org/code-dot-org/pull/67024 (reverted by code-dot-org/code-dot-org#67059) but with a couple changes explained below. The original PR was reverted because of unexpected UI test failure from a Star Wars droplet activity level. [Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1752275735831019)

The activity level from the UI test is Star Wars (droplet), and because it has game type `studio`, it is passed to `find_share_failure`. I added a [comment in `activities_controller`](https://github.com/code-dot-org/code-dot-org/blob/de7296c4b00ffa030766a888e6d49c8e83db9068/dashboard/app/controllers/activities_controller.rb#L61) about this. Because `"A", "B", "C"` were added to `USER_ENTERED_TEXT_INDICATORS`, the Star Wars program returned `true` for `should_filter_program` and was flagged for PII (R2-D2). With the updates in this PR, `should_filter_program` returns `false` for the Star Wars program, and is not filtered.

Changes in this PR compared to original https://github.com/code-dot-org/code-dot-org/pull/67024:
- The `poetry_setPromptWithChoices` block was deleted which was the only block with field names `"A", "B", "C"` which accepted strings from user so they can be removed from the `USER_ENTERED_TEXT_INDICATORS` list,
- `'title name\=\"VAL\"'` is removed from the indicators list which is renamed as `USER_ENTERED_TEXT_FIELDS` to more accurately describe the list. This was added by https://github.com/code-dot-org/code-dot-org/pull/2012 for CS in Algebra which has since been deprecated. (MSM stands from middle school math.)
- we are only filtering text that is displayed in the share mode of the project so excluding comments and variable names except in Play Lab. We are still filtering for comments in Play Lab because the comment field name is `TEXT`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1752275735831019)

## Testing story
Tested locally on different project types (Sprite Lab, Poetry Lab, Play Lab, and Star Wars (blockly).
Confirmed that`should_filter_program` returns `false` for the Star Wars program at http://localhost-studio.code.org:3000/courses/starwars/units/1/lessons/1/levels/15.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
