### PR TITLE
chore(marketing): remove Simple List component from CSforAll

### DIFF
--- a/frontend/apps/marketing/src/contentful/registration/csforall/index.ts
+++ b/frontend/apps/marketing/src/contentful/registration/csforall/index.ts
@@ -64,9 +64,6 @@ import RichText, {
 import Section, {
   SectionContentfulComponentDefinition,
 } from '@/components/contentful/section';
-import SimpleList, {
-  SimpleListContentfulComponentDefinition,
-} from '@/components/contentful/simpleList';
 import SkinnyBanner, {
   SkinnyBannerContentfulComponentDefinition,
 } from '@/components/contentful/skinnyBanner';
@@ -180,10 +177,6 @@ const contentfulRegistration = {
       options: {
         wrapContainerWidth: '100%',
       },
-    },
-    {
-      component: SimpleList,
-      definition: SimpleListContentfulComponentDefinition,
     },
     {
       component: SkinnyBanner,


### PR DESCRIPTION
Removes the Simple List component from CSforAll since the Rich Text component supports a simple list. This just removes the registration so it won't show up in the Contentful component sidebar, but keeps the component on Code.org and can be added back in the future if needed.

## Links 
Jira ticket: [CMS-930](https://codedotorg.atlassian.net/browse/CMS-930)