### PR TITLE
chore(marketing): remove es-ES translation field from Lab Test content entry

### DIFF
--- a/frontend/apps/marketing/tests/e2e/__snapshots__/6s4DKSio8Ott6c0lfzWJga.json
+++ b/frontend/apps/marketing/tests/e2e/__snapshots__/6s4DKSio8Ott6c0lfzWJga.json
@@ -53,24 +53,13 @@
         ]
       },
       "experienceLevel": {
-        "en-US": [
-          "Beginner"
-        ]
+        "en-US": ["Beginner"]
       },
       "devices": {
-        "en-US": [
-          "Laptop",
-          "Chromebook",
-          "Tablet"
-        ]
+        "en-US": ["Laptop", "Chromebook", "Tablet"]
       },
       "browsers": {
-        "en-US": [
-          "All modern browsers"
-        ],
-        "es-ES": [
-          "All modern browsers"
-        ]
+        "en-US": ["All modern browsers"]
       },
       "accessibility": {
         "en-US": [


### PR DESCRIPTION
Removes `es-ES` on the [Lab Test content entry](https://app.contentful.com/spaces/90t6bu6vlf76/environments/development/entries/6s4DKSio8Ott6c0lfzWJga) in Contentful to fix an error on production when trying to publish a new All The Things snapshot.

## Links
Jira ticket: [CMS-907](https://codedotorg.atlassian.net/browse/CMS-907)
Related PR: https://github.com/code-dot-org/code-dot-org/pull/67077