### PR TITLE
Revert "Revert "[MusicLab] Test that feedback receives focus post-run via new UI test""

### DIFF
--- a/apps/src/lab2/views/components/InstructionsPanel.tsx
+++ b/apps/src/lab2/views/components/InstructionsPanel.tsx
@@ -188,7 +188,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                 <TextToSpeech text={useMessage} />
               )}
               {useMessage && (
-                <div ref={feedbackRef} tabIndex={-1}>
+                <div id="focusable-message" ref={feedbackRef} tabIndex={-1}>
                   <EnhancedSafeMarkdown
                     markdown={useMessage}
                     className={moduleStyles.markdownText}

--- a/apps/src/lab2/views/components/InstructionsPanel.tsx
+++ b/apps/src/lab2/views/components/InstructionsPanel.tsx
@@ -188,7 +188,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                 <TextToSpeech text={useMessage} />
               )}
               {useMessage && (
-                <div id="focusable-message" ref={feedbackRef} tabIndex={-1}>
+                <div id="focusable-feedback" ref={feedbackRef} tabIndex={-1}>
                   <EnhancedSafeMarkdown
                     markdown={useMessage}
                     className={moduleStyles.markdownText}

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
@@ -1,0 +1,11 @@
+Feature: Music Lab workspaces load between levels
+
+Scenario: Ensure feedback message gets focus after keyboard nav run button
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/46/levels/2"
+  And I rotate to landscape
+  And I wait until element "[data-id='when-run-block']" is visible
+  And element "#focusable-message" does not have focus
+  # Press the run button and wait for the empty song to play
+  And I press keys ":space"
+  And I wait for 6 seconds
+  And element "#focusable-message" has focus

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
@@ -6,7 +6,7 @@ Scenario: Ensure feedback message gets focus after keyboard nav run button
   And I rotate to landscape
   And I wait until element "[data-id='when-run-block']" is visible
   And element "#focusable-feedback" does not have focus
-  # Press the run button and wait for the empty song to play
+  # Spacebar to press the run button and wait for the empty song to play
   And I press keys ":space"
   And I wait for 6 seconds
   And element "#focusable-feedback" has focus

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
@@ -6,7 +6,7 @@ Scenario: Ensure feedback message gets focus after keyboard nav run button
   And I rotate to landscape
   And I wait until element "[data-id='when-run-block']" is visible
   And element "#focusable-feedback" does not have focus
-  # Spacebar to press the run button and wait for the empty song to play
+  # Spacebar to play the empty song
   And I press keys ":space"
   And I wait for 6 seconds
   And element "#focusable-feedback" has focus

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
@@ -1,11 +1,12 @@
 Feature: Music Lab workspaces load between levels
 
+@no_mobile
 Scenario: Ensure feedback message gets focus after keyboard nav run button
   Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/46/levels/2"
   And I rotate to landscape
   And I wait until element "[data-id='when-run-block']" is visible
-  And element "#focusable-message" does not have focus
+  And element "#focusable-feedback" does not have focus
   # Press the run button and wait for the empty song to play
   And I press keys ":space"
   And I wait for 6 seconds
-  And element "#focusable-message" has focus
+  And element "#focusable-feedback" has focus

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -894,6 +894,10 @@ def element_exists?(selector)
   @browser.execute_script(jquery_element_exists(selector))
 end
 
+def element_focused?(selector)
+  @browser.execute_script("return document.querySelector(#{selector.dump}) === document.activeElement;")
+end
+
 def element_visible?(selector)
   @browser.execute_script(jquery_is_element_visible(selector))
 end
@@ -916,6 +920,14 @@ end
 
 Then /^element "([^"]*)" does not exist/ do |selector|
   expect(element_exists?(selector)).to eq(false)
+end
+
+Then /^element "([^"]*)" has focus/ do |selector|
+  expect(element_focused?(selector)).to eq(true)
+end
+
+Then /^element "([^"]*)" does not have focus/ do |selector|
+  expect(element_focused?(selector)).to eq(false)
 end
 
 Then /^element "([^"]*)" is hidden$/ do |selector|


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67252 and adds a @nomobile tag because keyboard shortcuts don't work on a mobile device