### PR TITLE
AI Chat: remove level properties context from ChatWorkspace

### DIFF
--- a/apps/src/aichat/utils.ts
+++ b/apps/src/aichat/utils.ts
@@ -31,11 +31,17 @@ export function getAssetUrl(
   channelId?: string,
   levelName?: string
 ) {
-  if (asset.source === 'project') {
+  if (asset.source === 'project' && channelId) {
     return `/v3/assets/${channelId}/${encodeURIComponent(asset.filename)}`;
-  } else {
+  }
+
+  if (asset.source === 'level' && levelName) {
     return `/level_starter_assets/${levelName}/${encodeURIComponent(
       asset.filename
     )}`;
   }
+
+  throw new Error(
+    'Either channel ID or level name must be provided for asset URL generation.'
+  );
 }

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -60,7 +60,11 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
 
-  const levelAichatSettings = levelProperties.aichatSettings;
+  const {
+    name: levelName,
+    aichatSettings: levelAichatSettings,
+    starterAssets,
+  } = levelProperties;
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
 
   const {currentAiCustomizations, viewMode, showModalType} = useAppSelector(
@@ -77,6 +81,8 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
   const hasUpdatedCustomizations = useAppSelector(
     state => state.aichat.hasUpdatedCustomizations
   );
+
+  const channelId = useAppSelector(state => state.lab.channel?.id);
 
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   // Attach save listeners whenever the project manager updates
@@ -344,7 +350,12 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
             >
               <ChatWorkspace
                 onClear={onClear}
-                levelProperties={levelProperties}
+                levelName={levelName}
+                channelId={channelId}
+                hasStarterAssets={
+                  starterAssets && Object.keys(starterAssets).length > 0
+                }
+                multimodalEnabled={levelAichatSettings?.multimodalEnabled}
               />
             </PanelContainer>
           </div>

--- a/apps/src/aichat/views/ChatEventView.tsx
+++ b/apps/src/aichat/views/ChatEventView.tsx
@@ -15,6 +15,7 @@ import {
   isNotification,
   isModelUpdate,
   ChatEventDescriptionKey,
+  ChatAsset,
 } from '../types';
 
 import ChatMessageView from './ChatMessageView';
@@ -35,6 +36,7 @@ const chatEventDescriptionsStudent = {
 interface ChatEventViewProps {
   event: ChatEvent;
   isTeacherView?: boolean;
+  buildAssetUrl?: (asset: ChatAsset) => string;
 }
 
 function formatModelUpdateText(update: ModelUpdate): string {
@@ -71,6 +73,7 @@ function formatModelUpdateText(update: ModelUpdate): string {
 const ChatEventView: React.FunctionComponent<ChatEventViewProps> = ({
   event,
   isTeacherView,
+  buildAssetUrl,
 }) => {
   const dispatch = useAppDispatch();
 
@@ -83,6 +86,7 @@ const ChatEventView: React.FunctionComponent<ChatEventViewProps> = ({
       <ChatMessageView
         chatMessage={event}
         isChatHistoryView={isTeacherView || false}
+        buildAssetUrl={buildAssetUrl}
       />
     );
   }

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -4,7 +4,7 @@ import React, {useEffect, useRef, useState} from 'react';
 
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {ChatEvent} from '../types';
+import {ChatAsset, ChatEvent} from '../types';
 
 import ChatEventView from './ChatEventView';
 import WaitingAnimation from './WaitingAnimation';
@@ -14,6 +14,7 @@ import moduleStyles from './chatWorkspace.module.scss';
 interface ChatEventsListProps {
   events: ChatEvent[];
   isTeacherView?: boolean;
+  buildAssetUrl?: (asset: ChatAsset) => string;
 }
 
 /**
@@ -22,6 +23,7 @@ interface ChatEventsListProps {
 const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   events,
   isTeacherView,
+  buildAssetUrl,
 }) => {
   const [inProgrammaticScroll, setInProgrammaticScroll] = useState(false);
   const [showScrollToBottom, setShowScrollToBottom] = useState(true);
@@ -105,6 +107,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
             event={event}
             key={event.timestamp}
             isTeacherView={isTeacherView}
+            buildAssetUrl={buildAssetUrl}
           />
         ))}
         <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />

--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -5,16 +5,14 @@ import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import CopyButton from '@cdo/apps/aiComponentLibrary/copyButton/CopyButton';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {ValueOf} from '@cdo/apps/types/utils';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
-import {useLevelProperties} from '../levelPropertiesContext';
 import {
+  ChatAsset,
   type ChatMessage as ChatMessageType,
   isCompletedChatMessage,
   isServerChatEvent,
 } from '../types';
-import {getAssetUrl} from '../utils';
 
 import FilePreview from './assets/FilePreview';
 import CleanFeedbackFooter from './teacherFeedback/CleanFeedbackFooter';
@@ -25,16 +23,16 @@ import styles from './chatWorkspace.module.scss';
 interface ChatMessageViewProps {
   chatMessage: ChatMessageType;
   isChatHistoryView: boolean;
+  buildAssetUrl?: (asset: ChatAsset) => string;
 }
 
 const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
   chatMessage,
   isChatHistoryView,
+  buildAssetUrl,
 }) => {
   const [showProfaneUserMessage, setShowProfaneUserMessage] = useState(false);
   const {status, role, chatMessageText, assets} = chatMessage;
-  const currentChannelId = useAppSelector(state => state.lab.channel?.id);
-  const levelName = useLevelProperties().name;
 
   const displayText = getChatMessageDisplayText(
     status,
@@ -90,12 +88,12 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
   }
 
   let header;
-  if (!isAssistant && assets && currentChannelId) {
+  if (!isAssistant && assets && buildAssetUrl) {
     header = (
       <div className={styles.assetCol}>
         {assets.map(asset => {
           const filename = asset.filename;
-          const url = getAssetUrl(asset, currentChannelId, levelName);
+          const url = buildAssetUrl(asset);
           return (
             <button
               key={filename}

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -4,10 +4,8 @@ import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 
-import {LevelProperties} from '@cdo/apps/lab2/types';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {LevelPropertiesContext} from '../levelPropertiesContext';
 import aichatI18n from '../locale';
 import {
   clearChatMessages,
@@ -16,8 +14,8 @@ import {
   getSelectMultimodalAvailable,
   selectAllVisibleMessages,
 } from '../redux';
-import {AichatLevelProperties, ChatButton} from '../types';
-import {getShortName} from '../utils';
+import {ChatAsset, ChatButton} from '../types';
+import {getAssetUrl, getShortName} from '../utils';
 
 import StagedFilesPreview from './assets/StagedFilesPreview';
 import UploadButton from './assets/UploadButton';
@@ -28,12 +26,15 @@ import UserChatMessageEditor from './UserChatMessageEditor';
 import moduleStyles from './chatWorkspace.module.scss';
 
 interface ChatWorkspaceProps {
-  // TODO: Temporary passing through level properties again because sub-components depend on the level properties context.
-  // When fully modularizing this component, we will instead pass through necessary data through props.
-  levelProperties: LevelProperties;
   chatButtons?: ChatButton[];
   hiddenContext?: string;
   onClear: () => void;
+
+  // Multimodal support
+  multimodalEnabled?: boolean;
+  channelId?: string;
+  levelName?: string;
+  hasStarterAssets?: boolean;
 }
 
 enum WorkspaceTeacherViewTab {
@@ -49,11 +50,21 @@ const eraserIcon: FontAwesomeV6IconProps = {
  * Renders the AI Chat Lab main chat workspace component.
  */
 const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
-  levelProperties,
   chatButtons,
   hiddenContext,
   onClear,
+  multimodalEnabled = false,
+  levelName,
+  channelId,
+  hasStarterAssets = false,
 }) => {
+  if (multimodalEnabled && (!levelName || !channelId)) {
+    console.warn(
+      'Multimodal support requires level name and channel ID. Multimodal features will not be available.'
+    );
+    multimodalEnabled = false;
+  }
+
   const [selectedTab, setSelectedTab] =
     useState<WorkspaceTeacherViewTab | null>(null);
 
@@ -70,6 +81,18 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       );
     }
   });
+
+  const multimodalAvailable =
+    useAppSelector(getSelectMultimodalAvailable(multimodalEnabled)) &&
+    !!levelName &&
+    !!channelId;
+
+  const buildAssetUrl = useCallback(
+    (asset: ChatAsset) => {
+      return getAssetUrl(asset, channelId, levelName);
+    },
+    [channelId, levelName]
+  );
 
   const dispatch = useAppDispatch();
 
@@ -128,14 +151,23 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
               selectedStudentName: selectedStudentName ?? '',
             }),
       tabContent: (
-        <ChatEventsList events={studentChatHistory} isTeacherView={true} />
+        <ChatEventsList
+          events={studentChatHistory}
+          isTeacherView={true}
+          buildAssetUrl={multimodalAvailable ? buildAssetUrl : undefined}
+        />
       ),
       iconLeft: iconValue,
     },
     {
       value: 'testStudentModel',
       text: aichatI18n.testStudentModel(),
-      tabContent: <ChatEventsList events={visibleItems} />,
+      tabContent: (
+        <ChatEventsList
+          events={visibleItems}
+          buildAssetUrl={multimodalAvailable ? buildAssetUrl : undefined}
+        />
+      ),
     },
   ];
 
