### PR TITLE
Lab2: allow levelbuilders to override edit and run requirement for submittable levels

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -202,6 +202,7 @@ export interface LevelProperties {
   teacherMarkdown?: string;
   predictSettings?: LevelPredictSettings;
   submittable?: boolean;
+  disableEditRunForSubmission?: boolean;
   finishUrl?: string;
   finishDialog?: string;
   offerBrowserTts?: boolean;

--- a/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
+++ b/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
@@ -43,6 +43,9 @@ const NavigationButton: React.FC<NavigationButtonProps> = ({
       <SubmitButton
         levelId={levelProperties.id}
         appName={levelProperties.appName}
+        disableEditRunForSubmission={
+          levelProperties.disableEditRunForSubmission
+        }
         hasRun={hasRun}
         hasEdited={hasEdited}
         className={className}
@@ -144,6 +147,7 @@ interface SubmitButtonProps {
   appName: string;
   hasRun: boolean;
   hasEdited: boolean;
+  disableEditRunForSubmission?: boolean;
   className?: string;
 }
 
@@ -155,6 +159,7 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
   appName,
   hasRun,
   hasEdited,
+  disableEditRunForSubmission = false,
   className,
 }) => {
   const hasSubmitted = useAppSelector(
@@ -164,7 +169,8 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
     state => state.progress.scriptId || undefined
   );
 
-  const enabled = hasSubmitted || (hasRun && hasEdited);
+  const enabled =
+    disableEditRunForSubmission || hasSubmitted || (hasRun && hasEdited);
   const buttonText = hasSubmitted ? commonI18n.unsubmit() : commonI18n.submit();
 
   const dialogControl = useDialogControl();

--- a/dashboard/app/models/levels/aichat.rb
+++ b/dashboard/app/models/levels/aichat.rb
@@ -33,6 +33,7 @@ class Aichat < Level
     aichat_settings
     starter_assets
     submittable
+    disable_edit_run_for_submission
   )
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/app/models/levels/music.rb
+++ b/dashboard/app/models/levels/music.rb
@@ -37,6 +37,7 @@ class Music < Blockly
     hide_share_and_remix
     is_project_level
     submittable
+    disable_edit_run_for_submission
     background
     level_data
     predict_settings

--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -31,6 +31,7 @@ class Pythonlab < Level
     hide_share_and_remix
     is_project_level
     submittable
+    disable_edit_run_for_submission
     starter_assets
     predict_settings
     validation_file

--- a/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
@@ -13,6 +13,12 @@
       grading. Submitting a solution means that it is marked as
       submitted and they can no longer edit it (unless a teacher returns
       it).
+    - if @level.is_a?(Pythonlab) || @level.is_a?(Music) || @level.is_a?(Aichat)
+      = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :disable_edit_run_for_submission, description: "Disable Edit and Run Requirement for Submission"}
+      %p
+        By default, submittable levels require the student to edit and
+        run their code before they can submit it. Check this box to
+        disable this requirement.
   - if @level.respond_to? :free_play
     .field
       = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :embed, description: "Embed"}

--- a/dashboard/config/levels/custom/music/Submittable Music Level 2.level
+++ b/dashboard/config/levels/custom/music/Submittable Music Level 2.level
@@ -1,0 +1,32 @@
+<Music>
+  <config><![CDATA[{
+  "published": true,
+  "game_id": 70,
+  "created_at": "2025-07-23T17:30:02.000Z",
+  "level_num": "custom",
+  "user_id": 1,
+  "properties": {
+    "encrypted": "false",
+    "long_instructions": "### Assessment 2\r\n\r\n> This level does **not** require you to edit and run your code before submitting. Good luck!\r\n\r\nCreate a song using multiple sounds! Each part of your song should include a different type of sound.\r\n\r\nExperiment and have fun!\r\n\r\n_Tips_:\r\n- Try using blocks from different packs.\r\n- Try using the Play Together and repeat blocks.\r\n- Try factoring your song using functions.",
+    "offer_browser_tts": "false",
+    "use_secondary_finish_button": "false",
+    "submittable": "true",
+    "hide_share_and_remix": "false",
+    "level_data": {
+      "library": "launch2024",
+      "packId": "carly_rae_jepsen_call_me_maybe"
+    },
+    "predict_settings": {
+      "isPredictLevel": false
+    },
+    "exemplar_settings": {
+      "playerEnabled": false,
+      "validationEnabled": false
+    },
+    "disable_edit_run_for_submission": "true",
+    "preload_asset_list": null
+  },
+  "audit_log": "[{\"changed_at\":\"2025-07-23T17:30:02.496+00:00\",\"changed\":[\"cloned from \\\"Submittable Music Level 1\\\"\"],\"cloned_from\":\"Submittable Music Level 1\"},{\"changed_at\":\"2025-07-23 17:32:01 +0000\",\"changed\":[\"long_instructions\",\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]"
+}]]></config>
+  <blocks/>
+</Music>

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -12,7 +12,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-06-26 22:16:46 UTC",
+    "serialized_at": "2025-07-23 17:30:22 UTC",
     "hide_within_course": false,
     "published_state": null,
     "instruction_type": null,
