### PR TITLE
Change title to remove AI if AI is disabled

### DIFF
--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -258,6 +258,23 @@ function RubricContainer({
     }
   };
 
+  const headerLeft = React.useMemo(
+    () =>
+      teacherHasEnabledAi ? (
+        <>
+          <img
+            src={aiBotOutlineIcon}
+            className={style.aiBotOutlineIcon}
+            alt={i18n.rubricAiHeaderText()}
+          />
+          <span>{i18n.rubricAiHeaderText()}</span>
+        </>
+      ) : (
+        i18n.rubric()
+      ),
+    [teacherHasEnabledAi]
+  );
+
   return (
     <Draggable
       defaultPosition={{x: positionX, y: positionY}}
@@ -297,14 +314,7 @@ function RubricContainer({
           // eslint-disable-next-line react/forbid-dom-props
           data-testid="ai-rubric-handle-test-id"
         >
-          <div className={style.rubricHeaderLeftSide}>
-            <img
-              src={aiBotOutlineIcon}
-              className={style.aiBotOutlineIcon}
-              alt={i18n.rubricAiHeaderText()}
-            />
-            <span>{i18n.rubricAiHeaderText()}</span>
-          </div>
+          <div className={style.rubricHeaderLeftSide}>{headerLeft}</div>
           <div className={style.rubricHeaderRightSide}>
             {canProvideFeedback && teacherHasEnabledAi && (
               <button

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -1258,6 +1258,36 @@ describe('RubricContainer', () => {
     );
   });
 
+  it('shows "Rubric" title when teacherHasEnabledAi is false', async () => {
+    stubFetch({
+      evalStatusForUser: {},
+      evalStatusForAll: {},
+      aiEvals: [],
+      teacherEvals: noEvals,
+      tourStatus: {seen: true},
+    });
+
+    render(
+      <Provider store={store}>
+        <RubricContainer
+          rubric={defaultRubric}
+          studentLevelInfo={defaultStudentInfo}
+          teacherHasEnabledAi={false}
+          onLevelForEvaluation={true}
+          reportingData={{}}
+          open
+        />
+      </Provider>
+    );
+    await wait();
+
+    expect(screen.queryByText(i18n.rubricAiHeaderText())).toBeNull();
+    // Verify AI-specific elements are not present
+    expect(
+      screen.queryByRole('img', {name: i18n.rubricAiHeaderText()})
+    ).toBeNull();
+  });
+
   it('sanitizes all intro text rendered by introjs', () => {
     STEPS.forEach((step, index) => {
       expect(typeof step.intro).toEqual(

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -14,6 +14,7 @@ import {
   restoreRedux,
   stubRedux,
 } from '@cdo/apps/redux';
+import currentUser from '@cdo/apps/templates/currentUserRedux';
 import {UnconnectedRubricFloatingActionButton as RubricFloatingActionButton} from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
 import teacherRubric, {
   setLoadedStudentStatusForTest,
@@ -56,6 +57,7 @@ const defaultProps = {
   rubric: defaultRubric,
   currentLevelName: 'test_level',
   studentLevelInfo: null,
+  aiEnabled: true,
 };
 
 describe('RubricFloatingActionButton', () => {
@@ -68,6 +70,7 @@ describe('RubricFloatingActionButton', () => {
       teacherRubric,
       teacherSections,
       teacherPanel,
+      currentUser,
     });
     store = getStore();
     sendEventSpy = jest.spyOn(analyticsReporter, 'sendEvent');


### PR DESCRIPTION
When AI is disabled, we don't want to have it mentioned in the floating modal header. Change from AI teaching assistant to Rubric in that case

<img width="779" height="549" alt="image" src="https://github.com/user-attachments/assets/4806fac1-5733-45cd-97ab-d56de0ef5ee0" />


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/TEACH-2083