@@ -156,51 +188,51 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     tabPanelsContainerClassName: moduleStyles.tabPanelsContainer,
   };
 
-  const multimodalEnabled = useAppSelector(
-    getSelectMultimodalAvailable(
-      (levelProperties as AichatLevelProperties).aichatSettings
-        ?.multimodalEnabled
-    )
-  );
-
   return (
-    <LevelPropertiesContext.Provider value={levelProperties}>
-      <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
-        {selectedStudent ? (
-          <Tabs {...tabArgs} />
-        ) : (
-          <ChatEventsList events={visibleItems} />
-        )}
+    <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
+      {selectedStudent ? (
+        <Tabs {...tabArgs} />
+      ) : (
+        <ChatEventsList
+          events={visibleItems}
+          buildAssetUrl={multimodalAvailable ? buildAssetUrl : undefined}
+        />
+      )}
 
-        <div className={moduleStyles.footer}>
-          {multimodalEnabled && <StagedFilesPreview />}
-          {canChatWithModel && (
-            <UserChatMessageEditor
-              editorContainerClassName={moduleStyles.messageEditorContainer}
-              chatButtons={chatButtons}
-              hiddenContext={hiddenContext}
+      <div className={moduleStyles.footer}>
+        {multimodalAvailable && (
+          <StagedFilesPreview buildAssetUrl={buildAssetUrl} />
+        )}
+        {canChatWithModel && (
+          <UserChatMessageEditor
+            editorContainerClassName={moduleStyles.messageEditorContainer}
+            chatButtons={chatButtons}
+            hiddenContext={hiddenContext}
+            multimodalAvailable={multimodalAvailable}
+          />
+        )}
+        <div className={moduleStyles.buttonRow}>
+          {multimodalAvailable && (
+            <UploadButton
+              isDisabled={!canChatWithModel || !!selectedStudent}
+              levelName={levelName}
+              hasStarterAssets={hasStarterAssets}
+              buildAssetUrl={buildAssetUrl}
             />
           )}
-          <div className={moduleStyles.buttonRow}>
-            {multimodalEnabled && (
-              <UploadButton
-                isDisabled={!canChatWithModel || !!selectedStudent}
-              />
-            )}
-            <Button
-              text={aichatI18n.clearChatButtonText()}
-              disabled={!canChatWithModel}
-              iconLeft={eraserIcon}
-              size="s"
-              type="secondary"
-              color="gray"
-              onClick={onClear}
-            />
-            <CopyChatHistoryButton isDisabled={!canChatWithModel} />
-          </div>
+          <Button
+            text={aichatI18n.clearChatButtonText()}
+            disabled={!canChatWithModel}
+            iconLeft={eraserIcon}
+            size="s"
+            type="secondary"
+            color="gray"
+            onClick={onClear}
+          />
+          <CopyChatHistoryButton isDisabled={!canChatWithModel} />
         </div>
       </div>
-    </LevelPropertiesContext.Provider>
+    </div>
   );
 };
 

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -4,30 +4,34 @@ import React, {useCallback, useEffect, useRef} from 'react';
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {useLevelProperties} from '../levelPropertiesContext';
-import {getSelectMultimodalAvailable, submitChatContents} from '../redux';
+import {submitChatContents} from '../redux';
 import {ChatButton} from '../types';
 
 import moduleStyles from './UserChatMessageEditor.module.scss';
 
-/**
- * Renders the AI Chat Lab user chat message editor component.
- */
-const UserChatMessageEditor: React.FunctionComponent<{
+interface UserChatMessageEditorProps {
   editorContainerClassName?: string;
   chatButtons?: ChatButton[];
   hiddenContext?: string;
-}> = ({editorContainerClassName, chatButtons, hiddenContext}) => {
+  multimodalAvailable?: boolean;
+}
+
+/**
+ * Renders the AI Chat Lab user chat message editor component.
+ */
+const UserChatMessageEditor: React.FunctionComponent<
+  UserChatMessageEditorProps
+> = ({
+  editorContainerClassName,
+  chatButtons,
+  hiddenContext,
+  multimodalAvailable,
+}) => {
   const isWaitingForChatResponse = useAppSelector(
     state => !!state.aichat.chatMessagePending
   );
 
   const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
-  const multimodalEnabled = useAppSelector(
-    getSelectMultimodalAvailable(
-      useLevelProperties().aichatSettings?.multimodalEnabled
-    )
-  );
   const chatAssets = useAppSelector(state =>
     state.aichat.stagedFiles.map(file => file.asset)
   );
@@ -46,7 +50,7 @@ const UserChatMessageEditor: React.FunctionComponent<{
             text: userMessage,
             hiddenContext: hiddenContext,
             assets:
-              multimodalEnabled && chatAssets.length > 0
+              multimodalAvailable && chatAssets.length > 0
                 ? chatAssets
                 : undefined,
           })
@@ -57,7 +61,7 @@ const UserChatMessageEditor: React.FunctionComponent<{
       isWaitingForChatResponse,
       dispatch,
       hiddenContext,
-      multimodalEnabled,
+      multimodalAvailable,
       chatAssets,
     ]
   );

--- a/apps/src/aichat/views/assets/StagedFilesPreview.tsx
+++ b/apps/src/aichat/views/assets/StagedFilesPreview.tsx
@@ -5,14 +5,13 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {MAX_FILE_SIZE_MB, MAX_NUM_FILES} from '../../constants';
-import {useLevelProperties} from '../../levelPropertiesContext';
 import aichatI18n from '../../locale';
 import {
   clearStagedFilesAlert,
   removeStagedFile,
   stagedFileUploadFinished,
 } from '../../redux';
-import {getAssetUrl} from '../../utils';
+import {ChatAsset} from '../../types';
 
 import FilePreview from './FilePreview';
 
@@ -30,11 +29,15 @@ const alerts = {
   ] as const,
 } satisfies {[key: string]: [string, AlertProps['type']]};
 
