### PR TITLE
feat(Tabs): add boolean hidePanels prop to Tabs

### DIFF
--- a/frontend/packages/component-library/src/tabs/Tabs.tsx
+++ b/frontend/packages/component-library/src/tabs/Tabs.tsx
@@ -37,6 +37,8 @@ export interface TabsProps {
   tabPanelsContainerClassName?: string;
   /** Custom id for Tab Panels container */
   tabPanelsContainerId?: string;
+  /** hide the Tab Panels container */
+  hidePanels?: boolean;
 }
 
 /**
@@ -62,6 +64,7 @@ const Tabs: React.FunctionComponent<TabsProps> = ({
   tabsContainerClassName,
   tabPanelsContainerId,
   tabPanelsContainerClassName,
+  hidePanels,
   type = 'primary',
   mode = 'light',
   size = 'm',
@@ -129,20 +132,22 @@ const Tabs: React.FunctionComponent<TabsProps> = ({
           ))}
         </ul>
       </div>
-      <div
-        className={classnames(tabPanelsContainerClassName)}
-        id={tabPanelsContainerId}
-      >
-        {tabs.map(tab => (
-          <_TabPanel
-            key={tab.value}
-            content={tab.tabContent}
-            isActive={tab.value === selectedTabValue}
-            id={`${nameStripped}-panel-${tab.value.replace(/\s+/g, '-')}`}
-            labelledBy={`${nameStripped}-tab-${tab.value.replace(/\s+/g, '-')}`}
-          />
-        ))}
-      </div>
+      {!hidePanels && (
+        <div
+          className={classnames(tabPanelsContainerClassName)}
+          id={tabPanelsContainerId}
+        >
+          {tabs.map(tab => (
+            <_TabPanel
+              key={tab.value}
+              content={tab.tabContent}
+              isActive={tab.value === selectedTabValue}
+              id={`${nameStripped}-panel-${tab.value.replace(/\s+/g, '-')}`}
+              labelledBy={`${nameStripped}-tab-${tab.value.replace(/\s+/g, '-')}`}
+            />
+          ))}
+        </div>
+      )}
     </>
   );
 };

--- a/frontend/packages/component-library/src/tabs/__tests__/Tabs.test.tsx
+++ b/frontend/packages/component-library/src/tabs/__tests__/Tabs.test.tsx
@@ -164,4 +164,25 @@ describe('Design System - Tabs', () => {
 
     expect(tooltip).toBeInTheDocument();
   });
+
+  it('hides tab panels when hidePanels is true', async () => {
+    renderTabs({
+      defaultSelectedTabValue: 'tab1',
+      tabs: [
+        {text: 'tab1', value: 'tab1', tabContent: <div>tab1 content</div>},
+        {text: 'tab2', value: 'tab2', tabContent: <div>tab2 content</div>},
+      ],
+      onChange: () => {},
+      name: 'test1',
+      hidePanels: true,
+    });
+
+    const tab1 = screen.getByText('tab1');
+    const tab2 = screen.getByText('tab2');
+
+    expect(tab1).toBeInTheDocument();
+    expect(tab2).toBeInTheDocument();
+    expect(screen.queryByText('tab1 content')).not.toBeInTheDocument();
+    expect(screen.queryByText('tab2 content')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
conditionally renders the tab panels. this was needed to use Tabs as route selection components with react-router. since the routing library handles rendering content, I made each tab's `tabContent` null since it's a valid react node, however the tab panels and their container need to be hidden to prevent empty elements in the dom. adding a `hidePanels` prop for that case

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3439

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
