### PR TITLE
AI Chat: provide model parameters directly to ChatWorkspace

### DIFF
--- a/apps/src/aichat/redux/index.ts
+++ b/apps/src/aichat/redux/index.ts
@@ -21,5 +21,4 @@ export {
   stagedFilesLimitExceeded,
   clearStagedFilesAlert,
   clearStagedFiles,
-  setSavedAiCustomizationProperty,
 } from './slice';

--- a/apps/src/aichat/redux/selectors/index.ts
+++ b/apps/src/aichat/redux/selectors/index.ts
@@ -2,7 +2,6 @@ import {createSelector} from '@reduxjs/toolkit';
 
 import type {RootState} from '@cdo/apps/types/redux';
 
-import {modelDescriptions} from '../../constants';
 import {
   allFieldsHidden,
   anyFieldsChanged,
@@ -46,13 +45,3 @@ export const selectHavePropertiesChanged = (state: RootState) =>
     state.aichat.savedAiCustomizations,
     state.aichat.currentAiCustomizations
   ).length > 0;
-
-export const getSelectMultimodalAvailable =
-  (multimodalEnabled?: boolean) =>
-  ({aichat}: RootState) => {
-    const multimodalSupported = modelDescriptions.find(
-      model => model.id === aichat.savedAiCustomizations.selectedModelId
-    )?.multimodal;
-
-    return multimodalSupported && multimodalEnabled;
-  };

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -245,20 +245,6 @@ const aichatSlice = createSlice({
       state.saveError = undefined;
       state.showResetMessage = false;
     },
-    setSavedAiCustomizationProperty: <T extends keyof AiCustomizations>(
-      state: AichatState,
-      action: PayloadAction<{
-        property: T;
-        value: AiCustomizations[T];
-      }>
-    ) => {
-      const {property, value} = action.payload;
-      const updatedAiCustomizations = {
-        ...state.savedAiCustomizations,
-        [property]: value,
-      };
-      state.savedAiCustomizations = updatedAiCustomizations;
-    },
     setModelCardProperty: <T extends keyof ModelCardInfo>(
       state: AichatState,
       action: PayloadAction<{
@@ -372,7 +358,6 @@ export const {
   removeUpdateMessage,
   resetToDefaultAiCustomizations,
   setAiCustomizationProperty,
-  setSavedAiCustomizationProperty,
   setModelCardProperty,
   setNewChatSession,
   setShowModalType,

--- a/apps/src/aichat/redux/thunks/onSaveComplete.ts
+++ b/apps/src/aichat/redux/thunks/onSaveComplete.ts
@@ -3,20 +3,11 @@ import {TestResults} from '@cdo/apps/constants';
 import {RootState} from '@cdo/apps/types/redux';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 
-import {
-  saveTypeToAnalyticsEvent,
-  RESET_CONVERSATION_CUSTOMIZATION_UPDATES,
-} from '../../constants';
+import {saveTypeToAnalyticsEvent} from '../../constants';
 import {ViewMode} from '../../types';
-import {
-  endSave,
-  setNewChatSession,
-  setSavedAiCustomizations,
-  setViewMode,
-} from '../slice';
-import {findChangedProperties, getNewRemoveId} from '../utils';
+import {endSave, setSavedAiCustomizations, setViewMode} from '../slice';
+import {findChangedProperties} from '../utils';
 
-import {addChatEvent} from './addChatEvent';
 import {sendAnalytics} from './sendAnalytics';
 
 // Thunk called after a save has completed successfully.
@@ -30,26 +21,8 @@ export const onSaveComplete =
       savedAiCustomizations,
       currentAiCustomizations
     );
-    if (
-      changedProperties.some(property =>
-        RESET_CONVERSATION_CUSTOMIZATION_UPDATES.includes(property)
-      )
-    ) {
-      dispatch(setNewChatSession());
-    }
 
     changedProperties.forEach(property => {
-      if (property !== 'modelCardInfo') {
-        dispatch(
-          addChatEvent({
-            removeId: getNewRemoveId(),
-            updatedField: property,
-            updatedValue: currentAiCustomizations[property],
-            timestamp: Date.now(),
-          })
-        );
-      }
-
       // Report to analytics the changed value for only selected model id and temperature properties.
       // Do not include the free text changes (system prompt and retrieval contexts).
       const propertiesChangedValueToReport = ['selectedModelId', 'temperature'];

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -23,6 +23,7 @@ import {
   PendingChatMessage,
   CompletedChatMessage,
   ChatAsset,
+  ModelParameters,
 } from '../../types';
 import {getNewRemoveId} from '../utils';
 
@@ -38,6 +39,7 @@ export const submitChatContents = createAsyncThunk(
   async (
     newUserMessageInput: {
       text: string;
+      modelParameters: ModelParameters;
       hiddenContext?: string;
       assets?: ChatAsset[];
     },
@@ -45,8 +47,8 @@ export const submitChatContents = createAsyncThunk(
   ) => {
     const dispatch = thunkAPI.dispatch as AppDispatch;
     const state = thunkAPI.getState() as RootState;
-    const {savedAiCustomizations: aiCustomizations, chatEventsCurrent} =
-      state.aichat;
+    const chatEventsCurrent = state.aichat.chatEventsCurrent;
+    const {text, hiddenContext, assets, modelParameters} = newUserMessageInput;
 
     // Clear any staged files if present (used with multimodal models)
     thunkAPI.dispatch(clearStagedFiles());
@@ -60,9 +62,9 @@ export const submitChatContents = createAsyncThunk(
     const newUserMessage: PendingChatMessage = {
       role: Role.USER,
       status: Status.UNKNOWN,
-      chatMessageText: newUserMessageInput.text,
-      hiddenContext: newUserMessageInput.hiddenContext,
-      assets: newUserMessageInput.assets,
+      chatMessageText: text,
+      hiddenContext,
+      assets,
       timestamp: Date.now(),
     };
     dispatch(setChatMessagePending(newUserMessage));
@@ -78,12 +80,7 @@ export const submitChatContents = createAsyncThunk(
       messages = await postAichatCompletionMessage(
         newUserMessage,
         chatEventsCurrent.filter(isCompletedChatMessage),
-        {
-          selectedModelId: aiCustomizations.selectedModelId,
-          systemPrompt: aiCustomizations.systemPrompt,
-          retrievalContexts: aiCustomizations.retrievalContexts,
-          temperature: aiCustomizations.temperature,
-        },
+        modelParameters,
         aichatContext
       );
 
@@ -110,7 +107,7 @@ export const submitChatContents = createAsyncThunk(
       .reportLoadTime('AichatModelResponseTime', Date.now() - startTime, [
         {
           name: 'ModelId',
-          value: aiCustomizations.selectedModelId,
+          value: modelParameters.selectedModelId,
         },
       ]);
 

--- a/apps/src/aichat/redux/utils.ts
+++ b/apps/src/aichat/redux/utils.ts
@@ -6,6 +6,7 @@ import {
   AiCustomizations,
   FieldVisibilities,
   ModelCardInfo,
+  ModelParameters,
   Visibility,
 } from '../types';
 
@@ -43,8 +44,8 @@ const haveDifferentValues = (
 // between the previous save and the current one,
 // such that we can display a notification for each to users.
 export const findChangedProperties = (
-  previous: AiCustomizations | undefined,
-  next: AiCustomizations
+  previous: ModelParameters | undefined,
+  next: ModelParameters
 ) => {
   const allKeys = getTypedKeys(next);
   if (!previous) {

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -42,7 +42,7 @@ import {
   setViewMode,
   updateAiCustomization,
 } from '../redux';
-import {AichatLevelProperties, ViewMode} from '../types';
+import {AichatLevelProperties, ModelParameters, ViewMode} from '../types';
 
 import ChatWorkspace from './ChatWorkspace';
 import {isDisabled} from './modelCustomization/utils';
@@ -66,10 +66,14 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
     starterAssets,
   } = levelProperties;
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
-
-  const {currentAiCustomizations, viewMode, showModalType} = useAppSelector(
-    state => state.aichat
+  const currentAiCustomizations = useAppSelector(
+    state => state.aichat.currentAiCustomizations
   );
+  const savedAiCustomizations = useAppSelector(
+    state => state.aichat.savedAiCustomizations
+  );
+  const viewMode = useAppSelector(state => state.aichat.viewMode);
+  const showModalType = useAppSelector(state => state.aichat.showModalType);
 
   const signInState = useAppSelector(state => state.currentUser.signInState);
 
@@ -263,6 +267,21 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
     );
   }, [dispatch]);
 
+  // Only recreate modelParameters when relevant customizations are updated.
+  const modelParameters: ModelParameters = useMemo(() => {
+    return {
+      selectedModelId: savedAiCustomizations.selectedModelId,
+      temperature: savedAiCustomizations.temperature,
+      retrievalContexts: savedAiCustomizations.retrievalContexts,
+      systemPrompt: savedAiCustomizations.systemPrompt,
+    };
+  }, [
+    savedAiCustomizations.selectedModelId,
+    savedAiCustomizations.temperature,
+    savedAiCustomizations.retrievalContexts,
+    savedAiCustomizations.systemPrompt,
+  ]);
+
   return (
     <LevelPropertiesContext.Provider value={levelProperties}>
       <div id="aichat-lab" className={moduleStyles.aichatLab}>
@@ -349,6 +368,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
               headerClassName={moduleStyles.panelHeader}
             >
               <ChatWorkspace
+                modelParameters={modelParameters}
                 onClear={onClear}
                 levelName={levelName}
                 channelId={channelId}

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -5,16 +5,23 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import usePrevious from '@cdo/apps/util/usePrevious';
 
+import {
+  modelDescriptions,
+  RESET_CONVERSATION_CUSTOMIZATION_UPDATES,
+} from '../constants';
 import aichatI18n from '../locale';
 import {
+  addChatEvent,
   clearChatMessages,
   clearStagedFiles,
   fetchUserChatHistory,
-  getSelectMultimodalAvailable,
   selectAllVisibleMessages,
+  setNewChatSession,
 } from '../redux';
-import {ChatAsset, ChatButton} from '../types';
+import {findChangedProperties, getNewRemoveId} from '../redux/utils';
+import {ChatAsset, ChatButton, ModelParameters} from '../types';
 import {getAssetUrl, getShortName} from '../utils';
 
 import StagedFilesPreview from './assets/StagedFilesPreview';
@@ -26,6 +33,7 @@ import UserChatMessageEditor from './UserChatMessageEditor';
 import moduleStyles from './chatWorkspace.module.scss';
 
 interface ChatWorkspaceProps {
+  modelParameters: ModelParameters;
   chatButtons?: ChatButton[];
   hiddenContext?: string;
   onClear: () => void;
@@ -50,6 +58,7 @@ const eraserIcon: FontAwesomeV6IconProps = {
  * Renders the AI Chat Lab main chat workspace component.
  */
 const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
+  modelParameters,
   chatButtons,
   hiddenContext,
   onClear,
@@ -68,7 +77,9 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   const [selectedTab, setSelectedTab] =
     useState<WorkspaceTeacherViewTab | null>(null);
 
-  const {studentChatHistory} = useAppSelector(state => state.aichat);
+  const studentChatHistory = useAppSelector(
+    state => state.aichat.studentChatHistory
+  );
   const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
   const visibleItems = useSelector(selectAllVisibleMessages);
   const currentUserId = useAppSelector(state => state.currentUser.userId);
@@ -82,10 +93,14 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     }
   });
 
+  const multimodalSupported = useMemo(() => {
+    return modelDescriptions.find(
+      model => model.id === modelParameters.selectedModelId
+    )?.multimodal;
+  }, [modelParameters.selectedModelId]);
+
   const multimodalAvailable =
-    useAppSelector(getSelectMultimodalAvailable(multimodalEnabled)) &&
-    !!levelName &&
-    !!channelId;
+    multimodalSupported && multimodalEnabled && !!levelName && !!channelId;
 
   const buildAssetUrl = useCallback(
     (asset: ChatAsset) => {
@@ -131,6 +146,34 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       setSelectedTab(null);
     }
   }, [selectedStudent, selectedTab]);
+
+  // Whenever model parameters change, 1) reset the chat session if necessary,
+  // and 2) log the changed properties to the chat history.
+  const previousParameters: ModelParameters = usePrevious(modelParameters);
+  useEffect(() => {
+    const changedProperties = findChangedProperties(
+      previousParameters,
+      modelParameters
+    );
+    if (
+      changedProperties.some(property =>
+        RESET_CONVERSATION_CUSTOMIZATION_UPDATES.includes(property)
+      )
+    ) {
+      dispatch(setNewChatSession());
+    }
+
+    changedProperties.forEach(property => {
+      dispatch(
+        addChatEvent({
+          removeId: getNewRemoveId(),
+          updatedField: property,
+          updatedValue: modelParameters[property],
+          timestamp: Date.now(),
+        })
+      );
+    });
+  }, [dispatch, previousParameters, modelParameters]);
 
   const iconValue: FontAwesomeV6IconProps = {
     iconName: 'lock',
@@ -205,6 +248,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
         )}
         {canChatWithModel && (
           <UserChatMessageEditor
+            modelParameters={modelParameters}
             editorContainerClassName={moduleStyles.messageEditorContainer}
             chatButtons={chatButtons}
             hiddenContext={hiddenContext}

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -5,11 +5,12 @@ import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/Us
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {submitChatContents} from '../redux';
-import {ChatButton} from '../types';
+import {ChatButton, ModelParameters} from '../types';
 
 import moduleStyles from './UserChatMessageEditor.module.scss';
 
 interface UserChatMessageEditorProps {
+  modelParameters: ModelParameters;
   editorContainerClassName?: string;
   chatButtons?: ChatButton[];
   hiddenContext?: string;
@@ -22,6 +23,7 @@ interface UserChatMessageEditorProps {
 const UserChatMessageEditor: React.FunctionComponent<
   UserChatMessageEditorProps
 > = ({
+  modelParameters,
   editorContainerClassName,
   chatButtons,
   hiddenContext,
@@ -48,6 +50,7 @@ const UserChatMessageEditor: React.FunctionComponent<
         dispatch(
           submitChatContents({
             text: userMessage,
+            modelParameters,
             hiddenContext: hiddenContext,
             assets:
               multimodalAvailable && chatAssets.length > 0
@@ -63,6 +66,7 @@ const UserChatMessageEditor: React.FunctionComponent<
       hiddenContext,
       multimodalAvailable,
       chatAssets,
+      modelParameters,
     ]
   );
 

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -1,15 +1,37 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 
-import {
-  setSavedAiCustomizationProperty,
-  clearChatMessages,
-} from '@cdo/apps/aichat/redux';
+import {clearChatMessages} from '@cdo/apps/aichat/redux';
+import {ModelParameters} from '@cdo/apps/aichat/types';
 import ChatWorkspace from '@cdo/apps/aichat/views/ChatWorkspace';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import {aiTutorModelId} from '../../ai/AiTutorModelId';
 
 import moduleStyles from './AiTutor2Chat.module.scss';
+
+const MODEL_PARAMETERS: ModelParameters = {
+  systemPrompt:
+    'You are an AI Computer Science Tutor that supports students through scaffolded learning, metacognitive reflection, and problem-solving strategies. Target the reading age of an American 7th grader. By default, when a student asks a question, you should respond with a clarifying question, a small hint, or a reflective nudge—to help them take the next step without solving the task for them. Do not give them the answer directly. If the student appears frustrated, you may include syntax or pseudocode. If the student explicitly asks for a HINT, provide a tip that nudges them forward to take the next step. If they ask for an EXAMPLE, give a short (1–3 line) conceptual code snippet from a different context that illustrates the relevant idea without solving the actual task. If they request DOCUMENTATION, share 1–3 concise and relevant references formatted with a clear keyword, short explanation and example code. Always work within the provided instructions, student code, and question, and tailor your support to encourage confidence, independence, and thoughtful programming.',
+  selectedModelId: aiTutorModelId,
+  temperature: 0.5,
+  retrievalContexts: [],
+};
+
+// Some pre-canned chat buttons.
+const CHAT_BUTTONS = [
+  {
+    label: 'example',
+    value: 'Can you give me an example?',
+  },
+  {
+    label: 'hint',
+    value: 'Can you give me a hint?',
+  },
+  {
+    label: 'doc',
+    value: 'Can you give me some documentation?',
+  },
+];
 
 interface AiTutor2ChatProps {
   hiddenContext: string;
@@ -21,45 +43,11 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
 }) => {
   const dispatch = useAppDispatch();
 
-  useEffect(() => {
-    // Give aichat a system prompt.
-    dispatch(
-      setSavedAiCustomizationProperty({
-        property: 'systemPrompt',
-        value:
-          'You are an AI Computer Science Tutor that supports students through scaffolded learning, metacognitive reflection, and problem-solving strategies. Target the reading age of an American 7th grader. By default, when a student asks a question, you should respond with a clarifying question, a small hint, or a reflective nudge—to help them take the next step without solving the task for them. Do not give them the answer directly. If the student appears frustrated, you may include syntax or pseudocode. If the student explicitly asks for a HINT, provide a tip that nudges them forward to take the next step. If they ask for an EXAMPLE, give a short (1–3 line) conceptual code snippet from a different context that illustrates the relevant idea without solving the actual task. If they request DOCUMENTATION, share 1–3 concise and relevant references formatted with a clear keyword, short explanation and example code. Always work within the provided instructions, student code, and question, and tailor your support to encourage confidence, independence, and thoughtful programming.',
-      })
-    );
-
-    // Give aichat a model to use.
-    dispatch(
-      setSavedAiCustomizationProperty({
-        property: 'selectedModelId',
-        value: aiTutorModelId,
-      })
-    );
-  }, [dispatch]);
-
-  // Some pre-canned chat buttons.
-  const chatButtons = [
-    {
-      label: 'example',
-      value: 'Can you give me an example?',
-    },
-    {
-      label: 'hint',
-      value: 'Can you give me a hint?',
-    },
-    {
-      label: 'doc',
-      value: 'Can you give me some documentation?',
-    },
-  ];
-
   return (
     <div className={moduleStyles.container}>
       <ChatWorkspace
-        chatButtons={chatButtons}
+        modelParameters={MODEL_PARAMETERS}
+        chatButtons={CHAT_BUTTONS}
         hiddenContext={hiddenContext}
         onClear={() => {
           dispatch(clearChatMessages());


### PR DESCRIPTION
More modularization 🙂 we now pass the `modelParameters` to the `submitChatCompletion` thunk directly, instead of grabbing them from the current `savedAiCustomizations`. In the same vein as the previous refactor PRs, this further decouples the `ChatWorkspace` (and the action of submitting a chat request) from the currently saved "model customizations", which is an AI Chat Lab construct pertaining to the model customization pane.

Previously in AI Tutor, we were manually getting around this by `dispatch`-ing actions to mock the state of the AI customizations even though we had no model customization pane or AI Chat lab. Now, the model parameters are simply provided as props to the `ChatWorkspace` component; as such, you can see the effect of this change most clearly in `AiTutor2Chat.tsx`.

Model update notifications are still displayed as they were before, but they're now dispatched whenever the incoming `modelParameters` prop changes; so in theory, if we were to expose a model selection dropdown or any other controls in AI Tutor (i.e. outside of AI Chat Lab), the model customization notifications would still appear as expected.

## Testing story

Tested locally with AI Chat lab and AI Tutor

## Follow-up work

Next few follow-ups on my mind:
- Add chat `client` to distinguish between the various clients that use the chat infrastructure (AI Chat lab, AI Tutor, Flow lab, etc)
- Potentially split out the "chat" part of AI Chat (`ChatWorkspace` and associated redux logic) into its own redux slice and/or own directory. I'm still thinking through the best way to do this to avoid a mega PR and minimize risk.
- A few minor refactors like reworking the `sendAnalytics` call to use the chat `client` and potentially storing the `userHasAichatAccess` outside of redux.