### PR TITLE
feat(playwright): use microsoft docker image to cache browsers

### DIFF
--- a/.github/actions/frontend/marketing/ui-tests/action.yml
+++ b/.github/actions/frontend/marketing/ui-tests/action.yml
@@ -32,27 +32,29 @@ runs:
   using: composite
 
   steps:
-    - name: Install Playwright
-      shell: bash
-      run: yarn playwright install --with-deps
-      working-directory: ./frontend/apps/marketing
-
     - name: Prepare UI Test Environment
       shell: bash
       working-directory: ./frontend/apps/marketing
       run: |
         echo "APPLITOOLS_API_KEY=${{ inputs.APPLITOOLS_API_KEY }}
-        DRAFT_MODE_TOKEN=${{ inputs.DRAFT_MODE_TOKEN }}" >> .env
+        DRAFT_MODE_TOKEN=${{ inputs.DRAFT_MODE_TOKEN }}
+        CI=true
+        STAGE=${{ inputs.ENVIRONMENT_TYPE }}
+        NEXT_PUBLIC_STAGE=${{ inputs.ENVIRONMENT_TYPE }}
+        APPLICATION_BASE_ADDRESS=${{ inputs.APPLICATION_BASE_ADDRESS }}
+        BRANCHED_TESTING_ENABLED=${{ inputs.BRANCHED_TESTING_ENABLED }}
+        PR_HEAD_REF=${{ inputs.PR_HEAD_REF }}
+        " >> .env
 
     - name: UI Tests
       shell: bash
-      env:
-        STAGE: ${{ inputs.ENVIRONMENT_TYPE }}
-        NEXT_PUBLIC_STAGE: ${{ inputs.ENVIRONMENT_TYPE }}
-        APPLICATION_BASE_ADDRESS: ${{ inputs.APPLICATION_BASE_ADDRESS }}
-        BRANCHED_TESTING_ENABLED: ${{ inputs.BRANCHED_TESTING_ENABLED }}
-        PR_HEAD_REF: ${{ inputs.PR_HEAD_REF }}
-      run: yarn workspace @code-dot-org/marketing test:ui:ci
+      run: |
+        docker run --network host \
+          --env-file ./apps/marketing/.env \
+          -v $PWD:/workspace \
+          -w /workspace/frontend \
+          mcr.microsoft.com/playwright:v1.49.1-noble \ # If updating playwright, also update the version in package.json
+          bash -c "corepack enable && yarn build --filter @code-dot-org/marketing && HOME=/root yarn workspace @code-dot-org/marketing test:ui:ci --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
       working-directory: ./frontend
 
     - name: Upload Playwright reports

--- a/.github/actions/frontend/marketing/ui-tests/action.yml
+++ b/.github/actions/frontend/marketing/ui-tests/action.yml
@@ -48,13 +48,14 @@ runs:
 
     - name: UI Tests
       shell: bash
+      # If updating playwright, also update the version in package.json
       run: |
         docker run --network host \
           --env-file ./apps/marketing/.env \
           -v $PWD:/workspace \
           -w /workspace/frontend \
-          mcr.microsoft.com/playwright:v1.49.1-noble \ # If updating playwright, also update the version in package.json
-          bash -c "corepack enable && yarn build --filter @code-dot-org/marketing && HOME=/root yarn workspace @code-dot-org/marketing test:ui:ci --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
+          mcr.microsoft.com/playwright:v1.49.1-noble \
+          bash -c "corepack enable && yarn build --filter @code-dot-org/marketing && HOME=/root yarn workspace @code-dot-org/marketing test:ui:ci"
       working-directory: ./frontend
 
     - name: Upload Playwright reports

--- a/.github/workflows/marketing-app-ci.yml
+++ b/.github/workflows/marketing-app-ci.yml
@@ -104,8 +104,9 @@ jobs:
 
       - name: Run Docker Container
         run: |
-          docker run -d --env-file .env --rm --name marketing \
-            -p 3001:3000 \
+          docker run -d --env-file .env --rm --name marketing \ 
+            --network=host \
+            -e PORT=3001 \
             marketing:test
           
           # Tail the docker logs

--- a/.github/workflows/marketing-app-ci.yml
+++ b/.github/workflows/marketing-app-ci.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run Docker Container
         run: |
-          docker run -d --env-file .env --rm --name marketing \ 
+          docker run -d --env-file .env --rm --name marketing \
             --network=host \
             -e PORT=3001 \
             marketing:test


### PR DESCRIPTION
This PR changes the UI testing process to use the official Microsoft Playwright docker image instead of installing dependencies each and every time a UI Test is run. Currently, the process of installing dependencies consumes approximately 5-6 minutes and carries a risk of the docker image failing to build if Ubuntu or Azure goes down. This mitigates the risk by using a pre-baked docker image with dependencies already available. Testing reveals that this speeds up testing by about 5 minutes, and is a precursor to sharding support.

There are minor rendering differences in the official Microsoft playwright image and the original Github Action based version which are resulting in slight pixel shifting in Firefox and Webkit. Those differences will be accepted upon merge.