### PR TITLE
Revert "Move Blockly theme preference to UserPreferences table"

### DIFF
--- a/apps/src/blockly/addons/cdoKeyboardNavigation.ts
+++ b/apps/src/blockly/addons/cdoKeyboardNavigation.ts
@@ -2,7 +2,8 @@ import {KeyboardNavigation} from '@blockly/keyboard-navigation';
 import * as GoogleBlockly from 'blockly/core';
 
 export function initializeKeyboardNavigation(
-  workspace: GoogleBlockly.WorkspaceSvg
+  workspace: GoogleBlockly.WorkspaceSvg,
+  theme: GoogleBlockly.Theme
 ) {
   unregisterShortcuts(['undo', 'redo']);
   backupShortcuts(['copy', 'paste', 'cut']);
@@ -21,6 +22,8 @@ export function initializeKeyboardNavigation(
   });
 
   enableShortcutModalEscape();
+  // Rerun user theme after Keyboard Experiment bug introduces incorrect theme
+  workspace.setTheme(Blockly.cdoUtils.getUserTheme(theme));
 }
 
 function unregisterShortcuts(shortcutNames: string[]) {

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -7,7 +7,6 @@ import {
   processIndividualBlock,
   removeIdsFromBlocks,
 } from '@cdo/apps/blockly/addons/cdoXml';
-import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
 
 import * as blockUtils from '../../block_utils';
@@ -22,7 +21,6 @@ import {
   ToolboxType,
 } from '../constants';
 import {blocks as procedureBlocks} from '../customBlocks/googleBlockly/proceduresBlocks';
-import cdoDark from '../themes/cdoDark';
 import cdoTheme from '../themes/cdoTheme';
 import {
   BlockColor,
@@ -395,43 +393,37 @@ export function getField(type: string) {
 }
 
 /**
- * Returns a theme object, based on user preferences, localStorage, and the current theme.
- *
- * @param {Theme} currentTheme - A fallback theme provided by the caller.
- * @returns {Promise<GoogleBlockly.Theme>} A resolved Blockly theme object.
+ * Returns a theme object, based on the presence of an option in the browser's localStorage.
+ * @param {?Theme} themeOption
+ * @returns {?Blockly.Field}
  */
-export async function getUserTheme(
-  currentTheme: GoogleBlockly.Theme | undefined
-): Promise<GoogleBlockly.Theme> {
+export function getUserTheme(themeOption: GoogleBlockly.Theme | undefined) {
   if (Blockly.isJigsaw) {
     // Jigsaw uses its own custom theme with an extra large font size.
     // Blocks use hard-coded colors instead of styles, so switching
     // palettes is not possible.
     return Blockly.themes.jigsaw;
   }
+  // Today we only store the theme's base name in localStorage, which never includes 'dark'.
+  // Until March, 2024 we stored the full theme name, so we need to convert it now.
+  // getBaseName strips the 'dark' suffix from a theme name, if present.
+  const localStorageThemeBaseName = getBaseName(localStorage.blocklyTheme);
 
-  const userPrefs = new UserPreferences();
-  const userPreferencesTheme = await userPrefs.getBlocklyTheme(() => {});
-  const baseThemeName =
-    userPreferencesTheme ||
-    // Today we only store the theme's base name in localStorage, which never includes 'dark'.
-    // Until March, 2024 we stored the full theme name, so we need to convert it now.
-    // getBaseName strips the 'dark' suffix from a theme name, if present.
-    getBaseName(localStorage.blocklyTheme);
-
-  if (!baseThemeName) {
-    // The user has not indicated a preference, so we use the lab theme or a safe default.
-    return currentTheme || (Blockly.isDarkTheme ? cdoDark : cdoTheme);
+  // For labs that use dark mode by default, ensure we are returning a dark theme.
+  if (themeOption?.name.endsWith(DARK_THEME_SUFFIX)) {
+    return localStorageThemeBaseName
+      ? Blockly.themes[
+          (localStorageThemeBaseName + DARK_THEME_SUFFIX) as Themes
+        ]
+      : themeOption;
+  } else {
+    // For all other labs, return a light mode theme.
+    return (
+      Blockly.themes[localStorageThemeBaseName as Themes] ||
+      themeOption ||
+      cdoTheme
+    );
   }
-
-  // The base theme name is the name of the theme, always without the 'dark' suffix.
-  // If the user is in dark mode, we append the 'dark' suffix to the base theme name.
-  const fullThemeName =
-    baseThemeName + (Blockly.isDarkTheme ? DARK_THEME_SUFFIX : '');
-  const userTheme = Blockly.themes[fullThemeName as Themes];
-  return (
-    userTheme || currentTheme || (Blockly.isDarkTheme ? cdoDark : cdoTheme)
-  );
 }
 
 /**

--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -4,7 +4,6 @@
 
 import * as GoogleBlockly from 'blockly/core';
 
-import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -18,7 +17,7 @@ import {
   BLOCK_TYPES,
 } from '../constants';
 import {ExtendedBlockSvg} from '../types';
-import {getBaseName, isDarkTheme, setThemeAndRenderBlocks} from '../utils';
+import {getBaseName, isDarkTheme} from '../utils';
 
 // Some options are only available to levelbuilders via start mode.
 // Literal strings are used for display text instead of translatable strings
@@ -451,10 +450,7 @@ const registerTheme = function (name: Themes, label: string, weight: number) {
       }
     },
     callback: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
-      // Save the theme to user preferences, falling back to localStorage for signed-out users.
-      new UserPreferences().setBlocklyTheme(name, () =>
-        localStorage.setItem(BLOCKLY_THEME, name)
-      );
+      localStorage.setItem(BLOCKLY_THEME, name);
       const currentTheme = scope.workspace?.getTheme();
       const themeName =
         name + (isDarkTheme(currentTheme) ? DARK_THEME_SUFFIX : '');
@@ -586,7 +582,18 @@ function setAllWorkspacesTheme(
   Blockly.Workspace.getAll().forEach(baseWorkspace => {
     // Headless workspaces do not have the ability to set the theme.
     const workspace = baseWorkspace as GoogleBlockly.WorkspaceSvg;
-    setThemeAndRenderBlocks(workspace, newTheme);
+    if (typeof workspace.setTheme === 'function') {
+      workspace.setTheme(newTheme);
+      // Re-render blocks if the font size changed.
+      // Once https://github.com/google/blockly/issues/7782 is resolved,
+      // we should be able to remove this.
+      if (newTheme.fontStyle?.size !== previousTheme?.fontStyle?.size) {
+        workspace.getAllBlocks().map(block => {
+          block.markDirty();
+          block.render();
+        });
+      }
+    }
   });
 }
 /**

--- a/apps/src/blockly/addons/functionEditor.ts
+++ b/apps/src/blockly/addons/functionEditor.ts
@@ -24,7 +24,6 @@ import {
   ProcedureBlockConfiguration,
   ProcedureType,
 } from '../types';
-import {setThemeAndRenderBlocks} from '../utils';
 
 import CdoConnectionChecker from './cdoConnectionChecker';
 import {frameSizes} from './cdoConstants';
@@ -89,16 +88,11 @@ export default class FunctionEditor {
       readOnly: options.readOnly,
       renderer: options.renderer,
       rtl: options.rtl,
-      theme: options.theme,
+      theme: Blockly.cdoUtils.getUserTheme(options.theme),
       toolbox,
       trashcan: false, // Don't use default trashcan.
       modalInputs: false,
     }) as EditorWorkspaceSvg;
-    Blockly.cdoUtils
-      .getUserTheme(this.editorWorkspace.getTheme())
-      .then((theme: GoogleBlockly.Theme) => {
-        setThemeAndRenderBlocks(this.editorWorkspace!, theme);
-      });
     this.editorWorkspace.registerToolboxCategoryCallback(
       'VARIABLE',
       variablesFlyoutCategory

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -124,7 +124,6 @@ import {
   strip,
   interpolateMsg,
   isDarkTheme,
-  setThemeAndRenderBlocks,
 } from './utils';
 
 const options = {
@@ -740,9 +739,10 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     xml,
     options = {}
   ) {
+    const theme = cdoUtils.getUserTheme(options.theme as GoogleBlockly.Theme);
     const workspace = new Blockly.WorkspaceSvg({
       readOnly: true,
-      theme: options.theme,
+      theme: theme,
       plugins: {},
       RTL: options.rtl,
       renderer: options.renderer || Renderers.DEFAULT,
@@ -767,11 +767,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     container.style.display = 'inline-block';
     container.appendChild(svg);
     svg.appendChild(workspace.createDom());
-    Blockly.cdoUtils
-      .getUserTheme(workspace.getTheme())
-      .then((theme: GoogleBlockly.Theme) => {
-        setThemeAndRenderBlocks(workspace, theme);
-      });
+    workspace.setTheme(theme);
     // We do not include hidden definitions in embedded workspaces
     // because embedded workspaces are only used for displaying blocks.
     const includeHiddenDefinitions = false;
@@ -813,7 +809,9 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.isJigsaw = optOptionsExtended.isJigsaw;
     const options = {
       ...optOptionsExtended,
-      theme: optOptionsExtended.theme || CdoTheme,
+      theme: cdoUtils.getUserTheme(
+        optOptionsExtended.theme as GoogleBlockly.Theme
+      ),
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,
@@ -876,9 +874,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.toolboxBlocks = options.toolbox;
     blocklyWrapper.showUnusedBlocks = options.showUnusedBlocks;
     blocklyWrapper.blockLimitMap = cdoUtils.createBlockLimitMap();
-    blocklyWrapper.isDarkTheme = isDarkTheme(
-      options.theme as GoogleBlockly.Theme | undefined
-    );
+    blocklyWrapper.isDarkTheme = isDarkTheme(options.theme);
 
     // Only allow toggling disabled blocks in start mode.
     // This is also important for ensuring that Blockly does not
@@ -889,11 +885,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       container,
       options
     ) as ExtendedWorkspaceSvg;
-    Blockly.cdoUtils
-      .getUserTheme(workspace.getTheme())
-      .then((theme: GoogleBlockly.Theme) => {
-        setThemeAndRenderBlocks(workspace, theme);
-      });
+
     workspace.defs = Blockly.createSvgElement(
       'defs',
       {id: 'blocklySvgDefs'},
@@ -916,7 +908,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
         experiments.BLOCKLY_KEYBOARD_NAVIGATION
       )
     ) {
-      initializeKeyboardNavigation(workspace);
+      initializeKeyboardNavigation(workspace, options.theme);
     }
 
     // Typically, we need to handle disabling blocks that are not connected to an

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -364,29 +364,3 @@ export function updateBlockEnabled(block: GoogleBlockly.Block) {
     Blockly.Events.setRecordUndo(initialUndoFlag);
   }
 }
-
-/**
- * Sets the theme for the workspace and re-renders blocks if the font size changed.
- *
- * @param {GoogleBlockly.Workspace} workspace - The Blockly workspace to set the theme for.
- * @param {GoogleBlockly.Theme} theme - The theme to apply to the workspace.
- */
-export function setThemeAndRenderBlocks(
-  workspace: GoogleBlockly.Workspace,
-  theme: GoogleBlockly.Theme
-) {
-  if (theme && workspace?.rendered) {
-    const renderedWorkspace = workspace as GoogleBlockly.WorkspaceSvg;
-    const previousTheme = renderedWorkspace.getTheme();
-    renderedWorkspace.setTheme(theme);
-    // Re-render blocks if the font size changed.
-    // Once https://github.com/google/blockly/issues/7782 is resolved,
-    // we should be able to remove this.
-    if (theme.fontStyle?.size !== previousTheme.fontStyle?.size) {
-      renderedWorkspace.getAllBlocks().map(block => {
-        block.markDirty();
-        block.render();
-      });
-    }
-  }
-}

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -163,81 +163,31 @@ export default class UserPreferences extends Record({userId: 'me'}) {
     }
   }
 
-  /**
-   * Fetches all user theme settings (e.g., global, blockly).
-   * @param {function} [errorCallback]
-   */
-  async getThemeSettings(errorCallback) {
+  async getGlobalTheme(errorCallback) {
     try {
       const themeResponse = await HttpClient.fetchJson(
         '/user_preference/theme'
       );
-      return themeResponse.value?.theme;
+      return themeResponse.value?.theme?.global;
     } catch (error) {
       // Don't call the error callback if 'Not found', as it just means the
       // user has not set a theme yet.
-      if (error?.response?.status !== 404) {
-        return errorCallback(error) ?? null;
+      if (error.response.status !== 404) {
+        errorCallback(error);
       }
       return null;
     }
   }
 
-  /**
-   * Fetches the user's global theme preference.
-   * @param {function} [errorCallback]
-   */
-  async getGlobalTheme(errorCallback) {
-    const theme = await this.getThemeSettings(errorCallback);
-    return theme?.global ?? null;
-  }
+  async setGlobalTheme(theme) {
+    const body = {
+      theme: {
+        global: theme,
+      },
+    };
 
-  /**
-   * Retrieves the user's Blockly theme preference.
-   * @param {function} [errorCallback]
-   */
-  async getBlocklyTheme(errorCallback) {
-    const theme = await this.getThemeSettings(errorCallback);
-    return theme?.blockly ?? null;
-  }
-
-  /**
-   * Sends new theme settings to the server.
-   * The server automatically merges them with any existing theme preferences.
-   *
-   * @param {Object} themeUpdate - A partial theme object to update (e.g., {global: 'Dark'}).
-   * @param {function} [errorCallback]
-   */
-  async updateThemeSettings(themeUpdate, errorCallback) {
-    try {
-      return await HttpClient.put(
-        '/user_preference',
-        JSON.stringify({theme: themeUpdate}),
-        true,
-        {'Content-Type': 'application/json'}
-      );
-    } catch (error) {
-      if (errorCallback) {
-        errorCallback(error);
-      }
-    }
-  }
-
-  /**
-   * Sets the user's global theme preference.
-   * @param {string} globalTheme - The name of the global theme to set (e.g., 'Dark').
-   */
-  async setGlobalTheme(globalTheme) {
-    return this.updateThemeSettings({global: globalTheme});
-  }
-
-  /**
-   * Sets the user's Blockly theme preference.
-   *
-   * @param {string} blocklyTheme - The name of the Blockly theme to set (e.g., 'cdodeutranopia').
-   * @param {function} [errorCallback] - Optional callback for handling errors, such as for signed out users.
-   */
-  async setBlocklyTheme(blocklyTheme, errorCallback) {
-    return this.updateThemeSettings({blockly: blocklyTheme}, errorCallback);
+    return HttpClient.put('/user_preference', JSON.stringify(body), true, {
+      'Content-Type': 'application/json',
+    });
   }
 }

--- a/dashboard/test/controllers/user_preferences_controller_test.rb
+++ b/dashboard/test/controllers/user_preferences_controller_test.rb
@@ -97,11 +97,11 @@ class UserPreferencesControllerTest < ActionController::TestCase
     preference = UserPreference.create!(user_id: @user.id, theme: initial_theme)
 
     new_theme = {
-      'blockly' => 'cdohighcontrast'
+      'Blockly' => 'cdohighcontrast'
     }
     merged_theme = {
       'global'=> 'Dark',
-      'blockly' => 'cdohighcontrast'
+      'Blockly' => 'cdohighcontrast'
     }
 
     assert_no_difference 'UserPreference.count' do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#66988

This caused unexpected eyes diffs where the blocks in places like toolboxes were not themed. I verified that by reverting the blocks are styled again. [Example failure](https://eyes.applitools.com/app/test-results/00000251649518505838/00000251649518444281/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor)