### PR TITLE
Global/localizejs pythonlab

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -377,6 +377,7 @@
     "survey-react": "^1.9.28",
     "swiper": "^11.0.5",
     "timers-browserify": "^2.0.12",
+    "tokenizr": "^1.7.0",
     "tone": "14.7.77",
     "uglify-js": "^3.18.0",
     "unified": "~9.2.0",

--- a/apps/src/codebridge/Console/Console.tsx
+++ b/apps/src/codebridge/Console/Console.tsx
@@ -207,6 +207,7 @@ const Console: React.FunctionComponent = () => {
       <div
         ref={terminalRef}
         className={moduleStyles.consoleV2}
+        data-notranslate
         id="uitest-codebridge-console"
       />
     </PanelContainer>

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRowName.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRowName.tsx
@@ -22,7 +22,7 @@ export const FileRowName: FileBrowserNameComponentType = ({item}) => {
       tooltipOverlayClassName={moduleStyles.nameContainer}
       className={moduleStyles.nameContainer}
     >
-      <span>{item.name}</span>
+      <span data-notranslate>{item.name}</span>
     </OverflowTooltip>
   );
 };

--- a/apps/src/codebridge/Localizer.ts
+++ b/apps/src/codebridge/Localizer.ts
@@ -1,0 +1,16 @@
+import type {ProjectFile} from '@cdo/apps/lab2/types';
+
+/**
+ * This is the base class for a source code localizer.
+ */
+abstract class Localizer {
+  readonly locale: string;
+
+  constructor(locale: string) {
+    this.locale = locale;
+  }
+
+  abstract localize(file: ProjectFile): ProjectFile;
+}
+
+export default Localizer;

--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -40,7 +40,7 @@ export const useInitialSources = (
   defaultSources: ProjectSources,
   levelProperties: CodebridgeLevelProperties,
   initialServerSource?: ProjectSources,
-  localizer?: Localizer
+  localizers?: Localizer[]
 ) => {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const exemplarSources = levelProperties.exemplarSources as MultiFileSource;
@@ -102,7 +102,10 @@ export const useInitialSources = (
 
             const projectFile = file as ProjectFile;
 
-            return [key, localizer?.localize(projectFile) || projectFile];
+            return [
+              key,
+              (localizers || []).reduce((a, b) => b.localize(a), projectFile),
+            ];
           })
         ),
       };
@@ -115,7 +118,7 @@ export const useInitialSources = (
 
       return {source, labConfig};
     },
-    [isStartMode, miniApp, serializedMaze, validationFile, localizer]
+    [isStartMode, miniApp, serializedMaze, validationFile, localizers]
   );
 
   // We memoize these objects so that they don't cause an unexpected re-render.

--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -1,4 +1,5 @@
 import {DEFAULT_FOLDER_ID, MAZE_FILE_NAME} from '@codebridge/constants';
