### PR TITLE
fix(marketing): add aria-label and remove aria-labelledby on Skinny Banner

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/skinnyBanner/SkinnyBanner.tsx
+++ b/frontend/apps/marketing/src/components/contentful/skinnyBanner/SkinnyBanner.tsx
@@ -50,7 +50,7 @@ const SkinnyBanner: React.FunctionComponent<SkinnyBannerProps> = ({
   return (
     <DSCOSkinnyBanner
       data-theme={contentMode}
-      aria-labelledby={heading}
+      aria-label={heading}
       className={className}
       heading={heading}
       description={description}


### PR DESCRIPTION
I used the wrong label type on the Skinny Banner component so the `Ensure landmarks are unique` error is still happening. Hoping this fixes it in subsequent builds.

## Links
Jira ticket: [CMS-907](https://codedotorg.atlassian.net/browse/CMS-907)
Related commit: https://github.com/code-dot-org/code-dot-org/pull/67083/commits/61afbf987b75ea50eda5328e64822192926ef50e