### PR TITLE
Update /yourschool to allow different tilesets for testing

### DIFF
--- a/bin/test_update_census_mapbox
+++ b/bin/test_update_census_mapbox
@@ -42,66 +42,64 @@ def make_location(lat, long)
 end
 
 def main
-  if rack_env?(:staging)
-    CDO.log.info "Loading census summary data."
-    AWS::S3.seed_from_file('cdo-census', AWS_ACCESS_REPORT_DATA_FILE) do |filename|
-      geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
-      entries_skipped = 0
+  CDO.log.info "Loading census summary data."
+  AWS::S3.seed_from_file('cdo-census', AWS_ACCESS_REPORT_DATA_FILE) do |filename|
+    geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
+    entries_skipped = 0
 
-      CSV.read(filename, **CSV_IMPORT_OPTIONS).each do |row|
-        # Parse or skip row data
-        parsed = row.to_hash.symbolize_keys
-        school = School.find_by_id(parsed[:school_id])
+    CSV.read(filename, **CSV_IMPORT_OPTIONS).each do |row|
+      # Parse or skip row data
+      parsed = row.to_hash.symbolize_keys
+      school = School.find_by_id(parsed[:school_id])
 
-        if school.nil?
-          entries_skipped += 1
-          next
-        end
-
-        teaches_cs = parsed[:teaches_cs] == 'unknown' ? 'U' : parsed[:teaches_cs]
-
-        # Add parsed row to map
-        geojson["features"] <<
-          {
-            geometry: {
-              coordinates: [school.longitude.to_f, school.latitude.to_f],
-              type: "Point"
-            },
-            properties: {
-              school_id: school.id,
-              year: ACCESS_REPORT_YEAR,
-              school_name: school.name.titleize,
-              school_city: school.city.titleize,
-              school_state: school.state,
-              teaches_cs: teaches_cs
-            },
-            type: "Feature"
-          }
+      if school.nil?
+        entries_skipped += 1
+        next
       end
 
-      CDO.log.info "#{entries_skipped} census summaries skipped due to no school_id match in database."
-      CDO.log.info "Census summaries loading: done processing #{filename}.\n"
+      teaches_cs = parsed[:teaches_cs] == 'unknown' ? 'U' : parsed[:teaches_cs]
 
-      file = Tempfile.new(['census', 'geojson'])
-      tiles = Tempfile.new([TEST_CENSUS_TILESET, 'mbtiles'])
-      file.write(JSON.pretty_generate(geojson))
-      _stdout, stderr, tippecanoe_status = Open3.capture3(
-        # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
-        # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
-        # The layer is called "census". DO NOT change the layer name without changing the map
-        # in the Mapbox UI.
-        "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"census\" --force #{file.path}"
-      )
-      upload_successful = false
-      if tippecanoe_status.success?
-        upload_successful = upload_maptiles(tiles.path, TEST_CENSUS_TILESET)
-      end
-      unless tippecanoe_status.success? && upload_successful
-        CDO.log.info "Error in uploading"
-        CDO.log.info "Success state: #{tippecanoe_status.success?}"
-        CDO.log.info "Tippecanoe status: #{stderr}"
-        CDO.log.info "Upload successful: #{upload_successful}"
-      end
+      # Add parsed row to map
+      geojson["features"] <<
+        {
+          geometry: {
+            coordinates: [school.longitude.to_f, school.latitude.to_f],
+            type: "Point"
+          },
+          properties: {
+            school_id: school.id,
+            year: ACCESS_REPORT_YEAR,
+            school_name: school.name.titleize,
+            school_city: school.city.titleize,
+            school_state: school.state,
+            teaches_cs: teaches_cs
+          },
+          type: "Feature"
+        }
+    end
+
+    CDO.log.info "#{entries_skipped} census summaries skipped due to no school_id match in database."
+    CDO.log.info "Census summaries loading: done processing #{filename}.\n"
+
+    file = Tempfile.new(['census', 'geojson'])
+    tiles = Tempfile.new([TEST_CENSUS_TILESET, 'mbtiles'])
+    file.write(JSON.pretty_generate(geojson))
+    _stdout, stderr, tippecanoe_status = Open3.capture3(
+      # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
+      # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
+      # The layer is called "census". DO NOT change the layer name without changing the map
+      # in the Mapbox UI.
+      "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"census\" --force #{file.path}"
+    )
+    upload_successful = false
+    if tippecanoe_status.success?
+      upload_successful = upload_maptiles(tiles.path, TEST_CENSUS_TILESET)
+    end
+    unless tippecanoe_status.success? && upload_successful
+      CDO.log.info "Error in uploading"
+      CDO.log.info "Success state: #{tippecanoe_status.success?}"
+      CDO.log.info "Tippecanoe status: #{stderr}"
+      CDO.log.info "Upload successful: #{upload_successful}"
     end
   end
 end

