### PR TITLE
fix(EditorialCard): add color property to icon to work in themes

### DIFF
--- a/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
+++ b/frontend/packages/component-library/src/cms/editorialCard/editorialCard.module.scss
@@ -23,6 +23,7 @@
       border-radius: 50%;
       background: var(--background-neutral-primary);
       border: 3px solid var(--text-neutral-primary);
+      color: var(--text-neutral-primary);
       outline: 0.375rem solid var(--background-brand-teal-light);
       margin: 0.375rem;
       width: 3.5rem;


### PR DESCRIPTION
Adds a color property to the icon on the Editorial Card component so it works with light and dark themes.

## Links
Jira ticket: [CMS-918](https://codedotorg.atlassian.net/browse/CMS-918)

## Testing story
This will have expceted Eyes diffs on the All The Things e2e tests. 

----

## Before
<img width="1045" height="307" alt="Before" src="https://github.com/user-attachments/assets/65ea8d23-b9d2-44d9-a403-dc2806cac63d" />

## After
<img width="1045" height="307" alt="After" src="https://github.com/user-attachments/assets/de9d3793-3198-4ee9-9938-c9fbf9fe69fa" />

