### PR TITLE
[Levelbuilder] Disable delete button for protected helper libraries

### DIFF
--- a/dashboard/app/views/libraries/edit.html.haml
+++ b/dashboard/app/views/libraries/edit.html.haml
@@ -18,13 +18,17 @@
         = f.submit class: 'btn', id: 'library_submit'
 
     - unless @library.new_record?
+      - protected_libraries = ['NativeSpriteLab', 'ValidationSetup']
+      - is_protected = protected_libraries.include?(@library.name)
       = form_for(@library,
         url: library_path(id: @library.name),
         html: {id: 'delete-library-form', method: 'delete'},
       ) do |f|
         = f.submit 'Delete Library',
-            data: {confirm: 'Are you sure you want to delete this library?'},
-            class: 'btn btn-danger'
+            data: {confirm: 'Are you sure you want to delete this library? Be sure it is not used in ANY published levels.'},
+            class: 'btn btn-danger',
+            disabled: is_protected,
+            title: (is_protected ? "#{@library.name} cannot be deleted." : nil)
 
 = link_to 'Back', libraries_path
 


### PR DESCRIPTION
Yesterday on levelbuilder, the `ValidationSetup` helper library was deleted, which caused builds to start failing. This library is automatically added to every `P5Lab` level with validation code. 
This branch aims to prevent this sort of accidental deletion from occurring in the future by disabling the delete button. This is also extended to the `NativeSpritelab` which is required in all Sprite Lab levels.

Levelbuilders will now see a tool tip over the disabled button:

<img width="1971" height="1508" alt="image" src="https://github.com/user-attachments/assets/b7158187-0276-4692-b2c6-9fcaa6cc93ad" />

Other libraries can still be deleted, and I've tweaked the confirmation text.
<img width="1001" height="478" alt="image" src="https://github.com/user-attachments/assets/1e617fec-7fef-462a-bf24-0560ae072b28" />



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
