### PR TITLE
feat(marketing): refactor Divider component to use MUI

### DIFF
--- a/frontend/apps/marketing/src/components/common/types/index.ts
+++ b/frontend/apps/marketing/src/components/common/types/index.ts
@@ -2,15 +2,15 @@
 // spacing props like margin or padding.
 export interface SpacingProps {
   /** None */
-  none: string;
+  none: number;
   /** Extra small */
-  xs: string;
+  xs: number;
   /** Small */
-  s: string;
+  s: number;
   /** Medium */
-  m: string;
+  m: number;
   /** Large */
-  l: string;
+  l: number;
 }
 
 export interface RemoveMarginBottomProps {

--- a/frontend/apps/marketing/src/components/common/types/index.ts
+++ b/frontend/apps/marketing/src/components/common/types/index.ts
@@ -1,3 +1,5 @@
+// Can be used for components that require
+// spacing props like margin or padding.
 export interface SpacingProps {
   /** None */
   none: string;

--- a/frontend/apps/marketing/src/components/common/types/index.ts
+++ b/frontend/apps/marketing/src/components/common/types/index.ts
@@ -1,3 +1,16 @@
+export interface SpacingProps {
+  /** None */
+  none: string;
+  /** Extra small */
+  xs: string;
+  /** Small */
+  s: string;
+  /** Medium */
+  m: string;
+  /** Large */
+  l: string;
+}
+
 export interface RemoveMarginBottomProps {
   /** Whether to remove the margin bottom */
   removeMarginBottom: boolean;

--- a/frontend/apps/marketing/src/components/contentful/afeEligibility/AFEForm.tsx
+++ b/frontend/apps/marketing/src/components/contentful/afeEligibility/AFEForm.tsx
@@ -5,7 +5,6 @@ import React, {useCallback, useRef, useState, useEffect} from 'react';
 
 import Button from '@code-dot-org/component-library/button';
 import Checkbox from '@code-dot-org/component-library/checkbox';
-import Divider from '@code-dot-org/component-library/divider';
 import {
   SimpleDropdown,
   CheckboxDropdown,
@@ -20,6 +19,8 @@ import {
 } from '@code-dot-org/component-library/typography';
 
 import {getStudioUrl} from '@/config/studio';
+
+import Divider from '../divider';
 
 import AFEContinueNotice from './AFEContinueNotice';
 import AFESuccessNotice from './AFESuccessNotice';

--- a/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
@@ -25,10 +25,10 @@ const spacingMap: Record<keyof SpacingProps, number> = {
 const getColorValue = (color: DividerProps['color']) => {
   switch (color) {
     case 'strong':
-      return 'var(--background-neutral-senary)';
+      return 'var(--background-neutral-senary)'; // TODO: Replace with theme color
     case 'primary':
     default:
-      return 'var(--background-neutral-quaternary)';
+      return 'var(--background-neutral-quaternary)'; // TODO: Replace with theme color
   }
 };
 

--- a/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
@@ -1,13 +1,57 @@
-import React from 'react';
+import MUIDivider from '@mui/material/Divider';
+import React, {HTMLAttributes} from 'react';
 
-import DSCODivider, {
-  DividerProps,
-} from '@code-dot-org/component-library/divider';
+import type {SpacingProps} from '@/components/common/types';
 
-import moduleStyles from './divider.module.scss';
+export type DividerProps = HTMLAttributes<HTMLElement> & {
+  /** Divider color */
+  color?: 'primary' | 'strong';
+  /** Divider margin */
+  margin?: keyof SpacingProps;
+  /** Divider custom className */
+  className?: string;
+};
 
-const Divider: React.FC<DividerProps> = ({...props}) => {
-  return <DSCODivider {...props} className={moduleStyles.divider} />;
+// Map SpacingProps keys to MUI spacing values
+const spacingMap: Record<keyof SpacingProps, number> = {
+  none: 0, // 0px
+  xs: 1, // 8px
+  s: 2, // 16px
+  m: 4, // 32px
+  l: 8, // 64px
+};
+
+// Map color values to CSS variables
+const getColorValue = (color: DividerProps['color']) => {
+  switch (color) {
+    case 'strong':
+      return 'var(--background-neutral-senary)';
+    case 'primary':
+    default:
+      return 'var(--background-neutral-quaternary)';
+  }
+};
+
+const Divider: React.FC<DividerProps> = ({
+  color = 'primary',
+  margin = 'm',
+  className,
+}) => {
+  return (
+    <MUIDivider
+      className={className}
+      orientation="horizontal"
+      variant="fullWidth"
+      sx={theme => ({
+        marginTop: theme.spacing(spacingMap[margin]),
+        marginBottom: theme.spacing(spacingMap[margin]),
+        ...(color && {
+          backgroundColor: getColorValue(color),
+        }),
+      })}
+      flexItem
+    />
+  );
 };
 
 export default Divider;

--- a/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
@@ -25,10 +25,10 @@ const spacingMap: Record<keyof SpacingProps, number> = {
 const getColorValue = (color: DividerProps['color']) => {
   switch (color) {
     case 'strong':
-      return 'var(--background-neutral-senary)'; // TODO: Replace with theme color
+      return 'var(--background-neutral-senary)'; // TODO: Replace with MUI theme color
     case 'primary':
     default:
-      return 'var(--background-neutral-quaternary)'; // TODO: Replace with theme color
+      return 'var(--background-neutral-quaternary)'; // TODO: Replace with MUI theme color
   }
 };
 

--- a/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
@@ -45,9 +45,7 @@ const Divider: React.FC<DividerProps> = ({
       sx={theme => ({
         marginTop: theme.spacing(spacingMap[margin]),
         marginBottom: theme.spacing(spacingMap[margin]),
-        ...(color && {
-          backgroundColor: getColorValue(color),
-        }),
+        backgroundColor: getColorValue(color),
       })}
       flexItem
     />

--- a/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
@@ -21,7 +21,7 @@ const spacingMap: Record<keyof SpacingProps, number> = {
   l: 8, // 64px
 };
 
-// Map color values to CSS variables
+// Get the color value based on the provided color prop
 const getColorValue = (color: DividerProps['color']) => {
   switch (color) {
     case 'strong':

--- a/frontend/apps/marketing/src/components/contentful/divider/__tests__/Divider.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/__tests__/Divider.test.tsx
@@ -31,11 +31,11 @@ describe('Divider Component', () => {
     const colorTestCases: {color: DividerProps['color']; expected: string}[] = [
       {
         color: 'primary',
-        expected: 'var(--background-neutral-quaternary)',
+        expected: 'var(--background-neutral-quaternary)', // TODO: Replace with MUI theme color
       },
       {
         color: 'strong',
-        expected: 'var(--background-neutral-senary)',
+        expected: 'var(--background-neutral-senary)', // TODO: Replace with MUI theme color
       },
     ];
 

--- a/frontend/apps/marketing/src/components/contentful/divider/__tests__/Divider.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/__tests__/Divider.test.tsx
@@ -10,7 +10,7 @@ describe('Divider Component', () => {
     expect(screen.getByRole('separator')).toBeInTheDocument();
   });
 
-  describe('margin prop', () => {
+  describe('renders margin based on margin prop', () => {
     const marginTestCases = [
       {margin: 'none', expected: 'margin: 0px 0px 0px 0px'},
       {margin: 'xs', expected: 'margin: 8px 0px 8px 0px'},
@@ -27,7 +27,7 @@ describe('Divider Component', () => {
     });
   });
 
-  describe('color prop', () => {
+  describe('renders color based on color prop', () => {
     const colorTestCases: {color: DividerProps['color']; expected: string}[] = [
       {
         color: 'primary',

--- a/frontend/apps/marketing/src/components/contentful/divider/__tests__/Divider.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/__tests__/Divider.test.tsx
@@ -1,0 +1,51 @@
+import {render, screen} from '@testing-library/react';
+
+import {SpacingProps} from '@/components/common/types';
+
+import Divider, {DividerProps} from '../Divider';
+
+describe('Divider Component', () => {
+  it('renders Divider component', () => {
+    render(<Divider />);
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  describe('margin prop', () => {
+    const marginTestCases = [
+      {margin: 'none', expected: 'margin: 0px 0px 0px 0px'},
+      {margin: 'xs', expected: 'margin: 8px 0px 8px 0px'},
+      {margin: 's', expected: 'margin: 16px 0px 16px 0px'},
+      {margin: 'm', expected: 'margin: 32px 0px 32px 0px'},
+      {margin: 'l', expected: 'margin: 64px 0px 64px 0px'},
+    ];
+
+    marginTestCases.forEach(({margin, expected}) => {
+      it(`applies ${margin} margin correctly`, () => {
+        render(<Divider margin={margin as keyof SpacingProps} />);
+        expect(screen.getByRole('separator')).toHaveStyle(expected);
+      });
+    });
+  });
+
+  describe('color prop', () => {
+    const colorTestCases: {color: DividerProps['color']; expected: string}[] = [
+      {
+        color: 'primary',
+        expected: 'var(--background-neutral-quaternary)',
+      },
+      {
+        color: 'strong',
+        expected: 'var(--background-neutral-senary)',
+      },
+    ];
+
+    colorTestCases.forEach(({color, expected}) => {
+      it(`applies ${color} color correctly`, () => {
+        render(<Divider color={color} />);
+        expect(screen.getByRole('separator')).toHaveStyle({
+          backgroundColor: expected,
+        });
+      });
+    });
+  });
+});

--- a/frontend/apps/marketing/src/components/contentful/divider/divider.module.scss
+++ b/frontend/apps/marketing/src/components/contentful/divider/divider.module.scss
@@ -1,4 +1,0 @@
-// Common divider style
-.divider {
-  max-width: 960px;
-}


### PR DESCRIPTION
Refactors the Divider component to use [MUI Divider](https://mui.com/material-ui/react-divider/). Doing this in preparation for refactoring the Section component ([CMS-908](https://codedotorg.atlassian.net/browse/CMS-908)) since it uses the Divider component. 

## Links
Jira ticket: [CMS-922](https://codedotorg.atlassian.net/browse/CMS-922)

## Testing story
Added unit tests and should have no Eyes diffs

----


https://github.com/user-attachments/assets/869d634f-d2c0-4611-b799-4d668f293a0c

