### PR TITLE
[All Labs] Overriding default focus states for progress bubbles

### DIFF
--- a/apps/src/templates/progress/styles.scss
+++ b/apps/src/templates/progress/styles.scss
@@ -1,10 +1,8 @@
-@import "color.scss";
+@import 'color.scss';
 
 .progress-bubble {
   &.enabled {
-    transition:
-      background-color 0.2s ease-out,
-      border-color 0.2s ease-out,
+    transition: background-color 0.2s ease-out, border-color 0.2s ease-out,
       color 0.2s ease-out;
     &:hover {
       text-decoration: none;
@@ -24,6 +22,16 @@ a.progress-bubble-link {
 
   &:hover {
     text-decoration: none;
+  }
+
+  &:focus {
+    // Override the default focus style to prevent outline
+    outline: none;
+  }
+
+  &:focus-visible {
+    // Use revert to allow browser default focus styles
+    outline: revert;
   }
 }
 


### PR DESCRIPTION
Fixes small regression introduced in https://github.com/code-dot-org/code-dot-org/pull/67239. 

Now that all the bubbles are focusable, they are picking up some undesirable styles for sighted users. This PR removes those default styles and reverts the focus-visible styes so keyboard navigation can still follow the outlines. 

An example on bubbles that do not require a full page reload (aka, the invalid anchor tags)

https://github.com/user-attachments/assets/f570aee4-d829-4264-840d-e4f57e010a0b


And an example with bubbles that do full page refreshes

https://github.com/user-attachments/assets/c2213fc3-507c-4d8c-8bd9-5e84e4d262a5



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1363

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
