### PR TITLE
[MusicLab] Timeline Keyboard interaction overhaul

### DIFF
--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -78,6 +78,7 @@
   "panelHeaderWorkspace": "Workspace",
   "panelHeaderControls": "Controls",
   "panelHeaderTimeline": "Timeline",
+  "timelineContainer": "Timeline: press enter to interact with song elements, escape to exit",
   "skip": "Skip",
   "continue": "Continue",
   "select": "Select",

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -14,6 +14,7 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import appConfig from '../appConfig';
 import {BlockMode, MIN_NUM_MEASURES} from '../constants';
+import musicI18n from '../locale';
 import {
   clearSelectedBlockId,
   getBlockMode,
@@ -246,7 +247,7 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
   return (
     <div
       id="timeline"
-      aria-label="Timeline"
+      aria-label={musicI18n.timelineContainer()}
       className={classNames(
         moduleStyles.timeline,
         isPlaying && moduleStyles.timelinePlaying

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -111,9 +111,58 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
     return eventHeight > 8 ? 3 : eventHeight > 6 ? 2 : 1;
   }, []);
 
+  const timelineElements = Array.from(
+    document.querySelectorAll<HTMLElement>('#timeline-element')
+  );
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      const currentIndex = timelineElements.indexOf(event.currentTarget);
+
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        // Move focus to the next element
+        const nextIndex = currentIndex + 1;
+        if (nextIndex < timelineElements.length) {
+          timelineElements[nextIndex].focus();
+        }
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        // Move focus to the previous element
+        const previousIndex = currentIndex - 1;
+        if (previousIndex >= 0) {
+          timelineElements[previousIndex].focus();
+        }
+      } else if (event.key === 'Escape') {
+        // Move focus back to the timeline container
+        const timelineContainer = document.getElementById('timeline');
+        if (timelineContainer) {
+          timelineContainer.focus();
+        }
+      } else if (event.key === 'Tab') {
+        // Prevent default tab behavior to avoid moving focus out of the timeline
+        event.preventDefault();
+      }
+    },
+    [timelineElements]
+  );
+
+  const enterExitTimeline = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      // Focus the first element if it exists
+      if (timelineElements.length > 0) {
+        timelineElements[0].focus();
+      }
+    }
+    if (event.key === 'Tab') {
+      // If Tab is pressed, we want to exit the timeline.
+      // This allows users to navigate away from the timeline using keyboard.
+      (event.currentTarget as HTMLElement).blur();
+    }
+  };
+
   const timelineElementProps = {
     paddingOffset,
     barWidth,
+    onKeyDown,
     getEventHeight,
     getEventVerticalSpace,
   };
@@ -201,6 +250,7 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
         isPlaying && moduleStyles.timelinePlaying
       )}
       onClick={onTimelineClick}
+      onKeyDown={enterExitTimeline}
       ref={timelineRef}
       tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
     >

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -120,13 +120,15 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
       const currentIndex = timelineElements.indexOf(event.currentTarget);
 
       if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
-        // Move focus to the next element
+        // Prevent scroll action & move focus to the next element
+        event.preventDefault();
         const nextIndex = currentIndex + 1;
         if (nextIndex < timelineElements.length) {
           timelineElements[nextIndex].focus();
         }
       } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
-        // Move focus to the previous element
+        // Prevent scroll action & move focus to the previous element
+        event.preventDefault();
         const previousIndex = currentIndex - 1;
         if (previousIndex >= 0) {
           timelineElements[previousIndex].focus();

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -22,6 +22,7 @@ import {
 } from '../redux/musicRedux';
 
 import usePlaybackUpdate from './hooks/usePlaybackUpdate';
+import {TimelineElementId} from './TimelineElement';
 import TimelineSampleEvents from './TimelineSampleEvents';
 import TimelineSimple2Events from './TimelineSimple2Events';
 import {useMusicSelector} from './types';
@@ -113,27 +114,23 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
   }, []);
 
   const timelineElements = Array.from(
-    document.querySelectorAll<HTMLElement>('#timeline-element')
+    document.querySelectorAll<HTMLElement>(`#${TimelineElementId}`)
   );
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>) => {
       const currentIndex = timelineElements.indexOf(event.currentTarget);
-
+      // For arrow keys, prevent scroll action and move focus accordingly, looping at start and end
       if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
-        // Prevent scroll action & move focus to the next element
         event.preventDefault();
-        const nextIndex = currentIndex + 1;
-        if (nextIndex < timelineElements.length) {
-          timelineElements[nextIndex].focus();
-        }
+        const nextIndex = (currentIndex + 1) % timelineElements.length;
+        timelineElements[nextIndex].focus();
       } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
