### PR TITLE
fix(localize): do not save phrases if not draft mode

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/__tests__/layout.test.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/__tests__/layout.test.tsx
@@ -1,8 +1,9 @@
 import {render} from '@testing-library/react';
-import {headers} from 'next/headers';
+import {draftMode, headers} from 'next/headers';
 
 import {Brand, getBrandFromHostname} from '@/config/brand';
 import {getGoogleAnalyticsMeasurementId} from '@/config/ga4';
+import {SupportedLocale} from '@/config/locale';
 import {getStage} from '@/config/stage';
 import {generateBootstrapValues} from '@/providers/statsig/statsig-backend';
 
@@ -10,6 +11,7 @@ import Layout from '../layout';
 
 jest.mock('next/headers', () => ({
   headers: jest.fn(),
+  draftMode: jest.fn(),
 }));
 
 jest.mock('@/config/brand', () => ({
@@ -81,11 +83,15 @@ describe('Layout', () => {
     (getGoogleAnalyticsMeasurementId as jest.Mock).mockReturnValue('GA-123456');
     (getStage as jest.Mock).mockReturnValue('production');
     (generateBootstrapValues as jest.Mock).mockResolvedValue({});
+    (draftMode as jest.Mock).mockReturnValue(false);
 
     const {findByText} = render(
       await Layout({
         children: <div>Child Component</div>,
-        params: Promise.resolve({brand: 'code.org' as Brand, locale: 'en-US'}),
+        params: Promise.resolve({
+          brand: 'code.org' as Brand,
+          locale: 'en-US' as SupportedLocale,
+        }),
       }),
     );
 
@@ -111,7 +117,10 @@ describe('Layout', () => {
     const {queryByText} = render(
       await Layout({
         children: <div>Child Component</div>,
-        params: Promise.resolve({brand: 'code.org' as Brand, locale: 'en-US'}),
+        params: Promise.resolve({
+          brand: 'code.org' as Brand,
+          locale: 'en-US' as SupportedLocale,
+        }),
       }),
     );
 
@@ -132,7 +141,10 @@ describe('Layout', () => {
     const {container} = render(
       await Layout({
         children: <div>Child Component</div>,
-        params: Promise.resolve({brand: 'code.org' as Brand, locale}),
+        params: Promise.resolve({
+          brand: 'code.org' as Brand,
+          locale: locale as SupportedLocale,
+        }),
       }),
     );
 
@@ -154,7 +166,10 @@ describe('Layout', () => {
     const {container} = render(
       await Layout({
         children: <div>Child Component</div>,
-        params: Promise.resolve({brand: 'code.org' as Brand, locale}),
+        params: Promise.resolve({
+          brand: 'code.org' as Brand,
+          locale: locale as SupportedLocale,
+        }),
       }),
     );
 

--- a/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import {ThemeProvider} from '@mui/material';
 import {AppRouterCacheProvider} from '@mui/material-nextjs/v15-appRouter';
 import {GoogleAnalytics} from '@next/third-parties/google';
+import {draftMode} from 'next/headers';
 
 import Footer from '@/components/footer';
 import Header from '@/components/header';
@@ -33,6 +34,7 @@ export default async function Layout({
   const statsigClientKey = process.env.STATSIG_CLIENT_KEY;
   const localeConfig = SUPPORTED_LOCALES_MAP.get(locale);
   const theme = getMuiTheme(brand);
+  const isDraftModeEnabled = (await draftMode()).isEnabled;
 
   return (
     <html lang={locale} dir={localeConfig?.isRTL ? 'rtl' : 'ltr'}>
@@ -42,7 +44,11 @@ export default async function Layout({
             <EnvironmentLoader />
             <NewRelicLoader />
             <OneTrustLoader brand={brand} />
-            <LocalizeLoader brand={brand} locale={locale} />
+            <LocalizeLoader
+              brand={brand}
+              locale={locale}
+              isDraftMode={isDraftModeEnabled}
+            />
 
             <OneTrustProvider>
               {googleAnalyticsMeasurementId && (

--- a/frontend/apps/marketing/src/providers/localize/LocalizeLoader.tsx
+++ b/frontend/apps/marketing/src/providers/localize/LocalizeLoader.tsx
@@ -8,7 +8,15 @@ import {getLocalizePath, getProjectId} from '@/config/localize';
 /**
  * Loads Localize in an SSR & CSR environment.
  */
-const LocalizeLoader = ({brand, locale}: {brand: Brand; locale: string}) => (
+const LocalizeLoader = ({
+  brand,
+  locale,
+  isDraftMode,
+}: {
+  brand: Brand;
+  locale: string;
+  isDraftMode: boolean;
+}) => (
   <>
     {/* Localize script for their widget from our CDN. */}
     <Script
@@ -69,6 +77,7 @@ const LocalizeLoader = ({brand, locale}: {brand: Brand; locale: string}) => (
                 'error-overlay-pagination',
                 'nextjs-container-build-error-version-status',
               ],
+              saveNewPhrases: isDraftMode,
             } as LocalizeJS.Context.Options);
           } else {
             console.warn('Localize project ID was not valid.');


### PR DESCRIPTION
By default, localizejs will save phrases if not in draft mode. However, we have observed browser extensions on our live site are causing phrases that do not originate from our platform to appear on localizejs. To mitigate this, phrases will only be saved if the phrases originate from our draft mode website which is limited to content editors. We do still need to be careful of content editors' extensions but this should be significantly less of a concern compared to the general public.
