### PR TITLE
Re-Add /enroll redirect

### DIFF
--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -955,6 +955,7 @@ Dashboard::Application.routes.draw do
 
       delete 'fit_weekend_registration/:application_guid', to: 'fit_weekend_registration#destroy'
 
+      get 'workshops/:workshop_id/enroll', to: redirect("/professional-learning/workshops/%{workshop_id}")
       get 'workshops/:workshop_id/join', action: 'join', controller: 'workshop_enrollment'
       get 'workshop_enrollment/:code', action: 'show', controller: 'workshop_enrollment'
       get 'workshop_enrollment/:code/cancel', action: 'cancel', controller: 'workshop_enrollment'


### PR DESCRIPTION
As part of cleaning up the old enroll form content, I removed the route to it [here](https://github.com/code-dot-org/code-dot-org/pull/67139/files#diff-3fffe83c5f87f14c4c59c00fc3556305f7d4a28ee7748b688700228b3c64e70dL960). We want to keep the redirect in place for users that have saved the old /enroll links, so this PR brings it back and redirects the user to the marketing page instead since that contains more information about the workshop.

### Without the redirect
![no route](https://github.com/user-attachments/assets/f9a24047-614d-4ad5-8498-23fffdfd1356)

### With redirect
![with redirect](https://github.com/user-attachments/assets/3dc24948-078f-49b4-934a-738394ace636)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3419)

## Testing story
Local testing.
