### PR TITLE
feat(workshops): remove new workshop button from workshop dashboard for csf facilitators

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
@@ -86,14 +86,12 @@ export class WorkshopIndex extends React.Component {
     const canDelete = this.props.permission.hasAny(
       WorkshopAdmin,
       Organizer,
-      ProgramManager,
-      CsfFacilitator
+      ProgramManager
     );
     const canCreate = this.props.permission.hasAny(
       WorkshopAdmin,
       Organizer,
-      ProgramManager,
-      CsfFacilitator
+      ProgramManager
     );
     const canSeeAttendanceReports = this.props.permission.hasAny(
       WorkshopAdmin,

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_indexTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_indexTest.js
@@ -35,10 +35,7 @@ describe('WorkshopIndex', () => {
     // to the list of buttons to which it has access
     let permissionButtonMap = new Map([
       [Facilitator, ['Legacy Facilitator Survey Summaries', 'Filter View']],
-      [
-        CsfFacilitator,
-        ['New Workshop', 'Legacy Facilitator Survey Summaries', 'Filter View'],
-      ],
+      [CsfFacilitator, ['Legacy Facilitator Survey Summaries', 'Filter View']],
       [Organizer, ['New Workshop', 'Attendance Reports', 'Filter View']],
       [ProgramManager, ['New Workshop', 'Attendance Reports', 'Filter View']],
       [


### PR DESCRIPTION
csf facilitator's ability to create workshops was removed in https://github.com/code-dot-org/code-dot-org/pull/66747

this removes the "new workshop" button from the ui for those users

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
