### PR TITLE
Revert "Revert "Move Blockly theme preference to UserPreferences table""

### DIFF
--- a/apps/src/blockly/addons/cdoKeyboardNavigation.ts
+++ b/apps/src/blockly/addons/cdoKeyboardNavigation.ts
@@ -2,8 +2,7 @@ import {KeyboardNavigation} from '@blockly/keyboard-navigation';
 import * as GoogleBlockly from 'blockly/core';
 
 export function initializeKeyboardNavigation(
-  workspace: GoogleBlockly.WorkspaceSvg,
-  theme: GoogleBlockly.Theme
+  workspace: GoogleBlockly.WorkspaceSvg
 ) {
   unregisterShortcuts(['undo', 'redo']);
   backupShortcuts(['copy', 'paste', 'cut']);
@@ -22,8 +21,6 @@ export function initializeKeyboardNavigation(
   });
 
   enableShortcutModalEscape();
-  // Rerun user theme after Keyboard Experiment bug introduces incorrect theme
-  workspace.setTheme(Blockly.cdoUtils.getUserTheme(theme));
 }
 
 function unregisterShortcuts(shortcutNames: string[]) {

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -7,6 +7,7 @@ import {
   processIndividualBlock,
   removeIdsFromBlocks,
 } from '@cdo/apps/blockly/addons/cdoXml';
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
 
 import * as blockUtils from '../../block_utils';
@@ -21,6 +22,7 @@ import {
   ToolboxType,
 } from '../constants';
 import {blocks as procedureBlocks} from '../customBlocks/googleBlockly/proceduresBlocks';
+import cdoDark from '../themes/cdoDark';
 import cdoTheme from '../themes/cdoTheme';
 import {
   BlockColor,
@@ -393,37 +395,43 @@ export function getField(type: string) {
 }
 
 /**
- * Returns a theme object, based on the presence of an option in the browser's localStorage.
- * @param {?Theme} themeOption
- * @returns {?Blockly.Field}
+ * Returns a theme object, based on user preferences, localStorage, and the current theme.
+ *
+ * @param {Theme} currentTheme - A fallback theme provided by the caller.
+ * @returns {Promise<GoogleBlockly.Theme>} A resolved Blockly theme object.
  */
-export function getUserTheme(themeOption: GoogleBlockly.Theme | undefined) {
+export async function getUserTheme(
+  currentTheme: GoogleBlockly.Theme | undefined
+): Promise<GoogleBlockly.Theme> {
   if (Blockly.isJigsaw) {
     // Jigsaw uses its own custom theme with an extra large font size.
     // Blocks use hard-coded colors instead of styles, so switching
     // palettes is not possible.
     return Blockly.themes.jigsaw;
   }
-  // Today we only store the theme's base name in localStorage, which never includes 'dark'.
-  // Until March, 2024 we stored the full theme name, so we need to convert it now.
-  // getBaseName strips the 'dark' suffix from a theme name, if present.
-  const localStorageThemeBaseName = getBaseName(localStorage.blocklyTheme);
 
-  // For labs that use dark mode by default, ensure we are returning a dark theme.
-  if (themeOption?.name.endsWith(DARK_THEME_SUFFIX)) {
-    return localStorageThemeBaseName
-      ? Blockly.themes[
-          (localStorageThemeBaseName + DARK_THEME_SUFFIX) as Themes
-        ]
-      : themeOption;
-  } else {
-    // For all other labs, return a light mode theme.
-    return (
-      Blockly.themes[localStorageThemeBaseName as Themes] ||
-      themeOption ||
-      cdoTheme
-    );
+  const userPrefs = new UserPreferences();
+  const userPreferencesTheme = await userPrefs.getBlocklyTheme(() => {});
+  const baseThemeName =
+    userPreferencesTheme ||
+    // Today we only store the theme's base name in localStorage, which never includes 'dark'.
+    // Until March, 2024 we stored the full theme name, so we need to convert it now.
+    // getBaseName strips the 'dark' suffix from a theme name, if present.
+    getBaseName(localStorage.blocklyTheme);
+
+  if (!baseThemeName) {
+    // The user has not indicated a preference, so we use the lab theme or a safe default.
+    return currentTheme || (Blockly.isDarkTheme ? cdoDark : cdoTheme);
   }
+
+  // The base theme name is the name of the theme, always without the 'dark' suffix.
+  // If the user is in dark mode, we append the 'dark' suffix to the base theme name.
+  const fullThemeName =
+    baseThemeName + (Blockly.isDarkTheme ? DARK_THEME_SUFFIX : '');
+  const userTheme = Blockly.themes[fullThemeName as Themes];
+  return (
+    userTheme || currentTheme || (Blockly.isDarkTheme ? cdoDark : cdoTheme)
+  );
 }
 
 /**

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -410,6 +410,13 @@ export async function getUserTheme(
     return Blockly.themes.jigsaw;
   }
 
+  // If a workspace was created without a theme, Blockly will default to 'classic',
+  // which we do not support. Use the default modern theme instead.
+  const supportedThemes = Object.keys(Blockly.themes);
+  if (!supportedThemes.includes(currentTheme?.name || '')) {
+    currentTheme = getDefaultTheme();
+  }
+
   const userPrefs = new UserPreferences();
   const userPreferencesTheme = await userPrefs.getBlocklyTheme(() => {});
   const baseThemeName =

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -410,13 +410,6 @@ export async function getUserTheme(
     return Blockly.themes.jigsaw;
   }
 
-  // If a workspace was created without a theme, Blockly will default to 'classic',
-  // which we do not support. Use the default modern theme instead.
-  const supportedThemes = Object.keys(Blockly.themes);
-  if (!supportedThemes.includes(currentTheme?.name || '')) {
-    currentTheme = getDefaultTheme();
-  }
-
   const userPrefs = new UserPreferences();
   const userPreferencesTheme = await userPrefs.getBlocklyTheme(() => {});
   const baseThemeName =

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -411,15 +411,16 @@ export async function getUserTheme(
   }
 
   const userPrefs = new UserPreferences();
-  const userPreferencesTheme = await userPrefs.getBlocklyTheme(() => {});
-  const baseThemeName =
-    userPreferencesTheme ||
-    // Today we only store the theme's base name in localStorage, which never includes 'dark'.
-    // Until March, 2024 we stored the full theme name, so we need to convert it now.
-    // getBaseName strips the 'dark' suffix from a theme name, if present.
-    getBaseName(localStorage.blocklyTheme);
+  const userThemePreference = await userPrefs.getBlocklyTheme(() => {});
+  // Today we only store the theme's base name in localStorage, which never includes 'dark'.
+  // Until March, 2024 we stored the full theme name, so we need to convert it now.
+  // getBaseName strips the 'dark' suffix from a theme name, if present.
+  const browserThemePreference = getBaseName(localStorage.blocklyTheme);
 
-  if (!baseThemeName) {
+  // Prioritize persistent user preference over local browser preference.
+  const themePreference = userThemePreference || browserThemePreference;
+
+  if (!themePreference) {
     // The user has not indicated a preference, so we use the lab theme or a safe default.
     return currentTheme || getDefaultTheme();
   }
@@ -427,7 +428,7 @@ export async function getUserTheme(
   // The base theme name is the name of the theme, always without the 'dark' suffix.
   // If the user is in dark mode, we append the 'dark' suffix to the base theme name.
   const fullThemeName =
-    baseThemeName + (Blockly.isDarkTheme ? DARK_THEME_SUFFIX : '');
+    themePreference + (Blockly.isDarkTheme ? DARK_THEME_SUFFIX : '');
   const userTheme = Blockly.themes[fullThemeName as Themes];
   return userTheme || currentTheme || getDefaultTheme();
 }

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -421,7 +421,7 @@ export async function getUserTheme(
 
   if (!baseThemeName) {
     // The user has not indicated a preference, so we use the lab theme or a safe default.
-    return currentTheme || (Blockly.isDarkTheme ? cdoDark : cdoTheme);
+    return currentTheme || getDefaultTheme();
   }
 
   // The base theme name is the name of the theme, always without the 'dark' suffix.
@@ -429,9 +429,12 @@ export async function getUserTheme(
   const fullThemeName =
     baseThemeName + (Blockly.isDarkTheme ? DARK_THEME_SUFFIX : '');
   const userTheme = Blockly.themes[fullThemeName as Themes];
-  return (
-    userTheme || currentTheme || (Blockly.isDarkTheme ? cdoDark : cdoTheme)
-  );
+  return userTheme || currentTheme || getDefaultTheme();
+}
+
+// Returns the default theme based on Blockly.isDarkTheme.
+export function getDefaultTheme() {
+  return Blockly.isDarkTheme ? cdoDark : cdoTheme;
 }
 
 /**

--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -4,6 +4,7 @@
 
 import * as GoogleBlockly from 'blockly/core';
 
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -17,7 +18,7 @@ import {
   BLOCK_TYPES,
 } from '../constants';
 import {ExtendedBlockSvg} from '../types';
-import {getBaseName, isDarkTheme} from '../utils';
+import {getBaseName, isDarkTheme, setThemeAndRenderBlocks} from '../utils';
 
 // Some options are only available to levelbuilders via start mode.
 // Literal strings are used for display text instead of translatable strings
@@ -450,7 +451,10 @@ const registerTheme = function (name: Themes, label: string, weight: number) {
       }
     },
     callback: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
-      localStorage.setItem(BLOCKLY_THEME, name);
+      // Save the theme to user preferences, falling back to localStorage for signed-out users.
+      new UserPreferences().setBlocklyTheme(name, () =>
+        localStorage.setItem(BLOCKLY_THEME, name)
+      );
       const currentTheme = scope.workspace?.getTheme();
       const themeName =
         name + (isDarkTheme(currentTheme) ? DARK_THEME_SUFFIX : '');
@@ -582,18 +586,7 @@ function setAllWorkspacesTheme(
   Blockly.Workspace.getAll().forEach(baseWorkspace => {
     // Headless workspaces do not have the ability to set the theme.
     const workspace = baseWorkspace as GoogleBlockly.WorkspaceSvg;
-    if (typeof workspace.setTheme === 'function') {
-      workspace.setTheme(newTheme);
-      // Re-render blocks if the font size changed.
-      // Once https://github.com/google/blockly/issues/7782 is resolved,
-      // we should be able to remove this.
-      if (newTheme.fontStyle?.size !== previousTheme?.fontStyle?.size) {
-        workspace.getAllBlocks().map(block => {
-          block.markDirty();
-          block.render();
-        });
-      }
-    }
+    setThemeAndRenderBlocks(workspace, newTheme);
   });
 }
 /**

--- a/apps/src/blockly/addons/functionEditor.ts
+++ b/apps/src/blockly/addons/functionEditor.ts
@@ -24,6 +24,7 @@ import {
   ProcedureBlockConfiguration,
   ProcedureType,
 } from '../types';
+import {setThemeAndRenderBlocks} from '../utils';
 
 import CdoConnectionChecker from './cdoConnectionChecker';
 import {frameSizes} from './cdoConstants';
@@ -88,11 +89,16 @@ export default class FunctionEditor {
       readOnly: options.readOnly,
       renderer: options.renderer,
       rtl: options.rtl,
-      theme: Blockly.cdoUtils.getUserTheme(options.theme),
+      theme: options.theme,
       toolbox,
       trashcan: false, // Don't use default trashcan.
       modalInputs: false,
     }) as EditorWorkspaceSvg;
+    Blockly.cdoUtils
+      .getUserTheme(this.editorWorkspace.getTheme())
+      .then((theme: GoogleBlockly.Theme) => {
+        setThemeAndRenderBlocks(this.editorWorkspace!, theme);
+      });
     this.editorWorkspace.registerToolboxCategoryCallback(
       'VARIABLE',
       variablesFlyoutCategory

--- a/apps/src/blockly/addons/functionEditor.ts
+++ b/apps/src/blockly/addons/functionEditor.ts
@@ -89,7 +89,7 @@ export default class FunctionEditor {
       readOnly: options.readOnly,
       renderer: options.renderer,
       rtl: options.rtl,
-      theme: options.theme,
+      theme: options.theme || Blockly.cdoUtils.getDefaultTheme(),
       toolbox,
       trashcan: false, // Don't use default trashcan.
       modalInputs: false,

--- a/apps/src/blockly/addons/functionEditor.ts
+++ b/apps/src/blockly/addons/functionEditor.ts
@@ -17,6 +17,7 @@ import {commonI18n} from '@cdo/apps/types/locale';
 import {getAlphanumericId} from '@cdo/apps/utils';
 
 import {BLOCK_TYPES} from '../constants';
+import CdoTheme from '../themes/cdoTheme';
 import {
   EditorWorkspaceSvg,
   ExtendedBlocklyOptions,
@@ -89,7 +90,7 @@ export default class FunctionEditor {
       readOnly: options.readOnly,
       renderer: options.renderer,
       rtl: options.rtl,
-      theme: options.theme,
+      theme: options.theme || CdoTheme,
       toolbox,
       trashcan: false, // Don't use default trashcan.
       modalInputs: false,

--- a/apps/src/blockly/addons/functionEditor.ts
+++ b/apps/src/blockly/addons/functionEditor.ts
@@ -89,7 +89,7 @@ export default class FunctionEditor {
       readOnly: options.readOnly,
       renderer: options.renderer,
       rtl: options.rtl,
-      theme: options.theme || Blockly.cdoUtils.getDefaultTheme(),
+      theme: options.theme,
       toolbox,
       trashcan: false, // Don't use default trashcan.
       modalInputs: false,

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -124,6 +124,7 @@ import {
   strip,
   interpolateMsg,
   isDarkTheme,
+  setThemeAndRenderBlocks,
 } from './utils';
 
 const options = {
@@ -739,10 +740,9 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     xml,
     options = {}
   ) {
-    const theme = cdoUtils.getUserTheme(options.theme as GoogleBlockly.Theme);
     const workspace = new Blockly.WorkspaceSvg({
       readOnly: true,
-      theme: theme,
+      theme: options.theme,
       plugins: {},
       RTL: options.rtl,
       renderer: options.renderer || Renderers.DEFAULT,
@@ -767,7 +767,11 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     container.style.display = 'inline-block';
     container.appendChild(svg);
     svg.appendChild(workspace.createDom());
-    workspace.setTheme(theme);
+    Blockly.cdoUtils
+      .getUserTheme(workspace.getTheme())
+      .then((theme: GoogleBlockly.Theme) => {
+        setThemeAndRenderBlocks(workspace, theme);
+      });
     // We do not include hidden definitions in embedded workspaces
     // because embedded workspaces are only used for displaying blocks.
     const includeHiddenDefinitions = false;
@@ -809,9 +813,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.isJigsaw = optOptionsExtended.isJigsaw;
     const options = {
       ...optOptionsExtended,
-      theme: cdoUtils.getUserTheme(
-        optOptionsExtended.theme as GoogleBlockly.Theme
-      ),
+      theme: optOptionsExtended.theme || CdoTheme,
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,
@@ -874,7 +876,9 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.toolboxBlocks = options.toolbox;
     blocklyWrapper.showUnusedBlocks = options.showUnusedBlocks;
     blocklyWrapper.blockLimitMap = cdoUtils.createBlockLimitMap();
-    blocklyWrapper.isDarkTheme = isDarkTheme(options.theme);
+    blocklyWrapper.isDarkTheme = isDarkTheme(
+      options.theme as GoogleBlockly.Theme | undefined
+    );
 
     // Only allow toggling disabled blocks in start mode.
     // This is also important for ensuring that Blockly does not
@@ -885,7 +889,11 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       container,
       options
     ) as ExtendedWorkspaceSvg;
-
+    Blockly.cdoUtils
+      .getUserTheme(workspace.getTheme())
+      .then((theme: GoogleBlockly.Theme) => {
+        setThemeAndRenderBlocks(workspace, theme);
+      });
     workspace.defs = Blockly.createSvgElement(
       'defs',
       {id: 'blocklySvgDefs'},
@@ -908,7 +916,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
         experiments.BLOCKLY_KEYBOARD_NAVIGATION
       )
     ) {
-      initializeKeyboardNavigation(workspace, options.theme);
+      initializeKeyboardNavigation(workspace);
     }
 
     // Typically, we need to handle disabling blocks that are not connected to an

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -742,7 +742,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   ) {
     const workspace = new Blockly.WorkspaceSvg({
       readOnly: true,
-      theme: options.theme,
+      theme: options.theme || blocklyWrapper.cdoUtils.getDefaultTheme(),
       plugins: {},
       RTL: options.rtl,
       renderer: options.renderer || Renderers.DEFAULT,
@@ -813,7 +813,8 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.isJigsaw = optOptionsExtended.isJigsaw;
     const options = {
       ...optOptionsExtended,
-      theme: optOptionsExtended.theme || CdoTheme,
+      theme:
+        optOptionsExtended.theme || blocklyWrapper.cdoUtils.getDefaultTheme(),
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -742,7 +742,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   ) {
     const workspace = new Blockly.WorkspaceSvg({
       readOnly: true,
-      theme: options.theme,
+      theme: options.theme || CdoTheme,
       plugins: {},
       RTL: options.rtl,
       renderer: options.renderer || Renderers.DEFAULT,
@@ -767,11 +767,6 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     container.style.display = 'inline-block';
     container.appendChild(svg);
     svg.appendChild(workspace.createDom());
-    Blockly.cdoUtils
-      .getUserTheme(workspace.getTheme())
-      .then((theme: GoogleBlockly.Theme) => {
-        setThemeAndRenderBlocks(workspace, theme);
-      });
     // We do not include hidden definitions in embedded workspaces
     // because embedded workspaces are only used for displaying blocks.
     const includeHiddenDefinitions = false;
@@ -781,6 +776,11 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       includeHiddenDefinitions
     );
 
+    Blockly.cdoUtils
+      .getUserTheme(workspace.getTheme())
+      .then((theme: GoogleBlockly.Theme) => {
+        setThemeAndRenderBlocks(workspace, theme, true);
+      });
     // Loop through all the parent blocks and remove vertical translation value
     // This makes the output more condensed and readable, while preserving
     // horizontal translation values for RTL rendering.

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -742,7 +742,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   ) {
     const workspace = new Blockly.WorkspaceSvg({
       readOnly: true,
-      theme: options.theme || blocklyWrapper.cdoUtils.getDefaultTheme(),
+      theme: options.theme,
       plugins: {},
       RTL: options.rtl,
       renderer: options.renderer || Renderers.DEFAULT,
@@ -813,8 +813,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.isJigsaw = optOptionsExtended.isJigsaw;
     const options = {
       ...optOptionsExtended,
-      theme:
-        optOptionsExtended.theme || blocklyWrapper.cdoUtils.getDefaultTheme(),
+      theme: optOptionsExtended.theme,
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -813,7 +813,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.isJigsaw = optOptionsExtended.isJigsaw;
     const options = {
       ...optOptionsExtended,
-      theme: optOptionsExtended.theme,
+      theme: optOptionsExtended.theme || CdoTheme,
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -364,3 +364,29 @@ export function updateBlockEnabled(block: GoogleBlockly.Block) {
     Blockly.Events.setRecordUndo(initialUndoFlag);
   }
 }
+
+/**
+ * Sets the theme for the workspace and re-renders blocks if the font size changed.
+ *
+ * @param {GoogleBlockly.Workspace} workspace - The Blockly workspace to set the theme for.
+ * @param {GoogleBlockly.Theme} theme - The theme to apply to the workspace.
+ */
+export function setThemeAndRenderBlocks(
+  workspace: GoogleBlockly.Workspace,
+  theme: GoogleBlockly.Theme
+) {
+  if (theme && workspace?.rendered) {
+    const renderedWorkspace = workspace as GoogleBlockly.WorkspaceSvg;
+    const previousTheme = renderedWorkspace.getTheme();
+    renderedWorkspace.setTheme(theme);
+    // Re-render blocks if the font size changed.
+    // Once https://github.com/google/blockly/issues/7782 is resolved,
+    // we should be able to remove this.
+    if (theme.fontStyle?.size !== previousTheme.fontStyle?.size) {
+      renderedWorkspace.getAllBlocks().map(block => {
+        block.markDirty();
+        block.render();
+      });
+    }
+  }
+}

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -373,7 +373,8 @@ export function updateBlockEnabled(block: GoogleBlockly.Block) {
  */
 export function setThemeAndRenderBlocks(
   workspace: GoogleBlockly.Workspace,
-  theme: GoogleBlockly.Theme
+  theme: GoogleBlockly.Theme,
+  forceRender = false
 ) {
   if (theme && workspace?.rendered) {
     const renderedWorkspace = workspace as GoogleBlockly.WorkspaceSvg;
@@ -382,7 +383,10 @@ export function setThemeAndRenderBlocks(
     // Re-render blocks if the font size changed.
     // Once https://github.com/google/blockly/issues/7782 is resolved,
     // we should be able to remove this.
-    if (theme.fontStyle?.size !== previousTheme.fontStyle?.size) {
+    if (
+      forceRender ||
+      theme.fontStyle?.size !== previousTheme.fontStyle?.size
+    ) {
       renderedWorkspace.getAllBlocks().map(block => {
         block.markDirty();
         block.render();

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -382,7 +382,10 @@ export function setThemeAndRenderBlocks(
     // Re-render blocks if the font size changed.
     // Once https://github.com/google/blockly/issues/7782 is resolved,
     // we should be able to remove this.
-    if (theme.fontStyle?.size !== previousTheme.fontStyle?.size) {
+    if (
+      !previousTheme.fontStyle?.size ||
+      theme.fontStyle?.size !== previousTheme.fontStyle?.size
+    ) {
       renderedWorkspace.getAllBlocks().map(block => {
         block.markDirty();
         block.render();

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -382,10 +382,7 @@ export function setThemeAndRenderBlocks(
     // Re-render blocks if the font size changed.
     // Once https://github.com/google/blockly/issues/7782 is resolved,
     // we should be able to remove this.
-    if (
-      !previousTheme.fontStyle?.size ||
-      theme.fontStyle?.size !== previousTheme.fontStyle?.size
-    ) {
+    if (theme.fontStyle?.size !== previousTheme.fontStyle?.size) {
       renderedWorkspace.getAllBlocks().map(block => {
         block.markDirty();
         block.render();

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -163,31 +163,81 @@ export default class UserPreferences extends Record({userId: 'me'}) {
     }
   }
 
-  async getGlobalTheme(errorCallback) {
+  /**
+   * Fetches all user theme settings (e.g., global, blockly).
+   * @param {function} [errorCallback]
+   */
+  async getThemeSettings(errorCallback) {
     try {
       const themeResponse = await HttpClient.fetchJson(
         '/user_preference/theme'
       );
-      return themeResponse.value?.theme?.global;
+      return themeResponse.value?.theme;
     } catch (error) {
       // Don't call the error callback if 'Not found', as it just means the
       // user has not set a theme yet.
-      if (error.response.status !== 404) {
-        errorCallback(error);
+      if (error?.response?.status !== 404) {
+        return errorCallback(error) ?? null;
       }
       return null;
     }
   }
 
-  async setGlobalTheme(theme) {
-    const body = {
-      theme: {
-        global: theme,
-      },
-    };
+  /**
+   * Fetches the user's global theme preference.
+   * @param {function} [errorCallback]
+   */
+  async getGlobalTheme(errorCallback) {
+    const theme = await this.getThemeSettings(errorCallback);
+    return theme?.global ?? null;
+  }
 
-    return HttpClient.put('/user_preference', JSON.stringify(body), true, {
-      'Content-Type': 'application/json',
-    });
+  /**
+   * Retrieves the user's Blockly theme preference.
+   * @param {function} [errorCallback]
+   */
+  async getBlocklyTheme(errorCallback) {
+    const theme = await this.getThemeSettings(errorCallback);
+    return theme?.blockly ?? null;
+  }
+
+  /**
+   * Sends new theme settings to the server.
+   * The server automatically merges them with any existing theme preferences.
+   *
+   * @param {Object} themeUpdate - A partial theme object to update (e.g., {global: 'Dark'}).
+   * @param {function} [errorCallback]
+   */
+  async updateThemeSettings(themeUpdate, errorCallback) {
+    try {
+      return await HttpClient.put(
+        '/user_preference',
+        JSON.stringify({theme: themeUpdate}),
+        true,
+        {'Content-Type': 'application/json'}
+      );
+    } catch (error) {
+      if (errorCallback) {
+        errorCallback(error);
+      }
+    }
+  }
+
+  /**
+   * Sets the user's global theme preference.
+   * @param {string} globalTheme - The name of the global theme to set (e.g., 'Dark').
+   */
+  async setGlobalTheme(globalTheme) {
+    return this.updateThemeSettings({global: globalTheme});
+  }
+
+  /**
+   * Sets the user's Blockly theme preference.
+   *
+   * @param {string} blocklyTheme - The name of the Blockly theme to set (e.g., 'cdodeutranopia').
+   * @param {function} [errorCallback] - Optional callback for handling errors, such as for signed out users.
+   */
+  async setBlocklyTheme(blocklyTheme, errorCallback) {
+    return this.updateThemeSettings({blockly: blocklyTheme}, errorCallback);
   }
 }

--- a/dashboard/test/controllers/user_preferences_controller_test.rb
+++ b/dashboard/test/controllers/user_preferences_controller_test.rb
@@ -97,11 +97,11 @@ class UserPreferencesControllerTest < ActionController::TestCase
     preference = UserPreference.create!(user_id: @user.id, theme: initial_theme)
 
     new_theme = {
-      'Blockly' => 'cdohighcontrast'
+      'blockly' => 'cdohighcontrast'
     }
     merged_theme = {
       'global'=> 'Dark',
-      'Blockly' => 'cdohighcontrast'
+      'blockly' => 'cdohighcontrast'
     }
 
     assert_no_difference 'UserPreference.count' do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67190
Redo of https://github.com/code-dot-org/code-dot-org/pull/66988

The first attempt caused unexpected eyes diffs where the blocks in embedded workspaces were not themed. @molly-moen  verified that by reverting the blocks are styled again. [Example failure](https://eyes.applitools.com/app/test-results/00000251649518505838/00000251649518444281/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor)

I attempted a few things here, but the changes between the original branch and this redo can be summarized here:
https://github.com/code-dot-org/code-dot-org/pull/67201/files/c798332487c0ce7b097bc7a8d97cd01ade5617f0..e47727256eb0093c10d8db585093074152d1136b

Essentially, we got into a state where embedded workspaces had Blockly's default 'classic' theme because we were no longer providing one when the workspace is created. Now, we will not consider that a supported theme and use on our safe 'modern' defaults.