### PR TITLE
Lab2: enable browser TTS if enabled on unit

### DIFF
--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -195,50 +195,38 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
         <div
           key={levelProperties.longInstructions}
           id="instructions-text"
-          className={classNames(moduleStyles.bubble)}
+          className={classNames(moduleStyles.bubble, moduleStyles.textContent)}
         >
+          <div className={moduleStyles.scrollingContent}>
+            <MainInstructionsContent
+              instructionsText={levelProperties.longInstructions}
+              handleInstructionsTextClick={handleInstructionsTextClick}
+            />
+            <PredictQuestion className={moduleStyles.predictQuestion} />
+          </div>
           {offerBrowserTts && (
-            <TextToSpeech
-              text={levelProperties.longInstructions}
-              higherPosition={!!bottomComponent}
+            <div className={moduleStyles.ttsContainer}>
+              <TextToSpeech text={levelProperties.longInstructions} />
+            </div>
+          )}
+          {validationSettings && (
+            <ValidationButton
+              onValidate={validationSettings.onValidate}
+              onStopValidation={validationSettings.onStopValidation}
+              isValidating={validationSettings.isValidating}
+              isValidateDisabled={validationSettings.isValidateDisabled}
             />
           )}
-          <div
-            id="instructions-text-content"
-            className={moduleStyles.textContent}
-          >
-            <div
-              className={
-                offerBrowserTts
-                  ? moduleStyles.scrollingContentWithTTS
-                  : moduleStyles.scrollingContentWithoutTTS
-              }
-            >
-              <MainInstructionsContent
-                instructionsText={levelProperties.longInstructions}
-                handleInstructionsTextClick={handleInstructionsTextClick}
-              />
-              <PredictQuestion className={moduleStyles.predictQuestion} />
+          {bottomComponent && (
+            <div className={moduleStyles.bottomComponent}>
+              {bottomComponent}
             </div>
-            {validationSettings && (
-              <ValidationButton
-                onValidate={validationSettings.onValidate}
-                onStopValidation={validationSettings.onStopValidation}
-                isValidating={validationSettings.isValidating}
-                isValidateDisabled={validationSettings.isValidateDisabled}
-              />
-            )}
-            {bottomComponent && (
-              <div className={moduleStyles.bottomComponent}>
-                {bottomComponent}
-              </div>
-            )}
-          </div>
+          )}
         </div>
         {validationResults && (
           <div className={moduleStyles.bubble}>
             <div className={moduleStyles.textContent}>
-              <div className={moduleStyles.scrollingContentWithoutTTS}>
+              <div className={moduleStyles.scrollingContent}>
                 <ValidationResults />
               </div>
             </div>

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -81,10 +81,16 @@
 }
 
 .textContent {
-  height: 100%;
+  overflow: hidden;
+  gap: 8px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+}
+
+.ttsContainer {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .bubbleNoSlide {
@@ -221,12 +227,7 @@
   min-height: 70px;
 }
 
-.scrollingContentWithTTS {
-  @extend %scrolling-content;
-  margin-bottom: 15px;
-}
-
-.scrollingContentWithoutTTS {
+.scrollingContent {
   @extend %scrolling-content;
 }
 

--- a/apps/src/lab2/views/components/Instructions/validation-results.module.scss
+++ b/apps/src/lab2/views/components/Instructions/validation-results.module.scss
@@ -42,12 +42,6 @@
   text-align: center;
 }
 
-// Using button to increase specificity of this class
-// (this allows it to take precedence over the component library button styles)
-button.validationButton {
-  margin-top: 8px;
-}
-
 .buttonInstruction {
   width: 100%;
   height: 32px;

--- a/apps/src/lab2/views/components/InstructionsPanel.tsx
+++ b/apps/src/lab2/views/components/InstructionsPanel.tsx
@@ -130,20 +130,11 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
               noTextAnimation && moduleStyles.noAnimation
             )}
           >
-            {offerBrowserTts && (
-              <TextToSpeech text={text} higherPosition={!!bottomComponent} />
-            )}
             <div
               id="instructions-text-content"
               className={moduleStyles.textContent}
             >
-              <div
-                className={
-                  offerBrowserTts
-                    ? moduleStyles.scrollingContentWithTTS
-                    : moduleStyles.scrollingContentWithoutTTS
-                }
-              >
+              <div className={moduleStyles.scrollingContent}>
                 <EnhancedSafeMarkdown
                   markdown={text}
                   className={moduleStyles.markdownText}
@@ -163,6 +154,11 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   </InstructorsOnly>
                 )}
               </div>
