### PR TITLE
fix(contentful): monkey patch cfTextAlign

### DIFF
--- a/frontend/apps/marketing/patches/@contentful-experiences-core-npm-2.0.1-c20f8b5e11.patch
+++ b/frontend/apps/marketing/patches/@contentful-experiences-core-npm-2.0.1-c20f8b5e11.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/index.js b/dist/index.js
+index bc6b4e91faa3ea3f01710e479759cbb19a764698..c33d75428fb0175ee1617c91b9923c112219537e 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -2018,7 +2018,7 @@ const buildCfStyles = (values) => {
+         lineHeight: values.cfLineHeight,
+         letterSpacing: values.cfLetterSpacing,
+         color: values.cfTextColor,
+-        textAlign: values.cfTextAlign,
++        textAlign: values.cfTextAlign === 'left' ? 'start' : values.cfTextAlign === 'right' ? 'end' : values.cfTextAlign,
+         textTransform: values.cfTextTransform,
+         objectFit: values.cfImageOptions?.objectFit,
+         objectPosition: values.cfImageOptions?.objectPosition,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,9 @@
     "typecheck": "turbo typecheck"
   },
   "prettier": "@code-dot-org/lint-config/prettier/index.mjs",
+  "resolutions": {
+    "@contentful/experiences-core@npm:2.0.1": "patch:@contentful/experiences-core@npm%3A2.0.1#~/apps/marketing/patches/@contentful-experiences-core-npm-2.0.1-c20f8b5e11.patch"
+  },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
     "@storybook/test-runner": "^0.19.1",
@@ -44,8 +47,5 @@
   "packageManager": "yarn@4.6.0",
   "engines": {
     "node": ">=20"
-  },
-  "resolutions": {
-    "@contentful/experiences-core@npm:2.0.1": "patch:@contentful/experiences-core@npm%3A2.0.1#~/apps/marketing/patches/@contentful-experiences-core-npm-2.0.1-c20f8b5e11.patch"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,5 +44,8 @@
   "packageManager": "yarn@4.6.0",
   "engines": {
     "node": ">=20"
+  },
+  "resolutions": {
+    "@contentful/experiences-core@npm:2.0.1": "patch:@contentful/experiences-core@npm%3A2.0.1#~/apps/marketing/patches/@contentful-experiences-core-npm-2.0.1-c20f8b5e11.patch"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1305,6 +1305,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@contentful/experiences-core@patch:@contentful/experiences-core@npm%3A2.0.1#~/apps/marketing/patches/@contentful-experiences-core-npm-2.0.1-c20f8b5e11.patch":
+  version: 2.0.1
+  resolution: "@contentful/experiences-core@patch:@contentful/experiences-core@npm%3A2.0.1#~/apps/marketing/patches/@contentful-experiences-core-npm-2.0.1-c20f8b5e11.patch::version=2.0.1&hash=883b0e"
+  dependencies:
+    "@contentful/experiences-validators": "npm:2.0.1"
+    "@contentful/rich-text-types": "npm:^17.0.0"
+  peerDependencies:
+    contentful: ">=10.6.0"
+  checksum: 10c0/239d409a9ff8d4002d41efba184e4b2db1ad1cedf5d0a99d4b6829b0f15a453be098f5721e432e31027f23088224c5ff7856216ab054c244e316a83a5345258b
+  languageName: node
+  linkType: hard
+
 "@contentful/experiences-sdk-react@npm:^2.0.1":
   version: 2.0.1
   resolution: "@contentful/experiences-sdk-react@npm:2.0.1"


### PR DESCRIPTION
This PR adds a temporary monkey patch to the Contentful Core SDK to force `left` to `start` and `right` to `end` to ensure compatability in LTR and RTL directions.