@@ -6394,6 +6394,9 @@
       "activity_section_position": 10,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Submittable Music Level 1"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6411,6 +6414,27 @@
     },
     {
       "chapter": 175,
+      "position": 11,
+      "activity_section_position": 11,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Submittable Music Level 2"
+        ],
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
+      },
+      "level_keys": [
+        "Submittable Music Level 2"
+      ]
+    },
+    {
+      "chapter": 176,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6434,7 +6458,7 @@
       ]
     },
     {
-      "chapter": 176,
+      "chapter": 177,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6458,7 +6482,7 @@
       ]
     },
     {
-      "chapter": 177,
+      "chapter": 178,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6482,7 +6506,7 @@
       ]
     },
     {
-      "chapter": 178,
+      "chapter": 179,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6506,7 +6530,7 @@
       ]
     },
     {
-      "chapter": 179,
+      "chapter": 180,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6530,7 +6554,7 @@
       ]
     },
     {
-      "chapter": 180,
+      "chapter": 181,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6554,11 +6578,14 @@
       ]
     },
     {
-      "chapter": 181,
+      "chapter": 182,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "AI Chat Submittable Level"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6575,7 +6602,7 @@
       ]
     },
     {
-      "chapter": 182,
+      "chapter": 183,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6599,7 +6626,7 @@
       ]
     },
     {
-      "chapter": 183,
+      "chapter": 184,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -6623,7 +6650,7 @@
       ]
     },
     {
-      "chapter": 184,
+      "chapter": 185,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6647,7 +6674,7 @@
       ]
     },
     {
-      "chapter": 185,
+      "chapter": 186,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6671,7 +6698,7 @@
       ]
     },
     {
-      "chapter": 186,
+      "chapter": 187,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6695,7 +6722,7 @@
       ]
     },
     {
-      "chapter": 187,
+      "chapter": 188,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6719,7 +6746,7 @@
       ]
     },
     {
-      "chapter": 188,
+      "chapter": 189,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6743,7 +6770,7 @@
       ]
     },
     {
-      "chapter": 189,
+      "chapter": 190,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6767,7 +6794,7 @@
       ]
     },
     {
-      "chapter": 190,
+      "chapter": 191,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6791,7 +6818,7 @@
       ]
     },
     {
-      "chapter": 191,
+      "chapter": 192,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6815,7 +6842,7 @@
       ]
     },
     {
-      "chapter": 192,
+      "chapter": 193,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -6839,7 +6866,7 @@
       ]
     },
     {
-      "chapter": 193,
+      "chapter": 194,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -6863,7 +6890,7 @@
       ]
     },
     {
-      "chapter": 194,
+      "chapter": 195,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -6887,7 +6914,7 @@
       ]
     },
     {
-      "chapter": 195,
+      "chapter": 196,
       "position": 10,
       "activity_section_position": 10,
       "assessment": false,
@@ -6911,7 +6938,7 @@
       ]
     },
     {
-      "chapter": 196,
+      "chapter": 197,
       "position": 11,
       "activity_section_position": 11,
       "assessment": false,
@@ -6935,7 +6962,7 @@
       ]
     },
     {
-      "chapter": 197,
+      "chapter": 198,
       "position": 12,
       "activity_section_position": 12,
       "assessment": false,
@@ -6959,7 +6986,7 @@
       ]
     },
     {
-      "chapter": 198,
+      "chapter": 199,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6983,7 +7010,7 @@
       ]
     },
     {
-      "chapter": 199,
+      "chapter": 200,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -7007,7 +7034,7 @@
       ]
     },
     {
-      "chapter": 200,
+      "chapter": 201,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -7031,7 +7058,7 @@
       ]
     },
     {
-      "chapter": 201,
+      "chapter": 202,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -7055,7 +7082,7 @@
       ]
     },
     {
-      "chapter": 202,
+      "chapter": 203,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -7079,7 +7106,7 @@
       ]
     },
     {
-      "chapter": 203,
+      "chapter": 204,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -7103,7 +7130,7 @@
       ]
     },
     {
-      "chapter": 204,
+      "chapter": 205,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -7127,7 +7154,7 @@
       ]
     },
     {
-      "chapter": 205,
+      "chapter": 206,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -7151,7 +7178,7 @@
       ]
     },
     {
-      "chapter": 206,
+      "chapter": 207,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -7175,7 +7202,7 @@
       ]
     },
     {
-      "chapter": 207,
+      "chapter": 208,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -7199,7 +7226,7 @@
       ]
     },
     {
-      "chapter": 208,
+      "chapter": 209,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -7223,7 +7250,7 @@
       ]
     },
     {
-      "chapter": 209,
+      "chapter": 210,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -8540,19 +8567,6 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist 1 new",
-        "script_level.level_keys": [
-          "2-3 Artist 1 new",
-          "ramp_video_artistIntro"
-        ],
-        "lesson.key": "Swapped Levels",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
-      }
-    },
-    {
-      "seeding_key": {
         "level.key": "ramp_video_artistIntro",
         "script_level.level_keys": [
           "2-3 Artist 1 new",
@@ -8566,7 +8580,20 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist Loops 2",
+        "level.key": "2-3 Artist 1 new",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new",
+          "ramp_video_artistIntro"
+        ],
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -8579,7 +8606,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "ramp_video_loopsArtist",
+        "level.key": "2-3 Artist Loops 2",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -9464,6 +9491,18 @@
     },
     {
       "seeding_key": {
+        "level.key": "Submittable Music Level 2",
+        "script_level.level_keys": [
+          "Submittable Music Level 2"
+        ],
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
+      }
+    },
+    {
+      "seeding_key": {
         "level.key": "AI Chat Test Level",
         "script_level.level_keys": [
           "AI Chat Test Level"
@@ -9915,6 +9954,14 @@
   ],
   "rubrics": [
     {
+      "level_name": "Submittable Music Level 1",
+      "seeding_key": {
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
       "level_name": "CSD U3 Sprites scene challenge_allthethings",
       "seeding_key": {
         "lesson.key": "lesson-51",
@@ -9924,6 +9971,19 @@
     }
   ],
   "learning_goals": [
+    {
+      "key": "4152d63a-af5c-40ea-a15f-b0a3ebd7414c",
+      "position": 1,
+      "learning_goal": "Test Rubric",
+      "ai_enabled": false,
+      "tips": null,
+      "seeding_key": {
+        "learning_goal.key": "4152d63a-af5c-40ea-a15f-b0a3ebd7414c",
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
     {
       "key": "78189d6e-11b2-44a8-83c8-027de9bed803",
       "position": 1,
@@ -9965,6 +10025,54 @@
     }
   ],
   "learning_goal_evidence_levels": [
+    {
+      "understanding": 0,
+      "teacher_description": "4",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 0,
+        "learning_goal.key": "4152d63a-af5c-40ea-a15f-b0a3ebd7414c",
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "3",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "4152d63a-af5c-40ea-a15f-b0a3ebd7414c",
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "2",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "4152d63a-af5c-40ea-a15f-b0a3ebd7414c",
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "1",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "4152d63a-af5c-40ea-a15f-b0a3ebd7414c",
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
     {
       "understanding": 0,
       "teacher_description": "No sprites used",


### PR DESCRIPTION
Curriculum would like a way to override the current edit and run requirement for submitting submittable levels, on a level-by-level basis. This is needed for the Music Lab curriculum for template backed levels that are checked against a rubric. I've only enabled this for Lab2 levels that support submittable projects (Pythonlab, AI Chat, Music). I also added a new level to the allthethings music lesson that showcases this behavior.

Level edit page:
<img width="795" height="225" alt="Screenshot 2025-07-23 at 10 35 23 AM" src="https://github.com/user-attachments/assets/b1282f16-95c8-4976-b357-3ef77f426bed" />

Submittable level with requirement disabled (this screenshot is taken immediately after loading the level)
<img width="1514" height="824" alt="Screenshot 2025-07-23 at 10 34 49 AM" src="https://github.com/user-attachments/assets/78f10102-433f-4380-9be3-ae22365ac673" />

## Links

https://codedotorg.atlassian.net/browse/LABS-1525

## Testing story

Tested locally with new level and confirmed behavior remains the same on existing levels.