### PR TITLE
fix(marketing): fix Footer language dropdown bug on Windows that was showing white text

### DIFF
--- a/frontend/apps/marketing/src/components/footerMui/FooterMui.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/FooterMui.tsx
@@ -7,7 +7,7 @@ import IconButton from '@mui/material/IconButton';
 import Link from '@mui/material/Link';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
-import Select from '@mui/material/Select';
+import NativeSelect from '@mui/material/NativeSelect';
 import Stack from '@mui/material/Stack';
 import {styled} from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
@@ -125,9 +125,8 @@ const FooterMui: React.FC<FooterProps> = ({
           </FooterLinks>
           {/* Language Selector */}
           <FormControl variant="standard">
-            <Select
+            <NativeSelect
               className="notranslate"
-              native
               disableUnderline
               name="language-select"
               IconComponent={KeyboardArrowDownIcon}
@@ -140,7 +139,7 @@ const FooterMui: React.FC<FooterProps> = ({
                   {lang.text}
                 </option>
               ))}
-            </Select>
+            </NativeSelect>
           </FormControl>
         </Grid>
         <Grid

--- a/frontend/apps/marketing/src/components/footerMui/FooterMui.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/FooterMui.tsx
@@ -7,7 +7,7 @@ import IconButton from '@mui/material/IconButton';
 import Link from '@mui/material/Link';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
-import NativeSelect from '@mui/material/NativeSelect';
+import Select from '@mui/material/Select';
 import Stack from '@mui/material/Stack';
 import {styled} from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
@@ -125,8 +125,9 @@ const FooterMui: React.FC<FooterProps> = ({
           </FooterLinks>
           {/* Language Selector */}
           <FormControl variant="standard">
-            <NativeSelect
+            <Select
               className="notranslate"
+              native
               disableUnderline
               name="language-select"
               IconComponent={KeyboardArrowDownIcon}
@@ -139,7 +140,7 @@ const FooterMui: React.FC<FooterProps> = ({
                   {lang.text}
                 </option>
               ))}
-            </NativeSelect>
+            </Select>
           </FormControl>
         </Grid>
         <Grid

--- a/frontend/apps/marketing/src/themes/csforall/styleOverrides/footer.ts
+++ b/frontend/apps/marketing/src/themes/csforall/styleOverrides/footer.ts
@@ -46,6 +46,10 @@ export const FOOTER_OVERRIDES: Components<Theme>['MuiFooter'] = {
         paddingInlineStart: theme.spacing(1.5),
         paddingInlineEnd: theme.spacing(4),
         borderRadius: 12,
+        '& option': {
+          background: theme.palette.common.white,
+          color: theme.palette.text.primary,
+        },
         '&:focus-visible': {
           outline: `1px solid ${theme.palette.common.white}`,
           outlineOffset: 4,


### PR DESCRIPTION
The language dropdown in the footer on Windows was showing white text on a white background, this fixes that.

## Links
Jira ticket: [CMS-974](https://codedotorg.atlassian.net/browse/CMS-974)

## Testing story
Tested locally on Windows machine and all Mac browsers.

----

## Before
<img width="455" height="858" alt="Screenshot 2025-07-29 at 12 06 24 PM" src="https://github.com/user-attachments/assets/03175eb1-ab26-43aa-8edb-c7cce4d13cfe" />

## After

<img width="527" height="873" alt="Screenshot 2025-07-29 145637" src="https://github.com/user-attachments/assets/5f32c459-326b-4135-b7ca-87b4930d03c6" />
