### PR TITLE
feat(workshops): add workshop overview routing

### DIFF
--- a/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
+++ b/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
@@ -24,7 +24,7 @@ interface WithRouterPropsType {
 interface RouteConfig {
   path: string;
   breadcrumbs?: string;
-  children?: RouteConfig[];
+  childRoutes?: RouteConfig[];
 }
 
 export const WithRouterProps: React.FC<
@@ -53,8 +53,8 @@ export const WithRouterProps: React.FC<
       if (matchPath(joinedPath, location.pathname)) {
         return config.breadcrumbs;
       }
-      if (config.children) {
-        const childBreadcrumbs = getBreadcrumbs(config.children, joinedPath);
+      if (config.childRoutes) {
+        const childBreadcrumbs = getBreadcrumbs(config.childRoutes, joinedPath);
         if (childBreadcrumbs) {
           return childBreadcrumbs;
         }

--- a/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
+++ b/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
@@ -46,7 +46,10 @@ export const WithRouterProps: React.FC<
     parentPath = ''
   ): string | undefined => {
     for (const config of configs) {
-      const joinedPath = [parentPath, config.path].filter(Boolean).join('/');
+      const joinedPath = [parentPath, config.path]
+        .filter(Boolean)
+        .join('/')
+        .replace(/\/\/+/g, '/');
       if (matchPath(joinedPath, location.pathname)) {
         return config.breadcrumbs;
       }

--- a/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
+++ b/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
@@ -23,7 +23,8 @@ interface WithRouterPropsType {
 
 interface RouteConfig {
   path: string;
-  breadcrumbs: string;
+  breadcrumbs?: string;
+  children?: RouteConfig[];
 }
 
 export const WithRouterProps: React.FC<
@@ -39,9 +40,26 @@ export const WithRouterProps: React.FC<
 
   // TODO: remove once ApplicationDashboard is refactored to react-router-dom
   // https://codedotorg.atlassian.net/browse/ACQ-3128
-  const breadcrumbs = routeConfigs?.find(config =>
-    matchPath(config.path, location.pathname)
-  )?.breadcrumbs;
+  // Recursively join parent and child paths for nested route matching
+  const getBreadcrumbs = (
+    configs: RouteConfig[] = [],
+    parentPath = ''
+  ): string | undefined => {
+    for (const config of configs) {
+      const joinedPath = [parentPath, config.path].filter(Boolean).join('/');
+      if (matchPath(joinedPath, location.pathname)) {
+        return config.breadcrumbs;
+      }
+      if (config.children) {
+        const childBreadcrumbs = getBreadcrumbs(config.children, joinedPath);
+        if (childBreadcrumbs) {
+          return childBreadcrumbs;
+        }
+      }
+    }
+  };
+
+  const breadcrumbs = getBreadcrumbs(routeConfigs);
   // Create routes structure that Header expects
   const routes = [
     {}, // First route is not used

--- a/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
+++ b/apps/src/code-studio/legacyDashboardRoutingCompatibility/WithRouterProps.tsx
@@ -46,10 +46,11 @@ export const WithRouterProps: React.FC<
     parentPath = ''
   ): string | undefined => {
     for (const config of configs) {
-      const joinedPath = [parentPath, config.path]
+      const joinedPath = [`/${parentPath}`, config.path]
         .filter(Boolean)
         .join('/')
         .replace(/\/\/+/g, '/');
+
       if (matchPath(joinedPath, location.pathname)) {
         return config.breadcrumbs;
       }

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopEnrollments.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopEnrollments.tsx
@@ -1,0 +1,5 @@
+import React, {FC} from 'react';
+
+export const WorkshopEnrollments: FC = () => {
+  return <div>Enrollments</div>;
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopOverview.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopOverview.tsx
@@ -1,0 +1,5 @@
+import React, {FC} from 'react';
+
+export const WorkshopOverview: FC = () => {
+  return <div>Overview</div>;
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopSurveys.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopSurveys.tsx
@@ -1,0 +1,5 @@
+import React, {FC} from 'react';
+
+export const WorkshopSurveys: FC = () => {
+  return <div>Surveys</div>;
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
@@ -1,7 +1,7 @@
 import Link from '@mui/material/Link';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-import React, {forwardRef} from 'react';
+import React, {FC, forwardRef} from 'react';
 import {
   Link as RouterLink,
   LinkProps,
@@ -10,17 +10,13 @@ import {
   useLocation,
 } from 'react-router-dom';
 
-const tabList = [
-  {label: 'Overview', path: ''},
-  {label: 'Enrollment', path: 'enrollments'},
-  {label: 'Surveys', path: 'surveys'},
-];
+import {WorkshopTabsProps} from '../types';
 
 const TabLink = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => (
   <Link ref={ref} {...props} component={RouterLink} />
 ));
 
-export const WorkshopTabs = () => {
+export const WorkshopTabs: FC<WorkshopTabsProps> = ({tabList}) => {
   const {workshopId} = useParams();
   const {pathname} = useLocation();
 
@@ -38,9 +34,7 @@ export const WorkshopTabs = () => {
             label={tab.label}
             value={tab.path}
             component={TabLink}
-            to={`/workshops/${workshopId}/temp${
-              tab.path ? `/${tab.path}` : ''
-            }`}
+            to={`/workshops/${workshopId}${tab.path ? `/${tab.path}` : ''}`}
           />
         ))}
       </Tabs>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
@@ -12,9 +12,8 @@ export const WorkshopTabs: FC<WorkshopTabsProps> = ({tabList}) => {
 
   const currentTabValue = useMemo(
     () =>
-      // filter out index path
-      tabList.filter(t => t.path).find(tab => pathname.includes(tab.path))
-        ?.path ?? '',
+      // exclude index path as it's the default
+      tabList.find(tab => tab.path && pathname.includes(tab.path))?.path ?? '',
     [pathname, tabList]
   );
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
@@ -1,43 +1,42 @@
-import Link from '@mui/material/Link';
-import Tab from '@mui/material/Tab';
-import Tabs from '@mui/material/Tabs';
-import React, {FC, forwardRef} from 'react';
-import {
-  Link as RouterLink,
-  LinkProps,
-  Outlet,
-  useParams,
-  useLocation,
-} from 'react-router-dom';
+import Tabs from '@code-dot-org/component-library/tabs';
+import React, {FC, useMemo} from 'react';
+import {Outlet, useLocation, useNavigate} from 'react-router-dom';
 
 import {WorkshopTabsProps} from '../types';
 
-const TabLink = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => (
-  <Link ref={ref} {...props} component={RouterLink} />
-));
+import styles from '../workshop.module.scss';
 
 export const WorkshopTabs: FC<WorkshopTabsProps> = ({tabList}) => {
-  const {workshopId} = useParams();
   const {pathname} = useLocation();
+  const navigate = useNavigate();
 
-  const currentTabValue =
-    tabList.find(tab =>
-      pathname.endsWith(`/workshops/${workshopId}/${tab.path}`)
-    )?.path || '';
+  const currentTabValue = useMemo(
+    () =>
+      // filter out index path
+      tabList.filter(t => t.path).find(tab => pathname.includes(tab.path))
+        ?.path ?? '',
+    [pathname, tabList]
+  );
+
+  const handleChange = (value: string) => {
+    navigate(value);
+  };
 
   return (
     <nav aria-label="Workshop sections">
-      <Tabs value={currentTabValue}>
-        {tabList.map(tab => (
-          <Tab
-            key={tab.label}
-            label={tab.label}
-            value={tab.path}
-            component={TabLink}
-            to={`/workshops/${workshopId}${tab.path ? `/${tab.path}` : ''}`}
-          />
-        ))}
-      </Tabs>
+      <Tabs
+        defaultSelectedTabValue={currentTabValue}
+        tabsContainerClassName={styles.tabList}
+        name="default_tabs"
+        onChange={handleChange}
+        onTabClose={() => {}}
+        tabs={tabList.map(tab => ({
+          // tabContent is null because Outlet will render appropriate components based on route
+          tabContent: null,
+          text: tab.label,
+          value: tab.path,
+        }))}
+      />
       <Outlet />
     </nav>
   );

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
@@ -33,7 +33,7 @@ export const WorkshopTabs: FC<WorkshopTabsProps> = ({tabList}) => {
           // tabContent is null because Outlet will render appropriate components based on route
           tabContent: null,
           text: tab.label,
-          value: tab.path,
+          value: tab.path ?? '',
         }))}
       />
       <Outlet />

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
@@ -1,0 +1,53 @@
+import Link from '@mui/material/Link';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import React, {forwardRef} from 'react';
+import {
+  Link as RouterLink,
+  LinkProps,
+  Outlet,
+  useParams,
+  useLocation,
+} from 'react-router-dom';
+
+const tabList = [
+  {label: 'Overview', path: ''},
+  {label: 'Enrollment', path: 'enrollments'},
+  {label: 'Surveys', path: 'surveys'},
+];
+
+const TabLink = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => (
+  <Link ref={ref} {...props} component={RouterLink} />
+));
+
+export const WorkshopTabs = () => {
+  const {workshopId} = useParams();
+  const {pathname} = useLocation();
+
+  // Determine the current tab by matching the last segment of the URL path.
+  // This correctly handles nested routes.
+  const pathSegments = pathname.split('/');
+  const lastSegment = pathSegments[pathSegments.length - 1];
+  const currentTabValue = tabList.some(tab => tab.path === lastSegment)
+    ? lastSegment
+    : '';
+
+  return (
+    <nav aria-label="Workshop sections">
+      <Tabs value={currentTabValue}>
+        {tabList.map(tab => (
+          <Tab
+            key={tab.label}
+            label={tab.label}
+            value={tab.path}
+            component={TabLink}
+            to={`/workshops/${workshopId}/temp${
+              tab.path ? `/${tab.path}` : ''
+            }`}
+          />
+        ))}
+      </Tabs>
+      <Outlet />
+    </nav>
+  );
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs.tsx
@@ -24,13 +24,10 @@ export const WorkshopTabs = () => {
   const {workshopId} = useParams();
   const {pathname} = useLocation();
 
-  // Determine the current tab by matching the last segment of the URL path.
-  // This correctly handles nested routes.
-  const pathSegments = pathname.split('/');
-  const lastSegment = pathSegments[pathSegments.length - 1];
-  const currentTabValue = tabList.some(tab => tab.path === lastSegment)
-    ? lastSegment
-    : '';
+  const currentTabValue =
+    tabList.find(tab =>
+      pathname.endsWith(`/workshops/${workshopId}/${tab.path}`)
+    )?.path || '';
 
   return (
     <nav aria-label="Workshop sections">

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/types.ts
@@ -1,6 +1,6 @@
 export interface Tab {
   label: string;
-  path: string;
+  path?: string;
 }
 
 export interface WorkshopTabsProps {

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/types.ts
@@ -1,0 +1,8 @@
+export interface Tab {
+  label: string;
+  path: string;
+}
+
+export interface WorkshopTabsProps {
+  tabList: Tab[];
+}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop/workshop.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop/workshop.module.scss
@@ -1,0 +1,5 @@
+.tabList {
+  ul {
+    width: 100%;
+  }
+}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -93,6 +93,13 @@ const routeConfigs = [
     path: 'workshops/:workshopId/temp',
     breadcrumbs: 'Workshops,Workshop',
     component: WorkshopTabs,
+    props: {
+      tabList: [
+        {label: 'Overview', path: 'temp'},
+        {label: 'Enrollment', path: 'temp/enrollments'},
+        {label: 'Surveys', path: 'temp/surveys'},
+      ],
+    },
     childRoutes: [
       {
         index: true,

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -95,9 +95,9 @@ const routeConfigs = [
     component: WorkshopTabs,
     props: {
       tabList: [
-        {label: 'Overview', path: 'temp'},
-        {label: 'Enrollment', path: 'temp/enrollments'},
-        {label: 'Surveys', path: 'temp/surveys'},
+        {label: 'Overview', path: ''},
+        {label: 'Enrollment', path: 'enrollments'},
+        {label: 'Surveys', path: 'surveys'},
       ],
     },
     childRoutes: [

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -61,35 +61,37 @@ const routeConfigs = [
     path: 'reports',
     breadcrumbs: 'Reports',
     component: ReportView,
+    withRouter: true,
   },
   {
     path: 'workshops',
     breadcrumbs: 'Workshops',
     component: WorkshopIndex,
+    withRouter: true,
   },
   {
     path: 'workshops/filter',
     breadcrumbs: 'Workshops,Filter',
     component: WorkshopFilter,
+    withRouter: true,
   },
   ...WorkshopCourseConfigs.map(config => ({
     path: `workshops/new/${config.slug}`,
     breadcrumbs: `Workshops,${workshopLabel(`New ${config.label}`)}`,
     component: WorkshopFormTemplate,
     props: {config},
-    noRouter: true,
   })),
   // replace with temp route when ready to switch over
   {
     path: 'workshops/:workshopId',
     breadcrumbs: 'Workshops,View Workshop',
     component: Workshop,
+    withRouter: true,
   },
   {
     // remove /temp for switch over
     path: 'workshops/:workshopId/temp',
-    breadcrumbs: 'Workshops,Workshop Overview',
-    noRouter: true,
+    breadcrumbs: 'Workshops,Workshop',
     component: WorkshopTabs,
     children: [
       {
@@ -99,12 +101,12 @@ const routeConfigs = [
       {
         path: 'enrollments',
         component: WorkshopEnrollments,
-        breadcrumbs: 'Workshops,Workshop Overview,Enrollments',
+        breadcrumbs: 'Workshops,Workshop,Enrollments',
       },
       {
         path: 'surveys',
         component: WorkshopSurveys,
-        breadcrumbs: 'Workshops,Workshop Overview,Surveys',
+        breadcrumbs: 'Workshops,Workshop,Surveys',
       },
     ],
   },
@@ -112,32 +114,36 @@ const routeConfigs = [
     path: 'workshops/:workshopId/edit',
     breadcrumbs: 'Workshops,Edit Workshop',
     component: WorkshopFormTemplate,
-    noRouter: true,
   },
   {
     path: 'workshops/:workshopId/attendance',
     breadcrumbs: 'Workshops,Workshop,Take Attendance',
     component: WorkshopAttendance,
+    withRouter: true,
   },
   {
     path: 'workshops/:workshopId/attendance/:sessionId',
     breadcrumbs: 'Workshops,Workshop,Take Attendance',
     component: WorkshopAttendance,
+    withRouter: true,
   },
   {
     path: 'daily_survey_results/:workshopId',
     breadcrumbs: 'Survey Results',
     component: DailySurveyResultsLoader,
+    withRouter: true,
   },
   {
     path: 'workshop_daily_survey_results/:workshopId',
     breadcrumbs: 'Survey Results',
     component: FoormDailySurveyResultsLoader,
+    withRouter: true,
   },
   {
     path: 'legacy_survey_summaries',
     breadcrumbs: 'Legacy Facilitator Survey Summaries',
     component: LegacySurveySummaries,
+    withRouter: true,
   },
 ];
 
@@ -155,6 +161,30 @@ const HeaderWrapper = () => {
     </>
   );
 };
+
+const renderRoute = ({
+  path,
+  index,
+  component: Component,
+  withRouter,
+  children,
+  props = {},
+}) => (
+  <Route
+    key={index ? 'index-route' : path}
+    path={path}
+    index={index}
+    element={
+      withRouter ? (
+        <WithRouterProps component={Component} {...props} />
+      ) : (
+        <Component {...props} />
+      )
+    }
+  >
+    {children?.map(renderRoute)}
+  </Route>
+);
 
 const WorkshopDashboard = ({
   permissionList,
@@ -194,38 +224,7 @@ const WorkshopDashboard = ({
           <Routes>
             <Route path="/" element={<HeaderWrapper />}>
               <Route index element={<Navigate to="/workshops" replace />} />
-              {routeConfigs.map(
-                ({
-                  path,
-                  component: Component,
-                  noRouter,
-                  children,
-                  props = {},
-                }) => (
-                  <Route
-                    key={path}
-                    path={path}
-                    element={
-                      noRouter ? (
-                        <Component {...props} />
-                      ) : (
-                        <WithRouterProps component={Component} {...props} />
-                      )
-                    }
-                  >
-                    {children?.map(
-                      ({component: ChildComponent, path, index}) => (
-                        <Route
-                          key={path ?? 'index-route'}
-                          path={path}
-                          index={index}
-                          element={<ChildComponent />}
-                        />
-                      )
-                    )}
-                  </Route>
-                )
-              )}
+              {routeConfigs.map(renderRoute)}
             </Route>
           </Routes>
         </RouterProvider>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -37,6 +37,10 @@ import FoormDailySurveyResultsLoader from './reports/foorm/results_loader';
 import DailySurveyResultsLoader from './reports/local_summer_workshop_daily_survey/results_loader';
 import ReportView from './reports/report_view';
 import Workshop from './workshop';
+import {WorkshopEnrollments} from './workshop/components/WorkshopEnrollments';
+import {WorkshopOverview} from './workshop/components/WorkshopOverview';
+import {WorkshopSurveys} from './workshop/components/WorkshopSurveys';
+import {WorkshopTabs} from './workshop/components/WorkshopTabs';
 import WorkshopFilter from './workshop_filter';
 import WorkshopIndex from './workshop_index';
 import {WorkshopFormTemplate} from './WorkshopFormTemplate';
@@ -75,10 +79,34 @@ const routeConfigs = [
     props: {config},
     noRouter: true,
   })),
+  // replace with temp route when ready to switch over
   {
     path: 'workshops/:workshopId',
     breadcrumbs: 'Workshops,View Workshop',
     component: Workshop,
+  },
+  {
+    // remove /temp for switch over
+    path: 'workshops/:workshopId/temp',
+    breadcrumbs: 'Workshops,Workshop Overview',
+    noRouter: true,
+    component: WorkshopTabs,
+    children: [
+      {
+        index: true,
+        component: WorkshopOverview,
+      },
+      {
+        path: 'enrollments',
+        component: WorkshopEnrollments,
+        breadcrumbs: 'Workshops,Workshop Overview,Enrollments',
+      },
+      {
+        path: 'surveys',
+        component: WorkshopSurveys,
+        breadcrumbs: 'Workshops,Workshop Overview,Surveys',
+      },
+    ],
   },
   {
     path: 'workshops/:workshopId/edit',
@@ -167,7 +195,13 @@ const WorkshopDashboard = ({
             <Route path="/" element={<HeaderWrapper />}>
               <Route index element={<Navigate to="/workshops" replace />} />
               {routeConfigs.map(
-                ({path, component: Component, noRouter, props = {}}) => (
+                ({
+                  path,
+                  component: Component,
+                  noRouter,
+                  children,
+                  props = {},
+                }) => (
                   <Route
                     key={path}
                     path={path}
@@ -178,7 +212,18 @@ const WorkshopDashboard = ({
                         <WithRouterProps component={Component} {...props} />
                       )
                     }
-                  />
+                  >
+                    {children?.map(
+                      ({component: ChildComponent, path, index}) => (
+                        <Route
+                          key={path ?? 'index-route'}
+                          path={path}
+                          index={index}
+                          element={<ChildComponent />}
+                        />
+                      )
+                    )}
+                  </Route>
                 )
               )}
             </Route>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -56,6 +56,26 @@ const store = createStore(
   })
 );
 
+const workshopChildRouteConfigs = [
+  {
+    label: 'Overview',
+    index: true,
+    component: WorkshopOverview,
+  },
+  {
+    label: 'Enrollment',
+    path: 'enrollments',
+    component: WorkshopEnrollments,
+    breadcrumbs: 'Workshops,Workshop,Enrollments',
+  },
+  {
+    label: 'Surveys',
+    path: 'surveys',
+    component: WorkshopSurveys,
+    breadcrumbs: 'Workshops,Workshop,Surveys',
+  },
+];
+
 const routeConfigs = [
   {
     path: 'reports',
@@ -94,28 +114,12 @@ const routeConfigs = [
     breadcrumbs: 'Workshops,Workshop',
     component: WorkshopTabs,
     props: {
-      tabList: [
-        {label: 'Overview', path: ''},
-        {label: 'Enrollment', path: 'enrollments'},
-        {label: 'Surveys', path: 'surveys'},
-      ],
+      tabList: workshopChildRouteConfigs.map(({label, path}) => ({
+        label,
+        path,
+      })),
     },
-    childRoutes: [
-      {
-        index: true,
-        component: WorkshopOverview,
-      },
-      {
-        path: 'enrollments',
-        component: WorkshopEnrollments,
-        breadcrumbs: 'Workshops,Workshop,Enrollments',
-      },
-      {
-        path: 'surveys',
-        component: WorkshopSurveys,
-        breadcrumbs: 'Workshops,Workshop,Surveys',
-      },
-    ],
+    childRoutes: workshopChildRouteConfigs,
   },
   {
     path: 'workshops/:workshopId/edit',

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -93,7 +93,7 @@ const routeConfigs = [
     path: 'workshops/:workshopId/temp',
     breadcrumbs: 'Workshops,Workshop',
     component: WorkshopTabs,
-    children: [
+    childRoutes: [
       {
         index: true,
         component: WorkshopOverview,
@@ -167,7 +167,7 @@ const renderRoute = ({
   index,
   component: Component,
   withRouter,
-  children,
+  childRoutes,
   props = {},
 }) => (
   <Route
@@ -182,7 +182,7 @@ const renderRoute = ({
       )
     }
   >
-    {children?.map(renderRoute)}
+    {childRoutes?.map(renderRoute)}
   </Route>
 );
 

--- a/apps/test/unit/code-studio/legacyDashboardRoutingCompatibility/WithRouterPropsTest.js
+++ b/apps/test/unit/code-studio/legacyDashboardRoutingCompatibility/WithRouterPropsTest.js
@@ -40,7 +40,7 @@ describe('WithRouterProps', () => {
   };
   const mockSearchParams = new URLSearchParams({key: 'value'});
   const mockRouteConfigs = [
-    {path: '/test-route', breadcrumbs: 'Test Breadcrumb'},
+    {path: 'test-route', breadcrumbs: 'Test Breadcrumb'},
   ];
 
   beforeEach(() => {
@@ -68,6 +68,99 @@ describe('WithRouterProps', () => {
     // https://codedotorg.atlassian.net/browse/ACQ-3128
     expect(screen.getByText(/routes:/)).toHaveTextContent(
       JSON.stringify([{}, {breadcrumbs: 'Test Breadcrumb'}])
+    );
+  });
+
+  it('handles nested routeConfigs and returns child breadcrumbs', () => {
+    const nestedRouteConfigs = [
+      {
+        path: 'parent',
+        breadcrumbs: 'Parent',
+        childRoutes: [
+          {
+            path: 'child',
+            breadcrumbs: 'Child',
+          },
+        ],
+      },
+    ];
+    useLocation.mockReturnValue({
+      pathname: '/parent/child',
+      search: '?nested=true',
+    });
+    matchPath.mockImplementation(
+      (path, pathname) =>
+        pathname === '/parent/child' && path === '/parent/child'
+    );
+    useSearchParams.mockReturnValue([new URLSearchParams({nested: 'true'})]);
+
+    render(
+      <WithRouterProps
+        component={TestComponent}
+        routeConfigs={nestedRouteConfigs}
+      />
+    );
+    expect(screen.getByText(/routes:/)).toHaveTextContent(
+      JSON.stringify([{}, {breadcrumbs: 'Child'}])
+    );
+  });
+
+  it('returns undefined breadcrumbs if no match in nested routeConfigs', () => {
+    const nestedRouteConfigs = [
+      {
+        path: 'parent',
+        breadcrumbs: 'Parent',
+        childRoutes: [
+          {
+            path: 'child',
+            breadcrumbs: 'Child',
+          },
+        ],
+      },
+    ];
+    useLocation.mockReturnValue({
+      pathname: '/parent/unknown',
+      search: '?nested=false',
+    });
+    matchPath.mockImplementation((path, pathname) => false);
+    useSearchParams.mockReturnValue([new URLSearchParams({nested: 'false'})]);
+
+    render(
+      <WithRouterProps
+        component={TestComponent}
+        routeConfigs={nestedRouteConfigs}
+      />
+    );
+    expect(screen.getByText(/routes:/)).toHaveTextContent(
+      JSON.stringify([{}, {breadcrumbs: undefined}])
+    );
+  });
+
+  it('normalizes multiple slashes in route path and matches breadcrumbs', () => {
+    const multiSlashRouteConfigs = [
+      {
+        path: '//parent//child',
+        breadcrumbs: 'MultiSlash',
+      },
+    ];
+    useLocation.mockReturnValue({
+      pathname: '/parent/child',
+      search: '?multi=true',
+    });
+    matchPath.mockImplementation(
+      (path, pathname) =>
+        path === '/parent/child' && pathname === '/parent/child'
+    );
+    useSearchParams.mockReturnValue([new URLSearchParams({multi: 'true'})]);
+
+    render(
+      <WithRouterProps
+        component={TestComponent}
+        routeConfigs={multiSlashRouteConfigs}
+      />
+    );
+    expect(screen.getByText(/routes:/)).toHaveTextContent(
+      JSON.stringify([{}, {breadcrumbs: 'MultiSlash'}])
     );
   });
 });

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabsTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabsTest.tsx
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom';
+import {act, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+
+import {WorkshopTabs} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabs';
+
+const tabList = [
+  {label: 'Overview', path: ''},
+  {label: 'Enrollment', path: 'enrollments'},
+  {label: 'Surveys', path: 'surveys'},
+];
+
+function renderWithRouter({initialPath = '/workshops/123'} = {}) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="/workshops/:workshopId/*"
+          element={<WorkshopTabs tabList={tabList} />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('WorkshopTabs', () => {
+  it('renders all tabs', () => {
+    renderWithRouter();
+    tabList.forEach(tab => {
+      expect(screen.getByRole('tab', {name: tab.label})).toBeInTheDocument();
+    });
+  });
+
+  it('selects the correct tab based on the route', () => {
+    renderWithRouter({initialPath: '/workshops/123/enrollments'});
+    const enrollmentTab = screen.getByRole('tab', {name: 'Enrollment'});
+    expect(enrollmentTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('navigates to the correct route when a tab is clicked', async () => {
+    renderWithRouter();
+    const user = userEvent.setup();
+    const surveysTab = screen.getByRole('tab', {name: 'Surveys'});
+    await act(async () => {
+      await user.click(surveysTab);
+    });
+    expect(screen.getByRole('tab', {name: 'Surveys'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+});

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabsTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshop/components/WorkshopTabsTest.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import {act, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
@@ -43,9 +43,7 @@ describe('WorkshopTabs', () => {
     renderWithRouter();
     const user = userEvent.setup();
     const surveysTab = screen.getByRole('tab', {name: 'Surveys'});
-    await act(async () => {
-      await user.click(surveysTab);
-    });
+    await user.click(surveysTab);
     expect(screen.getByRole('tab', {name: 'Surveys'})).toHaveAttribute(
       'aria-selected',
       'true'


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This pr adds `WorkshopTabs` as the component rendered under a new temporary route `workshop_dashboard/workshops/:workshopId/temp`. `WorkshopTabs` has a react router `Outlet` for new child routes, rendering placeholder components `WorkshopOverview` for the index route, `WorkshopEnrollments` for the `/enrollments` route and `WorkshopSurveys` for the `/surveys` route.


https://github.com/user-attachments/assets/623f3fc6-243c-4bef-840e-da7480eb7c67



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3408

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
