### PR TITLE
Adding unit_group_id to unit_scripts table

### DIFF
--- a/dashboard/app/models/user_script.rb
+++ b/dashboard/app/models/user_script.rb
@@ -13,6 +13,7 @@
 #  updated_at       :datetime
 #  properties       :text(65535)
 #  deleted_at       :datetime
+#  unit_group_id    :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20250729212602_add_unit_group_id_to_user_scripts.rb
+++ b/dashboard/db/migrate/20250729212602_add_unit_group_id_to_user_scripts.rb
@@ -1,0 +1,5 @@
+class AddUnitGroupIdToUserScripts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_scripts, :unit_group_id, :integer
+  end
+end


### PR DESCRIPTION
The UserScript table creates a new row whenever a User makes progress in a Unit (Script was the old name). Now that Units can be shared between multiple UnitGroups, we want to track what UnitGroup the User was in when they made progress in a Unit. This PR adds the column `unit_group_id` to UserScript in order to record the UnitGroup the User is making progress in.

Future PR's will update the indexes for UserScript.
 
## Links
* [Jira](https://codedotorg.atlassian.net/browse/TEACH-1555)

## Testing story
Created an adhoc with a clone of the prodoction database. Confirmed that adding the new column was fast and did not timeout.

## Follow-up work
* A future PR will add a new index related to this column. Adding the index is slow, so a special oneoff script will need to be created.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
