### PR TITLE
AI Chat: prevent extra model update notifications

### DIFF
--- a/apps/src/aichat/redux/index.ts
+++ b/apps/src/aichat/redux/index.ts
@@ -21,4 +21,5 @@ export {
   stagedFilesLimitExceeded,
   clearStagedFilesAlert,
   clearStagedFiles,
+  clearHasSetStartingCustomizations,
 } from './slice';

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -52,6 +52,7 @@ const initialState: AichatState = {
   hasUpdatedCustomizations: false,
   saveError: undefined,
   showResetMessage: false,
+  hasSetStartingCustomizations: false,
 };
 
 const aichatSlice = createSlice({
@@ -198,6 +199,10 @@ const aichatSlice = createSlice({
       // Reset sent message and updated customizations flags
       state.hasSentMessage = false;
       state.hasUpdatedCustomizations = false;
+      state.hasSetStartingCustomizations = true;
+    },
+    clearHasSetStartingCustomizations: state => {
+      state.hasSetStartingCustomizations = false;
     },
     resetToDefaultAiCustomizations: (
       state,
@@ -373,4 +378,5 @@ export const {
   stagedFilesLimitExceeded,
   clearStagedFilesAlert,
   setSaveError,
+  clearHasSetStartingCustomizations,
 } = aichatSlice.actions;

--- a/apps/src/aichat/redux/state.ts
+++ b/apps/src/aichat/redux/state.ts
@@ -47,6 +47,8 @@ export interface AichatState {
     | undefined;
   // If the user has a sent a message on this level
   hasSentMessage: boolean;
+  // If starting customizations have been set on this level
+  hasSetStartingCustomizations: boolean;
   // If the user has updated customizations on this level
   hasUpdatedCustomizations: boolean;
   // Error message to display if a save fails

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -12,9 +12,11 @@ import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarn
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import FlowLab from '@cdo/apps/flowlab/views/flow/FlowLab';
 import {PERMISSIONS} from '@cdo/apps/lab2/constants';
+import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LabProps} from '@cdo/apps/lab2/types';
+import {LifecycleEvent} from '@cdo/apps/lab2/utils';
 import InstructionsV2 from '@cdo/apps/lab2/views/components/Instructions/InstructionsV2';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
@@ -36,6 +38,7 @@ import {
   onSaveComplete,
   onSaveFail,
   onSaveNoop,
+  clearHasSetStartingCustomizations,
   resetToDefaultAiCustomizations,
   selectAllFieldsHidden,
   sendAnalytics,
@@ -93,6 +96,10 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
 
   const isLevelbuilder = useAppSelector(state =>
     state.lab.permissions?.includes(PERMISSIONS.LEVELBUILDER)
+  );
+
+  const hasSetStartingCustomizations = useAppSelector(
+    state => state.aichat.hasSetStartingCustomizations
   );
 
   const projectManager = Lab2Registry.getInstance().getProjectManager();
@@ -274,6 +281,10 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
     );
   }, [dispatch]);
 
+  useLifecycleNotifier(LifecycleEvent.LevelLoadStarted, () => {
+    dispatch(clearHasSetStartingCustomizations());
+  });
+
   // Only recreate modelParameters when relevant customizations are updated.
   const modelParameters: ModelParameters = useMemo(() => {
     return {
@@ -378,16 +389,18 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
               className={moduleStyles.panelContainer}
               headerClassName={moduleStyles.panelHeader}
             >
-              <ChatWorkspace
-                modelParameters={modelParameters}
-                onClear={onClear}
-                levelName={levelName}
-                channelId={channelId}
-                hasStarterAssets={
-                  starterAssets && Object.keys(starterAssets).length > 0
-                }
-                multimodalEnabled={levelAichatSettings?.multimodalEnabled}
-              />
+              {hasSetStartingCustomizations && (
+                <ChatWorkspace
+                  modelParameters={modelParameters}
+                  onClear={onClear}
+                  levelName={levelName}
+                  channelId={channelId}
+                  hasStarterAssets={
+                    starterAssets && Object.keys(starterAssets).length > 0
+                  }
+                  multimodalEnabled={levelAichatSettings?.multimodalEnabled}
+                />
+              )}
             </PanelContainer>
           </div>
         </div>


### PR DESCRIPTION
As an unintentional side effect of https://github.com/code-dot-org/code-dot-org/pull/67157, we started showing and logging some extra model update notifications. This was because we were using the change in the `modelParameters` props as a signal to dispatch the updates; however in AI Chat Lab, there's a brief period where the `savedAiCustomizations` get initialized to the default (blank) AI customizations, before we load the student's project and the level properties, and then set the `savedAiCustomizations` to the actual last saved value. This brief change was registering as a model update, so we were emitting these as notifications, even though the student didn't actually make these changes themselves.

This solution is a little bit of a band-aid 🙁 we now track a flag in redux that tells us if we're in the process of loading a new level and setting the initial starting customizations, and if so, we don't render the `ChatWorkspace`. That way, the first time the `ChatWorkspace` receives the modelParameters props, they are the actual initial student customizations, not the default unset ones.

There are more ideal and cleaner ways to solve this that don't rely on a flag and specific order of events, but this starts getting into the over lab lifecycle and the manner in which we load data through level changes, which is something we've been thinking about and tackling more holistically in a [separate effort](https://docs.google.com/document/d/1fpyd88e-mXkyUQrE1ILRh-na6zz9glz9rpcQu80o34o/edit?tab=t.0#heading=h.t3fbrr4fg4s7) 🙂 I'd still like to work towards a better solution for this case, but this should at least prevent unnecessary updates from showing up in AI Chat Lab for now.

## Links

https://codedotorg.slack.com/archives/C06FELVTV0Q/p1752872954351969

## Testing story

Tested locally in exploring Gen AI and AIF levels; tested changing levels and changing students in the teacher panel.