### PR TITLE
feat(account settings): make educator role editable

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -29,6 +29,7 @@
   "accountInformation_reviewErrors": "Review errors above and try again.",
   "accountInformation_updateSuccess": "Account information successfully updated.",
   "accountInformation_emailUpdateSuccess": "Email successfully updated.",
+  "accountInformation_educatorRoleCannotBeRemoved": "Educator role cannot be removed.",
   "accountExistingAccountCardContentWorkshopEnroll": "You’ll need to sign in to your Code.org account to enroll in this workshop.",
   "accountExistingAccountCardDefaultDescription": "You'll need to sign in to your Code.org account to access this page.",
   "accountKeepStudentAccountCardTitle": "Keep my student account",

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -10,6 +10,8 @@ import React, {useEffect, useMemo, useState} from 'react';
 
 import {hashEmail} from '@cdo/apps/code-studio/hashEmail';
 import {queryParams} from '@cdo/apps/code-studio/utils';
+import {roleItemGroups} from '@cdo/apps/signUpFlow/FinishTeacherAccount';
+import locale from '@cdo/apps/signUpFlow/locale';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import {navigateToHref} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -6,7 +6,7 @@ import Link from '@code-dot-org/component-library/link';
 import TextField from '@code-dot-org/component-library/textField';
 import {Heading2} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {ChangeEvent, useEffect, useMemo, useState} from 'react';
 
 import {hashEmail} from '@cdo/apps/code-studio/hashEmail';
 import {queryParams} from '@cdo/apps/code-studio/utils';
@@ -119,6 +119,25 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
       sessionStorage.removeItem(ACCOUNT_UPDATE_SUCCESS);
     }
   }, []);
+
+  const handleRoleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    if (educatorRole && !e.target.value) {
+      setErrors(prevErrors => ({
+        ...prevErrors,
+        educator_role: [
+          ...(prevErrors.educator_role ?? []),
+          i18n.accountInformation_educatorRoleCannotBeRemoved(),
+        ],
+      }));
+    } else {
+      setEducatorRole(e.target.value);
+      setErrors(prevErrors => {
+        const updatedErrors = {...prevErrors};
+        delete updatedErrors.educator_role;
+        return updatedErrors;
+      });
+    }
+  };
 
   const handleSubmitAccountSettingsUpdate = async () => {
     resetMessages();
@@ -359,9 +378,7 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
               labelText={locale.what_is_your_role()}
               name="educator_role"
               selectedValue={educatorRole}
-              onChange={e => {
-                setEducatorRole(e.target.value);
-              }}
+              onChange={handleRoleChange}
               itemGroups={roleItemGroups}
               dropdownTextThickness="thin"
               errorMessage={getError('educator_role')}

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -72,6 +72,9 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
   );
   const [age, setAge] = useState(userAge ?? '');
   const [usState, setUsState] = useState(userProperties?.us_state ?? '');
+  const [educatorRole, setEducatorRole] = useState(
+    userProperties?.educator_role ?? ''
+  );
   const [password, setPassword] = useState('');
   const [passwordConfirmation, setPasswordConfirmation] = useState('');
   const [currentPassword, setCurrentPassword] = useState('');
@@ -135,6 +138,7 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
       facilitator_info_attributes: isFacilitator
         ? {bio: facilitatorBio}
         : undefined,
+      educator_role: !isStudent && educatorRole ? educatorRole : undefined,
     };
     const response = await fetch('/users', {
       method: 'PUT',
@@ -344,6 +348,23 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
               maxLength={20}
               minLength={5}
               errorMessage={getError('username')}
+            />
+          )}
+
+          {/* educator_role */}
+          {!isStudent && (
+            <SimpleDropdown
+              id="educator_role"
+              className={classNames(styles.dropdownContainer)}
+              labelText={locale.what_is_your_role()}
+              name="educator_role"
+              selectedValue={educatorRole}
+              onChange={e => {
+                setEducatorRole(e.target.value);
+              }}
+              itemGroups={roleItemGroups}
+              dropdownTextThickness="thin"
+              errorMessage={getError('educator_role')}
             />
           )}
 

--- a/apps/src/accounts/AccountInformation/style.module.scss
+++ b/apps/src/accounts/AccountInformation/style.module.scss
@@ -20,5 +20,11 @@
       padding: 0.5rem 0.75rem;
       margin: 0;
     }
+
+    &.dropdownContainer {
+      > div {
+        width: 100%;
+      }
+    }
   }
 }