+              {offerBrowserTts && (
+                <div className={moduleStyles.ttsContainer}>
+                  <TextToSpeech text={text} />
+                </div>
+              )}
               {bottomComponent && (
                 <div className={moduleStyles.bottomComponent}>
                   {bottomComponent}

--- a/apps/src/lab2/views/components/TextToSpeech.module.scss
+++ b/apps/src/lab2/views/components/TextToSpeech.module.scss
@@ -2,18 +2,10 @@
 
 .playButton {
   @include remove-button-styles;
-  display: flex;
-  position: absolute;
-  bottom: 7px;
-  inset-inline-end: 7px;
   opacity: 35%;
   cursor: pointer;
   transition: opacity 0.2s ease;
   color: var(--text-neutral-primary);
-
-  &HigherPosition {
-    bottom: 58px;
-  }
 
   &Playing {
     opacity: 100%;

--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -12,7 +12,6 @@ import moduleStyles from './TextToSpeech.module.scss';
 
 interface TextToSpeechProps {
   text: string;
-  higherPosition?: boolean;
 }
 
 const usePause = queryParams('tts-play-pause') === 'true';
@@ -29,10 +28,7 @@ const ttsButtonEnabled =
 /**
  * TextToSpeech play button.
  */
-const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({
-  text,
-  higherPosition,
-}) => {
+const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
   const {isTtsAvailable, speak, cancel, pause, resume} =
     useBrowserTextToSpeech();
   const [isPlaying, setIsPlaying] = useState(false);
@@ -90,8 +86,7 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({
     <button
       className={classNames(
         moduleStyles.playButton,
-        isPlaying && moduleStyles.playButtonPlaying,
-        higherPosition && moduleStyles.playButtonHigherPosition
+        isPlaying && moduleStyles.playButtonPlaying
       )}
       onClick={playText}
       onKeyDown={handleKeyDown}

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -131,11 +131,18 @@
 }
 
 .textContent {
-  height: 100%;
+  overflow: hidden;
+  gap: 8px;
   padding: 15px 0 5px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+}
+
+.ttsContainer {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 10px;
 }
 
 %scrolling-content {
@@ -145,14 +152,8 @@
   padding: 0 10px;
 }
 
-.scrollingContentWithTTS {
+.scrollingContent {
   @extend %scrolling-content;
-  margin-bottom: 25px;
-}
-
-.scrollingContentWithoutTTS {
-  @extend %scrolling-content;
-  margin-bottom: 10px;
 }
 
 %message {

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -912,6 +912,8 @@ class Level < ApplicationRecord
     properties_camelized[:isAssessment] = script_level&.assessment
     properties_camelized[:progressionType] = script_level&.primm_progression_type
     properties_camelized[:enableBlocklyKeyboardNavigation] = script&.enable_blockly_keyboard_navigation
+    # Enable browser TTS if the script has TTS enabled, or if the level itself has it enabled.
+    properties_camelized[:offerBrowserTts] = offer_browser_tts || script&.tts
 
     if try(:project_template_level).try(:start_sources)
       properties_camelized['templateSources'] = try(:project_template_level).try(:start_sources)

--- a/dashboard/app/views/levels/editors/_aichat.html.haml
+++ b/dashboard/app/views/levels/editors/_aichat.html.haml
@@ -3,4 +3,5 @@
 = render partial: 'levels/editors/fields/starter_assets', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
+= render partial: 'levels/editors/fields/browser_tts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_pythonlab.html.haml
+++ b/dashboard/app/views/levels/editors/_pythonlab.html.haml
@@ -10,4 +10,5 @@
 = render partial: 'levels/editors/fields/skip_url', locals: {f: f}
 = render partial: 'levels/editors/fields/enable_micro_bit', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
+= render partial: 'levels/editors/fields/browser_tts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_browser_tts.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_browser_tts.html.haml
@@ -3,5 +3,6 @@
 
 #browser_tts_area.in.collapse
   // Only available on lab2 labs currently.
+  %strong NOTE: If this level is used in a unit that has TTS enabled, this will be automatically enabled regardless of this setting.
   = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :offer_browser_tts, description: "Enable Browser Text-to-Speech"} if @level.uses_lab2?
 

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -79,7 +79,7 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "should return level_properties" do
-    level = create :maze, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
+    level = create :maze, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other", offer_browser_tts: true}
 
     get :level_properties, params: {id: level}
     assert_response :success
@@ -101,7 +101,8 @@ class LevelsControllerTest < ActionController::TestCase
       "baseAssetUrl" => "/blockly/",
       "isAssessment" => nil,
       "progressionType" => nil,
-      "enableBlocklyKeyboardNavigation" => nil
+      "enableBlocklyKeyboardNavigation" => nil,
+      "offerBrowserTts" => true
     }
     assert_equal(expected_body, body)
   end

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -101,8 +101,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     AzureTextToSpeech.unstub(:get_voices)
   end
 
-  test "should return level_properties " do
-    script = create(:script, :in_single_unit_course)
+  test "should return level_properties" do
+    script = create(:script, :in_single_unit_course, tts: true)
     lesson_group = create(:lesson_group, script: script)
     lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :maze, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
@@ -130,6 +130,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal body["usesProjects"], false
     assert_equal body["exampleSolutions"], []
     assert_equal body["helpVideos"], []
+    assert_equal body["offerBrowserTts"], true
     assert_match Regexp.new("^/courses/bogus-single-unit-course-[0-9]+/units/1"), body["finishUrl"]
   end
 


### PR DESCRIPTION
For most of our units and legacy labs, TTS is enabled at the unit-level, which kicks off a process of creating pre-baked text-to-speech audio files that need to be updated whenever the level content changes. In Lab2 (specifically for the Music Lab Hour of Code tutorial in 2024), we piloted a much more [lightweight TTS solution](https://github.com/code-dot-org/code-dot-org/pull/60896) that uses the native browser TTS capability to read text directly off the screen, choosing a voice appropriate for the current locale.

This change now automatically enables browser TTS on Lab2 levels if the unit has TTS enabled, even if the specific `offerBrowserTts` property isn't set on the level.

Most of the changes here are actually just reworking the UI to properly render the TTS button in AI Chat and Python Lab (the existing styling clashed with some elements on the page). 

Before (TTS enabled without any styling fixes):
- Music Lab: <img width="1514" height="824" alt="Screenshot 2025-07-18 at 12 24 07 PM" src="https://github.com/user-attachments/assets/4fea8fe0-bf8f-466f-a98d-217ff46a36f8" />
- Music Lab with Exemplar player: <img width="1513" height="823" alt="Screenshot 2025-07-18 at 12 23 59 PM" src="https://github.com/user-attachments/assets/0a44c174-38a3-4e76-bdec-daaad168eb9c" />
- AI Chat: <img width="1513" height="826" alt="Screenshot 2025-07-18 at 12 23 51 PM" src="https://github.com/user-attachments/assets/be7df46e-175d-4d49-8fa8-b7a4623e68e6" />
- Python Lab: <img width="1516" height="825" alt="Screenshot 2025-07-18 at 12 23 44 PM" src="https://github.com/user-attachments/assets/df82e3ea-2f6a-4e50-840f-92bfa89e2329" />

After:
- Music Lab: <img width="1514" height="821" alt="Screenshot 2025-07-18 at 12 14 25 PM" src="https://github.com/user-attachments/assets/f6f281ca-0149-49a3-98c0-23fbddb82908" />
- Music Lab with Exemplar player: <img width="1513" height="823" alt="Screenshot 2025-07-18 at 12 14 35 PM" src="https://github.com/user-attachments/assets/354f8b60-0eed-4349-8469-9ded9b8dfc8c" />
- AI Chat: <img width="1512" height="825" alt="Screenshot 2025-07-18 at 12 14 43 PM" src="https://github.com/user-attachments/assets/992e15a4-35fd-478d-a0c7-326e132b77f9" />
- Python Lab: <img width="1512" height="826" alt="Screenshot 2025-07-18 at 12 15 14 PM" src="https://github.com/user-attachments/assets/0441b1a3-e161-4ffd-8071-44e2a7c0083e" />

## Links

https://codedotorg.atlassian.net/browse/LABS-1502

## Testing story

Tested locally with Music, AI Chat, Python Lab, and Panels levels in units that had TTS enabled.