### PR TITLE
Enable Deployment of Multiple Marketing Site Types

### DIFF
--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -106,6 +106,7 @@ jobs:
         working-directory: ./frontend/apps/marketing/cicd/3-app
         run: |
           bundle exec ruby deploy.rb --environment_type ${{ vars.ENVIRONMENT_TYPE }} \
+            --site_type ${{ vars.SITE_TYPE }} \
             --region ${{ vars.AWS_REGION }} \
             --hosted_zone_id ${{ secrets.ROOT_HOSTED_ZONE_ID }} \
             --base_domain_name ${{ vars.APPLICATION_BASE_DOMAIN }} \

--- a/frontend/apps/marketing/cicd/3-app/deploy.rb
+++ b/frontend/apps/marketing/cicd/3-app/deploy.rb
@@ -15,6 +15,7 @@ CERTIFICATE_TEMPLATE_FILE = 'cloudfront-certificate.yml.erb'
 # Default options
 options = {
   environment_type: 'development',
+  site_type: 'corporate',
   region: 'us-east-1',
   base_domain_name: 'marketing-sites.dev-code.org',
   subdomain_name: 'code',
@@ -28,12 +29,20 @@ opt_parser = OptionParser.new do |opts|
   opts.banner = "Usage: ./deploy.rb [options]"
 
   opts.on(
-    '--environment_type TYPE',
+    '--environment_type ENVIRONMENT_TYPE',
     %w[development test production],
     "Environment type (development, test, or production)",
     "Default: development"
-  ) do |env_type|
-    options[:environment_type] = env_type
+  ) do |environment_type|
+    options[:environment_type] = environment_type
+  end
+
+  opts.on(
+    '--site_type SITE_TYPE',
+    %w[corporate csforall],
+    "Code identifying the site type (corporate csforall)",
+    ) do |site_type|
+    options[:site_type] = site_type
   end
 
   opts.on(
@@ -173,31 +182,50 @@ def process_template(template_file, output_file, binding_object)
   end
 end
 
-def deploy_stack(stack_name, template_file, parameters, region, role_arn, environment_type)
+def deploy_stack(stack_name:, template_file:, parameters: {}, region:, role_arn: nil, tags: {}, capabilities: [])
   temp_dir = File.join(Dir.pwd, 'tmp')
   FileUtils.mkdir_p(temp_dir)
+  parameter_path = nil  # Initialize to nil
 
-  param_file = "parameters_#{stack_name}_#{Time.now.to_i}.json"
-  parameter_path = File.join(temp_dir, param_file)
-  parameter_content = parameters.map {|k, v| {"ParameterKey" => k, "ParameterValue" => v.to_s}}
-  File.write(parameter_path, JSON.pretty_generate(parameter_content))
+  # Build the AWS CLI command
+  command_parts = [
+    "aws cloudformation deploy",
+    "--stack-name #{stack_name}",
+    "--template-file #{template_file}",
+    "--region #{region}"
+  ]
+
+  # Add capabilities if any are specified
+  unless capabilities.empty?
+    command_parts << "--capabilities #{capabilities.join(' ')}"
+  end
+
+  command_parts << "--role-arn #{role_arn}" if role_arn
+
+  # Add parameters if any
+  unless parameters.empty?
+    param_file = "parameters_#{stack_name}_#{Time.now.to_i}.json"
+    parameter_path = File.join(temp_dir, param_file)
+    parameter_content = parameters.map {|k, v| {"ParameterKey" => k, "ParameterValue" => v.to_s}}
+    File.write(parameter_path, JSON.pretty_generate(parameter_content))
+    command_parts << "--parameter-overrides file://#{parameter_path}"
+  end
+
+  # Add tags only if there are any
+  unless tags.empty?
+    tag_string = tags.map {|k, v| "#{k}=#{v}"}.join(" ")
+    command_parts << "--tags #{tag_string}"
+  end
+
+  command = command_parts.join(" \\\n    ")
 
   begin
-    command = <<~CMD
-      aws cloudformation deploy \\
-          --stack-name #{stack_name} \\
-          --template-file #{template_file} \\
-          --parameter-overrides file://#{parameter_path} \\
-          --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \\
-          --region #{region} \\
-          --role-arn #{role_arn} \\
-          --tags environment-type=#{environment_type}
-    CMD
-
     execute_command(command, "Deploying stack '#{stack_name}' in region '#{region}'")
   ensure
-    # Clean up the parameter file regardless of success or failure.
-    FileUtils.rm_f(parameter_path)
+    # Clean up the parameter file if it was created
+    if parameter_path && File.exist?(parameter_path)
+      FileUtils.rm_f(parameter_path)
+    end
   end
 end
 
@@ -274,12 +302,12 @@ begin
     }
 
     deploy_stack(
-      cert_stack_name,
-      cert_template_path,
-      cert_parameters,
-      "us-east-1",
-      options[:role_arn],
-      options[:environment_type]
+      stack_name: cert_stack_name,
+      template_file: cert_template_path,
+      parameters: cert_parameters,
+      region: 'us-east-1',
+      role_arn: options[:role_arn],
+      tags: {'environment-type' => options[:environment_type], 'site-type' => options[:site_type]}
     )
 
     # Step 3: Get certificate ARN from stack output.
