### PR TITLE
Remove instances of binaryphoto.png

### DIFF
--- a/pegasus/sites/virtual/curriculum-6-8/1/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/1/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/10/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/10/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/11/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/11/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/2/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/2/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/3/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/3/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/4/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/4/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/5/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/5/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/6/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/6/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/7/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/7/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/8/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/8/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/9/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/9/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-2-3/1/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-2-3/1/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-2-3/2/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-2-3/2/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-4-5/1/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-4-5/1/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-4-5/2/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-4-5/2/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-k-1/1/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-k-1/1/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-k-1/2/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-6-8/k-5_holding/curriculum-k-1/2/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-course1/1/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-course1/1/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-course1/6/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-course1/6/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-course2/1/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-course2/1/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-course2/14/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-course2/14/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-course2/2/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-course2/2/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677

--- a/pegasus/sites/virtual/curriculum-course2/9/binaryphoto.png
+++ b/pegasus/sites/virtual/curriculum-course2/9/binaryphoto.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0173c8d20040779ac92f37e64263e2a525775998b2346a50c4f498eba159d924
-size 137677


### PR DESCRIPTION
There are no uncommented out references in our codebase to `binaryphoto`, which was added in our first commit. I also checked in Athena using the query below and found zero access to any of these images over the past week.

Query:

```
SELECT 
  *
FROM cdo_access_logs.access_logs
WHERE datehour >= '2025/07/14/01'
  AND "cs-host" = 'code.org'
  AND "cs-uri-stem"  LIKE '%binaryphoto.png%' 
limit 20
```

