### PR TITLE
Restore Workshop Dashboard UI test

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
@@ -13,16 +13,6 @@ import WorkshopPanel from './WorkshopPanel';
 
 import style from './workshopLinks.module.scss';
 
-const MAX_URL_TEXT_LENGTH = 46;
-
-const shortenUrlText = (link: string): string => {
-  if (link.length > MAX_URL_TEXT_LENGTH) {
-    return `${link.slice(0, MAX_URL_TEXT_LENGTH - 3)}...`;
-  } else {
-    return link;
-  }
-};
-
 const CopyLinkButton: React.FunctionComponent<{link: string}> = ({link}) => {
   const [icon, setIcon] = useState('copy');
 
@@ -75,9 +65,7 @@ const WorkshopLinks: React.FunctionComponent<{
             rel="noopener noreferrer"
             className={style.workshopLink}
           >
-            {shortenUrlText(
-              `${window.location.origin}/professional-learning/workshops/${workshopId}`
-            )}
+            {`https://studio.code.org/professional-learning/workshops/${workshopId}`}
           </a>
           <CopyLinkButton
             link={`${window.location.origin}/professional-learning/workshops/${workshopId}`}
@@ -99,9 +87,7 @@ const WorkshopLinks: React.FunctionComponent<{
               rel="noopener noreferrer"
               className={style.workshopLink}
             >
-              {shortenUrlText(
-                `${window.location.origin}/pd/workshops/${workshopId}/join`
-              )}
+              {`https://studio.code.org/pd/workshops/${workshopId}/join`}
             </a>
             <CopyLinkButton
               link={`${window.location.origin}/pd/workshops/${workshopId}/join`}

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
@@ -58,19 +58,15 @@ const WorkshopLinks: React.FunctionComponent<{
           Share this page with teachers to promote your workshop. It includes
           key details and will guide them to the correct registration process.
         </BodyFourText>
-        <div className={style.buttonContainer}>
-          <a
-            href={`${window.location.origin}/professional-learning/workshops/${workshopId}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={style.workshopLink}
-          >
-            {`https://studio.code.org/professional-learning/workshops/${workshopId}`}
-          </a>
-          <CopyLinkButton
-            link={`${window.location.origin}/professional-learning/workshops/${workshopId}`}
-          />
-        </div>
+        <a
+          href={`${window.location.origin}/professional-learning/workshops/${workshopId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={style.workshopLink}
+        >{`${window.location.origin}/professional-learning/workshops/${workshopId}`}</a>
+        <CopyLinkButton
+          link={`${window.location.origin}/professional-learning/workshops/${workshopId}`}
+        />
       </div>
       {hasCustomRegistrationLink && (
         <div className={classNames(style.linkColumn, style.secondLinkColumn)}>
@@ -80,19 +76,17 @@ const WorkshopLinks: React.FunctionComponent<{
             Code.org after registering through your system. This ensures they're
             counted for attendance, surveys, and certificates.
           </BodyFourText>
-          <div className={style.buttonContainer}>
-            <a
-              href={`${window.location.origin}/pd/workshops/${workshopId}/join`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={style.workshopLink}
-            >
-              {`https://studio.code.org/pd/workshops/${workshopId}/join`}
-            </a>
-            <CopyLinkButton
-              link={`${window.location.origin}/pd/workshops/${workshopId}/join`}
-            />
-          </div>
+          <a
+            href={`${window.location.origin}/pd/workshops/${workshopId}/join`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={style.workshopLink}
+          >
+            {`${window.location.origin}/pd/workshops/${workshopId}/join`}
+          </a>
+          <CopyLinkButton
+            link={`${window.location.origin}/pd/workshops/${workshopId}/join`}
+          />
         </div>
       )}
     </div>

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
@@ -13,6 +13,16 @@ import WorkshopPanel from './WorkshopPanel';
 
 import style from './workshopLinks.module.scss';
 
+const MAX_URL_TEXT_LENGTH = 46;
+
+const shortenUrlText = (link: string): string => {
+  if (link.length > MAX_URL_TEXT_LENGTH) {
+    return `${link.slice(0, MAX_URL_TEXT_LENGTH - 3)}...`;
+  } else {
+    return link;
+  }
+};
+
 const CopyLinkButton: React.FunctionComponent<{link: string}> = ({link}) => {
   const [icon, setIcon] = useState('copy');
 
@@ -64,7 +74,11 @@ const WorkshopLinks: React.FunctionComponent<{
             target="_blank"
             rel="noopener noreferrer"
             className={style.workshopLink}
-          >{`${window.location.origin}/professional-learning/workshops/${workshopId}`}</a>
+          >
+            {shortenUrlText(
+              `${window.location.origin}/professional-learning/workshops/${workshopId}`
+            )}
+          </a>
           <CopyLinkButton
             link={`${window.location.origin}/professional-learning/workshops/${workshopId}`}
           />
@@ -84,7 +98,11 @@ const WorkshopLinks: React.FunctionComponent<{
               target="_blank"
               rel="noopener noreferrer"
               className={style.workshopLink}
-            >{`${window.location.origin}/pd/workshops/${workshopId}/join`}</a>
+            >
+              {shortenUrlText(
+                `${window.location.origin}/pd/workshops/${workshopId}/join`
+              )}
+            </a>
             <CopyLinkButton
               link={`${window.location.origin}/pd/workshops/${workshopId}/join`}
             />

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
@@ -19,8 +19,9 @@ const CopyLinkButton: React.FunctionComponent<{link: string}> = ({link}) => {
   return (
     <Button
       text="Copy link"
+      type="secondary"
       size="xs"
-      color={buttonColors.white}
+      color={buttonColors.gray}
       iconLeft={{iconName: icon, iconStyle: 'solid'}}
       className={style.copyLinkButton}
       onClick={() => copyToClipboard(link, () => setIcon('check'))}

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopLinks.tsx
@@ -81,9 +81,7 @@ const WorkshopLinks: React.FunctionComponent<{
             target="_blank"
             rel="noopener noreferrer"
             className={style.workshopLink}
-          >
-            {`${window.location.origin}/pd/workshops/${workshopId}/join`}
-          </a>
+          >{`${window.location.origin}/pd/workshops/${workshopId}/join`}</a>
           <CopyLinkButton
             link={`${window.location.origin}/pd/workshops/${workshopId}/join`}
           />

--- a/apps/src/code-studio/pd/workshop_dashboard/workshopLinks.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshopLinks.module.scss
@@ -68,5 +68,4 @@
 .copyLinkButton {
   min-width: 90px;
   height: fit-content;
-  border: 1px solid var(--neutral-gray-40);
 }

--- a/apps/src/code-studio/pd/workshop_dashboard/workshopLinks.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshopLinks.module.scss
@@ -7,6 +7,7 @@
   .linkColumn {
     display: flex;
     flex-direction: column;
+    align-items: start;
     flex: 1 1 0;
     gap: 0.375rem;
 
@@ -37,23 +38,13 @@
       font-size: 12px;
     }
 
-    .buttonContainer {
-      display: flex;
-      flex-direction: row;
-      align-items: baseline;
-      gap: 0.375rem;
-      text-align: start;
-
-      .workshopLink {
-        width: fit-content;
-        padding: 0;
-        font-size: 13px;
-        font-weight: 600px;
-        color: var(--brand-purple-50);
-      }
+    .workshopLink {
+      width: fit-content;
+      padding: 0;
+      font-size: 13px;
+      font-weight: 600px;
+      color: var(--brand-purple-50);
     }
-
-    
 
     h5, p, span {
       margin: 0 !important;
@@ -77,4 +68,5 @@
 .copyLinkButton {
   min-width: 90px;
   height: fit-content;
+  border: 1px solid var(--neutral-gray-40);
 }

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
@@ -20,7 +20,7 @@ describe('WorkshopLinks', () => {
     screen.getByText('Your Workshop Links');
     screen.getByText('Marketing Page');
     screen.getByText(
-      'https://studio.code.org/professional-learning/workshops/1'
+      `${window.location.origin}/professional-learning/workshops/1`
     );
     expect(screen.getAllByText('Copy link').length).toBe(1);
   });
@@ -32,9 +32,9 @@ describe('WorkshopLinks', () => {
     screen.getByText('Marketing Page');
     screen.getByText('Join Workshop Page');
     screen.getByText(
-      'https://studio.code.org/professional-learning/workshops/1'
+      `${window.location.origin}/professional-learning/workshops/1`
     );
-    screen.getByText('https://studio.code.org/pd/workshops/1/join');
+    screen.getByText(`${window.location.origin}/pd/workshops/1/join`);
     expect(screen.getAllByText('Copy link').length).toBe(2);
   });
 });

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
@@ -19,7 +19,9 @@ describe('WorkshopLinks', () => {
 
     screen.getByText('Your Workshop Links');
     screen.getByText('Marketing Page');
-    screen.getByText(`${window.location.origin}/profession...`);
+    screen.getByText(
+      'https://studio.code.org/professional-learning/workshops/1'
+    );
     expect(screen.getAllByText('Copy link').length).toBe(1);
   });
 
@@ -29,8 +31,10 @@ describe('WorkshopLinks', () => {
     screen.getByText('Your Workshop Links');
     screen.getByText('Marketing Page');
     screen.getByText('Join Workshop Page');
-    screen.getByText(`${window.location.origin}/profession...`);
-    screen.getByText(`${window.location.origin}/pd/worksho...`);
+    screen.getByText(
+      'https://studio.code.org/professional-learning/workshops/1'
+    );
+    screen.getByText('https://studio.code.org/pd/workshops/1/join');
     expect(screen.getAllByText('Copy link').length).toBe(2);
   });
 });

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
@@ -19,9 +19,7 @@ describe('WorkshopLinks', () => {
 
     screen.getByText('Your Workshop Links');
     screen.getByText('Marketing Page');
-    screen.getByText(
-      `${window.location.origin}/professional-learning/workshops/1`
-    );
+    screen.getByText('https://studio.code.org/professional-learni...');
     expect(screen.getAllByText('Copy link').length).toBe(1);
   });
 
@@ -31,10 +29,8 @@ describe('WorkshopLinks', () => {
     screen.getByText('Your Workshop Links');
     screen.getByText('Marketing Page');
     screen.getByText('Join Workshop Page');
-    screen.getByText(
-      `${window.location.origin}/professional-learning/workshops/1`
-    );
-    screen.getByText(`${window.location.origin}/pd/workshops/1/join`);
+    screen.getByText('https://studio.code.org/professional-learni...');
+    screen.getByText('https://studio.code.org/pd/workshops/1/join');
     expect(screen.getAllByText('Copy link').length).toBe(2);
   });
 });

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/WorkshopLinksTest.tsx
@@ -19,7 +19,7 @@ describe('WorkshopLinks', () => {
 
     screen.getByText('Your Workshop Links');
     screen.getByText('Marketing Page');
-    screen.getByText('https://studio.code.org/professional-learni...');
+    screen.getByText(`${window.location.origin}/profession...`);
     expect(screen.getAllByText('Copy link').length).toBe(1);
   });
 
@@ -29,8 +29,8 @@ describe('WorkshopLinks', () => {
     screen.getByText('Your Workshop Links');
     screen.getByText('Marketing Page');
     screen.getByText('Join Workshop Page');
-    screen.getByText('https://studio.code.org/professional-learni...');
-    screen.getByText('https://studio.code.org/pd/workshops/1/join');
+    screen.getByText(`${window.location.origin}/profession...`);
+    screen.getByText(`${window.location.origin}/pd/worksho...`);
     expect(screen.getAllByText('Copy link').length).toBe(2);
   });
 });

--- a/dashboard/test/ui/features/acquisition_products/pd/workshop_dashboard.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/workshop_dashboard.feature
@@ -2,7 +2,6 @@
 @eyes
 Feature: Workshop Dashboard
 
-@skip
 Scenario: New workshop: BYOW
   Given I am a program manager named "Test BYO PM" for regional partner "Test Partner"
   Given there is a facilitator named "Test BYO Facilitator 1" for course "Build Your Own Workshop"

--- a/dashboard/test/ui/features/acquisition_products/pd/workshop_dashboard.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/workshop_dashboard.feature
@@ -28,7 +28,7 @@ Scenario: New workshop: BYOW
   And I press keys "123 Main St" for element "input[name='locationAddress']"
   And I click selector "button:contains('Add Date')"
   And I select the "Virtual" option in the last dropdown named "format"
-  And I press keys "https://www.example.com" for element "input[name='meetingLink']"
+  And I press keys "https://example.com" for element "input[name='meetingLink']"
   And I wait until the dropdown named "regionalPartnerId" has option "Test Partner"
   And I select the "Test Partner" option in dropdown named "regionalPartnerId"
   And I press keys "Test BYO Facilitator 1\n" for element "#multiselect"
@@ -37,7 +37,7 @@ Scenario: New workshop: BYOW
   And I press keys "$100" for element "input[name='fee']"
   And I select the "National" option in dropdown named "participantGroupType"
   And I press keys "Get ready to learn!" for element "textarea[name='notes']"
-  And I press keys "https://www.register.org" for element "input[name='registrationLink']"
+  And I press keys "https://register.org" for element "input[name='registrationLink']"
   And I click selector "label:contains('Hide this workshop from the public workshop catalog')"
 
   And I see no difference for "new workshop details: BYO"

--- a/dashboard/test/ui/features/acquisition_products/pd/workshop_dashboard.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/workshop_dashboard.feature
@@ -28,7 +28,7 @@ Scenario: New workshop: BYOW
   And I press keys "123 Main St" for element "input[name='locationAddress']"
   And I click selector "button:contains('Add Date')"
   And I select the "Virtual" option in the last dropdown named "format"
-  And I press keys "example.com" for element "input[name='meetingLink']"
+  And I press keys "https://www.example.com" for element "input[name='meetingLink']"
   And I wait until the dropdown named "regionalPartnerId" has option "Test Partner"
   And I select the "Test Partner" option in dropdown named "regionalPartnerId"
   And I press keys "Test BYO Facilitator 1\n" for element "#multiselect"
@@ -37,7 +37,7 @@ Scenario: New workshop: BYOW
   And I press keys "$100" for element "input[name='fee']"
   And I select the "National" option in dropdown named "participantGroupType"
   And I press keys "Get ready to learn!" for element "textarea[name='notes']"
-  And I press keys "register.org" for element "input[name='registrationLink']"
+  And I press keys "https://www.register.org" for element "input[name='registrationLink']"
   And I click selector "label:contains('Hide this workshop from the public workshop catalog')"
 
   And I see no difference for "new workshop details: BYO"


### PR DESCRIPTION
After a flaky [eyes test failure](https://eyes.applitools.com/app/test-results/00000251650898384561/00000251650898384439/steps/2?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor), we had to skip this test because it was inconsistently stretching the links to either be on 1 line or 2. Since the /join link is on the cusp of being on 1 or 2 lines based on the widths of the numbers of its workshop id, this PR moves the copy button to the row beneath it to give the text more room.

This PR also adds the `https://` prefix to test links typed into the workshop dashboard eyes test since we now require full valid links in those fields.

### Eyes test failure
![issue](https://github.com/user-attachments/assets/a0926b36-19e8-40a5-a10c-c2d56122de25)

### With fix
![new](https://github.com/user-attachments/assets/8e642c4e-b23c-4dd5-940e-2b408bb16508)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3375)
PR that skipped the test: [here](https://github.com/code-dot-org/code-dot-org/pull/66847)
Applitools diff that showed the issue: [here](https://eyes.applitools.com/app/test-results/00000251650898384561/00000251650898384439/steps/2?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor)

## Testing story
Locally tested and ensured test passed on drone.
