### PR TITLE
AI Chat: log multimodal response times as separate Metric

### DIFF
--- a/dashboard/app/helpers/aichat_ai_client.rb
+++ b/dashboard/app/helpers/aichat_ai_client.rb
@@ -154,8 +154,7 @@ class AichatAiClient
 
     messages.each do |message|
       if message['assets'].is_a?(Array)
-
-        messages_with_assets_count +=1 if message['assets'].size > 1
+        messages_with_assets_count +=1 unless message['assets'].empty?
 
         message['assets'].each do |asset|
           filename = asset['filename']

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -127,6 +127,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
 
   private def report_job_start(request)
     @start_time = Time.now
+
     Cdo::Metrics.push(SharedConstants::AICHAT_METRICS_NAMESPACE,
       [
         {
@@ -146,30 +147,47 @@ class AichatRequestChatCompletionJob < ApplicationJob
   private def report_job_finish(request)
     execution_time = Time.now - @start_time
     status_name = SharedConstants::AI_REQUEST_EXECUTION_STATUS.key(request.execution_status).to_s
-    Cdo::Metrics.push(SharedConstants::AICHAT_METRICS_NAMESPACE,
-      [
-        {
-          metric_name: "#{self.class.name}.Finish",
-          value: 1,
-          unit: 'Count',
-          timestamp: Time.now,
-          dimensions: [
-            {name: 'Environment', value: CDO.rack_env},
-            {name: 'ModelId', value: get_model_id(request)},
-            {name: 'ExecutionStatus', value: status_name},
-          ],
-        },
-        {
-          metric_name: "#{self.class.name}.ExecutionTime",
-          value: execution_time,
-          unit: 'Seconds',
-          timestamp: Time.now,
-          dimensions: [
-            {name: 'Environment', value: CDO.rack_env},
-            {name: 'ModelId', value: get_model_id(request)},
-          ],
-        }
-      ]
-    )
+
+    execution_time_metric_base = {
+      metric_name: "#{self.class.name}.ExecutionTime",
+      value: execution_time,
+      unit: 'Seconds',
+      timestamp: Time.now,
+      dimensions: [],
+    }
+
+    execution_time_dimensions_base = [
+      {name: 'Environment', value: CDO.rack_env},
+      {name: 'ModelId', value: get_model_id(request)},
+    ]
+
+    metrics = [
+      {
+        metric_name: "#{self.class.name}.Finish",
+        value: 1,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: [
+          {name: 'Environment', value: CDO.rack_env},
+          {name: 'ModelId', value: get_model_id(request)},
+          {name: 'ExecutionStatus', value: status_name},
+        ],
+      },
+      execution_time_metric_base.merge({dimensions: execution_time_dimensions_base}),
+    ]
+
+    model_id = get_model_id(request)
+    if openai_or_gemini?(model_id)
+      multimodal_dimension = {name: 'Multimodal', value: request_multimodal?(request).to_s}
+      execution_time_metric_multimodal = execution_time_metric_base.merge({dimensions: execution_time_dimensions_base + [multimodal_dimension]})
+      metrics.push(execution_time_metric_multimodal)
+    end
+
+    Cdo::Metrics.push(SharedConstants::AICHAT_METRICS_NAMESPACE, metrics)
+  end
+
+  private def request_multimodal?(request)
+    (request.new_message['assets']&.length || 0) > 0 ||
+      request.stored_messages.any? {|message| (message['assets']&.length || 0) > 0}
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -2250,9 +2250,9 @@ FactoryBot.define do
 
   factory :aichat_request do
     association :user
-    model_customizations {{temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test", selectedModelId: "test"}.to_json}
-    new_message {{chatMessageText: "hello", role: 'user', status: 'unknown', timestamp: Time.now.to_i}.to_json}
-    stored_messages {[].to_json}
+    model_customizations {{temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test", selectedModelId: "test"}}
+    new_message {{chatMessageText: "hello", role: 'user', status: 'unknown', timestamp: Time.now.to_i}}
+    stored_messages {[]}
     level_id {1}
     script_id {1}
     project_id {1}


### PR DESCRIPTION
Add a new CloudWatch Metric that captures response times for multimodal vs. not for gpt-4o-mini and Gemini models.

The alternative here would be to add a new Dimension to our existing Metric that reports execution time. As I understand it, adding a new Dimension would generate entirely new Metrics (ie, Metrics are unique per any combination of Dimension values), so we would need to rework our existing dashboards to aggregate across true/false values for multimodal (these generate separate Metrics).

Not sure how other folks feel, but I am not a huge fan of having to aggregate across Metrics to track basic information like response times. I expect that in the future, non-multimodal will become a smaller and smaller fraction of the total requests that we are making, and that the distinction between multimodal input vs. not will become less of interest. With this approach, we can add a graph that splits response times by multimodal true/false using the new Metric, which feels like the main thing we want to track.

## Links

- Slack discussion (a bit ancient 😅 ): https://codedotorg.slack.com/archives/C06FELVTV0Q/p1746664306742289

## Testing story

Tested manually that I was generating new (and expected) metrics in CloudWatch with these changes locally.

## Follow-up work

A follow-up would be to add a new graph to our dashboard that tracks response times for multimodal vs. not for models that support multimodal. I don't plan to add alarming based on this Metric.