### PR TITLE
feat(config): add site-type configuration

### DIFF
--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
           bundle exec ruby deploy.rb --environment_type ${{ vars.ENVIRONMENT_TYPE }} \
             --region ${{ vars.AWS_REGION }} \
+            --site_code ${{ vars.APPLICATION_SITE_CODE }} \
             --hosted_zone_id ${{ secrets.ROOT_HOSTED_ZONE_ID }} \
             --base_domain_name ${{ vars.APPLICATION_BASE_DOMAIN }} \
             --subdomain_name ${{ vars.APPLICATION_SUBDOMAIN_NAME }} \

--- a/frontend/apps/marketing/cicd/3-app/deploy.rb
+++ b/frontend/apps/marketing/cicd/3-app/deploy.rb
@@ -37,6 +37,14 @@ opt_parser = OptionParser.new do |opts|
   end
 
   opts.on(
+    '--site_code SITE_CODE',
+    %w[corporate csforall],
+    "Site code (corporate csforall)",
+    ) do |site_code|
+    options[:site_code] = site_code
+  end
+
+  opts.on(
     '--region REGION',
     String,
     "AWS Region to deploy this marketing site",
@@ -218,6 +226,7 @@ begin
 
   missing_params = []
   missing_params << "hosted_zone_id" unless options[:hosted_zone_id]
+  missing_params << "site_code" unless options[:site_code]
   missing_params << "container_image_hash" unless options[:container_image_hash]
   missing_params << "web_application_server_secrets_arn" unless options[:web_application_server_secrets_arn]
   missing_params << "role_arn" unless options[:role_arn]

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -2,6 +2,7 @@
 # Get region configuration and selected AZs from the new configuration structure
 region_config = MarketingSites::Configuration::regions[options[:region].to_sym]
 selected_azs = region_config[:selected_availability_zones]
+site_config = MarketingSites::Configuration::SITES[options[:site_code].to_sym]
 %>
 AWSTemplateFormatVersion: 2010-09-09
 
@@ -409,10 +410,6 @@ Resources:
             # such as the withRedirect middleware
             - Name: HOSTNAME
               Value: 0.0.0.0
-            - Name: CONTENTFUL_SPACE_ID
-              Value: 90t6bu6vlf76
-            - Name: CONTENTFUL_ENV_ID
-              Value: master
             - Name: CONTENTFUL_API_HOST
               Value: cdn.contentful.com
             - Name: CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID
@@ -438,6 +435,10 @@ Resources:
               Value: delta
             - Name: OTEL_EXPORTER_OTLP_ENDPOINT
               Value: https://otlp.nr-data.net
+<% site_config[:env].each do |environmentVariableName, value| %>
+            - Name: <%= environmentVariableName %>
+              Value: <%= value %>
+<% end %>
           Essential: true
           Image: !Sub "ghcr.io/code-dot-org/marketing@${ContainerImageHashDigest}"
           Name: web

--- a/frontend/apps/marketing/cicd/config.rb
+++ b/frontend/apps/marketing/cicd/config.rb
@@ -48,6 +48,24 @@ module MarketingSites
       us-west-2
     ].freeze
 
+    # Site configuration
+    SITES = {
+      # Code.org corporate website
+      corporate: {
+        env: {
+          CONTENTFUL_SPACE_ID: '90t6bu6vlf76',
+          CONTENTFUL_ENV_ID: 'master'
+        }
+      },
+      # CS For All
+      csforall: {
+        env: {
+          CONTENTFUL_SPACE_ID: '27jkibac934d',
+          CONTENTFUL_ENV_ID: 'master'
+        }
+      },
+    }
+
     class << self
       def regions
         @regions ||= build_dynamic_regions


### PR DESCRIPTION
This PR updates the logic for deploying the marketing sites to differentiate by the site code to inject different environment variables into the ECS task definition. It also adds the CSForAll site code configuration.