### PR TITLE
fix(fonts): translate locales to BCP-47

### DIFF
--- a/frontend/apps/marketing/src/bootstrap/index.tsx
+++ b/frontend/apps/marketing/src/bootstrap/index.tsx
@@ -4,6 +4,8 @@ import {useEffect} from 'react';
 import {injectFontAwesome} from '@code-dot-org/fonts';
 import FontLoader from '@code-dot-org/fonts/FontLoader';
 
+import {getDashboardLocale} from '@/config/locale';
+
 interface BootstrapProps {
   locale: string;
 }
@@ -14,7 +16,7 @@ const Bootstrap = ({locale}: BootstrapProps) => {
 
   return (
     <>
-      <FontLoader locale={locale} />
+      <FontLoader locale={getDashboardLocale(locale)} />
     </>
   );
 };


### PR DESCRIPTION
While testing UI test sharding, it revealed that the fonts being used is the system default for Ubuntu in Playwright as Noto Sans was not available via the web font. This was caused by the localizejs locales not exactly matching to dashboard locales and was missed in an earlier eyes test because the localizations changed in addition to the fonts.