### PR TITLE
[MusicLab] Test that feedback receives focus post-run via new UI test

### DIFF
--- a/apps/src/lab2/views/components/InstructionsPanel.tsx
+++ b/apps/src/lab2/views/components/InstructionsPanel.tsx
@@ -188,7 +188,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                 <TextToSpeech text={useMessage} />
               )}
               {useMessage && (
-                <div ref={feedbackRef} tabIndex={-1}>
+                <div id="focusable-message" ref={feedbackRef} tabIndex={-1}>
                   <EnhancedSafeMarkdown
                     markdown={useMessage}
                     className={moduleStyles.markdownText}

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
@@ -1,0 +1,11 @@
+Feature: Music Lab workspaces load between levels
+
+Scenario: Ensure feedback message gets focus after keyboard nav run button
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/46/levels/2"
+  And I rotate to landscape
+  And I wait until element "[data-id='when-run-block']" is visible
+  And element "#focusable-message" does not have focus
+  # Press the run button and wait for the empty song to play
+  And I press keys ":space"
+  And I wait for 5 seconds
+  And element "#focusable-message" has focus

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
@@ -7,5 +7,5 @@ Scenario: Ensure feedback message gets focus after keyboard nav run button
   And element "#focusable-message" does not have focus
   # Press the run button and wait for the empty song to play
   And I press keys ":space"
-  And I wait for 5 seconds
+  And I wait for 6 seconds
   And element "#focusable-message" has focus

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -894,6 +894,10 @@ def element_exists?(selector)
   @browser.execute_script(jquery_element_exists(selector))
 end
 
+def element_focused?(selector)
+  @browser.execute_script("return $(#{selector.dump}).is(':focus');")
+end
+
 def element_visible?(selector)
   @browser.execute_script(jquery_is_element_visible(selector))
 end
@@ -916,6 +920,14 @@ end
 
 Then /^element "([^"]*)" does not exist/ do |selector|
   expect(element_exists?(selector)).to eq(false)
+end
+
+Then /^element "([^"]*)" has focus/ do |selector|
+  expect(element_focused?(selector)).to eq(true)
+end
+
+Then /^element "([^"]*)" does not have focus/ do |selector|
+  expect(element_focused?(selector)).to eq(false)
 end
 
 Then /^element "([^"]*)" is hidden$/ do |selector|

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -895,7 +895,7 @@ def element_exists?(selector)
 end
 
 def element_focused?(selector)
-  @browser.execute_script("return $(#{selector.dump}).is(':focus');")
+  @browser.execute_script("return document.querySelector(#{selector.dump}) === document.activeElement;")
 end
 
 def element_visible?(selector)


### PR DESCRIPTION
As a followup to https://github.com/code-dot-org/code-dot-org/pull/66727/files, this adds a test to ensure that we don't lose the feature of focusing on feedback after the song finishes playing.

My initial thought was for a unit test, but the run button is rendered by a component very far away from the instructions panel. Using the newest react testing library, it doesn't quite make sense to render both (or the instructionsPanel with a fake button). This makes more sense as an integrations test in a UI format, hence the new test. I was not sure how to write one without the short wait, because two measures of playing an empty song is the minimum. Ideally in this case, we wouldn't have the autoplay stop two full measures after the song finishes, but that decision was made [here](https://github.com/code-dot-org/code-dot-org/pull/63781) for validation reasons.

## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1293

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
