### PR TITLE
feat(workshops): ensure links have protocol

### DIFF
--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -56,7 +56,7 @@ class Pd::Session < ApplicationRecord
 
   def valid_meeting_link_format
     unless self.class.valid_url?(meeting_link)
-      errors.add(:meeting_link, "is not a valid URL")
+      errors.add(:meeting_link, "is not valid or is missing http or https")
     end
   end
 

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -55,7 +55,7 @@ class Pd::Session < ApplicationRecord
   end
 
   def valid_meeting_link_format
-    unless self.class.valid_url?(meeting_link, true)
+    unless self.class.valid_url?(meeting_link)
       errors.add(:meeting_link, "is not a valid URL")
     end
   end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -170,7 +170,7 @@ class Pd::Workshop < ApplicationRecord
   end
 
   def valid_registration_link_format
-    unless self.class.valid_url?(registration_link, true)
+    unless self.class.valid_url?(registration_link)
       errors.add(:registration_link, "is not a valid URL")
     end
   end
@@ -194,7 +194,7 @@ class Pd::Workshop < ApplicationRecord
 
   def set_registration_link
     if [COURSE_CSD, COURSE_CSP, COURSE_CSA].include?(course) && local_summer?
-      self.registration_link = "/pd/application/teacher"
+      self.registration_link = "https://studio.code.org/pd/application/teacher"
     end
   end
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -194,7 +194,7 @@ class Pd::Workshop < ApplicationRecord
 
   def set_registration_link
     if [COURSE_CSD, COURSE_CSP, COURSE_CSA].include?(course) && local_summer?
-      self.registration_link = "https://studio.code.org/pd/application/teacher"
+      self.registration_link = Rails.application.routes.url_helpers.pd_application_teacher_url
     end
   end
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -171,7 +171,7 @@ class Pd::Workshop < ApplicationRecord
 
   def valid_registration_link_format
     unless self.class.valid_url?(registration_link)
-      errors.add(:registration_link, "is not a valid URL")
+      errors.add(:registration_link, "is not valid or is missing http or https")
     end
   end
 

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -22,6 +22,11 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert_equal 'End must occur after the start', session.errors.full_messages[0]
   end
 
+  test 'valid_meeting_link_format validation passes' do
+    session = build :pd_session, meeting_link: 'https://good/url/here'
+    assert session.valid?
+  end
+
   test 'valid_meeting_link_format validation error' do
     session = build :pd_session, meeting_link: 'bad/url here'
     refute session.valid?
@@ -97,10 +102,10 @@ class Pd::SessionTest < ActiveSupport::TestCase
     session = create(
       :pd_session,
       session_format: 'virtual',
-      meeting_link: 'example.com',
+      meeting_link: 'https://example.com',
     )
 
-    assert_equal 'Virtual meeting: example.com', session.formatted_location_details
+    assert_equal 'Virtual meeting: https://example.com', session.formatted_location_details
   end
 
   test 'formatted_location_details for virtual session without meeting_link' do

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -31,7 +31,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
     session = build :pd_session, meeting_link: 'bad/url here'
     refute session.valid?
     assert_equal 1, session.errors.messages.count
-    assert_equal 'Meeting link is not a valid URL', session.errors.full_messages[0]
+    assert_equal 'Meeting link is not valid or is missing http or https', session.errors.full_messages[0]
   end
 
   test 'formatted_date' do

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1368,7 +1368,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop = build :workshop, registration_link: 'bad/url here'
     refute workshop.valid?
     assert_equal 1, workshop.errors.messages.count
-    assert_equal 'Registration link is not a valid URL', workshop.errors.full_messages[0]
+    assert_equal 'Registration link is not valid or is missing http or https', workshop.errors.full_messages[0]
   end
 
   test 'registration_link defaults to teacher app link if applications are required' do

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1374,7 +1374,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   test 'registration_link defaults to teacher app link if applications are required' do
     workshop = create :workshop, course: Pd::Workshop::COURSE_CSD, subject: SUBJECT_SUMMER_WORKSHOP
 
-    assert_equal "https://studio.code.org/pd/application/teacher", workshop.registration_link
+    assert_equal Rails.application.routes.url_helpers.pd_application_teacher_url, workshop.registration_link
   end
 
   test 'registration_link does not default to anything if applications are not required' do

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1359,10 +1359,22 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_includes workshop.errors.full_messages, 'Description is required'
   end
 
+  test 'valid_registration_link_format validation passes' do
+    workshop = build :workshop, registration_link: 'https://good/url/here'
+    assert workshop.valid?
+  end
+
+  test 'valid_registration_link_format validation error' do
+    workshop = build :workshop, registration_link: 'bad/url here'
+    refute workshop.valid?
+    assert_equal 1, workshop.errors.messages.count
+    assert_equal 'Registration link is not a valid URL', workshop.errors.full_messages[0]
+  end
+
   test 'registration_link defaults to teacher app link if applications are required' do
     workshop = create :workshop, course: Pd::Workshop::COURSE_CSD, subject: SUBJECT_SUMMER_WORKSHOP
 
-    assert_equal "/pd/application/teacher", workshop.registration_link
+    assert_equal "https://studio.code.org/pd/application/teacher", workshop.registration_link
   end
 
   test 'registration_link does not default to anything if applications are not required' do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
when I first created the url validator module I added a second param to skip protocol validation. now that we want to ensure workshop registration_link and session meeting_link start with `http://` or `https://` all that needed to be done was remove the second argument and update the tests 🙌 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
