### PR TITLE
feat(workshops): render markdown for ws description notes

### DIFF
--- a/apps/src/code-studio/pd/workshops/components/WorkshopDetails.tsx
+++ b/apps/src/code-studio/pd/workshops/components/WorkshopDetails.tsx
@@ -1,6 +1,6 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Tags from '@code-dot-org/component-library/tags';
-import {
+import Typography, {
   Heading2,
   Heading3,
   BodyTwoText,
@@ -11,6 +11,7 @@ import React from 'react';
 
 import {DATA_SHARING_NOTICE} from '@cdo/apps/code-studio/pd/constants';
 import {WorkshopInfo} from '@cdo/apps/code-studio/pd/workshops/types';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
 import WorkshopFacilitatorsList from './WorkshopFacilitatorsList';
 import WorkshopSessionsList from './WorkshsopSessionsList';
@@ -76,13 +77,17 @@ const WorkshopDetails: React.FC<WorkshopDetailsProps> = ({
 
       <section className={moduleStyles.workshopDetailsItem}>
         <Heading3 visualAppearance={'heading-xs'}>Description:</Heading3>
-        <BodyTwoText>{description}</BodyTwoText>
+        <Typography semanticTag="div" visualAppearance="body-two">
+          <SafeMarkdown unwrapped markdown={description} />
+        </Typography>
       </section>
 
       {notes && (
         <section className={moduleStyles.workshopDetailsItem}>
           <Heading3 visualAppearance={'heading-xs'}>Attendee Notes:</Heading3>
-          <BodyTwoText>{notes}</BodyTwoText>
+          <Typography semanticTag="div" visualAppearance="body-two">
+            <SafeMarkdown unwrapped markdown={notes} />
+          </Typography>
         </section>
       )}
 

--- a/apps/src/code-studio/pd/workshops/workshopMarketingPage.module.scss
+++ b/apps/src/code-studio/pd/workshops/workshopMarketingPage.module.scss
@@ -90,6 +90,10 @@ $mobile-padding: 4rem 1.5rem;
               max-width: unset;
             }
           }
+
+          li {
+            margin: 0;
+          }
         }
       }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This adds `SafeMarkdown` to the workshop details component to render the workshop description and notes fields. it uses the Typography wrapper to apply body-two text style.

<img width="1251" height="141" alt="Screenshot 2025-07-21 at 1 32 43 PM" src="https://github.com/user-attachments/assets/5e4df234-e8f1-4543-9571-67bab4838ddb" />

<img width="1258" height="217" alt="Screenshot 2025-07-21 at 1 32 59 PM" src="https://github.com/user-attachments/assets/ddd6cec3-551a-4d2a-b088-80b793e758c3" />

<img width="1688" height="1273" alt="Screenshot 2025-07-21 at 1 29 36 PM" src="https://github.com/user-attachments/assets/87010275-9458-491b-be1d-de574cbbd830" />

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3396

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
