### PR TITLE
add unit prefix to unit group unit

### DIFF
--- a/dashboard/app/models/unit_group_unit.rb
+++ b/dashboard/app/models/unit_group_unit.rb
@@ -2,10 +2,11 @@
 #
 # Table name: course_scripts
 #
-#  id        :integer          not null, primary key
-#  course_id :integer          not null
-#  script_id :integer          not null
-#  position  :integer          not null
+#  id          :integer          not null, primary key
+#  course_id   :integer          not null
+#  script_id   :integer          not null
+#  position    :integer          not null
+#  unit_prefix :string(255)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20250709141326_add_unit_prefix_to_unit_group_unit.rb
+++ b/dashboard/db/migrate/20250709141326_add_unit_prefix_to_unit_group_unit.rb
@@ -1,0 +1,5 @@
+class AddUnitPrefixToUnitGroupUnit < ActiveRecord::Migration[6.1]
+  def change
+    add_column :course_scripts, :unit_prefix, :string
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_07_09_125438) do
+ActiveRecord::Schema.define(version: 2025_07_09_141326) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -518,6 +518,7 @@ ActiveRecord::Schema.define(version: 2025_07_09_125438) do
     t.integer "course_id", null: false
     t.integer "script_id", null: false
     t.integer "position", null: false
+    t.string "unit_prefix"
     t.index ["course_id"], name: "index_course_scripts_on_course_id"
     t.index ["script_id"], name: "index_course_scripts_on_script_id"
   end


### PR DESCRIPTION
This PR adds a column `unit_prefix` to the `unit_group_unit` model. Part of #67007