### PR TITLE
Restore Image Optimizer's Cache Expiration

### DIFF
--- a/lib/cdo/optimizer.rb
+++ b/lib/cdo/optimizer.rb
@@ -96,11 +96,7 @@ module Cdo
       cache_key = Optimizer.cache_key(data)
       cache.fetch(cache_key) do
         # Write `false` to cache to prevent concurrent image optimizations.
-        #
-        # The expiry here is almost certainly unnecessary; adding it mostly to
-        # help debug some unexpected runaway growth by conclusively ruling this
-        # operation out as a culprit. Can be removed once we're done debugging.
-        cache.write(cache_key, false, expires_in: 1.day)
+        cache.write(cache_key, false)
         IMAGE_OPTIM.optimize_image_data(data) || data
       end
     rescue => exception
@@ -110,9 +106,7 @@ module Cdo
           key: cache_key
         }
       )
-      # Only cache results in the CDO shared cache for a short while; we mostly
-      # rely on CloudFront to cache this content.
-      cache.write(cache_key, data, expires_in: 1.day) if cache && cache_key
+      cache.write(cache_key, data) if cache && cache_key
       data
     end
   end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/66993

We've successfully debugged the runaway cache growth, and no longer need such a short cache duration. We would still like some kind of expiration for these entries, but as of https://github.com/code-dot-org/code-dot-org/pull/67114 all entries get one by default! So we no longer have any need to specify an explicit expiration for these entries.
