### PR TITLE
Fix the behavior of the progress view toggle

### DIFF
--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -53,7 +53,7 @@ export default class UserPreferences extends Record({userId: 'me'}) {
 
   /**
    * Save the preference to show v1 or v2 progress table.
-   * @param {boolean} showProgressTableV2: True if showing progress table v2, false otherwise.
+   * @param {string} showProgressTableV2: True if showing progress table v2, 'legacy' if showing v1.
    */
   setShowProgressTableV2(showProgressTableV2) {
     return $.post(`/api/v1/users/show_progress_table_v2`, {

--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -53,7 +53,7 @@ export default class UserPreferences extends Record({userId: 'me'}) {
 
   /**
    * Save the preference to show v1 or v2 progress table.
-   * @param {string} showProgressTableV2: True if showing progress table v2, 'legacy' if showing v1.
+   * @param {string} showProgressTableV2: 'v2' if showing progress table v2, 'legacy' if showing v1.
    */
   setShowProgressTableV2(showProgressTableV2) {
     return $.post(`/api/v1/users/show_progress_table_v2`, {

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -26,7 +26,7 @@ export interface CurrentUserState {
   under13: boolean;
   over21: boolean;
   isTeacher: boolean | undefined;
-  showProgressTableV2: boolean;
+  showProgressTableV2: string;
   progressTableV2ClosedBeta: boolean;
   childAccountComplianceState: string | null;
   inSection: boolean | null;

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -131,6 +131,7 @@ const initialState = {
   inSection: null,
   userCreatedAt: null,
   userSharingDisabled: false,
+  showProgressTableV2: 'v2',
 };
 
 export default function currentUser(state = initialState, action) {

--- a/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
+++ b/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
@@ -97,7 +97,7 @@ function InviteToV2ProgressModal({
     });
     setHasSeenProgressTableInviteData(true);
     setHasSeenProgressTableInvite(true);
-    setShowProgressTableV2(true);
+    setShowProgressTableV2('v2');
     setHasJustSwitchedToV2(true);
     closeModal();
   }, [

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -118,7 +118,7 @@ function SectionProgressSelector({
     displayV2FromUrl ||
     (isPreferenceSet
       ? showProgressTableV2 === V2_SETTING_KEY
-      : DCDO.get('progress-table-v2-default-v2', false));
+      : DCDO.get('progress-table-v2-default-v2', true));
 
   const ProgressV1OrV2ToggleLink = () => (
     <div className={styles.toggleViews}>

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -102,7 +102,9 @@ function SectionProgressSelector({
 
   // If the user has not selected manually the v1 or v2 table, show the DCDO defined default.
   // If a user has selected manually, show that version.
-  const isPreferenceSet = showProgressTableV2 !== undefined;
+  // A user has selected manually if the preference is set to true or false and is not null/undefined.
+  const isPreferenceSet =
+    showProgressTableV2 === true || showProgressTableV2 === false;
   const params = queryParams('view');
 
   // If there is a url pram, use that param to determine to show V2.

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -110,7 +110,6 @@ function SectionProgressSelector({
     showProgressTableV2 === V2_SETTING_KEY ||
     showProgressTableV2 === V1_SETTING_KEY;
   const params = queryParams('view');
-  console.log('lfm', {isPreferenceSet, showProgressTableV2});
 
   // If there is a url pram, use that param to determine to show V2.
   const displayV2FromUrl = params === 'v2';

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -50,9 +50,8 @@ function SectionProgressSelector({
 
     return (
       displayV2FromUrl ||
-      (isPreferenceSet
-        ? showProgressTableV2 === V2_SETTING_KEY
-        : DCDO.get('progress-table-v2-default-v2', true))
+      !isPreferenceSet ||
+      showProgressTableV2 === V2_SETTING_KEY
     );
   }, [showProgressTableV2, params]);
 

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -23,6 +23,9 @@ import SectionProgressV2 from './SectionProgressV2';
 
 import styles from './progress-header.module.scss';
 
+const V2_SETTING_KEY = 'v2';
+const V1_SETTING_KEY = 'legacy';
+
 function SectionProgressSelector({
   showProgressTableV2,
   setShowProgressTableV2,
@@ -36,9 +39,9 @@ function SectionProgressSelector({
   useEffect(() => {
     const params = queryParams('view');
     if (params === 'v2') {
-      setShowProgressTableV2(true);
+      setShowProgressTableV2(V2_SETTING_KEY);
       setHasJustToggledViews(true);
-      new UserPreferences().setShowProgressTableV2(true);
+      new UserPreferences().setShowProgressTableV2(V2_SETTING_KEY);
     }
   }, [setShowProgressTableV2, setHasJustToggledViews]);
 
@@ -52,12 +55,13 @@ function SectionProgressSelector({
   };
 
   const onShowProgressTableV2Change = useCallback(() => {
-    const shouldShowV2 = !showProgressTableV2;
-    new UserPreferences().setShowProgressTableV2(shouldShowV2);
-    setShowProgressTableV2(shouldShowV2);
+    const shouldShowString =
+      showProgressTableV2 === V2_SETTING_KEY ? V1_SETTING_KEY : V2_SETTING_KEY;
+    new UserPreferences().setShowProgressTableV2(shouldShowString);
+    setShowProgressTableV2(shouldShowString);
     setHasJustToggledViews(true);
 
-    if (shouldShowV2) {
+    if (shouldShowString === V2_SETTING_KEY) {
       analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_NEW_PROGRESS, {
         sectionId: sectionId,
       });
@@ -102,10 +106,11 @@ function SectionProgressSelector({
 
   // If the user has not selected manually the v1 or v2 table, show the DCDO defined default.
   // If a user has selected manually, show that version.
-  // A user has selected manually if the preference is set to true or false and is not null/undefined.
   const isPreferenceSet =
-    showProgressTableV2 === true || showProgressTableV2 === false;
+    showProgressTableV2 === V2_SETTING_KEY ||
+    showProgressTableV2 === V1_SETTING_KEY;
   const params = queryParams('view');
+  console.log('lfm', {isPreferenceSet, showProgressTableV2});
 
   // If there is a url pram, use that param to determine to show V2.
   const displayV2FromUrl = params === 'v2';
@@ -113,7 +118,7 @@ function SectionProgressSelector({
   const displayV2 =
     displayV2FromUrl ||
     (isPreferenceSet
-      ? showProgressTableV2
+      ? showProgressTableV2 === V2_SETTING_KEY
       : DCDO.get('progress-table-v2-default-v2', false));
 
   const ProgressV1OrV2ToggleLink = () => (
@@ -173,7 +178,7 @@ function SectionProgressSelector({
 }
 
 SectionProgressSelector.propTypes = {
-  showProgressTableV2: PropTypes.bool,
+  showProgressTableV2: PropTypes.string,
   progressTableV2ClosedBeta: PropTypes.bool,
   setShowProgressTableV2: PropTypes.func.isRequired,
   sectionId: PropTypes.number,

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -36,6 +36,26 @@ function SectionProgressSelector({
 }) {
   const [hasJustToggledViews, setHasJustToggledViews] = useState(false);
 
+  const params = queryParams('view');
+
+  const displayV2 = React.useMemo(() => {
+    // If the user has not selected manually the v1 or v2 table, show the DCDO defined default.
+    // If a user has selected manually, show that version.
+    const isPreferenceSet =
+      showProgressTableV2 === V2_SETTING_KEY ||
+      showProgressTableV2 === V1_SETTING_KEY;
+
+    // If there is a url pram, use that param to determine to show V2.
+    const displayV2FromUrl = params === 'v2';
+
+    return (
+      displayV2FromUrl ||
+      (isPreferenceSet
+        ? showProgressTableV2 === V2_SETTING_KEY
+        : DCDO.get('progress-table-v2-default-v2', true))
+    );
+  }, [showProgressTableV2, params]);
+
   useEffect(() => {
     const params = queryParams('view');
     if (params === 'v2') {
@@ -55,8 +75,7 @@ function SectionProgressSelector({
   };
 
   const onShowProgressTableV2Change = useCallback(() => {
-    const shouldShowString =
-      showProgressTableV2 === V2_SETTING_KEY ? V1_SETTING_KEY : V2_SETTING_KEY;
+    const shouldShowString = displayV2 ? V1_SETTING_KEY : V2_SETTING_KEY;
     new UserPreferences().setShowProgressTableV2(shouldShowString);
     setShowProgressTableV2(shouldShowString);
     setHasJustToggledViews(true);
@@ -71,7 +90,7 @@ function SectionProgressSelector({
       });
       removeQueryParams();
     }
-  }, [showProgressTableV2, setShowProgressTableV2, sectionId]);
+  }, [displayV2, setShowProgressTableV2, sectionId]);
 
   const debouncedOnShowProgressTableV2Change = _.debounce(
     onShowProgressTableV2Change,
@@ -103,22 +122,6 @@ function SectionProgressSelector({
   if (!allowSelection) {
     return <SectionProgress />;
   }
-
-  // If the user has not selected manually the v1 or v2 table, show the DCDO defined default.
-  // If a user has selected manually, show that version.
-  const isPreferenceSet =
-    showProgressTableV2 === V2_SETTING_KEY ||
-    showProgressTableV2 === V1_SETTING_KEY;
-  const params = queryParams('view');
-
-  // If there is a url pram, use that param to determine to show V2.
-  const displayV2FromUrl = params === 'v2';
-
-  const displayV2 =
-    displayV2FromUrl ||
-    (isPreferenceSet
-      ? showProgressTableV2 === V2_SETTING_KEY
-      : DCDO.get('progress-table-v2-default-v2', true));
 
   const ProgressV1OrV2ToggleLink = () => (
     <div className={styles.toggleViews}>

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -53,7 +53,6 @@ describe('SectionProgressSelector', () => {
     store.dispatch(setUnit(1, 1));
 
     DCDO.set('progress-table-v2-enabled', true);
-    DCDO.set('progress-table-v2-default-v2', false);
     DCDO.set('progress-table-v2-closed-beta-enabled', false);
 
     postStub = jest.spyOn($, 'post').mockClear().mockImplementation();
@@ -102,6 +101,7 @@ describe('SectionProgressSelector', () => {
 
   it('shows v1', () => {
     renderDefault();
+    store.dispatch(setShowProgressTableV2('legacy'));
 
     screen.getByText(V1_PAGE_LINK_TEXT);
     // eslint-disable-next-line no-restricted-properties
@@ -125,21 +125,7 @@ describe('SectionProgressSelector', () => {
     expect(screen.queryByTestId(V1_TEST_ID)).toBeFalsy();
   });
 
-  it('shows default v1 if no user preference', () => {
-    renderDefault();
-    store.dispatch(setShowProgressTableV2(undefined));
-
-    screen.getByText(V1_PAGE_LINK_TEXT);
-    // eslint-disable-next-line no-restricted-properties
-    screen.getByTestId(V1_TEST_ID);
-
-    expect(screen.queryByText(V2_PAGE_LINK_TEXT)).toBeFalsy();
-    // eslint-disable-next-line no-restricted-properties
-    expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
-  });
-
   it('shows default v2 if no user preference', () => {
-    DCDO.set('progress-table-v2-default-v2', true);
     store.dispatch(setShowProgressTableV2(undefined));
     renderDefault();
 

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -49,7 +49,7 @@ describe('SectionProgressSelector', () => {
     });
 
     store = getStore();
-    store.dispatch(setShowProgressTableV2(false));
+    store.dispatch(setShowProgressTableV2('legacy'));
     store.dispatch(setUnit(1, 1));
 
     DCDO.set('progress-table-v2-enabled', true);
@@ -83,7 +83,7 @@ describe('SectionProgressSelector', () => {
   it('does not show toggle link if disabled', () => {
     DCDO.set('progress-table-v2-enabled', false);
     renderDefault();
-    store.dispatch(setShowProgressTableV2(true));
+    store.dispatch(setShowProgressTableV2('v2'));
 
     expect(screen.queryByText(V1_PAGE_LINK_TEXT)).toBeFalsy();
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).toBeFalsy();
@@ -92,7 +92,7 @@ describe('SectionProgressSelector', () => {
   it('shows v1 if disabled', () => {
     DCDO.set('progress-table-v2-enabled', false);
     renderDefault();
-    store.dispatch(setShowProgressTableV2(true));
+    store.dispatch(setShowProgressTableV2('v2'));
 
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
@@ -114,7 +114,7 @@ describe('SectionProgressSelector', () => {
 
   it('shows v2', () => {
     renderDefault();
-    store.dispatch(setShowProgressTableV2(true));
+    store.dispatch(setShowProgressTableV2('v2'));
 
     screen.getByText(V2_PAGE_LINK_TEXT);
     // eslint-disable-next-line no-restricted-properties
@@ -247,7 +247,7 @@ describe('SectionProgressSelector', () => {
     store.dispatch(setHasSeenProgressTableInvite(false));
 
     renderDefault();
-    store.dispatch(setShowProgressTableV2(true));
+    store.dispatch(setShowProgressTableV2('v2'));
 
     // Click the link to switch to V1
     const link = screen.getByText(V2_PAGE_LINK_TEXT);

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -161,7 +161,7 @@ describe('SectionProgressSelector', () => {
     expect(postStub).toHaveBeenCalledWith(
       '/api/v1/users/show_progress_table_v2',
       {
-        show_progress_table_v2: true,
+        show_progress_table_v2: 'v2',
       }
     );
   });

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -226,10 +226,13 @@ class Api::V1::UsersController < Api::V1::JSONApiController
   def post_show_progress_table_v2
     return head :unauthorized unless current_user
 
-    show_v2_arg = !!params[:show_progress_table_v2].try(:to_bool)
-    current_user.show_progress_table_v2 = show_v2_arg
+    if params[:show_progress_table_v2] != 'legacy' && params[:show_progress_table_v2] != 'v2'
+      return head :bad_request
+    end
 
-    if show_v2_arg
+    current_user.show_progress_table_v2 = params[:show_progress_table_v2]
+
+    if params[:show_progress_table_v2] == 'v2'
       current_user.progress_table_v2_timestamp = DateTime.now
     else
       current_user.progress_table_v1_timestamp = DateTime.now

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -76,27 +76,27 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
   test 'a post request to show_progress_table_v2 updates show_progress_table_v2' do
     sign_in(@user)
     assert_nil @user.show_progress_table_v2
-    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: true}
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'v2'}
     assert_response :success
     @user.reload
-    assert @user.show_progress_table_v2
+    assert_equal 'v2', @user.show_progress_table_v2
 
-    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: false}
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'legacy'}
     assert_response :success
     @user.reload
-    refute @user.show_progress_table_v2
+    assert_equal 'legacy', @user.show_progress_table_v2
   end
 
   test 'a post request to show_progress_table_v2 updates appropriate timestamp' do
     sign_in(@user)
     assert_nil @user.progress_table_v2_timestamp
-    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: true}
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'v2'}
     assert_response :success
     @user.reload
     assert @user.progress_table_v2_timestamp
     assert_nil @user.progress_table_v1_timestamp
 
-    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: false}
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'legacy'}
     assert_response :success
     @user.reload
     assert @user.progress_table_v2_timestamp

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v1.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v1.feature
@@ -5,47 +5,47 @@ Feature: Using the teacher dashboard homepage (v1)
     Given I am on "http://studio.code.org/home"
     Given I use a cookie to mock the DCDO key "teacher-homepage-v2" as "false"
 
-  # Scenario: Attempt to join a section you own redirects to dashboard with error message
-  #   Given I am a teacher
-  #   And I create a new student section and go home
-  #   And I attempt to join the section
-  #   Then I wait until element "div.alert" is visible
-  #   And element "div.alert" contains text matching "Sorry, you can't join your own section"
+  Scenario: Attempt to join a section you own redirects to dashboard with error message
+    Given I am a teacher
+    And I create a new student section and go home
+    And I attempt to join the section
+    Then I wait until element "div.alert" is visible
+    And element "div.alert" contains text matching "Sorry, you can't join your own section"
 
-  # Scenario: Attempt to join an invalid section through the homepage
-  #   Given I am a teacher and go home
-  #   And I wait until element "button.ui-test-join-section" is visible
-  #   And I press keys "INVALID" for element "input.ui-test-join-section"
-  #   And I click selector "button.ui-test-join-section"
-  #   Then I wait until element ".announcement-notification" is visible
-  #   And element ".announcement-notification" contains text matching "Section INVALID doesn't exist"
+  Scenario: Attempt to join an invalid section through the homepage
+    Given I am a teacher and go home
+    And I wait until element "button.ui-test-join-section" is visible
+    And I press keys "INVALID" for element "input.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
+    Then I wait until element ".announcement-notification" is visible
+    And element ".announcement-notification" contains text matching "Section INVALID doesn't exist"
 
-  # Scenario: Attempt to join a section you own from teacher dashboard provides notification
-  #   Given I am a teacher
-  #   And I create a new student section and go home
-  #   And I wait until element "button.ui-test-join-section" is visible
-  #   And I enter the section code into "input.ui-test-join-section"
-  #   And I click selector "button.ui-test-join-section"
-  #   Then I wait until element ".announcement-notification" is visible
-  #   And element ".announcement-notification" contains text matching "You are already an instructor for section"
+  Scenario: Attempt to join a section you own from teacher dashboard provides notification
+    Given I am a teacher
+    And I create a new student section and go home
+    And I wait until element "button.ui-test-join-section" is visible
+    And I enter the section code into "input.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
+    Then I wait until element ".announcement-notification" is visible
+    And element ".announcement-notification" contains text matching "You are already an instructor for section"
 
-  # Scenario: Decline invitation to new progress view
-  #   Given I am on "http://studio.code.org"
-  #   When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
-  #   Given I create an authorized teacher-associated student named "Sally"
-  #   Given I am assigned to course "allthethingscourse" unit 1
-  #   And I complete the level on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/1"
+  Scenario: Decline invitation to new progress view
+    Given I am on "http://studio.code.org"
+    When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
+    Given I create an authorized teacher-associated student named "Sally"
+    Given I am assigned to course "allthethingscourse" unit 1
+    And I complete the level on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/1"
 
-  #   When I sign in as "Teacher_Sally" and go home
-  #   And I get levelbuilder access
-  #   And I wait until element "a:contains('Untitled Section')" is visible
-  #   And I save the section id from row 0 of the section table
-  #   Then I navigate to teacher dashboard for the section I saved
-  #   Then I click selector "#ui-test-toggle-progress-view"
-  #   And I reload the page
-  #   Then I click selector "#ui-close-dialog"
-  #   And I wait until element "#uitest-course-dropdown" is visible
-  #   And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"
+    When I sign in as "Teacher_Sally" and go home
+    And I get levelbuilder access
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved
+    Then I click selector "#ui-test-toggle-progress-view"
+    And I reload the page
+    Then I click selector "#ui-close-dialog"
+    And I wait until element "#uitest-course-dropdown" is visible
+    And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"
 
   Scenario: Accept invitation to new progress view and see new view immediately.
     Given I am on "http://studio.code.org"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v1.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v1.feature
@@ -1,47 +1,51 @@
 @no_mobile
 Feature: Using the teacher dashboard homepage (v1)
 
-  Scenario: Attempt to join a section you own redirects to dashboard with error message
-    Given I am a teacher
-    And I create a new student section and go home
-    And I attempt to join the section
-    Then I wait until element "div.alert" is visible
-    And element "div.alert" contains text matching "Sorry, you can't join your own section"
+  Background:
+    Given I am on "http://studio.code.org/home"
+    Given I use a cookie to mock the DCDO key "teacher-homepage-v2" as "false"
 
-  Scenario: Attempt to join an invalid section through the homepage
-    Given I am a teacher and go home
-    And I wait until element "button.ui-test-join-section" is visible
-    And I press keys "INVALID" for element "input.ui-test-join-section"
-    And I click selector "button.ui-test-join-section"
-    Then I wait until element ".announcement-notification" is visible
-    And element ".announcement-notification" contains text matching "Section INVALID doesn't exist"
+  # Scenario: Attempt to join a section you own redirects to dashboard with error message
+  #   Given I am a teacher
+  #   And I create a new student section and go home
+  #   And I attempt to join the section
+  #   Then I wait until element "div.alert" is visible
+  #   And element "div.alert" contains text matching "Sorry, you can't join your own section"
 
-  Scenario: Attempt to join a section you own from teacher dashboard provides notification
-    Given I am a teacher
-    And I create a new student section and go home
-    And I wait until element "button.ui-test-join-section" is visible
-    And I enter the section code into "input.ui-test-join-section"
-    And I click selector "button.ui-test-join-section"
-    Then I wait until element ".announcement-notification" is visible
-    And element ".announcement-notification" contains text matching "You are already an instructor for section"
+  # Scenario: Attempt to join an invalid section through the homepage
+  #   Given I am a teacher and go home
+  #   And I wait until element "button.ui-test-join-section" is visible
+  #   And I press keys "INVALID" for element "input.ui-test-join-section"
+  #   And I click selector "button.ui-test-join-section"
+  #   Then I wait until element ".announcement-notification" is visible
+  #   And element ".announcement-notification" contains text matching "Section INVALID doesn't exist"
 
-  Scenario: Decline invitation to new progress view
-    Given I am on "http://studio.code.org"
-    When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
-    Given I create an authorized teacher-associated student named "Sally"
-    Given I am assigned to course "allthethingscourse" unit 1
-    And I complete the level on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/1"
+  # Scenario: Attempt to join a section you own from teacher dashboard provides notification
+  #   Given I am a teacher
+  #   And I create a new student section and go home
+  #   And I wait until element "button.ui-test-join-section" is visible
+  #   And I enter the section code into "input.ui-test-join-section"
+  #   And I click selector "button.ui-test-join-section"
+  #   Then I wait until element ".announcement-notification" is visible
+  #   And element ".announcement-notification" contains text matching "You are already an instructor for section"
 
-    When I sign in as "Teacher_Sally" and go home
-    And I get levelbuilder access
-    And I wait until element "a:contains('Untitled Section')" is visible
-    And I save the section id from row 0 of the section table
-    Then I navigate to teacher dashboard for the section I saved
-    Then I click selector "#ui-test-toggle-progress-view"
-    And I reload the page
-    Then I click selector "#ui-close-dialog"
-    And I wait until element "#uitest-course-dropdown" is visible
-    And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"
+  # Scenario: Decline invitation to new progress view
+  #   Given I am on "http://studio.code.org"
+  #   When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
+  #   Given I create an authorized teacher-associated student named "Sally"
+  #   Given I am assigned to course "allthethingscourse" unit 1
+  #   And I complete the level on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/1"
+
+  #   When I sign in as "Teacher_Sally" and go home
+  #   And I get levelbuilder access
+  #   And I wait until element "a:contains('Untitled Section')" is visible
+  #   And I save the section id from row 0 of the section table
+  #   Then I navigate to teacher dashboard for the section I saved
+  #   Then I click selector "#ui-test-toggle-progress-view"
+  #   And I reload the page
+  #   Then I click selector "#ui-close-dialog"
+  #   And I wait until element "#uitest-course-dropdown" is visible
+  #   And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"
 
   Scenario: Accept invitation to new progress view and see new view immediately.
     Given I am on "http://studio.code.org"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/view_other_teacher_dashboard_pages.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/view_other_teacher_dashboard_pages.feature
@@ -8,7 +8,6 @@ Feature: Views the pages on the teacher dashboard that are untested elsewhere
   @properties_encryption_key
   Scenario: Viewing teacher dashboard pages
     Given I am on "http://studio.code.org"
-    When I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to course "allthethingscourse" unit 1
     And I complete the level on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/1"

--- a/lib/cdo/sauce_connect.rb
+++ b/lib/cdo/sauce_connect.rb
@@ -98,7 +98,7 @@ module Cdo
             sleep 0.1
             while (line = log_file.gets)
               lines << line
-              if line.strip.end_with?(SC_START_MESSAGE)
+              if line.strip.includes?(SC_START_MESSAGE)
                 return :success, lines
               end
             end

--- a/lib/cdo/sauce_connect.rb
+++ b/lib/cdo/sauce_connect.rb
@@ -98,7 +98,7 @@ module Cdo
             sleep 0.1
             while (line = log_file.gets)
               lines << line
-              if line.strip.includes?(SC_START_MESSAGE)
+              if line.strip.end_with?(SC_START_MESSAGE)
                 return :success, lines
               end
             end

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -38,7 +38,7 @@ class DCDOBase < DynamicConfigBase
       # Whether to allow the user to toggle between the v1 and v2 progress tables.
       'progress-table-v2-enabled': DCDO.get('progress-table-v2-enabled', false),
       # Whether to show the v1 or v2 progress table by default.
-      'progress-table-v2-default-v2': DCDO.get('progress-table-v2-default-v2', false),
+      'progress-table-v2-default-v2': DCDO.get('progress-table-v2-default-v2', true),
       # Whether to allow users with `progress_table_v2_closed_beta` user preference to toggle between v1 and v2.
       'progress-table-v2-closed-beta-enabled': DCDO.get('progress-table-v2-closed-beta-enabled', false),
       # Whether the scholarship dropdown is locked on the application dashboard.

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -37,8 +37,6 @@ class DCDOBase < DynamicConfigBase
       'amplitude-event-sample-rates': DCDO.get('amplitude-event-sample-rates', {}),
       # Whether to allow the user to toggle between the v1 and v2 progress tables.
       'progress-table-v2-enabled': DCDO.get('progress-table-v2-enabled', false),
-      # Whether to show the v1 or v2 progress table by default.
-      'progress-table-v2-default-v2': DCDO.get('progress-table-v2-default-v2', true),
       # Whether to allow users with `progress_table_v2_closed_beta` user preference to toggle between v1 and v2.
       'progress-table-v2-closed-beta-enabled': DCDO.get('progress-table-v2-closed-beta-enabled', false),
       # Whether the scholarship dropdown is locked on the application dashboard.


### PR DESCRIPTION
The `progress-table-v2-default-v2` DCDO flag was meant to change whether a user who had not ever selected the toggle to view the v2 would see the v1 or v2 progress page by default. This logic was not working because the server was sending back `null` for both `false` and unset values. We had no way to determine whether a user had clicked the toggle or was seeing the page for the first time.

This PR fixes that issue by changing from a boolean value for `showProgressV2` on the user setting to a string value with either `legacy` or `v2`. Now, we can check if the user has set `legacy` or if the value is null.

This will have a side effect of wiping any current settings and will one-time default all users to the v2 view. This is expected and helpful based on our progress deprecation plan. See [thread](https://codedotorg.slack.com/archives/C06ERUABG01/p1752861115719289).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/TEACH-2117
