### PR TITLE
feat(marketing): refactor Image component to use MUI

### DIFF
--- a/frontend/apps/marketing/src/components/common/definitions/index.ts
+++ b/frontend/apps/marketing/src/components/common/definitions/index.ts
@@ -112,6 +112,46 @@ export const hideImagesDefinition: Record<string, ComponentDefinitionVariable> =
     },
   };
 
+// Used in the Image component
+export const imageSrcDefinition: Record<string, ComponentDefinitionVariable> = {
+  src: {
+    displayName: 'Image source',
+    type: 'Media',
+    defaultValue: undefined,
+    group: 'content',
+    validations: {
+      bindingSourceType: ['asset', 'manual'],
+    },
+  },
+};
+
+export const imageAltTextDefinition: Record<
+  string,
+  ComponentDefinitionVariable
+> = {
+  altText: {
+    displayName: 'Alt text',
+    type: 'Text',
+    defaultValue: '',
+    group: 'content',
+    validations: {
+      bindingSourceType: ['asset', 'manual', 'entry'],
+    },
+  },
+};
+
+export const imageHasRoundedCornersDefinition: Record<
+  string,
+  ComponentDefinitionVariable
+> = {
+  hasRoundedCorners: {
+    displayName: 'Rounded corners',
+    type: 'Boolean',
+    defaultValue: true,
+    group: 'style',
+  },
+};
+
 // Used in the Section component
 export const sectionPaddingDefinition: Record<
   string,

--- a/frontend/apps/marketing/src/components/contentful/carousels/imageCarousel/ImageCarousel.tsx
+++ b/frontend/apps/marketing/src/components/contentful/carousels/imageCarousel/ImageCarousel.tsx
@@ -42,7 +42,7 @@ const ImageCarousel: React.FC<ImageCarouselProps> = ({
 
           return {
             id: title,
-            slide: <Image src={file?.url} altText={description} />,
+            slide: <Image src={file?.url ?? ''} altText={description ?? ''} />,
           };
         }),
     [slides],

--- a/frontend/apps/marketing/src/components/contentful/carousels/imageCarousel/ImageCarousel.tsx
+++ b/frontend/apps/marketing/src/components/contentful/carousels/imageCarousel/ImageCarousel.tsx
@@ -42,7 +42,7 @@ const ImageCarousel: React.FC<ImageCarouselProps> = ({
 
           return {
             id: title,
-            slide: <Image src={file?.url ?? ''} altText={description ?? ''} />,
+            slide: <Image src={file?.url} altText={description ?? ''} />,
           };
         }),
     [slides],

--- a/frontend/apps/marketing/src/components/contentful/carousels/imageCarousel/ImageCarousel.tsx
+++ b/frontend/apps/marketing/src/components/contentful/carousels/imageCarousel/ImageCarousel.tsx
@@ -42,7 +42,13 @@ const ImageCarousel: React.FC<ImageCarouselProps> = ({
 
           return {
             id: title,
-            slide: <Image src={file?.url} altText={description ?? ''} />,
+            slide: (
+              <Image
+                src={file?.url}
+                altText={description ?? ''}
+                hasRoundedCorners
+              />
+            ),
           };
         }),
     [slides],

--- a/frontend/apps/marketing/src/components/contentful/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/Image.tsx
@@ -7,7 +7,7 @@ import React, {ImgHTMLAttributes} from 'react';
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 
 export interface ImageProps
