### PR TITLE
AI Chat: allow access via DCDO

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -733,7 +733,7 @@ class Section < ApplicationRecord
       codechella2025
     ]
 
-    # Note that as of May 2025, sc ript-specific assignment without course assignment
+    # Note that as of May 2025, script-specific assignment without course assignment
     # is not possible, so the first condition here is not necessary.
     if (gen_ai_scripts + csaif_scripts).include?(script&.name) ||
         (csaif_courses + gen_ai_courses + other_courses).include?(unit_group&.name)

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -733,10 +733,21 @@ class Section < ApplicationRecord
       codechella2025
     ]
 
-    # Note that as of May 2025, script-specific assignment without course assignment
+    # Note that as of May 2025, sc ript-specific assignment without course assignment
     # is not possible, so the first condition here is not necessary.
-    (gen_ai_scripts + csaif_scripts).include?(script&.name) ||
-      (csaif_courses + gen_ai_courses + other_courses).include?(unit_group&.name)
+    if (gen_ai_scripts + csaif_scripts).include?(script&.name) ||
+        (csaif_courses + gen_ai_courses + other_courses).include?(unit_group&.name)
+      return true
+    end
+
+    # In case we overlook a course that should have access,
+    # allow levelbuilders to dynamically allow access to AI Chat via DCDO.
+    # Note that levelbuilders should specify UNIT slugs (eg, aif1-2025),
+    # not COURSE slugs (eg, problem-solving-with-ai-2025)
+    dcdo_scripts = DCDO.get('aichat_access_units', [])
+    dcdo_scripts.flat_map do |name|
+      Unit.find_by(name: name)&.unit_groups || []
+    end.map(&:name).include?(unit_group&.name)
   end
 
   def reset_code_review_groups(new_groups)

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -1484,6 +1484,17 @@ class SectionTest < ActiveSupport::TestCase
     refute si.deleted?
   end
 
+  test 'section grants access to AI Chat when DCDO flag enabled' do
+    script = Unit.find_by_name('jigsaw')
+    unit_group = create :unit_group, name: 'somecourse', version_year: '1991', family_name: 'some-family'
+    create :unit_group_unit, unit_group: unit_group, script: script, position: 1
+    section = create :section, unit_group: unit_group
+
+    refute section.assigned_ai_chat?
+    DCDO.stubs(:get).with('aichat_access_units', []).returns([script.name])
+    assert section.assigned_ai_chat?
+  end
+
   def set_up_code_review_groups
     # create a new section to avoid extra unassigned students
     @code_review_group_section = create(:section, user: @teacher, login_type: 'word')


### PR DESCRIPTION
Adds support for a DCDO flag (`aichat_access_units`) that can be used to dynamically add access to AI Chat. Specifically, levelbuilders/admins can add a unit slug, and we'll look up the courses where that unit appears. If the section is assigned any of those courses, we allow access. Using units instead of courses was a request from the curriculum team to deduplicate things since we reuse units across courses. [An example is here](https://codedotorg.slack.com/archives/C03DBDN67B7/p1753292766995849?thread_ts=1753290701.761369&cid=C03DBDN67B7).

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1385

## Testing story

Tested manually that I could add/remove access locally for a student via DCDO, and added a unit test.