### PR TITLE
Codebridge: another rendering optimization and a clean-up

### DIFF
--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -13,7 +13,7 @@ import React, {useEffect, useMemo} from 'react';
 
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
-import {LabConfig, ProjectSources} from '@cdo/apps/lab2/types';
+import {ProjectSources} from '@cdo/apps/lab2/types';
 import {BackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
 import BackpackClientApi from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -31,7 +31,6 @@ type CodebridgeProps = {
   startSources: ProjectSources;
   onRun?: OnRunFunction;
   onStop?: () => void;
-  labConfig?: LabConfig;
   sendConsoleInput?: SendConsoleInputFunction;
   levelProperties: CodebridgeLevelProperties;
   projectPickerSettings?: ProjectPickerSettings;
@@ -46,7 +45,6 @@ export const Codebridge = React.memo(
     startSources,
     onRun,
     onStop,
-    labConfig,
     sendConsoleInput,
     levelProperties,
     projectPickerSettings,
@@ -147,7 +145,6 @@ export const Codebridge = React.memo(
           startSources,
           onRun,
           onStop,
-          labConfig,
           sendConsoleInput,
           levelProperties,
           projectPickerSettings,

--- a/apps/src/codebridge/Console/Console.tsx
+++ b/apps/src/codebridge/Console/Console.tsx
@@ -32,9 +32,12 @@ const Console: React.FunctionComponent = () => {
   const [consoleManager, setConsoleManager] = useState<ConsoleManager | null>(
     null
   );
-  const {labConfig, sendConsoleInput, levelProperties} = useCodebridgeContext();
+  const {sendConsoleInput, levelProperties} = useCodebridgeContext();
   const appName = levelProperties.appName;
-  const hasMiniApp = !!labConfig?.miniApp?.name;
+
+  const hasMiniApp = useAppSelector(
+    state => !!state.lab2Project.projectSources?.labConfig?.miniApp?.name
+  );
   const fontSizeKey = useAppSelector(
     state => state.lab2View.consoleFontSizeKey
   );

--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -34,7 +34,7 @@ import moduleStyles from './console.module.scss';
 // Can be extended in the future to include a test button.
 const ControlButtons: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
-  const {onRun, onStop, labConfig, levelProperties} = useCodebridgeContext();
+  const {onRun, onStop, levelProperties} = useCodebridgeContext();
   const {id: levelId, appName, predictSettings} = levelProperties;
   const isPredictLevel = predictSettings?.isPredictLevel;
   const levelPath =
@@ -58,7 +58,9 @@ const ControlButtons: React.FunctionComponent = () => {
   const awaitingPredictSubmit =
     !isStartMode && isPredictLevel && !hasPredictResponse;
 
-  const miniApp = labConfig?.miniApp?.name;
+  const miniApp = useAppSelector(
+    state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
+  );
 
   const resetStatus = useCallback(() => {
     dispatch(setHasRun(false));

--- a/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
+++ b/apps/src/codebridge/MiniAppPreview/MiniAppPreview.tsx
@@ -41,7 +41,7 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
   showMaximizeButton = true,
   handleScaling,
 }) => {
-  const {labConfig, levelProperties} = useCodebridgeContext();
+  const {levelProperties} = useCodebridgeContext();
   const [isResetButtonDisabled, setIsResetButtonDisabled] = useState(true);
   const isRunning = useAppSelector(state => state.lab2System.isRunning);
 
@@ -53,7 +53,9 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
     setIsResetButtonDisabled(true);
   }, [levelProperties.id]);
 
-  const miniApp = labConfig?.miniApp?.name;
+  const miniApp = useAppSelector(
+    state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
+  );
 
   const miniAppComponent = useMemo(() => {
     if (miniApp === MiniApps.Neighborhood) {
@@ -64,7 +66,7 @@ const MiniAppPreview: React.FunctionComponent<MiniAppPreviewProps> = ({
 
   const resetMiniApp = () => {
     setIsResetButtonDisabled(true);
-    if (labConfig?.miniApp.name === MiniApps.Neighborhood) {
+    if (miniApp === MiniApps.Neighborhood) {
       CodebridgeRegistry.getInstance().getNeighborhood()?.reset();
     }
   };

--- a/apps/src/codebridge/Workspace/HorizontalOutput.tsx
+++ b/apps/src/codebridge/Workspace/HorizontalOutput.tsx
@@ -6,6 +6,7 @@ import React, {useRef, useState, useCallback, useMemo, useEffect} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
 import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import BaseOutput from './BaseOutput';
 import {
@@ -31,8 +32,11 @@ const HorizontalOutput: React.FunctionComponent<HorizontalOutputProps> = ({
   setOutputHeight,
   className,
 }) => {
-  const {labConfig, levelProperties} = useCodebridgeContext();
-  const miniApp = labConfig?.miniApp?.name;
+  const {levelProperties} = useCodebridgeContext();
+
+  const miniApp = useAppSelector(
+    state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
+  );
   const style = {
     height,
   };

--- a/apps/src/codebridge/Workspace/VerticalOutput.tsx
+++ b/apps/src/codebridge/Workspace/VerticalOutput.tsx
@@ -6,6 +6,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
 import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import BaseOutput from './BaseOutput';
 import {
@@ -29,8 +30,10 @@ const VerticalOutput: React.FunctionComponent<VerticalOutputProps> = ({
   width,
   setOutputWidth,
 }) => {
-  const {labConfig, levelProperties} = useCodebridgeContext();
-  const miniApp = labConfig?.miniApp?.name;
+  const {levelProperties} = useCodebridgeContext();
+  const miniApp = useAppSelector(
+    state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
+  );
   const style = {
     width,
   };

--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -49,6 +49,9 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
   const projectTooLarge = useAppSelector(
     state => state.lab2Project.projectTooLarge
   );
+  const showFileBrowser = useAppSelector(
+    state => state.codebridgeWorkspace.showFileBrowser
+  );
   const dispatch = useAppDispatch();
 
   const headerContent = (
@@ -112,22 +115,22 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
       >
         <div
           className={classnames(moduleStyles.workspaceWorkarea, {
-            [moduleStyles.withFileBrowser]: config.showFileBrowser,
+            [moduleStyles.withFileBrowser]: showFileBrowser,
           })}
         >
           <div
             className={classnames(moduleStyles.workspaceToggleButtonContainer, {
-              [moduleStyles.withFileBrowser]: config.showFileBrowser,
+              [moduleStyles.withFileBrowser]: showFileBrowser,
             })}
           >
             <ToggleFileBrowserButton />
           </div>
           <FileTabs />
-          {config.showFileBrowser && <FileBrowser />}
+          {showFileBrowser && <FileBrowser />}
           {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
           <div
             className={classnames(moduleStyles.workplaceEditorWrapper, {
-              [moduleStyles.withFileBrowser]: config.showFileBrowser,
+              [moduleStyles.withFileBrowser]: showFileBrowser,
             })}
             tabIndex={0}
             onKeyDown={onKeyDown}

--- a/apps/src/codebridge/codebridgeContext/codebridgeContext.tsx
+++ b/apps/src/codebridge/codebridgeContext/codebridgeContext.tsx
@@ -1,6 +1,6 @@
 import React, {createContext, useContext} from 'react';
 
-import {LabConfig, ProjectSources} from '@cdo/apps/lab2/types';
+import {ProjectSources} from '@cdo/apps/lab2/types';
 
 import {
   ConfigType,
@@ -18,7 +18,6 @@ export type CodebridgeContextType = {
   onRun?: OnRunFunction;
   onStop?: OnStopFunction;
   startSources: ProjectSources;
-  labConfig?: LabConfig;
   sendConsoleInput?: SendConsoleInputFunction;
   levelProperties: CodebridgeLevelProperties;
   projectPickerSettings?: ProjectPickerSettings;
@@ -33,7 +32,7 @@ export const CodebridgeContext = createContext<CodebridgeContextType | null>(
 export const useCodebridgeContext = () => {
   const context = useContext(CodebridgeContext);
   if (context === null) {
-    throw new Error('CDO IDE Context has not been provided!');
+    throw new Error('Codebridge Context has not been provided!');
   }
   return context;
 };

--- a/apps/src/codebridge/components/ToggleFileBrowserButton.tsx
+++ b/apps/src/codebridge/components/ToggleFileBrowserButton.tsx
@@ -11,7 +11,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {setShowFileBrowser} from '../redux/workspaceRedux';
 
 /*
-  This component will look to the `showFileBrowser` boolean in the config and flip it back and forth.
+  This component will look to the `showFileBrowser` boolean in redux and flip it back and forth.
   If we're showing it, the icon is solid, and if not, the icon is regular.
 */
 

--- a/apps/src/codebridge/components/ToggleFileBrowserButton.tsx
+++ b/apps/src/codebridge/components/ToggleFileBrowserButton.tsx
@@ -6,8 +6,9 @@ import {
 import React, {useCallback} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {useCodebridgeContext} from '../codebridgeContext';
+import {setShowFileBrowser} from '../redux/workspaceRedux';
 
 /*
   This component will look to the `showFileBrowser` boolean in the config and flip it back and forth.
@@ -15,15 +16,14 @@ import {useCodebridgeContext} from '../codebridgeContext';
 */
 
 const ToggleFileBrowserButton: React.FunctionComponent = () => {
-  const {config, setConfig} = useCodebridgeContext();
+  const showFileBrowser = useAppSelector(
+    state => state.codebridgeWorkspace.showFileBrowser
+  );
+  const dispatch = useAppDispatch();
 
   const onClick = useCallback(
-    () =>
-      setConfig({
-        ...config,
-        showFileBrowser: !config.showFileBrowser,
-      }),
-    [config, setConfig]
+    () => dispatch(setShowFileBrowser(!showFileBrowser)),
+    [showFileBrowser, dispatch]
   );
 
   const tooltipProps: TooltipProps = {
@@ -38,7 +38,7 @@ const ToggleFileBrowserButton: React.FunctionComponent = () => {
       <WithTooltip tooltipProps={tooltipProps}>
         <Button
           icon={{
-            iconStyle: config.showFileBrowser ? 'solid' : 'regular',
+            iconStyle: showFileBrowser ? 'solid' : 'regular',
             iconName: 'folder',
           }}
           isIconOnly
@@ -46,7 +46,7 @@ const ToggleFileBrowserButton: React.FunctionComponent = () => {
           ariaLabel={codebridgeI18n.toggleFileBrowser()}
           size={'xs'}
           type={'tertiary'}
-          aria-expanded={config.showFileBrowser}
+          aria-expanded={showFileBrowser}
           color={'black'}
         />
       </WithTooltip>

--- a/apps/src/codebridge/redux/workspaceRedux.ts
+++ b/apps/src/codebridge/redux/workspaceRedux.ts
@@ -3,11 +3,13 @@ import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 export interface CodebridgeWorkspaceState {
   showLockedFilesBanner: boolean;
   widgetViewShowCode: boolean;
+  showFileBrowser: boolean;
 }
 
 export const initialState: CodebridgeWorkspaceState = {
   showLockedFilesBanner: false,
   widgetViewShowCode: false,
+  showFileBrowser: true,
 };
 
 // SLICE
@@ -21,10 +23,16 @@ const workspaceSlice = createSlice({
     setWidgetViewShowCode(state, action: PayloadAction<boolean>) {
       state.widgetViewShowCode = action.payload;
     },
+    setShowFileBrowser(state, action: PayloadAction<boolean>) {
+      state.showFileBrowser = action.payload;
+    },
   },
 });
 
-export const {setShowLockedFilesBanner, setWidgetViewShowCode} =
-  workspaceSlice.actions;
+export const {
+  setShowLockedFilesBanner,
+  setWidgetViewShowCode,
+  setShowFileBrowser,
+} = workspaceSlice.actions;
 
 export default workspaceSlice.reducer;

--- a/apps/src/codebridge/types.ts
+++ b/apps/src/codebridge/types.ts
@@ -38,7 +38,6 @@ export type ConfigType = {
   PreviewComponents?: {[key: string]: PreviewComponent};
   languageMapping: {[key: string]: LanguageSupport};
   activeLayout?: LayoutKey;
-  showFileBrowser: boolean;
   validMimeTypes?: string[];
   layoutComponents: {
     horizontal: React.FunctionComponent<LayoutProps>;

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -254,7 +254,6 @@ const PythonlabView: React.FunctionComponent<
           startSources={levelStartSources}
           onRun={onRun}
           onStop={stopPythonCode}
-          labConfig={labConfig}
           sendConsoleInput={sendInput}
           levelProperties={levelProperties}
           projectPickerSettings={projectPickerSettings}

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -71,7 +71,6 @@ const defaultConfig: ConfigType = {
     share: ShareView,
     widget: HorizontalLayout,
   },
-  showFileBrowser: true,
 };
 
 const PythonlabView: React.FunctionComponent<

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -30,7 +30,6 @@ const defaultConfig: ConfigType = {
     vertical: VerticalLayout,
     horizontal: HorizontalLayout,
   },
-  showFileBrowser: true,
 };
 
 const defaultSource: MultiFileSource = {

--- a/apps/test/unit/codebridge/test_utils.ts
+++ b/apps/test/unit/codebridge/test_utils.ts
@@ -65,7 +65,6 @@ export const getDefaultCodebridgeContext = () => {
       PreviewComponents: undefined,
       languageMapping: {},
       activeLayout: undefined,
-      showFileBrowser: false,
       validMimeTypes: undefined,
       layoutComponents: {
         horizontal: () => null,


### PR DESCRIPTION
Two follow-ups to #67054:
- Instead of passing `labConfig` in via the codebridge config, just get it from redux. This doesn't do much for rendering since the labconfig only changes if you change project types, which is very rare. But it is in line with the change to get sources from redux, as sources and labConfig are part of the same object.
- Take the file browser open setting out of `CodebridgeContext`. This was always set to true by default, and there's been no request to have it closed by default for some levels (and that would be a level property anyway). It's now in the codebridge workspace redux. This is a rendering optimization, because toggling the file browser now does not cause a bunch of unrelated components to re-render.

There is still one changing piece of config in the CodebridgeContext, `activeLayout`. I kept this in the context because it is something that effects the entire layout, which is an appropriate use for context. We also have to basically re-render everything when we switch layouts anyway, so there wouldn't be much benefit to moving it.

Screen recordings of before/after to show rendering optimization with file browser change are below. Note how the console and instructions were re-rendering when the file browser was toggled before, and now they are not.

### Before

https://github.com/user-attachments/assets/8dee642b-07f3-44a6-bc0a-84487478ff34


### After

https://github.com/user-attachments/assets/1eda449a-e362-4465-962b-84b98d39a467


## Testing story
Tested locally.


## Follow-up work
As I have time I'll keep looking for optimizations here.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