--- a/apps/src/accounts/AccountInformation/types.ts
+++ b/apps/src/accounts/AccountInformation/types.ts
@@ -1,6 +1,7 @@
 interface UserProperties {
   gender_student_input?: string;
   us_state?: string;
+  educator_role?: string;
   [key: string]: unknown;
 }
 export interface AccountInformationProps {

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -40,7 +40,7 @@ import {
 
 import style from './signUpFlowStyles.module.scss';
 
-const roleItemGroups = [
+export const roleItemGroups = [
   {
     label: '',
     groupItems: [{value: '', text: locale.select_a_role()}],

--- a/apps/test/unit/accounts/AccountInformationTest.jsx
+++ b/apps/test/unit/accounts/AccountInformationTest.jsx
@@ -325,4 +325,69 @@ describe('AccountInformation', () => {
     expect(facilitatorBioTextarea).toBeInTheDocument();
     expect(facilitatorBioTextarea.value).toBe(userFacilitatorBio);
   });
+
+  it('does not block updates if user never had an educator_role', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    render(<AccountInformation {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: {value: 'coder1'},
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {name: /update account information/i})
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/users', expect.any(Object));
+      expect(
+        screen.getByText(/account information successfully updated/i)
+      ).toBeInTheDocument();
+    });
+
+    const fetchArgs = mockFetch.mock.calls[0][1];
+    expect(JSON.parse(fetchArgs.body)).toEqual({
+      user: {
+        name: 'Mr. Doe',
+        username: 'coder1',
+        given_name: '',
+        family_name: '',
+        educator_role: undefined,
+        password: '',
+        password_confirmation: '',
+        current_password: '',
+        age: '21+',
+        gender_student_input: undefined,
+        us_state: undefined,
+        country_code: undefined,
+      },
+    });
+  });
+
+  it('does not allow removing educator_role after it is set', () => {
+    render(<AccountInformation {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText(/what is your primary role/i), {
+      target: {value: 'classroom_teacher'},
+    });
+
+    const roleErrorText = 'Educator role cannot be removed.';
+
+    expect(screen.queryByText(roleErrorText)).not.toBeInTheDocument();
+
+    // attempt to clear educator_role value
+    fireEvent.change(screen.getByLabelText(/what is your primary role/i), {
+      target: {value: ''},
+    });
+
+    expect(screen.getByText(roleErrorText)).toBeInTheDocument();
+
+    // educator_role cannot be cleared once it is set
+    expect(screen.getByLabelText(/what is your primary role/i).value).toBe(
+      'classroom_teacher'
+    );
+  });
 });

--- a/apps/test/unit/accounts/AccountInformationTest.jsx
+++ b/apps/test/unit/accounts/AccountInformationTest.jsx
@@ -138,6 +138,9 @@ describe('AccountInformation', () => {
     fireEvent.change(screen.getByLabelText(/last name/i), {
       target: {value: 'Doe'},
     });
+    fireEvent.change(screen.getByLabelText(/what is your primary role/i), {
+      target: {value: 'classroom_teacher'},
+    });
     fireEvent.change(screen.getByLabelText(/^password$/i), {
       target: {value: 'newpassword'},
     });
@@ -166,6 +169,7 @@ describe('AccountInformation', () => {
         username: 'janedoe',
         given_name: 'Jane',
         family_name: 'Doe',
+        educator_role: 'classroom_teacher',
         password: 'newpassword',
         password_confirmation: 'newpassword',
         current_password: 'currentpassword',

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -545,6 +545,7 @@ class RegistrationsController < Devise::RegistrationsController
       :username,
       :given_name,
       :family_name,
+      :educator_role,
       :password,
       :encrypted_password,
       :current_password,

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -756,7 +756,7 @@ class User < ApplicationRecord
 
   def downgrade_to_student
     return true if student? # No-op if user is already a student
-    update(user_type: TYPE_STUDENT, given_name: nil, family_name: nil)
+    update(user_type: TYPE_STUDENT, given_name: nil, family_name: nil, educator_role: nil)
   end
 
   def upgrade_to_teacher(email, email_preference = nil)

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -4,6 +4,8 @@
 - @page_title = t('activerecord.attributes.user.edit_header')
 - no_email = current_user.no_personal_email? || params[:noEmail] == 'true'
 
+= render 'devise/registrations/sign_up_locale'
+
 = render_parental_permission_banner(current_user, request)
 
 = link_to :back do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
this adds the `educator_role` dropdown to the account settings page. rather than validating the `educator_role` in the user model, we opted for some simple front end validation that would prevent the user from clearing out their `educator_role` if it's already set. if a user signed up before `educator_role` was added, they can update other account properties without choosing an `educator_role`, but if it already exists, this will prevent them from clearing it.

https://github.com/user-attachments/assets/5bba0c9c-c7ac-4fc3-b1a6-0063b1baa683


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