--- a/bin/test_update_census_mapbox
+++ b/bin/test_update_census_mapbox
@@ -1,14 +1,22 @@
 #!/usr/bin/env ruby
 
-# The map on code.org/yourschool is run off of Mapbox.
-# This script updates the data on Mapbox by reading the rows from
-# the given AWS file and creating maptiles with Mapbox's command
-# line tool, Tippecanoe, and uploading them to Mapbox's server
-# under the `censustiles-dev` tileset.
+# The map on code.org/yourschool is run off of Mapbox. This script updates the data on the
+# Mapbox tileset under the TEST_CENSUS_TILESET name. It reads from the given AWS file and
+# creates maptiles with Mapbox's command line tool, Tippecanoe, and uploading them to Mapbox's
+# server.
 #
-# This can be used on staging to test that the data and script will
-# work with the new year's data before merging + running on
-# production using ./bin/update_census_mapbox.
+# This can be used to test the new data on production before having it go live to everyone by
+# updating this script's data file and access report year (and tileset name if a new name is
+# desired), running it on production-daemon, and navigating to:
+# code.org/yourschool?tileset=[value-of-TEST_CENSUS_TILESET]
+#
+# If this looks good on production, then you can publish that data (i.e. you won't need a URL
+# param, and it will be the default map data):
+# 1) Update the seeding file name to the new file in census_summary.rb
+# 2) Update the CURRENT_CENSUS_SCHOOL_YEAR constant to the new school year
+# 3) Wait for those changes to hit production and for CensusSummaries to be seeded by the
+#    new file
+# 4) Run ./bin/update_census_mapbox on production-daemon
 #
 # Note: This script does not read from the CensusSummaries table while
 # the real update_census_mapbox script does. Both read from the
@@ -21,6 +29,7 @@ require_relative './cron/upload_to_mapbox'
 raise "CDO.mapbox_upload_token is not defined" unless CDO.mapbox_upload_token
 
 # Constants to update for the given year
+TEST_CENSUS_TILESET = 'censustiles-dev'
 AWS_ACCESS_REPORT_DATA_FILE = "access-report-data-files-2024/final-csv/final_csv_2024_09_30.csv"
 ACCESS_REPORT_YEAR = "2024"
 
@@ -74,7 +83,7 @@ def main
       CDO.log.info "Census summaries loading: done processing #{filename}.\n"
 
       file = Tempfile.new(['census', 'geojson'])
-      tiles = Tempfile.new(['censustiles-dev', 'mbtiles'])
+      tiles = Tempfile.new([TEST_CENSUS_TILESET, 'mbtiles'])
       file.write(JSON.pretty_generate(geojson))
       _stdout, stderr, tippecanoe_status = Open3.capture3(
         # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
@@ -85,20 +94,13 @@ def main
       )
       upload_successful = false
       if tippecanoe_status.success?
