### PR TITLE
Fix "INF-1780 Grant iam:TagRole to CloudFormationService role"

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -71,7 +71,6 @@ Resources:
                   # AWS::IAM::Role
                   - iam:CreateRole
                   - iam:PutRolePermissionsBoundary
-                  - iam:TagRole
                   # Managed policies attached to a Role
                   - iam:AttachRolePolicy
                   - iam:DetachRolePolicy

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -52,6 +52,8 @@ Resources:
                   - iam:CreatePolicyVersion
                   - iam:DeletePolicy
                   - iam:DeletePolicyVersion
+                  - iam:TagRole
+                  - iam:UntagRole
                 NotResource: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/*"
               - Effect: Allow
                 Action:


### PR DESCRIPTION
Fixes code-dot-org/code-dot-org#67413

The first pass at this accidentally added `TagRole` to a policy statement that was intended for role creation/manipulation where PermissionBoundaries could be applied, and required them to be. TagRole doesn't involve PermissionBoundaries, so we could never satisfy that condition.