### PR TITLE
feat(marketing): show Header and Footer components on Code.org site only

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
@@ -59,10 +59,9 @@ export default async function Layout({
                 clientKey={statsigClientKey}
                 values={statsigBootstrapValues}
               >
-                <Header />
+                {brand === Brand.CODE_DOT_ORG && <Header />}
                 {children}
-
-                <Footer locale={locale} />
+                {brand === Brand.CODE_DOT_ORG && <Footer locale={locale} />}
               </StatsigProvider>
             </OneTrustProvider>
 


### PR DESCRIPTION
Shows the Header and Footer components on Code.org only in preparation for the CSforAll site since these will not be shared.

## Links
Jira ticket: [CMS-917](https://codedotorg.atlassian.net/browse/CMS-917)

----

## Code.org
<img width="1768" height="642" alt="Screenshot 2025-07-16 at 12 52 37 PM" src="https://github.com/user-attachments/assets/29819ac5-b696-4f5b-92ba-fa0eb78a72ea" />


## CSforAll
<img width="1768" height="642" alt="Screenshot 2025-07-16 at 12 51 58 PM" src="https://github.com/user-attachments/assets/3ec1f297-3a8a-47ff-9082-6b77c62623f5" />
