### PR TITLE
Add deprecation text for k12 courses

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -29,6 +29,7 @@ class LessonsController < ApplicationController
     return render :forbidden unless script.is_migrated
 
     if script.is_deprecated
+      @deprecated_course_name = script.name
       return render 'errors/deprecated_course'
     end
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -83,6 +83,7 @@ class ScriptLevelsController < ApplicationController
     # Check if the script or current level is deprecated
     level_is_deprecated = @script_level&.level_deprecated?
     if @script.is_deprecated || level_is_deprecated
+      @deprecated_course_name = @script.name
       return render 'errors/deprecated_course'
     end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -19,6 +19,7 @@ class ScriptsController < ApplicationController
 
   def show
     if @script.is_deprecated
+      @deprecated_course_name = @script.name
       return render 'errors/deprecated_course'
     end
     #TODO: TEACH-2050 Modularity support redirect to property. Currently this redirects to the script path, which
@@ -212,6 +213,7 @@ class ScriptsController < ApplicationController
   def edit
     # Deprecated scripts should not be edited.
     if @script.is_deprecated
+      @deprecated_course_name = @script.name
       return render 'errors/deprecated_course'
     end
     raise "The new unit editor does not support level variants with experiments" if @script.is_migrated && @script.script_levels.any?(&:has_experiment?)

--- a/dashboard/app/views/errors/deprecated_course.html.haml
+++ b/dashboard/app/views/errors/deprecated_course.html.haml
@@ -1,3 +1,18 @@
+:ruby
+  if @deprecated_course_name == Unit::COURSE1_NAME
+    description = I18n.t('course_deprecated.course1_retired', coursea_url: "/courses/coursea?viewAs=Instructor", pre_reader_express_url: "/courses/pre-express?viewAs=Instructor", markdown: :inline)
+    elsif @deprecated_course_name == Unit::COURSE2_NAME
+      description = I18n.t('course_deprecated.course2_retired', coursec_url: "/courses/coursec?viewAs=Instructor", course_d_url: "/courses/coursed?viewAs=Instructor", markdown: :inline)
+    elsif @deprecated_course_name == Unit::COURSE3_NAME
+      description = I18n.t('course_deprecated.course3_retired', course_e_url: "/courses/coursee?viewAs=Instructor", course_f_url: "/courses/coursef?viewAs=Instructor", markdown: :inline)
+    elsif @deprecated_course_name == Unit::COURSE4_NAME
+      description = I18n.t('course_deprecated.course4_retired', course_f_url: "/courses/coursef?viewAs=Instructor", markdown: :inline)
+    elsif @deprecated_course_name == Unit::TWENTY_HOUR_NAME
+      description = I18n.t('course_deprecated.accelerated_course_retired', express_course_url: "/courses/express?viewAs=Instructor", markdown: :inline)
+  else
+    description = I18n.t('course_deprecated.title', path_type: I18n.t('course_deprecated.curriculum'))
+  end
+
 .not-found-page.deprecated-course-page
   .error-parent
     .deprecated-course-child
@@ -7,6 +22,6 @@
         %a.design-system-btn{href: '/projects'}
           = I18n.t('course_deprecated.projects_button')
       - else
-        %p= I18n.t('course_deprecated.title', path_type: I18n.t('course_deprecated.curriculum'))
+        %p!= description
       %a.design-system-btn{href: 'https://support.code.org/hc/en-us/articles/16268528601101-List-of-Deprecated-or-Non-Supported-Code-org-Courses'}
         = I18n.t('course_deprecated.button')

--- a/dashboard/app/views/errors/deprecated_course.html.haml
+++ b/dashboard/app/views/errors/deprecated_course.html.haml
@@ -1,14 +1,14 @@
 :ruby
   if @deprecated_course_name == Unit::COURSE1_NAME
-    description = I18n.t('course_deprecated.course1_retired', coursea_url: "/courses/coursea?viewAs=Instructor", pre_reader_express_url: "/courses/pre-express?viewAs=Instructor", markdown: :inline)
+    description = I18n.t('course_deprecated.course1_retired', coursea_url: course_path('coursea', viewAs: 'Instructor'), pre_reader_express_url: course_path('pre-express', viewAs: 'Instructor'), markdown: :inline)
     elsif @deprecated_course_name == Unit::COURSE2_NAME