-  extends Omit<ImgHTMLAttributes<HTMLElement>, 'width' | 'height'> {
+  extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'width' | 'height'> {
   /** Image source */
   src: string;
   /** Image alt text */
@@ -16,10 +16,6 @@ export interface ImageProps
   decoration?: 'none' | 'border' | 'shadow';
   /** Image has rounded corners */
   hasRoundedCorners?: boolean;
-  /** Image width */
-  width?: string | number;
-  /** Image height */
-  height?: string | number;
   /** Custom className */
   className?: string;
 }

--- a/frontend/apps/marketing/src/components/contentful/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/Image.tsx
@@ -2,7 +2,7 @@
 import {styled} from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import classNames from 'classnames';
-import React, {useMemo, ImgHTMLAttributes} from 'react';
+import React, {ImgHTMLAttributes} from 'react';
 
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 
@@ -54,10 +54,8 @@ const Image: React.FC<ImageProps> = ({
   hasRoundedCorners,
   className,
 }) => {
-  const imgSrc = useMemo(() => src && getAbsoluteImageUrl(src), [src]);
-
   // Show placeholder text until a content entry is added
-  if (!imgSrc) {
+  if (!src) {
     return (
       <Typography variant="body3" sx={{color: 'var(--text-neutral-primary)'}}>
         <em>

--- a/frontend/apps/marketing/src/components/contentful/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/Image.tsx
@@ -2,7 +2,7 @@
 import {styled} from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import classNames from 'classnames';
-import React, {ImgHTMLAttributes} from 'react';
+import React, {ImgHTMLAttributes, useMemo} from 'react';
 
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 
@@ -50,8 +50,11 @@ const Image: React.FC<ImageProps> = ({
   hasRoundedCorners,
   className,
 }) => {
+  // Get the image source URL from Contentful
+  const imageSource = useMemo(() => src && getAbsoluteImageUrl(src), [src]);
+
   // Show placeholder text until a content entry is added
-  if (!src) {
+  if (!src || !imageSource) {
     return (
       <Typography variant="body3" sx={{color: 'var(--text-neutral-primary)'}}>
         <em>
@@ -71,11 +74,7 @@ const Image: React.FC<ImageProps> = ({
         className,
       )}
     >
-      <ImageElement
-        alt={altText}
-        loading="lazy"
-        src={getAbsoluteImageUrl(src)}
-      />
+      <ImageElement alt={altText} loading="lazy" src={imageSource} />
     </ImageRoot>
   );
 };

--- a/frontend/apps/marketing/src/components/contentful/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/Image.tsx
@@ -9,7 +9,7 @@ import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 export interface ImageProps
   extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'width' | 'height'> {
   /** Image source */
-  src: string;
+  src?: string;
   /** Image alt text */
   altText?: string;
   /** Image decoration */
@@ -74,7 +74,7 @@ const Image: React.FC<ImageProps> = ({
         className,
       )}
     >
-      <ImageElement alt={altText} loading="lazy" src={imageSource} />
+      <ImageElement alt={altText || ''} loading="lazy" src={imageSource} />
     </ImageRoot>
   );
 };

--- a/frontend/apps/marketing/src/components/contentful/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/Image.tsx
@@ -1,47 +1,86 @@
-import React, {useMemo} from 'react';
-
-import DSCOImage from '@code-dot-org/component-library/image';
+'use client';
+import {styled} from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import classNames from 'classnames';
+import React, {useMemo, ImgHTMLAttributes} from 'react';
 
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 
-type ImageProps = {
-  /** Image URL */
-  src?: string | null;
+export interface ImageProps
+  extends Omit<ImgHTMLAttributes<HTMLElement>, 'width' | 'height'> {
+  /** Image source */
+  src: string;
   /** Image alt text */
   altText?: string;
+  /** Image loading attribute */
+  loading?: 'eager' | 'lazy';
   /** Image decoration */
   decoration?: 'none' | 'border' | 'shadow';
-  /** Image has rounded corners */
+  /** Has rounded corners */
   hasRoundedCorners?: boolean;
-};
+  /** Custom className */
+  className?: string;
+}
+
+const ImageRoot = styled('figure', {
+  name: 'MuiImage',
+  slot: 'root',
+})(() => ({
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+  overflow: 'hidden',
+  margin: 0,
+}));
+
+const ImageElement = styled('img', {
+  name: 'MuiImage',
+  slot: 'imageElement',
+})(() => ({
+  display: 'block',
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  margin: 0,
+  padding: 0,
+}));
 
 const Image: React.FC<ImageProps> = ({
   src,
   altText,
   decoration,
   hasRoundedCorners,
+  className,
 }) => {
   const imgSrc = useMemo(() => src && getAbsoluteImageUrl(src), [src]);
 
   // Show placeholder text until a content entry is added
   if (!imgSrc) {
     return (
-      <div style={{color: 'var(--text-neutral-primary)'}}>
+      <Typography variant="body3" sx={{color: 'var(--text-neutral-primary)'}}>
         <em>
           <strong>🖼️ Image placeholder.</strong> Please add an "Image" content
           type or image asset entry in the Content sidebar.
         </em>
-      </div>
+      </Typography>
     );
   }
 
   return (
-    <DSCOImage
-      src={imgSrc}
-      altText={altText}
-      decoration={decoration}
-      hasRoundedCorners={hasRoundedCorners}
-    />
+    <ImageRoot
+      className={classNames(
+        decoration === 'border' && `image--hasBorder`,
+        decoration === 'shadow' && `image--hasShadow`,
+        hasRoundedCorners && `image--hasRoundedCorners`,
+        className,
+      )}
+    >
+      <ImageElement
+        alt={altText}
+        loading="lazy"
+        src={getAbsoluteImageUrl(src)}
+      />
+    </ImageRoot>
   );
 };
 

--- a/frontend/apps/marketing/src/components/contentful/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/Image.tsx
@@ -14,7 +14,7 @@ export interface ImageProps
   altText?: string;
   /** Image decoration */
   decoration?: 'none' | 'border' | 'shadow';
-  /** Has rounded corners */
+  /** Image has rounded corners */
   hasRoundedCorners?: boolean;
   /** Image width */
   width?: string | number;

--- a/frontend/apps/marketing/src/components/contentful/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/Image.tsx
@@ -12,12 +12,14 @@ export interface ImageProps
   src: string;
   /** Image alt text */
   altText?: string;
-  /** Image loading attribute */
-  loading?: 'eager' | 'lazy';
   /** Image decoration */
   decoration?: 'none' | 'border' | 'shadow';
   /** Has rounded corners */
   hasRoundedCorners?: boolean;
+  /** Image width */
+  width?: string | number;
+  /** Image height */
+  height?: string | number;
   /** Custom className */
   className?: string;
 }

--- a/frontend/apps/marketing/src/components/contentful/image/__tests__/Image.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/__tests__/Image.test.tsx
@@ -1,0 +1,60 @@
+import {render, screen} from '@testing-library/react';
+
+import Image from '../Image';
+
+describe('Image Component', () => {
+  it('renders Image component', () => {
+    render(<Image src="test.jpg" altText={'This is an image'} />);
+    expect(screen.getByRole('img')).toHaveAttribute('alt', 'This is an image');
+  });
+
+  it('applies border decoration class', () => {
+    render(<Image src="test.jpg" altText="With border" decoration="border" />);
+    const figure = screen.getByRole('figure');
+    expect(figure.className).toMatch(/image--hasBorder/);
+  });
+
+  it('applies shadow decoration class', () => {
+    render(<Image src="test.jpg" altText="With shadow" decoration="shadow" />);
+    const figure = screen.getByRole('figure');
+    expect(figure.className).toMatch(/image--hasShadow/);
+  });
+
+  it('applies rounded corners class', () => {
+    render(
+      <Image
+        src="test.jpg"
+        altText="Has rounded corners"
+        hasRoundedCorners={true}
+      />,
+    );
+    const figure = screen.getByRole('figure');
+    expect(figure.className).toMatch(/image--hasRoundedCorners/);
+  });
+
+  it('renders Image with provided className styles', () => {
+    const className = 'customClass';
+    const cssSelector = `figure.${className}`;
+    const classStyle = 'width: 100px;';
+
+    render(
+      <Image src="test.jpg" altText="This is an image" className={className} />,
+    );
+    const imageFigure = screen.getByRole('figure');
+
+    expect(imageFigure).not.toHaveStyle(classStyle);
+
+    // Add custom CSS directly in the test
+    const style = document.createElement('style');
+    style.innerHTML = `${cssSelector} { ${classStyle} }`;
+    document.head.appendChild(style);
+
+    expect(imageFigure).toHaveStyle(classStyle);
+  });
+
+  it('sets loading attribute to lazy by default', () => {
+    render(<Image src="test.jpg" altText="Lazy load" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('loading', 'lazy');
+  });
+});

--- a/frontend/apps/marketing/src/components/contentful/image/imageCSforAllContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/image/imageCSforAllContentfulDefinition.ts
@@ -1,6 +1,12 @@
 // Creates a definition for the Image component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 
+import {
+  imageSrcDefinition,
+  imageAltTextDefinition,
+  imageHasRoundedCornersDefinition,
+} from '@/components/common/definitions';
+
 export const ImageCSforAllContentfulComponentDefinition: ComponentDefinition = {
   id: 'image',
   name: 'Image',
@@ -15,24 +21,8 @@ export const ImageCSforAllContentfulComponentDefinition: ComponentDefinition = {
       'https://contentful-images.code.org/90t6bu6vlf76/2Yl2LTZiEjpF9cTPzzC4TS/f6d57839806b1d310d1f527042c49e8b/component_image_tooltip.png',
   },
   variables: {
-    src: {
-      displayName: 'Image source',
-      type: 'Media',
-      defaultValue: undefined,
-      group: 'content',
-      validations: {
-        bindingSourceType: ['asset', 'manual'],
-      },
-    },
-    altText: {
-      displayName: 'Alt text',
-      type: 'Text',
-      defaultValue: '',
-      group: 'content',
-      validations: {
-        bindingSourceType: ['asset', 'manual', 'entry'],
-      },
-    },
+    ...imageSrcDefinition,
+    ...imageAltTextDefinition,
     decoration: {
       displayName: 'Decoration',
       type: 'Text',
@@ -45,11 +35,6 @@ export const ImageCSforAllContentfulComponentDefinition: ComponentDefinition = {
         ],
       },
     },
-    hasRoundedCorners: {
-      displayName: 'Rounded corners',
-      type: 'Boolean',
-      defaultValue: true,
-      group: 'style',
-    },
+    ...imageHasRoundedCornersDefinition,
   },
 };

--- a/frontend/apps/marketing/src/components/contentful/image/imageCSforAllContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/image/imageCSforAllContentfulDefinition.ts
@@ -1,7 +1,7 @@
 // Creates a definition for the Image component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 
-export const ImageContentfulComponentDefinition: ComponentDefinition = {
+export const ImageCSforAllContentfulComponentDefinition: ComponentDefinition = {
   id: 'image',
   name: 'Image',
   category: '03: Content Building Blocks',
@@ -42,7 +42,6 @@ export const ImageContentfulComponentDefinition: ComponentDefinition = {
         in: [
           {value: 'none', displayName: 'None'},
           {value: 'border', displayName: 'Border'},
-          {value: 'shadow', displayName: 'Shadow'},
         ],
       },
     },

--- a/frontend/apps/marketing/src/components/contentful/image/imageCorporateSiteContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/image/imageCorporateSiteContentfulDefinition.ts
@@ -1,6 +1,12 @@
 // Creates a definition for the Image component to be used in Contentful Studio
 import {ComponentDefinition} from '@contentful/experiences-sdk-react';
 
+import {
+  imageSrcDefinition,
+  imageAltTextDefinition,
+  imageHasRoundedCornersDefinition,
+} from '@/components/common/definitions';
+
 export const ImageCorporateSiteContentfulComponentDefinition: ComponentDefinition =
   {
     id: 'image',
@@ -16,24 +22,8 @@ export const ImageCorporateSiteContentfulComponentDefinition: ComponentDefinitio
         'https://contentful-images.code.org/90t6bu6vlf76/2Yl2LTZiEjpF9cTPzzC4TS/f6d57839806b1d310d1f527042c49e8b/component_image_tooltip.png',
     },
     variables: {
-      src: {
-        displayName: 'Image source',
-        type: 'Media',
-        defaultValue: undefined,
-        group: 'content',
-        validations: {
-          bindingSourceType: ['asset', 'manual'],
-        },
-      },
-      altText: {
-        displayName: 'Alt text',
-        type: 'Text',
-        defaultValue: '',
-        group: 'content',
-        validations: {
-          bindingSourceType: ['asset', 'manual', 'entry'],
-        },
-      },
+      ...imageSrcDefinition,
+      ...imageAltTextDefinition,
       decoration: {
         displayName: 'Decoration',
         type: 'Text',
@@ -47,11 +37,6 @@ export const ImageCorporateSiteContentfulComponentDefinition: ComponentDefinitio
           ],
         },
       },
-      hasRoundedCorners: {
-        displayName: 'Rounded corners',
-        type: 'Boolean',
-        defaultValue: true,
-        group: 'style',
-      },
+      ...imageHasRoundedCornersDefinition,
     },
   };

--- a/frontend/apps/marketing/src/components/contentful/image/imageCorporateSiteContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/image/imageCorporateSiteContentfulDefinition.ts
@@ -1,0 +1,57 @@
+// Creates a definition for the Image component to be used in Contentful Studio
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+export const ImageCorporateSiteContentfulComponentDefinition: ComponentDefinition =
+  {
+    id: 'image',
+    name: 'Image',
+    category: '03: Content Building Blocks',
+    builtInStyles: ['cfWidth', 'cfHeight'],
+    thumbnailUrl:
+      'https://contentful-images.code.org/90t6bu6vlf76/2erlhdZVjByJbpMw9UKcWE/ee11e8a21370bbcd3b1b0b702b00d0e5/component_image_thumbnail.png',
+    tooltip: {
+      description:
+        'Add an image to your layout. Supports border and shadow decorations.',
+      imageUrl:
+        'https://contentful-images.code.org/90t6bu6vlf76/2Yl2LTZiEjpF9cTPzzC4TS/f6d57839806b1d310d1f527042c49e8b/component_image_tooltip.png',
+    },
+    variables: {
+      src: {
+        displayName: 'Image source',
+        type: 'Media',
+        defaultValue: undefined,
+        group: 'content',
+        validations: {
+          bindingSourceType: ['asset', 'manual'],
+        },
+      },
+      altText: {
+        displayName: 'Alt text',
+        type: 'Text',
+        defaultValue: '',
+        group: 'content',
+        validations: {
+          bindingSourceType: ['asset', 'manual', 'entry'],
+        },
+      },
+      decoration: {
+        displayName: 'Decoration',
+        type: 'Text',
+        defaultValue: 'none',
+        group: 'style',
+        validations: {
+          in: [
+            {value: 'none', displayName: 'None'},
+            {value: 'border', displayName: 'Border'},
+            {value: 'shadow', displayName: 'Shadow'},
+          ],
+        },
+      },
+      hasRoundedCorners: {
+        displayName: 'Rounded corners',
+        type: 'Boolean',
+        defaultValue: true,
+        group: 'style',
+      },
+    },
+  };

--- a/frontend/apps/marketing/src/components/contentful/image/index.ts
+++ b/frontend/apps/marketing/src/components/contentful/image/index.ts
@@ -1,3 +1,4 @@
 // Export the Component Definition for use in Contentful Studio
-export {ImageContentfulComponentDefinition} from './imageContentfulDefinition';
+export {ImageCorporateSiteContentfulComponentDefinition} from './imageCorporateSiteContentfulDefinition';
+export {ImageCSforAllContentfulComponentDefinition} from './imageCSforAllContentfulDefinition';
 export {default} from './Image';

--- a/frontend/apps/marketing/src/contentful/registration/code.org/index.ts
+++ b/frontend/apps/marketing/src/contentful/registration/code.org/index.ts
@@ -58,7 +58,7 @@ import Iframe, {
   IframeContentfulComponentDefinition,
 } from '@/components/contentful/iframe';
 import Image, {
-  ImageContentfulComponentDefinition,
+  ImageCorporateSiteContentfulComponentDefinition,
 } from '@/components/contentful/image';
 import Link, {
   LinkContentfulComponentDefinition,
@@ -191,7 +191,7 @@ const contentfulRegistration = {
     },
     {
       component: Image,
-      definition: ImageContentfulComponentDefinition,
+      definition: ImageCorporateSiteContentfulComponentDefinition,
     },
     {
       component: ImageCarousel,

--- a/frontend/apps/marketing/src/contentful/registration/csforall/index.ts
+++ b/frontend/apps/marketing/src/contentful/registration/csforall/index.ts
@@ -47,7 +47,7 @@ import Iframe, {
   IframeContentfulComponentDefinition,
 } from '@/components/contentful/iframe';
 import Image, {
-  ImageContentfulComponentDefinition,
+  ImageCSforAllContentfulComponentDefinition,
 } from '@/components/contentful/image';
 import Link, {
   LinkContentfulComponentDefinition,
@@ -155,7 +155,7 @@ const contentfulRegistration = {
     },
     {
       component: Image,
-      definition: ImageContentfulComponentDefinition,
+      definition: ImageCSforAllContentfulComponentDefinition,
     },
     {
       component: ImageCarousel,

--- a/frontend/apps/marketing/src/themes/code.org/index.ts
+++ b/frontend/apps/marketing/src/themes/code.org/index.ts
@@ -11,6 +11,9 @@ import {STYLE_OVERRIDES} from './styleOverrides';
 const theme = createTheme({
   cssVariables: true,
   components: STYLE_OVERRIDES,
+  shape: {
+    borderRadius: 4,
+  },
   typography: {
     fontFamily: createFontStack(FIGTREE_FONT, NOTO_FONT),
     h1: {

--- a/frontend/apps/marketing/src/themes/code.org/styleOverrides/image.ts
+++ b/frontend/apps/marketing/src/themes/code.org/styleOverrides/image.ts
@@ -1,0 +1,17 @@
+import {Components, Theme} from '@mui/material/styles';
+
+export const IMAGE_OVERRIDES: Components<Theme>['MuiImage'] = {
+  styleOverrides: {
+    root: ({theme}) => ({
+      '&.image--hasBorder': {
+        border: `1px solid var(--borders-neutral-primary)`,
+      },
+      '&.image--hasShadow': {
+        boxShadow: '0.5rem 0.5rem 0 0 var(--background-brand-teal-light)',
+      },
+      '&.image--hasRoundedCorners': {
+        borderRadius: theme.shape.borderRadius,
+      },
+    }),
+  },
+};

--- a/frontend/apps/marketing/src/themes/code.org/styleOverrides/index.ts
+++ b/frontend/apps/marketing/src/themes/code.org/styleOverrides/index.ts
@@ -2,12 +2,14 @@ import {Components, Theme} from '@mui/material/styles';
 
 import {CONTAINER_OVERRIDES} from './container';
 import {DIVIDER_OVERRIDES} from './divider';
+import {IMAGE_OVERRIDES} from './image';
 import {LINK_OVERRIDES} from './link';
 import {TYPOGRAPHY_OVERRIDES} from './typography';
 
 export const STYLE_OVERRIDES: Components<Theme> = {
   MuiContainer: CONTAINER_OVERRIDES,
   MuiDivider: DIVIDER_OVERRIDES,
+  MuiImage: IMAGE_OVERRIDES,
   MuiLink: LINK_OVERRIDES,
   MuiTypography: TYPOGRAPHY_OVERRIDES,
 };

--- a/frontend/apps/marketing/src/themes/csforall/index.ts
+++ b/frontend/apps/marketing/src/themes/csforall/index.ts
@@ -34,6 +34,9 @@ const theme = createTheme({
     },
   },
   components: STYLE_OVERRIDES,
+  shape: {
+    borderRadius: 32,
+  },
   typography: {
     fontFamily: createFontStack(ROBOTO_MONO_FONT, NOTO_FONT),
     h1: {

--- a/frontend/apps/marketing/src/themes/csforall/styleOverrides/image.ts
+++ b/frontend/apps/marketing/src/themes/csforall/styleOverrides/image.ts
@@ -4,7 +4,7 @@ export const IMAGE_OVERRIDES: Components<Theme>['MuiImage'] = {
   styleOverrides: {
     root: ({theme}) => ({
       '&.image--hasBorder': {
-        border: `1px solid` + theme.palette.common.black,
+        border: `1px solid ${theme.palette.common.black}`,
       },
       '&.image--hasRoundedCorners': {
         borderRadius: theme.shape.borderRadius,

--- a/frontend/apps/marketing/src/themes/csforall/styleOverrides/image.ts
+++ b/frontend/apps/marketing/src/themes/csforall/styleOverrides/image.ts
@@ -1,0 +1,14 @@
+import {Components, Theme} from '@mui/material/styles';
+
+export const IMAGE_OVERRIDES: Components<Theme>['MuiImage'] = {
+  styleOverrides: {
+    root: ({theme}) => ({
+      '&.image--hasBorder': {
+        border: `1px solid` + theme.palette.common.black,
+      },
+      '&.image--hasRoundedCorners': {
+        borderRadius: theme.shape.borderRadius,
+      },
+    }),
+  },
+};

--- a/frontend/apps/marketing/src/themes/csforall/styleOverrides/index.ts
+++ b/frontend/apps/marketing/src/themes/csforall/styleOverrides/index.ts
@@ -3,6 +3,7 @@ import {Components, Theme} from '@mui/material/styles';
 import {BUTTON_OVERRIDES} from './button';
 import {CONTAINER_OVERRIDES} from './container';
 import {DIVIDER_OVERRIDES} from './divider';
+import {IMAGE_OVERRIDES} from './image';
 import {LINK_OVERRIDES} from './link';
 import {TYPOGRAPHY_OVERRIDES} from './typography';
 
@@ -10,6 +11,7 @@ export const STYLE_OVERRIDES: Components<Theme> = {
   MuiButton: BUTTON_OVERRIDES,
   MuiContainer: CONTAINER_OVERRIDES,
   MuiDivider: DIVIDER_OVERRIDES,
+  MuiImage: IMAGE_OVERRIDES,
   MuiLink: LINK_OVERRIDES,
   MuiTypography: TYPOGRAPHY_OVERRIDES,
 };

--- a/frontend/apps/marketing/src/types/mui.d.ts
+++ b/frontend/apps/marketing/src/types/mui.d.ts
@@ -1,4 +1,24 @@
+import {
+  ComponentsOverrides,
+  ComponentsVariants,
+  Theme as MuiTheme,
+} from '@mui/material/styles';
+
+import {ImageProps} from '@/components/contentful/image';
+
+type Theme = Omit<MuiTheme, 'components'>;
+
 declare module '@mui/material/styles' {
+  // Custom Palette definitions
+  interface Palette {
+    tertiary: Palette['primary'];
+  }
+
+  interface PaletteOptions {
+    tertiary?: PaletteOptions['primary'];
+  }
+
+  // Custom Typography definitions
   interface TypographyVariants {
     body3: React.CSSProperties;
     body4: React.CSSProperties;
@@ -8,22 +28,29 @@ declare module '@mui/material/styles' {
     body3?: React.CSSProperties;
     body4?: React.CSSProperties;
   }
+
+  // Custom components definitions
+  interface ComponentNameToClassKey {
+    MuiImage: 'root' | 'imageElement';
+  }
+
+  interface ComponentsPropsList {
+    MuiImage: Partial<ImageProps>;
+  }
+
+  interface Components {
+    MuiImage?: {
+      defaultProps?: ComponentsPropsList['MuiImage'];
+      styleOverrides?: ComponentsOverrides<Theme>['MuiImage'];
+      variants?: ComponentsVariants['MuiImage'];
+    };
+  }
 }
 
 declare module '@mui/material/Typography' {
   interface TypographyPropsVariantOverrides {
     body3: true;
     body4: true;
-  }
-}
-
-declare module '@mui/material/styles' {
-  interface Palette {
-    tertiary: Palette['primary'];
-  }
-
-  interface PaletteOptions {
-    tertiary?: PaletteOptions['primary'];
   }
 }
 


### PR DESCRIPTION
Refactors the Image component to use MUI and adds CSforAll theme support. This creates a custom [themed component](https://mui.com/material-ui/customization/creating-themed-components/) so we can style it across multiple sites based on their needs similarly to built-in MUI components (Typography, Button, etc). 

## Links
Jira ticket: [CMS-944](https://codedotorg.atlassian.net/browse/CMS-944)

## Testing story
Added unit tests and should have no Eyes diffs.

----

## Code.org

https://github.com/user-attachments/assets/0fa382fd-c45a-444f-b454-cc3a542c1c4e



## CSforAll

https://github.com/user-attachments/assets/fc41a632-0e97-48d9-8fdd-f7bb24df493c

