### PR TITLE
Lab2: fix TTS icon position in feedback bubble

### DIFF
--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -261,9 +261,6 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
               id="instructions-feedback-message"
               className={moduleStyles.bubble}
             >
-              {offerBrowserTts && useMessage && !canShowNextButton && (
-                <TextToSpeech text={useMessage} />
-              )}
               {useMessage && (
                 <div ref={feedbackRef} tabIndex={-1}>
                   <EnhancedSafeMarkdown
@@ -280,6 +277,11 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
                 className={moduleStyles.buttonInstruction}
                 size={'s'}
               />
+              {offerBrowserTts && useMessage && !canShowNextButton && (
+                <div className={moduleStyles.ttsContainer}>
+                  <TextToSpeech text={useMessage} />
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/apps/src/lab2/views/components/InstructionsPanel.tsx
+++ b/apps/src/lab2/views/components/InstructionsPanel.tsx
@@ -180,24 +180,28 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
               id="instructions-feedback-message"
               className={moduleStyles['message-' + theme]}
             >
+              <div className={moduleStyles.messageContent}>
+                {useMessage && (
+                  <div id="focusable-feedback" ref={feedbackRef} tabIndex={-1}>
+                    <EnhancedSafeMarkdown
+                      markdown={useMessage}
+                      className={moduleStyles.markdownText}
+                      handleInstructionsTextClick={handleInstructionsTextClick}
+                    />
+                  </div>
+                )}
+                <NavigationButton
+                  levelProperties={levelProperties}
+                  hasRun={hasRun}
+                  hasEdited={hasEdited}
+                  className={moduleStyles.buttonInstruction}
+                />
+              </div>
               {offerBrowserTts && useMessage && !canShowNextButton && (
-                <TextToSpeech text={useMessage} />
-              )}
-              {useMessage && (
-                <div id="focusable-feedback" ref={feedbackRef} tabIndex={-1}>
-                  <EnhancedSafeMarkdown
-                    markdown={useMessage}
-                    className={moduleStyles.markdownText}
-                    handleInstructionsTextClick={handleInstructionsTextClick}
-                  />
+                <div className={moduleStyles.ttsContainer}>
+                  <TextToSpeech text={useMessage} />
                 </div>
               )}
-              <NavigationButton
-                levelProperties={levelProperties}
-                hasRun={hasRun}
-                hasEdited={hasEdited}
-                className={moduleStyles.buttonInstruction}
-              />
             </div>
           </div>
         )}

--- a/apps/src/lab2/views/components/InstructionsPanel.tsx
+++ b/apps/src/lab2/views/components/InstructionsPanel.tsx
@@ -190,12 +190,14 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                     />
                   </div>
                 )}
-                <NavigationButton
-                  levelProperties={levelProperties}
-                  hasRun={hasRun}
-                  hasEdited={hasEdited}
-                  className={moduleStyles.buttonInstruction}
-                />
+                <div className={moduleStyles.navigationContainer}>
+                  <NavigationButton
+                    levelProperties={levelProperties}
+                    hasRun={hasRun}
+                    hasEdited={hasEdited}
+                    className={moduleStyles.buttonInstruction}
+                  />
+                </div>
               </div>
               {offerBrowserTts && useMessage && !canShowNextButton && (
                 <div className={moduleStyles.ttsContainer}>

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -179,6 +179,10 @@
   padding: 0 20px;
 }
 
+.navigationContainer {
+  padding-bottom: 10px;
+}
+
 .predictSummary {
   padding: 0;
   margin-top: 8px;

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -158,8 +158,8 @@
 
 %message {
   position: relative;
-  padding: 15px 20px;
   border-radius: 4px;
+  padding: 15px 0 5px;
   animation: slidein 0.5s;
 }
 
@@ -173,6 +173,10 @@
   @extend %message;
   background-color: $light_gray_50;
   color: $neutral_dark;
+}
+
+.messageContent {
+  padding: 0 20px;
 }
 
 .predictSummary {
@@ -197,7 +201,9 @@
     font-size: 1.75em;
     line-height: 1.2em;
 
-    &, em, strong {
+    &,
+    em,
+    strong {
       font-family: $barlowSemiCondensed-semibold;
     }
   }


### PR DESCRIPTION
Fixes the position of the browser TTS icon in Lab2 instruction feedback bubbles.

Before:
- Instructions V1
<img width="1514" height="826" alt="Screenshot 2025-07-28 at 11 43 29 AM" src="https://github.com/user-attachments/assets/64a8c397-5283-4089-8c6d-39df4a8f6fbe" />
- Instructions V2
<img width="1512" height="825" alt="Screenshot 2025-07-28 at 11 41 26 AM" src="https://github.com/user-attachments/assets/b4015bd8-4b0b-45da-83f4-3dad2edfd523" />

After:
- Instructions V1
<img width="1512" height="826" alt="Screenshot 2025-07-28 at 11 56 24 AM" src="https://github.com/user-attachments/assets/9334008d-6ae6-41e8-80c7-2ee47b68eaec" />
- Instructions V2
<img width="1510" height="825" alt="Screenshot 2025-07-28 at 11 58 48 AM" src="https://github.com/user-attachments/assets/291ea4c1-16d5-49fe-ab53-050f61c471d7" />

## Links

https://codedotorg.slack.com/archives/C043ZKQ4BS6/p1753726909156749

## Testing story

Tested locally with Music Lab feedback messages.