### PR TITLE
Finish cleanup of AI Chat endpoints on AI iteration tools admin page

### DIFF
--- a/apps/src/levelbuilder/ai-iteration-tools/ai-tutor/AITutorTester.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/ai-tutor/AITutorTester.tsx
@@ -99,7 +99,7 @@ const AITutorTester: React.FC = () => {
         <br />
         <br />
         <br />
-        <AITutorTesterSampleColumns endpoint={'ai-tutor'} />
+        <AITutorTesterSampleColumns />
         <div>
           <div className={styles.buttonSpacing}>
             <input

--- a/apps/src/levelbuilder/ai-iteration-tools/ai-tutor/AITutorTesterSampleColumns.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/ai-tutor/AITutorTesterSampleColumns.tsx
@@ -1,30 +1,18 @@
 import React from 'react';
 
-import {ValueOf} from '@cdo/apps/types/utils';
-import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
-
-import {genAIEndpointIds} from './constants';
-import {Endpoint} from './types';
-
 import style from './ai-tutor-tester.module.scss';
 
 /**
  * Renders a table that explains the columns that can be in uploaded csvs for the AITutorTester.
  */
 
-interface SampleColumnsProps {
-  endpoint: Endpoint;
-}
-
-const AITutorTesterSampleColumns: React.FC<SampleColumnsProps> = ({
-  endpoint,
-}) => {
-  const studentInputRow = {
-    columnHeader: 'studentInput',
-    description:
-      'REQUIRED. The student\'s question e.g. "Why doesn\'t my code compile?"',
-  };
-  const basicRows = [
+const AITutorTesterSampleColumns: React.FC = () => {
+  const rows = [
+    {
+      columnHeader: 'studentInput',
+      description:
+        'REQUIRED. The student\'s question e.g. "Why doesn\'t my code compile?"',
+    },
     {
       columnHeader: 'systemPrompt',
       description:
@@ -35,8 +23,6 @@ const AITutorTesterSampleColumns: React.FC<SampleColumnsProps> = ({
       description:
         "OPTIONAL. If provided, will be used to fetch the level's instructions and test files if applicable. Reminder: it needs to be the levelId for the level in the environment in which you're running the tester.",
     },
-  ];
-  const aiTutorRows = [
     {
       columnHeader: 'studentCode',
       description: "OPTIONAL. The student's code.",
@@ -47,23 +33,6 @@ const AITutorTesterSampleColumns: React.FC<SampleColumnsProps> = ({
         'OPTIONAL. If provided will be used to determine the programming language.',
     },
   ];
-  const genAIRows = [
-    {
-      columnHeader: 'temperature',
-      description:
-        'OPTIONAL. Temperature parameter for model customization. Default is 0.8.',
-    },
-  ];
-
-  let rows = [studentInputRow];
-
-  if (endpoint === 'ai-tutor') {
-    rows = rows.concat(basicRows, aiTutorRows);
-  } else if (
-    genAIEndpointIds.includes(endpoint as ValueOf<typeof AiChatModelIds>)
-  ) {
-    rows = rows.concat(basicRows, genAIRows);
-  }
 
   return (
     <div>

--- a/apps/src/levelbuilder/ai-iteration-tools/ai-tutor/constants.ts
+++ b/apps/src/levelbuilder/ai-iteration-tools/ai-tutor/constants.ts
@@ -1,62 +1,13 @@
-import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
-
-// Non-Gen AI endpoint constants.
+// Endpoint constants.
 export const AI_TUTOR_ENDPOINT = 'ai-tutor';
 export const LLM_GUARD_ENDPOINT = 'llm-guard';
 
-const endpoints = [
+export const availableEndpoints = [
   {
     id: AI_TUTOR_ENDPOINT,
     name: 'AI Tutor + Webpurify',
   },
 ];
-
-const genAIEndpoints = [
-  {
-    id: AiChatModelIds.MISTRAL,
-    name: 'Mistral Base + Webpurify',
-  },
-  {
-    id: AiChatModelIds.ARITHMO,
-    name: 'Mistral Arithmo + Webpurify',
-  },
-  {
-    id: AiChatModelIds.BIOMISTRAL,
-    name: 'Mistral Biomistral + Webpurify',
-  },
-  {
-    id: AiChatModelIds.KAREN,
-    name: 'Mistral Karen + Webpurify',
-  },
-  {
-    id: AiChatModelIds.PIRATE,
-    name: 'Mistral Pirate + Webpurify',
-  },
-  {
-    id: AiChatModelIds.CHATGPT,
-    name: 'ChatGPT + Webpurify',
-  },
-  {
-    id: AiChatModelIds.GEMINI_2_0_FLASH,
-    name: 'Google Gemini 2.0 Flash + Webpurify',
-  },
-  {
-    id: AiChatModelIds.GEMINI_2_5_FLASH,
-    name: 'Google Gemini 2.5 Flash + Webpurify',
-  },
-  {
-    id: AiChatModelIds.GEMINI_2_5_PRO,
-    name: 'Google Gemini 2.0 Pro + Webpurify',
-  },
-  {
-    id: AiChatModelIds.LEARNLM,
-    name: 'Google LearnLM + Webpurify',
-  },
-];
-
-export const genAIEndpointIds = genAIEndpoints.map(endpoint => endpoint.id);
-
-export const availableEndpoints = endpoints.concat(genAIEndpoints);
 
 // Temperature set as default during model customization when Gen Ai levels are created.
 export const DEFAULT_TEMPERATURE = 0.8;

--- a/apps/src/levelbuilder/ai-iteration-tools/ai-tutor/types.ts
+++ b/apps/src/levelbuilder/ai-iteration-tools/ai-tutor/types.ts
@@ -1,9 +1,0 @@
-import {ValueOf} from '@cdo/apps/types/utils';
-import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
-
-import {AI_TUTOR_ENDPOINT, LLM_GUARD_ENDPOINT} from './constants';
-
-export type Endpoint =
-  | ValueOf<typeof AiChatModelIds>
-  | typeof AI_TUTOR_ENDPOINT
-  | typeof LLM_GUARD_ENDPOINT;


### PR DESCRIPTION
[A previous PR](https://github.com/code-dot-org/code-dot-org/pull/63368#discussion_r1925619138) removed support for testing AI Chat-specific endpoints via an admin tool at `/ai_iteration/tools`. This PR finishes that cleanup. Main motivation here is that prior to this change, we'd get a TypeScript error every time we added a new model for AI Chat use.

## Testing story

Confirmed that `/ai_iteration/tools` still rendered properly after this change.