### PR TITLE
Only pass Account Information update fields if available to the user

### DIFF
--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -155,7 +155,7 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
     }
     if (isStudent) {
       userUpdates['country_code'] = countryCode;
-      if (gender) {
+      if (showGenderInput) {
         userUpdates['gender_student_input'] = gender;
       }
       if (isUSA) {

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -142,23 +142,36 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
   const handleSubmitAccountSettingsUpdate = async () => {
     resetMessages();
     setErrors({});
-    const userUpdates = {
+
+    const userUpdates: {[key: string]: unknown} = {
       name,
-      username,
-      given_name: givenName,
-      family_name: familyName,
       password,
       password_confirmation: passwordConfirmation,
       current_password: currentPassword,
       age: isStudent ? age : '21+',
-      gender_student_input: isStudent && gender ? gender : undefined,
-      us_state: isStudent && isUSA ? usState : undefined,
-      country_code: isStudent ? countryCode : undefined,
-      facilitator_info_attributes: isFacilitator
-        ? {bio: facilitatorBio}
-        : undefined,
-      educator_role: !isStudent && educatorRole ? educatorRole : undefined,
     };
+    if (userUsername) {
+      userUpdates['username'] = username;
+    }
+    if (isStudent) {
+      userUpdates['country_code'] = countryCode;
+      if (gender) {
+        userUpdates['gender_student_input'] = gender;
+      }
+      if (isUSA) {
+        userUpdates['us_state'] = usState;
+      }
+    } else {
+      userUpdates['given_name'] = givenName;
+      userUpdates['family_name'] = familyName;
+      if (educatorRole) {
+        userUpdates['educator_role'] = educatorRole;
+      }
+    }
+    if (isFacilitator) {
+      userUpdates['facilitator_info_attributes'] = {bio: facilitatorBio};
+    }
+
     const response = await fetch('/users', {
       method: 'PUT',
       headers: {

--- a/apps/test/unit/accounts/AccountInformationTest.jsx
+++ b/apps/test/unit/accounts/AccountInformationTest.jsx
@@ -119,6 +119,130 @@ describe('AccountInformation', () => {
     ).toBeInTheDocument();
   });
 
+  it('only passes available student fields into update call for students', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    render(
+      <AccountInformation
+        {...defaultProps}
+        userDisplayName="Student Name"
+        userType="student"
+        isStudent={true}
+        userUsername="StudentUsername"
+        showGenderInput={true}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/age/i), {
+      target: {value: '14'},
+    });
+    fireEvent.change(screen.getByLabelText(/state/i), {
+      target: {value: 'CA'},
+    });
+    fireEvent.click(
+      screen.getByRole('button', {name: /update account information/i})
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/users', expect.any(Object));
+      expect(
+        screen.getByText(/account information successfully updated/i)
+      ).toBeInTheDocument();
+    });
+
+    const fetchArgs = mockFetch.mock.calls[0][1];
+    expect(JSON.parse(fetchArgs.body)).toEqual({
+      user: {
+        name: 'Student Name',
+        username: 'StudentUsername',
+        password: '',
+        password_confirmation: '',
+        current_password: '',
+        age: '14',
+        gender_student_input: '',
+        us_state: 'CA',
+      },
+    });
+  });
+
+  it('only passes available teacher fields into update call for teachers', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    render(<AccountInformation {...defaultProps} />);
+
+    fireEvent.click(
+      screen.getByRole('button', {name: /update account information/i})
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/users', expect.any(Object));
+      expect(
+        screen.getByText(/account information successfully updated/i)
+      ).toBeInTheDocument();
+    });
+
+    const fetchArgs = mockFetch.mock.calls[0][1];
+    expect(JSON.parse(fetchArgs.body)).toEqual({
+      user: {
+        name: 'Mr. Doe',
+        username: 'johndoe',
+        given_name: '',
+        family_name: '',
+        educator_role: undefined,
+        password: '',
+        password_confirmation: '',
+        current_password: '',
+        age: '21+',
+      },
+    });
+  });
+
+  it('only passes available facilitator fields into update call for facilitators', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    const userFacilitatorBio =
+      'This is a facilitator bio with a long enough description.';
+    render(
+      <AccountInformation
+        {...defaultProps}
+        isFacilitator={true}
+        userFacilitatorBio={userFacilitatorBio}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {name: /update account information/i})
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/users', expect.any(Object));
+      expect(
+        screen.getByText(/account information successfully updated/i)
+      ).toBeInTheDocument();
+    });
+
+    const fetchArgs = mockFetch.mock.calls[0][1];
+    expect(JSON.parse(fetchArgs.body)).toEqual({
+      user: {
+        name: 'Mr. Doe',
+        username: 'johndoe',
+        given_name: '',
+        family_name: '',
+        password: '',
+        password_confirmation: '',
+        current_password: '',
+        age: '21+',
+        facilitator_info_attributes: {bio: userFacilitatorBio},
+      },
+    });
+  });
+
   it('submits form with updated information and displays success alert', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
Currently, [users are experiencing validation errors](https://codedotorg.slack.com/archives/CFTFD6BPV/p1753792087551949) when trying to update their info to join workshops even though their fields all look right. This is because the Account Information page passes in all fields (even if they're not shown to the user) so the update is triggering validation for fields they may not even see.

This PR ensures we only pass Account Information update fields if they're shown to the user. I did this by just using the same conditionals that determine whether a given field is rendered or not to determine whether we pass it or not.

### Student with username
![student update](https://github.com/user-attachments/assets/9a58332a-354a-4664-ba62-faefb09fd2ea)

### Student without username
![no username](https://github.com/user-attachments/assets/c580c8f0-bc46-47c5-825c-1b8cb3353a47)

### Teacher
![teacher update](https://github.com/user-attachments/assets/e7ef6458-da3c-4470-a9c9-f8832d14f849)

### Facilitator
![facilitator update](https://github.com/user-attachments/assets/116c78e4-f19d-45ce-be93-7f29a0798baa)

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/CFTFD6BPV/p1753792087551949)

## Testing story
Local testing and updating unit tests.
