### PR TITLE
fix(HeroBanner): set type color on announcement banner icon on DSCO component

### DIFF
--- a/frontend/packages/component-library/src/heroBanner/HeroBanner.tsx
+++ b/frontend/packages/component-library/src/heroBanner/HeroBanner.tsx
@@ -102,6 +102,7 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
         text={announcementBannerProps.text}
         icon={announcementBannerProps.icon}
         link={announcementBannerProps.link}
+        type="gray"
       />
     )}
     <div


### PR DESCRIPTION
Adds `type="gray` to DSCO version of the HeroBanner component. 

## Links
Jira ticket: [CMS-915](https://codedotorg.atlassian.net/browse/CMS-915)
Related PR: https://github.com/code-dot-org/code-dot-org/pull/67036
Slack convo: [here](https://codedotorg.slack.com/archives/C08DVJWA03G/p1752686550354599?thread_ts=1752616466.088299&cid=C08DVJWA03G)

## Testing story
This will cause an Eyes diff w/ a new baseline showing a white icon

----

## Before
<img width="1337" height="472" alt="Before" src="https://github.com/user-attachments/assets/a707157b-9c9a-444f-a911-c9848f8eac8a" />


## After
<img width="1337" height="472" alt="After" src="https://github.com/user-attachments/assets/25721b6c-6a06-4886-b052-f9ffee791189" />
