### PR TITLE
Evaluate Student Learning: auto reloads and csv templates for skills & levels skills crud

### DIFF
--- a/apps/src/levelbuilder/skills/LevelsSkillsCreator.tsx
+++ b/apps/src/levelbuilder/skills/LevelsSkillsCreator.tsx
@@ -1,4 +1,5 @@
 import {Button} from '@code-dot-org/component-library/button';
+import Link from '@code-dot-org/component-library/link';
 import Papa from 'papaparse';
 import React, {useState} from 'react';
 
@@ -68,6 +69,7 @@ const LevelsSkillsCreator: React.FC = () => {
           }`
         );
       }
+      window.location.reload();
     }
   };
 
@@ -79,9 +81,16 @@ const LevelsSkillsCreator: React.FC = () => {
         are environment specific. You can check the Skills table on this page
         for skillId and the gray admin box on a level page for the levelId. The
         levelId is also in the url of the level edit page: /levels/levelId/edit.
-        After upload of your CSV, reload the page and double-check the Levels
-        Skills association table to ensure skills are associated with levels
-        correctly.
+        After upload of your CSV, double-check the Levels Skills association
+        table to ensure skills are associated with levels correctly. You can
+        copy this{' '}
+        <Link
+          openInNewTab
+          href="https://docs.google.com/spreadsheets/d/1avXwCQ2qK5V3hhmFm_yk1IHzF-tUA30Tm2ZA5rq31ww/edit?usp=sharing"
+        >
+          template
+        </Link>{' '}
+        to get started.
       </p>
       <br />
       <div>

--- a/apps/src/levelbuilder/skills/SkillsCreator.tsx
+++ b/apps/src/levelbuilder/skills/SkillsCreator.tsx
@@ -1,4 +1,5 @@
 import {Button} from '@code-dot-org/component-library/button';
+import Link from '@code-dot-org/component-library/link';
 import Papa from 'papaparse';
 import React, {useState} from 'react';
 
@@ -86,6 +87,7 @@ const SkillsCreator: React.FC<SkillsCreatorProps> = ({skills}) => {
       }
     }
     alert('Skills created successfully!');
+    window.location.reload();
   };
 
   return (
@@ -94,8 +96,15 @@ const SkillsCreator: React.FC<SkillsCreatorProps> = ({skills}) => {
       <p>
         Upload a CSV of skills with the following columns: key, concept,
         description, evaluationCriteria. Key must be unique. After upload of
-        your CSV, reload the page and double-check the Skills Table to ensure
-        your newly created skills are as expected.
+        your CSV, double-check the Skills Table to ensure your newly created
+        skills are as expected. You can copy this{' '}
+        <Link
+          openInNewTab
+          href="https://docs.google.com/spreadsheets/d/1gRuwitEoPM3kXRPSPJUSIxoahnsqO-lPxDnx3eSqdLI/edit?usp=sharing"
+        >
+          template
+        </Link>{' '}
+        to get started.
       </p>
       <br />
       <div>

--- a/apps/src/levelbuilder/skills/SkillsEditDialog.tsx
+++ b/apps/src/levelbuilder/skills/SkillsEditDialog.tsx
@@ -21,6 +21,7 @@ const SkillsEditDialog: React.FC<SkillsEditDialogProps> = ({
   const handleSave = () => {
     updateSkill(editedSkill.id, editedSkill);
     onClose();
+    window.location.reload();
   };
 
   const getInputForm = () => {


### PR DESCRIPTION
A few quality of life improvements for /skills. We know auto re-load the page after skills are added or edited and after skills are associated with levels. Additionally, I've linked view only templates of the csv headings that are needed to create skills and associate skills with levels. 
<img width="1044" height="595" alt="Screenshot 2025-07-22 at 11 18 50 AM" src="https://github.com/user-attachments/assets/9e49576f-8405-4b53-acc4-1e492761f22a" />

[skill upload template](https://docs.google.com/spreadsheets/d/1gRuwitEoPM3kXRPSPJUSIxoahnsqO-lPxDnx3eSqdLI/edit?gid=0#gid=0)
[levels skills template ](https://docs.google.com/spreadsheets/d/1avXwCQ2qK5V3hhmFm_yk1IHzF-tUA30Tm2ZA5rq31ww/edit?gid=0#gid=0)