### PR TITLE
add project updated_ip to pii scrubber

### DIFF
--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -88,6 +88,9 @@ module Services
         # PD data
         scrub_pd_surveys
         scrub_pd_enrollments
+
+        # Project IP addresses (but no other project data)
+        scrub_project_ips
       end
 
       # Legacy delete acccounts helper client for purging data from deprecated tables
@@ -102,6 +105,12 @@ module Services
 
       private def pd_enrollments
         @pd_enrollments ||= user.pd_enrollments.with_deleted
+      end
+
+      private def scrub_project_ips
+        Project.where(storage_id: user.user_storage_id).each do |project|
+          project.update(updated_ip: '')
+        end
       end
 
       # Deletes PII from deprecated tables that no longer have a corresponding ActiveRecord model.

--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -108,9 +108,9 @@ module Services
       end
 
       private def scrub_project_ips
-        DASHBOARD_DB[:projects]
-          .where(storage_id: user.user_storage_id)
-          .update(updated_ip: '', updated_at: Time.now)
+        DASHBOARD_DB[:projects].
+          where(storage_id: user.user_storage_id).
+          update(updated_ip: '', updated_at: Time.now)
       end
 
       # Deletes PII from deprecated tables that no longer have a corresponding ActiveRecord model.

--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -108,9 +108,9 @@ module Services
       end
 
       private def scrub_project_ips
-        Project.where(storage_id: user.user_storage_id).each do |project|
-          project.update(updated_ip: '')
-        end
+        DASHBOARD_DB[:projects]
+          .where(storage_id: user.user_storage_id)
+          .update(updated_ip: '', updated_at: Time.now)
       end
 
       # Deletes PII from deprecated tables that no longer have a corresponding ActiveRecord model.

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -1,8 +1,10 @@
 require 'test_helper'
+require 'testing/projects_test_utils'
 require 'cdo/delete_accounts_helper'
 
 class Services::User::PiiScrubberTest < ActiveSupport::TestCase
   include Minitest::RSpecMocks
+  include ProjectsTestUtils
 
   let(:email) {Faker::Internet.unique.email}
   let(:user) do
@@ -81,17 +83,15 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
     end
 
     context 'when user has project' do
-      # The project factory is prone to issues, so we create a project directly.
-      let(:project) {Project.create(storage_id: user.user_storage_id, updated_ip: '127.0.0.1')}
-
-      after do
-        project.destroy
-      end
-
+      
       it 'removes updated_ip' do
-        _(project.updated_ip).must_be :present?
-        scrub_pii
-        _(project.reload.updated_ip).must_be :empty?
+        # The project factory causes db issues, so we use ProjectsTestUtils instead.
+        with_channel_for(user) do |project_id, storage_id|
+          project = projects_table.where(id: project_id).first
+          _(project[:updated_ip]).must_be :present?
+          scrub_pii
+          _(projects_table.where(id: project_id).first[:updated_ip]).must_be :empty?
+        end
       end
     end
 

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -80,6 +80,21 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
       end
     end
 
+    context 'when user has project' do
+      # The project factory is prone to issues, so we create a project directly.
+      let(:project) {Project.create(storage_id: user.user_storage_id, updated_ip: '127.0.0.1')}
+
+      after do
+        project.destroy
+      end
+
+      it 'removes updated_ip' do
+        _(project.updated_ip).must_be :present?
+        scrub_pii
+        _(project.reload.updated_ip).must_be :empty?
+      end
+    end
+
     context 'when user is not soft-deleted' do
       let(:soft_deleted_user) {false}
 

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -83,10 +83,9 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
     end
 
     context 'when user has project' do
-      
       it 'removes updated_ip' do
         # The project factory causes db issues, so we use ProjectsTestUtils instead.
-        with_channel_for(user) do |project_id, storage_id|
+        with_channel_for(user) do |project_id, _storage_id|
           project = projects_table.where(id: project_id).first
           _(project[:updated_ip]).must_be :present?
           scrub_pii


### PR DESCRIPTION
Removes `updated_ip` from projects during the PII scrub process.


## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1558)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
