### PR TITLE
AI Chat: clean up types for safety check

### DIFF
--- a/apps/src/aichat/types/toxicity.ts
+++ b/apps/src/aichat/types/toxicity.ts
@@ -14,28 +14,8 @@ export interface FlaggedField {
   field: ToxicityCheckedField;
   toxicity: {
     text: string;
-    blockedBy: SafetyService;
-    details: BlocklistDetails | WebPurifyDetails | ComprehendDetails;
-  };
-}
-
-type SafetyService = 'blocklist' | 'webpurify' | 'comprehend';
-
-interface BlocklistDetails {
-  blockedWord: string;
-}
-
-interface WebPurifyDetails {
-  type: 'email' | 'address' | 'phone' | 'profanity';
-  content: string;
-}
-
-interface ComprehendDetails {
-  flaggedSegment: string;
-  toxicity: number;
-  maxCategory: {
-    name: string;
-    score: number;
+    blockedBy: 'openai';
+    details: {evaluation: string};
   };
 }
 

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -62,7 +62,6 @@ module AichatSafetyHelper
 
       if evaluation == 'INAPPROPRIATE'
         details = {evaluation: evaluation}
-
       end
 
       report_openai_safety_check("Finish", attempts)


### PR DESCRIPTION
Quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/67334 -- updates/simplifies our frontend types to match what we're actually doing safety-wise (ie, use OpenAI, which wasn't even listed as a possible type 🙃 )