### PR TITLE
Unify casing type for workshop enrollment props

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
@@ -23,29 +23,23 @@ import {SUBMISSION_STATUSES} from './constants';
 
 import style from './workshop_join.module.scss';
 
-interface WorkshopJoinProps
-  extends Pick<
-      WorkshopInfo,
-      | 'id'
-      | 'course'
-      | 'subject'
-      | 'name'
-      | 'format'
-      | 'regionalPartnerName'
-      | 'sessions'
-    >,
-    UserInfoForWorkshop {
+type WorkshopJoinProps = {
+  workshopInfo: Pick<
+    WorkshopInfo,
+    | 'id'
+    | 'course'
+    | 'subject'
+    | 'name'
+    | 'format'
+    | 'regionalPartnerName'
+    | 'sessions'
+  >;
+  userInfo: UserInfoForWorkshop['userInfo'];
   workshopEnrollmentStatus: string;
-}
+};
 
 const WorkshopJoin: React.FunctionComponent<WorkshopJoinProps> = ({
-  id,
-  course,
-  subject,
-  name,
-  format,
-  regionalPartnerName,
-  sessions,
+  workshopInfo,
   userInfo,
   workshopEnrollmentStatus,
 }) => {
@@ -53,7 +47,9 @@ const WorkshopJoin: React.FunctionComponent<WorkshopJoinProps> = ({
     workshopEnrollmentStatus
   );
   const [submissionErrorMessage, setSubmissionErrorMessage] = useState('');
-  const {submitEnrollment, isSubmitting, error} = useWorkshopEnrollmentApi(id);
+  const {submitEnrollment, isSubmitting, error} = useWorkshopEnrollmentApi(
+    workshopInfo?.id
+  );
 
   const handleSubmitEnrollment = async () => {
     const result = await submitEnrollment(userInfo?.id);
@@ -73,15 +69,15 @@ const WorkshopJoin: React.FunctionComponent<WorkshopJoinProps> = ({
   const navigateOnEnrollSuccess = () => {
     // Redirect to My PL landing page. The WORKSHOP_ENROLLMENT_COMPLETED_EVENT event will be logged
     // on that page since event logs immediately followed by redirects sometimes do not fire.
-    sessionStorage.setItem('workshopId', `${id}`);
-    sessionStorage.setItem('workshopCourse', course);
-    sessionStorage.setItem('workshopSubject', subject || '');
-    sessionStorage.setItem('workshopName', name || '');
-    sessionStorage.setItem('workshopFormat', format);
-    sessionStorage.setItem('rpName', regionalPartnerName || '');
+    sessionStorage.setItem('workshopId', `${workshopInfo.id}`);
+    sessionStorage.setItem('workshopCourse', workshopInfo.course);
+    sessionStorage.setItem('workshopSubject', workshopInfo.subject || '');
+    sessionStorage.setItem('workshopName', workshopInfo.name || '');
+    sessionStorage.setItem('workshopFormat', workshopInfo.format);
+    sessionStorage.setItem('rpName', workshopInfo.regionalPartnerName || '');
     sessionStorage.setItem(
       'sessionTimeInfo',
-      sessions ? JSON.stringify(sessions) : ''
+      workshopInfo.sessions ? JSON.stringify(workshopInfo.sessions) : ''
     );
 
     navigateToHref('/my-professional-learning');
@@ -117,7 +113,7 @@ const WorkshopJoin: React.FunctionComponent<WorkshopJoinProps> = ({
             email={userInfo.email}
             schoolName={userInfo.schoolInfo?.schoolName}
             schoolType={userInfo.schoolInfo?.schoolType}
-            returnToHref={`/pd/workshops/${id}/join`}
+            returnToHref={`/pd/workshops/${workshopInfo.id}/join`}
             className={style.userPassport}
           />
         )}

--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
@@ -12,7 +12,10 @@ import UserPassport, {
   isMissingUserInfo,
 } from '@cdo/apps/code-studio/pd/workshops/components/UserPassport';
 import {useWorkshopEnrollmentApi} from '@cdo/apps/code-studio/pd/workshops/hooks/useWorkshopEnrollmentApi';
-import {GetUserInfoForWorkshopResponse} from '@cdo/apps/code-studio/pd/workshops/types';
+import {
+  WorkshopInfo,
+  UserInfoForWorkshop,
+} from '@cdo/apps/code-studio/pd/workshops/types';
 import AccountBanner from '@cdo/apps/templates/account/AccountBanner';
 import {navigateToHref} from '@cdo/apps/utils';
 
@@ -20,41 +23,40 @@ import {SUBMISSION_STATUSES} from './constants';
 
 import style from './workshop_join.module.scss';
 
-interface SessionCalendarEvent {
-  id: number;
-  start: string;
-  end: string;
-  is_local: boolean;
-  session_format: string;
-  location_address?: string;
-  meeting_link?: string;
-  description?: string;
-  notes?: string;
+interface WorkshopJoinProps
+  extends Pick<
+      WorkshopInfo,
+      | 'id'
+      | 'course'
+      | 'subject'
+      | 'name'
+      | 'format'
+      | 'regionalPartnerName'
+      | 'sessions'
+    >,
+    UserInfoForWorkshop {
+  workshopEnrollmentStatus: string;
 }
 
-const WorkshopJoin: React.FunctionComponent<{
-  workshop_enrollment_status: string;
-  workshop_info: {
-    id: number;
-    course: string;
-    subject?: string;
-    name?: string;
-    format: string;
-    rp_name?: string;
-    session_info_for_calendar?: SessionCalendarEvent[];
-  };
-  user_info: GetUserInfoForWorkshopResponse['userInfo'];
-}> = ({workshop_enrollment_status, workshop_info, user_info}) => {
+const WorkshopJoin: React.FunctionComponent<WorkshopJoinProps> = ({
+  id,
+  course,
+  subject,
+  name,
+  format,
+  regionalPartnerName,
+  sessions,
+  userInfo,
+  workshopEnrollmentStatus,
+}) => {
   const [enrollmentStatus, setEnrollmentStatus] = useState(
-    workshop_enrollment_status
+    workshopEnrollmentStatus
   );
   const [submissionErrorMessage, setSubmissionErrorMessage] = useState('');
-  const {submitEnrollment, isSubmitting, error} = useWorkshopEnrollmentApi(
-    workshop_info.id
-  );
+  const {submitEnrollment, isSubmitting, error} = useWorkshopEnrollmentApi(id);
 
   const handleSubmitEnrollment = async () => {
-    const result = await submitEnrollment(user_info?.id);
+    const result = await submitEnrollment(userInfo?.id);
 
     if (result?.workshop_enrollment_status === SUBMISSION_STATUSES.SUCCESS) {
       navigateOnEnrollSuccess();
@@ -71,17 +73,15 @@ const WorkshopJoin: React.FunctionComponent<{
   const navigateOnEnrollSuccess = () => {
     // Redirect to My PL landing page. The WORKSHOP_ENROLLMENT_COMPLETED_EVENT event will be logged
     // on that page since event logs immediately followed by redirects sometimes do not fire.
-    sessionStorage.setItem('workshopId', `${workshop_info.id}`);
-    sessionStorage.setItem('workshopCourse', workshop_info.course);
-    sessionStorage.setItem('workshopSubject', workshop_info.subject || '');
-    sessionStorage.setItem('workshopName', workshop_info.name || '');
-    sessionStorage.setItem('workshopFormat', workshop_info.format);
-    sessionStorage.setItem('rpName', workshop_info.rp_name || '');
+    sessionStorage.setItem('workshopId', `${id}`);
+    sessionStorage.setItem('workshopCourse', course);
+    sessionStorage.setItem('workshopSubject', subject || '');
+    sessionStorage.setItem('workshopName', name || '');
+    sessionStorage.setItem('workshopFormat', format);
+    sessionStorage.setItem('rpName', regionalPartnerName || '');
     sessionStorage.setItem(
       'sessionTimeInfo',
-      workshop_info.session_info_for_calendar
-        ? JSON.stringify(workshop_info.session_info_for_calendar)
-        : ''
+      sessions ? JSON.stringify(sessions) : ''
     );
 
     navigateToHref('/my-professional-learning');
@@ -106,18 +106,18 @@ const WorkshopJoin: React.FunctionComponent<{
             className={style.joinWorkshopButton}
             onClick={handleSubmitEnrollment}
             isPending={isSubmitting}
-            disabled={isMissingUserInfo(user_info) || !!error}
+            disabled={isMissingUserInfo(userInfo) || !!error}
           />
         </div>
-        {user_info && (
+        {userInfo && (
           <UserPassport
-            displayName={user_info.display_name}
-            givenName={user_info.first_name}
-            familyName={user_info.last_name}
-            email={user_info.email}
-            schoolName={user_info.school_info?.school_name}
-            schoolType={user_info.school_info?.school_type}
-            returnToHref={`/pd/workshops/${workshop_info.id}/join`}
+            displayName={userInfo.displayName}
+            givenName={userInfo.givenName}
+            familyName={userInfo.familyName}
+            email={userInfo.email}
+            schoolName={userInfo.schoolInfo?.schoolName}
+            schoolType={userInfo.schoolInfo?.schoolType}
+            returnToHref={`/pd/workshops/${id}/join`}
             className={style.userPassport}
           />
         )}

--- a/apps/src/code-studio/pd/workshops/WorkshopMarketingPage.tsx
+++ b/apps/src/code-studio/pd/workshops/WorkshopMarketingPage.tsx
@@ -7,10 +7,7 @@ import EnrollInWorkshop from './components/EnrollInWorkshop';
 import OrganizerInformation from './components/OrganizerInformation';
 import WorkshopDetails from './components/WorkshopDetails';
 import WorkshopEventJsonLdData from './components/WorkshopEventJsonLdData';
-import {
-  GetUserInfoForWorkshopResponse,
-  GetWorkshopInfoScriptDataResponse,
-} from './types';
+import {UserInfoForWorkshop, WorkshopInfo} from './types';
 
 import moduleStyles from './workshopMarketingPage.module.scss';
 
@@ -26,29 +23,29 @@ const workshopMarketingBreadcrumbs: LinkWithText[] = [
 ];
 
 interface WorkshopMarketingPageProps
-  extends GetWorkshopInfoScriptDataResponse,
-    GetUserInfoForWorkshopResponse {}
+  extends WorkshopInfo,
+    UserInfoForWorkshop {}
 
 const WorkshopMarketingPage: React.FunctionComponent<
   WorkshopMarketingPageProps
 > = props => {
   const {
     id,
-    course_offerings,
+    courseOfferings,
     name,
     course,
     subject,
     format,
     capacity,
-    num_enrollments,
-    grade_levels,
+    numEnrollments,
+    gradeLevels,
     sessions,
     fee,
     prereq,
     description,
     notes,
-    custom_registration_link,
-    regional_partner_name,
+    customRegistrationLink,
+    regionalPartnerName,
     organizer,
     facilitators,
     userInfo,
@@ -71,23 +68,23 @@ const WorkshopMarketingPage: React.FunctionComponent<
         <div className={moduleStyles.bodyContainer}>
           <WorkshopDetails
             name={name}
-            grade_levels={grade_levels}
+            gradeLevels={gradeLevels}
             sessions={sessions}
             fee={fee}
             prereq={prereq}
             description={description}
             notes={notes}
-            course_offerings={course_offerings}
+            courseOfferings={courseOfferings}
             facilitators={facilitators}
           />
 
           <aside className={moduleStyles.sidebar}>
             <EnrollInWorkshop
               id={id}
-              custom_registration_link={custom_registration_link}
+              customRegistrationLink={customRegistrationLink}
               capacity={capacity}
-              num_enrollments={num_enrollments}
-              regional_partner_name={regional_partner_name}
+              numEnrollments={numEnrollments}
+              regionalPartnerName={regionalPartnerName}
               userInfo={userInfo}
               course={course}
               subject={subject}
@@ -98,7 +95,7 @@ const WorkshopMarketingPage: React.FunctionComponent<
 
             <OrganizerInformation
               organizer={organizer}
-              regional_partner_name={regional_partner_name}
+              regionalPartnerName={regionalPartnerName}
             />
           </aside>
         </div>

--- a/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
+++ b/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
@@ -8,8 +8,8 @@ import {
 import React from 'react';
 
 import {
-  GetUserInfoForWorkshopResponse,
-  GetWorkshopInfoScriptDataResponse,
+  UserInfoForWorkshop,
+  WorkshopInfo,
 } from '@cdo/apps/code-studio/pd/workshops/types';
 
 import {useWorkshopEnrollment} from './../hooks/useWorkshopEnrollment';
@@ -21,28 +21,28 @@ const WORKSHOP_ENROLL_SOURCE_PAGE = 'workshop enroll';
 
 interface EnrollInWorkshopProps
   extends Pick<
-      GetWorkshopInfoScriptDataResponse,
-      | 'custom_registration_link'
-      | 'num_enrollments'
+      WorkshopInfo,
+      | 'customRegistrationLink'
+      | 'numEnrollments'
       | 'capacity'
       | 'id'
-      | 'regional_partner_name'
+      | 'regionalPartnerName'
       | 'course'
       | 'sessions'
       | 'name'
       | 'format'
       | 'subject'
     >,
-    GetUserInfoForWorkshopResponse {}
+    UserInfoForWorkshop {}
 /** Component to display the enrollment information for a workshop. */
 const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
   id,
-  custom_registration_link,
-  num_enrollments,
+  customRegistrationLink,
+  numEnrollments,
   capacity,
   sessions,
   userInfo,
-  regional_partner_name,
+  regionalPartnerName,
   course,
   format,
   name,
@@ -50,9 +50,9 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
 }) => {
   const {handleClick, isSubmitting, alertState, setAlertState} =
     useWorkshopEnrollment({
-      workshop_id: id,
-      user_id: userInfo?.id,
-      regional_partner_name,
+      workshopId: id,
+      userId: userInfo?.id,
+      regionalPartnerName,
       course,
       format,
       name,
@@ -60,18 +60,18 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
       sessions,
     });
 
-  const is_student = userInfo?.is_student || false;
-  const is_signed_out = !userInfo;
-  const isFull = num_enrollments >= capacity;
+  const isStudent = userInfo?.isStudent || false;
+  const isSignedOut = !userInfo;
+  const isFull = numEnrollments >= capacity;
 
   const buildEnrollButtonLink = (enrollLink: string) => {
-    if (is_signed_out) {
+    if (isSignedOut) {
       return `/logged_out?source_page=${encodeURIComponent(
         WORKSHOP_ENROLL_SOURCE_PAGE
       )}&return_to=${encodeURIComponent(enrollLink)}`;
     }
 
-    if (is_student) {
+    if (isStudent) {
       return `/teacher_account_required?source_page=${encodeURIComponent(
         WORKSHOP_ENROLL_SOURCE_PAGE
       )}&return_to=${encodeURIComponent(enrollLink)}`;
@@ -93,7 +93,7 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
       );
     }
 
-    if (custom_registration_link) {
+    if (customRegistrationLink) {
       return (
         <>
           <BodyThreeText>
@@ -101,7 +101,7 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
             partner.
           </BodyThreeText>
           <LinkButton
-            href={custom_registration_link}
+            href={customRegistrationLink}
             target="_blank"
             className={moduleStyles.fullWidthButton}
             type="primary"
@@ -113,14 +113,14 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
       );
     }
 
-    if (is_student || is_signed_out) {
+    if (isStudent || isSignedOut) {
       return (
         <LinkButton
           className={moduleStyles.fullWidthButton}
           type="primary"
           size="m"
           href={buildEnrollButtonLink(`/professional-learning/workshops/${id}`)}
-          text={is_student ? 'Switch to teacher account' : 'Sign-in to enroll'}
+          text={isStudent ? 'Switch to teacher account' : 'Sign-in to enroll'}
           iconRight={{iconName: 'right-to-bracket'}}
         />
       );
@@ -130,12 +130,12 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
       <div className={moduleStyles.internalEnrollButton}>
         {userInfo && (
           <UserPassport
-            displayName={userInfo.display_name}
-            givenName={userInfo.first_name}
-            familyName={userInfo.last_name}
+            displayName={userInfo.displayName}
+            givenName={userInfo.givenName}
+            familyName={userInfo.familyName}
             email={userInfo.email}
-            schoolName={userInfo.school_info?.school_name}
-            schoolType={userInfo.school_info?.school_type}
+            schoolName={userInfo.schoolInfo?.schoolName}
+            schoolType={userInfo.schoolInfo?.schoolType}
             returnToHref={`/professional-learning/workshops/${id}`}
             className={moduleStyles.userPassport}
           />

--- a/apps/src/code-studio/pd/workshops/components/OrganizerInformation.tsx
+++ b/apps/src/code-studio/pd/workshops/components/OrganizerInformation.tsx
@@ -13,13 +13,13 @@ import moduleStyles from './../workshopMarketingPage.module.scss';
 
 type OrganizerInformationProps = {
   organizer: OrganizerInfo;
-  regional_partner_name?: string;
+  regionalPartnerName?: string;
 };
 
 /** Component to display the organizer information for a workshop. */
 const OrganizerInformation: React.FC<OrganizerInformationProps> = ({
   organizer,
-  regional_partner_name,
+  regionalPartnerName,
 }) => {
   return (
     <div className={moduleStyles.card}>
@@ -37,11 +37,11 @@ const OrganizerInformation: React.FC<OrganizerInformationProps> = ({
             {organizer.email}
           </Link>
         </BodyThreeText>
-        {regional_partner_name && (
+        {regionalPartnerName && (
           <BodyThreeText>
             <FontAwesomeV6Icon iconName="building" />
             <StrongText>Regional Partner:</StrongText>
-            {regional_partner_name}
+            {regionalPartnerName}
           </BodyThreeText>
         )}
       </div>

--- a/apps/src/code-studio/pd/workshops/components/UserPassport.tsx
+++ b/apps/src/code-studio/pd/workshops/components/UserPassport.tsx
@@ -8,20 +8,20 @@ import classNames from 'classnames';
 import React from 'react';
 
 import {AccountSettingsSectionUrlParams} from '@cdo/apps/accounts/accountUpdateConstants';
-import {GetUserInfoForWorkshopResponse} from '@cdo/apps/code-studio/pd/workshops/types';
+import {UserInfoForWorkshop} from '@cdo/apps/code-studio/pd/workshops/types';
 import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 
 import style from './userPassport.module.scss';
 
 export const isMissingUserInfo = (
-  userInfo: GetUserInfoForWorkshopResponse['userInfo']
+  userInfo: UserInfoForWorkshop['userInfo']
 ) => {
   return (
     !userInfo ||
-    !userInfo.first_name ||
-    !userInfo.last_name ||
+    !userInfo.givenName ||
+    !userInfo.familyName ||
     !userInfo.email ||
-    (!userInfo.school_info?.school_name && !userInfo.school_info?.school_type)
+    (!userInfo.schoolInfo?.schoolName && !userInfo.schoolInfo?.schoolType)
   );
 };
 

--- a/apps/src/code-studio/pd/workshops/components/WorkshopDetails.tsx
+++ b/apps/src/code-studio/pd/workshops/components/WorkshopDetails.tsx
@@ -10,7 +10,7 @@ import {
 import React from 'react';
 
 import {DATA_SHARING_NOTICE} from '@cdo/apps/code-studio/pd/constants';
-import {GetWorkshopInfoScriptDataResponse} from '@cdo/apps/code-studio/pd/workshops/types';
+import {WorkshopInfo} from '@cdo/apps/code-studio/pd/workshops/types';
 
 import WorkshopFacilitatorsList from './WorkshopFacilitatorsList';
 import WorkshopSessionsList from './WorkshsopSessionsList';
@@ -19,28 +19,28 @@ import moduleStyles from './../workshopMarketingPage.module.scss';
 
 interface WorkshopDetailsProps
   extends Pick<
-    GetWorkshopInfoScriptDataResponse,
+    WorkshopInfo,
     | 'name'
-    | 'grade_levels'
+    | 'gradeLevels'
     | 'sessions'
     | 'fee'
     | 'prereq'
     | 'description'
     | 'notes'
-    | 'course_offerings'
+    | 'courseOfferings'
     | 'facilitators'
   > {}
 
 /** Component to display the details of a workshop. */
 const WorkshopDetails: React.FC<WorkshopDetailsProps> = ({
   name,
-  grade_levels,
+  gradeLevels,
   sessions,
   fee,
   prereq,
   description,
   notes,
-  course_offerings,
+  courseOfferings,
   facilitators,
 }) => {
   return (
@@ -50,7 +50,7 @@ const WorkshopDetails: React.FC<WorkshopDetailsProps> = ({
         <div className={moduleStyles.workshopUnderHeadingDetails}>
           <BodyTwoText className={moduleStyles.gradeLevels}>
             <FontAwesomeV6Icon iconName="users" />
-            <StrongText>Grades:</StrongText> {grade_levels?.join(', ')}
+            <StrongText>Grades:</StrongText> {gradeLevels?.join(', ')}
           </BodyTwoText>
           {prereq && (
             <BodyTwoText className={moduleStyles.prerequisites}>
@@ -86,13 +86,13 @@ const WorkshopDetails: React.FC<WorkshopDetailsProps> = ({
         </section>
       )}
 
-      {course_offerings && course_offerings.length > 0 && (
+      {courseOfferings && courseOfferings.length > 0 && (
         <section className={moduleStyles.workshopDetailsItem}>
           <Heading3 visualAppearance="heading-xs">PL Topics Covered:</Heading3>
           <Tags
             size="s"
             className={moduleStyles.plTopicsTags}
-            tagsList={course_offerings.map(course => ({label: course}))}
+            tagsList={courseOfferings.map(course => ({label: course}))}
           />
         </section>
       )}

--- a/apps/src/code-studio/pd/workshops/components/WorkshopEventJsonLdData.tsx
+++ b/apps/src/code-studio/pd/workshops/components/WorkshopEventJsonLdData.tsx
@@ -12,11 +12,7 @@ import type {
 
 import {WorkshopFormats} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
-import type {
-  GetWorkshopInfoScriptDataResponse,
-  OrganizerInfo,
-  SessionInfo,
-} from './../types';
+import type {WorkshopInfo, OrganizerInfo, SessionInfo} from './../types';
 
 const EVENT_ATTENDANCE_MODES = {
   in_person: 'https://schema.org/OfflineEventAttendanceMode',
@@ -194,24 +190,24 @@ const getAudience = (grade_levels?: string[]) => {
     : undefined;
 };
 
-const WorkshopEventJsonLdData: React.FC<GetWorkshopInfoScriptDataResponse> = ({
+const WorkshopEventJsonLdData: React.FC<WorkshopInfo> = ({
   name,
   description,
   sessions,
   format,
-  location_name,
+  locationName,
   fee,
   capacity,
-  num_enrollments,
+  numEnrollments,
   organizer,
-  regional_partner_name,
-  grade_levels,
+  regionalPartnerName,
+  gradeLevels,
   course,
   subject,
-  course_offerings,
+  courseOfferings,
 }) => {
   const {startDate, endDate} = getWorkshopDates(sessions);
-  const {offer, priceNumber} = getOffer(fee, capacity, num_enrollments);
+  const {offer, priceNumber} = getOffer(fee, capacity, numEnrollments);
 
   return (
     <JsonLd<EducationEvent>
@@ -224,12 +220,12 @@ const WorkshopEventJsonLdData: React.FC<GetWorkshopInfoScriptDataResponse> = ({
         description,
         eventAttendanceMode: EVENT_ATTENDANCE_MODES[format],
         eventStatus: EVENT_STATUSES.Scheduled as EventStatusType,
-        location: getLocation(format, location_name, sessions),
-        organizer: getOrganizer(organizer, regional_partner_name),
+        location: getLocation(format, locationName, sessions),
+        organizer: getOrganizer(organizer, regionalPartnerName),
         offers: offer,
         isAccessibleForFree: priceNumber === 0 ? true : undefined,
-        audience: getAudience(grade_levels),
-        keywords: getKeywords(course, subject, course_offerings),
+        audience: getAudience(gradeLevels),
+        keywords: getKeywords(course, subject, courseOfferings),
         url: getPageUrl(),
       }}
     />

--- a/apps/src/code-studio/pd/workshops/components/WorkshopFacilitatorsList.tsx
+++ b/apps/src/code-studio/pd/workshops/components/WorkshopFacilitatorsList.tsx
@@ -9,7 +9,7 @@ import {
 import classNames from 'classnames';
 import React, {useState} from 'react';
 
-import {FacilitatorInfo, GetWorkshopInfoScriptDataResponse} from './../types';
+import {FacilitatorInfo, WorkshopInfo} from './../types';
 
 import moduleStyles from './workshopFaccilitatorsList.module.scss';
 
@@ -63,7 +63,7 @@ const FacilitatorItem: React.FC<{facilitator: FacilitatorInfo}> = ({
 };
 
 interface WorkshopSessionsListProps
-  extends Pick<GetWorkshopInfoScriptDataResponse, 'facilitators'> {}
+  extends Pick<WorkshopInfo, 'facilitators'> {}
 
 /** Component to render a list of workshop facilitators. */
 const WorkshopFacilitatorsList: React.FC<WorkshopSessionsListProps> = ({

--- a/apps/src/code-studio/pd/workshops/components/WorkshsopSessionsList.tsx
+++ b/apps/src/code-studio/pd/workshops/components/WorkshsopSessionsList.tsx
@@ -12,7 +12,7 @@ import {
 } from '@cdo/apps/code-studio/pd/sessionDateUtils';
 import {TIME_FORMAT} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshopConstants';
 
-import {GetWorkshopInfoScriptDataResponse, SessionInfo} from './../types';
+import {WorkshopInfo, SessionInfo} from './../types';
 
 import moduleStyles from './workshopSessionsList.module.scss';
 
@@ -52,8 +52,7 @@ const renderSessionsListItem = (session: SessionInfo) => {
     </li>
   );
 };
-interface WorkshopSessionsListProps
-  extends Pick<GetWorkshopInfoScriptDataResponse, 'sessions'> {}
+interface WorkshopSessionsListProps extends Pick<WorkshopInfo, 'sessions'> {}
 
 /** Component to render a list of workshop sessions. */
 const WorkshopSessionsList: React.FC<WorkshopSessionsListProps> = ({

--- a/apps/src/code-studio/pd/workshops/hooks/useWorkshopEnrollment.ts
+++ b/apps/src/code-studio/pd/workshops/hooks/useWorkshopEnrollment.ts
@@ -2,31 +2,26 @@ import {LinkProps} from '@code-dot-org/component-library/link';
 import {useState} from 'react';
 
 import {SUBMISSION_STATUSES} from '@cdo/apps/code-studio/pd/workshop_enrollment/constants';
-import {GetWorkshopInfoScriptDataResponse} from '@cdo/apps/code-studio/pd/workshops/types';
+import {WorkshopInfo} from '@cdo/apps/code-studio/pd/workshops/types';
 import {navigateToHref} from '@cdo/apps/utils';
 
 import {useWorkshopEnrollmentApi} from './useWorkshopEnrollmentApi';
 
 type WorkshopEnrollmentHandlerProps = Pick<
-  GetWorkshopInfoScriptDataResponse,
-  | 'regional_partner_name'
-  | 'format'
-  | 'course'
-  | 'name'
-  | 'subject'
-  | 'sessions'
+  WorkshopInfo,
+  'regionalPartnerName' | 'format' | 'course' | 'name' | 'subject' | 'sessions'
 > & {
-  workshop_id: number;
-  user_id?: number;
+  workshopId: number;
+  userId?: number;
 };
 
 /**
  * Handles the enrollment logic for a workshop, differentiating between various submission statuses
  * */
 export function useWorkshopEnrollment({
-  workshop_id,
-  user_id,
-  regional_partner_name,
+  workshopId,
+  userId,
+  regionalPartnerName,
   course,
   format,
   name,
@@ -34,7 +29,7 @@ export function useWorkshopEnrollment({
   sessions,
 }: WorkshopEnrollmentHandlerProps) {
   const {submitEnrollment, isSubmitting, error} =
-    useWorkshopEnrollmentApi(workshop_id);
+    useWorkshopEnrollmentApi(workshopId);
   const [alertState, setAlertState] = useState<{
     show: boolean;
     text: string;
@@ -42,7 +37,7 @@ export function useWorkshopEnrollment({
   }>({show: false, text: ''});
 
   const handleClick = async () => {
-    const result = await submitEnrollment(user_id);
+    const result = await submitEnrollment(userId);
 
     switch (result?.workshop_enrollment_status) {
       case SUBMISSION_STATUSES.DUPLICATE:
@@ -77,8 +72,8 @@ export function useWorkshopEnrollment({
         });
         break;
       case SUBMISSION_STATUSES.SUCCESS:
-        sessionStorage.setItem('rpName', regional_partner_name || '');
-        sessionStorage.setItem('workshopId', `${workshop_id}`);
+        sessionStorage.setItem('rpName', regionalPartnerName || '');
+        sessionStorage.setItem('workshopId', `${workshopId}`);
         sessionStorage.setItem('workshopCourse', course);
         sessionStorage.setItem('workshopSubject', subject || '');
         sessionStorage.setItem('workshopName', name || '');

--- a/apps/src/code-studio/pd/workshops/types.ts
+++ b/apps/src/code-studio/pd/workshops/types.ts
@@ -22,6 +22,8 @@ export interface SessionInfo {
   location_address?: string;
   meeting_link?: string;
   session_format: SessionFormat;
+  description?: string;
+  notes?: string;
 }
 
 export interface GetWorkshopInfoScriptDataResponse {
@@ -46,22 +48,111 @@ export interface GetWorkshopInfoScriptDataResponse {
   facilitators?: FacilitatorInfo[];
 }
 
-export type UserInfoForWorkshop = {
+export interface WorkshopInfo {
   id: number;
-  email: string;
-  display_name: string;
-  is_student?: boolean;
-  first_name?: string;
-  last_name?: string;
-  school_info?: {
-    school_id?: number;
-    country?: string;
-    school_name?: string;
-    school_zip?: string;
-    school_type?: string;
-  };
+  course: string;
+  subject?: string;
+  courseOfferings?: string[];
+  name?: string;
+  capacity: number;
+  numEnrollments: number;
+  gradeLevels?: string[];
+  sessions: SessionInfo[];
+  format: keyof typeof WorkshopFormats;
+  locationName?: string;
+  fee?: string;
+  prereq?: string;
+  description?: string;
+  notes?: string;
+  customRegistrationLink?: string;
+  regionalPartnerName?: string;
+  organizer: OrganizerInfo;
+  facilitators?: FacilitatorInfo[];
+}
+
+export const workshopInfoDataResponseToParams = (
+  response: GetWorkshopInfoScriptDataResponse
+) => {
+  return {
+    id: response.id,
+    course: response.course,
+    subject: response.subject,
+    courseOfferings: response.course_offerings,
+    name: response.name,
+    capacity: response.capacity,
+    numEnrollments: response.num_enrollments,
+    gradeLevels: response.grade_levels,
+    sessions: response.sessions,
+    format: response.format,
+    locationName: response.location_name,
+    fee: response.fee,
+    prereq: response.prereq,
+    description: response.description,
+    notes: response.notes,
+    customRegistrationLink: response.custom_registration_link,
+    regionalPartnerName: response.regional_partner_name,
+    organizer: response.organizer,
+    facilitators: response.facilitators,
+  } as WorkshopInfo;
 };
 
 export interface GetUserInfoForWorkshopResponse {
-  userInfo: UserInfoForWorkshop | null;
+  userInfo: {
+    id: number;
+    email: string;
+    display_name: string;
+    is_student?: boolean;
+    given_name?: string;
+    family_name?: string;
+    school_info?: {
+      school_id?: number;
+      country?: string;
+      school_name?: string;
+      school_zip?: string;
+      school_type?: string;
+    };
+  } | null;
 }
+
+export type UserInfoForWorkshop = {
+  userInfo: {
+    id: number;
+    email: string;
+    displayName: string;
+    isStudent?: boolean;
+    givenName?: string;
+    familyName?: string;
+    schoolInfo?: {
+      schoolId?: number;
+      country?: string;
+      schoolName?: string;
+      schoolZip?: string;
+      schoolType?: string;
+    };
+  } | null;
+};
+
+export const userInfoDataResponseToParams = (
+  response: GetUserInfoForWorkshopResponse
+) => {
+  if (!response) return null;
+
+  const userInfo = response.userInfo;
+  return {
+    userInfo: {
+      id: userInfo?.id,
+      email: userInfo?.email,
+      displayName: userInfo?.display_name,
+      isStudent: userInfo?.is_student,
+      givenName: userInfo?.given_name,
+      familyName: userInfo?.family_name,
+      schoolInfo: {
+        schoolId: userInfo?.school_info?.school_id,
+        country: userInfo?.school_info?.country,
+        schoolName: userInfo?.school_info?.school_name,
+        schoolZip: userInfo?.school_info?.school_zip,
+        schoolType: userInfo?.school_info?.school_type,
+      },
+    },
+  } as UserInfoForWorkshop;
+};

--- a/apps/src/code-studio/pd/workshops/types.ts
+++ b/apps/src/code-studio/pd/workshops/types.ts
@@ -71,8 +71,10 @@ export interface WorkshopInfo {
 }
 
 export const workshopInfoDataResponseToParams = (
-  response: GetWorkshopInfoScriptDataResponse
+  response: GetWorkshopInfoScriptDataResponse | null
 ) => {
+  if (!response) return null;
+
   return {
     id: response.id,
     course: response.course,
@@ -97,21 +99,19 @@ export const workshopInfoDataResponseToParams = (
 };
 
 export interface GetUserInfoForWorkshopResponse {
-  userInfo: {
-    id: number;
-    email: string;
-    display_name: string;
-    is_student?: boolean;
-    given_name?: string;
-    family_name?: string;
-    school_info?: {
-      school_id?: number;
-      country?: string;
-      school_name?: string;
-      school_zip?: string;
-      school_type?: string;
-    };
-  } | null;
+  id: number;
+  email: string;
+  display_name: string;
+  is_student?: boolean;
+  given_name?: string;
+  family_name?: string;
+  school_info?: {
+    school_id?: number;
+    country?: string;
+    school_name?: string;
+    school_zip?: string;
+    school_type?: string;
+  };
 }
 
 export type UserInfoForWorkshop = {
@@ -133,25 +133,24 @@ export type UserInfoForWorkshop = {
 };
 
 export const userInfoDataResponseToParams = (
-  response: GetUserInfoForWorkshopResponse
+  response: GetUserInfoForWorkshopResponse | null
 ) => {
   if (!response) return null;
 
-  const userInfo = response.userInfo;
   return {
     userInfo: {
-      id: userInfo?.id,
-      email: userInfo?.email,
-      displayName: userInfo?.display_name,
-      isStudent: userInfo?.is_student,
-      givenName: userInfo?.given_name,
-      familyName: userInfo?.family_name,
+      id: response.id,
+      email: response.email,
+      displayName: response.display_name,
+      isStudent: response.is_student,
+      givenName: response.given_name,
+      familyName: response.family_name,
       schoolInfo: {
-        schoolId: userInfo?.school_info?.school_id,
-        country: userInfo?.school_info?.country,
-        schoolName: userInfo?.school_info?.school_name,
-        schoolZip: userInfo?.school_info?.school_zip,
-        schoolType: userInfo?.school_info?.school_type,
+        schoolId: response.school_info?.school_id,
+        country: response.school_info?.country,
+        schoolName: response.school_info?.school_name,
+        schoolZip: response.school_info?.school_zip,
+        schoolType: response.school_info?.school_type,
       },
     },
   } as UserInfoForWorkshop;

--- a/apps/src/code-studio/pd/workshops/types.ts
+++ b/apps/src/code-studio/pd/workshops/types.ts
@@ -72,7 +72,7 @@ export interface WorkshopInfo {
 
 export const workshopInfoDataResponseToParams = (
   response: GetWorkshopInfoScriptDataResponse | null
-) => {
+): WorkshopInfo | null => {
   if (!response) return null;
 
   return {
@@ -95,7 +95,7 @@ export const workshopInfoDataResponseToParams = (
     regionalPartnerName: response.regional_partner_name,
     organizer: response.organizer,
     facilitators: response.facilitators,
-  } as WorkshopInfo;
+  };
 };
 
 export interface GetUserInfoForWorkshopResponse {
@@ -134,7 +134,7 @@ export type UserInfoForWorkshop = {
 
 export const userInfoDataResponseToParams = (
   response: GetUserInfoForWorkshopResponse | null
-) => {
+): UserInfoForWorkshop | null => {
   if (!response) return null;
 
   return {
@@ -153,5 +153,5 @@ export const userInfoDataResponseToParams = (
         schoolType: response.school_info?.school_type,
       },
     },
-  } as UserInfoForWorkshop;
+  };
 };

--- a/apps/src/sites/studio/pages/pd/professional_learning/workshops/index.js
+++ b/apps/src/sites/studio/pages/pd/professional_learning/workshops/index.js
@@ -1,35 +1,23 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import {
+  workshopInfoDataResponseToParams,
+  userInfoDataResponseToParams,
+} from '@cdo/apps/code-studio/pd/workshops/types';
 import WorkshopMarketingPage from '@cdo/apps/code-studio/pd/workshops/WorkshopMarketingPage';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 document.addEventListener('DOMContentLoaded', function () {
-  const workshopInfo = getScriptData('workshopInfo');
+  const workshopInfoParams = workshopInfoDataResponseToParams(
+    getScriptData('workshopInfo')
+  );
+  const userInfoParams = userInfoDataResponseToParams(
+    getScriptData('userInfo')
+  );
 
   ReactDOM.render(
-    <WorkshopMarketingPage
-      id={workshopInfo.id}
-      course={workshopInfo.course}
-      subject={workshopInfo.subject}
-      course_offerings={workshopInfo.course_offerings}
-      name={workshopInfo.name}
-      capacity={workshopInfo.capacity}
-      num_enrollments={workshopInfo.num_enrollments}
-      grade_levels={workshopInfo.grade_levels}
-      sessions={workshopInfo.sessions}
-      format={workshopInfo.format}
-      location_name={workshopInfo.location_name}
-      fee={workshopInfo.fee}
-      prereq={workshopInfo.prereq}
-      description={workshopInfo.description}
-      notes={workshopInfo.notes}
-      custom_registration_link={workshopInfo.custom_registration_link}
-      regional_partner_name={workshopInfo.regional_partner_name}
-      organizer={workshopInfo.organizer}
-      facilitators={workshopInfo.facilitators}
-      userInfo={getScriptData('userInfo')}
-    />,
+    <WorkshopMarketingPage {...workshopInfoParams} {...userInfoParams} />,
     document.getElementById('workshop-container')
   );
 });

--- a/apps/src/sites/studio/pages/pd/workshop_enrollment/join.js
+++ b/apps/src/sites/studio/pages/pd/workshop_enrollment/join.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function () {
     <WorkshopJoin
       workshopEnrollmentStatus={joinInfo.workshop_enrollment_status}
       workshopInfo={workshopInfoParams}
-      userInfo={userInfoParams}
+      userInfo={userInfoParams.userInfo}
     />,
     document.getElementById('join-workshop-container')
   );

--- a/apps/src/sites/studio/pages/pd/workshop_enrollment/join.js
+++ b/apps/src/sites/studio/pages/pd/workshop_enrollment/join.js
@@ -2,11 +2,25 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import WorkshopJoin from '@cdo/apps/code-studio/pd/workshop_enrollment/WorkshopJoin';
+import {
+  workshopInfoDataResponseToParams,
+  userInfoDataResponseToParams,
+} from '@cdo/apps/code-studio/pd/workshops/types';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 document.addEventListener('DOMContentLoaded', function () {
+  const joinInfo = getScriptData('props');
+  const workshopInfoParams = workshopInfoDataResponseToParams(
+    joinInfo.workshop_info
+  );
+  const userInfoParams = userInfoDataResponseToParams(joinInfo.user_info);
+
   ReactDOM.render(
-    <WorkshopJoin {...getScriptData('props')} />,
+    <WorkshopJoin
+      workshopEnrollmentStatus={joinInfo.workshop_enrollment_status}
+      workshopInfo={workshopInfoParams}
+      userInfo={userInfoParams}
+    />,
     document.getElementById('join-workshop-container')
   );
 });

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/WorkshopJoinTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/WorkshopJoinTest.tsx
@@ -12,12 +12,14 @@ jest.mock('@cdo/apps/util/AuthenticityTokenStore', () => ({
 }));
 
 const DEFAULT_PROPS = {
-  id: 1,
-  course: 'Build Your Own Workshop',
-  name: 'My Sick Workshop',
-  format: 'virtual' as const,
-  regionalPartnerName: 'Reggie Partner',
-  sessions: [],
+  workshopInfo: {
+    id: 1,
+    course: 'Build Your Own Workshop',
+    name: 'My Sick Workshop',
+    format: 'virtual' as const,
+    regionalPartnerName: 'Reggie Partner',
+    sessions: [],
+  },
   userInfo: {
     id: 1,
     displayName: 'Ms. McEntire',
@@ -142,7 +144,7 @@ describe('WorkshopJoin', () => {
       screen.getByText('Error submitting');
 
       expect(fetchStub).toHaveBeenCalledWith(
-        `/api/v1/pd/workshops/${DEFAULT_PROPS.id}/enrollments`,
+        `/api/v1/pd/workshops/${DEFAULT_PROPS.workshopInfo.id}/enrollments`,
         {
           method: 'POST',
           headers: {
@@ -179,7 +181,7 @@ describe('WorkshopJoin', () => {
 
     await waitFor(() => {
       expect(fetchStub).toHaveBeenCalledWith(
-        `/api/v1/pd/workshops/${DEFAULT_PROPS.id}/enrollments`,
+        `/api/v1/pd/workshops/${DEFAULT_PROPS.workshopInfo.id}/enrollments`,
         {
           method: 'POST',
           headers: {

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/WorkshopJoinTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/WorkshopJoinTest.tsx
@@ -12,29 +12,27 @@ jest.mock('@cdo/apps/util/AuthenticityTokenStore', () => ({
 }));
 
 const DEFAULT_PROPS = {
-  workshop_enrollment_status: SUBMISSION_STATUSES.UNSUBMITTED,
-  workshop_info: {
+  id: 1,
+  course: 'Build Your Own Workshop',
+  name: 'My Sick Workshop',
+  format: 'virtual' as const,
+  regionalPartnerName: 'Reggie Partner',
+  sessions: [],
+  userInfo: {
     id: 1,
-    course: 'Build Your Own Workshop',
-    name: 'My Sick Workshop',
-    format: 'Virtual',
-    rp_name: 'Reggie Partner',
-    session_info_for_calendar: [],
-  },
-  user_info: {
-    id: 1,
-    display_name: 'Ms. McEntire',
-    first_name: 'Reba',
-    last_name: 'McEntire',
+    displayName: 'Ms. McEntire',
+    givenName: 'Reba',
+    familyName: 'McEntire',
     email: 'reba@mcentire.com',
-    school_info: {
-      school_id: 1,
+    schoolInfo: {
+      schoolId: 1,
       country: 'United States',
-      school_name: 'Sample School Name',
-      school_zip: '11111',
-      school_type: undefined,
+      schoolName: 'Sample School Name',
+      schoolZip: '11111',
+      schoolType: undefined,
     },
   },
+  workshopEnrollmentStatus: SUBMISSION_STATUSES.UNSUBMITTED,
 };
 
 const renderDefault = (overrideProps = {}) => {
@@ -44,42 +42,42 @@ const renderDefault = (overrideProps = {}) => {
 
 describe('WorkshopJoin', () => {
   it('enrollment status of Duplicate tells user they are already enrolled', () => {
-    renderDefault({workshop_enrollment_status: SUBMISSION_STATUSES.DUPLICATE});
+    renderDefault({workshopEnrollmentStatus: SUBMISSION_STATUSES.DUPLICATE});
     screen.getByText('Duplicate enrollment');
   });
 
   it('enrollment status of Own tells user they cannot enroll in their own workshop', () => {
-    renderDefault({workshop_enrollment_status: SUBMISSION_STATUSES.OWN});
+    renderDefault({workshopEnrollmentStatus: SUBMISSION_STATUSES.OWN});
     screen.getByText('Your own workshop');
   });
 
   it('enrollment status of Closed tells user the workshop is closed', () => {
-    renderDefault({workshop_enrollment_status: SUBMISSION_STATUSES.CLOSED});
+    renderDefault({workshopEnrollmentStatus: SUBMISSION_STATUSES.CLOSED});
     screen.getByText('Closed');
   });
 
   it('enrollment status of Full tells user the workshop is full', () => {
-    renderDefault({workshop_enrollment_status: SUBMISSION_STATUSES.FULL});
+    renderDefault({workshopEnrollmentStatus: SUBMISSION_STATUSES.FULL});
     screen.getByText('Full');
   });
 
   it('enrollment status of Not Found tells user the workshop cannot be found', () => {
-    renderDefault({workshop_enrollment_status: SUBMISSION_STATUSES.NOT_FOUND});
+    renderDefault({workshopEnrollmentStatus: SUBMISSION_STATUSES.NOT_FOUND});
     screen.getByText('Not found');
   });
 
   it('enrollment status of Unsubmitted shows user the info to enroll and their UserPassport', () => {
     renderDefault({
-      workshop_enrollment_status: SUBMISSION_STATUSES.UNSUBMITTED,
+      workshopEnrollmentStatus: SUBMISSION_STATUSES.UNSUBMITTED,
     });
 
     screen.getByText('Review your information');
-    screen.getByText(DEFAULT_PROPS.user_info.display_name);
+    screen.getByText(DEFAULT_PROPS.userInfo.displayName);
     screen.getByText(
-      `${DEFAULT_PROPS.user_info.first_name} ${DEFAULT_PROPS.user_info.last_name}`
+      `${DEFAULT_PROPS.userInfo.givenName} ${DEFAULT_PROPS.userInfo.familyName}`
     );
-    screen.getByText(DEFAULT_PROPS.user_info.email);
-    screen.getByText(DEFAULT_PROPS.user_info.school_info.school_name);
+    screen.getByText(DEFAULT_PROPS.userInfo.email);
+    screen.getByText(DEFAULT_PROPS.userInfo.schoolInfo.schoolName);
   });
 
   it('enroll button is enabled and no errors are shown if all UserPassport fields are present', () => {
@@ -94,13 +92,13 @@ describe('WorkshopJoin', () => {
 
   it('enroll button is enabled and no errors are shown if user does not teach in a school setting', () => {
     const noSchoolSettingSchoolInfo = {
-      ...DEFAULT_PROPS.user_info.school_info,
-      school_type: NonSchoolOptions.NO_SCHOOL_SETTING,
+      ...DEFAULT_PROPS.userInfo.schoolInfo,
+      schoolType: NonSchoolOptions.NO_SCHOOL_SETTING,
     };
     renderDefault({
-      user_info: {
-        ...DEFAULT_PROPS.user_info,
-        school_info: noSchoolSettingSchoolInfo,
+      userInfo: {
+        ...DEFAULT_PROPS.userInfo,
+        schoolInfo: noSchoolSettingSchoolInfo,
       },
     });
 
@@ -113,9 +111,9 @@ describe('WorkshopJoin', () => {
 
   it('enroll button is disabled and errors are shown if there are missing UserPassport fields', () => {
     renderDefault({
-      user_info: {
-        first_name: '',
-        school_info: {},
+      userInfo: {
+        givenName: '',
+        schoolInfo: {},
       },
     });
 
@@ -144,7 +142,7 @@ describe('WorkshopJoin', () => {
       screen.getByText('Error submitting');
 
       expect(fetchStub).toHaveBeenCalledWith(
-        `/api/v1/pd/workshops/${DEFAULT_PROPS.workshop_info.id}/enrollments`,
+        `/api/v1/pd/workshops/${DEFAULT_PROPS.id}/enrollments`,
         {
           method: 'POST',
           headers: {
@@ -152,7 +150,7 @@ describe('WorkshopJoin', () => {
             'X-CSRF-Token': 'authToken',
           },
           body: JSON.stringify({
-            user_id: DEFAULT_PROPS.user_info.id,
+            user_id: DEFAULT_PROPS.userInfo.id,
           }),
         }
       );
@@ -181,7 +179,7 @@ describe('WorkshopJoin', () => {
 
     await waitFor(() => {
       expect(fetchStub).toHaveBeenCalledWith(
-        `/api/v1/pd/workshops/${DEFAULT_PROPS.workshop_info.id}/enrollments`,
+        `/api/v1/pd/workshops/${DEFAULT_PROPS.id}/enrollments`,
         {
           method: 'POST',
           headers: {
@@ -189,7 +187,7 @@ describe('WorkshopJoin', () => {
             'X-CSRF-Token': 'authToken',
           },
           body: JSON.stringify({
-            user_id: DEFAULT_PROPS.user_info.id,
+            user_id: DEFAULT_PROPS.userInfo.id,
           }),
         }
       );

--- a/apps/test/unit/code-studio/pd/workshops/components/EnrollInWorkshopTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshops/components/EnrollInWorkshopTest.tsx
@@ -6,28 +6,28 @@ import {SessionFormat} from '@cdo/apps/code-studio/pd/workshop_dashboard/Worksho
 import EnrollInWorkshop from '@cdo/apps/code-studio/pd/workshops/components/EnrollInWorkshop';
 
 const baseUserInfo = {
-  is_student: false,
+  isStudent: false,
   id: 123,
   email: 'sample@google.com',
-  display_name: 'Mr. Doe',
-  first_name: 'John',
-  last_name: 'Doe',
-  school_info: {
-    school_id: 1,
+  displayName: 'Mr. Doe',
+  givenName: 'John',
+  familyName: 'Doe',
+  schoolInfo: {
+    schoolId: 1,
     country: 'United States',
-    school_name: 'School Academy',
+    schoolName: 'School Academy',
     zip: '11111',
-    school_type: undefined,
+    schoolType: undefined,
   },
 };
 
 const baseProps = {
   id: 1,
-  custom_registration_link: undefined,
-  num_enrollments: 0,
+  customRegistrationLink: undefined,
+  numEnrollments: 0,
   capacity: 10,
   userInfo: baseUserInfo,
-  regional_partner_name: 'Sample Partner',
+  regionalPartnerName: 'Sample Partner',
   course: 'CS Principles',
   name: 'Sample Workshop',
   format: 'hybrid' as const,
@@ -55,13 +55,13 @@ describe('EnrollInWorkshop', () => {
   });
 
   it('shows "Workshop is full" button if full', () => {
-    render(<EnrollInWorkshop {...baseProps} num_enrollments={10} />);
+    render(<EnrollInWorkshop {...baseProps} numEnrollments={10} />);
     const fullButton = screen.getByRole('button', {name: /Workshop is full/i});
     expect(fullButton).toBeDisabled();
   });
 
   it('enroll button is disabled if user information is missing', () => {
-    const missingFirstNameUserInfo = {...baseUserInfo, first_name: ''};
+    const missingFirstNameUserInfo = {...baseUserInfo, givenName: ''};
     render(
       <EnrollInWorkshop {...baseProps} userInfo={missingFirstNameUserInfo} />
     );
@@ -81,7 +81,7 @@ describe('EnrollInWorkshop', () => {
     expect(enrollButton).toBeEnabled();
   });
 
-  it('enroll button sends logged out users to logged out gate if workshop has no custom_registration_link', () => {
+  it('enroll button sends logged out users to logged out gate if workshop has no customRegistrationLink', () => {
     render(<EnrollInWorkshop {...baseProps} userInfo={null} />);
     const linkButton = screen.getByRole('link', {
       name: /Sign-in to enroll/i,
@@ -94,11 +94,11 @@ describe('EnrollInWorkshop', () => {
     );
   });
 
-  it('enroll button sends students to update account type gate if workshop has no custom_registration_link', () => {
+  it('enroll button sends students to update account type gate if workshop has no customRegistrationLink', () => {
     render(
       <EnrollInWorkshop
         {...baseProps}
-        userInfo={{...baseUserInfo, is_student: true}}
+        userInfo={{...baseUserInfo, isStudent: true}}
       />
     );
     const linkButton = screen.getByRole('link', {
@@ -112,7 +112,7 @@ describe('EnrollInWorkshop', () => {
     );
   });
 
-  it('shows internal enrollment button to teachers if workshop has no custom_registration_link', () => {
+  it('shows internal enrollment button to teachers if workshop has no customRegistrationLink', () => {
     render(<EnrollInWorkshop {...baseProps} />);
     const enrollButton = screen.getByRole('button', {
       name: /Enroll in this workshop/i,
@@ -121,13 +121,13 @@ describe('EnrollInWorkshop', () => {
     expect(enrollButton).toBeEnabled();
   });
 
-  it('enroll button sends signed-out users to partner registration link if custom_registration_link is present', () => {
+  it('enroll button sends signed-out users to partner registration link if customRegistrationLink is present', () => {
     const customLink = 'https://partner.org/enroll';
     render(
       <EnrollInWorkshop
         {...baseProps}
         userInfo={null}
-        custom_registration_link={customLink}
+        customRegistrationLink={customLink}
       />
     );
 
@@ -141,13 +141,13 @@ describe('EnrollInWorkshop', () => {
     expect(linkButton).toHaveAttribute('href', customLink);
   });
 
-  it('enroll button sends student users to partner registration link if custom_registration_link is present', () => {
+  it('enroll button sends student users to partner registration link if customRegistrationLink is present', () => {
     const customLink = 'https://partner.org/enroll';
     render(
       <EnrollInWorkshop
         {...baseProps}
-        userInfo={{...baseUserInfo, is_student: true}}
-        custom_registration_link={customLink}
+        userInfo={{...baseUserInfo, isStudent: true}}
+        customRegistrationLink={customLink}
       />
     );
 
@@ -161,10 +161,10 @@ describe('EnrollInWorkshop', () => {
     expect(linkButton).toHaveAttribute('href', customLink);
   });
 
-  it('enroll button sends teachers users to partner registration link if custom_registration_link is present', () => {
+  it('enroll button sends teachers users to partner registration link if customRegistrationLink is present', () => {
     const customLink = 'https://partner.org/enroll';
     render(
-      <EnrollInWorkshop {...baseProps} custom_registration_link={customLink} />
+      <EnrollInWorkshop {...baseProps} customRegistrationLink={customLink} />
     );
 
     expect(

--- a/apps/test/unit/code-studio/pd/workshops/components/OrganizerInformationTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshops/components/OrganizerInformationTest.tsx
@@ -14,7 +14,7 @@ describe('OrganizerInformation', () => {
     render(
       <OrganizerInformation
         organizer={organizer}
-        regional_partner_name="The Best Regional Partner"
+        regionalPartnerName="The Best Regional Partner"
         {...props}
       />
     );
@@ -45,7 +45,7 @@ describe('OrganizerInformation', () => {
   });
 
   it('does not render regional partner name if not provided', () => {
-    setup({regional_partner_name: undefined});
+    setup({regionalPartnerName: undefined});
     expect(screen.queryByText(/regional partner:/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/test/unit/code-studio/pd/workshops/components/WorkshopDetailsTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshops/components/WorkshopDetailsTest.tsx
@@ -7,7 +7,7 @@ import WorkshopDetails from '@cdo/apps/code-studio/pd/workshops/components/Works
 
 const baseProps = {
   name: 'Cybersecurity Basics Workshop',
-  grade_levels: ['K', '1', '2'],
+  gradeLevels: ['K', '1', '2'],
   sessions: [
     {
       id: 1,
@@ -24,7 +24,7 @@ const baseProps = {
   prereq: 'Some workshop A, Some workshop B',
   description: 'Workshop description goes here.',
   notes: 'Bring your device. Stay hydrated!',
-  course_offerings: ['AI and Machine Learning', 'Apps with Devices'],
+  courseOfferings: ['AI and Machine Learning', 'Apps with Devices'],
   facilitators: [
     {
       name: 'Facilitator A',
@@ -76,7 +76,7 @@ describe('WorkshopDetails', () => {
 
   it('renders course offering tags if provided', () => {
     render(<WorkshopDetails {...baseProps} />);
-    baseProps.course_offerings.forEach(course =>
+    baseProps.courseOfferings.forEach(course =>
       expect(screen.getByText(course)).toBeInTheDocument()
     );
   });
@@ -111,7 +111,7 @@ describe('WorkshopDetails', () => {
   });
 
   it('does not render course tags section if list is empty', () => {
-    render(<WorkshopDetails {...baseProps} course_offerings={[]} />);
+    render(<WorkshopDetails {...baseProps} courseOfferings={[]} />);
     expect(screen.queryByText(/PL Topics Covered/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/test/unit/code-studio/pd/workshops/components/WorkshopEventJsonLdDataTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshops/components/WorkshopEventJsonLdDataTest.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 
 import WorkshopEventJsonLdData from '@cdo/apps/code-studio/pd/workshops/components/WorkshopEventJsonLdData';
 import {
-  GetWorkshopInfoScriptDataResponse,
+  WorkshopInfo,
   SessionInfo,
 } from '@cdo/apps/code-studio/pd/workshops/types';
 
 describe('WorkshopEventJsonLdData', () => {
-  const mockData: GetWorkshopInfoScriptDataResponse = {
+  const mockData: WorkshopInfo = {
     id: 1,
     name: 'Sample Workshop',
     description: 'Workshop Description',
@@ -22,16 +22,16 @@ describe('WorkshopEventJsonLdData', () => {
       } as SessionInfo,
     ],
     format: 'in_person',
-    location_name: 'Sample Location',
+    locationName: 'Sample Location',
     fee: '100',
     capacity: 10,
-    num_enrollments: 5,
+    numEnrollments: 5,
     organizer: {name: 'Organizer Name', email: 'organizer@email.com'},
-    regional_partner_name: 'Regional Partner',
-    grade_levels: ['K', '1', '2'],
+    regionalPartnerName: 'Regional Partner',
+    gradeLevels: ['K', '1', '2'],
     course: 'CS Fundamentals',
     subject: 'Computer Science',
-    course_offerings: ['Course A'],
+    courseOfferings: ['Course A'],
   };
 
   it('renders JSON-LD data correctly', () => {

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -135,7 +135,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       @script_data = {
         props: {
           workshop_enrollment_status: enroll_status,
-          workshop_info: @workshop.summarize_for_marketing_page,
+          workshop_info: @workshop&.summarize_for_marketing_page,
           user_info: current_user&.summarize_for_workshop
         }.to_json
       }

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -135,15 +135,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       @script_data = {
         props: {
           workshop_enrollment_status: enroll_status,
-          workshop_info: {
-            id: @workshop.try(:id),
-            course: @workshop.try(:course),
-            subject: @workshop.try(:subject),
-            name: @workshop.try(:name),
-            format: @workshop.try(:format),
-            rp_name: @workshop.try(:regional_partner).try(:name),
-            session_info_for_calendar: @workshop.try(:sessions)&.map(&:session_info_for_calendar)
-          },
+          workshop_info: @workshop.summarize_for_marketing_page,
           user_info: current_user&.summarize_for_workshop
         }.to_json
       }

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1308,8 +1308,8 @@ class User < ApplicationRecord
       email: email,
       is_student: user_type == TYPE_STUDENT,
       display_name: name,
-      first_name: given_name,
-      last_name: family_name,
+      given_name: given_name,
+      family_name: family_name,
       school_info: Queries::SchoolInfo.current_school(self),
     }
   end


### PR DESCRIPTION
Currently, there's a mix of snake casing and camel casing with our workshop enrollment files. This PR unifies them so that backend props are camel cased and frontend props are snake cased. As part of this cleanup, I simplified some of the parameters and updated the user summary to use `given_name` and `family_name` instead of `first_name` and `last_name` (since we now only pass the `user_id` when enrolling a user).

### Workshop Marketing page still works as expected
![marketing page](https://github.com/user-attachments/assets/9b9e4249-a0d0-46ff-8f97-e38b2125acef)

### Workshop Join page still works as expected
![join workshop](https://github.com/user-attachments/assets/e09b7101-4d2f-4faa-93fb-8366787b226b)

### Can enroll as expected

https://github.com/user-attachments/assets/4960ec18-b705-4239-bbf1-1925e799e829

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3402)

## Testing story
Local testing and updating unit tests.
