### PR TITLE
Fix GitHub Actions OpenID Connect for Multiple Marketing Sites Site Types

### DIFF
--- a/frontend/apps/marketing/cicd/1-setup/account-resources.yml.erb
+++ b/frontend/apps/marketing/cicd/1-setup/account-resources.yml.erb
@@ -291,8 +291,10 @@ Resources:
               StringEquals:
                 # See: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#configuring-the-role-and-trust-policy
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
-              StringLike:
-                token.actions.githubusercontent.com:sub: 'repo:code-dot-org/code-dot-org:environment:marketing-sites-<%=environment_type%>-*'
+                token.actions.githubusercontent.com:sub:
+<%    MarketingSites::Configuration.site_types.each do |site_type| -%>
+                  - 'repo:code-dot-org/code-dot-org:environment:marketing-sites-<%=environment_type%>-<%=site_type%>'
+<%    end -%>
       Policies:
         - PolicyName: github-actions-cloudformation-policy
           PolicyDocument:


### PR DESCRIPTION
GitHub Actions is not able to assume the GitHub Actions Role since we added the wildcard to support multiple site-types. Try explicitly listing each environment-type + site-type combination.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