-        // Prevent scroll action & move focus to the previous element
         event.preventDefault();
-        const previousIndex = currentIndex - 1;
-        if (previousIndex >= 0) {
-          timelineElements[previousIndex].focus();
-        }
+        const previousIndex =
+          (currentIndex - 1 + timelineElements.length) %
+          timelineElements.length;
+        timelineElements[previousIndex].focus();
       } else if (event.key === 'Escape') {
         // Move focus back to the timeline container
         const timelineContainer = document.getElementById('timeline');
@@ -156,8 +153,7 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
       }
     }
     if (event.key === 'Tab') {
-      // If Tab is pressed, we want to exit the timeline.
-      // This allows users to navigate away from the timeline using keyboard.
+      // If tab is pressed, we know they are moving on to the next tabbable object
       (event.currentTarget as HTMLElement).blur();
     }
   };

--- a/apps/src/music/views/TimelineElement.tsx
+++ b/apps/src/music/views/TimelineElement.tsx
@@ -16,6 +16,7 @@ import moduleStyles from './timeline.module.scss';
 interface TimelineElementProps {
   eventData: PlaybackEvent;
   barWidth: number;
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
   height: number;
   top: number;
   left: number;
@@ -27,6 +28,7 @@ interface TimelineElementProps {
 const TimelineElement: React.FunctionComponent<TimelineElementProps> = ({
   eventData,
   barWidth,
+  onKeyDown,
   height,
   top,
   left,
@@ -64,7 +66,10 @@ const TimelineElement: React.FunctionComponent<TimelineElementProps> = ({
 
   return (
     <button
+      id={'timeline-element'}
+      tabIndex={-1}
       type="button"
+      onKeyDown={onKeyDown}
       aria-label={friendlyLabel}
       className={classNames(
         'timeline-element',

--- a/apps/src/music/views/TimelineElement.tsx
+++ b/apps/src/music/views/TimelineElement.tsx
@@ -13,6 +13,8 @@ import SoundStyle from '../utils/SoundStyle';
 
 import moduleStyles from './timeline.module.scss';
 
+export const TimelineElementId = 'timeline-element';
+
 interface TimelineElementProps {
   eventData: PlaybackEvent;
   barWidth: number;
@@ -66,13 +68,12 @@ const TimelineElement: React.FunctionComponent<TimelineElementProps> = ({
 
   return (
     <button
-      id={'timeline-element'}
+      id={TimelineElementId}
       tabIndex={-1}
       type="button"
       onKeyDown={onKeyDown}
       aria-label={friendlyLabel}
       className={classNames(
-        'timeline-element',
         moduleStyles.timelineElement,
         SoundStyle[soundType]?.classNameBackground,
         SoundStyle[soundType]?.classNameBorder,

--- a/apps/src/music/views/TimelineSampleEvents.jsx
+++ b/apps/src/music/views/TimelineSampleEvents.jsx
@@ -12,6 +12,7 @@ import TimelineElement from './TimelineElement';
 const TimelineSampleEvents = ({
   paddingOffset,
   barWidth,
+  onKeyDown,
   getEventHeight,
   getEventVerticalSpace,
 }) => {
@@ -45,6 +46,7 @@ const TimelineSampleEvents = ({
           key={index}
           eventData={eventData}
           barWidth={barWidth}
+          onKeyDown={onKeyDown}
           height={eventHeight - eventVerticalSpace}
           top={32 + getVerticalOffsetForEventId(eventData.id)}
           left={paddingOffset + barWidth * (eventData.when - 1)}
@@ -58,6 +60,7 @@ const TimelineSampleEvents = ({
 TimelineSampleEvents.propTypes = {
   paddingOffset: PropTypes.number.isRequired,
   barWidth: PropTypes.number.isRequired,
+  onKeyDown: PropTypes.func.isRequired,
   getEventHeight: PropTypes.func.isRequired,
   getEventVerticalSpace: PropTypes.func.isRequired,
 };

--- a/apps/src/music/views/TimelineSimple2Events.tsx
+++ b/apps/src/music/views/TimelineSimple2Events.tsx
@@ -185,13 +185,20 @@ const sortByTriggered = function (
 interface TimelineSimple2EventsProps {
   paddingOffset: number;
   barWidth: number;
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
   getEventHeight: (numUniqueRows: number, availableHeight?: number) => number;
   getEventVerticalSpace: (eventHeight: number) => number;
 }
 
 const TimelineSimple2Events: React.FunctionComponent<
   TimelineSimple2EventsProps
-> = ({paddingOffset, barWidth, getEventHeight, getEventVerticalSpace}) => {
+> = ({
+  paddingOffset,
+  barWidth,
+  onKeyDown,
+  getEventHeight,
+  getEventVerticalSpace,
+}) => {
   const soundEventsOriginal = useMusicSelector(
     state => state.music.playbackEvents
   );
@@ -280,6 +287,7 @@ const TimelineSimple2Events: React.FunctionComponent<
           key={index}
           eventData={eventData}
           barWidth={barWidth}
+          onKeyDown={onKeyDown}
           height={eventHeight - eventVerticalSpace}
           top={
             32 +

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -20,7 +20,7 @@ Scenario Outline: Dragging play sound block
   And I wait until element "[data-id='when-run-block']" is visible
 
   # There should be no music timeline entry yet.
-  And element ".timeline-element" is not visible
+  And element "#timeline-element" is not visible
 
   # Open the first category.
   And I press the first ".blocklyTreeRow" element
@@ -29,7 +29,7 @@ Scenario Outline: Dragging play sound block
   Then I drag block "play_sound_at_current_location_simple2" to block "when-run-block"
 
   # There should now be a music timeline entry.
-  And element ".timeline-element" is visible
+  And element "#timeline-element" is visible
 
   # Click the field inside the attached "play sound" block.
   And I click block field "[data-id='when-run-block'] > [data-id='play_sound_at_current_location_simple2'] > .blocklyEditableField"
@@ -47,7 +47,7 @@ Scenario Outline: Dragging play sound block
   And I wait until element "#sounds-panel" is not visible
 
   # There should still be a music timeline entry.
-  And element ".timeline-element" is visible
+  And element "#timeline-element" is visible
 
 Examples:
   | url                                                       | test_name               |


### PR DESCRIPTION
This is a large overhaul of keyboard navigation for the music lab timeline. 

Prior behavior: Each timeline event was a tab stop, and the elements were in the dom order (that is, you had to tab through them to get past the timeline). 

New behavior: Each timeline event is hidden from the tab order. If you tab to the timeline, the container is highlighted (and the new aria label with instructions to enter and exit is read aloud if you have a screen reader turned on). I took advantage of the same pattern I built for the Pythonlab editor, where you have to press enter to 'enter' the timeline, and escape to exit the timeline.

Once you hit enter, focus is placed on the first item, and you use arrow keys (namely, right or down, and then left or up) to move through the list of timeline elements. There is a future state where we might differentiate between right and down, and between up and left, but we opted to keep the default ordering for now. This arrow key navigation is more in line with what folks will expect via the blockly keyboard plugin. 

If you press enter on a timeline element, it will still turn off and on highlights in the blockly workspace, which matches the current click interactions. 

If focus is on the timeline container, you can use arrow keys to smoothly scroll (the browser default behavior) across the timeline. Once you enter the timeline container, the arrow keys have a preventDefault(), so that the timeline will shift only when necessary (if the next timeline element you focus on is off-screen). 

A demo (I show that you can tab past the timeline easily, move between elements with the arrow keys, exit the timeline section and scroll horizontally with the keys, and finally that you can press enter to highlight and un-highlight the blocks):

https://github.com/user-attachments/assets/9ccf85dc-d6b1-4a99-a588-3154f1dec722

And a video of the arrow keys looping back at the end and the start!

https://github.com/user-attachments/assets/dcd0a495-a4fe-416b-826c-ad5c61a82046



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1355
- https://codedotorg.atlassian.net/browse/SL-1356

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
