### PR TITLE
Fix terminate_build Script

### DIFF
--- a/bin/terminate_build
+++ b/bin/terminate_build
@@ -58,8 +58,7 @@ begin
 
   begin
     CDO.log.info "Killing process group #{process_group_id}..."
-    # The negative ID specifies we want to kill all processes in the Process Group with that ID.
-    Process.kill('KILL', -process_group_id.to_i)  # SIGKILL to process group
+    Process.kill('-KILL', process_group_id.to_i)  # SIGKILL to process group
     CDO.log.info 'Done killing the current build and its child processes!'
     ChatClient.log "Done killing the current build and its child processes!", color: 'red'
   rescue Errno::ESRCH

--- a/bin/terminate_build
+++ b/bin/terminate_build
@@ -42,7 +42,7 @@ ChatClient.log "A user has invoked bin/terminate_build on this environment's dae
 # Command issued by cron to execute the continuous deployment system.
 BUILD_COMMAND = "/bin/sh -c BUNDLE_GEMFILE=/home/ubuntu/#{CDO.env}/Gemfile bundle exec /home/ubuntu/#{CDO.env}/bin/cronjob /home/ubuntu/#{CDO.env}/aws/ci_build dev+build@code.org".freeze
 # Flag file at the root of the project indicating that a build is currently executing.
-STARTED = 'build-started'.freeze
+STARTED = "/home/ubuntu/#{CDO.env}/build-started".freeze
 
 begin
   process_list = execute_system_command("ps -C sh -o pid,pgid,args")
@@ -58,7 +58,8 @@ begin
 
   begin
     CDO.log.info "Killing process group #{process_group_id}..."
-    Process.kill('-KILL', process_group_id.to_i)  # SIGKILL to process group
+    # The negative ID specifies we want to kill all processes in the Process Group with that ID.
+    Process.kill('KILL', -process_group_id.to_i)  # SIGKILL to process group
     CDO.log.info 'Done killing the current build and its child processes!'
     ChatClient.log "Done killing the current build and its child processes!", color: 'red'
   rescue Errno::ESRCH
@@ -76,7 +77,7 @@ begin
     CDO.log.error "Failed to delete build-started file: #{exception.message}"
     # Don't re-raise since this shouldn't be considered a build termination failure
   end
-rescue Exception => exception  # Catch ALL exceptions, not just StandardError
+rescue => exception
   CDO.log.error "Failed to terminate build processes: #{exception.class}: #{exception.message}"
   CDO.log.error "Backtrace: #{exception.backtrace.first(5).join(', ')}" if exception.backtrace
   ChatClient.log "Failed to terminate build processes: #{exception.class}: #{exception.message}", color: 'red'

--- a/bin/terminate_build
+++ b/bin/terminate_build
@@ -56,10 +56,18 @@ begin
   CDO.log.info 'Killing the following aws/ci_build process and all of its child processes:'
   execute_system_command("pgrep -g #{process_group_id} -a")
 
-  # The hyphen ('-') in front of the Process Group ID specifies we want to kill all processes with that Process Group ID.
-  execute_system_command("kill -9 -#{process_group_id}")
-  CDO.log.info 'Done killing the current build and its child processes!'
-  ChatClient.log "Done killing the current build and its child processes!", color: 'red'
+  begin
+    CDO.log.info "Killing process group #{process_group_id}..."
+    # The negative ID specifies we want to kill all processes in the Process Group with that ID.
+    Process.kill('KILL', -process_group_id.to_i)  # SIGKILL to process group
+    CDO.log.info 'Done killing the current build and its child processes!'
+    ChatClient.log "Done killing the current build and its child processes!", color: 'red'
+  rescue Errno::ESRCH
+    CDO.log.info 'Process group was already terminated.'
+  rescue Exception => exception
+    CDO.log.error "Error killing process group: #{exception.message}"
+    raise
+  end
 
   begin
     CDO.log.info 'Deleting the file build-started to prevent a new build from starting on the current commit.'
@@ -69,8 +77,9 @@ begin
     CDO.log.error "Failed to delete build-started file: #{exception.message}"
     # Don't re-raise since this shouldn't be considered a build termination failure
   end
-rescue => exception
-  CDO.log.error "Failed to terminate build processes: #{exception.message}"
-  ChatClient.log "Failed to terminate build processes: #{exception.message}", color: 'red'
+rescue Exception => exception  # Catch ALL exceptions, not just StandardError
+  CDO.log.error "Failed to terminate build processes: #{exception.class}: #{exception.message}"
+  CDO.log.error "Backtrace: #{exception.backtrace.first(5).join(', ')}" if exception.backtrace
+  ChatClient.log "Failed to terminate build processes: #{exception.class}: #{exception.message}", color: 'red'
   raise
 end


### PR DESCRIPTION
The `terminate_build` script is not working, possibly because our usage of `Open3.capture3` to invoke the `kill` command in a shell was causing it to kill itself. Switch to using `Process.kill`.

Slack Discussion:
* https://codedotorg.slack.com/archives/C0T0PNTM3/p1752677738458009
* https://codedotorg.slack.com/archives/C046G4TRLEN/p1752007655579089?thread_ts=1752007168.955829&cid=C046G4TRLEN

## Testing story

Tested successfully on the test server.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
