### PR TITLE
fix(dev): constantize Improper neutralization of code injection on local_development

### DIFF
--- a/lib/cdo/local_development.rb
+++ b/lib/cdo/local_development.rb
@@ -45,12 +45,18 @@ module Cdo
       # until we find one that works.
       base = nil
       relative_path = []
+      allowed_classes = [
+        'CdoSoundLibrary::HocSongMeta::Populate',
+        'CdoSoundLibrary::Populate',
+        'Populate'
+      ] # Add all allowed Populate classes here
       until class_parts.empty?
-        begin
-          base = [*class_parts, 'Populate'].join('::').constantize
+        potential_class = [*class_parts, 'Populate'].join('::')
+        if allowed_classes.include?(potential_class)
+          base = potential_class.constantize
           relative_path << path_parts.pop
-          break if base
-        rescue NameError
+          break
+        else
           class_parts.pop
         end
       end


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/blob/b0bf4e5610fae37ea9f3db145ce6771dc65747f1/lib/cdo/local_development.rb#L49-L53

Directly evaluating user input (an HTTP request parameter) as code without first sanitizing the input allows an attacker arbitrary code execution. This can occur when user input is passed to code that interprets it as an expression to be evaluated, using methods such as `Kernel.eval` or `Kernel.send`.



To prevent code injection, the dynamic class resolution logic should be replaced with a safer alternative. Instead of dynamically constructing and evaluating class names using `constantize`, a whitelist of allowed classes should be maintained, and the class name should be validated against this whitelist. This ensures that only expected classes can be used, regardless of the input. fix involves:
1. Creating a whitelist of allowed classes that can be used as populators.
2. Validating the constructed class name against this whitelist before proceeding.
3. Raising an error or ignoring invalid class names.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
