### PR TITLE
feat(marketing): reorganize theme files

### DIFF
--- a/frontend/apps/marketing/src/themes/code.org/constants/fonts.ts
+++ b/frontend/apps/marketing/src/themes/code.org/constants/fonts.ts
@@ -1,0 +1,2 @@
+export const BARLOW_FONT = 'Barlow Semi Condensed Semibold';
+export const FIGTREE_FONT = 'Figtree';

--- a/frontend/apps/marketing/src/themes/code.org/index.ts
+++ b/frontend/apps/marketing/src/themes/code.org/index.ts
@@ -5,126 +5,12 @@ import {NOTO_FONT} from '@/themes/constants/fonts';
 
 import {createFontStack} from '../common/constants';
 
-const BARLOW_FONT = 'Barlow Semi Condensed Semibold';
-const FIGTREE_FONT = 'Figtree';
+import {BARLOW_FONT, FIGTREE_FONT} from './constants/fonts';
+import {STYLE_OVERRIDES} from './styleOverrides';
 
 const theme = createTheme({
   cssVariables: true,
-  palette: {
-    primary: {
-      main: '#000000',
-    },
-  },
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          '&.MuiButton-contained.MuiButton-colorPrimary': {
-            backgroundColor: 'var(--brand-purple-50)',
-          },
-        },
-      },
-    },
-    MuiDivider: {
-      styleOverrides: {
-        root: ({theme}) => ({
-          '&.MuiDivider-root.divider--color-primary': {
-            borderColor: 'var(--background-neutral-quaternary)',
-          },
-          '&.MuiDivider-root.divider--color-strong': {
-            borderColor: 'var(--background-neutral-senary)',
-          },
-          '&.MuiDivider-root.divider--margin-none': {
-            marginTop: 0,
-            marginBottom: 0,
-          },
-          '&.MuiDivider-root.divider--margin-xs': {
-            marginTop: theme.spacing(1),
-            marginBottom: theme.spacing(1),
-          },
-          '&.MuiDivider-root.divider--margin-s': {
-            marginTop: theme.spacing(2),
-            marginBottom: theme.spacing(2),
-          },
-          '&.MuiDivider-root.divider--margin-m': {
-            marginTop: theme.spacing(4),
-            marginBottom: theme.spacing(4),
-          },
-          '&.MuiDivider-root.divider--margin-l': {
-            marginTop: theme.spacing(8),
-            marginBottom: theme.spacing(8),
-          },
-        }),
-      },
-    },
-    MuiLink: {
-      styleOverrides: {
-        root: {
-          color: 'var(--text-brand-purple-primary)',
-          fontWeight: 500,
-          textDecoration: 'underline',
-          transition: 'color 0.2s ease-in-out',
-          '&:hover': {
-            color: 'var(--text-brand-purple-secondary)',
-            '& svg': {
-              color: 'var(--text-brand-purple-secondary)',
-            },
-          },
-          '& svg': {
-            color: 'var(--text-brand-purple-primary)',
-            transition: 'color 0.2s ease-in-out',
-          },
-        },
-      },
-    },
-    MuiTypography: {
-      styleOverrides: {
-        root: {
-          color: 'var(--text-neutral-primary)',
-          // Overline styles
-          '&.MuiTypography-overline.overline--color-primary': {
-            color: 'var(--text-brand-teal-primary)',
-          },
-          '&.MuiTypography-overline.overline--color-secondary': {
-            color: 'var(--text-neutral-quaternary)',
-          },
-          '&.MuiTypography-overline.overline--size-s': {
-            fontSize: '0.625rem', // 10px
-          },
-          '&.MuiTypography-overline.overline--size-m': {
-            fontSize: '0.75rem', // 12px
-          },
-          '&.MuiTypography-overline.overline--size-l': {
-            fontSize: '0.875rem', // 14px
-          },
-          // End Overline styles
-        },
-        gutterBottom: ({theme}) => ({
-          '&.MuiTypography-h1': {
-            marginBottom: theme.spacing(3), // 24px
-          },
-          '&.MuiTypography-h2': {
-            marginBottom: theme.spacing(2.125), // 16px
-          },
-          '&.MuiTypography-h3': {
-            marginBottom: theme.spacing(1.75), // 14px
-          },
-          '&.MuiTypography-h4': {
-            marginBottom: theme.spacing(1.5), // 12px
-          },
-          '&.MuiTypography-h5': {
-            marginBottom: theme.spacing(1.125), // 10px
-          },
-          '&.MuiTypography-h6': {
-            marginBottom: theme.spacing(1), // 8px
-          },
-          '&.MuiTypography-overline': {
-            marginBottom: theme.spacing(2), // 16px
-          },
-        }),
-      },
-    },
-  },
+  components: STYLE_OVERRIDES,
   typography: {
     fontFamily: createFontStack(FIGTREE_FONT, NOTO_FONT),
     h1: {

--- a/frontend/apps/marketing/src/themes/code.org/styleOverrides/divider.ts
+++ b/frontend/apps/marketing/src/themes/code.org/styleOverrides/divider.ts
@@ -1,0 +1,34 @@
+import {Components, Theme} from '@mui/material/styles';
+
+export const DIVIDER_OVERRIDES: Components<Theme>['MuiDivider'] = {
+  styleOverrides: {
+    root: ({theme}) => ({
+      '&.MuiDivider-root.divider--color-primary': {
+        borderColor: 'var(--background-neutral-quaternary)',
+      },
+      '&.MuiDivider-root.divider--color-strong': {
+        borderColor: 'var(--background-neutral-senary)',
+      },
+      '&.MuiDivider-root.divider--margin-none': {
+        marginTop: 0,
+        marginBottom: 0,
+      },
+      '&.MuiDivider-root.divider--margin-xs': {
+        marginTop: theme.spacing(1),
+        marginBottom: theme.spacing(1),
+      },
+      '&.MuiDivider-root.divider--margin-s': {
+        marginTop: theme.spacing(2),
+        marginBottom: theme.spacing(2),
+      },
+      '&.MuiDivider-root.divider--margin-m': {
+        marginTop: theme.spacing(4),
+        marginBottom: theme.spacing(4),
+      },
+      '&.MuiDivider-root.divider--margin-l': {
+        marginTop: theme.spacing(8),
+        marginBottom: theme.spacing(8),
+      },
+    }),
+  },
+};

--- a/frontend/apps/marketing/src/themes/code.org/styleOverrides/index.ts
+++ b/frontend/apps/marketing/src/themes/code.org/styleOverrides/index.ts
@@ -1,0 +1,11 @@
+import {Components, Theme} from '@mui/material/styles';
+
+import {DIVIDER_OVERRIDES} from './divider';
+import {LINK_OVERRIDES} from './link';
+import {TYPOGRAPHY_OVERRIDES} from './typography';
+
+export const STYLE_OVERRIDES: Components<Theme> = {
+  MuiDivider: DIVIDER_OVERRIDES,
+  MuiLink: LINK_OVERRIDES,
+  MuiTypography: TYPOGRAPHY_OVERRIDES,
+};

--- a/frontend/apps/marketing/src/themes/code.org/styleOverrides/link.ts
+++ b/frontend/apps/marketing/src/themes/code.org/styleOverrides/link.ts
@@ -1,0 +1,22 @@
+import {Components, Theme} from '@mui/material/styles';
+
+export const LINK_OVERRIDES: Components<Theme>['MuiLink'] = {
+  styleOverrides: {
+    root: {
+      color: 'var(--text-brand-purple-primary)',
+      fontWeight: 500,
+      textDecoration: 'underline',
+      transition: 'color 0.2s ease-in-out',
+      '&:hover': {
+        color: 'var(--text-brand-purple-secondary)',
+        '& svg': {
+          color: 'var(--text-brand-purple-secondary)',
+        },
+      },
+      '& svg': {
+        color: 'var(--text-brand-purple-primary)',
+        transition: 'color 0.2s ease-in-out',
+      },
+    },
+  },
+};

--- a/frontend/apps/marketing/src/themes/code.org/styleOverrides/typography.ts
+++ b/frontend/apps/marketing/src/themes/code.org/styleOverrides/typography.ts
@@ -1,0 +1,49 @@
+import {Components, Theme} from '@mui/material/styles';
+
+export const TYPOGRAPHY_OVERRIDES: Components<Theme>['MuiTypography'] = {
+  styleOverrides: {
+    root: {
+      color: 'var(--text-neutral-primary)',
+      // Overline styles
+      '&.MuiTypography-overline.overline--color-primary': {
+        color: 'var(--text-brand-teal-primary)',
+      },
+      '&.MuiTypography-overline.overline--color-secondary': {
+        color: 'var(--text-neutral-quaternary)',
+      },
+      '&.MuiTypography-overline.overline--size-s': {
+        fontSize: '0.625rem', // 10px
+      },
+      '&.MuiTypography-overline.overline--size-m': {
+        fontSize: '0.75rem', // 12px
+      },
+      '&.MuiTypography-overline.overline--size-l': {
+        fontSize: '0.875rem', // 14px
+      },
+      // End Overline styles
+    },
+    gutterBottom: ({theme}) => ({
+      '&.MuiTypography-h1': {
+        marginBottom: theme.spacing(3), // 24px
+      },
+      '&.MuiTypography-h2': {
+        marginBottom: theme.spacing(2.125), // 16px
+      },
+      '&.MuiTypography-h3': {
+        marginBottom: theme.spacing(1.75), // 14px
+      },
+      '&.MuiTypography-h4': {
+        marginBottom: theme.spacing(1.5), // 12px
+      },
+      '&.MuiTypography-h5': {
+        marginBottom: theme.spacing(1.125), // 10px
+      },
+      '&.MuiTypography-h6': {
+        marginBottom: theme.spacing(1), // 8px
+      },
+      '&.MuiTypography-overline': {
+        marginBottom: theme.spacing(2), // 16px
+      },
+    }),
+  },
+};

--- a/frontend/apps/marketing/src/themes/csforall/constants/colors.ts
+++ b/frontend/apps/marketing/src/themes/csforall/constants/colors.ts
@@ -1,3 +1,5 @@
 export const COLORS = {
   black: '#15092C',
+  primary: '#2C079F',
+  secondary: '#CA01E4',
 };

--- a/frontend/apps/marketing/src/themes/csforall/constants/colors.ts
+++ b/frontend/apps/marketing/src/themes/csforall/constants/colors.ts
@@ -1,0 +1,3 @@
+export const COLORS = {
+  black: '#15092C',
+};

--- a/frontend/apps/marketing/src/themes/csforall/constants/fonts.ts
+++ b/frontend/apps/marketing/src/themes/csforall/constants/fonts.ts
@@ -1,0 +1,2 @@
+export const FIGTREE_FONT = 'Figtree';
+export const ROBOTO_MONO_FONT = 'Roboto Mono';

--- a/frontend/apps/marketing/src/themes/csforall/index.ts
+++ b/frontend/apps/marketing/src/themes/csforall/index.ts
@@ -1,17 +1,13 @@
 'use client';
 import {createTheme} from '@mui/material';
-import {alpha} from '@mui/material/styles';
 
 import {NOTO_FONT} from '@/themes/constants/fonts';
 
 import {createFontStack} from '../common/constants';
 
-const FIGTREE_FONT = 'Figtree';
-const ROBOTO_MONO_FONT = 'Roboto Mono';
-
-const COLORS = {
-  black: '#15092C',
-};
+import {COLORS} from './constants/colors';
+import {FIGTREE_FONT, ROBOTO_MONO_FONT} from './constants/fonts';
+import {STYLE_OVERRIDES} from './styleOverrides';
 
 const theme = createTheme({
   cssVariables: true,
@@ -30,129 +26,7 @@ const theme = createTheme({
       black: COLORS.black,
     },
   },
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        root: ({theme}) => ({
-          fontFamily: ROBOTO_MONO_FONT,
-          '&:focus-visible': {
-            outline: '2px solid ' + theme.palette.primary.main,
-            outlineOffset: '2px',
-          },
-          textTransform: 'none',
-          border: '1px solid transparent',
-          '&.MuiButton-contained.button--color-emphasized': {
-            backgroundColor: theme.palette.secondary.main,
-            '&:hover': {
-              backgroundColor: theme.palette.secondary.dark,
-            },
-          },
-          '&.MuiButton-contained.button--color-primary': {
-            backgroundColor: theme.palette.primary.main,
-            '&:hover': {
-              backgroundColor: theme.palette.primary.dark,
-            },
-          },
-          '&.MuiButton-outlined.button--color-secondary': {
-            color: theme.palette.common.black,
-            borderColor: theme.palette.common.black,
-            '&:hover': {
-              backgroundColor: theme.palette.grey[100],
-            },
-          },
-          '&.MuiButton-contained.MuiButton-sizeSmall, &.MuiButton-outlined.MuiButton-sizeSmall':
-            {
-              fontSize: '1rem',
-              padding: theme.spacing(1.25, 2.5),
-              borderRadius: theme.spacing(3),
-            },
-          '&.MuiButton-contained.MuiButton-sizeMedium, &.MuiButton-outlined.MuiButton-sizeMedium':
-            {
-              fontSize: '1.125rem',
-              padding: theme.spacing(1.5, 3),
-              borderRadius: theme.spacing(4),
-            },
-          '&.MuiButton-contained.MuiButton-sizeLarge, &.MuiButton-outlined.MuiButton-sizeLarge':
-            {
-              fontSize: '1.25rem',
-              padding: theme.spacing(2, 5),
-              borderRadius: theme.spacing(8),
-            },
-        }),
-      },
-    },
-    MuiDivider: {
-      styleOverrides: {
-        root: ({theme}) => ({
-          '&.MuiDivider-root.divider--color-primary': {
-            borderColor: theme.palette.divider,
-          },
-          '&.MuiDivider-root.divider--color-strong': {
-            borderColor: theme.palette.divider,
-            borderStyle: 'dashed',
-          },
-          '&.MuiDivider-root.divider--margin-none': {
-            marginTop: 0,
-            marginBottom: 0,
-          },
-          '&.MuiDivider-root.divider--margin-xs': {
-            marginTop: theme.spacing(3),
-            marginBottom: theme.spacing(3),
-          },
-          '&.MuiDivider-root.divider--margin-s': {
-            marginTop: theme.spacing(5),
-            marginBottom: theme.spacing(5),
-          },
-          '&.MuiDivider-root.divider--margin-m': {
-            marginTop: theme.spacing(7),
-            marginBottom: theme.spacing(7),
-          },
-          '&.MuiDivider-root.divider--margin-l': {
-            marginTop: theme.spacing(8),
-            marginBottom: theme.spacing(8),
-          },
-        }),
-      },
-    },
-    MuiTypography: {
-      styleOverrides: {
-        root: ({theme}) => ({
-          color: theme.palette.text.primary,
-          // Overline styles
-          '&.MuiTypography-overline': {
-            display: 'inline-block',
-            paddingBlock: theme.spacing(0.5), // 4px
-            paddingInline: theme.spacing(1), // 8px
-            borderRadius: 8,
-          },
-          '&.MuiTypography-overline.overline--color-primary': {
-            color: theme.palette.primary.main,
-            border: `1px solid ${theme.palette.primary.main}`,
-          },
-          '&.MuiTypography-overline.overline--color-secondary': {
-            color: theme.palette.secondary.dark,
-            backgroundColor: alpha(theme.palette.secondary.main, 0.1),
-            border: `1px solid ${theme.palette.secondary.dark}`,
-          },
-          '&.MuiTypography-overline.overline--size-s': {
-            fontSize: '0.75rem', // 12px
-          },
-          '&.MuiTypography-overline.overline--size-m': {
-            fontSize: '0.875rem', // 14px
-          },
-          '&.MuiTypography-overline.overline--size-l': {
-            fontSize: '1rem', // 16px
-          },
-          // End Overline styles
-        }),
-        gutterBottom: ({theme}) => ({
-          '&.MuiTypography-overline': {
-            marginBottom: theme.spacing(2), // 16px
-          },
-        }),
-      },
-    },
-  },
+  components: STYLE_OVERRIDES,
   typography: {
     fontFamily: createFontStack(ROBOTO_MONO_FONT, NOTO_FONT),
     h1: {

--- a/frontend/apps/marketing/src/themes/csforall/index.ts
+++ b/frontend/apps/marketing/src/themes/csforall/index.ts
@@ -13,10 +13,10 @@ const theme = createTheme({
   cssVariables: true,
   palette: {
     primary: {
-      main: '#2C079F',
+      main: COLORS.primary,
     },
     secondary: {
-      main: '#CA01E4',
+      main: COLORS.secondary,
     },
     text: {
       primary: COLORS.black,

--- a/frontend/apps/marketing/src/themes/csforall/styleOverrides/button.ts
+++ b/frontend/apps/marketing/src/themes/csforall/styleOverrides/button.ts
@@ -1,0 +1,54 @@
+import {Components, Theme} from '@mui/material/styles';
+
+const ROBOTO_MONO_FONT = 'Roboto Mono';
+
+export const BUTTON_OVERRIDES: Components<Theme>['MuiButton'] = {
+  styleOverrides: {
+    root: ({theme}) => ({
+      fontFamily: ROBOTO_MONO_FONT,
+      '&:focus-visible': {
+        outline: '2px solid ' + theme.palette.primary.main,
+        outlineOffset: '2px',
+      },
+      textTransform: 'none',
+      border: '1px solid transparent',
+      '&.MuiButton-contained.button--color-emphasized': {
+        backgroundColor: theme.palette.secondary.main,
+        '&:hover': {
+          backgroundColor: theme.palette.secondary.dark,
+        },
+      },
+      '&.MuiButton-contained.button--color-primary': {
+        backgroundColor: theme.palette.primary.main,
+        '&:hover': {
+          backgroundColor: theme.palette.primary.dark,
+        },
+      },
+      '&.MuiButton-outlined.button--color-secondary': {
+        color: theme.palette.common.black,
+        borderColor: theme.palette.common.black,
+        '&:hover': {
+          backgroundColor: theme.palette.grey[100],
+        },
+      },
+      '&.MuiButton-contained.MuiButton-sizeSmall, &.MuiButton-outlined.MuiButton-sizeSmall':
+        {
+          fontSize: '1rem',
+          padding: theme.spacing(1.25, 2.5),
+          borderRadius: theme.spacing(3),
+        },
+      '&.MuiButton-contained.MuiButton-sizeMedium, &.MuiButton-outlined.MuiButton-sizeMedium':
+        {
+          fontSize: '1.125rem',
+          padding: theme.spacing(1.5, 3),
+          borderRadius: theme.spacing(4),
+        },
+      '&.MuiButton-contained.MuiButton-sizeLarge, &.MuiButton-outlined.MuiButton-sizeLarge':
+        {
+          fontSize: '1.25rem',
+          padding: theme.spacing(2, 5),
+          borderRadius: theme.spacing(8),
+        },
+    }),
+  },
+};

--- a/frontend/apps/marketing/src/themes/csforall/styleOverrides/divider.ts
+++ b/frontend/apps/marketing/src/themes/csforall/styleOverrides/divider.ts
@@ -1,0 +1,35 @@
+import {Components, Theme} from '@mui/material/styles';
+
+export const DIVIDER_OVERRIDES: Components<Theme>['MuiDivider'] = {
+  styleOverrides: {
+    root: ({theme}) => ({
+      '&.MuiDivider-root.divider--color-primary': {
+        borderColor: theme.palette.divider,
+      },
+      '&.MuiDivider-root.divider--color-strong': {
+        borderColor: theme.palette.divider,
+        borderStyle: 'dashed',
+      },
+      '&.MuiDivider-root.divider--margin-none': {
+        marginTop: 0,
+        marginBottom: 0,
+      },
+      '&.MuiDivider-root.divider--margin-xs': {
+        marginTop: theme.spacing(3),
+        marginBottom: theme.spacing(3),
+      },
+      '&.MuiDivider-root.divider--margin-s': {
+        marginTop: theme.spacing(5),
+        marginBottom: theme.spacing(5),
+      },
+      '&.MuiDivider-root.divider--margin-m': {
+        marginTop: theme.spacing(7),
+        marginBottom: theme.spacing(7),
+      },
+      '&.MuiDivider-root.divider--margin-l': {
+        marginTop: theme.spacing(8),
+        marginBottom: theme.spacing(8),
+      },
+    }),
+  },
+};

--- a/frontend/apps/marketing/src/themes/csforall/styleOverrides/index.ts
+++ b/frontend/apps/marketing/src/themes/csforall/styleOverrides/index.ts
@@ -1,0 +1,11 @@
+import {Components, Theme} from '@mui/material/styles';
+
+import {BUTTON_OVERRIDES} from './button';
+import {DIVIDER_OVERRIDES} from './divider';
+import {TYPOGRAPHY_OVERRIDES} from './typography';
+
+export const STYLE_OVERRIDES: Components<Theme> = {
+  MuiButton: BUTTON_OVERRIDES,
+  MuiDivider: DIVIDER_OVERRIDES,
+  MuiTypography: TYPOGRAPHY_OVERRIDES,
+};

--- a/frontend/apps/marketing/src/themes/csforall/styleOverrides/typography.ts
+++ b/frontend/apps/marketing/src/themes/csforall/styleOverrides/typography.ts
@@ -1,0 +1,40 @@
+import {Components, Theme, alpha} from '@mui/material/styles';
+
+export const TYPOGRAPHY_OVERRIDES: Components<Theme>['MuiTypography'] = {
+  styleOverrides: {
+    root: ({theme}) => ({
+      color: theme.palette.text.primary,
+      // Overline styles
+      '&.MuiTypography-overline': {
+        display: 'inline-block',
+        paddingBlock: theme.spacing(0.5), // 4px
+        paddingInline: theme.spacing(1), // 8px
+        borderRadius: 8,
+      },
+      '&.MuiTypography-overline.overline--color-primary': {
+        color: theme.palette.primary.main,
+        border: `1px solid ${theme.palette.primary.main}`,
+      },
+      '&.MuiTypography-overline.overline--color-secondary': {
+        color: theme.palette.secondary.dark,
+        backgroundColor: alpha(theme.palette.secondary.main, 0.1),
+        border: `1px solid ${theme.palette.secondary.dark}`,
+      },
+      '&.MuiTypography-overline.overline--size-s': {
+        fontSize: '0.75rem', // 12px
+      },
+      '&.MuiTypography-overline.overline--size-m': {
+        fontSize: '0.875rem', // 14px
+      },
+      '&.MuiTypography-overline.overline--size-l': {
+        fontSize: '1rem', // 16px
+      },
+      // End Overline styles
+    }),
+    gutterBottom: ({theme}) => ({
+      '&.MuiTypography-overline': {
+        marginBottom: theme.spacing(2), // 16px
+      },
+    }),
+  },
+};


### PR DESCRIPTION
Extracts component style overrides for the Code.org and CSforAll MUI theme files. This will make editing component styles easier and keep the theme files from getting bloated and hard to use.

## Links
Jira ticket: [CMS-933](https://codedotorg.atlassian.net/browse/CMS-933)

## Testing story
Tested locally to make sure nothing changes and should pass all tests