### PR TITLE
Web Lab 2: Add "For Teachers Only" markdown editor to levelbuilder

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -169,12 +169,6 @@ class Level < ApplicationRecord
     !unplugged?
   end
 
-  # This does not include DSL levels which also use teacher markdown
-  # but access it in a different way
-  def include_teacher_only_markdown_editor?
-    uses_droplet? || is_a?(Blockly) || is_a?(ExternalLink) || is_a?(Weblab) || is_a?(CurriculumReference) || is_a?(StandaloneVideo)
-  end
-
   def enable_scrolling?
     is_a?(Blockly)
   end

--- a/dashboard/app/views/levels/editors/_weblab2.html.haml
+++ b/dashboard/app/views/levels/editors/_weblab2.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'levels/editors/fields/long_instructions', locals: {f: f}
-
+= render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
 = render partial: 'levels/editors/fields/weblab2_fields', locals: {f: f}
 
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}


### PR DESCRIPTION
Adds a markdown editor on Web Lab 2 levels for the "For Teachers Only" section.

## Links

- Jira: https://codedotorg.atlassian.net/browse/CT-1245

## Testing story

Tested manually that adding some markdown via the level edit page resulted in being able to view the content in the "For Teachers Only" on the level itself, and saw appropriate changes made to the .level file.