### PR TITLE
feat(marketing): add CSforAll theme support for Divider

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/Divider.tsx
@@ -1,4 +1,5 @@
 import MUIDivider from '@mui/material/Divider';
+import classNames from 'classnames';
 import React, {HTMLAttributes} from 'react';
 
 import type {SpacingProps} from '@/components/common/types';
@@ -12,26 +13,6 @@ export type DividerProps = HTMLAttributes<HTMLElement> & {
   className?: string;
 };
 
-// Map SpacingProps keys to MUI spacing values
-const spacingMap: Record<keyof SpacingProps, number> = {
-  none: 0, // 0px
-  xs: 1, // 8px
-  s: 2, // 16px
-  m: 4, // 32px
-  l: 8, // 64px
-};
-
-// Get the color value based on the provided color prop
-const getColorValue = (color: DividerProps['color']) => {
-  switch (color) {
-    case 'strong':
-      return 'var(--background-neutral-senary)'; // TODO: Replace with MUI theme color
-    case 'primary':
-    default:
-      return 'var(--background-neutral-quaternary)'; // TODO: Replace with MUI theme color
-  }
-};
-
 const Divider: React.FC<DividerProps> = ({
   color = 'primary',
   margin = 'm',
@@ -39,14 +20,13 @@ const Divider: React.FC<DividerProps> = ({
 }) => {
   return (
     <MUIDivider
-      className={className}
+      className={classNames(
+        `divider--color-${color}`,
+        `divider--margin-${margin}`,
+        className,
+      )}
       orientation="horizontal"
       variant="fullWidth"
-      sx={theme => ({
-        marginTop: theme.spacing(spacingMap[margin]),
-        marginBottom: theme.spacing(spacingMap[margin]),
-        backgroundColor: getColorValue(color),
-      })}
       flexItem
     />
   );

--- a/frontend/apps/marketing/src/components/contentful/divider/__tests__/Divider.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/divider/__tests__/Divider.test.tsx
@@ -1,7 +1,5 @@
 import {render, screen} from '@testing-library/react';
 
-import {SpacingProps} from '@/components/common/types';
-
 import Divider, {DividerProps} from '../Divider';
 
 describe('Divider Component', () => {
@@ -10,21 +8,10 @@ describe('Divider Component', () => {
     expect(screen.getByRole('separator')).toBeInTheDocument();
   });
 
-  describe('renders margin based on margin prop', () => {
-    const marginTestCases = [
-      {margin: 'none', expected: 'margin: 0px 0px 0px 0px'},
-      {margin: 'xs', expected: 'margin: 8px 0px 8px 0px'},
-      {margin: 's', expected: 'margin: 16px 0px 16px 0px'},
-      {margin: 'm', expected: 'margin: 32px 0px 32px 0px'},
-      {margin: 'l', expected: 'margin: 64px 0px 64px 0px'},
-    ];
-
-    marginTestCases.forEach(({margin, expected}) => {
-      it(`applies ${margin} margin correctly`, () => {
-        render(<Divider margin={margin as keyof SpacingProps} />);
-        expect(screen.getByRole('separator')).toHaveStyle(expected);
-      });
-    });
+  it('applies the correct margin class based on the margin prop', () => {
+    render(<Divider margin="l" />);
+    const separator = screen.getByRole('separator');
+    expect(separator).toHaveClass('divider--margin-l');
   });
 
   describe('renders color based on color prop', () => {

--- a/frontend/apps/marketing/src/components/contentful/divider/dividerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/divider/dividerContentfulDefinition.ts
@@ -24,7 +24,11 @@ export const DividerContentfulComponentDefinition: ComponentDefinition = {
       validations: {
         in: [
           {value: 'primary', displayName: 'Primary'},
-          {value: 'strong', displayName: 'Strong'},
+          // This value is `strong` in existing usage of this component on Code.org,
+          // but a Secondary displayName label is more generic for different themes.
+          // Keeping the value as `strong` so it can be used in existing components
+          // without breaking, but the dropdown will say "Secondary" on all sites.
+          {value: 'strong', displayName: 'Secondary'},
         ],
       },
     },

--- a/frontend/apps/marketing/src/themes/code.org/index.ts
+++ b/frontend/apps/marketing/src/themes/code.org/index.ts
@@ -27,10 +27,10 @@ const theme = createTheme({
       styleOverrides: {
         root: ({theme}) => ({
           ['&.MuiDivider-root.divider--color-primary']: {
-            backgroundColor: 'var(--background-neutral-quaternary)',
+            borderColor: 'var(--background-neutral-quaternary)',
           },
           ['&.MuiDivider-root.divider--color-strong']: {
-            backgroundColor: 'var(--background-neutral-senary)',
+            borderColor: 'var(--background-neutral-senary)',
           },
           ['&.MuiDivider-root.divider--margin-none']: {
             marginTop: 0,

--- a/frontend/apps/marketing/src/themes/code.org/index.ts
+++ b/frontend/apps/marketing/src/themes/code.org/index.ts
@@ -23,6 +23,38 @@ const theme = createTheme({
         },
       },
     },
+    MuiDivider: {
+      styleOverrides: {
+        root: ({theme}) => ({
+          ['&.MuiDivider-root.divider--color-primary']: {
+            backgroundColor: 'var(--background-neutral-quaternary)',
+          },
+          ['&.MuiDivider-root.divider--color-strong']: {
+            backgroundColor: 'var(--background-neutral-senary)',
+          },
+          ['&.MuiDivider-root.divider--margin-none']: {
+            marginTop: 0,
+            marginBottom: 0,
+          },
+          ['&.MuiDivider-root.divider--margin-xs']: {
+            marginTop: theme.spacing(1),
+            marginBottom: theme.spacing(1),
+          },
+          ['&.MuiDivider-root.divider--margin-s']: {
+            marginTop: theme.spacing(2),
+            marginBottom: theme.spacing(2),
+          },
+          ['&.MuiDivider-root.divider--margin-m']: {
+            marginTop: theme.spacing(4),
+            marginBottom: theme.spacing(4),
+          },
+          ['&.MuiDivider-root.divider--margin-l']: {
+            marginTop: theme.spacing(8),
+            marginBottom: theme.spacing(8),
+          },
+        }),
+      },
+    },
     MuiLink: {
       styleOverrides: {
         root: {

--- a/frontend/apps/marketing/src/themes/csforall/index.ts
+++ b/frontend/apps/marketing/src/themes/csforall/index.ts
@@ -1,16 +1,65 @@
 'use client';
 import {createTheme} from '@mui/material';
 
+const COLORS = {
+  black: '#15092C',
+};
+
 const theme = createTheme({
   cssVariables: true,
+  palette: {
+    primary: {
+      main: '#D401F2',
+    },
+    secondary: {
+      main: '#2C079F',
+    },
+    text: {
+      primary: COLORS.black,
+    },
+    divider: COLORS.black,
+  },
   components: {
     MuiButton: {
       styleOverrides: {
-        root: {
+        root: ({theme}) => ({
           ['&.MuiButton-contained.MuiButton-colorPrimary']: {
-            backgroundColor: '#15092c',
+            backgroundColor: theme.palette.primary.main,
           },
-        },
+        }),
+      },
+    },
+    MuiDivider: {
+      styleOverrides: {
+        root: ({theme}) => ({
+          ['&.MuiDivider-root.divider--color-primary']: {
+            borderColor: theme.palette.divider,
+          },
+          ['&.MuiDivider-root.divider--color-strong']: {
+            borderColor: theme.palette.divider,
+            borderStyle: 'dashed',
+          },
+          ['&.MuiDivider-root.divider--margin-none']: {
+            marginTop: 0,
+            marginBottom: 0,
+          },
+          ['&.MuiDivider-root.divider--margin-xs']: {
+            marginTop: theme.spacing(3),
+            marginBottom: theme.spacing(3),
+          },
+          ['&.MuiDivider-root.divider--margin-s']: {
+            marginTop: theme.spacing(5),
+            marginBottom: theme.spacing(5),
+          },
+          ['&.MuiDivider-root.divider--margin-m']: {
+            marginTop: theme.spacing(7),
+            marginBottom: theme.spacing(7),
+          },
+          ['&.MuiDivider-root.divider--margin-l']: {
+            marginTop: theme.spacing(8),
+            marginBottom: theme.spacing(8),
+          },
+        }),
       },
     },
   },


### PR DESCRIPTION
Refactors the Divider component to work with both Code.org and CSforAll themes. I had to move the styling to the theme files using classes instead of inside the component.  

## Links
Jira ticket: [CMS-924](https://codedotorg.atlassian.net/browse/CMS-924)
Figma mock: [here](https://www.figma.com/design/tuDYegU9vzctJLnJeqJ5Mn/Theme-Exploration?node-id=168-2798&t=izs7Iqb345dHKgaY-1)

## Testing story
Updated unit tests, should have no Eyes diffs for Code.org.

----

## Code.org
<img width="1775" height="750" alt="Screenshot 2025-07-18 at 8 12 58 AM" src="https://github.com/user-attachments/assets/3c158427-7124-49ed-a54f-c73460863217" />


## CSforAll
<img width="1775" height="750" alt="Screenshot 2025-07-18 at 8 13 02 AM" src="https://github.com/user-attachments/assets/1a89e1e4-0daf-4022-8d45-266950f53fac" />
