### PR TITLE
Remove Temporary `enable-expire-other-sessions` DCDO Flag

### DIFF
--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -168,14 +168,13 @@
       %span#change-user-type-status
       %button.btn#change-user-type-button{disabled: true}= t('signup_form.user_type_button')
 
-- if DCDO.get('enable-expire-other-sessions', false) # TODO: remove flag once feature is stable
-  %div#expire-other-sessions
-    %hr
-    %h2= t('user.expire_other_sessions')
-    %p= t('user.expire_other_sessions_description')
-    = form_for(resource, as: resource_name, url: expire_other_path, html: {method: :delete}) do |expire_other_form|
-      .farSide
-        = expire_other_form.submit t('user.expire_other_sessions_button'), class: 'btn btn-warning'
+%div#expire-other-sessions
+  %hr
+  %h2= t('user.expire_other_sessions')
+  %p= t('user.expire_other_sessions_description')
+  = form_for(resource, as: resource_name, url: expire_other_path, html: {method: :delete}) do |expire_other_form|
+    .farSide
+      = expire_other_form.submit t('user.expire_other_sessions_button'), class: 'btn btn-warning'
 
 - if current_user.can_delete_own_account?
   -# Mount point for React DeleteAccount component.


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/59763, which added some functionality to user's Account Settings page but gated it behind a DCDO flag so we could quickly turn it off if it revealed any problems.

The feature has been live for several weeks now, and we have (to my knowledge) no reported problems related to it. At this point I think it's safe to call this feature stable and remove the flag.
