### PR TITLE
Fix bug where empty sections list doesn't show coteacher invitation

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -91,7 +91,7 @@ $(document).ready(function () {
       {sections.length === 0 ? (
         // If a teacher has no sections, we will send them directly to the homepage to bypass
         // all of the section loading logic in the TeacherNavigationRouter.
-        <TeacherHomepage />
+        <TeacherHomepage studioUrlPrefix={scriptData.studioUrlPrefix} />
       ) : (
         <TeacherNavigationRouter
           studioUrlPrefix={scriptData.studioUrlPrefix}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
@@ -23,12 +23,10 @@ import _ from 'lodash';
 import React, {useState} from 'react';
 
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
-import {AgeGatedSectionsBanner} from '@cdo/apps/templates/policy_compliance/AgeGatedSectionsModal/AgeGatedSectionsBanner';
 import {
   removeSectionOrThrow,
   setSectionOrder,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import {atRiskAgeGatedSections} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {SectionMap} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
@@ -37,7 +35,6 @@ import {
   getFilteredSectionOrderIds,
   saveSectionOrder,
 } from '../../teacherDashboard/sectionOrderUtils';
-import CoteacherInviteNotification from '../CoteacherInviteNotification';
 
 import {SectionCard} from './SectionCard';
 import {SectionDeleteModal} from './SectionDeleteModal';
@@ -68,17 +65,6 @@ export const SectionList: React.FC<SectionListProps> = ({
   showHiddenOnly,
 }) => {
   const dispatch = useAppDispatch();
-
-  const [CAPmodalOpen, setCAPModalOpen] = React.useState(false);
-  const toggleCAPModal = () => {
-    setCAPModalOpen(!CAPmodalOpen);
-  };
-
-  const ageGatedSections = useAppSelector(atRiskAgeGatedSections);
-
-  const shouldDisplayAtRiskAgeGatedWarning = () => {
-    return ageGatedSections?.length > 0;
-  };
 
   const [sectionToDelete, setSectionToDelete] = useState<number>(NO_SECTION_ID);
   const sections: SectionMap = useAppSelector(
@@ -177,41 +163,31 @@ export const SectionList: React.FC<SectionListProps> = ({
   return (
     <div id="ui-test-section-list">
       {sectionsAreLoaded ? (
-        <>
-          {shouldDisplayAtRiskAgeGatedWarning() && (
-            <AgeGatedSectionsBanner
-              toggleModal={toggleCAPModal}
-              modalOpen={CAPmodalOpen}
-              ageGatedSections={ageGatedSections}
-            />
-          )}
-          <CoteacherInviteNotification isForPl={false} destructiveLoad={true} />
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
-            modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+        >
+          <SortableContext
+            items={sortableSectionIds}
+            strategy={verticalListSortingStrategy}
           >
-            <SortableContext
-              items={sortableSectionIds}
-              strategy={verticalListSortingStrategy}
-            >
-              <ol className={styles.sectionList}>
-                {sectionIdsToShow.map(id =>
-                  sections[id] ? (
-                    <SectionCard
-                      id={id}
-                      key={id}
-                      section={sections[id]}
-                      onDeleteClickCallback={onDeleteClickCallback}
-                      studioUrlPrefix={studioUrlPrefix}
-                    />
-                  ) : null
-                )}
-              </ol>
-            </SortableContext>
-          </DndContext>
-        </>
+            <ol className={styles.sectionList}>
+              {sectionIdsToShow.map(id =>
+                sections[id] ? (
+                  <SectionCard
+                    id={id}
+                    key={id}
+                    section={sections[id]}
+                    onDeleteClickCallback={onDeleteClickCallback}
+                    studioUrlPrefix={studioUrlPrefix}
+                  />
+                ) : null
+              )}
+            </ol>
+          </SortableContext>
+        </DndContext>
       ) : (
         <Spinner size="large" />
       )}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -3,13 +3,16 @@ import React from 'react';
 
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {atRiskAgeGatedSections} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
+import {AgeGatedSectionsBanner} from '../../policy_compliance/AgeGatedSectionsModal/AgeGatedSectionsBanner';
 import {
   asyncLoadTeacherHomepageSectionData,
   asyncLoadCoteacherInvite,
 } from '../../teacherDashboard/teacherSectionsRedux';
+import CoteacherInviteNotification from '../CoteacherInviteNotification';
 
 import {EmptyHomepage} from './EmptyHomepage';
 import {Header} from './Header';
@@ -31,6 +34,17 @@ export const TeacherHomepage: React.FC<TeacherHomepageProps> = ({
   const teacherName = useAppSelector(state => state.currentUser.displayName);
 
   const dispatch = useAppDispatch();
+
+  const [CAPmodalOpen, setCAPModalOpen] = React.useState(false);
+  const toggleCAPModal = () => {
+    setCAPModalOpen(!CAPmodalOpen);
+  };
+
+  const ageGatedSections = useAppSelector(atRiskAgeGatedSections);
+
+  const shouldDisplayAtRiskAgeGatedWarning = () => {
+    return ageGatedSections?.length > 0 || true; // DO NOT MERGE || true
+  };
 
   React.useEffect(() => {
     dispatch(asyncLoadTeacherHomepageSectionData());
@@ -85,6 +99,18 @@ export const TeacherHomepage: React.FC<TeacherHomepageProps> = ({
               setSelectedArchiveToggle={onArchiveToggleChange}
             />
 
+            {shouldDisplayAtRiskAgeGatedWarning() && (
+              <AgeGatedSectionsBanner
+                toggleModal={toggleCAPModal}
+                modalOpen={CAPmodalOpen}
+                ageGatedSections={ageGatedSections}
+              />
+            )}
+
+            <CoteacherInviteNotification
+              isForPl={false}
+              destructiveLoad={true}
+            />
             {numSections === 0 ? (
               <EmptyHomepage showHiddenOnly={showHiddenOnly} />
             ) : (

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -43,7 +43,7 @@ export const TeacherHomepage: React.FC<TeacherHomepageProps> = ({
   const ageGatedSections = useAppSelector(atRiskAgeGatedSections);
 
   const shouldDisplayAtRiskAgeGatedWarning = () => {
-    return ageGatedSections?.length > 0 || true; // DO NOT MERGE || true
+    return ageGatedSections?.length > 0;
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
The CoteacherInvite was previously rendered in the SectionList component, which is not rendered unless the user has sections. This PR moves the CAP banner and the coteacher invite up from the section list to the teacher homepage. I also moved the CAP banner so that the order was preserved, although the CAP banner will never be shown with an empty section list.

<img width="1628" height="1546" alt="image" src="https://github.com/user-attachments/assets/119a65f5-b012-41b4-8da6-fd792347b50b" />
Note: The CAP banner is displaying because of some removed debug code, it will never be shown with an empty section list.
<img width="1698" height="1118" alt="image" src="https://github.com/user-attachments/assets/c92b8c62-cf4b-4166-842e-f3ee9c7a3fe1" />
<img width="1740" height="1364" alt="image" src="https://github.com/user-attachments/assets/663dd6b6-6012-46e0-b266-90a8c69c03a9" />



## Links


- Jira: https://codedotorg.atlassian.net/browse/TEACH-2129
