### PR TITLE
Fix cutoff text in rubrics

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -609,6 +609,7 @@ h2.studentName {
 
 .evidenceLevelLabel {
   @include main-font-semi-bold;
+  color: var(--text-neutral-primary);
   font-size: 0.875rem;
   line-height: 154%;
   margin-bottom: 0;
@@ -1113,9 +1114,12 @@ p.evidenceLevelHeaderText {
 .evidenceLevelSetHorizontalV2 {
   display: flex;
   flex-direction: row;
-  height: 100px;
   width: 100%;
   gap: 8px;
+
+  p {
+    margin-bottom: 0;
+  }
 }
 
 .evidenceLevelOptionV2 {


### PR DESCRIPTION
Before:
<img width="729" height="369" alt="image" src="https://github.com/user-attachments/assets/7633e099-71a1-4865-9d7f-84b90104e5e5" />

After:
<img width="1450" height="686" alt="image" src="https://github.com/user-attachments/assets/d4fd117f-80e9-4056-bc47-0d1ce6e65887" />
<img width="1456" height="908" alt="image" src="https://github.com/user-attachments/assets/c0d64e3f-8340-48bc-9391-d69470343453" />

And still works for normal or minimal text:
<img width="1436" height="528" alt="image" src="https://github.com/user-attachments/assets/3ccd1de0-320c-4ea1-a2c2-2a67351bf275" />
<img width="1474" height="650" alt="image" src="https://github.com/user-attachments/assets/ee2dc983-e387-4445-93f0-d981a9667078" />

Also removes a bit of unintentional extra margin after the text and fixed the text color of the Give Feedback label on musiclab

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/TEACH-2081
