### PR TITLE
unitSelectionRedux now stores the selected Unit and Course - 2nd attempt

### DIFF
--- a/apps/src/code-studio/calendarRedux.ts
+++ b/apps/src/code-studio/calendarRedux.ts
@@ -12,6 +12,8 @@ interface CalendarLesson {
 
 export interface CalendarState {
   unitName: string | null;
+  unitPosition: number | null;
+  courseName: string | null;
   showCalendar: boolean;
   calendarLessons: CalendarLesson[] | null;
   versionYear: number | null;
@@ -19,6 +21,8 @@ export interface CalendarState {
 
 interface CalendarDataPayload {
   unitName: string | null;
+  unitPosition: number | null;
+  courseName: string | null;
   showCalendar: boolean;
   calendarLessons: CalendarLesson[] | null;
   versionYear: number | null;
@@ -26,6 +30,8 @@ interface CalendarDataPayload {
 
 const initialState: CalendarState = {
   unitName: null,
+  unitPosition: null,
+  courseName: null,
   showCalendar: false,
   calendarLessons: null,
   versionYear: null,
@@ -37,6 +43,8 @@ const calendarReduxSlice = createSlice({
   reducers: {
     setCalendarData(state, action: PayloadAction<CalendarDataPayload>) {
       state.unitName = action.payload.unitName;
+      state.unitPosition = action.payload.unitPosition;
+      state.courseName = action.payload.courseName;
       state.showCalendar = action.payload.showCalendar;
       state.calendarLessons = action.payload.calendarLessons;
       state.versionYear = action.payload.versionYear;

--- a/apps/src/code-studio/components/progress/UnitSummaryUtils.tsx
+++ b/apps/src/code-studio/components/progress/UnitSummaryUtils.tsx
@@ -172,7 +172,7 @@ interface UnitData {
   wrapupVideo: string | null;
   calendarLessons: CalendarLesson[];
   redirect_unit_url: string | null;
-  unit_position: string | null;
+  unit_position: number | null;
 }
 
 export const setUnitSummaryReduxData = (
@@ -215,6 +215,8 @@ export const setUnitSummaryReduxData = (
   dispatch(
     setCalendarData({
       unitName: unitData.name,
+      unitPosition: unitData.unit_position,
+      courseName: unitData.course_name,
       showCalendar: !!unitData.showCalendar,
       calendarLessons: unitData.calendarLessons,
       versionYear: unitData.version_year

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -5,8 +5,7 @@
 import HttpClient from '../util/HttpClient';
 
 // Action type constants
-export const SET_SCRIPT = 'unitSelection/SET_SCRIPT';
-export const SET_UNIT_NAME = 'unitSelection/SET_UNIT_NAME';
+export const SET_UNIT = 'unitSelection/SET_UNIT';
 export const SET_COURSES = 'unitSelection/SET_COURSES';
 
 export const START_LOADING_COURSES = 'unitSelection/START_LOADING_COURSES';
@@ -16,7 +15,11 @@ export const FINISHED_LOADING_COURSES =
 const SET_LOADED_SECTION_ID = 'unitSelection/SET_LOADED_SECTION_ID';
 
 // Action creators
-export const setScriptId = scriptId => ({type: SET_SCRIPT, scriptId});
+export const setUnit = (scriptId, courseVersionId) => ({
+  type: SET_UNIT,
+  scriptId,
+  courseVersionId,
+});
 export const setCoursesWithProgress = coursesWithProgress => ({
   type: SET_COURSES,
   coursesWithProgress,
@@ -35,21 +38,30 @@ export const finishedLoadingCoursesWithProgress = () => ({
 
 // Selectors
 export const getSelectedUnitId = state => state.unitSelection.scriptId;
+export const getSelectedCourseId = state => state.unitSelection.courseVersionId;
+
+export const getSelectedCourse = state => {
+  const courseVersionId = getSelectedCourseId(state);
+  return state.unitSelection.coursesWithProgress.find(
+    c => c.id === courseVersionId
+  );
+};
+
+export const getSelectedCourseName = state => {
+  return getSelectedCourse(state)?.course_name || null;
+};
 
 const getSelectedUnit = state => {
-  const scriptId = state.unitSelection.scriptId;
-  if (!scriptId) {
+  const courseVersionId = getSelectedCourseId(state);
+  const unitId = getSelectedUnitId(state);
+  if (!courseVersionId || !unitId) {
     return null;
   }
 
-  let unit;
-  state.unitSelection.coursesWithProgress.forEach(course => {
-    const tempUnit = course.units.find(unit => scriptId === unit.id);
-    if (tempUnit) {
-      unit = tempUnit;
-    }
-  });
-  return unit;
+  const course = state.unitSelection.coursesWithProgress.find(
+    course => course.id === courseVersionId
+  );
+  return course?.units.find(unit => unitId === unit.id);
 };
 
 export const getSelectedUnitName = state => {
@@ -68,6 +80,10 @@ export const getSelectedScriptDescription = state => {
 
 export const doesCurrentCourseUseFeedback = state => {
   return !!getSelectedUnit(state)?.is_feedback_enabled;
+};
+
+export const getSelectedUnitPosition = state => {
+  return getSelectedUnit(state) ? getSelectedUnit(state).position : null;
 };
 
 export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
@@ -109,6 +125,7 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
 // Initial state of unitSelectionRedux
 const initialState = {
   scriptId: null,
+  courseVersionId: null,
   coursesWithProgress: [],
   isLoadingCoursesWithProgress: false,
   loadedSectionId: null,
@@ -120,19 +137,40 @@ export default function unitSelection(state = initialState, action) {
 
     const firstUnit = firstCourse ? firstCourse.units[0] : null;
 
+    // If the currently selected Unit is the new set of coursesWithProgress,
+    // the default to selecting the first Unit.
+    let scriptId = firstUnit?.id;
+    let courseVersionId = firstCourse?.id;
+    if (state.scriptId && state.courseVersionId) {
+      const selectedUnit = action.coursesWithProgress.find(
+        course => course.id === state.courseVersionId
+      );
+      if (selectedUnit) {
+        const selectedUnitIndex = selectedUnit.units.findIndex(
+          unit => unit.id === state.scriptId
+        );
+        if (selectedUnitIndex >= 0) {
+          scriptId = state.scriptId;
+          courseVersionId = state.courseVersionId;
+        }
+      }
+    }
+
     return {
       ...state,
       coursesWithProgress: action.coursesWithProgress,
       // This automatically selects the first unit of the first course
-      // unless a scriptId is already set
-      scriptId: state.scriptId === null ? firstUnit?.id : state.scriptId,
+      // unless a Unit is already set
+      scriptId: scriptId,
+      courseVersionId: courseVersionId,
     };
   }
 
-  if (action.type === SET_SCRIPT) {
+  if (action.type === SET_UNIT) {
     return {
       ...state,
       scriptId: action.scriptId,
+      courseVersionId: action.courseVersionId,
     };
   }
 

--- a/apps/src/templates/UnitSelectorV2.jsx
+++ b/apps/src/templates/UnitSelectorV2.jsx
@@ -8,7 +8,7 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
   asyncLoadCoursesWithProgress,
-  setScriptId,
+  setUnit,
 } from '@cdo/apps/redux/unitSelectionRedux';
 import {loadUnitProgress} from '@cdo/apps/templates/sectionProgress/sectionProgressLoader';
 import i18n from '@cdo/locale';
@@ -37,9 +37,10 @@ function UnitSelectorV2({
   filterToSelectedCourse = false,
   sectionId,
   unitId,
+  courseVersionId,
   coursesWithProgress,
   className,
-  setScriptId,
+  setUnit,
   asyncLoadCoursesWithProgress,
   isLoadingCourses,
   isLoadingSectionData,
@@ -54,8 +55,13 @@ function UnitSelectorV2({
 
   const onSelectUnit = React.useCallback(
     e => {
-      const newUnitId = parseInt(e.target.value);
-      setScriptId(newUnitId);
+      const value = e.target.value;
+      const [newCourseVersionId, newUnitId] = value
+        .split('-')
+        .map(id => parseInt(id));
+      setUnit(newUnitId, newCourseVersionId);
+      // TODO: TEACH-1938 Pass the newCourseVersionId to the progress API
+      // loadUnitProgress(newUnitId, newCourseVersionId, sectionId);
       loadUnitProgress(newUnitId, sectionId);
 
       recordEvent('change_script', sectionId, {
@@ -69,7 +75,7 @@ function UnitSelectorV2({
         unitId: newUnitId,
       });
     },
-    [unitId, setScriptId, sectionId]
+    [unitId, setUnit, sectionId]
   );
 
   const itemGroups = coursesWithProgress
@@ -81,10 +87,13 @@ function UnitSelectorV2({
     )
     .map(version => ({
       label: version.display_name,
-      groupItems: version.units.map(unit => ({
-        value: unit.id,
-        text: unit.name,
-      })),
+      groupItems: version.units.map(unit => {
+        const itemValue = `${version.id}-${unit.id}`;
+        return {
+          value: itemValue,
+          text: unit.name,
+        };
+      }),
     }));
 
   const loadingDropdown = () => (
@@ -105,7 +114,7 @@ function UnitSelectorV2({
   return (
     <SimpleDropdown
       itemGroups={itemGroups}
-      selectedValue={unitId}
+      selectedValue={`${courseVersionId}-${unitId}`}
       name="unitSelector"
       onChange={onSelectUnit}
       className={className}
@@ -122,9 +131,10 @@ function UnitSelectorV2({
 UnitSelectorV2.propTypes = {
   filterToSelectedCourse: PropTypes.bool,
   unitId: PropTypes.number,
+  courseVersionId: PropTypes.number,
   sectionId: PropTypes.number,
   coursesWithProgress: PropTypes.array.isRequired,
-  setScriptId: PropTypes.func.isRequired,
+  setUnit: PropTypes.func.isRequired,
   className: PropTypes.string,
   asyncLoadCoursesWithProgress: PropTypes.func.isRequired,
   isLoadingCourses: PropTypes.bool,
@@ -137,6 +147,7 @@ export const UnconnectedUnitSelectorV2 = UnitSelectorV2;
 export default connect(
   state => ({
     unitId: state.unitSelection.scriptId,
+    courseVersionId: state.unitSelection.courseVersionId,
     sectionId: state.teacherSections.selectedSectionId,
     coursesWithProgress: state.unitSelection.coursesWithProgress,
     isLoadingCourses: state.unitSelection.isLoadingCoursesWithProgress,
@@ -146,8 +157,8 @@ export default connect(
         ?.courseVersionId,
   }),
   dispatch => ({
-    setScriptId(scriptId) {
-      dispatch(setScriptId(scriptId));
+    setUnit(unitId, courseVersionId) {
+      dispatch(setUnit(unitId, courseVersionId));
     },
     asyncLoadCoursesWithProgress() {
       dispatch(asyncLoadCoursesWithProgress());

--- a/apps/src/templates/sectionAssessments/SectionAssessments.jsx
+++ b/apps/src/templates/sectionAssessments/SectionAssessments.jsx
@@ -4,7 +4,7 @@ import {CSVLink} from 'react-csv';
 import {connect} from 'react-redux';
 
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
-import {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {
   asyncLoadAssessments,
@@ -62,8 +62,9 @@ class SectionAssessments extends Component {
     isLoading: PropTypes.bool.isRequired,
     assessmentList: PropTypes.array.isRequired,
     scriptId: PropTypes.number,
+    courseVersionId: PropTypes.number,
     assessmentId: PropTypes.number,
-    setScriptId: PropTypes.func.isRequired,
+    setUnit: PropTypes.func.isRequired,
     setAssessmentId: PropTypes.func.isRequired,
     asyncLoadAssessments: PropTypes.func.isRequired,
     multipleChoiceSurveyResults: PropTypes.array,
@@ -86,10 +87,10 @@ class SectionAssessments extends Component {
     asyncLoadAssessments(sectionId, scriptId);
   }
 
-  onSelectScript = newScriptId => {
-    const {setScriptId, asyncLoadAssessments, scriptId, sectionId} = this.props;
+  onSelectScript = (newScriptId, newCourseVersionId) => {
+    const {setUnit, asyncLoadAssessments, scriptId, sectionId} = this.props;
     asyncLoadAssessments(sectionId, newScriptId);
-    setScriptId(newScriptId);
+    setUnit(newScriptId, newCourseVersionId);
 
     this.logEvent('select_script', {
       old_script_id: scriptId,
@@ -182,6 +183,7 @@ class SectionAssessments extends Component {
     const {
       sectionName,
       scriptId,
+      courseVersionId,
       assessmentList,
       assessmentId,
       isLoading,
@@ -203,7 +205,11 @@ class SectionAssessments extends Component {
             <div style={{...h3Style, ...styles.header}}>
               {i18n.selectACourse()}
             </div>
-            <UnitSelector scriptId={scriptId} onChange={this.onSelectScript} />
+            <UnitSelector
+              scriptId={scriptId}
+              courseVersionId={courseVersionId}
+              onChange={this.onSelectScript}
+            />
           </div>
           {!isLoading && assessmentList.length > 0 && (
             <div style={styles.assessmentSelection}>
@@ -367,6 +373,7 @@ export default connect(
     isLoading: !!state.sectionAssessments.isLoading,
     assessmentList: getCurrentScriptAssessmentList(state),
     scriptId: state.unitSelection.scriptId,
+    courseVersionId: state.unitSelection.courseVersionId,
     assessmentId: state.sectionAssessments.assessmentId,
     isCurrentAssessmentSurvey: isCurrentAssessmentSurvey(state),
     totalStudentSubmissions: countSubmissionsForCurrentAssessment(state),
@@ -375,8 +382,8 @@ export default connect(
     studentList: state.teacherSections.selectedStudents,
   }),
   dispatch => ({
-    setScriptId(scriptId) {
-      dispatch(setScriptId(scriptId));
+    setUnit(scriptId, courseVersionId) {
+      dispatch(setUnit(scriptId, courseVersionId));
     },
     asyncLoadAssessments(sectionId, scriptId) {
       return dispatch(asyncLoadAssessments(sectionId, scriptId));

--- a/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
+++ b/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
@@ -1,5 +1,5 @@
 import {
-  SET_SCRIPT,
+  SET_UNIT,
   getSelectedUnitName,
   doesCurrentCourseUseFeedback,
 } from '@cdo/apps/redux/unitSelectionRedux';
@@ -164,7 +164,7 @@ export const asyncLoadAssessments = (sectionId, scriptId) => {
 };
 
 export default function sectionAssessments(state = initialState, action) {
-  if (action.type === SET_SCRIPT) {
+  if (action.type === SET_UNIT) {
     return {
       ...state,
       studentId: ALL_STUDENT_FILTER,

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -6,7 +6,7 @@ import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import logToCloud from '@cdo/apps/logToCloud';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import ProgressTableView from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableView';
 import SectionProgressToggle from '@cdo/apps/templates/sectionProgress/SectionProgressToggle';
 import StandardsView from '@cdo/apps/templates/sectionProgress/standards/StandardsView';
@@ -42,11 +42,12 @@ class SectionProgress extends Component {
   static propTypes = {
     //Provided by redux
     scriptId: PropTypes.number,
+    courseVersionId: PropTypes.number,
     sectionId: PropTypes.number,
     currentView: PropTypes.oneOf(Object.values(ViewType)),
     setCurrentView: PropTypes.func.isRequired,
     scriptData: unitDataPropType,
-    setScriptId: PropTypes.func.isRequired,
+    setUnit: PropTypes.func.isRequired,
     setLessonOfInterest: PropTypes.func.isRequired,
     isLoadingProgress: PropTypes.bool.isRequired,
     isRefreshingProgress: PropTypes.bool,
@@ -121,8 +122,8 @@ class SectionProgress extends Component {
     }
   }
 
-  onChangeScript = scriptId => {
-    this.props.setScriptId(scriptId);
+  onChangeScript = (scriptId, courseVersionId) => {
+    this.props.setUnit(scriptId, courseVersionId);
 
     this.recordEvent('change_script', {
       old_script_id: this.props.scriptId,
@@ -196,6 +197,7 @@ class SectionProgress extends Component {
     const {
       currentView,
       scriptId,
+      courseVersionId,
       scriptData,
       sectionId,
       showStandardsIntroDialog,
@@ -221,7 +223,11 @@ class SectionProgress extends Component {
             <div style={{...h3Style, ...styles.heading}}>
               {i18n.selectACourse()}
             </div>
-            <UnitSelector scriptId={scriptId} onChange={this.onChangeScript} />
+            <UnitSelector
+              scriptId={scriptId}
+              courseVersionId={courseVersionId}
+              onChange={this.onChangeScript}
+            />
           </div>
           {levelDataInitialized && (
             <div style={styles.toggle}>
@@ -315,6 +321,7 @@ export const UnconnectedSectionProgress = SectionProgress;
 export default connect(
   state => ({
     scriptId: state.unitSelection.scriptId,
+    courseVersionId: state.unitSelection.courseVersionId,
     sectionId: state.teacherSections.selectedSectionId,
     currentView: state.sectionProgress.currentView,
     scriptData: getCurrentUnitData(state),
@@ -323,8 +330,8 @@ export default connect(
     showStandardsIntroDialog: !state.currentUser.hasSeenStandardsReportInfo,
   }),
   dispatch => ({
-    setScriptId(scriptId) {
-      dispatch(setScriptId(scriptId));
+    setUnit(scriptId, courseVersionId) {
+      dispatch(setUnit(scriptId, courseVersionId));
     },
     setLessonOfInterest(lessonOfInterest) {
       dispatch(setLessonOfInterest(lessonOfInterest));

--- a/apps/src/templates/sectionProgress/UnitSelector.js
+++ b/apps/src/templates/sectionProgress/UnitSelector.js
@@ -11,6 +11,7 @@ import skeletonizeContent from '@cdo/apps/sharedComponents/skeletonize-content.m
 function UnitSelector({
   sectionId,
   scriptId,
+  courseVersionId,
   onChange,
   coursesWithProgress,
   asyncLoadCoursesWithProgress,
@@ -36,7 +37,16 @@ function UnitSelector({
       />
     </div>
   );
+  const onSelectUnit = e => {
+    const value = e.target.value;
+    const [newCourseVersionId, newUnitId] = value.includes('-')
+      ? value.split('-').map(id => parseInt(id))
+      : [undefined, parseInt(value)];
+    onChange(newUnitId, newCourseVersionId);
+  };
 
+  const selectedValue =
+    scriptId && courseVersionId ? `${courseVersionId}-${scriptId}` : undefined;
   return isLoadingSectionData ||
     isLoadingCourses ||
     !coursesWithProgress ||
@@ -45,15 +55,15 @@ function UnitSelector({
   ) : (
     <div>
       <select
-        value={scriptId || undefined}
-        onChange={event => onChange(parseInt(event.target.value))}
+        value={selectedValue}
+        onChange={onSelectUnit}
         className={styles.dropdown}
         id="uitest-course-dropdown"
       >
         {coursesWithProgress.map((version, index) => (
           <optgroup key={index} label={version.display_name}>
             {version.units.map(unit => (
-              <option key={unit.id} value={unit.id}>
+              <option key={unit.id} value={`${version.id}-${unit.id}`}>
                 {unit.name}
               </option>
             ))}
@@ -67,6 +77,7 @@ function UnitSelector({
 UnitSelector.propTypes = {
   coursesWithProgress: PropTypes.array.isRequired,
   scriptId: PropTypes.number,
+  courseVersionId: PropTypes.number,
   sectionId: PropTypes.number,
   onChange: PropTypes.func.isRequired,
   asyncLoadCoursesWithProgress: PropTypes.func.isRequired,

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {SET_SCRIPT} from '@cdo/apps/redux/unitSelectionRedux';
+import {SET_UNIT} from '@cdo/apps/redux/unitSelectionRedux';
 import {trySetLocalStorage, tryGetLocalStorage} from '@cdo/apps/utils';
 
 import firehoseClient from '../../metrics/firehose';
@@ -103,7 +103,7 @@ const initialState = {
 };
 
 export default function sectionProgress(state = initialState, action) {
-  if (action.type === SET_SCRIPT) {
+  if (action.type === SET_UNIT) {
     return {
       ...state,
       lessonOfInterest: INITIAL_LESSON_OF_INTEREST,

--- a/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
@@ -8,7 +8,7 @@ import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import {
   getSelectedScriptFriendlyName,
   getSelectedScriptDescription,
-  setScriptId,
+  setUnit,
 } from '@cdo/apps/redux/unitSelectionRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {getCurrentUnitData} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
@@ -45,7 +45,7 @@ function StandardsReport({
   numLessonsCompleted,
   numLessonsInUnit,
   setTeacherCommentForReport,
-  setScriptId,
+  setUnit,
   lessonsByStandard,
 }) {
   React.useEffect(() => {
@@ -55,19 +55,16 @@ function StandardsReport({
       );
       const scriptIdFromTD =
         window.opener.teacherDashboardStoreInformation.scriptId;
-      setScriptId(scriptIdFromTD);
+      const courseVersionIdFromTD =
+        window.opener.teacherDashboardStoreInformation.courseVersionId;
+      setUnit(scriptIdFromTD, courseVersionIdFromTD);
       loadUnitProgress(scriptIdFromTD, sectionId);
     } catch (e) {
       throw new Error(
         '/standards_report must be opened from the `generate PDF report` button of the Standards tab on the v1 progress page on a section assigned to curriculum that has standards (e.g. `Course C (2023)`).'
       );
     }
-  }, [
-    sectionId,
-    setTeacherCommentForReport,
-    setScriptId,
-    numStudentsInSection,
-  ]);
+  }, [sectionId, setTeacherCommentForReport, setUnit, numStudentsInSection]);
 
   const getLinkToOverview = () => {
     return scriptData ? `${scriptData.path}?section_id=${sectionId}` : null;
@@ -193,7 +190,7 @@ StandardsReport.propTypes = {
   numLessonsCompleted: PropTypes.number,
   numLessonsInUnit: PropTypes.number,
   setTeacherCommentForReport: PropTypes.func.isRequired,
-  setScriptId: PropTypes.func.isRequired,
+  setUnit: PropTypes.func.isRequired,
   lessonsByStandard: PropTypes.object,
 };
 
@@ -243,8 +240,8 @@ export default connect(
     setTeacherCommentForReport(comment) {
       dispatch(setTeacherCommentForReport(comment));
     },
-    setScriptId(scriptId) {
-      dispatch(setScriptId(scriptId));
+    setUnit(scriptId, courseVersionId) {
+      dispatch(setUnit(scriptId, courseVersionId));
     },
   })
 )(StandardsReport);

--- a/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
@@ -28,6 +28,7 @@ class StandardsViewHeaderButtons extends Component {
     // redux
     setTeacherCommentForReport: PropTypes.func.isRequired,
     scriptId: PropTypes.number,
+    courseVersionId: PropTypes.number,
     selectedLessons: PropTypes.array.isRequired,
     unpluggedLessons: PropTypes.array.isRequired,
     fetchStudentLevelScores: PropTypes.func,
@@ -97,6 +98,7 @@ class StandardsViewHeaderButtons extends Component {
     window.teacherDashboardStoreInformation = {
       teacherComment: this.state.comment,
       scriptId: this.props.scriptId,
+      courseVersionId: this.props.courseVersionId,
     };
     firehoseClient.putRecord(
       {
@@ -216,6 +218,7 @@ export const UnconnectedStandardsViewHeaderButtons = StandardsViewHeaderButtons;
 export default connect(
   state => ({
     scriptId: state.unitSelection.scriptId,
+    courseVersionId: state.unitSelection.courseVersionId,
     selectedLessons: state.sectionStandardsProgress.selectedLessons,
     unpluggedLessons: getUnpluggedLessonsForScript(state),
   }),

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -87,6 +87,7 @@ export interface ServerSection {
   course_id: number | null;
   course_offering_id?: number | null;
   course_version_id?: number | null;
+  courseVersionName?: string | null;
   createdAt?: string;
   grades?: string[];
   hidden: boolean;
@@ -106,6 +107,7 @@ export interface ServerSection {
   sync_enabled?: boolean;
   tts_autoplay_enabled?: boolean;
   unit_id?: number | null;
+  unitName?: string | null;
   unitPosition?: number | null;
   avatar_color?: number | null;
   avatar_emoji?: number | null;

--- a/apps/src/templates/teacherNavigation/CalendarEmptyState.tsx
+++ b/apps/src/templates/teacherNavigation/CalendarEmptyState.tsx
@@ -15,7 +15,9 @@ import {
 
 export const CalendarEmptyState: React.FC = () => {
   const selectedSection = useAppSelector(selectedSectionSelector);
-  const versionYear = useAppSelector(state => state.calendar?.versionYear);
+  const versionYear = useAppSelector(state => {
+    return state.calendar?.versionYear;
+  });
   const isLegacyScript = versionYear ? versionYear < 2021 : false;
   const hasCalendar = useAppSelector(state => state.calendar?.showCalendar);
   const showNoCurriculumAssigned = !selectedSection.courseOfferingId;

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -13,6 +13,8 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
   asyncLoadCoursesWithProgress,
   getSelectedUnitName,
+  getSelectedUnitPosition,
+  getSelectedCourseName,
 } from '@cdo/apps/redux/unitSelectionRedux';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
@@ -41,6 +43,13 @@ const UnitCalendar: React.FC = () => {
   const selectedSection = useAppSelector(selectedSectionSelector);
 
   const unitName = useSelector(state => getSelectedUnitName(state));
+  let unitPosition = useSelector(state => getSelectedUnitPosition(state));
+  let courseName = useSelector(state => getSelectedCourseName(state));
+
+  if (!(unitPosition && courseName)) {
+    unitPosition = selectedSection.unitPosition;
+    courseName = selectedSection.courseVersionName;
+  }
 
   const hasCalendar = useAppSelector(state => state.calendar?.showCalendar);
 
@@ -48,19 +57,18 @@ const UnitCalendar: React.FC = () => {
     state => state.calendar?.calendarLessons
   );
 
-  const calendarUnitName = useAppSelector(state => state.calendar?.unitName);
+  const calendarCourseName = useAppSelector(
+    state => state.calendar?.courseName
+  );
+  const calendarUnitPosition = useAppSelector(
+    state => state.calendar?.unitPosition
+  );
 
   const {userId, userType} = useAppSelector(state => state.currentUser);
 
   const isLoadingCoursesWithProgress = useSelector(
     (state: {unitSelection: {isLoadingCoursesWithProgress: boolean}}) =>
       state.unitSelection.isLoadingCoursesWithProgress
-  );
-
-  const unitToLoad = React.useMemo(
-    () =>
-      !!selectedSection.unitName ? unitName || selectedSection.unitName : null,
-    [unitName, selectedSection.unitName]
   );
 
   const dispatch = useAppDispatch();
@@ -70,10 +78,12 @@ const UnitCalendar: React.FC = () => {
   }, [dispatch]);
 
   useEffect(() => {
-    if (!selectedSection.courseOfferingId || !unitToLoad) {
+    if (!selectedSection.courseOfferingId || !(courseName && unitPosition)) {
       dispatch(
         setCalendarData({
           unitName: null,
+          unitPosition: null,
+          courseName: null,
           showCalendar: false,
           calendarLessons: null,
           versionYear: null,
@@ -81,17 +91,18 @@ const UnitCalendar: React.FC = () => {
       );
     } else if (
       !isLoading &&
-      unitToLoad &&
+      courseName &&
+      unitPosition &&
       userType &&
       userId &&
       (hasCalendar === undefined ||
         calendarLessons === null ||
-        (unitToLoad !== calendarUnitName && unitName !== null))
+        courseName !== calendarCourseName ||
+        unitPosition !== calendarUnitPosition)
     ) {
       setIsLoading(true);
-      HttpClient.fetchJson<UnitSummaryResponse>(
-        `/dashboardapi/unit_summary/${unitToLoad}`
-      )
+      const fetchUnitSummaryPath = `/dashboardapi/unit_summary/${courseName}/${unitPosition}`;
+      HttpClient.fetchJson<UnitSummaryResponse>(fetchUnitSummaryPath)
         .then(response => response?.value)
         .then(responseJson => {
           // Initialize Redux state with the new data
@@ -99,14 +110,14 @@ const UnitCalendar: React.FC = () => {
           setIsLoading(false);
 
           analyticsReporter.sendEvent(EVENTS.VIEW_UNIT_CALENDAR, {
-            unitToLoad,
+            unitName,
           });
         })
         .catch(error => {
           console.error('Error loading unit calendar', error);
 
           analyticsReporter.sendEvent(EVENTS.UNIT_CALENDAR_FAILURE, {
-            unitToLoad,
+            unitName,
           });
           return null;
         });
@@ -122,8 +133,11 @@ const UnitCalendar: React.FC = () => {
     dispatch,
     isLoading,
     selectedSection.courseOfferingId,
-    unitToLoad,
-    calendarUnitName,
+    selectedSection.courseVersionName,
+    courseName,
+    unitPosition,
+    calendarCourseName,
+    calendarUnitPosition,
   ]);
 
   const weeklyMinutesOptions = WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS.map(

--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -1,7 +1,7 @@
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {getStore} from '@cdo/apps/redux';
-import {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
 import {
@@ -62,10 +62,11 @@ export const setSelectedSectionData = (sectionData: any) => {
   getStore().dispatch(
     setStudentsForCurrentSection(sectionData.id, sectionData.students)
   );
-  // Default the scriptId to the script assigned to the section
-  const defaultScriptId = sectionData.script ? sectionData.script.id : null;
-  if (defaultScriptId) {
-    getStore().dispatch(setScriptId(defaultScriptId));
+  // Default Unit assigned to the section
+  const defaultUnitId = sectionData.script ? sectionData.script.id : null;
+  const defaultCourseId = sectionData.course_id;
+  if (defaultUnitId) {
+    getStore().dispatch(setUnit(defaultUnitId, defaultCourseId));
   }
 
   if (!sectionData.sharing_disabled && sectionData.script.project_sharing) {

--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -64,9 +64,9 @@ export const setSelectedSectionData = (sectionData: any) => {
   );
   // Default Unit assigned to the section
   const defaultUnitId = sectionData.script ? sectionData.script.id : null;
-  const defaultCourseId = sectionData.course_id;
+  const defaultCourseVersionId = sectionData.course_version_id;
   if (defaultUnitId) {
-    getStore().dispatch(setUnit(defaultUnitId, defaultCourseId));
+    getStore().dispatch(setUnit(defaultUnitId, defaultCourseVersionId));
   }
 
   if (!sectionData.sharing_disabled && sectionData.script.project_sharing) {

--- a/apps/src/templates/textResponses/TextResponses.jsx
+++ b/apps/src/templates/textResponses/TextResponses.jsx
@@ -5,10 +5,7 @@ import {CSVLink} from 'react-csv';
 import {connect} from 'react-redux';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import {
-  setScriptId,
-  getSelectedUnitName,
-} from '@cdo/apps/redux/unitSelectionRedux';
+import {setUnit, getSelectedUnitName} from '@cdo/apps/redux/unitSelectionRedux';
 import UnitSelector from '@cdo/apps/templates/sectionProgress/UnitSelector';
 import {loadTextResponsesFromServer} from '@cdo/apps/templates/textResponses/textReponsesDataApi';
 import TextResponsesLessonSelector from '@cdo/apps/templates/textResponses/TextResponsesLessonSelector';
@@ -28,7 +25,7 @@ const CSV_HEADERS = [
 ];
 const PADDING = 8;
 
-function TextResponses({sectionId, scriptId, scriptName, setScriptId}) {
+function TextResponses({sectionId, scriptId, scriptName, setUnit}) {
   const [textResponsesByScript, setTextResponsesByScript] = useState({});
   const [isLoadingResponses, setIsLoadingResponses] = useState(false);
   const [filterByLessonName, setFilterByLessonName] = useState(null);
@@ -76,8 +73,8 @@ function TextResponses({sectionId, scriptId, scriptName, setScriptId}) {
     [textResponsesByScript]
   );
 
-  const onChangeScript = scriptId => {
-    setScriptId(scriptId);
+  const onChangeScript = (scriptId, courseVersionId) => {
+    setUnit(scriptId, courseVersionId);
     setFilterByLessonName(null);
   };
 
@@ -137,7 +134,7 @@ TextResponses.propTypes = {
   sectionId: PropTypes.number.isRequired,
   scriptId: PropTypes.number,
   scriptName: PropTypes.string,
-  setScriptId: PropTypes.func.isRequired,
+  setUnit: PropTypes.func.isRequired,
 };
 
 const styles = {
@@ -171,11 +168,12 @@ export default connect(
   state => ({
     sectionId: state.teacherSections.selectedSectionId,
     scriptId: state.unitSelection.scriptId,
+    courseVersionId: state.unitSelection.courseVersionId,
     scriptName: getSelectedUnitName(state),
   }),
   dispatch => ({
-    setScriptId(scriptId) {
-      dispatch(setScriptId(scriptId));
+    setUnit(scriptId, courseVersionId) {
+      dispatch(setUnit(scriptId, courseVersionId));
     },
   })
 )(TextResponses);

--- a/apps/test/unit/code-studio/components/progress/TeacherUnitOverviewTest.tsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherUnitOverviewTest.tsx
@@ -70,7 +70,7 @@ const UNIT_SUMMARY = {
   lessonGroups: [],
   isPlCourse: false,
   plc: false,
-  unit_position: '1',
+  unit_position: 1,
 };
 
 const navigate = jest.fn();

--- a/apps/test/unit/redux/unitSelectionReduxTest.js
+++ b/apps/test/unit/redux/unitSelectionReduxTest.js
@@ -1,6 +1,7 @@
 import unitSelection, {
-  setScriptId,
+  setUnit,
   getSelectedUnitName,
+  getSelectedUnitPosition,
   getSelectedScriptDescription,
   setCoursesWithProgress,
 } from '@cdo/apps/redux/unitSelectionRedux';
@@ -13,59 +14,132 @@ describe('unitSelectionRedux', () => {
     const action = setCoursesWithProgress(fakeCoursesWithProgress);
     const nextState = unitSelection(initialState, action);
     expect(nextState.scriptId).toEqual(2);
+    expect(nextState.courseVersionId).toEqual(1);
   });
 
   describe('getSelectedUnitName', () => {
-    it('returns the script name of the selected script', () => {
-      const state = {
-        unitSelection: {
-          scriptId: 5,
-          coursesWithProgress: fakeCoursesWithProgress,
-        },
-      };
-      expect(getSelectedUnitName(state)).toEqual('csd1-2018');
+    describe('with no section selected', () => {
+      it('returns the script name of the selected script', () => {
+        const state = {
+          unitSelection: {
+            scriptId: 5,
+            courseVersionId: 2,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+        };
+        expect(getSelectedUnitName(state)).toEqual('csd1-2018');
+      });
+
+      it('returns null if no script is selected', () => {
+        const state = {
+          unitSelection: {
+            scriptId: null,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+        };
+        expect(getSelectedUnitName(state)).toBeNull();
+      });
+
+      describe('with section selected', () => {
+        it('returns the script name of the selected script', () => {
+          const state = {
+            unitSelection: {
+              scriptId: 5,
+              courseVersionId: 2,
+              coursesWithProgress: fakeCoursesWithProgress,
+            },
+            teacherSections: {
+              selectedSectionId: 99,
+              sections: {
+                99: {
+                  courseVersionId: 2,
+                },
+              },
+            },
+          };
+          expect(getSelectedUnitName(state)).toEqual('csd1-2018');
+        });
+      });
     });
 
-    it('returns null if no script is selected', () => {
-      const state = {
-        unitSelection: {
-          scriptId: null,
-          coursesWithProgress: fakeCoursesWithProgress,
-        },
-      };
-      expect(getSelectedUnitName(state)).toBeNull();
-    });
-  });
+    describe('getSelectedScriptDescription', () => {
+      it('returns the script description of the selected script', () => {
+        const state = {
+          unitSelection: {
+            scriptId: 9,
+            courseVersionId: 3,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+        };
+        expect(getSelectedScriptDescription(state)).toEqual(
+          'Make a flappy game!'
+        );
+      });
 
-  describe('getSelectedScriptDescription', () => {
-    it('returns the script description of the selected script', () => {
-      const state = {
-        unitSelection: {
-          scriptId: 9,
-          coursesWithProgress: fakeCoursesWithProgress,
-        },
-      };
-      expect(getSelectedScriptDescription(state)).toEqual(
-        'Make a flappy game!'
-      );
+      it('returns null if no script is selected', () => {
+        const state = {
+          unitSelection: {
+            scriptId: null,
+            coursesWithProgress: fakeCoursesWithProgress,
+          },
+        };
+        expect(getSelectedScriptDescription(state)).toEqual(null);
+      });
     });
 
-    it('returns null if no script is selected', () => {
-      const state = {
-        unitSelection: {
-          scriptId: null,
-          coursesWithProgress: fakeCoursesWithProgress,
-        },
-      };
-      expect(getSelectedScriptDescription(state)).toEqual(null);
-    });
-  });
+    describe('getSelectedUnitPosition', () => {
+      describe('with no section selected', () => {
+        it('returns the script name of the selected script', () => {
+          const state = {
+            unitSelection: {
+              scriptId: 5,
+              courseVersionId: 2,
+              coursesWithProgress: fakeCoursesWithProgress,
+            },
+          };
+          expect(getSelectedUnitPosition(state)).toEqual(1);
+        });
 
-  describe('setScriptId', () => {
-    it('sets the script id', () => {
-      const action = setScriptId(130);
-      const nextState = unitSelection(initialState, action);
-      expect(nextState.scriptId).toEqual(130);
+        it('returns null if no script is selected', () => {
+          const state = {
+            unitSelection: {
+              scriptId: null,
+              coursesWithProgress: fakeCoursesWithProgress,
+            },
+          };
+          expect(getSelectedUnitPosition(state)).toBeNull();
+        });
+      });
+
+      describe('with section selected', () => {
+        it('returns the script name of the selected script', () => {
+          const state = {
+            unitSelection: {
+              scriptId: 5,
+              courseVersionId: 2,
+              coursesWithProgress: fakeCoursesWithProgress,
+            },
+            teacherSections: {
+              selectedSectionId: 99,
+              sections: {
+                99: {
+                  courseVersionId: 2,
+                },
+              },
+            },
+          };
+          expect(getSelectedUnitPosition(state)).toEqual(1);
+        });
+      });
+    });
+
+    describe('setUnit', () => {
+      it('sets the Unit', () => {
+        const action = setUnit(130, 999);
+        const nextState = unitSelection(initialState, action);
+        expect(nextState.scriptId).toEqual(130);
+        expect(nextState.courseVersionId).toEqual(999);
+      });
     });
   });
 });

--- a/apps/test/unit/templates/UnitSelectorV2Test.jsx
+++ b/apps/test/unit/templates/UnitSelectorV2Test.jsx
@@ -10,7 +10,7 @@ const DEFAULT_PROPS = {
   coursesWithProgress: fakeCoursesWithProgress,
   scriptId: 2, // Course A (2018)
   sectionId: 1,
-  setScriptId: () => {},
+  setUnit: () => {},
   onChange: () => {},
   asyncLoadCoursesWithProgress: () => {},
   isLoadingCourses: false,
@@ -35,17 +35,15 @@ describe('UnitSelector', () => {
   });
 
   it('sets scriptId on change', () => {
-    const setScriptId = jest.fn();
-    render(
-      <UnconnectedUnitSelectorV2 {...DEFAULT_PROPS} setScriptId={setScriptId} />
-    );
+    const setUnit = jest.fn();
+    render(<UnconnectedUnitSelectorV2 {...DEFAULT_PROPS} setUnit={setUnit} />);
     const dropdown = screen.getByRole('combobox');
     fireEvent.click(dropdown);
 
     const option = screen.getByRole('option', {name: 'Flappy'});
     fireEvent.change(dropdown, {target: {value: option.value}});
 
-    expect(setScriptId).toHaveBeenCalledTimes(1);
+    expect(setUnit).toHaveBeenCalledTimes(1);
   });
 
   it('loads courses on initial render', () => {

--- a/apps/test/unit/templates/sectionAssessments/sectionAssessmentsReduxTest.js
+++ b/apps/test/unit/templates/sectionAssessments/sectionAssessmentsReduxTest.js
@@ -1,4 +1,4 @@
-import {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import sectionAssessments, {
   setAssessmentResponses,
   setSurveys,
@@ -44,7 +44,7 @@ describe('sectionAssessmentsRedux', () => {
           1: [{question: 'a question', puzzle: 2}],
         },
       };
-      const action = setScriptId(2);
+      const action = setUnit(2, 99);
       const nextState = sectionAssessments(currentState, action);
       expect(nextState.studentId).toEqual(0);
       expect(nextState.assessmentResponsesByScript).toEqual(
@@ -183,6 +183,7 @@ describe('sectionAssessmentsRedux', () => {
       const rootState = {
         unitSelection: {
           scriptId: 123,
+          courseVersionId: 321,
           coursesWithProgress: [
             {
               id: 321,
@@ -221,6 +222,7 @@ describe('sectionAssessmentsRedux', () => {
       const rootState = {
         unitSelection: {
           scriptId: 123,
+          courseVersionId: 321,
           coursesWithProgress: [
             {
               id: 321,
@@ -286,6 +288,7 @@ describe('sectionAssessmentsRedux', () => {
         sectionAssessments: initialState,
         unitSelection: {
           scriptId: 3,
+          courseVersionId: 321,
         },
       };
     });
@@ -735,6 +738,7 @@ describe('sectionAssessmentsRedux', () => {
           ...rootState,
           unitSelection: {
             scriptId: 2,
+            courseVersionId: 321,
             coursesWithProgress: [
               {id: 321, name: 'fake-name', units: [{id: 2, key: 'csd'}]},
             ],
@@ -749,6 +753,7 @@ describe('sectionAssessmentsRedux', () => {
           ...rootState,
           unitSelection: {
             scriptId: 2,
+            courseVersionId: 321,
             coursesWithProgress: [
               {id: 321, name: 'fake-name', units: [{id: 2, key: 'csf'}]},
             ],
@@ -1482,6 +1487,7 @@ describe('sectionAssessmentsRedux', () => {
           ...rootState,
           unitSelection: {
             scriptId: 2,
+            courseVersionId: 321,
           },
           sectionAssessments: {
             ...rootState.sectionAssessments,

--- a/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
+++ b/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
@@ -14,7 +14,7 @@ jest.mock('@cdo/apps/templates/sectionProgress/sectionProgressLoader', () => ({
 const DEFAULT_PROPS = {
   setLessonOfInterest: () => {},
   setCurrentView: () => {},
-  setScriptId: () => {},
+  setUnit: () => {},
   scriptId: 123,
   sectionId: 2,
   currentView: ViewType.SUMMARY,

--- a/apps/test/unit/templates/sectionProgress/StandardsReportTest.tsx
+++ b/apps/test/unit/templates/sectionProgress/StandardsReportTest.tsx
@@ -5,7 +5,7 @@ import {Provider} from 'react-redux';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import unitSelection, {
   setCoursesWithProgress,
-  setScriptId,
+  setUnit,
 } from '@cdo/apps/redux/unitSelectionRedux';
 import currentUser from '@cdo/apps/templates/currentUserRedux';
 import * as progressLoader from '@cdo/apps/templates/sectionProgress/sectionProgressLoader';
@@ -26,7 +26,8 @@ import {replaceOnWindow, restoreOnWindow} from '../../../util/testUtils';
 
 // TODO: convert to @testing-library/react
 const DEFAULT_PROPS = {
-  scriptId: 2,
+  unitId: 2,
+  courseVersionId: 1,
   teacherName: 'Awesome Teacher',
   sectionName: 'Great Section',
   teacherComment: null as string | null,
@@ -37,8 +38,9 @@ const DEFAULT_PROPS = {
   setTeacherCommentForReport: (comment: string) => {
     DEFAULT_PROPS.teacherComment = comment;
   },
-  setScriptId: (scriptId: number) => {
-    DEFAULT_PROPS.scriptId = scriptId;
+  setUnit: (unitId: number, courseVersionId: number) => {
+    DEFAULT_PROPS.unitId = unitId;
+    DEFAULT_PROPS.courseVersionId = courseVersionId;
   },
   sectionId: 6,
   scriptData: {
@@ -99,6 +101,7 @@ describe('StandardsReport', () => {
     replaceOnWindow('opener', {
       teacherDashboardStoreInformation: {
         scriptId: 1,
+        courseVersionId: 1,
         teacherComment: teacherComment,
       },
     });
@@ -119,7 +122,7 @@ describe('StandardsReport', () => {
       addDataByUnit({unitDataByUnit: {[UNIT_DATA.id]: UNIT_DATA}})
     );
 
-    store.dispatch(setScriptId(1));
+    store.dispatch(setUnit(UNIT_DATA.id, 1));
     store.dispatch(
       setCoursesWithProgress([
         {

--- a/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
@@ -1,4 +1,4 @@
-import {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import {ViewType} from '@cdo/apps/templates/sectionProgress/sectionProgressConstants';
 import sectionProgress, {
   setCurrentView,
@@ -59,13 +59,13 @@ const lessonOfInterest = 16;
 describe('sectionProgressRedux', () => {
   const initialState = sectionProgress(undefined, {});
 
-  describe('setScriptId', () => {
+  describe('setUnit', () => {
     it('setting the unit id resets the lesson of interest', () => {
       const action = setLessonOfInterest(lessonOfInterest);
       const nextState = sectionProgress(initialState, action);
 
       // This action is from unitSelectionRedux but affects sectionProgress
-      const action2 = setScriptId(130);
+      const action2 = setUnit(130, 99);
       const nextState2 = sectionProgress(nextState, action2);
       assert.deepEqual(nextState2.lessonOfInterest, 1);
     });

--- a/apps/test/unit/templates/sectionProgressV2/ExpandedProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ExpandedProgressDataColumnTest.jsx
@@ -8,7 +8,7 @@ import {
   restoreRedux,
   stubRedux,
 } from '@cdo/apps/redux';
-import unitSelection, {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import unitSelection, {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import {
   fakeLessonWithLevels,
   fakeStudentLevelProgress,
@@ -44,6 +44,7 @@ const FAKE_SECTION = {
   sharing_disabled: false,
   script: null,
   course_id: 29,
+  course_version_id: 99,
   studentCount: 5,
   students: Object.values(STUDENTS),
   hidden: false,
@@ -62,7 +63,7 @@ describe('ExpandedProgressDataColumn', () => {
     stubRedux();
     registerReducers({sectionProgress, unitSelection, teacherSections});
     store = getStore();
-    store.dispatch(setScriptId(1));
+    store.dispatch(setUnit(1, 99));
     store.dispatch(
       addDataByUnit({studentLevelProgressByUnit: {1: LEVEL_PROGRESS}})
     );

--- a/apps/test/unit/templates/sectionProgressV2/LessonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LessonProgressDataColumnTest.jsx
@@ -8,7 +8,7 @@ import {
   restoreRedux,
   stubRedux,
 } from '@cdo/apps/redux';
-import unitSelection, {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import unitSelection, {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import {
   fakeLessonWithLevels,
   fakeLesson,
@@ -83,7 +83,7 @@ describe('LessonProgressDataColumn', () => {
     });
 
     store = getStore();
-    store.dispatch(setScriptId(1));
+    store.dispatch(setUnit(1, 1));
     store.dispatch(
       addDataByUnit({
         unitDataByUnit: {},

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -11,7 +11,7 @@ import {
   restoreRedux,
   stubRedux,
 } from '@cdo/apps/redux';
-import unitSelection, {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import unitSelection, {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import currentUser, {
   setShowProgressTableV2,
   setProgressTableV2ClosedBeta,
@@ -50,7 +50,7 @@ describe('SectionProgressSelector', () => {
 
     store = getStore();
     store.dispatch(setShowProgressTableV2(false));
-    store.dispatch(setScriptId(1));
+    store.dispatch(setUnit(1, 1));
 
     DCDO.set('progress-table-v2-enabled', true);
     DCDO.set('progress-table-v2-default-v2', false);

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {Provider} from 'react-redux';
 
 import {registerReducers, restoreRedux, stubRedux} from '@cdo/apps/redux';
-import unitSelection, {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import unitSelection, {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import currentUser from '@cdo/apps/templates/currentUserRedux';
 import * as sectionProgressLoader from '@cdo/apps/templates/sectionProgress/sectionProgressLoader';
 import sectionProgress, {
@@ -36,7 +36,7 @@ describe('SectionProgressV2', () => {
     });
 
     store = createStore(5, 5);
-    store.dispatch(setScriptId(1));
+    store.dispatch(setUnit(1, 99));
     store.dispatch(finishLoadingProgress());
     jest
       .spyOn(sectionProgressLoader, 'loadUnitProgress')

--- a/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
@@ -8,7 +8,7 @@ import {
   restoreRedux,
   stubRedux,
 } from '@cdo/apps/redux';
-import unitSelection, {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
+import unitSelection, {setUnit} from '@cdo/apps/redux/unitSelectionRedux';
 import {fakeLessonWithLevels} from '@cdo/apps/templates/progress/progressTestHelpers';
 import sectionProgress, {
   expandMetadataForStudents,
@@ -37,6 +37,7 @@ const FAKE_SECTION = {
   sharing_disabled: false,
   script: null,
   course_id: 29,
+  course_version_id: 99,
   studentCount: 5,
   students: Object.values(STUDENTS),
   hidden: false,
@@ -58,7 +59,7 @@ describe('SkeletonProgressDataColumn', () => {
     stubRedux();
     registerReducers({sectionProgress, unitSelection, teacherSections});
     store = getStore();
-    store.dispatch(setScriptId(1));
+    store.dispatch(setUnit(1, 99));
 
     store.dispatch(setSections([FAKE_SECTION]));
     store.dispatch(selectSection(FAKE_SECTION.id));

--- a/apps/test/unit/templates/teacherNavigation/UnitCalendarTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/UnitCalendarTest.tsx
@@ -23,62 +23,96 @@ import teacherSections, {
   selectSection,
   setSections,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {ServerSection} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import UnitCalendar from '@cdo/apps/templates/teacherNavigation/UnitCalendar';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import i18n from '@cdo/locale';
 
-const SECTIONS = [
+const SECTIONS: ServerSection[] = [
   {
     id: 1,
     name: 'Period 2',
     course_offering_id: 123,
-    courseVersionId: 2023,
+    course_version_id: 2024,
+    courseVersionName: 'csd-2024',
+    course_display_name: 'CSD 2024',
+    course_id: 2024,
     unitName: 'csd1-2024',
-    unitSelection: {
-      unitName: 'csd1-2024',
-    },
+    unitPosition: 1,
+    code: '',
+    hidden: false,
+    isAssignedStandaloneCourse: false,
+    lesson_extras: false,
+    login_type: '',
+    pairing_allowed: false,
+    sharing_disabled: false,
+    studentCount: 0,
   },
   {
     id: 9,
     name: 'Period 9',
     course_offering_id: null,
-    courseVersionId: null,
-    unitName: null,
-    unitSelection: null,
+    course_version_id: null,
+    courseVersionName: null,
+    code: '',
+    course_id: null,
+    hidden: false,
+    isAssignedStandaloneCourse: false,
+    lesson_extras: false,
+    login_type: '',
+    pairing_allowed: false,
+    sharing_disabled: false,
+    studentCount: 0,
   },
   {
     id: 10,
     name: 'Period 10',
     course_offering_id: 123,
-    courseVersionId: 2023,
+    course_version_id: 2024,
     courseVersionName: 'csd-2024',
-    unitName: null,
-    unitSelection: null,
+    course_id: 2024,
     course_display_name: 'CSD',
+    code: '',
+    hidden: false,
+    isAssignedStandaloneCourse: false,
+    lesson_extras: false,
+    login_type: '',
+    pairing_allowed: false,
+    sharing_disabled: false,
+    studentCount: 0,
   },
   {
     id: 11,
     name: 'Period 11',
     course_offering_id: 1234,
-    courseVersionId: 20234,
-    courseVersionName: 'csd1-2020',
+    course_version_id: 2020,
+    courseVersionName: 'csd-2020',
+    course_id: 2020,
     unitName: 'csd1-2020',
-    unitSelection: {
-      unitName: 'csd1-2020',
-    },
-    course_display_name: 'CSD1-2020',
+    unitPosition: 1,
+    course_display_name: 'CSD-2020',
+    code: '',
+    hidden: false,
+    isAssignedStandaloneCourse: false,
+    lesson_extras: false,
+    login_type: '',
+    pairing_allowed: false,
+    sharing_disabled: false,
+    studentCount: 0,
   },
 ];
 
 const UNIT_SUMMARY = {
   id: 1,
   name: 'csd1-2024',
+  course_name: 'csd-2024',
+  unit_position: 1,
   lessons: [],
   title: "Unit 1 - Problem Solving and Computing ('23-'24)",
   description: 'CSD description',
   studentDescription: 'CSD student description',
   course_versions: {},
-  courseVersionId: 2,
+  courseVersionId: 2024,
   lessonGroups: [],
   isPlCourse: false,
   plc: false,
@@ -104,13 +138,17 @@ const NO_SHOW_CALENDAR_UNIT_SUMMARY = {
 
 const LEGACY_UNIT_SUMMARY = {
   ...UNIT_SUMMARY,
+  id: 2,
   name: 'csd1-2020',
+  course_name: 'csd-2020',
+  unit_position: 1,
+  courseVersionId: 2020,
   version_year: '2020',
 };
 
 const COURSES_WITH_PROGRESS = [
   {
-    id: 1,
+    id: 2024,
     display_name: 'CSD',
     units: [
       {
@@ -118,7 +156,7 @@ const COURSES_WITH_PROGRESS = [
         version_year: UNIT_SUMMARY.version_year,
         key: UNIT_SUMMARY.name,
         name: UNIT_SUMMARY.title,
-        position: null,
+        position: 1,
       },
     ],
   },
@@ -126,7 +164,7 @@ const COURSES_WITH_PROGRESS = [
 
 const LEGACY_COURSES_WITH_PROGRESS = [
   {
-    id: 1,
+    id: 2020,
     display_name: 'CSD',
     units: [
       {
@@ -134,7 +172,7 @@ const LEGACY_COURSES_WITH_PROGRESS = [
         version_year: LEGACY_UNIT_SUMMARY.version_year,
         key: LEGACY_UNIT_SUMMARY.name,
         name: LEGACY_UNIT_SUMMARY.title,
-        position: null,
+        position: 1,
       },
     ],
   },
@@ -299,6 +337,6 @@ describe('UnitCalendar', () => {
 
     screen.getByAltText(i18n.calendarNotAvailable());
     screen.getByText(i18n.calendarNotAvailable());
-    screen.getByText(i18n.calendarLegacyMessage({courseName: 'CSD1-2020'}));
+    screen.getByText(i18n.calendarLegacyMessage({courseName: 'CSD-2020'}));
   });
 });

--- a/apps/test/unit/templates/textResponses/TextResponsesTest.js
+++ b/apps/test/unit/templates/textResponses/TextResponsesTest.js
@@ -58,7 +58,7 @@ describe('TextResponses', () => {
           <TextResponses
             sectionId={2}
             scriptId={1}
-            setScriptId={() => {}}
+            setUnit={() => {}}
             scriptName="A Script"
           />
         );
@@ -75,7 +75,7 @@ describe('TextResponses', () => {
           <TextResponses
             sectionId={2}
             scriptId={1}
-            setScriptId={() => {}}
+            setUnit={() => {}}
             scriptName="A Script"
           />
         );
@@ -96,7 +96,7 @@ describe('TextResponses', () => {
           <TextResponses
             sectionId={2}
             scriptId={1}
-            setScriptId={() => {}}
+            setUnit={() => {}}
             scriptName="A Script"
           />
         );
@@ -114,7 +114,7 @@ describe('TextResponses', () => {
           <TextResponses
             sectionId={2}
             scriptId={1}
-            setScriptId={() => {}}
+            setUnit={() => {}}
             scriptName="A Script"
           />
         );
@@ -147,7 +147,7 @@ describe('TextResponses', () => {
           <TextResponses
             sectionId={2}
             scriptId={1}
-            setScriptId={() => {}}
+            setUnit={() => {}}
             scriptName="A Script"
           />
         );

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -292,7 +292,16 @@ class ApiController < ApplicationController
 
   def show_courses_with_progress
     section = load_section
-    render json: CourseVersion.courses_for_unit_selector(section.participant_unit_ids)
+    unit_ids = section.participant_unit_ids
+    # Always include the Units assigned to the Section.
+    if section.course_id
+      unit_group = UnitGroup.get_from_cache(section.course_id)
+    elsif section.script_id
+      # Some older Sections only have a script_id defined.
+      unit_group = Unit.get_from_cache(section.script_id)&.unit_group
+    end
+    unit_ids.concat(unit_group.default_units.pluck(:id)).uniq! if unit_group
+    render json: CourseVersion.courses_for_unit_selector(unit_ids, current_user)
   end
 
   use_reader_connection_for_route(:section_level_progress)

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -189,10 +189,10 @@ class CourseVersion < ApplicationRecord
   # CSD has multiple headers in the list with the units for that year under it.
   # See fakeCoursesWithProgress in teacherDashboardTestHelpers.js for an example of what
   # the resulting data looks like
-  def self.courses_for_unit_selector(unit_ids)
+  def self.courses_for_unit_selector(unit_ids, user)
     standalone_units = Unit.joins(:course_version).where(id: unit_ids).map {|u| u.course_version.course_offering&.summarize_for_unit_selector(unit_ids)}.compact.uniq
 
-    unit_groups =  Unit.joins(unit_groups: :course_version).where(id: unit_ids).where(course_version: {content_root_type: 'UnitGroup'}).flat_map {|u| u.unit_groups.map(&:course_version)}.map(&:summarize_for_unit_selector).uniq
+    unit_groups =  Unit.joins(unit_groups: :course_version).where(id: unit_ids).where(course_version: {content_root_type: 'UnitGroup'}).flat_map {|u| u.unit_groups.map(&:course_version)}.select {|cv| cv.course_assignable?(user)}.map(&:summarize_for_unit_selector).uniq
 
     standalone_units.concat(unit_groups).sort_by {|c| c[:display_name]}
   end
@@ -227,6 +227,7 @@ class CourseVersion < ApplicationRecord
     end
     {
       id: id,
+      course_name: content_root.name,
       display_name: content_root.launched? ? content_root.localized_title : content_root.localized_title + ' *',
       units: unit_summaries.sort_by {|u| u[:position]},
     }

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -654,7 +654,7 @@ class Section < ApplicationRecord
   def participant_unit_ids
     # This performs two queries, but could be optimized to perform only one by
     # doing additional joins.
-    Unit.joins(:user_scripts).where(user_scripts: {user_id: students.pluck(:id)}).distinct.select {|s| s.course_assignable?(user)}.pluck(:id)
+    Unit.joins(:user_scripts).where(user_scripts: {user_id: students.pluck(:id)}).distinct.pluck(:id)
   end
 
   def code_review_enabled?

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1946,6 +1946,117 @@ class ApiControllerTest < ActionController::TestCase
     end
   end
 
+  describe '#show_courses_with_progress' do
+    let(:call_api) do
+      get :show_courses_with_progress, params: {section_id: section.id}
+    end
+    let(:response) do
+      call_api
+      JSON.parse(@response.body, symbolize_names: true)
+    end
+    let(:context) {create :modular_course_context}
+    let(:new_unit_group) {context[:new_unit_group]}
+    let(:original_unit_group) {context[:original_unit_group]}
+    let(:teacher) {create :teacher}
+    let(:user) {teacher}
+    let(:section) {create :section, user: teacher, course_id: new_unit_group.id}
+
+    before do
+      sign_in user if user
+    end
+
+    context 'user is not signed in' do
+      let(:user) {nil}
+
+      it 'returns a 302 response' do
+        call_api
+        assert_response :forbidden
+      end
+    end
+
+    context 'user is unaffiliated student' do
+      let(:user) {create :student}
+
+      it 'returns a 403 response' do
+        call_api
+        assert_response :forbidden
+      end
+    end
+
+    context 'user is unaffiliated teacher' do
+      let(:user) {create :teacher}
+
+      it 'returns a 403 response' do
+        call_api
+        assert_response :forbidden
+      end
+    end
+
+    context 'section.course_id defined' do
+      let(:section) {create :section, user: user, course_id: new_unit_group.id}
+
+      it 'returns a 200 response' do
+        assert_response :success
+      end
+
+      it 'returns a list of course summaries' do
+        _(response).must_be_instance_of Array
+        response.each do |course|
+          _(course).must_be_instance_of Hash
+        end
+      end
+
+      it 'returns the original_unit_group' do
+        _(response.find {|cv| cv[:id] == original_unit_group.course_version.id}).must_be_instance_of Hash
+      end
+
+      it 'returns the new_unit_group' do
+        _(response.find {|cv| cv[:id] == new_unit_group.course_version.id}).must_be_instance_of Hash
+      end
+    end
+
+    context 'student in section' do
+      let(:student) {create :student}
+
+      before do
+        section.add_student(student)
+      end
+
+      it 'returns a 200 response' do
+        assert_response :success
+      end
+
+      it 'returns a list of course summaries' do
+        _(response).must_be_instance_of Array
+        response.each do |course|
+          _(course).must_be_instance_of Hash
+        end
+      end
+
+      it 'returns the original_unit_group' do
+        _(response.find {|cv| cv[:id] == original_unit_group.course_version.id}).must_be_instance_of Hash
+      end
+
+      it 'returns the new_unit_group' do
+        _(response.find {|cv| cv[:id] == new_unit_group.course_version.id}).must_be_instance_of Hash
+      end
+
+      context 'student has progress in an unrelated course' do
+        let(:outside_unit_group) {create :single_unit_course, :stable}
+        let!(:outside_course_version) {create :course_version, content_root: outside_unit_group}
+
+        before do
+          # add progress for User in outside course
+          create :user_script, user: student, script: outside_unit_group.default_units.first
+        end
+
+        it 'returns the outside_unit_group' do
+          _(response.find {|cv| cv[:id] == outside_course_version.id}).must_be_instance_of Hash
+        end
+      end
+    end
+  end
+
   private def create_script_with_bonus_levels
     script = create :script, :in_single_unit_course
     lesson_group = create :lesson_group, script: script

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -68,6 +68,10 @@ FactoryBot.define do
     participant_audience {"student"}
     instructor_audience {"teacher"}
 
+    trait :stable do
+      published_state {Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable}
+    end
+
     trait :pl_course do
       participant_audience {"teacher"}
       instructor_audience {"facilitator"}
@@ -2263,6 +2267,30 @@ FactoryBot.define do
     role {:assistant}
     content {"Lorem ipsum"}
     is_preset {false}
+  end
+
+  factory :modular_course_context, class: Hash do
+    skip_create
+    initialize_with do
+      original_unit_group = create :unit_group, :stable
+      new_unit_group = create :unit_group, :stable
+      unit_a = create :unit, :with_levels
+      unit_b = create :unit, :with_levels
+
+      [original_unit_group, new_unit_group].each do |unit_group|
+        create :course_version, content_root: unit_group
+        [unit_a, unit_b].each_with_index do |unit, index|
+          create :unit_group_unit, unit_group: unit_group, script: unit, position: index + 1
+        end
+      end
+
+      {
+        original_unit_group: original_unit_group,
+        new_unit_group: new_unit_group,
+        unit_a: unit_a,
+        unit_b: unit_b,
+      }
+    end
   end
 
   factory :sign_in do

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -35,18 +35,19 @@ class CourseVersionTest < ActiveSupport::TestCase
 
     @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
     @pilot_unit = create :script, pilot_experiment: 'my-experiment'
-    create(:single_unit_course, :with_course_offering, unit: @pilot_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-42')
+    create(:single_unit_course, :with_course_offering, unit: @pilot_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-42', pilot_experiment: 'my-experiment')
 
     @pilot_instructor = create :facilitator, pilot_experiment: 'my-pl-experiment'
     @pilot_pl_unit = create :script, pilot_experiment: 'my-pl-experiment'
-    create(:single_unit_course, :with_course_offering, :pl_course, unit: @pilot_pl_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-52')
+    create(:single_unit_course, :with_course_offering, :pl_course, unit: @pilot_pl_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-52', pilot_experiment: 'my-pl-experiment')
 
     @partner = create :teacher, pilot_experiment: 'my-editor-experiment', editor_experiment: 'ed-experiment'
     @partner_unit = create :script, pilot_experiment: 'my-editor-experiment', editor_experiment: 'ed-experiment'
-    create(:single_unit_course, :with_course_offering, unit: @partner_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-112')
+    create(:single_unit_course, :with_course_offering, unit: @partner_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-112', pilot_experiment: 'my-editor-experiment')
   end
+
   test 'get courses with participant progress for student should return no courses' do
-    assert_equal CourseVersion.courses_for_unit_selector([]).length, 0
+    assert_equal 0, CourseVersion.courses_for_unit_selector([], @student).length
   end
 
   test 'get courses with participant progress for levelbuilder should return all courses where followers in section have progress' do
@@ -72,7 +73,7 @@ class CourseVersionTest < ActiveSupport::TestCase
       @unit_facilitator_to_teacher.id
     ]
 
-    assert_equal CourseVersion.courses_for_unit_selector(student_unit_ids).pluck(:display_name).sort, expected_course_info
+    assert_equal expected_course_info, CourseVersion.courses_for_unit_selector(student_unit_ids, @levelbuilder).pluck(:display_name).sort
   end
 
   test 'get courses with participant progress for pilot teacher should return courses where pilot teacher can be instructor' do
@@ -80,7 +81,7 @@ class CourseVersionTest < ActiveSupport::TestCase
       @pilot_unit.original_unit_group.name + " *",
     ].sort
 
-    assert_equal CourseVersion.courses_for_unit_selector([@pilot_unit.id]).pluck(:display_name).sort, expected_course_info
+    assert_equal expected_course_info, CourseVersion.courses_for_unit_selector([@pilot_unit.id], @pilot_teacher).pluck(:display_name).sort
   end
 
   test 'get courses with participant progress for teacher should only return courses where they can be the instructor' do
@@ -94,7 +95,7 @@ class CourseVersionTest < ActiveSupport::TestCase
       @unit_teacher_to_students.id
     ]
 
-    assert_equal CourseVersion.courses_for_unit_selector(student_unit_ids).pluck(:display_name).sort, expected_course_info
+    assert_equal expected_course_info, CourseVersion.courses_for_unit_selector(student_unit_ids, @teacher).pluck(:display_name).sort
   end
 
   test 'get courses with participant progress for facilitator should return all courses, amd units where facilitator can be instructor and followers in section have progress' do
@@ -116,7 +117,7 @@ class CourseVersionTest < ActiveSupport::TestCase
       @unit_facilitator_to_teacher.id
     ]
 
-    courses_with_progress = CourseVersion.courses_for_unit_selector(student_unit_ids)
+    courses_with_progress = CourseVersion.courses_for_unit_selector(student_unit_ids, @facilitator)
 
     assert_equal expected_course_info, courses_with_progress.pluck(:display_name).sort
 


### PR DESCRIPTION
## Important Note
This is the second attempt to make this change. The [first attempt](https://github.com/code-dot-org/code-dot-org/pull/66364) needed to be reverted because when it was deployed to our test server a couple UI tests were failing. These test found a bug where the UnitGroup#id was being passed to something expecting  a CourseVersion#id. That fix is in [this commit](https://github.com/code-dot-org/code-dot-org/pull/67113/commits/0bcefea5e8d39dde0f1ac241269285c9e75039a8)
## Description
|UnitSelector|
|----|
|![Screenshot 2025-06-06 at 1 50 38 AM](https://github.com/user-attachments/assets/828c9dd2-561d-422a-971f-05781cce1b79)|

On the Teacher Dashboard, teacher's can select the Unit and Course they want to view the Calendar, Progress, etc of. Before Modularity, Units were only associated with a single Course, so we only store the UnitID the teacher selected. However, now Units can be in multiple courses, so we need to store both the UnitID and CourseID.

* UnitSelected and UnitSelectorV2 dropdown value change: `<unit_id>` -> `<course_version_id-unit_id>`
* Change unitSelectionRedux `SET_SCRIPT` to `SET_UNIT` and `SET_UNIT` expects a `scriptId` AND `courseVersionId`.
* Update all the consumers of unitSelectionRedux to use `setUnit`.
* Update unitSelectionRedux to select the Unit based on the `scriptId` AND `courseVersionId`, rather than returning the first Unit with a matching `scriptId`.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/TEACH-1937)
* [First attempt](https://github.com/code-dot-org/code-dot-org/pull/66364)

## Testing story
* Manually tested
* Automated tests