### PR TITLE
Set a Default Expiry for All `shared_cache` Entries

### DIFF
--- a/lib/cdo/shared_cache.rb
+++ b/lib/cdo/shared_cache.rb
@@ -1,6 +1,7 @@
 require 'active_support'
 require 'active_support/cache'
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/integer/time'
 require 'honeybadger/ruby'
 require 'dalli/elasticache'
 
@@ -27,6 +28,7 @@ module Cdo
         return nil unless memcached_hosts.present?
 
         ActiveSupport::Cache::MemCacheStore.new memcached_hosts, {
+          expires_in: 1.month, # prevent permanent entries, but let them stick around for a while
           value_max_bytes: 64.megabytes # max size of single value
         }
       end


### PR DESCRIPTION
In order to both make it simpler to recover from runaway cache growth events and encourage developers to treat the shared cache as an inherently ephemeral data store, we set a default expiration that will apply to any entry which does not specify an expiration of its own.

I grepped through our codebase for all uses of the shared cache, and I believe we only have four pieces of functionality that will be affected by this change (the rest all set expirations manually):
  1. https://github.com/code-dot-org/code-dot-org/blob/7cc43ed6fe885ea1872e5233ceb9b355ffa8c617/dashboard/app/helpers/profanity_helper.rb#L20
  2. https://github.com/code-dot-org/code-dot-org/blob/7cc43ed6fe885ea1872e5233ceb9b355ffa8c617/dashboard/lib/api/v1/school_autocomplete.rb#L55
  3. https://github.com/code-dot-org/code-dot-org/blob/7cc43ed6fe885ea1872e5233ceb9b355ffa8c617/dashboard/lib/services/curriculum_pdfs/utils.rb#L49-L56
  4. https://github.com/code-dot-org/code-dot-org/blob/7cc43ed6fe885ea1872e5233ceb9b355ffa8c617/lib/dynamic_config/datastore_cache.rb#L81-L91

In the first three cases, we don't expect the underlying values to change or need updating ever, so we've cached them indefinitely to avoid unnecessary recomputation. I don't think any of these operations are expensive enough that repeating them once a month will be significant.

In the last case, it's the opposite; we explicitly update that cache every time we spin up a new frontend web app server, so we're never going to expire this anyway.

## Testing story

Verified on an adhoc that with this change in place:
- calls to `CDO.shared_cache.write` that do not specify `expires_in` will default to a one month expiry
- calls that do specify an expiry will use that expiry
- repeated writes to the same key will repeatedly update the expiry

## Caching

We expect to see a slightly increased rate of cache writes, but I don't expect it to be notable.