-      description = I18n.t('course_deprecated.course2_retired', coursec_url: "/courses/coursec?viewAs=Instructor", course_d_url: "/courses/coursed?viewAs=Instructor", markdown: :inline)
+      description = I18n.t('course_deprecated.course2_retired', coursec_url: course_path('coursec', viewAs: 'Instructor'), course_d_url: course_path('coursed', viewAs: 'Instructor'), markdown: :inline)
     elsif @deprecated_course_name == Unit::COURSE3_NAME
-      description = I18n.t('course_deprecated.course3_retired', course_e_url: "/courses/coursee?viewAs=Instructor", course_f_url: "/courses/coursef?viewAs=Instructor", markdown: :inline)
+      description = I18n.t('course_deprecated.course3_retired', course_e_url: course_path('coursee', viewAs: 'Instructor'), course_f_url: course_path('coursef', viewAs: 'Instructor'), markdown: :inline)
     elsif @deprecated_course_name == Unit::COURSE4_NAME
-      description = I18n.t('course_deprecated.course4_retired', course_f_url: "/courses/coursef?viewAs=Instructor", markdown: :inline)
+      description = I18n.t('course_deprecated.course4_retired', course_f_url: course_path('coursef', viewAs: 'Instructor'), markdown: :inline)
     elsif @deprecated_course_name == Unit::TWENTY_HOUR_NAME
-      description = I18n.t('course_deprecated.accelerated_course_retired', express_course_url: "/courses/express?viewAs=Instructor", markdown: :inline)
+      description = I18n.t('course_deprecated.accelerated_course_retired', express_course_url: course_path('express', viewAs: 'Instructor'), markdown: :inline)
   else
     description = I18n.t('course_deprecated.title', path_type: I18n.t('course_deprecated.curriculum'))
   end

--- a/dashboard/config/locales/base/en.yml
+++ b/dashboard/config/locales/base/en.yml
@@ -1455,6 +1455,11 @@ en:
     project_type: "project type"
     button: "View alternative courses"
     projects_button: "Go to Projects"
+    course1_retired: We’re sorry! Course 1 has been retired. We recommend [Course A](%{coursea_url}) or [Pre-reader Express](%{pre_reader_express_url}) as a replacement.
+    course2_retired: We’re sorry! Course 2 has been retired. We recommend [Course C](%{coursec_url}) or [Course D](%{course_d_url}) as a replacement.
+    course3_retired: We’re sorry! Course 3 has been retired. We recommend [Course E](%{course_e_url}) or [Course F](%{course_f_url}) as a replacement.
+    course4_retired: We’re sorry! Course 4 has been retired. We recommend [Course F](%{course_f_url}) as a replacement.
+    accelerated_course_retired: We’re sorry! The Accelerated Course has been retired. We recommend [Express Course](%{express_course_url}) as a replacement.
   hoc_tutorial_email_subject: "Rock the Hour of Code with Code.org Tutorials!"
   hoc_tutorial_email_content:
     dear_teacher: "Dear %{teacher_name},"


### PR DESCRIPTION
This PR sets up the deprecation pages for Courses 1-4 and Accelerated. It does not officially deprecate these courses. That work will come in a follow-up PR, but want to get this change in now so that the text can be translated.

|Course|Deprecation Page|
|---|---|
|20-hour|<img width="1902" height="957" alt="Screenshot 2025-07-30 105138" src="https://github.com/user-attachments/assets/d7192dcd-50b3-4c5e-85a3-9c3eb0f0dcfe" />|
|Course 1|<img width="1901" height="954" alt="Screenshot 2025-07-30 105152" src="https://github.com/user-attachments/assets/bd005d99-69ac-4f98-9c0d-e23ebe42d8d8" />|
|Course2|<img width="1900" height="954" alt="Screenshot 2025-07-30 105203" src="https://github.com/user-attachments/assets/4c4b9ed4-68d9-450c-b19b-2d657348013c" />|
|Course3|<img width="1903" height="957" alt="Screenshot 2025-07-30 105214" src="https://github.com/user-attachments/assets/bf913f42-7d5a-4bd5-80d8-a91b59372d1e" />|
|Course4|<img width="1902" height="955" alt="Screenshot 2025-07-30 105224" src="https://github.com/user-attachments/assets/9548b30a-27d8-487f-b830-1d0346c25a32" />|

Other deprecated courses page and project deprecation page still work

<img width="1900" height="955" alt="Screenshot 2025-07-30 105311" src="https://github.com/user-attachments/assets/77ea72ac-26ed-49a2-86d4-e8c8119fe140" />
<img width="1903" height="953" alt="Screenshot 2025-07-30 105334" src="https://github.com/user-attachments/assets/b3e02712-7c63-4d1b-ac8e-5eb35cbeff82" />



