### PR TITLE
Support sauce connect 5.3

### DIFF
--- a/lib/cdo/sauce_connect.rb
+++ b/lib/cdo/sauce_connect.rb
@@ -98,7 +98,7 @@ module Cdo
             sleep 0.1
             while (line = log_file.gets)
               lines << line
-              if line.strip.end_with?(SC_START_MESSAGE)
+              if line.strip.include?(SC_START_MESSAGE)
                 return :success, lines
               end
             end


### PR DESCRIPTION
The `sc` tool changed its log output format between sc 5.2 and 5.3. We watch for the command to report "you may start your tests", but the new log format no longer puts that at the end of the log line.

Tested on:
- sc 5.2 (bin/sauce_connect still works)
- sc 5.3 (bin/sauce_connect now works)