### PR TITLE
feat(docker): add docker images to speed up ci/cd

### DIFF
--- a/.github/workflows/frontend-docker-images.yml
+++ b/.github/workflows/frontend-docker-images.yml
@@ -1,0 +1,39 @@
+name: Build and Push Frontend Next.js Docker Images
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # Every Sunday at 3am UTC
+  workflow_dispatch:
+    # Allow manual trigger
+
+jobs:
+  # Job: build-frontend-base
+  # This job builds a docker image for the frontend-base repository and pushes the docker image to GitHub Packages.
+  build-frontend-base:
+    name: Build and Push frontend-base
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend-base image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ./docker/frontend/base
+          file: ./docker/frontend/base/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/code-dot-org/frontend-base:latest

--- a/docker/frontend/README.md
+++ b/docker/frontend/README.md
@@ -1,0 +1,24 @@
+# Code.org Frontend Docker Images
+
+## Overview
+
+![](./architecture-diagram.drawio.png)
+
+This directory contains Docker images for Code.org Next.js frontend applications. These images are intended for internal use only. External usage is not supported.
+
+- Images are automatically built and published weekly on Sunday at 3am UTC via GitHub Actions.
+- Images can also be built and published manually by maintainers.
+- Images are not supported for public use outside of Code.org applications.
+
+## Images
+
+### `code-dot-org/frontend-base`
+- Base image for all Next.js frontend applications at Code.org.
+- Extends Ubuntu 24.04 LTS.
+- Installs Node.js 20 LTS, curl, enables corepack, and sets up Yarn 4.6.0 globally.
+
+## Maintenance
+
+To trigger a manual build and publish of the images, maintainers can run the GitHub Actions workflow `frontend-docker-images.yml`.
+
+This would only need to be done in case of a critical security update or other urgent issues that cannot wait for the next scheduled build.

--- a/docker/frontend/architecture-diagram.drawio.png
+++ b/docker/frontend/architecture-diagram.drawio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:300fe6aefaec5c5a61f1e642dc33a0183926349974ae22012773391775c5718d
+size 19477

--- a/docker/frontend/base/Dockerfile
+++ b/docker/frontend/base/Dockerfile
@@ -1,0 +1,24 @@
+# Code.org frontend-base Docker image
+# Not for public usage outside Code.org applications
+FROM ubuntu:24.04
+LABEL maintainer="Code.org Engineering"
+LABEL description="Base image for Code.org Next.js frontend applications. Not supported for external use."
+
+# If changing yarn versions, also update the version in frontend/package.json
+ENV YARN_VERSION=4.6.0
+# If changing Node.js versions, also update the version in frontend/.nvmrc
+ENV NODE_VERSION=20
+
+# Install curl and Node.js 20 LTS
+# For Yarn upgrades, refer to frontend/package.json to the locked yarn version
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - && \
+    apt-get install -y nodejs && \
+    corepack enable && \
+    corepack prepare yarn@$YARN_VERSION --activate && \
+    yarn --version && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set default shell
+SHELL ["/bin/bash", "-c"]

--- a/docker/frontend/base/Dockerfile
+++ b/docker/frontend/base/Dockerfile
@@ -9,8 +9,8 @@ ENV YARN_VERSION=4.6.0
 # If changing Node.js versions, also update the version in frontend/.nvmrc
 ENV NODE_VERSION=20
 
-# Install curl and Node.js 20 LTS
-# For Yarn upgrades, refer to frontend/package.json to the locked yarn version
+# If performing a Yarn upgrades, refer to frontend/package.json to the locked yarn version
+# The apt-get clean and removal of /var/lib/apt/lists is to reduce image size.
 RUN apt-get update && \
     apt-get install -y curl && \
     curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - && \

--- a/frontend/apps/marketing/Dockerfile
+++ b/frontend/apps/marketing/Dockerfile
@@ -5,15 +5,7 @@
 # Code.org marketing app.                                                         #
 ###################################################################################
 
-FROM ubuntu:20.04 AS base
-
-# install operating system dependencies
-RUN apt-get update && \
-    apt-get install -y curl
-
-# install node, based on instructions at https://github.com/nodesource/distributions#using-ubuntu-1
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs
+FROM ghcr.io/code-dot-org/frontend-base:latest AS base
 
 ##############################################################################
 # Source Code Layer                                                          #
@@ -28,9 +20,6 @@ RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
 ##############################################################################
 
 FROM base AS source-code
-
-# Enable corepack
-RUN corepack enable
 
 WORKDIR /app
 

--- a/frontend/apps/marketing/Dockerfile
+++ b/frontend/apps/marketing/Dockerfile
@@ -5,6 +5,7 @@
 # Code.org marketing app.                                                         #
 ###################################################################################
 
+# See: docker/frontend/base/Dockerfile
 FROM ghcr.io/code-dot-org/frontend-base:latest AS base
 
 ##############################################################################


### PR DESCRIPTION
<img width="221" height="391" alt="image" src="https://github.com/user-attachments/assets/3ae18a30-2f45-4ebc-834e-430c0e32d387" />


This PR adds a base docker image which automatically builds every Sunday at 3am which allows for security and maintenance updates on an automated schedule. This base docker image is needed as one of the most frequent causes of outages on the `frontend` deployment and PR pipeline are outages to Ubuntu packages. This docker image mitigates this issue by creating a snapshot which is then used by the build process to create the `marketing-sites` application image as a layer.

Furthermore, the elimination of the need to download and install Ubuntu packages speeds up the CI/CD process by 1 minute.
