### PR TITLE
Allow teacher of project owner to view flagged legacy project

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -3259,6 +3259,7 @@
   "viewPageAs": "View page as:",
   "viewParentLetter": "View parent letter",
   "viewProgressButton": "View progress",
+  "viewProject": "View Project",
   "viewSection": "View section",
   "viewStudentResponses": "View student responses",
   "viewUnitOverview": "View Unit Overview",

--- a/apps/src/code-studio/components/AbuseExclamation.jsx
+++ b/apps/src/code-studio/components/AbuseExclamation.jsx
@@ -8,14 +8,13 @@ export default function AbuseExclamation({
   i18n,
   isOwner,
   canViewFlaggedProject,
-  channelId,
 }) {
   let finalLink, finalLinkText;
   if (isOwner) {
-    finalLink = `${channelId}/edit`;
+    finalLink = `${window.location.href}/edit`;
     finalLinkText = i18n.edit_project;
   } else if (canViewFlaggedProject) {
-    finalLink = `${channelId}/view`;
+    finalLink = `${window.location.href}/view`;
     finalLinkText = i18n.view_project;
   } else {
     finalLink = 'https://studio.code.org';
@@ -48,5 +47,4 @@ AbuseExclamation.propTypes = {
   }).isRequired,
   isOwner: PropTypes.bool.isRequired,
   canViewFlaggedProject: PropTypes.bool, // Make required once we add different view for teacher of project owner in lab2.
-  channelId: PropTypes.string.isRequired,
 };

--- a/apps/src/code-studio/components/AbuseExclamation.jsx
+++ b/apps/src/code-studio/components/AbuseExclamation.jsx
@@ -4,11 +4,19 @@ import React from 'react';
 import AbuseError from './AbuseError';
 import AlertExclamation from './AlertExclamation';
 
