### PR TITLE
Skip image moderation for small custom image uploads

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -273,7 +273,7 @@
   "animationPicker_returnToLibrary": "Return to library",
   "animationPicker_title": "{assetType} Library",
   "animationPicker_undoRestrictedShareInstructions": "You can use Version History to undo this change.",
-  "animationPicker_unsupportedDimensions": "Please make sure the width and height of your image are both greater than 128 pixels.",
+  "animationPicker_unsupportedDimensions": "Please make sure the width and height of your image are both greater than 127 pixels.",
   "animationPicker_unsupportedType": "Sorry, this file type is not supported.",
   "animationPicker_unsupportedSize": "Please make sure the image you are trying to upload is smaller than 100 KB.",
   "animationPicker_uploadImage": "Upload image",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -273,7 +273,6 @@
   "animationPicker_returnToLibrary": "Return to library",
   "animationPicker_title": "{assetType} Library",
   "animationPicker_undoRestrictedShareInstructions": "You can use Version History to undo this change.",
-  "animationPicker_unsupportedDimensions": "Please make sure the width and height of your image are both greater than 127 pixels.",
   "animationPicker_unsupportedType": "Sorry, this file type is not supported.",
   "animationPicker_unsupportedSize": "Please make sure the image you are trying to upload is smaller than 100 KB.",
   "animationPicker_uploadImage": "Upload image",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -273,6 +273,7 @@
   "animationPicker_returnToLibrary": "Return to library",
   "animationPicker_title": "{assetType} Library",
   "animationPicker_undoRestrictedShareInstructions": "You can use Version History to undo this change.",
+  "animationPicker_unsupportedDimensions": "Please make sure the width and height of your image are both greater than 128 pixels.",
   "animationPicker_unsupportedType": "Sorry, this file type is not supported.",
   "animationPicker_unsupportedSize": "Please make sure the image you are trying to upload is smaller than 100 KB.",
   "animationPicker_uploadImage": "Upload image",

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -174,6 +174,22 @@ class AnimationPicker extends React.Component {
     );
   }
 
+  validateImageDimensions = file => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const img = new Image();
+        img.onload = () => {
+          resolve(img.width > 128 && img.height > 128);
+        };
+        img.onerror = reject;
+        img.src = reader.result;
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  };
+
   /**
    * Send the uploaded image file to be moderated. Then continue with uploadStart.
    */
@@ -183,39 +199,62 @@ class AnimationPicker extends React.Component {
       console.error('No file found in upload data.');
       return;
     }