@@ -301,6 +329,7 @@ begin
       "BaseDomainName" => options[:base_domain_name],
       "SubdomainName" => options[:subdomain_name],
       "EnvironmentType" => options[:environment_type],
+      "SiteType" => options[:site_type],
       "ContainerImageHashDigest" => options[:container_image_hash],
       "CloudFrontTLSCertificateArn" => certificate_arn,
       "WebApplicationServerSecretsARN" => options[:web_application_server_secrets_arn],
@@ -308,12 +337,13 @@ begin
     }
 
     deploy_stack(
-      options[:stack_name],
-      marketing_site_template_path,
-      marketing_site_stack_parameters,
-      options[:region],
-      options[:role_arn],
-      options[:environment_type]
+      stack_name: options[:stack_name],
+      template_file: marketing_site_template_path,
+      parameters: marketing_site_stack_parameters,
+      region: options[:region],
+      role_arn: options[:role_arn],
+      tags: {'environment-type' => options[:environment_type], 'site-type' => options[:site_type]},
+      capabilities: %w(CAPABILITY_IAM CAPABILITY_NAMED_IAM) # Marketing Sites templates creates ECS Task / Task Exec Roles.
     )
 
     puts "\nDeployment process completed successfully!"

--- a/frontend/apps/marketing/cicd/3-app/deploy.rb
+++ b/frontend/apps/marketing/cicd/3-app/deploy.rb
@@ -222,7 +222,7 @@ def deploy_stack(stack_name:, template_file:, parameters: {}, region:, role_arn:
   begin
     execute_command(command, "Deploying stack '#{stack_name}' in region '#{region}'")
   ensure
-    # Clean up the parameter file if it was created
+    # Clean up the parameter file if the parameter_path was set and the file exists
     if parameter_path && File.exist?(parameter_path)
       FileUtils.rm_f(parameter_path)
     end

--- a/frontend/apps/marketing/cicd/3-app/deploy.rb
+++ b/frontend/apps/marketing/cicd/3-app/deploy.rb
@@ -185,7 +185,7 @@ end
 def deploy_stack(stack_name:, template_file:, parameters: {}, region:, role_arn: nil, tags: {}, capabilities: [])
   temp_dir = File.join(Dir.pwd, 'tmp')
   FileUtils.mkdir_p(temp_dir)
-  parameter_path = nil  # Initialize to nil
+  parameter_path = nil
 
   # Build the AWS CLI command
   command_parts = [

--- a/frontend/apps/marketing/cicd/3-app/deploy.rb
+++ b/frontend/apps/marketing/cicd/3-app/deploy.rb
@@ -307,7 +307,10 @@ begin
       parameters: cert_parameters,
       region: 'us-east-1',
       role_arn: options[:role_arn],
-      tags: {'environment-type' => options[:environment_type], 'site-type' => options[:site_type]}
+      tags: {
+        'environment-type' => options[:environment_type],
+        'site-type' => options[:site_type]
+      }
     )
 
     # Step 3: Get certificate ARN from stack output.
@@ -342,7 +345,10 @@ begin
       parameters: marketing_site_stack_parameters,
       region: options[:region],
       role_arn: options[:role_arn],
-      tags: {'environment-type' => options[:environment_type], 'site-type' => options[:site_type]},
+      tags: {
+        'environment-type' => options[:environment_type],
+        'site-type' => options[:site_type]
+      },
       capabilities: %w(CAPABILITY_IAM CAPABILITY_NAMED_IAM) # Marketing Sites templates creates ECS Task / Task Exec Roles.
     )
 

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -26,6 +26,10 @@ Parameters:
     Type: String
     Default: development
     Description: Is this a 'development', 'test', or 'production' system?
