### PR TITLE
Allows the CAP parent permission email to be account email if parent created

### DIFF
--- a/dashboard/lib/forms/child_account/parental_permission_request.rb
+++ b/dashboard/lib/forms/child_account/parental_permission_request.rb
@@ -56,6 +56,10 @@ module Forms
       end
 
       private def parent_email_is_not_own
+        # Allow the parent email if the parent created the account, as they
+        # would generally want to email themselves to give permission.
+        return if child_account.parent_created_account?
+
         # Removes any subaddressing from the email to prevent abuse
         sanitized_parent_email = parent_email.sub(/\+[^@]+@/, '@')
         return unless child_account.hashed_email == Digest::MD5.hexdigest(sanitized_parent_email)

--- a/dashboard/test/lib/forms/child_account/parental_permission_request_test.rb
+++ b/dashboard/test/lib/forms/child_account/parental_permission_request_test.rb
@@ -113,6 +113,21 @@ class Forms::ChildAccount::ParentalPermissionRequestTest < ActiveSupport::TestCa
       assert_equal ["A request cannot be sent to your own email address"], permission_request_form.errors.full_messages
     end
 
+    test 'validates that provided parent email can be child email if parent created' do
+      child_email = 'child@email.com'
+
+      @child_account.update!(email: child_email, parent_email: child_email)
+      @parent_email = child_email
+
+      permission_request_form = Forms::ChildAccount::ParentalPermissionRequest.new(
+        child_account: @child_account,
+        parent_email: @parent_email,
+      )
+
+      assert permission_request_form.request
+      assert_equal [], permission_request_form.errors.full_messages
+    end
+
     test 'validates whether limit for resend requests has not been reached' do
       create(
         :parental_permission_request,

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -304,7 +304,12 @@ class ActiveSupport::TestCase
     expressions.zip(exps).each_with_index do |(code, e), i|
       error  = "#{code.inspect} didn't change"
       error  = "#{message}.\n#{error}" if message
-      refute_equal(before[i], e.call, error)
+      # Avoid a deprecation notice when using refute_equal with nil
+      if before[i].nil?
+        refute_nil(e.call, error)
+      else
+        refute_equal(before[i], e.call, error)
+      end
     end
   end
 
@@ -325,7 +330,12 @@ class ActiveSupport::TestCase
     expressions.zip(exps).each_with_index do |(code, e), i|
       error  = "#{code.inspect} didn't change"
       error  = "#{message}.\n#{error}" if message
-      assert_equal(before[i], e.call, error)
+      # Avoid a deprecation notice when using assert_equal with nil
+      if before[i].nil?
+        assert_nil(e.call, error)
+      else
+        assert_equal(before[i], e.call, error)
+      end
     end
   end
 


### PR DESCRIPTION
This was discovered via at least one zendesk support ticket where a parent could not unlock the account for their child that they created for them. There is no copy on the page that says that this should be possible (which may be why it is very under-reported), but it is generally possible in the proper lockout, but in this case, they were presented with the pre-lockout modal. This modal did not allow the account email in any circumstance. This corrects this behavior.

## Testing story

Added a validation. Red/green'd the test with the added implementation.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
