### PR TITLE
fix(workshops): handle enrollment with missing user_id

### DIFF
--- a/dashboard/lib/pd/summary/teacher_summary.rb
+++ b/dashboard/lib/pd/summary/teacher_summary.rb
@@ -38,8 +38,10 @@ module Pd::Summary
       conditions = {pd_session_id: session_ids}
       if teacher&.id
         conditions[:teacher_id] = teacher.id
-      else
+      elsif enrollment.id
         conditions[:pd_enrollment_id] = enrollment.id
+      else
+        return teacher_attendance
       end
       attendances = Pd::Attendance.where(conditions)
 

--- a/dashboard/lib/pd/summary/teacher_summary.rb
+++ b/dashboard/lib/pd/summary/teacher_summary.rb
@@ -35,7 +35,13 @@ module Pd::Summary
     def calculate_teacher_attendance
       teacher_attendance = TeacherAttendanceTotal.new
       session_ids = workshop.sessions.pluck(:id)
-      attendances = Pd::Attendance.where(pd_session_id: session_ids, teacher_id: teacher.id)
+      conditions = {pd_session_id: session_ids}
+      if teacher&.id
+        conditions[:teacher_id] = teacher.id
+      else
+        conditions[:pd_enrollment_id] = enrollment.id
+      end
+      attendances = Pd::Attendance.where(conditions)
 
       attendances.each do |attendance|
         session = workshop.sessions.find {|s| s.id == attendance.pd_session_id}

--- a/dashboard/test/lib/pd/summary/teacher_summary_test.rb
+++ b/dashboard/test/lib/pd/summary/teacher_summary_test.rb
@@ -26,6 +26,14 @@ module Pd::Summary
       assert_equal attendance.hours, 12
     end
 
+    test 'calculate_teacher_attendance returns correct days and hours for teachers without accounts' do
+      @enrollment.update(user_id: nil)
+      attendance = @teacher_summary.calculate_teacher_attendance
+      assert_kind_of TeacherSummary::TeacherAttendanceTotal, attendance
+      assert_equal attendance.days, 2
+      assert_equal attendance.hours, 12
+    end
+
     test 'generate_teacher_summary_line_item returns expected summary' do
       line_item = @teacher_summary.generate_teacher_summary_line_item
       assert_equal @enrollment.first_name, line_item[:teacher_first_name]


### PR DESCRIPTION
search for teacher attendances by enrollment if no user_id is available. fixes this honeybadger [error](https://app.honeybadger.io/projects/3240/faults/122133077)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3404
- honeybadger: https://app.honeybadger.io/projects/3240/faults/122133077

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
