### PR TITLE
CMS-795: Remove `primaryButton` placeholder data from Action Block components

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/actionBlockContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/defaultActionBlock/actionBlockContentfulDefinition.ts
@@ -64,12 +64,6 @@ export const ActionBlockContentfulComponentDefinition: ComponentDefinition = {
       type: 'Link',
       group: 'content',
       description: 'The primary button of the action block.',
-      defaultValue: {
-        fields: {
-          label: 'Primary button',
-          url: '#',
-        },
-      },
       validations: {
         bindingSourceType: ['entry'],
       },

--- a/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/fullWidthActionBlockContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/actionBlocks/fullWidthActionBlock/fullWidthActionBlockContentfulDefinition.ts
@@ -65,12 +65,6 @@ export const FullWidthActionBlockContentfulComponentDefinition: ComponentDefinit
         type: 'Link',
         group: 'content',
         description: 'The primary button of the action block.',
-        defaultValue: {
-          fields: {
-            label: 'Primary button',
-            url: '#',
-          },
-        },
         validations: {
           bindingSourceType: ['entry'],
         },


### PR DESCRIPTION
## Vertical Action Block
<img width="100%" alt="ActionBlock" src="https://github.com/user-attachments/assets/3ffe9539-e8fc-4d31-b169-64dcaf64b6e9" />

## Full-Width Action Block
<img width="100%" alt="FullWidthActionBlock" src="https://github.com/user-attachments/assets/2bf8c009-fd23-4d4f-8e15-42b564439113" />

## Links
- JIRA task: [CMS-795](https://codedotorg.atlassian.net/browse/CMS-795)