### PR TITLE
feat(ui-tests): shard by browser

### DIFF
--- a/.github/actions/frontend/marketing/ui-tests/action.yml
+++ b/.github/actions/frontend/marketing/ui-tests/action.yml
@@ -68,7 +68,7 @@ runs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
-        name: blob-report-${{ matrix.shardIndex }}
+        name: blob-report-${{ inputs.SHARD_INDEX }}
         path: frontend/apps/marketing/blob-report
         retention-days: 1
 

--- a/.github/actions/frontend/marketing/ui-tests/action.yml
+++ b/.github/actions/frontend/marketing/ui-tests/action.yml
@@ -17,6 +17,12 @@ inputs:
   ENVIRONMENT_TYPE:
     description: "local, pr, test, or production"
     required: true
+  SHARD_INDEX:
+    description: "The shard index to use for the tests."
+    required: true
+  SHARD_TOTAL:
+    description: "The total number of shards to use for the tests."
+    required: true
   GITHUB_ENVIRONMENT_NAME:
     description: "The name of the GitHub environment to use for this action"
     required: false
@@ -55,19 +61,21 @@ runs:
           -v $PWD:/workspace \
           -w /workspace/frontend \
           mcr.microsoft.com/playwright:v1.49.1-noble \
-          bash -c "corepack enable && HOME=/root yarn workspace @code-dot-org/marketing test:ui:ci"
+          bash -c "corepack enable && HOME=/root yarn workspace @code-dot-org/marketing test:ui:ci --shard ${{ inputs.SHARD_INDEX }}/${{ inputs.SHARD_TOTAL }}"
       working-directory: ./frontend
 
-    - name: Upload Playwright reports
-      if: failure()
-      id: deployment
-      uses: actions/upload-pages-artifact@v3
+    - name: Upload shard blob report to GitHub Actions Artifacts
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
       with:
-        path: frontend/apps/marketing/playwright-report
-        name: playwright-report
+        name: blob-report-${{ matrix.shardIndex }}
+        path: frontend/apps/marketing/blob-report
+        retention-days: 1
 
     - name: Run Google Lighthouse Audits
       uses: treosh/lighthouse-ci-action@9917efea514615fb2ff2890f5b8be2d51e703b6e
+      # Only run lighthouse audits once
+      if: inputs.SHARD_INDEX == 1
       env:
         HTTP_PROTOCOL: ${{ inputs.APPLICATION_BASE_ADDRESS == 'code.marketing-sites.localhost:3001' && 'http' || 'https' }}
       with:

--- a/.github/actions/frontend/marketing/ui-tests/action.yml
+++ b/.github/actions/frontend/marketing/ui-tests/action.yml
@@ -75,7 +75,7 @@ runs:
     - name: Run Google Lighthouse Audits
       uses: treosh/lighthouse-ci-action@9917efea514615fb2ff2890f5b8be2d51e703b6e
       # Only run lighthouse audits once
-      if: inputs.SHARD_INDEX == 1
+      if: inputs.SHARD_INDEX == '1'
       env:
         HTTP_PROTOCOL: ${{ inputs.APPLICATION_BASE_ADDRESS == 'code.marketing-sites.localhost:3001' && 'http' || 'https' }}
       with:

--- a/.github/actions/frontend/merge-playwright-reports/action.yml
+++ b/.github/actions/frontend/merge-playwright-reports/action.yml
@@ -1,0 +1,26 @@
+name: "Merge Playwright Test Reports"
+description: "Merges playwright test reports from multiple shards into one single report"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Frontend
+      uses: ./.github/actions/frontend/setup
+
+    - name: Download blob reports from GitHub Actions Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: all-blob-reports
+        pattern: blob-report-*
+        merge-multiple: true
+
+    - name: Merge into HTML Report
+      shell: bash
+      run: yarn dlx playwright merge-reports --reporter html ./all-blob-reports
+
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-report--attempt-${{ github.run_attempt }}
+        path: playwright-report
+        retention-days: 1

