### PR TITLE
Add validation of image dimensions when image uploaded via Animation Picker

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -273,7 +273,7 @@
   "animationPicker_returnToLibrary": "Return to library",
   "animationPicker_title": "{assetType} Library",
   "animationPicker_undoRestrictedShareInstructions": "You can use Version History to undo this change.",
-  "animationPicker_unsupportedDimensions": "Please make sure the width and height of your image are both greater than 128 pixels.",
+  "animationPicker_unsupportedDimensions": "Please make sure the width and height of your image are both greater than 127 pixels.",
   "animationPicker_unsupportedType": "Sorry, this file type is not supported.",
   "animationPicker_unsupportedSize": "Please make sure the image you are trying to upload is smaller than 100 KB.",
   "animationPicker_uploadImage": "Upload image",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -273,6 +273,7 @@
   "animationPicker_returnToLibrary": "Return to library",
   "animationPicker_title": "{assetType} Library",
   "animationPicker_undoRestrictedShareInstructions": "You can use Version History to undo this change.",
+  "animationPicker_unsupportedDimensions": "Please make sure the width and height of your image are both greater than 128 pixels.",
   "animationPicker_unsupportedType": "Sorry, this file type is not supported.",
   "animationPicker_unsupportedSize": "Please make sure the image you are trying to upload is smaller than 100 KB.",
   "animationPicker_uploadImage": "Upload image",

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -174,6 +174,22 @@ class AnimationPicker extends React.Component {
     );
   }
 
+  validateImageDimensions = file => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const img = new Image();
+        img.onload = () => {
+          resolve(img.width > 128 && img.height > 128);
+        };
+        img.onerror = reject;
+        img.src = reader.result;
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  };
+
   /**
    * Send the uploaded image file to be moderated. Then continue with uploadStart.
    */
@@ -183,39 +199,62 @@ class AnimationPicker extends React.Component {
       console.error('No file found in upload data.');
       return;
     }