-const StagedFilesPreview: React.FC = () => {
+interface StagedFilesPreviewProps {
+  buildAssetUrl: (asset: ChatAsset) => string;
+}
+
+const StagedFilesPreview: React.FC<StagedFilesPreviewProps> = ({
+  buildAssetUrl,
+}) => {
   const dispatch = useAppDispatch();
   const stagedFiles = useAppSelector(state => state.aichat.stagedFiles);
-  const currentChannelId = useAppSelector(state => state.lab.channel?.id);
-  const levelName = useLevelProperties().name;
 
   const [alertMessage, style] = useAppSelector(state => {
     if (!state.aichat.stagedFilesAlert) {
@@ -57,11 +60,7 @@ const StagedFilesPreview: React.FC = () => {
             <FilePreview
               key={key}
               type={filename.endsWith('.pdf') ? 'pdf' : 'image'}
-              url={`${getAssetUrl(
-                asset,
-                currentChannelId,
-                levelName
-              )}?t=${key}`}
+              url={`${buildAssetUrl(asset)}?t=${key}`}
               filename={filename}
               isUploading={status === 'uploading'}
               onRemove={() => dispatch(removeStagedFile(key))}

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -16,7 +16,6 @@ import {
   MAX_FILE_SIZE_MB,
   MAX_NUM_FILES,
 } from '../../constants';
-import {useLevelProperties} from '../../levelPropertiesContext';
 import aichatI18n from '../../locale';
 import {
   addStagedFile,
@@ -25,20 +24,28 @@ import {
   stagedFilesLimitExceeded,
   stagedFileUploadFinished,
 } from '../../redux';
-import {AssetSource} from '../../types';
+import {AssetSource, ChatAsset} from '../../types';
 
 import styles from './upload-button.module.scss';
 
-const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
+interface UploadButtonProps {
+  isDisabled: boolean;
+  levelName: string;
+  buildAssetUrl: (asset: ChatAsset) => string;
+  hasStarterAssets?: boolean;
+}
+
+const UploadButton: React.FC<UploadButtonProps> = ({
+  isDisabled,
+  levelName,
+  buildAssetUrl,
+  hasStarterAssets = false,
+}) => {
   const dispatch = useAppDispatch();
-  const currentChannelId = useAppSelector(state => state.lab.channel?.id);
   const numStagedFiles = useAppSelector(
     state => state.aichat.stagedFiles.length
   );
   const numAllowedFiles = MAX_NUM_FILES - numStagedFiles;
-  const {name: levelName, starterAssets} = useLevelProperties();
-  const hasStarterAssets =
-    starterAssets && Object.keys(starterAssets).length > 0;
   const [showAssetManager, setShowAssetManager] = useState(false);
 
   const onUploadFiles = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -57,23 +64,21 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
 
     const allowedFiles = Array.from(files)
       .slice(0, numAllowedFiles)
-      .map<[string, string, File]>(file => [
+      .map<[string, ChatAsset, File]>(file => [
         // Create a unique key for each upload in case the same file is uploaded more than once.
         `${file.name}-${Date.now()}`,
-        file.name,
+        {filename: file.name, source: AssetSource.PROJECT},
         file,
       ]);
 
-    for (const [key, filename] of allowedFiles) {
-      dispatch(
-        addStagedFile({key, asset: {filename, source: AssetSource.PROJECT}})
-      );
+    for (const [key, asset] of allowedFiles) {
+      dispatch(addStagedFile({key, asset}));
     }
 
     let uploadSuccessCount = 0;
     let sizeLimitExceededCount = 0;
     let uploadFailureCount = 0;
-    for (const [key, filename, file] of allowedFiles) {
+    for (const [key, asset, file] of allowedFiles) {
       if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
         sizeLimitExceededCount += 1;
         dispatch(
@@ -86,10 +91,7 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
       }
 
       try {
-        await HttpClient.put(
-          `/v3/assets/${currentChannelId}/${encodeURIComponent(filename)}`,
-          file
-        );
+        await HttpClient.put(buildAssetUrl(asset), file);
         uploadSuccessCount += 1;
 
         dispatch(stagedFileUploadFinished({key, status: 'uploaded'}));
@@ -165,10 +167,6 @@ const UploadButton: React.FC<{isDisabled: boolean}> = ({isDisabled}) => {
       })
     );
   };
-
-  if (!currentChannelId) {
-    return null;
-  }
 
   const buttonProps: ButtonProps = {
     type: 'secondary',

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -8,19 +8,16 @@ import ChatWorkspace from '@cdo/apps/aichat/views/ChatWorkspace';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import {aiTutorModelId} from '../../ai/AiTutorModelId';
-import {LevelProperties} from '../../types';
 
 import moduleStyles from './AiTutor2Chat.module.scss';
 
 interface AiTutor2ChatProps {
   hiddenContext: string;
-  levelProperties: LevelProperties;
 }
 
 // A free chat with lab-supplied context added to each question.
 const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
   hiddenContext,
-  levelProperties,
 }) => {
   const dispatch = useAppDispatch();
 
@@ -67,7 +64,6 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
         onClear={() => {
           dispatch(clearChatMessages());
         }}
-        levelProperties={levelProperties}
       />
     </div>
   );

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -124,10 +124,7 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
               className={moduleStyles.rightmostColumn}
             >
               <div className={moduleStyles.inside}>
-                <AiTutor2Chat
-                  hiddenContext={aiTutor2Context}
-                  levelProperties={levelProperties}
-                />
+                <AiTutor2Chat hiddenContext={aiTutor2Context} />
               </div>
             </PanelContainer>
           </div>


### PR DESCRIPTION
This undoes the quick fix in https://github.com/code-dot-org/code-dot-org/pull/66915 in favor of a more decoupled approach where the relevant fields from `levelProperties` are passed into the `ChatWorkspace` component as distinct props (all only relevant for multimodal chat anyway).

This breaks ChatWorkspace's dependency on `levelProperties` and the assumption that it necessary has to be used in a lab/level context. It most likely will be regardless, but this removes assumptions enforces a separation between lab-specific code, and core chat functionality.

## Testing story

Tested locally with AI Chat multimodal and AI Tutor.