-export default function AbuseExclamation({i18n, isOwner}) {
+export default function AbuseExclamation({
+  i18n,
+  isOwner,
+  canViewFlaggedProject,
+  channelId,
+}) {
   let finalLink, finalLinkText;
   if (isOwner) {
-    finalLink = 'edit';
+    finalLink = `${channelId}/edit`;
     finalLinkText = i18n.edit_project;
+  } else if (canViewFlaggedProject) {
+    finalLink = `${channelId}/view`;
+    finalLinkText = i18n.view_project;
   } else {
     finalLink = 'https://studio.code.org';
     finalLinkText = i18n.go_to_code_studio;
@@ -35,7 +43,10 @@ AbuseExclamation.propTypes = {
     tos: PropTypes.string.isRequired,
     contact_us: PropTypes.string.isRequired,
     edit_project: PropTypes.string.isRequired,
+    view_project: PropTypes.string,
     go_to_code_studio: PropTypes.string.isRequired,
   }).isRequired,
   isOwner: PropTypes.bool.isRequired,
+  canViewFlaggedProject: PropTypes.bool, // Make required once we add different view for teacher of project owner in lab2.
+  channelId: PropTypes.string.isRequired,
 };

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -258,10 +258,11 @@ function tryToUploadShareImageToS3({image, level}) {
 }
 
 /**
- * Loads project and checks to see if it is abusive or if sharing is disabled
- * for the owner.
+ * Loads project and checks to see if sharing is disabled for the owner.
+ * If the project is flagged for abuse or privacy/profanity, 'not found' is returned and caught
+ * for users who are not the owner nor the owner's teacher. See can_view_flagged_assets in files_api.rb.
  * @returns {Promise.<AppOptionsConfig>} Resolves when project has loaded and is
- * not abusive. Never resolves if abusive.
+ * not flagged. Never resolves if flagged.
  */
 function loadProjectAndCheckAbuse(appOptions) {
   return new Promise((resolve, reject) => {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -416,6 +416,13 @@ var projects = (module.exports = {
     return !!(current && current.isOwner);
   },
 
+  /**
+   * @returns {boolean}
+   */
+  isTeacherOfProjectOwnerOrProjectValidator() {
+    return !!isTeacherOfProjectOwner || appOptions.canResetAbuse;
+  },
+
   isPublished() {
     return !!(current && current.publishedAt);
   },
@@ -497,12 +504,12 @@ var projects = (module.exports = {
     // manipulated by the user. In this case that's okay, since all that does
     // is allow them to view a project that was marked as abusive.
     // If current user is teacher of project's owner, then allow them to view as well.
-    const hasEditOrViewPermissions =
-      this.isOwner() || appOptions.canResetAbuse || isTeacherOfProjectOwner;
+    const hasViewPermissions =
+      appOptions.canResetAbuse || isTeacherOfProjectOwner;
 
     const isEditOrViewPage = pageAction === 'edit' || pageAction === 'view';
 
-    return hasEditOrViewPermissions && isEditOrViewPage;
+    return (this.isOwner() || hasViewPermissions) && isEditOrViewPage;
   },
 
   channelNotFound() {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -417,9 +417,10 @@ var projects = (module.exports = {
   },
 
   /**
-   * @returns {boolean}
+   * @returns {boolean} true if the current user is a teacher of the owner of the project or
+   * a project validator.
    */
-  isTeacherOfProjectOwnerOrProjectValidator() {
+  canViewFlaggedProject() {
     return !!isTeacherOfProjectOwner || appOptions.canResetAbuse;
   },
 

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -103,6 +103,7 @@ let newSourceVersionInterval = 15 * 60 * 1000; // 15 minutes
 var currentAbuseScore = 0;
 var sharingDisabled = false;
 var currentHasPrivacyProfanityViolation = false;
+var isTeacherOfProjectOwner = false;
 var currentShareFailureEnglish = '';
 var currentShareFailureIntl = '';
 var intlLanguage = false;
@@ -495,10 +496,13 @@ var projects = (module.exports = {
     // NOTE: appOptions.canResetAbuse is not a security setting as it can be
     // manipulated by the user. In this case that's okay, since all that does
     // is allow them to view a project that was marked as abusive.
-    const hasEditPermissions = this.isOwner() || appOptions.canResetAbuse;
+    // If current user is teacher of project's owner, then allow them to view as well.
+    const hasEditOrViewPermissions =
+      this.isOwner() || appOptions.canResetAbuse || isTeacherOfProjectOwner;
+
     const isEditOrViewPage = pageAction === 'edit' || pageAction === 'view';
 
-    return hasEditPermissions && isEditOrViewPage;
+    return hasEditOrViewPermissions && isEditOrViewPage;
   },
 
   channelNotFound() {
@@ -1968,6 +1972,19 @@ function fetchShareFailure(resolve) {
   });
 }
 
+function fetchIsTeacherOfProjectOwner(resolve) {
+  channels.fetch(current.id + '/is_teacher_of_project_owner', (err, data) => {
+    isTeacherOfProjectOwner =
+      (data && !!data.is_teacher_of_project_owner) || isTeacherOfProjectOwner;
+    resolve();
+    if (err) {
+      // Throw an error so that things like New Relic see this. This shouldn't
+      // affect anything else.
+      throw err;
+    }
+  });
+}
+
 function fetchPrivacyProfanityViolations(resolve) {
   channels.fetch(current.id + '/privacy-profanity', (err, data) => {
     // data.has_violation is 0 or true, coerce to a boolean.
@@ -1990,6 +2007,7 @@ function fetchAbuseScoreAndPrivacyViolations(project) {
   const promises = [
     new Promise(fetchAbuseScore),
     new Promise(fetchShareFailure),
+    new Promise(fetchIsTeacherOfProjectOwner),
   ];
 
   if (OPEN_ENDED_PROJECTS_YOUNG_AGE.includes(project.getStandaloneApp())) {

--- a/apps/src/code-studio/initApp/renderAbusive.js
+++ b/apps/src/code-studio/initApp/renderAbusive.js
@@ -26,8 +26,7 @@ export default (project, tosText) => {
         go_to_code_studio: msg.goToCodeStudio(),
       },
       isOwner: project.isOwner(),
-      canViewFlaggedProject:
-        project.isTeacherOfProjectOwnerOrProjectValidator(),
+      canViewFlaggedProject: project.canViewFlaggedProject(),
     }),
     document.getElementById('codeApp')
   );

--- a/apps/src/code-studio/initApp/renderAbusive.js
+++ b/apps/src/code-studio/initApp/renderAbusive.js
@@ -28,7 +28,6 @@ export default (project, tosText) => {
       isOwner: project.isOwner(),
       canViewFlaggedProject:
         project.isTeacherOfProjectOwnerOrProjectValidator(),
-      channelId: project.getCurrentId(),
     }),
     document.getElementById('codeApp')
   );

--- a/apps/src/code-studio/initApp/renderAbusive.js
+++ b/apps/src/code-studio/initApp/renderAbusive.js
@@ -12,6 +12,7 @@ import showProjectAdmin from '../showProjectAdmin';
  * @param {string} tosText
  */
 export default (project, tosText) => {
+  console.log('project.getCurrentId', project.getCurrentId());
   ReactDOM.render(
     React.createElement(AbuseExclamation, {
       i18n: {
@@ -22,9 +23,13 @@ export default (project, tosText) => {
           )}`,
         }),
         edit_project: msg.editProject(),
+        view_project: msg.viewProject(),
         go_to_code_studio: msg.goToCodeStudio(),
       },
       isOwner: project.isOwner(),
+      canViewFlaggedProject:
+        project.isTeacherOfProjectOwnerOrProjectValidator(),
+      channelId: project.getCurrentId(),
     }),
     document.getElementById('codeApp')
   );

--- a/apps/src/code-studio/initApp/renderAbusive.js
+++ b/apps/src/code-studio/initApp/renderAbusive.js
@@ -12,7 +12,6 @@ import showProjectAdmin from '../showProjectAdmin';
  * @param {string} tosText
  */
 export default (project, tosText) => {
-  console.log('project.getCurrentId', project.getCurrentId());
   ReactDOM.render(
     React.createElement(AbuseExclamation, {
       i18n: {

--- a/apps/src/lab2/views/ProjectBlockedUI.tsx
+++ b/apps/src/lab2/views/ProjectBlockedUI.tsx
@@ -19,8 +19,10 @@ export const ProjectBlockedUI: React.FunctionComponent<{
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   const shareUrl = projectManager ? projectManager.getShareUrl() : null;
   const isOwner = useAppSelector(state => state.lab.channel?.isOwner || false);
+  const channelId = useAppSelector(state => state.lab.channel?.id) || '';
   const abuseExclamationProps = {
     isOwner,
+    channelId,
     i18n:
       blockedType === 'projectAbuse'
         ? {

--- a/apps/src/lab2/views/ProjectBlockedUI.tsx
+++ b/apps/src/lab2/views/ProjectBlockedUI.tsx
@@ -19,10 +19,8 @@ export const ProjectBlockedUI: React.FunctionComponent<{
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   const shareUrl = projectManager ? projectManager.getShareUrl() : null;
   const isOwner = useAppSelector(state => state.lab.channel?.isOwner || false);
-  const channelId = useAppSelector(state => state.lab.channel?.id) || '';
   const abuseExclamationProps = {
     isOwner,
-    channelId,
     i18n:
       blockedType === 'projectAbuse'
         ? {

--- a/apps/test/unit/code-studio/components/AbuseExclamationTest.jsx
+++ b/apps/test/unit/code-studio/components/AbuseExclamationTest.jsx
@@ -13,7 +13,8 @@ describe('AbuseExclamation', () => {
           edit_project: 'edit project',
           go_to_code_studio: 'go to code studio',
         }}
-        isOwner
+        isOwner={false}
+        channelId="test-channel-id"
       />
     );
     expect(wrapper.find('AbuseError').length).toBe(1);
@@ -29,7 +30,8 @@ describe('AbuseExclamation', () => {
           edit_project: 'edit project',
           go_to_code_studio: 'go to code studio',
         }}
-        isOwner
+        isOwner={true}
+        channelId="test-channel-id"
       />
     );
     expect(wrapper.find('a').text()).toContain('edit project');
@@ -45,6 +47,7 @@ describe('AbuseExclamation', () => {
           go_to_code_studio: 'go to code studio',
         }}
         isOwner={false}
+        channelId="test-channel-id"
       />
     );
     expect(wrapper.find('a').text()).toContain('go to code studio');

--- a/apps/test/unit/code-studio/components/AbuseExclamationTest.jsx
+++ b/apps/test/unit/code-studio/components/AbuseExclamationTest.jsx
@@ -31,13 +31,29 @@ describe('AbuseExclamation', () => {
           go_to_code_studio: 'go to code studio',
         }}
         isOwner={true}
-        channelId="test-channel-id"
       />
     );
     expect(wrapper.find('a').text()).toContain('edit project');
   });
 
-  it('shows code studio link if isOwener is false', () => {
+  it('shows view link if canViewFlaggedProject is true', () => {
+    const wrapper = shallow(
+      <AbuseExclamation
+        i18n={{
+          tos: 'terms of service',
+          contact_us: 'contact us',
+          edit_project: 'edit project',
+          view_project: 'view project',
+          go_to_code_studio: 'go to code studio',
+        }}
+        isOwner={false}
+        canViewFlaggedProject={true}
+      />
+    );
+    expect(wrapper.find('a').text()).toContain('view project');
+  });
+
+  it('shows code studio link if isOwner is false', () => {
     const wrapper = shallow(
       <AbuseExclamation
         i18n={{
@@ -47,7 +63,6 @@ describe('AbuseExclamation', () => {
           go_to_code_studio: 'go to code studio',
         }}
         isOwner={false}
-        channelId="test-channel-id"
       />
     );
     expect(wrapper.find('a').text()).toContain('go to code studio');

--- a/dashboard/legacy/middleware/channels_api.rb
+++ b/dashboard/legacy/middleware/channels_api.rb
@@ -256,7 +256,7 @@ class ChannelsApi < Sinatra::Base
   #
   # GET /v3/channels/<channel-id>/sharing_disabled
   #
-  # Get the ability to share a project based on it's owner's share setting.
+  # Get the ability to share a project based on its owner's share setting.
   #
   get %r{/v3/channels/([^/]+)/sharing_disabled} do |id|
     dont_cache
@@ -267,6 +267,22 @@ class ChannelsApi < Sinatra::Base
       bad_request
     end
     {sharing_disabled: value}.to_json
+  end
+
+  #
+  # GET /v3/channels/<channel-id>/is_teacher_of_project_owner
+  #
+  # Get if the current user is a teacher of the project owner.
+  #
+  get %r{/v3/channels/([^/]+)/is_teacher_of_project_owner} do |id|
+    dont_cache
+    content_type :json
+    begin
+      value = Projects.new(get_storage_id).get_is_teacher_of_project_owner(id, current_user_id)
+    rescue ArgumentError, OpenSSL::Cipher::CipherError
+      bad_request
+    end
+    {is_teacher_of_project_owner: value}.to_json
   end
 
   #

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -47,7 +47,7 @@ class FilesApi < Sinatra::Base
     end
   end
 
-  def can_view_abusive_assets?(encrypted_channel_id)
+  def can_view_flagged_assets?(encrypted_channel_id)
     return true if owns_channel?(encrypted_channel_id) || admin? || has_permission?('project_validator')
 
     # teachers can see abusive assets of their students
@@ -70,10 +70,6 @@ class FilesApi < Sinatra::Base
   # Default to cannot view if there is an error
   rescue Projects::NotFound, ArgumentError, OpenSSL::Cipher::CipherError
     false
-  end
-
-  def can_view_profane_or_pii_assets?(encrypted_channel_id)
-    owns_channel?(encrypted_channel_id) || admin? || has_permission?('project_validator')
   end
 
   def file_too_large(quota_type)
@@ -274,8 +270,8 @@ class FilesApi < Sinatra::Base
     abuse_score = [metadata['abuse_score'].to_i, metadata['abuse-score'].to_i].max
     project = Projects.new(get_storage_id).get(encrypted_channel_id)
     project_type = project[:projectType]&.downcase
-    not_found if abuse_score >= SharedConstants::ABUSE_CONSTANTS.ABUSE_THRESHOLD && !can_view_abusive_assets?(encrypted_channel_id)
-    not_found if profanity_privacy_violation?(filename, result[:body], project_type) && !can_view_profane_or_pii_assets?(encrypted_channel_id)
+    not_found if abuse_score >= SharedConstants::ABUSE_CONSTANTS.ABUSE_THRESHOLD && !can_view_flagged_assets?(encrypted_channel_id)
+    not_found if profanity_privacy_violation?(filename, result[:body], project_type) && !can_view_flagged_assets?(encrypted_channel_id)
     not_found if code_projects_domain_root_route && !codeprojects_can_view?(encrypted_channel_id)
 
     if code_projects_domain_root_route && html?(response.headers)

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -209,8 +209,6 @@ class Projects
   def get_is_teacher_of_project_owner(channel_id, current_user_id)
     owner_storage_id, __ = storage_decrypt_channel_id(channel_id)
     owner_user_id = user_id_for_storage_id(owner_storage_id)
-    # A project can always be shared with a project owner's teacher, even
-    # if the project is flagged for privacy/profanity or abuse.
     teaches_student?(owner_user_id, current_user_id)
   end
 

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -205,6 +205,15 @@ class Projects
     true
   end
 
+  # Determine if the current user is teacher of project owner.
+  def get_is_teacher_of_project_owner(channel_id, current_user_id)
+    owner_storage_id, __ = storage_decrypt_channel_id(channel_id)
+    owner_user_id = user_id_for_storage_id(owner_storage_id)
+    # A project can always be shared with a project owner's teacher, even
+    # if the project is flagged for privacy/profanity or abuse.
+    teaches_student?(owner_user_id, current_user_id)
+  end
+
   def users_paired_on_level?(project_id, current_user_id, owner_user_id, owner_storage_id)
     channel_tokens_table = DASHBOARD_DB[:channel_tokens]
     level_id_row = channel_tokens_table.where(storage_app_id: project_id, storage_id: owner_storage_id).first

--- a/dashboard/legacy/test/middleware/helpers/test_projects.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_projects.rb
@@ -234,4 +234,35 @@ class ProjectsTest < Minitest::Test
 
     assert_equal expected_thumbnail_url, project.get(channel_id)['thumbnailUrl']
   end
+
+  def test_get_is_teacher_of_project_owner_returns_true_when_user_is_teacher
+    student_user_id = 100
+    teacher_user_id = 200
+    student_storage_id = create_storage_id_for_user(student_user_id)
+
+    project = Projects.new(student_storage_id)
+    channel_id = project.create({projectType: 'spritelab'}, ip: 123)
+
+    # Stub storage_decrypt_channel_id to return the correct owner storage ID.
+    project.expects(:storage_decrypt_channel_id).with(channel_id).returns([student_storage_id, 123])
+    project.expects(:user_id_for_storage_id).with(student_storage_id).returns(student_user_id)
+    project.expects(:teaches_student?).with(student_user_id, teacher_user_id).returns(true)
+
+    assert_equal true, project.get_is_teacher_of_project_owner(channel_id, teacher_user_id)
+  end
+
+  def test_get_is_teacher_of_project_owner_returns_false_when_user_is_not_teacher
+    student_user_id = 100
+    non_teacher_user_id = 300
+    student_storage_id = create_storage_id_for_user(student_user_id)
+
+    project = Projects.new(student_storage_id)
+    channel_id = project.create({projectType: 'spritelab'}, ip: 123)
+
+    project.expects(:storage_decrypt_channel_id).with(channel_id).returns([student_storage_id, 123])
+    project.expects(:user_id_for_storage_id).with(student_storage_id).returns(student_user_id)
+    project.expects(:teaches_student?).with(student_user_id, non_teacher_user_id).returns(false)
+
+    assert_equal false, project.get_is_teacher_of_project_owner(channel_id, non_teacher_user_id)
+  end
 end

--- a/dashboard/legacy/test/middleware/test_sources.rb
+++ b/dashboard/legacy/test/middleware/test_sources.rb
@@ -243,13 +243,12 @@ class SourcesTest < FilesApiTestBase
       assert not_found?
     end
 
-    # teacher cannot view
+    # teacher or project owner can view
     with_session(:teacher) do
       teacher_api = FilesApiTestHelper.new(current_session, 'sources', @channel)
       FilesApi.any_instance.stubs(:teaches_student?).returns(true)
       teacher_api.get_object(filename)
-      refute successful?
-      assert not_found?
+      assert successful?
       FilesApi.any_instance.unstub(:teaches_student?)
     end
 

--- a/dashboard/legacy/test/middleware/test_sources.rb
+++ b/dashboard/legacy/test/middleware/test_sources.rb
@@ -243,7 +243,7 @@ class SourcesTest < FilesApiTestBase
       assert not_found?
     end
 
-    # teacher or project owner can view
+    # teacher can view
     with_session(:teacher) do
       teacher_api = FilesApiTestHelper.new(current_session, 'sources', @channel)
       FilesApi.any_instance.stubs(:teaches_student?).returns(true)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR enables a teacher user to view a legacy project that is flagged and blocked due to abuse/PII/profanity if the user is a teacher of the project owner. Currently, project owners can edit their projects that have been flagged, and project validators can view flagged projects. Code.org's sharing policy is [being updated](https://docs.google.com/document/d/1uRPSJTs3y7E8jB8T7MTagdEGEv_jaXUGUw7PVNkXyK4/edit?tab=t.0) so this share allowance for teachers of project owners is part of the update.

For context, if a user is a student and `sharing_disabled` is `true`, then the user can only share projects with their teacher. Now that we are automatically flagging and blocking projects due to filtering of program text via WebPurify and uploading of custom images via Azure Image Moderation, we enable teachers to view blocked projects so that they can still assess their students's projects and help report false positive cases.

This PR also fixes a bug in the 'Edit project' link in the share mode of a blocked project. Currently on `prod`, the 'Edit project' link goes to '/projects/project-type/edit' instead of '/projects/project-type/channel-id/edit'. See 'Before update' screencast below.

## Before update

https://github.com/user-attachments/assets/b8e4558a-b3e1-4f0a-9cca-1eccdb2861f3


## After update
The screencast shows a project is blocked due to its abuse score; its owner is 'student`'. In share view:
- the project owner clicks on the 'Edit project' link and correctly goes to '/edit' page,
- a project validator can click on 'View project' link and go to '/view' page with the workspace alert,
- a teacher of the project owner, 'teacher1', can also  click on 'View project' link and go to '/view' page with the workspace alert,
- a teacher that is NOT a teacher of the project owner, 'teacher3', sees the blocked UI in share view and clicks on Code Studio link that goes to the home page on production.

https://github.com/user-attachments/assets/aaaab4b7-3d75-43aa-9d50-ea195f3ec053





## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/SL-1332
- [Updated sharing policy](https://docs.google.com/document/d/1uRPSJTs3y7E8jB8T7MTagdEGEv_jaXUGUw7PVNkXyK4/edit?tab=t.0)
- [Current state of share/edit/view modes](https://docs.google.com/document/d/1GEWYqetCJYXF49i-ngU7q_tfhmPyg7BwtvWVXWeEHLM/edit?tab=t.h1rp6ow7jr5i)

## Testing story
Tested locally using a student account, a teacher account with the student in a section, a teacher account that is not a teacher of the student, and a project validator account. 

Updated unit tests, added tests in `AbuseExclamationTest.jsx` and `test_projects.rb`. 
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
