### PR TITLE
Disabling MusicLab test on Safari

### DIFF
--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_feedback_autofocus.feature
@@ -1,6 +1,8 @@
 Feature: Music Lab workspaces load between levels
 
 @no_mobile
+@no_safari
+# TODO: This test has been flaky on Safari. Investigate and re-enable.
 Scenario: Ensure feedback message gets focus after keyboard nav run button
   Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/46/levels/2"
   And I rotate to landscape


### PR DESCRIPTION
I've tested the functionality on safari and it works, so just disabling safari test for now.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
