### PR TITLE
Strip Metadata from Resized Images

### DIFF
--- a/lib/cdo/pegasus/graphics.rb
+++ b/lib/cdo/pegasus/graphics.rb
@@ -33,6 +33,11 @@ def load_manipulated_image(path, mode, width, height, scale = nil)
     else
       nil
     end
+
+    # Strip all profiles and comments from the resulting image.
+    # Particularly important for removing any modification timestamps added by
+    # resizing, which can otherwise make calculated cache keys inconsistent.
+    image.strip!
   end
   ilist
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67056 and https://github.com/code-dot-org/code-dot-org/pull/66993; part of our work to address runaway cache growth. See thread [here](https://codedotorg.slack.com/archives/C03CK49G9/p1752029298057709) for more details

Our investigation revealed that we were only repeated generating cache keys for PNG images which had been processed by our dynamic image resizing middleware, and inspection of a resized image with `exiftool` confirms the presence of a new "Modify Date" metadata field. Because we generate the cache key for an optimized image from a hash of the contents of the "original" image, when we attempt to optimize a resize image the presence of this metadata field results in a different hash every second.

To resolve, this PR proposes we strip all metadata from resized images.

## Links

- https://rmagick.github.io/image3.html#strip_bang

## Testing story

I reproduced the problem locally with the following command:

```ruby
Digest::MD5.hexdigest(load_manipulated_image(File.join(Rails.root, "../shared/images/courses/logo_artist.png"), :fill, 70, 70).to_blob)
```

Without the change in this PR, it will return a different result every second. With this change, it consistently returns the same result.

## Follow-up work

Once this PR is deployed, we can run https://github.com/code-dot-org/code-dot-org/pull/67056 to clean up the entries generated during this period of instability

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
