### PR TITLE
Codebridge: update active file logic

### DIFF
--- a/apps/src/lab2/utils/multiFileSourceEditUtils.ts
+++ b/apps/src/lab2/utils/multiFileSourceEditUtils.ts
@@ -234,7 +234,7 @@ const getNewActiveFileId = (
   if (fileBeingClosed.active) {
     // List of open files before fileBeingClosed was closed.
     const oldOpenFiles = source.openFiles;
-    if (!oldOpenFiles) {
+    if (!oldOpenFiles || oldOpenFiles.length === 0) {
       return undefined;
     }
     // Find the index of fileBeingClosed.

--- a/apps/src/lab2/utils/multiFileSourceEditUtils.ts
+++ b/apps/src/lab2/utils/multiFileSourceEditUtils.ts
@@ -1,7 +1,12 @@
 import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
-import {getOpenFileIds, sortFilesByName} from '@cdo/apps/codebridge/utils';
+import {getOpenFileIds} from '@cdo/apps/codebridge/utils';
 import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
-import {FileId, FolderId, MultiFileSource} from '@cdo/apps/lab2/types';
+import {
+  FileId,
+  FolderId,
+  MultiFileSource,
+  ProjectFile,
+} from '@cdo/apps/lab2/types';
 
 import {
   getNextFileId,
@@ -92,34 +97,12 @@ export const closeFileHelper = (
     openFiles: source.openFiles?.filter(openFileId => openFileId !== fileId),
   };
 
-  // If the file was active, then we want to activate whatever file was next to it.
-  // Choose the recent file before hand if possible, and otherwise after, alphabetically sorted.
-  if (file.active) {
-    // List of open files before we closed.
-    const oldSortedFiles = sortFilesByName(source, {
-      mustBeOpen: true,
-    });
-    // Find our index.
-    const fileIdx = oldSortedFiles.findIndex(f => f.id === file.id)!;
-    // If there's a file before us, use that one.
-
-    let newActiveFileId;
-    if (fileIdx > 0) {
-      newActiveFileId = oldSortedFiles[fileIdx - 1].id;
-    }
-    // Otherwise, check to see if there's a file after us. And if so, use that one.
-    // We're removing this file from our list, so we have one fewer item in the list,
-    // so we need to decrement by 1
-    else if (fileIdx < oldSortedFiles.length - 1) {
-      newActiveFileId = oldSortedFiles[fileIdx + 1].id;
-    }
-
-    if (newActiveFileId) {
-      newSource.files[newActiveFileId] = {
-        ...newSource.files[newActiveFileId],
-        active: true,
-      };
-    }
+  const newActiveFileId = getNewActiveFileId(source, file);
+  if (newActiveFileId) {
+    newSource.files[newActiveFileId] = {
+      ...newSource.files[newActiveFileId],
+      active: true,
+    };
   }
 
   return newSource;
@@ -144,8 +127,16 @@ export const deleteFileHelper = (
     },
     openFiles: newOpenFileIds,
   };
-
+  const fileToBeDeleted = newSource.files[fileId];
   delete newSource.files[fileId];
+
+  const newActiveFileId = getNewActiveFileId(source, fileToBeDeleted);
+  if (newActiveFileId) {
+    newSource.files[newActiveFileId] = {
+      ...newSource.files[newActiveFileId],
+      active: true,
+    };
+  }
 
   return newSource;
 };
@@ -217,5 +208,51 @@ export const deleteFolderHelper = (
     }
   }
 
+  // Update the active file if necessary.
+  const activeFile = Object.values(newSource.files).find(f => f.active);
+  if (!activeFile) {
+    if (newSource.openFiles && newSource.openFiles.length > 0) {
+      // If there are any open files, set the first one as active.
+      const firstOpenFileId = newSource.openFiles[0];
+      newSource.files[firstOpenFileId] = {
+        ...newSource.files[firstOpenFileId],
+        active: true,
+      };
+    }
+  }
+
   return newSource;
+};
+
+// If we either close or delete a file, we may need to update the active file.
+// This will happen if the file being closed or deleted is the active file.
+// Return the new active file ID, or undefined if there is no new active file.
+const getNewActiveFileId = (
+  source: MultiFileSource,
+  fileBeingClosed: ProjectFile
+) => {
+  if (fileBeingClosed.active) {
+    // List of open files before fileBeingClosed was closed.
+    const oldOpenFiles = source.openFiles;
+    if (!oldOpenFiles) {
+      return undefined;
+    }
+    // Find the index of fileBeingClosed.
+    const fileIdx = oldOpenFiles.findIndex(f => f === fileBeingClosed.id)!;
+    // If there's a file before fileBeingClosed, use that one.
+
+    let newActiveFileId;
+    if (fileIdx > 0) {
+      newActiveFileId = oldOpenFiles[fileIdx - 1];
+    }
+    // Otherwise, check to see if there's a file after fileBeingClosed. If so, use that one.
+    // We're removing fileBeingClosed from the list of open files, so we have one fewer item in the list,
+    // so we need to decrement by 1
+    else if (fileIdx < oldOpenFiles.length - 1) {
+      newActiveFileId = oldOpenFiles[fileIdx + 1];
+    }
+
+    return newActiveFileId;
+  }
+  return undefined;
 };

--- a/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
+++ b/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
@@ -56,7 +56,11 @@ const createMockMultiFileSource = (
   overrides: Partial<MultiFileSource> = {}
 ): MultiFileSource => ({
   files: {
-    '1': createMockFile('1', {name: 'index.html', language: 'html'}),
+    '1': createMockFile('1', {
+      name: 'index.html',
+      language: 'html',
+      active: true,
+    }),
     '2': createMockFile('2', {name: 'script.js', language: 'javascript'}),
   },
   folders: {
@@ -300,17 +304,19 @@ describe('lab2ProjectRedux', () => {
 
   describe('closeFile', () => {
     it('should close a file', () => {
-      const initialProjectSources = createMockProjectSources();
+      const initialProjectSources = createMockProjectSources({
+        openFiles: ['1', '2'],
+      });
       const initialStateWithSources = {
         ...initialState,
         projectSources: initialProjectSources,
       };
 
       const state = reducer(initialStateWithSources, closeFile('1'));
-
-      expect(
-        (state.projectSources!.source as MultiFileSource).files['1'].active
-      ).toBe(false);
+      const newSource = state.projectSources!.source as MultiFileSource;
+      expect(newSource.files['1'].active).toBe(false);
+      expect(newSource.openFiles).toEqual(['2']);
+      expect(newSource.files['2'].active).toBe(true);
       expect(state.hasEdited).toBe(false); // Closing doesn't count as edit
     });
 
@@ -322,7 +328,9 @@ describe('lab2ProjectRedux', () => {
 
   describe('deleteFile', () => {
     it('should delete an existing file', () => {
-      const initialProjectSources = createMockProjectSources();
+      const initialProjectSources = createMockProjectSources({
+        openFiles: ['1', '2'],
+      });
       const initialStateWithSources = {
         ...initialState,
         projectSources: initialProjectSources,
@@ -330,9 +338,10 @@ describe('lab2ProjectRedux', () => {
 
       const state = reducer(initialStateWithSources, deleteFile('1'));
 
-      expect(
-        (state.projectSources!.source as MultiFileSource).files['1']
-      ).toBeUndefined();
+      const newSource = state.projectSources!.source as MultiFileSource;
+      expect(newSource.files['1']).toBeUndefined();
+      expect(newSource.openFiles).toEqual(['2']);
+      expect(newSource.files['2'].active).toBe(true);
       expect(state.hasEdited).toBe(true);
     });
 
@@ -566,7 +575,31 @@ describe('lab2ProjectRedux', () => {
 
   describe('deleteFolder', () => {
     it('should delete an existing folder', () => {
-      const initialProjectSources = createMockProjectSources();
+      const initialProjectSources = {
+        source: {
+          files: {
+            '1': createMockFile('1', {
+              name: 'index.html',
+              language: 'html',
+            }),
+            '2': createMockFile('2', {
+              name: 'script.js',
+              language: 'javascript',
+            }),
+            '3': createMockFile('3', {
+              name: 'style.css',
+              language: 'css',
+              folderId: '1',
+              active: true,
+            }),
+          },
+          folders: {
+            '1': createMockFolder('1'),
+          },
+          openFiles: ['1', '2', '3'],
+        },
+        labConfig: undefined,
+      };
       const initialStateWithSources = {
         ...initialState,
         projectSources: initialProjectSources,
@@ -574,9 +607,9 @@ describe('lab2ProjectRedux', () => {
 
       const state = reducer(initialStateWithSources, deleteFolder('1'));
 
-      expect(
-        (state.projectSources!.source as MultiFileSource).folders['1']
-      ).toBeUndefined();
+      const newSource = state.projectSources!.source as MultiFileSource;
+      expect(newSource.folders['1']).toBeUndefined();
+      expect(newSource.files['1'].active).toBe(true);
       expect(state.hasEdited).toBe(true);
     });
 


### PR DESCRIPTION
I noticed sometimes my project in Python Lab/Web Lab 2 had no "active" file despite having open files. This was because if you deleted the active file, we weren't properly updating another file to be "active". This wasn't very noticeable because our logic for showing a file in the editor would fall back to the first open file if there was no active file, but did cause some weirdness with the current html file preview, since it relies on active files.

To fix this, I applied the same logic we use when closing an active file to deleting a file. I updated that logic a bit to use the `openFiles` list to decide which file to activate next, rather than sorting the files. I think the sorting was from a time when we didn't allow rearranging the file tabs in the editor. Now we can open the next file in the editor rather than the next file alphabetically.

If the user deletes an entire folder, we just go to the first open file, since multiple open files could have been deleted.

## Testing story
Tested locally and updated unit tests.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
