### PR TITLE
Fix name mismatch when sending existingSchoolInfo to teacher homepage

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageConstants.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageConstants.tsx
@@ -2,6 +2,6 @@ export interface SchoolInfo {
   country: string;
   school_name: string;
   school_zip: string;
-  school_id: string;
-  school_type: string;
+  school_id?: string;
+  school_type?: string;
 }

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -80,11 +80,8 @@ export const TeacherHomepageDrawer: React.FC = () => {
     schoolType: existingSchoolInfo?.school_type,
   });
 
-  const schoolName =
-    schoolInfo.schoolsList.find(school => school.value === schoolInfo.schoolId)
-      ?.text ||
-    schoolInfo.schoolName ||
-    i18n.schoolInfoDialogDescriptionNoName();
+  const existingSchoolName =
+    existingSchoolInfo?.school_name || i18n.schoolInfoDialogDescriptionNoName();
 
   const tryUpdateSchoolInfo = async () => {
     const hasNcesId =
@@ -208,7 +205,7 @@ export const TeacherHomepageDrawer: React.FC = () => {
         <BodyTwoText>
           {schoolInfoConfirmationOpen
             ? `${i18n.schoolInfoDialogDescription()}${i18n.schoolInfoDialogDescriptionSchoolName(
-                {schoolName}
+                {schoolName: existingSchoolName}
               )}`
             : success
             ? i18n.schoolInfoDrawerSuccess()

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawerTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawerTest.tsx
@@ -28,7 +28,7 @@ import i18n from '@cdo/locale';
 describe('TeacherHomepageDrawer', () => {
   const schoolInfo: SchoolInfo = {
     country: 'US',
-    school_name: '',
+    school_name: 'School One',
     school_zip: '12345',
     school_id: '1',
     school_type: 'public',
@@ -50,6 +50,13 @@ describe('TeacherHomepageDrawer', () => {
     setSchoolName: jest.fn(),
     setSchoolZip: jest.fn(),
     reset: jest.fn(),
+  };
+
+  const customSchoolInfo: SchoolInfo = {
+    country: 'US',
+    school_name: 'Test School',
+    school_zip: '12345',
+    school_type: undefined,
   };
 
   const mockSchoolInfoCustomSchool = {
@@ -101,13 +108,17 @@ describe('TeacherHomepageDrawer', () => {
     );
   }
 
-  function fetchSpySetup(showInterstitial: boolean, showConfirmation: boolean) {
+  function fetchSpySetup(
+    showInterstitial: boolean,
+    showConfirmation: boolean,
+    existingSchoolInfo: SchoolInfo
+  ) {
     fetchSpy.mockImplementation((url: string) => {
       return Promise.resolve({
         value: {
           showSchoolInfoInterstitial: showInterstitial,
           showSchoolInfoConfirmation: showConfirmation,
-          existingSchoolInfo: schoolInfo,
+          existingSchoolInfo: existingSchoolInfo,
         },
         response: new Response(),
       });
@@ -115,7 +126,7 @@ describe('TeacherHomepageDrawer', () => {
   }
 
   it('renders the correct title, subtitle, and school data inputs when showSchoolInfoInterstitial is true', async () => {
-    fetchSpySetup(true, false);
+    fetchSpySetup(true, false, schoolInfo);
     schoolInfoSpy.mockReturnValue(mockSchoolInfo);
     renderComponent();
     await act(async () => await new Promise(process.nextTick));
@@ -125,7 +136,7 @@ describe('TeacherHomepageDrawer', () => {
   });
 
   it('sends analytics event when the secondary button is clicked', async () => {
-    fetchSpySetup(true, false);
+    fetchSpySetup(true, false, schoolInfo);
     schoolInfoSpy.mockReturnValue(mockSchoolInfo);
     renderComponent();
     await act(async () => await new Promise(process.nextTick));
@@ -135,7 +146,7 @@ describe('TeacherHomepageDrawer', () => {
   });
 
   it('sends analytics event and calls updateSchoolInfo when the school data entry submit button is clicked', async () => {
-    fetchSpySetup(true, false);
+    fetchSpySetup(true, false, schoolInfo);
     schoolInfoSpy.mockReturnValue(mockSchoolInfo);
     renderComponent();
     await act(async () => await new Promise(process.nextTick));
@@ -146,7 +157,7 @@ describe('TeacherHomepageDrawer', () => {
   });
 
   it('displays success message after school data entry submit button is clicked', async () => {
-    fetchSpySetup(true, false);
+    fetchSpySetup(true, false, schoolInfo);
     schoolInfoSpy.mockReturnValue(mockSchoolInfo);
     renderComponent();
     await act(async () => await new Promise(process.nextTick));
@@ -157,7 +168,7 @@ describe('TeacherHomepageDrawer', () => {
   });
 
   it('renders the correct title and subtitle when showSchoolInfoConfirmation is true', async () => {
-    fetchSpySetup(false, true);
+    fetchSpySetup(false, true, schoolInfo);
     schoolInfoSpy.mockReturnValue(mockSchoolInfo);
     const schoolName = 'School One';
     renderComponent();
@@ -175,7 +186,7 @@ describe('TeacherHomepageDrawer', () => {
   });
 
   it('displays a custom school name on the confirmation first page when the teacher has entered one', async () => {
-    fetchSpySetup(false, true);
+    fetchSpySetup(false, true, customSchoolInfo);
     schoolInfoSpy.mockReturnValue(mockSchoolInfoCustomSchool);
     const schoolName = 'Test School';
     renderComponent();
@@ -193,7 +204,7 @@ describe('TeacherHomepageDrawer', () => {
   });
 
   it('sends analytics event and displays the school data inputs after clicking the primary button when showSchoolInfoConfirmation is true', async () => {
-    fetchSpySetup(false, true);
+    fetchSpySetup(false, true, schoolInfo);
     schoolInfoSpy.mockReturnValue(mockSchoolInfo);
     renderComponent();
     await act(async () => await new Promise(process.nextTick));

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -64,7 +64,7 @@ class TeacherDashboardController < ApplicationController
     render json: {
       showSchoolInfoInterstitial: show_school_info_interstitial,
       showSchoolInfoConfirmation: show_school_info_confirmation,
-      schoolInfo: school_info,
+      existingSchoolInfo: school_info,
     }
   end
 end


### PR DESCRIPTION
I was working on a different task when I realized that the response of `get_school_info_interstitial_data` returned `schoolInfo` while the client expected `existingSchoolInfo`. This PR does two things:
- updates the backend to have `existingSchoolInfo` in the response (simple key change)
- uses that data on the client to fetch the name of a user's currently school. This required some tests updates, but most of the updates are fairly boilerplate.

This is also a speculative fix for the inconsistent behavior we've seen around the school name in the school info confirmation flow (which I have not reproed).

Screenshot of the confirmation flow:

<img width="1218" height="908" alt="Screenshot 2025-07-18 074210" src="https://github.com/user-attachments/assets/c588e4e6-6a73-4e71-a08d-6e4534c724eb" />



