### PR TITLE
feat(fonts): support multi-tenant font config

### DIFF
--- a/frontend/apps/design-system-storybook/.storybook/preview.js
+++ b/frontend/apps/design-system-storybook/.storybook/preview.js
@@ -2,7 +2,7 @@ import {default as RtlPreview} from 'storybook-addon-rtl/preview';
 
 import {loadFonts, injectFontAwesome} from '@code-dot-org/fonts';
 
-import '@code-dot-org/fonts/index.css';
+import '@code-dot-org/fonts/brands/code.org/index.css';
 import './preview.module.scss';
 
 injectFontAwesome();

--- a/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
@@ -17,7 +17,7 @@ import OneTrustLoader from '@/providers/onetrust/OneTrustLoader';
 import OneTrustProvider from '@/providers/onetrust/OneTrustProvider';
 import {generateBootstrapValues} from '@/providers/statsig/statsig-backend';
 import StatsigProvider from '@/providers/statsig/StatsigProvider';
-import {getMuiTheme} from '@/themes';
+import {getCriticalFonts, getMuiTheme} from '@/themes';
 
 export default async function Layout({
   children,
@@ -29,6 +29,7 @@ export default async function Layout({
   const syncParams = await params;
   const {brand, locale} = syncParams;
 
+  await getCriticalFonts(brand);
   const googleAnalyticsMeasurementId = getGoogleAnalyticsMeasurementId(brand);
   const statsigBootstrapValues = await generateBootstrapValues();
   const statsigClientKey = process.env.STATSIG_CLIENT_KEY;

--- a/frontend/apps/marketing/src/app/layout.tsx
+++ b/frontend/apps/marketing/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type {Metadata} from 'next';
 
 import '@code-dot-org/component-library-styles/colors.scss';
-import '@code-dot-org/fonts/index.css';
 
 import './globals.css';
 

--- a/frontend/apps/marketing/src/themes/code.org/critical-fonts.ts
+++ b/frontend/apps/marketing/src/themes/code.org/critical-fonts.ts
@@ -1,0 +1,4 @@
+/**
+ * Load critical fonts that must be available immediately here. For deferred (optional) fonts, use the FontLoader.
+ */
+import '@code-dot-org/fonts/brands/code.org/index.css';

--- a/frontend/apps/marketing/src/themes/code.org/index.ts
+++ b/frontend/apps/marketing/src/themes/code.org/index.ts
@@ -1,10 +1,12 @@
 'use client';
 import {createTheme} from '@mui/material';
 
+import {NOTO_FONT} from '@/themes/constants/fonts';
+
 const BARLOW_FONT = 'Barlow Semi Condensed Semibold';
 const FIGTREE_FONT = 'Figtree';
-const NOTO_FONT =
-  'Noto Sans, Noto Sans Math, Noto Sans Arabic, Noto Sans Armenian, Noto Sans Bengali, Noto Sans SC, Noto Sans TC, Noto Sans Devanagari, Noto Sans Georgian, Noto Sans Hebrew, Noto Sans JP, Noto Sans Kannada, Noto Sans Khmer, Noto Sans KR, Noto Sans Myanmar, Noto Sans Sinhala, Noto Sans Tamil, Noto Sans Telugu, Noto Sans Thai, Noto Sans Thaana';
+
+const HEADING_FONT = [BARLOW_FONT, NOTO_FONT, 'sans-serif'].join(', ');
 
 const theme = createTheme({
   cssVariables: true,
@@ -106,25 +108,25 @@ const theme = createTheme({
   typography: {
     fontFamily: [FIGTREE_FONT, NOTO_FONT, 'sans-serif'].join(', '),
     h1: {
-      fontFamily: [BARLOW_FONT, NOTO_FONT, 'sans-serif'].join(', '),
+      fontFamily: HEADING_FONT,
       fontSize: '3rem', // 48px
       fontWeight: 500,
       lineHeight: 1.16,
     },
     h2: {
-      fontFamily: [BARLOW_FONT, NOTO_FONT, 'sans-serif'].join(', '),
+      fontFamily: HEADING_FONT,
       fontSize: '2.125rem', // 34px
       fontWeight: 500,
       lineHeight: 1.24,
     },
     h3: {
-      fontFamily: [BARLOW_FONT, NOTO_FONT, 'sans-serif'].join(', '),
+      fontFamily: HEADING_FONT,
       fontSize: '1.75rem', // 28px
       fontWeight: 500,
       lineHeight: 1.28,
     },
     h4: {
-      fontFamily: [BARLOW_FONT, NOTO_FONT, 'sans-serif'].join(', '),
+      fontFamily: HEADING_FONT,
       fontSize: '1.5rem', // 24px
       fontWeight: 500,
       lineHeight: 1.32,

--- a/frontend/apps/marketing/src/themes/constants/fonts.ts
+++ b/frontend/apps/marketing/src/themes/constants/fonts.ts
@@ -1,0 +1,2 @@
+export const NOTO_FONT =
+  'Noto Sans, Noto Sans Math, Noto Sans Arabic, Noto Sans Armenian, Noto Sans Bengali, Noto Sans SC, Noto Sans TC, Noto Sans Devanagari, Noto Sans Georgian, Noto Sans Hebrew, Noto Sans JP, Noto Sans Kannada, Noto Sans Khmer, Noto Sans KR, Noto Sans Myanmar, Noto Sans Sinhala, Noto Sans Tamil, Noto Sans Telugu, Noto Sans Thai, Noto Sans Thaana';

--- a/frontend/apps/marketing/src/themes/csforall/critical-fonts.ts
+++ b/frontend/apps/marketing/src/themes/csforall/critical-fonts.ts
@@ -1,0 +1,1 @@
+import '@code-dot-org/fonts/brands/CSForAll/index.css';

--- a/frontend/apps/marketing/src/themes/csforall/index.ts
+++ b/frontend/apps/marketing/src/themes/csforall/index.ts
@@ -1,6 +1,8 @@
 'use client';
 import {createTheme} from '@mui/material';
 
+import {NOTO_FONT} from '@/themes/constants/fonts';
+
 const COLORS = {
   black: '#15092C',
 };
@@ -62,6 +64,9 @@ const theme = createTheme({
         }),
       },
     },
+  },
+  typography: {
+    fontFamily: ['Roboto Mono', 'Figtree', NOTO_FONT].join(','),
   },
 });
 

--- a/frontend/apps/marketing/src/themes/index.ts
+++ b/frontend/apps/marketing/src/themes/index.ts
@@ -12,3 +12,13 @@ export function getMuiTheme(brand: Brand) {
       return CDOTheme;
   }
 }
+
+export async function getCriticalFonts(brand: Brand) {
+  switch (brand) {
+    case Brand.CS_FOR_ALL:
+      return await import('@/themes/csforall/critical-fonts');
+    case Brand.CODE_DOT_ORG:
+    default:
+      return await import('@/themes/code.org/critical-fonts');
+  }
+}

--- a/frontend/packages/fonts/package.json
+++ b/frontend/packages/fonts/package.json
@@ -20,7 +20,7 @@
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     },
-    "./index.css": "./dist/index.css",
+    "./brands/*": "./dist/brands/*",
     "./locales/*": "./dist/locales/*",
     "./FontLoader": {
       "types": {
@@ -82,6 +82,7 @@
     "@fontsource/noto-sans-myanmar": "^5.1.1",
     "@fontsource/noto-sans-sc": "^5.1.1",
     "@fontsource/noto-sans-tc": "^5.1.1",
+    "@fontsource/roboto-mono": "^5.2.6",
     "eslint": "^9.16.0",
     "prettier": "3.4.2",
     "react": "^18.3.1",

--- a/frontend/packages/fonts/src/brands/CSForAll/index.scss
+++ b/frontend/packages/fonts/src/brands/CSForAll/index.scss
@@ -1,0 +1,3 @@
+@use '../../fonts/roboto-mono';
+@use '../../fonts/figtree';
+@use '../../fonts/noto-sans';

--- a/frontend/packages/fonts/src/brands/code.org/index.scss
+++ b/frontend/packages/fonts/src/brands/code.org/index.scss
@@ -1,0 +1,3 @@
+@use '../../fonts/figtree';
+@use '../../fonts/noto-sans';
+@use '../../fonts/barlow';

--- a/frontend/packages/fonts/src/constants.ts
+++ b/frontend/packages/fonts/src/constants.ts
@@ -40,6 +40,35 @@ export const LOCALES_WITH_INTERNATIONAL_FONTS = [
 export type InternationalFontLocale =
   (typeof LOCALES_WITH_INTERNATIONAL_FONTS)[number];
 
+export const FALLBACK_FONT_FAMILIES_BY_LOCALE: {
+  [locale in InternationalFontLocale]: string[];
+} = {
+  'ar-SA': ['Noto Sans Arabic'],
+  'fa-AF': ['Noto Sans Arabic'],
+  'fa-IR': ['Noto Sans Arabic'],
+  'ps-AF': ['Noto Sans Arabic'],
+  'ur-PK': ['Noto Sans Arabic'],
+  'bn-BD': ['Noto Sans Bengali'],
+  'dv-MV': ['Noto Sans Thaana'],
+  'he-IL': ['Noto Sans Hebrew'],
+  'hi-IN': ['Noto Sans Devanagari'],
+  'mr-IN': ['Noto Sans Devanagari'],
+  'ne-NP': ['Noto Sans Devanagari'],
+  'hy-AM': ['Noto Sans Armenian'],
+  'ja-JP': ['Noto Sans JP'],
+  'ka-GE': ['Noto Sans Georgian'],
+  'kn-IN': ['Noto Sans Kannada'],
+  'km-KH': ['Noto Sans Khmer'],
+  'ko-KR': ['Noto Sans KR'],
+  'my-MM': ['Noto Sans Myanmar'],
+  'si-LK': ['Noto Sans Sinhala'],
+  'ta-IN': ['Noto Sans Tamil'],
+  'te-IN': ['Noto Sans Telugu'],
+  'th-TH': ['Noto Sans Thai'],
+  'zh-CN': ['Noto Sans SC'],
+  'zh-TW': ['Noto Sans TC'],
+};
+
 /**
  * Uses the document.fonts API to load fonts via the defined font face.
  * Promise resolves when all Code.org fonts are resolved and the DOM is noted as ready.

--- a/frontend/packages/fonts/src/fonts/roboto-mono.scss
+++ b/frontend/packages/fonts/src/fonts/roboto-mono.scss
@@ -1,0 +1,2 @@
+@use '@fontsource/roboto-mono/scss/mixins' as RobotoMono;
+@include RobotoMono.faces($family: 'Roboto Mono');

--- a/frontend/packages/fonts/src/index.scss
+++ b/frontend/packages/fonts/src/index.scss
@@ -1,3 +1,0 @@
-@use './fonts/figtree';
-@use './fonts/noto-sans';
-@use './fonts/barlow';

--- a/frontend/packages/fonts/src/resolver/getFontByLocale.ts
+++ b/frontend/packages/fonts/src/resolver/getFontByLocale.ts
@@ -1,4 +1,7 @@
-import {InternationalFontLocale} from '@/constants';
+import {
+  FALLBACK_FONT_FAMILIES_BY_LOCALE,
+  InternationalFontLocale,
+} from '@/constants';
 
 export function getFontByLocale(locale: InternationalFontLocale) {
   switch (locale) {
@@ -54,4 +57,11 @@ export function getFontByLocale(locale: InternationalFontLocale) {
       // Return false if there are no fallback locales
       return Promise.resolve(false);
   }
+}
+
+export function getFallbackFontFamilyByLocale(
+  locale: InternationalFontLocale,
+): string[] {
+  console.log('locale: ', locale);
+  return FALLBACK_FONT_FAMILIES_BY_LOCALE[locale] ?? [];
 }

--- a/frontend/packages/fonts/tsup.config.ts
+++ b/frontend/packages/fonts/tsup.config.ts
@@ -100,11 +100,11 @@ const cssEntrypointsByLocale = createLocaleCSSConfig(
 );
 
 /**
- * The default fonts for Code.org as an entrypoint
+ * The default fonts for various brands as an entrypoint
  */
 const defaultCSSEntrypoints = createLocaleCSSConfig(
-  ['./src/index.scss'],
-  'dist',
+  ['./src/brands/**/index.scss'],
+  'dist/brands',
 );
 
 export default defineConfig([

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1133,6 +1133,7 @@ __metadata:
     "@fontsource/noto-sans-myanmar": "npm:^5.1.1"
     "@fontsource/noto-sans-sc": "npm:^5.1.1"
     "@fontsource/noto-sans-tc": "npm:^5.1.1"
+    "@fontsource/roboto-mono": "npm:^5.2.6"
     eslint: "npm:^9.16.0"
     prettier: "npm:3.4.2"
     react: "npm:^18.3.1"
@@ -2639,6 +2640,13 @@ __metadata:
   version: 5.1.1
   resolution: "@fontsource/noto-sans-tc@npm:5.1.1"
   checksum: 10c0/78657cf4c08cfdb311d94e6558d51df3d6042cc1dde625fd6c6b5e5975c7b27e7fd3933b1d14c3a335f5e6f33f39a6cba015732bedb4b1d58f3d55d451bd306e
+  languageName: node
+  linkType: hard
+
+"@fontsource/roboto-mono@npm:^5.2.6":
+  version: 5.2.6
+  resolution: "@fontsource/roboto-mono@npm:5.2.6"
+  checksum: 10c0/a0ac77aacdce5b5fa4a1a4cdb364615e52a208040d5cfdf0537fcf9d84fd3130b7321e627969948430cc557599f4bdd89e38cd7ceaf13cf429b108f697c6a72e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the ability to have different font configs per tenant. For CSForAll, the main font is Roboto Mono with headings as Figtree.

This PR also adds Roboto Mono to the fonts package.

<img width="890" height="1245" alt="Screenshot From 2025-07-18 13-35-40" src="https://github.com/user-attachments/assets/19d06b80-e571-45f5-a767-6e2562ad054c" />