--- a/.github/actions/frontend/setup/action.yml
+++ b/.github/actions/frontend/setup/action.yml
@@ -1,6 +1,12 @@
 name: "Install & Setup Frontend Directory"
 description: "Setup for the frontend directory"
 
+inputs:
+  INSTALL_DEPENDENCIES:
+    description: "Whether to install dependencies. Defaults to true"
+    default: "true"
+    required: false
+
 runs:
   using: composite
   steps:
@@ -12,12 +18,14 @@ runs:
       uses: rharkor/caching-for-turbo@a1c4079258ae08389be75b57d4d7a70f23c1c66d # v1.8
 
     - uses: actions/setup-node@v4
+      if: inputs.INSTALL_DEPENDENCIES == 'true'
       with:
         node-version-file: ".nvmrc"
         cache: "yarn"
         cache-dependency-path: 'frontend/yarn.lock'
 
     - name: Install dependencies
+      if: inputs.INSTALL_DEPENDENCIES == 'true'
       shell: bash
       run: yarn install
       working-directory: ./frontend

--- a/.github/workflows/marketing-app-ci.yml
+++ b/.github/workflows/marketing-app-ci.yml
@@ -19,26 +19,8 @@ defaults:
     working-directory: ./frontend
 
 jobs:
-  build:
-    runs-on: ubuntu-24.04
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-          sparse-checkout: |
-            frontend
-            .github
-
-      - name: Setup Frontend
-        uses: ./.github/actions/frontend/setup
-
-      - name: Build
-        run: yarn build --filter @code-dot-org/marketing
-
   dryrun-release:
     runs-on: ubuntu-24.04
-    needs: build
 
     steps:
       - uses: actions/checkout@v4
@@ -54,10 +36,10 @@ jobs:
       - name: Dryrun Release
         run: yarn release:dryrun --filter @code-dot-org/marketing
 
-  ui-tests:
+  build-docker:
+    # Skip CI docker build if this is not a pull request.
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-24.04
-    needs: build
 
     steps:
       - uses: actions/checkout@v4
@@ -69,9 +51,8 @@ jobs:
 
       - name: Setup Frontend
         uses: ./.github/actions/frontend/setup
-
-      - name: Build
-        run: yarn build --filter @code-dot-org/marketing
+        with:
+          INSTALL_DEPENDENCIES: false # We don't need to install dependencies for the Docker build.
 
       - name: Build Docker image
         id: build-docker-image
@@ -87,6 +68,54 @@ jobs:
             TURBO_TEAM=${{ vars.TURBO_REPO_TEAM }}
             TURBO_TOKEN=${{ secrets.TURBO_REPO_TOKEN }}
             TURBO_API=${{ vars.TURBO_REPO_API }}
+
+      - name: Save Docker Image to Artifacts
+        run: docker save marketing:test | zstd -T0 > marketing-test-${{ github.run_id }}.tar.zst
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          compression: 0
+          name: marketing-test-${{ github.run_id }}.tar.zst
+          path: frontend/marketing-test-${{ github.run_id }}.tar.zst
+
+  ui-tests:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-24.04
+    needs: build-docker
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        # shardTotal is used to determine how many shards there are in total.
+        shardTotal: [4]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          sparse-checkout: |
+            frontend
+            .github
+
+      - name: Setup Frontend
+        uses: ./.github/actions/frontend/setup
+
+      - name: Build
+        run: yarn build --filter @code-dot-org/marketing
+
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: marketing-test-${{ github.run_id }}.tar.zst
+          path: frontend
+
+      - name: Extract Docker image artifact
+        run: zstd -d marketing-test-${{ github.run_id }}.tar.zst
+
+      - name: Load Docker image
+        run: docker load -i marketing-test-${{ github.run_id }}.tar
 
       - name: Prepare Test Environment
         shell: bash
@@ -112,10 +141,6 @@ jobs:
           # Tail the docker logs
           docker logs -f marketing &
 
-      - name: Clean unused docker build artifacts
-        run: |
-          docker system prune --all --force
-
       - name: UI Tests
         uses: ./.github/actions/frontend/marketing/ui-tests
         with:
