### PR TITLE
feat(marketing): add ability to override brand

### DIFF
--- a/frontend/apps/marketing/src/config/brand.ts
+++ b/frontend/apps/marketing/src/config/brand.ts
@@ -72,3 +72,16 @@ export function getBrandFromHostname(hostname: string | null) {
     Brand.CODE_DOT_ORG
   );
 }
+
+export function getBrandFromString(brandString: string | null) {
+  switch (brandString) {
+    case Brand.CODE_DOT_ORG:
+      return Brand.CODE_DOT_ORG;
+    case Brand.HOUR_OF_CODE:
+      return Brand.HOUR_OF_CODE;
+    case Brand.CS_FOR_ALL:
+      return Brand.CS_FOR_ALL;
+    default:
+      return undefined;
+  }
+}

--- a/frontend/apps/marketing/src/middleware/withBrand.ts
+++ b/frontend/apps/marketing/src/middleware/withBrand.ts
@@ -1,7 +1,7 @@
 import {draftMode} from 'next/headers';
 import {NextRequest, NextResponse} from 'next/server';
 
-import {getBrandFromHostname} from '@/config/brand';
+import {getBrandFromHostname, getBrandFromString} from '@/config/brand';
 import {PREVIEW_HOSTNAMES} from '@/config/preview';
 
 import {MiddlewareFactory} from './types';
@@ -21,8 +21,11 @@ export const withBrand: MiddlewareFactory = () => {
     const url = request.nextUrl;
 
     // Get hostname of request (e.g. test.code.org, code.org, localhost.code.org:3001)
+    const brandOverride = request.headers.get('x-brand-override');
     const hostname = request.headers.get('host');
-    const brand = getBrandFromHostname(hostname);
+
+    const brand =
+      getBrandFromString(brandOverride) ?? getBrandFromHostname(hostname);
     const isPreviewHostname = PREVIEW_HOSTNAMES.has(hostname);
 
     if (isPreviewHostname) {


### PR DESCRIPTION
This PR adds a header which allows UI tests to override the brand to allow the same "All the Things" code that is in the Code.org space to be used for CSForAll to eliminate the need to maintain multiple experiences and sync them together.