### PR TITLE
Music Lab: start reporting to Statsig in parallel with Amplitude

### DIFF
--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -19,7 +19,7 @@ import {
 } from './statsigHelpers';
 
 // A flag that can be toggled to send events regardless of environment
-const ALWAYS_SEND = true;
+const ALWAYS_SEND = false;
 const NO_EVENT_NAME = 'NO_VALID_EVENT_NAME_LOG_ERROR';
 
 class StatsigReporter {

--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -19,7 +19,7 @@ import {
 } from './statsigHelpers';
 
 // A flag that can be toggled to send events regardless of environment
-const ALWAYS_SEND = false;
+const ALWAYS_SEND = true;
 const NO_EVENT_NAME = 'NO_VALID_EVENT_NAME_LOG_ERROR';
 
 class StatsigReporter {

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -225,7 +225,7 @@ export default class AnalyticsReporter {
   }
 
   onButtonClicked(buttonName: string, properties?: object) {
-    this.trackUIEvent('Button clicked (Ben test)', {
+    this.trackUIEvent('Button clicked', {
       buttonName,
       ...properties,
     });

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -75,7 +75,6 @@ interface SessionEndPayload extends CommonSessionFields {
   soundsUsed: string[];
 }
 
-// define Project interface based on tracked properties
 interface ProjectContext {
   levelType?: string;
   mode?: string;

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -11,6 +11,11 @@ import * as GoogleBlockly from 'blockly/core';
 
 import DCDO from '@cdo/apps/dcdo';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+// We are transitioning off of a standalone Amplitude project for Music Lab
+// and onto Code.org's main Statsig project.
+// In the short term, we log to both projects to establish parity between the two logging systems.
+import {PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import cdoAnalyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import trackEvent from '@cdo/apps/util/trackEvent';
 import {
   getEnvironment,
@@ -258,6 +263,7 @@ export default class AnalyticsReporter {
       this.log(logMessage);
     }
 
+    cdoAnalyticsReporter.sendEvent(eventType, payload, PLATFORMS.STATSIG);
     track(eventType, payload).promise;
   }
 
@@ -338,6 +344,7 @@ export default class AnalyticsReporter {
 
     this.session = undefined;
 
+    cdoAnalyticsReporter.sendEvent('Session end', payload, PLATFORMS.STATSIG);
     track('Session end', payload);
     flush();
 

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -377,7 +377,7 @@ export default class AnalyticsReporter {
     }
   }
 
-  private sendStatsigEvent(eventName: string, payload: object = {}) {
+  private sendStatsigEvent(eventName: string, payload: object) {
     // We include project properties as part of the event payload rather than as user properties in Statsig.
     const combinedPayload = this.projectContext
       ? {...payload, ...this.projectContext}

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -75,13 +75,14 @@ interface SessionEndPayload extends CommonSessionFields {
   soundsUsed: string[];
 }
 
-const trackedProjectProperties = [
-  'levelType',
-  'mode',
-  'channelId',
-  'levelPath',
-  'scriptName',
-] as const;
+// define Project interface based on tracked properties
+interface ProjectContext {
+  levelType?: string;
+  mode?: string;
+  channelId?: string;
+  levelPath?: string;
+  scriptName?: string;
+}
 
 /**
  * An analytics reporter specifically used for the Music Lab prototype, which logs analytics
@@ -113,6 +114,7 @@ export default class AnalyticsReporter {
   }
 
   private session: Session | undefined;
+  private projectContext: ProjectContext | undefined;
   private startInProgress: boolean = false;
 
   async startSession() {
@@ -184,14 +186,21 @@ export default class AnalyticsReporter {
   }
 
   setProjectProperty(
-    property: (typeof trackedProjectProperties)[number],
-    value: string | number | undefined
+    property: keyof ProjectContext,
+    value: string | undefined
   ) {
     if (!this.session) {
       this.log('No session in progress');
       return;
     }
 
+    // For Statsig
+    if (!this.projectContext) {
+      this.projectContext = {};
+    }
+    this.projectContext[property] = value;
+
+    // For Amplitude
     const identifyEvent = new Identify();
     if (value) {
       identifyEvent.set(property, value);
@@ -199,6 +208,7 @@ export default class AnalyticsReporter {
       identifyEvent.unset(property);
     }
     identify(identifyEvent);
+
     this.log(`Project property: ${property}: ${value}`);
   }
 
@@ -216,7 +226,7 @@ export default class AnalyticsReporter {
   }
 
   onButtonClicked(buttonName: string, properties?: object) {
-    this.trackUIEvent('Button clicked', {
+    this.trackUIEvent('Button clicked (Ben test)', {
       buttonName,
       ...properties,
     });
@@ -263,7 +273,7 @@ export default class AnalyticsReporter {
       this.log(logMessage);
     }
 
-    cdoAnalyticsReporter.sendEvent(eventType, payload, PLATFORMS.STATSIG);
+    this.sendStatsigEvent(eventType, payload);
     track(eventType, payload).promise;
   }
 
@@ -344,7 +354,7 @@ export default class AnalyticsReporter {
 
     this.session = undefined;
 
-    cdoAnalyticsReporter.sendEvent('Session end', payload, PLATFORMS.STATSIG);
+    this.sendStatsigEvent('Session end', payload);
     track('Session end', payload);
     flush();
 
@@ -366,5 +376,18 @@ export default class AnalyticsReporter {
       const environment = getEnvironment();
       return `${environment}-${userIdString}`;
     }
+  }
+
+  private sendStatsigEvent(eventName: string, payload: object = {}) {
+    // We include project properties as part of the event payload rather than as user properties in Statsig.
+    const combinedPayload = this.projectContext
+      ? {...payload, ...this.projectContext}
+      : payload;
+
+    cdoAnalyticsReporter.sendEvent(
+      eventName,
+      combinedPayload,
+      PLATFORMS.STATSIG
+    );
   }
 }

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -384,7 +384,7 @@ export default class AnalyticsReporter {
       : payload;
 
     cdoAnalyticsReporter.sendEvent(
-      eventName,
+      `Music Lab ${eventName}`,
       combinedPayload,
       PLATFORMS.STATSIG
     );

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -185,9 +185,9 @@ export default class AnalyticsReporter {
     );
   }
 
-  setProjectProperty(
-    property: keyof ProjectContext,
-    value: string | undefined
+  setProjectProperty<K extends keyof ProjectContext>(
+    property: K,
+    value: ProjectContext[K]
   ) {
     if (!this.session) {
       this.log('No session in progress');


### PR DESCRIPTION
Starts reporting Music Lab events to Statsig in parallel with our existing Amplitude reporting.

Some of the Amplitude API functionality that is done in this helper is already handled in our statsigReporter, including initialization, establishing the user, etc.

One change here is to start reporting "project properties" (eg, channel ID, level path) as part of the event payload rather than as a user property.

I don't expect that this will be the last change we'll need to make here, but I think the easiest path forward is to start logging to Statsig and see what differences we see between what's appearing there and what's in Amplitude.

I think we'll know pretty fast if we have issues in core metrics, but there may be a longer tail of making sure we have full parity with Amplitude on less prominent metrics.

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1014

## Testing story

I tested manually that I was able to see the events I was emitting locally in Statsig.