### PR TITLE
fix(draft): don't enable draft if already draft

### DIFF
--- a/frontend/apps/marketing/src/middleware/withBrand.ts
+++ b/frontend/apps/marketing/src/middleware/withBrand.ts
@@ -24,9 +24,9 @@ export const withBrand: MiddlewareFactory = () => {
     const hostname = request.headers.get('host');
     const brand = getBrandFromHostname(hostname);
     const isPreviewHostname = PREVIEW_HOSTNAMES.has(hostname);
+    const draft = await draftMode();
 
-    if (isPreviewHostname) {
-      const draft = await draftMode();
+    if (!draft.isEnabled && isPreviewHostname) {
       draft.enable();
     }
 


### PR DESCRIPTION
If draft mode is already enabled, activating draft mode again can cause an error in dev server mode which ends up deactivating draft mode.
