### PR TITLE
fix: use levelbuilder studio url

### DIFF
--- a/frontend/apps/marketing/src/config/__tests__/studio.test.ts
+++ b/frontend/apps/marketing/src/config/__tests__/studio.test.ts
@@ -31,6 +31,37 @@ describe('getStudioBaseUrl', () => {
     (getStage as jest.Mock).mockReturnValue('unknown');
     expect(getStudioBaseUrl()).toBe('https://studio.code.org');
   });
+
+  describe('levelbuilder special case', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let originalWindow: any;
+    beforeEach(() => {
+      originalWindow = global.window;
+    });
+    afterEach(() => {
+      if (originalWindow === undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (global as any).window;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (global as any).window = originalWindow;
+      }
+    });
+
+    it('should return the levelbuilder studio URL when in browser and hostname is levelbuilder.code.org', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).window = {location: {hostname: 'levelbuilder.code.org'}};
+      expect(getStudioBaseUrl()).toBe('https://levelbuilder-studio.code.org');
+    });
+
+    it('should not throw and should return correct URL when window is undefined (SSR)', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (global as any).window;
+      (getStage as jest.Mock).mockReturnValue('production');
+      expect(() => getStudioBaseUrl()).not.toThrow();
+      expect(getStudioBaseUrl()).toBe('https://studio.code.org');
+    });
+  });
 });
 
 describe('getStudioUrl', () => {

--- a/frontend/apps/marketing/src/config/studio.ts
+++ b/frontend/apps/marketing/src/config/studio.ts
@@ -1,6 +1,13 @@
 import {getStage} from './stage';
 
 export function getStudioBaseUrl() {
+  if (
+    typeof window !== 'undefined' &&
+    window.location.hostname === 'levelbuilder.code.org'
+  ) {
+    return 'https://levelbuilder-studio.code.org';
+  }
+
   switch (getStage()) {
     case 'development':
     case 'pr':


### PR DESCRIPTION
When accessing the alias website, `levelbuilder.code.org`, the studio URL should be `levelbuilder-studio.code.org`.

Context on slack: https://codedotorg.slack.com/archives/C03CK49G9/p1751401403757659