@@ -126,3 +151,22 @@ jobs:
           DRAFT_MODE_TOKEN: ci-draft-mode
           BRANCHED_TESTING_ENABLED: ${{ inputs.BRANCHED_TESTING_ENABLED }}
           PR_HEAD_REF: ${{ inputs.PR_HEAD_REF }}
+          SHARD_INDEX: ${{ matrix.shardIndex }}
+          SHARD_TOTAL: ${{ matrix.shardTotal }}
+
+  merge-reports:
+    # Merge reports after playwright-tests, even if some shards have failed
+    if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+    needs: [ ui-tests ]
+
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          sparse-checkout: |
+            frontend
+            .github
+
+      - name: Merge Playwright Reports
+        uses: ./.github/actions/frontend/merge-playwright-reports

--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -124,12 +124,19 @@ jobs:
             --distribution-id $CLOUDFRONT_DISTRIBUTION_ID \
             --paths "/*"
 
-  tests:
+  ui-tests:
     runs-on: ubuntu-24.04
     environment: marketing-sites-${{ inputs.ENVIRONMENT_TYPE }}-${{ inputs.SITE_TYPE }}
     if: ${{ inputs.SITE_TYPE == 'corporate' }}
     needs:
       - deploy
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        # shardTotal is used to determine how many shards there are in total.
+        shardTotal: [4]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -155,3 +162,20 @@ jobs:
           APPLICATION_BASE_ADDRESS: "${{ vars.APPLICATION_SUBDOMAIN_NAME }}.${{ vars.APPLICATION_BASE_DOMAIN }}"
           DRAFT_MODE_TOKEN: ${{ secrets.DRAFT_MODE_TOKEN }}
           GITHUB_ENVIRONMENT_NAME: ${{ env.GITHUB_ENVIRONMENT_NAME }}
+          SHARD_INDEX: ${{ matrix.shardIndex }}
+          SHARD_TOTAL: ${{ matrix.shardTotal }}
+
+  merge-reports:
+    needs: [ ui-tests ]
+
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          sparse-checkout: |
+            frontend
+            .github
+
+      - name: Merge Playwright Reports
+        uses: ./.github/actions/frontend/merge-playwright-reports

--- a/.github/workflows/marketing-app-deploy.yml
+++ b/.github/workflows/marketing-app-deploy.yml
@@ -37,7 +37,6 @@ jobs:
   # This job builds a docker image for the frontend repository and pushes the docker image to Github Packages.
   # More information: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
   build-and-push-image:
-    needs: ci
     runs-on: ubuntu-24.04
 
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
@@ -107,7 +106,9 @@ jobs:
 
   # Deploy test environments in parallel
   deploy-test:
-    needs: build-and-push-image
+    needs:
+      - ci
+      - build-and-push-image
     uses: ./.github/workflows/marketing-app-deploy-to-environment.yml
     secrets: inherit
     # Do not allow other deployments to deploy while this deployment is in progress.
@@ -126,6 +127,7 @@ jobs:
   # Deploy production environments in parallel, after test environments completes successfully
   deploy-production:
     needs:
+      - ci
       - build-and-push-image
       - deploy-test
     uses: ./.github/workflows/marketing-app-deploy-to-environment.yml

--- a/frontend/apps/marketing/playwright.config.ts
+++ b/frontend/apps/marketing/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig<EyesFixture>({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? '75%' : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: '@applitools/eyes-playwright/reporter',
+  reporter: process.env.CI ? 'blob' : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
This PR shards UI tests by browser to cut test times by a third. UI tests currently takes approximately 28 minutes to run and continues to increase linearly. This PR addresses this issue by parallelizing tests using the [Playwright Sharding](https://playwright.dev/docs/test-sharding) mechanism which allows for horizontal scaling of the tests. 

Ths brings the approximate time to run down to about 10 minutes.

**Note**: Currently the tests are bottlenecked on Eyes which has a limit of 10 concurrent runs.