### PR TITLE
Update PII purge process to delete first and last names

### DIFF
--- a/dashboard/app/models/concerns/user/purgeable.rb
+++ b/dashboard/app/models/concerns/user/purgeable.rb
@@ -25,6 +25,8 @@ module User::Purgeable
 
     self.studio_person_id = nil
     self.name = nil
+    self.given_name = nil
+    self.family_name = nil
     self.username = "#{SYSTEM_DELETED_USERNAME}_#{random_suffix}"
     self.current_sign_in_ip = nil
     self.last_sign_in_ip = nil


### PR DESCRIPTION
Updates the PII purge process to delete a user's first and last names (stored as `given_name` and `family_name`, respectively). I already purged user name data in several spots when I first added `given_name` and updated `family_name`:
- [Clears the `given_name` and `family_name` in the PII scrubber](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/services/user/pii_scrubber.rb#L69-L70)
- [Clears the `given_name` and `family_name` of section students upon deleting the last section they're in](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/follower.rb#L57-L76)
- [Downgrading to student clears the `given_name` and `family_name` of the user](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/user.rb#L757-L760)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3348)

## Testing story
A lot of the testing coverage either already existed or was added [here](https://github.com/code-dot-org/code-dot-org/pull/66599) when I first added `given_name` and made updates to `family_name`.