-        upload_successful = upload_maptiles(tiles.path, 'censustiles-dev')
+        upload_successful = upload_maptiles(tiles.path, TEST_CENSUS_TILESET)
       end
       unless tippecanoe_status.success? && upload_successful
         CDO.log.info "Error in uploading"
-        CDO.log.info `Success state: #{tippecanoe_status.success?}`
-        CDO.log.info `Upload successful: #{upload_successful}`
-        Honeybadger.notify(
-          error_message: "Updating Census map on Mapbox failed",
-          error_class: "Census Map Update Failure",
-          context: {
-            tippecanoe_status: stderr,
-            upload_status: upload_successful
-          }
-        )
+        CDO.log.info "Success state: #{tippecanoe_status.success?}"
+        CDO.log.info "Tippecanoe status: #{stderr}"
+        CDO.log.info "Upload successful: #{upload_successful}"
       end
     end
   end

--- a/bin/test_update_census_mapbox
+++ b/bin/test_update_census_mapbox
@@ -5,10 +5,11 @@
 # creates maptiles with Mapbox's command line tool, Tippecanoe, and uploading them to Mapbox's
 # server.
 #
-# This can be used to test the new data on production before having it go live to everyone by
-# updating this script's data file and access report year (and tileset name if a new name is
-# desired), running it on production-daemon, and navigating to:
-# code.org/yourschool?tileset=censustiles-dev
+# This can be used to test the new data on production before having it go live to everyone by:
+# 1) Run this script on production-daemon and pass in the access report year and data file:
+#     - ./bin/test_update_census_mapbox [ACCESS_REPORT_YEAR] [ACCESS_REPORT_DATA_FILE]
+#     - Example: ./bin/test_update_census_mapbox 2024 access-report-data-files-2024/final-csv/final_csv_2024_09_30.csv
+# 2) Navigate to https://code.org/en-US/your-school?tileset=censustiles-dev to view results
 #
 # If this looks good on production, then you can publish that data (i.e. you won't need a URL
 # param, and it will be the default map data):
@@ -28,10 +29,7 @@ require_relative './cron/upload_to_mapbox'
 
 raise "CDO.mapbox_upload_token is not defined" unless CDO.mapbox_upload_token
 
-# Constants to update for the given year
 TEST_CENSUS_TILESET = 'censustiles-dev'
-AWS_ACCESS_REPORT_DATA_FILE = "access-report-data-files-2024/final-csv/final_csv_2024_09_30.csv"
-ACCESS_REPORT_YEAR = "2024"
 
 CSV_IMPORT_OPTIONS = {col_sep: ",", headers: true, encoding: 'bom|utf-8'}.freeze
 
@@ -42,8 +40,12 @@ def make_location(lat, long)
 end
 
 def main
+  raise ArgumentError.new("Wrong number of arguments: Expected access report year and access report data file.") unless ARGV.length == 2
+  access_report_year = ARGV[0]
+  aws_access_report_data_file = ARGV[1]
+
   CDO.log.info "Loading census summary data."
-  AWS::S3.seed_from_file('cdo-census', AWS_ACCESS_REPORT_DATA_FILE) do |filename|
+  AWS::S3.seed_from_file('cdo-census', aws_access_report_data_file) do |filename|
     geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
     entries_skipped = 0
 
