### PR TITLE
[AIChat] Bugfix: Timeouts/False Positive Moderation from OpenAI 

### DIFF
--- a/dashboard/app/helpers/aichat_openai_completions_client.rb
+++ b/dashboard/app/helpers/aichat_openai_completions_client.rb
@@ -35,7 +35,8 @@ class AichatOpenaiCompletionsClient < AichatAiClient
     )
 
     # We expose a temperature scale of 0.1-1 to users, but OpenAI's API allows a scale of 0-2.
-    temperature *= 2
+    # As of 7/11/25, testing revealed temperatures exceeding 1.5 generate garbage and trigger timeouts/false moderation calls
+    temperature *= 1.5
 
     messages = [
       {role: "system", content: [{type: "text", text: system_instructions}]},

--- a/dashboard/app/helpers/aichat_openai_completions_client.rb
+++ b/dashboard/app/helpers/aichat_openai_completions_client.rb
@@ -36,7 +36,7 @@ class AichatOpenaiCompletionsClient < AichatAiClient
 
     # We expose a temperature scale of 0.1-1 to users, but OpenAI's API allows a scale of 0-2.
     # As of 7/11/25, testing revealed temperatures exceeding 1.5 generate garbage and trigger timeouts/false moderation calls
-    temperature *= 1.5
+    temperature *= DCDO.get('openai_temperature_scaling_factor', 1.5)
 
     messages = [
       {role: "system", content: [{type: "text", text: system_instructions}]},

--- a/dashboard/test/helpers/aichat_openai_completions_client_test.rb
+++ b/dashboard/test/helpers/aichat_openai_completions_client_test.rb
@@ -9,7 +9,7 @@ class AichatOpenaiCompletionsClientTest < AichatAiClientTest
   let(:request_body_without_messages) do
     {
       model: endpoint_model_id,
-      temperature: 1.0
+      temperature: 0.75
     }
   end
 


### PR DESCRIPTION
[Initial Ticket](https://codedotorg.atlassian.net/browse/LABS-1464)
Initial Slack Discussion/Investigation Results: https://codedotorg.slack.com/archives/C06FELVTV0Q/p1751402310350279

Follow-up Discussion on long-term solution: https://codedotorg.slack.com/archives/C043ZKQ4BS6/p1752175396426449

## Changes Summary
- Globally reduced OpenAI accessible temperature to a scaling of [0, 1.5] from [0, 2] due to temperatures exceeding 1.5 causing timeouts/false positives in our moderation layer due to gpt-4o-mini being unable to[ terminate and generating garbage endlessly](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1747883446578619), resulting in a 20% error rate in our Spanish pilot
- Intended as short-term solution to bring us to a steady-state while evaluating long-term solutions on how to retain "sweet spots" for different modules