-    this.setState({
-      pendingUploadData: data,
-    });
-
-    HttpClient.post(`/v3/images/moderate`, file, true, {
-      'Content-Type': file.type,
-    })
-      .then(response => response.json())
-      .then(json => {
-        // If rating is not 'everyone' or 'unknown', then flag project for image moderation.
-        if (json.rating !== 'everyone' && json.rating !== 'unknown') {
-          this.setState({
-            showFlaggedModal: true,
-          });
-          analyticsReporter.sendEvent(
-            EVENTS.FLAGGED_CUSTOM_IMAGE,
-            {
-              UploaderType: 'Animation Picker',
-              ProjectType: this.props.projectType,
-            },
-            PLATFORMS.STATSIG
-          );
-        } else {
-          // If the image is rated 'everyone' or 'unknown', continue with upload.
-          this.props.onUploadStart(this.state.pendingUploadData);
+    if (data.files[0].size >= MAX_UPLOAD_SIZE) {
+      this.props.onUploadError(msg.animationPicker_unsupportedSize());
+      return;
+    }
+    if (
+      data.files[0].type !== 'image/png' &&
+      data.files[0].type !== 'image/jpeg'
+    ) {
+      this.props.onUploadError(msg.animationPicker_unsupportedType());
+      return;
+    }
+    this.validateImageDimensions(file)
+      .then(isValid => {
+        if (!isValid) {
+          this.props.onUploadError(msg.animationPicker_unsupportedDimensions());
+          return;
         }
+
+        this.setState({
+          pendingUploadData: data,
+        });
+
+        HttpClient.post(`/v3/images/moderate`, file, true, {
+          'Content-Type': file.type,
+        })
+          .then(response => response.json())
+          .then(json => {
+            // If rating is not 'everyone' or 'unknown', then flag project for image moderation.
+            if (json.rating !== 'everyone' && json.rating !== 'unknown') {
+              this.setState({
+                showFlaggedModal: true,
+              });
+              analyticsReporter.sendEvent(
+                EVENTS.FLAGGED_CUSTOM_IMAGE,
+                {
+                  UploaderType: 'Animation Picker',
+                  ProjectType: this.props.projectType,
+                },
+                PLATFORMS.STATSIG
+              );
+            } else {
+              // If the image is rated 'everyone' or 'unknown', continue with upload.
+              this.props.onUploadStart(this.state.pendingUploadData);
+            }
+          })
+          .catch(err => {
+            this.setState({
+              showFlaggedModal: true,
+              flaggedModalError: msg.animationPicker_uploadingError(),
+            });
+            MetricsReporter.logError('Azure image moderation error: ' + err);
+          });
       })
       .catch(err => {
-        this.setState({
-          showFlaggedModal: true,
-          flaggedModalError: msg.animationPicker_uploadingError(),
-        });
-        MetricsReporter.logError('Azure image moderation error: ' + err);
+        MetricsReporter.logError('Error validating image dimensions: ' + err);
+        this.props.onUploadError(msg.animationPicker_uploadingError());
       });
   };
 
@@ -336,17 +375,8 @@ export default connect(
       dispatch(pickLibraryAnimation(animation));
     },
     onUploadStart(data) {
-      if (data.files[0].size >= MAX_UPLOAD_SIZE) {
-        dispatch(handleUploadError(msg.animationPicker_unsupportedSize()));
-      } else if (
-        data.files[0].type === 'image/png' ||
-        data.files[0].type === 'image/jpeg'
-      ) {
-        dispatch(beginUpload(data.files[0].name));
-        data.submit();
-      } else {
-        dispatch(handleUploadError(msg.animationPicker_unsupportedType()));
-      }
+      dispatch(beginUpload(data.files[0].name));
+      data.submit();
     },
     onUploadDone(result) {
       dispatch(handleUploadComplete(result));

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -174,13 +174,13 @@ class AnimationPicker extends React.Component {
     );
   }
 
-  validateImageDimensions = file => {
+  getImageDimensions = file => {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => {
         const img = new Image();
         img.onload = () => {
-          resolve(img.width > 127 && img.height > 127);
+          resolve({width: img.width, height: img.height});
         };
         img.onerror = reject;
         img.src = reader.result;
@@ -210,10 +210,11 @@ class AnimationPicker extends React.Component {
       this.props.onUploadError(msg.animationPicker_unsupportedType());
       return;
     }
-    this.validateImageDimensions(file)
-      .then(isValid => {
-        if (!isValid) {
-          this.props.onUploadError(msg.animationPicker_unsupportedDimensions());
+    this.getImageDimensions(file)
+      .then(({width, height}) => {
+        if (width < 128 || height < 128) {
+          // Skip moderation, upload directly.
+          this.props.onUploadStart(data);
           return;
         }
 
@@ -250,7 +251,7 @@ class AnimationPicker extends React.Component {
           });
       })
       .catch(err => {
-        MetricsReporter.logError('Error validating image dimensions: ' + err);
+        MetricsReporter.logError('Error getting image dimensions: ' + err);
         this.props.onUploadError(msg.animationPicker_uploadingError());
       });
   };

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -180,7 +180,7 @@ class AnimationPicker extends React.Component {
       reader.onload = () => {
         const img = new Image();
         img.onload = () => {
-          resolve(img.width > 128 && img.height > 128);
+          resolve(img.width > 127 && img.height > 127);
         };
         img.onerror = reject;
         img.src = reader.result;

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -245,10 +245,7 @@ class AnimationPicker extends React.Component {
             }
           })
           .catch(err => {
-            this.setState({
-              showFlaggedModal: true,
-              flaggedModalError: msg.animationPicker_uploadingError(),
-            });
+            this.props.onUploadError(msg.animationPicker_uploadingError());
             MetricsReporter.logError('Azure image moderation error: ' + err);
           });
       })

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -213,7 +213,9 @@ class AnimationPicker extends React.Component {
     this.getImageDimensions(file)
       .then(({width, height}) => {
         if (width < 128 || height < 128) {
-          // Skip moderation, upload directly.
+          // We skip moderation of small images because Azure Content Moderator has a minimum
+          // requirement for their evaluate endpoint.
+          // TODO: resize small images and then moderate. https://codedotorg.atlassian.net/browse/SL-1367
           this.props.onUploadStart(data);
           return;
         }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds a check for dimension size of custom images that are uploaded via the Animation Picker. If either dimension is `< 128`, then we will skip moderation of the image. The reasons is that the Azure Content Moderator requires that both dimensions of an image be `>= 128`.

We recently implemented image moderation on Friday July 15 in the evening. Since then, there have been over 400 [HoneyBadger error reports](https://app.honeybadger.io/projects/3240/faults/122296560).

<img width="1177" height="660" alt="Screenshot 2025-07-30 at 12 32 02 PM" src="https://github.com/user-attachments/assets/79781678-632f-4692-8605-b8b2ccc74e99" />



This has not blocked users, but the [first idea I considered was requiring that uploaded images have dimensions `> 127`](https://github.com/code-dot-org/code-dot-org/pull/67429). However, considering this is the summertime, and we've already had this number of small image uploads, it seems unreasonable to block the upload of small images in Sprite Lab, Poetry Lab, and Game Lab.

~~Thus, I propose skipping content moderation of small images for now.~~ @dju90 approved that we skip content moderation of small images for now. I am logging a [follow-up ticket](https://codedotorg.atlassian.net/browse/SL-1367) to scale small images to meet the Azure Content Moderator size requirements and then send the request to evaluate.

FYI, Azure Content Moderator [is deprecated](https://learn.microsoft.com/en-us/azure/ai-services/content-moderator/overview) as of Feb 2024 and will be retired March 2027.  As a comparison, Azure AI Content Safety is available as an option and its minimum size requirement is 50 x 50 pixels. [reference](https://learn.microsoft.com/en-us/azure/ai-services/content-safety/quickstart-image?tabs=visual-studio%2Cwindows&pivots=programming-language-rest) We have not yet decided which service we will replace Azure Content Moderator with, but most likely the input size requirement will be less strict. At that point, we can consider again whether to block images that do not meet the minimum size requirement.

FYI, although we've been receiving HoneyBadger error reports, this has not had an impact on users.
The reason is that [`ImageModeration`](https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/image_moderation.rb) is a wrapper for [`AzureContentModerator`](https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/azure_content_moderator.rb), and if the request to AzureContentModerator results in an exception, we notify HoneyBadger (yay!), and  return `:unknown`. This PR will resolve these error reports.
https://github.com/code-dot-org/code-dot-org/blob/22485e25022f17fd99e975ad20f5e387019982f5/lib/cdo/image_moderation.rb#L17-L33

If `unknown` is received on the frontend, we allow image upload.
https://github.com/code-dot-org/code-dot-org/blob/22485e25022f17fd99e975ad20f5e387019982f5/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx#L196


## After update

Screencast showing uploading of:
- a 128x128 image -> moderate request is shown in Network tab
- a 127 x 127 image -> NO request to moderate endpoint
- a 68 x 312 image -> NO request to moderate endpoint



https://github.com/user-attachments/assets/f55bf02e-fa49-4596-96f7-4864ca101c24



Screencast showing an error message when the moderate request fails. I updated this so that the uerror message uses `renderVisibleBody` UI since it could happen for an image that was not flagged.


https://github.com/user-attachments/assets/72604900-025a-4488-a081-032f649143ad

Screencast showing error message in abuse modal since the error would occur while modal is open.

https://github.com/user-attachments/assets/53384f42-8be5-4e2e-8b66-82ceb22387e1


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/SL-1366

## Testing story

The API documentation for Azure Image Moderator is sparse. I didn't find information about the input requirement of a minimum size. https://learn.microsoft.com/en-us/rest/api/cognitiveservices/contentmoderator/image-moderation/evaluate?view=rest-cognitiveservices-contentmoderator-v1.0

However, from the content of the error message and local testing, I verified (by printing the response body) that both the image width and height must be `>127`. If an image has dimensions that are both > 127 pixels, a request can be made successfully to the Azure Content Moderator `evaluate` endpoint. 

Screencast of
1. 128x128 image -> success
2. 127x127 image -> failure
3. 68x312 image -> failure

https://github.com/user-attachments/assets/715c22ff-7244-4cf6-a94d-a7bc5e3a9a90


<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->
- Resize small images being uploaded to meet moderation requirements https://codedotorg.atlassian.net/browse/SL-1367


## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
