### PR TITLE
CMS-736: Remove certificate images from Pegasus

### DIFF
--- a/pegasus/sites.v3/code.org/public/images/20hours_certificate.jpg
+++ b/pegasus/sites.v3/code.org/public/images/20hours_certificate.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37f07e1a429d5f255186ce061d33291b4ecffc745a5b9174c05c7530a6fb4379
-size 1279640

--- a/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate.png
+++ b/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e145f103df7b84647fa9cdca35e18b78ba4d5d67ccac2fc568fcf46ce1daca7
-size 306315

--- a/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Aquatic.png
+++ b/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Aquatic.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c98815e2dfd9962e7e1ca5b140038699c38c99f4cb125ee7ed98c97b0aba35e
-size 303009

--- a/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Generation_Ai.png
+++ b/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Generation_Ai.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2db425403b3a2187a9ae2974b96875412c74342c9c0b982b4e39be9e73eab40
-size 371244

--- a/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Hero.png
+++ b/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Hero.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5008fc672529c8747d00527421c977b99a001efa2051a0bd6cfb375904ac26da
-size 366796

--- a/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Show.png
+++ b/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Show.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2367d18f06780a8a7dd5f22f2bd38b0b3ea81739a86ac10de9450a8620156f4
-size 224626

--- a/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee.png
+++ b/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccc5a91ca0eb0f089ddedbd53191141ac76180f5a414192309956655da06fdbe
-size 60705

--- a/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee_empathy.png
+++ b/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee_empathy.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a10a7a44d3343753849155b63e435360e41e1ca845ac38980ee1da5d7f806b7d
-size 244639

--- a/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee_estate.png
+++ b/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee_estate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c293ae6318e8540f8b3c05e49b1d1a51bdd96d0bc27a3f677c7641cf56b70f4
-size 244764

--- a/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee_timecraft.png
+++ b/pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee_timecraft.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9151a943382b452617c3f9a370ccdbdd4df4a2f747f18b2fe8fd891204283589
-size 36566

--- a/pegasus/sites.v3/code.org/public/images/blank_certificate.png
+++ b/pegasus/sites.v3/code.org/public/images/blank_certificate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:291e177c3e208749961374e6f491e4efebfe87a43e398dc338408d3092cba8fd
-size 2759725

--- a/pegasus/sites.v3/code.org/public/images/hour_of_code_certificate.jpg
+++ b/pegasus/sites.v3/code.org/public/images/hour_of_code_certificate.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99883100525cd511ccec365b64405867e8adf778cc4df9b4eda1bdcb8b1ea005
-size 2630751

--- a/pegasus/sites.v3/code.org/public/images/music_hoc_certificate.png
+++ b/pegasus/sites.v3/code.org/public/images/music_hoc_certificate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd8cf9f91a31c26e45ef01af965f3f4c9885f38c8b1ba00abf73e1c1c0140ea0
-size 386686

--- a/pegasus/sites.v3/code.org/public/images/oceans_hoc_certificate.png
+++ b/pegasus/sites.v3/code.org/public/images/oceans_hoc_certificate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd25088e062c035352457f9a96b86fa2243b512fc63f00bab800d31c76625880
-size 363911

--- a/pegasus/sites.v3/code.org/public/images/self_paced_pl_certificate.png
+++ b/pegasus/sites.v3/code.org/public/images/self_paced_pl_certificate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0ec11610af59d63c1ab7019e5b0b8dee09b07fe9e03333c6a31f9df63db6fe1
-size 1237239

--- a/pegasus/sparse-patterns/no-pegasus-content
+++ b/pegasus/sparse-patterns/no-pegasus-content
@@ -38,21 +38,3 @@ pegasus/sites.v3/code.org/public/certificates/splat.haml
 pegasus/sites.v3/code.org/public/congrats.haml
 pegasus/sites.v3/code.org/public/congrats/splat.haml
 pegasus/sites.v3/code.org/public/sharecertificate.moved
-
-# certificate images
-# TODO: move to dashboard server
-pegasus/sites.v3/code.org/public/images/20hours_certificate.jpg
-pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate.png
-pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Aquatic.png
-pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Generation_Ai.png
-pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Hero.png
-pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_Show.png
-pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee.png
-pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee_empathy.png
-pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee_estate.png
-pegasus/sites.v3/code.org/public/images/MC_Hour_Of_Code_Certificate_mee_timecraft.png
-pegasus/sites.v3/code.org/public/images/blank_certificate.png
-pegasus/sites.v3/code.org/public/images/hour_of_code_certificate.jpg
-pegasus/sites.v3/code.org/public/images/music_hoc_certificate.png
-pegasus/sites.v3/code.org/public/images/oceans_hoc_certificate.png
-pegasus/sites.v3/code.org/public/images/self_paced_pl_certificate.png


### PR DESCRIPTION
## Links
- JIRA task: [CMS-736](https://codedotorg.atlassian.net/browse/CMS-736)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/67098