@@ -68,7 +70,7 @@ def main
           },
           properties: {
             school_id: school.id,
-            year: ACCESS_REPORT_YEAR,
+            year: access_report_year,
             school_name: school.name.titleize,
             school_city: school.city.titleize,
             school_state: school.state,

--- a/bin/test_update_census_mapbox
+++ b/bin/test_update_census_mapbox
@@ -8,12 +8,12 @@
 # This can be used to test the new data on production before having it go live to everyone by
 # updating this script's data file and access report year (and tileset name if a new name is
 # desired), running it on production-daemon, and navigating to:
-# code.org/yourschool?tileset=[value-of-TEST_CENSUS_TILESET]
+# code.org/yourschool?tileset=censustiles-dev
 #
 # If this looks good on production, then you can publish that data (i.e. you won't need a URL
 # param, and it will be the default map data):
 # 1) Update the seeding file name to the new file in census_summary.rb
-# 2) Update the CURRENT_CENSUS_SCHOOL_YEAR constant to the new school year
+# 2) Update the CURRENT_CENSUS_SCHOOL_YEAR constant to the new school year in census_summary.rb
 # 3) Wait for those changes to hit production and for CensusSummaries to be seeded by the
 #    new file
 # 4) Run ./bin/update_census_mapbox on production-daemon

--- a/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/AdoptionMap.tsx
+++ b/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/AdoptionMap.tsx
@@ -50,6 +50,12 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
   onTakeSurveyClick,
 }) => {
   const mapRef = useRef<MapRef>(null);
+  const mapTileset = useMemo(
+    () =>
+      new URLSearchParams(window.location.search).get('tileset') ??
+      MAP_TILESET_ID,
+    [],
+  );
 
   const [mapLoaded, setMapLoaded] = useState(false);
   const [popupData, setPopupData] = useState<{
@@ -94,7 +100,7 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
       mapInstance.once('moveend', () => {
         let newPopupData;
 
-        const schoolPoint = mapInstance.querySourceFeatures(MAP_TILESET_ID, {
+        const schoolPoint = mapInstance.querySourceFeatures(mapTileset, {
           sourceLayer: MAP_POINT_LAYER_ID,
           filter: ['all', ['==', 'school_id', school.nces_id]],
         })[0];
@@ -214,13 +220,13 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
         <NavigationControl position="bottom-right" showCompass={false} />
 
         <Source
-          id={MAP_TILESET_ID}
+          id={mapTileset}
           type="vector"
-          url={`mapbox://codeorg.${MAP_TILESET_ID}`}
+          url={`mapbox://codeorg.${mapTileset}`}
         >
           <Layer
             id={NO_CS_SCHOOLS_LAYER_ID}
-            source={MAP_TILESET_ID}
+            source={mapTileset}
             source-layer={MAP_POINT_LAYER_ID}
             layout={{visibility: 'visible'}}
             type="circle"
@@ -247,7 +253,7 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
           />
           <Layer
             id={CS_SCHOOLS_LAYER_ID}
-            source={MAP_TILESET_ID}
+            source={mapTileset}
             source-layer={MAP_POINT_LAYER_ID}
             layout={{visibility: 'visible'}}
             type="circle"

--- a/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/AdoptionMap.tsx
+++ b/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/AdoptionMap.tsx
@@ -50,12 +50,6 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
   onTakeSurveyClick,
 }) => {
   const mapRef = useRef<MapRef>(null);
-  const mapTileset = useMemo(
-    () =>
-      new URLSearchParams(window.location.search).get('tileset') ??
-      MAP_TILESET_ID,
-    [],
-  );
 
   const [mapLoaded, setMapLoaded] = useState(false);
   const [popupData, setPopupData] = useState<{
@@ -100,7 +94,7 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
       mapInstance.once('moveend', () => {
         let newPopupData;
 
-        const schoolPoint = mapInstance.querySourceFeatures(mapTileset, {
+        const schoolPoint = mapInstance.querySourceFeatures(MAP_TILESET_ID, {
           sourceLayer: MAP_POINT_LAYER_ID,
           filter: ['all', ['==', 'school_id', school.nces_id]],
         })[0];
@@ -220,13 +214,13 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
         <NavigationControl position="bottom-right" showCompass={false} />
 
         <Source
-          id={mapTileset}
+          id={MAP_TILESET_ID}
           type="vector"
-          url={`mapbox://codeorg.${mapTileset}`}
+          url={`mapbox://codeorg.${MAP_TILESET_ID}`}
         >
           <Layer
             id={NO_CS_SCHOOLS_LAYER_ID}
-            source={mapTileset}
+            source={MAP_TILESET_ID}
             source-layer={MAP_POINT_LAYER_ID}
             layout={{visibility: 'visible'}}
             type="circle"
@@ -253,7 +247,7 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
           />
           <Layer
             id={CS_SCHOOLS_LAYER_ID}
-            source={mapTileset}
+            source={MAP_TILESET_ID}
             source-layer={MAP_POINT_LAYER_ID}
             layout={{visibility: 'visible'}}
             type="circle"


### PR DESCRIPTION
Currently, the [/your-school](https://code.org/en-US/your-school) map pulls data from our `censustiles` tileset. The way we updated this year-over-year before was to run `./bin/test_staging_update_census_mapbox` on staging, which read data from the new year's access report data and pushed it to a tileset called `censustiles-dev`. We then had a separate page (which has since been removed) with a copy of the map that pulls data from the `censustiles-dev` tileset instead. This is a pretty cumbersome solution and is being simplified with this PR and a followup PR.

This PR:
- Allows the script to be run in any environment (and has a file rename to reflect that)
- Updates the script to use a constant dev tileset name and have an updated comment at the top
- Defines census data set and census year as parameters when running the script
- Removes the unnecessary HoneyBadger call that we would only want when the equivalent logic is being run on the actual Access Report data import (not the test import)

The followup PR:
- Update the `AdoptionMap` component to default read from the `censustiles` tileset, but allow a URL parameter to define a different tileset to read from instead (this way, we can update the `censustiles-dev` tileset and view the results in plain sight without regular users viewing it or compromising the map page in case the data published to the `censustiles-dev` tileset is bad)

This PR is being split up so that this test script update can hit production, then I can run it on production with an old data set (e.g. 2023's data set) to populate `censustiles-dev` with the old data. Then I'll be able to test if pointing the `AdoptionMap` to the test data will show the old data properly. Unfortunately, I can't test the script locally due to `tippecanoe` not working locally, so I'm not able to combine all the changes into 1 PR.

To more easily view the changes made in PR, here are the commits of actual changes (after a certain number of changes it split the file changes into a file deletion + new file, rather than one file being modified (since I renamed it) so it's hard to see what changes I made in the direct comparison):
- [Rename and start cleanup on script file](https://github.com/code-dot-org/code-dot-org/pull/67359/commits/e294fa12b1e23e55ead0c3f4f6a5d2d5f27f8bf2) (ignore changes to `AdoptionMap` as those are being moved to another PR)
- [Allow script to run in any environment](https://github.com/code-dot-org/code-dot-org/pull/67359/commits/90b8f4bfeb9752569f3a40996f74a72caae90753) (hide whitespace for this)
- [Tiny update to comments](https://github.com/code-dot-org/code-dot-org/pull/67359/commits/b3899d3818aee2c158064b4aa8751be6b213004c)
- [Set census year and data doc as command prompt arguments](https://github.com/code-dot-org/code-dot-org/pull/67359/commits/79db06d4841ff5156b8ccb992a284392f187186e)

### Run with 0 arguments throws error
![0 arguments](https://github.com/user-attachments/assets/ac28cae2-bd84-4cd4-affe-49f9b3b38d5f)

### Run with 1 argument throws error
![1 argument](https://github.com/user-attachments/assets/10b301fc-2495-4019-aa83-25ff98f512c6)

### Run with 2 arguments runs fine (as far as it can go locally)
I also added a `puts` statement to list the arguments just so it was clear that it was parsing them correctly. That statement was then removed before committed.

![2 arguments](https://github.com/user-attachments/assets/366113c2-eeab-4b29-947b-4cbffd3b605c)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3376)

## Testing story
This script can't run locally unfortunately due to a lot of `mapbox` update features not working locally (namely, `tippecanoe`). But I test ran it to make sure that the right number of arguments is expected, and it doesn't touch any of the data tables other than reading from the `School` data table so it should totally safe to run on production.
