### PR TITLE
fix(cloudfront): add back cloudfront distribution export

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -756,8 +756,4 @@ Outputs:
     Description: Fully qualified domain name of the marketing site
     Value: !Sub "${SubdomainName}.${BaseDomainName}"
   CloudFrontDistributionId:
-    Value:
-      Ref: CloudFrontDistribution
-    Export:
-      Name:
-        'Fn::Sub': '${AWS::StackName}-CloudFrontDistributionId'
+    Value: !Ref CloudFrontDistribution

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -755,3 +755,9 @@ Outputs:
   SiteDomainName:
     Description: Fully qualified domain name of the marketing site
     Value: !Sub "${SubdomainName}.${BaseDomainName}"
+  CloudFrontDistributionId:
+    Value:
+      Ref: CloudFrontDistribution
+    Export:
+      Name:
+        'Fn::Sub': '${AWS::StackName}-CloudFrontDistributionId'


### PR DESCRIPTION
The `CloudFrontDistribution` is used by the Github Action deploy workflow to invalidate the cache.

Tested in this [workflow](https://github.com/code-dot-org/code-dot-org/actions/runs/16388372816/job/46311025352) and it appears to work to fully deploy the app.