-    this.setState({
-      pendingUploadData: data,
-    });
-
-    HttpClient.post(`/v3/images/moderate`, file, true, {
-      'Content-Type': file.type,
-    })
-      .then(response => response.json())
-      .then(json => {
-        // If rating is not 'everyone' or 'unknown', then flag project for image moderation.
-        if (json.rating !== 'everyone' && json.rating !== 'unknown') {
-          this.setState({
-            showFlaggedModal: true,
-          });
-          analyticsReporter.sendEvent(
-            EVENTS.FLAGGED_CUSTOM_IMAGE,
-            {
-              UploaderType: 'Animation Picker',
-              ProjectType: this.props.projectType,
-            },
-            PLATFORMS.STATSIG
-          );
-        } else {
-          // If the image is rated 'everyone' or 'unknown', continue with upload.
-          this.props.onUploadStart(this.state.pendingUploadData);
+    if (data.files[0].size >= MAX_UPLOAD_SIZE) {
+      this.props.onUploadError(msg.animationPicker_unsupportedSize());
+      return;
+    }
+    if (
+      data.files[0].type !== 'image/png' &&
+      data.files[0].type !== 'image/jpeg'
+    ) {
+      this.props.onUploadError(msg.animationPicker_unsupportedType());
+      return;
+    }
+    this.validateImageDimensions(file)
+      .then(isValid => {
+        if (!isValid) {
+          this.props.onUploadError(msg.animationPicker_unsupportedDimensions());
+          return;
         }
+
+        this.setState({
+          pendingUploadData: data,
+        });
+
+        HttpClient.post(`/v3/images/moderate`, file, true, {
+          'Content-Type': file.type,
+        })
+          .then(response => response.json())
+          .then(json => {
+            // If rating is not 'everyone' or 'unknown', then flag project for image moderation.
+            if (json.rating !== 'everyone' && json.rating !== 'unknown') {
+              this.setState({
+                showFlaggedModal: true,
+              });
+              analyticsReporter.sendEvent(
+                EVENTS.FLAGGED_CUSTOM_IMAGE,
+                {
+                  UploaderType: 'Animation Picker',
+                  ProjectType: this.props.projectType,
+                },
+                PLATFORMS.STATSIG
+              );
+            } else {
+              // If the image is rated 'everyone' or 'unknown', continue with upload.
+              this.props.onUploadStart(this.state.pendingUploadData);
+            }
+          })
+          .catch(err => {
+            this.setState({
+              showFlaggedModal: true,
+              flaggedModalError: msg.animationPicker_uploadingError(),
+            });
+            MetricsReporter.logError('Azure image moderation error: ' + err);
+          });
       })
       .catch(err => {
-        this.setState({
-          showFlaggedModal: true,
-          flaggedModalError: msg.animationPicker_uploadingError(),
-        });
-        MetricsReporter.logError('Azure image moderation error: ' + err);
+        MetricsReporter.logError('Error validating image dimensions: ' + err);
+        this.props.onUploadError(msg.animationPicker_uploadingError());
       });
   };
 
@@ -336,17 +375,8 @@ export default connect(
       dispatch(pickLibraryAnimation(animation));
     },
     onUploadStart(data) {
-      if (data.files[0].size >= MAX_UPLOAD_SIZE) {
-        dispatch(handleUploadError(msg.animationPicker_unsupportedSize()));
-      } else if (
-        data.files[0].type === 'image/png' ||
-        data.files[0].type === 'image/jpeg'
-      ) {
-        dispatch(beginUpload(data.files[0].name));
-        data.submit();
-      } else {
-        dispatch(handleUploadError(msg.animationPicker_unsupportedType()));
-      }
+      dispatch(beginUpload(data.files[0].name));
+      data.submit();
     },
     onUploadDone(result) {
       dispatch(handleUploadComplete(result));

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -180,7 +180,7 @@ class AnimationPicker extends React.Component {
       reader.onload = () => {
         const img = new Image();
         img.onload = () => {
-          resolve(img.width > 128 && img.height > 128);
+          resolve(img.width > 127 && img.height > 127);
         };
         img.onerror = reject;
         img.src = reader.result;

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -245,10 +245,7 @@ class AnimationPicker extends React.Component {
             }
           })
           .catch(err => {
-            this.setState({
-              showFlaggedModal: true,
-              flaggedModalError: msg.animationPicker_uploadingError(),
-            });
+            this.props.onUploadError(msg.animationPicker_uploadingError());
             MetricsReporter.logError('Azure image moderation error: ' + err);
           });
       })


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds a requirement for custom images uploaded via Animation Picker that the dimensions of the image must be `> 127 pixels`. We recently implemented image moderation with Azure Content Moderator, and there is a minimum required size for moderating images. We started receiving [HoneyBadger error reports](https://app.honeybadger.io/projects/3240/faults/122361905) after [deploying image moderation](https://github.com/code-dot-org/code-dot-org/pull/67301) late last week with message:
`AzureContentModerator::RequestFailed: Request to Azure failed with status 400 Image Size Error {"Title"=>"Image Size Error", "Message"=>"Image size 326x112 in pixels is not in allowed range; > 128"}`

The API documentation for Azure Image Moderator is sparse. I didn't find information about the input requirement of a minimum size. https://learn.microsoft.com/en-us/rest/api/cognitiveservices/contentmoderator/image-moderation/evaluate?view=rest-cognitiveservices-contentmoderator-v1.0

However, from the content of the error message and local testing, I verified that both the image width and height must be `>127`. I was able to make a request with a `128x128`px image successfully. See Testing Story below.

Although we've been receiving HoneyBadger error reports, this has not had an impact on users.
The reason is that [`ImageModeration`](https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/image_moderation.rb) is a wrapper for [`AzureContentModerator`](https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/azure_content_moderator.rb), and if the request to AzureContentModerator results in an exception, we notify HoneyBadger (yay!), and  return `:unknown`
https://github.com/code-dot-org/code-dot-org/blob/22485e25022f17fd99e975ad20f5e387019982f5/lib/cdo/image_moderation.rb#L17-L33

And if `unknown` is received on the frontend, we allow image upload.
https://github.com/code-dot-org/code-dot-org/blob/22485e25022f17fd99e975ad20f5e387019982f5/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx#L196

## After update

Screencast showing that a 128x128 image is uploaded successfully, but then when the user attempts to upload a 127x127 and a 68x312 both receive the error message 'Please make sure the width and height of your image are both greater than 127 pixels.' At the end, the user attempts to upload a large image and receives error message 'Please make sure the image you are trying to upload is smaller than 100 KB.'


https://github.com/user-attachments/assets/f543c90e-5dbd-49a8-8ccf-d1f14f913263

Screencast showing an error message when the moderate request fails. I updated this so that the uerror message uses `renderVisibleBody` UI since it could happen for an image that was not flagged.


https://github.com/user-attachments/assets/72604900-025a-4488-a081-032f649143ad

Screencast showing error message in abuse modal since the error would occur while modal is open.

https://github.com/user-attachments/assets/53384f42-8be5-4e2e-8b66-82ceb22387e1



## An aside
While in `azure_content_moderator.rb` I wonder if I can remove the firehose event based on [observability discusssion](https://docs.google.com/document/d/1hEVN-a5gEW0TqWoLYStzVCw4Hz1qjsnA6iMHjBbozS8/edit?disco=AAABoZ2zQz8). We're already logging moderation errors via Metrics Reporter added in https://github.com/code-dot-org/code-dot-org/pull/67387. cc: @sanchitmalhotra126 who was present during the discussion.



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/SL-1353

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

I verified (printed the response body) that if an image has dimensions that are > 127 pixels, a request can be made successfully to the Azure Content Moderator `evaluate` endpoint. The documentation for the input requirements this endpoint [is sparse]( https://learn.microsoft.com/en-us/rest/api/cognitiveservices/contentmoderator/image-moderation/evaluate?view=rest-cognitiveservices-contentmoderator-v1.0).
Screencast of
1. 128x128 image -> success
2. 127x127 image -> failure
3. 68x312 image -> failure

https://github.com/user-attachments/assets/715c22ff-7244-4cf6-a94d-a7bc5e3a9a90

Then with the added requirement for image dimensions, I confirmed the error message was displayed appropriately. See after update above.


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
