### PR TITLE
[Google Blockly] Fix K1 "move by length" blocks

### DIFF
--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -1055,7 +1055,9 @@ exports.install = function (blockly, blockInstallOptions) {
           this.setTooltip(directionConfig.tooltip);
           if (hasLengthInput) {
             var dropdown = new blockly.FieldImageDropdown(
-              directionConfig.lengths
+              directionConfig.lengths,
+              directionConfig.imageDimensions.width,
+              directionConfig.imageDimensions.height
             );
             dropdown.setValue(directionConfig.defaultDropdownValue);
             input.appendField(dropdown, 'length');


### PR DESCRIPTION
A bug is causing a set of Artist blocks to be created as "unknown blocks", which breaks several solutions to puzzles in Course 1. For example, no sample foot is shown for the student here:
https://studio.code.org/courses/course1/units/1/lessons/8/levels/1?solution=true
<img width="861" height="402" alt="image" src="https://github.com/user-attachments/assets/73030c94-cb8d-4d15-9234-588fb7f282b5" />
This makes passing the level impossible.
With CDO Blockly, a `simple_move_right_length` block is rendered correctly:
<img width="898" height="468" alt="image" src="https://github.com/user-attachments/assets/8a8c918d-e52f-483d-96ab-e657d3b697c9" />

Because of differences in the Blockly APIs, Google Blockly is not getting the image dimensions that are needed to created the image. See the field constructor:
https://github.com/code-dot-org/code-dot-org/blob/mike/move-length-blocks/apps/src/blockly/addons/cdoFieldImageDropdown.ts#L25-L26

We can pass the width and height in where the block is created which allows the block to be created correctly.
<img width="736" height="422" alt="image" src="https://github.com/user-attachments/assets/8b36511b-8929-4f3a-bf8a-49275430aa2a" />

This conveniently doesn't cause any regressions in CDO Blockly.

This also fixes a related issue where a levelbuilder-only toolbox category fails to work. 

This block was evidently only ever used in solution blocks which made it easy to miss when migrating Artist to mainline.

Before:
<img width="396" height="358" alt="image" src="https://github.com/user-attachments/assets/03037add-8030-47eb-9dd4-e97ca3186fb4" />

After:
<img width="483" height="547" alt="image" src="https://github.com/user-attachments/assets/8669426d-56f0-4ac1-8d39-5391313ca17e" />
 

## Links

https://codeorg.zendesk.com/agent/tickets/543682

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
