### PR TITLE
AI Chat: Add access to missing course

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -726,6 +726,7 @@ class Section < ApplicationRecord
       the-fabric-of-the-internet-and-ai-2025
       cybersecurity-and-global-impacts-2025
       insights-from-data-and-ai-2025
+      problem-solving-with-ai-2025
     ]
 
     # In order to support an organizational event.


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add AI Chat access to the `problem-solving-with-ai-2025` course. This one was missing from the original list added in #65934. 

## Links

 - [slack discussion](https://codedotorg.slack.com/archives/C03DBDN67B7/p1753290701761369)
 - [zendesk](https://codeorg.zendesk.com/agent/tickets/546375)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->
Tested locally that student assigned to this course can access ai chat