+import type Localizer from '@codebridge/Localizer';
 import {CodebridgeLevelProperties, MazeCell} from '@codebridge/types';
 import {
   combineStartSourcesAndValidation,
@@ -15,10 +16,12 @@ import {
 } from '@cdo/apps/lab2/projects/utils';
 import {
   MultiFileSource,
+  ProjectFile,
   ProjectFileType,
   ProjectSources,
 } from '@cdo/apps/lab2/types';
 import {getNextFileId} from '@cdo/apps/lab2/utils/multiFileSourceUtils';
+
 /**
  * Custom hook that determines the initial sources for the current level.
  * It selects various sources including from the student's project, the start sources
@@ -33,11 +36,11 @@ import {getNextFileId} from '@cdo/apps/lab2/utils/multiFileSourceUtils';
  * @param {ProjectSources} defaultSources - The default sources to use if no other sources are found.
  * @returns {ProjectSources} - The initial sources to use.
  */
-
 export const useInitialSources = (
   defaultSources: ProjectSources,
   levelProperties: CodebridgeLevelProperties,
-  initialServerSource: ProjectSources | undefined
+  initialServerSource?: ProjectSources,
+  localizer?: Localizer
 ) => {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const exemplarSources = levelProperties.exemplarSources as MultiFileSource;
@@ -88,6 +91,22 @@ export const useInitialSources = (
       }
       startCode = repairOpenFiles(startCode);
 
+      // Localize, if desired
+      startCode = {
+        ...startCode,
+        files: Object.fromEntries(
+          Object.entries(startCode.files).map(([key, file]) => {
+            if (typeof file === 'string') {
+              return [key, file];
+            }
+
+            const projectFile = file as ProjectFile;
+
+            return [key, localizer?.localize(projectFile) || projectFile];
+          })
+        ),
+      };
+
       const source = isStartMode
         ? combineStartSourcesAndValidation(startCode, validationFile)
         : startCode;
@@ -96,7 +115,7 @@ export const useInitialSources = (
 
       return {source, labConfig};
     },
-    [isStartMode, miniApp, serializedMaze, validationFile]
+    [isStartMode, miniApp, serializedMaze, validationFile, localizer]
   );
 
   // We memoize these objects so that they don't cause an unexpected re-render.

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -1,3 +1,4 @@
+import type Localizer from '@codebridge/Localizer';
 import {CodebridgeLevelProperties} from '@codebridge/types';
 import {prepareSourceForLevelbuilderSave} from '@codebridge/utils';
 import {useEffect, useMemo, useRef} from 'react';
@@ -23,7 +24,8 @@ import {useInitialSources} from './useInitialSources';
 export const useSource = (
   defaultSources: ProjectSources,
   levelProperties: CodebridgeLevelProperties,
-  initiaServerSources: ProjectSources | undefined
+  initialServerSources?: ProjectSources,
+  localizer?: Localizer
 ) => {
   const dispatch = useAppDispatch();
   const source = useAppSelector(
@@ -36,7 +38,12 @@ export const useSource = (
     levelStartSources,
     templateStartSources,
     parsedDefaultSources,
-  } = useInitialSources(defaultSources, levelProperties, initiaServerSources);
+  } = useInitialSources(
+    defaultSources,
+    levelProperties,
+    initialServerSources,
+    localizer
+  );
   const previousLevelIdRef = useRef<number | null>(null);
   const previousInitialSources = useRef<ProjectSources | null>(null);
 

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -25,7 +25,7 @@ export const useSource = (
   defaultSources: ProjectSources,
   levelProperties: CodebridgeLevelProperties,
   initialServerSources?: ProjectSources,
-  localizer?: Localizer
+  localizers?: Localizer[]
 ) => {
   const dispatch = useAppDispatch();
   const source = useAppSelector(
@@ -42,7 +42,7 @@ export const useSource = (
     defaultSources,
     levelProperties,
     initialServerSources,
-    localizer
+    localizers
   );
   const previousLevelIdRef = useRef<number | null>(null);
   const previousInitialSources = useRef<ProjectSources | null>(null);

--- a/apps/src/localization/Localization.ts
+++ b/apps/src/localization/Localization.ts
@@ -165,6 +165,10 @@ export class Localization extends TypedEventEmitter<LocalizationEventMap> {
     });
   }
 
+  isLocalizeJS(): boolean {
+    return !!this.Localize;
+  }
+
   async waitUntilLoaded(): Promise<boolean> {
     if (this.loader === undefined) {
       return true;

--- a/apps/src/pythonlab/PythonLocalizer.ts
+++ b/apps/src/pythonlab/PythonLocalizer.ts
@@ -13,7 +13,9 @@ class PythonLocalizer extends Localizer {
       return file;
     }
 
-    if (!localization.isLocalizeJS() || localization.locale === 'en') {
+    // Only localize if we are using LocalizeJS and we are currently viewing
+    // with a language that is not some form of English
+    if (!localization.isLocalizeJS() || localization.locale.startsWith('en')) {
       return file;
     }
 

--- a/apps/src/pythonlab/PythonLocalizer.ts
+++ b/apps/src/pythonlab/PythonLocalizer.ts
@@ -1,0 +1,152 @@
+import Localizer from '@codebridge/Localizer';
+import Tokenizr from 'tokenizr';
+
+import {ProjectFile} from '@cdo/apps/lab2/types';
+import localization from '@cdo/apps/localization';
+
+/**
+ * This localizes Python source code.
+ */
+class PythonLocalizer extends Localizer {
+  localize(file: ProjectFile) {
+    if (file.language !== 'py') {
+      return file;
+    }
+
+    if (!localization.isLocalizeJS() || localization.locale === 'en') {
+      return file;
+    }
+
+    const code = file.contents;
+
+    const tokenizer = new Tokenizr();
+
+    // Keywords
+    tokenizer.rule(/\bif\b|\belif\b|\belse\b|\bdef\b/, (ctx, match) => {
+      ctx.accept('keyword', match[0]);
+    });
+
+    // Match boolean literals
+    tokenizer.rule(/\bTrue\b|\bFalse\b/, (ctx, match) => {
+      ctx.accept('boolean', match[0] === 'True');
+    });
+
+    tokenizer.rule(/\bNone\b/, (ctx, _match) => {
+      ctx.accept('none');
+    });
+
+    // Match string literals
+    tokenizer.rule(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/, (ctx, match) =>
+      ctx.accept('string', match[0])
+    );
+
+    // Match comments
+    tokenizer.rule(/#[^\n]*/, (ctx, match) => ctx.accept('comment', match[0]));
+    tokenizer.rule(/'''[\s\S]*?'''|"""[\s\S]*?"""/, (ctx, match) =>
+      ctx.accept('comment', match[0])
+    );
+
+    // Match numbers
+    tokenizer.rule(/\b[+-]?\d+(\.\d+)?\b/, (ctx, match) => {
+      ctx.accept('number', parseInt(match[0]));
+    });
+
+    // Match identifiers (variable names, function names, etc.)
+    tokenizer.rule(/[a-zA-Z_][a-zA-Z0-9_]*/, (ctx, match) => {
+      ctx.accept('identifier', match[0]);
+    });
+
+    // Match operators
+    tokenizer.rule(/==|!=|<=|>=|<|>|\+|\-|\*|\/|%|\=\=/, (ctx, match) => {
+      ctx.accept('operator', match[0]);
+    });
+
+    // Match punctuation
+    tokenizer.rule(/[(){}\[\],.:;]/, (ctx, match) => {
+      ctx.accept('punctuation', match[0]);
+    });
+
+    // Ignore whitespace
+    tokenizer.rule(/[ \t\r\n]+/, (ctx, _match) => {
+      ctx.ignore();
+    });
+
+    // Just put any characters we do not otherwise understand down the drain
+    tokenizer.rule(/./, (ctx, _match) => {
+      ctx.ignore();
+    });
+
+    // Parse the starter code
+    tokenizer.input(code);
+
+    // Keep track of the position difference as we go
+    let adjustedPosition = 0;
+    let localized = code;
+    try {
+      tokenizer.tokens().forEach(token => {
+        // Get the actual text content for the different localizable tokens
+        const content =
+          token.type === 'string'
+            ? token.value.substring(1, token.value.length - 1).trim()
+            : token.type === 'comment'
+            ? token.value.substring(1).trim()
+            : undefined;
+
+        // Get the localized versions
+        const localizedRaw =
+          content !== undefined
+            ? localization.translate(`[${token.type}] ${content}`, [
+                `python-${token.type}`,
+              ])
+            : undefined;
+
+        const localizedContent = localizedRaw?.startsWith(`[${token.type}] `)
+          ? localizedRaw?.substring(token.type.length + 3) || content
+          : content;
+
+        if (
+          localizedRaw !== undefined &&
+          !(localizedRaw || '').startsWith(`[${token.type}] `)
+        ) {
+          console.warn(
+            'Python localization failed since translated string does not start with the appropriate magic word.',
+            token.type,
+            content,
+            localizedContent
+          );
+        }
+
+        // Reform the token content with the localized strings
+        const replaceWith =
+          token.type === 'string'
+            ? `${token.value[0]}${localizedContent || ''}${token.value[0]}`
+            : token.type === 'comment'
+            ? `# ${localizedContent?.trim() || ''}`
+            : undefined;
+
+        // Replace the content, if necessary
+        if (replaceWith !== undefined) {
+          localized =
+            localized.substring(0, token.pos - adjustedPosition) +
+            replaceWith +
+            localized.substring(
+              token.pos - adjustedPosition + token.value.length
+            );
+
+          // Readjust positions for tokens after this substitution
+          adjustedPosition += token.value.length - replaceWith.length;
+        }
+      });
+    } catch (err) {
+      // Ignore any unlikely errors during tokenization
+    }
+
+    // Parse the python content
+    return {
+      ...file,
+      contents: localized,
+    };
+  }
+}
+
+export default PythonLocalizer;

--- a/apps/src/pythonlab/PythonLocalizer.ts
+++ b/apps/src/pythonlab/PythonLocalizer.ts
@@ -106,6 +106,8 @@ class PythonLocalizer extends Localizer {
           ? localizedRaw?.substring(token.type.length + 3) || content
           : content;
 
+        console.log('PYTHONLAB LOCALIZATION', localizedRaw, localizedContent);
+
         if (
           localizedRaw !== undefined &&
           !(localizedRaw || '').startsWith(`[${token.type}] `)

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -19,6 +19,7 @@ import {changeProjectType} from '@cdo/apps/lab2/redux/lab2ProjectReduxThunks';
 import {submitPredictResponse} from '@cdo/apps/lab2/redux/predictLevelRedux';
 import {LabProps, MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
+import {useLocalization} from '@cdo/apps/localization';
 import pythonlabI18n from '@cdo/apps/pythonlab/locale';
 import {
   restartPyodideIfProgramIsRunning,
@@ -47,6 +48,7 @@ import VerticalLayout from './layout/VerticalLayout';
 import PythonValidationTracker from './progress/PythonValidationTracker';
 import PythonValidator from './progress/PythonValidator';
 import {handleRunClick, stopPythonCode} from './pyodideRunner';
+import PythonLocalizer from './PythonLocalizer';
 
 import moduleStyles from './pythonlab-view.module.scss';
 
@@ -77,10 +79,17 @@ const PythonlabView: React.FunctionComponent<
   LabProps<CodebridgeLevelProperties, ProjectSources>
 > = ({levelProperties, initialSources}) => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
+  const locale = useLocalization();
+
+  const localizer: PythonLocalizer = useMemo(
+    () => new PythonLocalizer(locale),
+    [locale]
+  );
   const {startSources} = useSource(
     DEFAULT_PROJECT,
     levelProperties,
-    initialSources
+    initialSources,
+    localizer
   );
   const validationFile = levelProperties.validationFile;
   const isPredictLevel = levelProperties.predictSettings?.isPredictLevel;

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -89,7 +89,7 @@ const PythonlabView: React.FunctionComponent<
     DEFAULT_PROJECT,
     levelProperties,
     initialSources,
-    localizer
+    [localizer]
   );
   const validationFile = levelProperties.validationFile;
   const isPredictLevel = levelProperties.predictSettings?.isPredictLevel;

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -11260,6 +11260,7 @@ __metadata:
     swiper: "npm:^11.0.5"
     terser-webpack-plugin: "npm:^5.3.10"
     timers-browserify: "npm:^2.0.12"
+    tokenizr: "npm:^1.7.0"
     tone: "npm:14.7.77"
     ts-jest: "npm:^29.1.2"
     ts-loader: "npm:^9.5.1"
@@ -29240,6 +29241,13 @@ canvg@gabelerner/canvg:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10/952c29e2a85d7123239b5cfdd889a0dde47ab0497f0913d70588f19c53f7e0b5327c95f4651e413c74b785147f9637b17410ac8c846d5d4a20a5a33eb6dc3a45
+  languageName: node
+  linkType: hard
+
+"tokenizr@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "tokenizr@npm:1.7.0"
+  checksum: 10/2e3a01bf14dc94994dafd991f9071d09080066e9d932c7be88e7f42984c1a9207db43c6bb19d9c0d23bf0bca4fa4426f3df99b23fce909114b61b590816f70e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Initial pass at adding a 'localization' agent when determining the start sources for Python that will allow localization of the strings and comments in the Python code via Codebridge.

This should allow other languages and file types in the future... say, CSV data and such, by adding a localizer class for that file type as well.

## Links

- Jira: 

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