+  SiteType:
+    Type: String
+    Default: corporate
+    Description: Code identifying the site type ('corporate', 'csforall', etc.)
   ContainerImageHashDigest:
     Type: String
     Description: The sha256sum of the marketing sites Next.js container image.
@@ -356,7 +360,7 @@ Resources:
   FargateServiceTaskDefTaskRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "marketing-sites-${EnvironmentType}-${SubdomainName}-task-role"
+      RoleName: !Sub "marketing-sites-${EnvironmentType}-${SiteType}-${SubdomainName}-task"
       AssumeRolePolicyDocument:
         Statement:
           - Action: sts:AssumeRole
@@ -368,7 +372,7 @@ Resources:
   FargateServiceTaskDefExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "marketing-sites-${EnvironmentType}-${SubdomainName}-task-exec-role"
+      RoleName: !Sub "marketing-sites-${EnvironmentType}-${SiteType}-${SubdomainName}-task-exec"
       AssumeRolePolicyDocument:
         Statement:
           - Action: sts:AssumeRole
@@ -409,10 +413,6 @@ Resources:
             # such as the withRedirect middleware
             - Name: HOSTNAME
               Value: 0.0.0.0
-            - Name: CONTENTFUL_SPACE_ID
-              Value: 90t6bu6vlf76
-            - Name: CONTENTFUL_ENV_ID
-              Value: master
             - Name: CONTENTFUL_API_HOST
               Value: cdn.contentful.com
             - Name: CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID
@@ -438,6 +438,10 @@ Resources:
               Value: delta
             - Name: OTEL_EXPORTER_OTLP_ENDPOINT
               Value: https://otlp.nr-data.net
+<% MarketingSites::Configuration.site_config(options[:site_type], options[:environment_type])[:environment_variables].each do |name, value| %>
+            - Name: <%= name %>
+              Value: <%= value %>
+<% end %>
           Essential: true
           Image: !Sub "ghcr.io/code-dot-org/marketing@${ContainerImageHashDigest}"
           Name: web

--- a/frontend/apps/marketing/cicd/config.rb
+++ b/frontend/apps/marketing/cicd/config.rb
@@ -67,10 +67,18 @@ module MarketingSites
       # Site-specific configuration (applies to all environments for that site type)
       site_defaults: {
         corporate: {
-          contentful_space_id: '90t6bu6vlf76',
+          # Environment Variables to pass to the Next.js web application server.
+          environment_variables: {
+            CONTENTFUL_SPACE_ID: '90t6bu6vlf76',
+            CONTENTFUL_ENV_ID: 'master'
+          },
         }.freeze,
         csforall: {
-          contentful_space_id: '27jkibac934d',
+          # Environment Variables to pass to the Next.js web application server.
+          environment_variables: {
+            CONTENTFUL_SPACE_ID: '27jkibac934d',
+            CONTENTFUL_ENV_ID: 'master'
+          },
         }.freeze
       }.freeze,
 


### PR DESCRIPTION
Add Site Type to Marketing Site deployment system to support provisioning additional kinds of websites (CSforALL, HourofAI, etc.) beyond just our corporate site (code.org).

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
