### PR TITLE
Focus on the AIDiff text box when choosing a prompt

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -158,7 +158,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
       ]);
     }
     if (!prompt.followUpPrompts && !prompt.response) {
-      //getAIResponse(prompt.prompt, true, prompt.label);
+      getAIResponse(prompt.prompt, true, prompt.label);
     }
     userMessageEditorRef.current?.focus();
   };

--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -160,7 +160,6 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
     if (!prompt.followUpPrompts && !prompt.response) {
       getAIResponse(prompt.prompt, true, prompt.label);
     }
-    userMessageEditorRef.current?.focus();
   };
 
   const onSuggestPrompts = () => {
@@ -249,6 +248,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         .finally(() => {
           setIsWaitingForResponse(false);
           chatResponseCallback();
+          userMessageEditorRef.current?.focus();
         });
     },
     [context, threadId, viewAsUserId, chatResponseCallback, sendChatEvent]

--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -106,6 +106,8 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
 
   const [threadId, setThreadId] = useState(null);
 
+  const userMessageEditorRef = useRef<HTMLTextAreaElement>(null);
+
   const viewAsUserId = useAppSelector(
     state => state.progress?.viewAsUserId || undefined
   );
@@ -156,8 +158,9 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
       ]);
     }
     if (!prompt.followUpPrompts && !prompt.response) {
-      getAIResponse(prompt.prompt, true, prompt.label);
+      //getAIResponse(prompt.prompt, true, prompt.label);
     }
+    userMessageEditorRef.current?.focus();
   };
 
   const onSuggestPrompts = () => {
@@ -301,6 +304,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         messages={messageHistory}
         waiting={isWaitingForResponse}
         disableEndButtons={disableEndButtons}
+        userMessageEditorRef={userMessageEditorRef}
       />
     </div>
   );

--- a/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
@@ -16,6 +16,7 @@ interface AiDiffChatFooterProps {
   messages: ChatItem[];
   waiting: boolean;
   disableEndButtons: boolean;
+  userMessageEditorRef?: React.RefObject<HTMLTextAreaElement>;
 }
 
 const AiDiffChatFooter: React.FC<AiDiffChatFooterProps> = ({
@@ -24,10 +25,12 @@ const AiDiffChatFooter: React.FC<AiDiffChatFooterProps> = ({
   messages,
   waiting,
   disableEndButtons,
+  userMessageEditorRef,
 }) => {
   return (
     <div className={style.chatFooter}>
       <UserMessageEditor
+        ref={userMessageEditorRef}
         onSubmit={onSubmit}
         disabled={waiting}
         customPlaceholder={commonI18n.aiDifferentiation_write_message()}

--- a/dashboard/app/controllers/aidiff_threads_controller.rb
+++ b/dashboard/app/controllers/aidiff_threads_controller.rb
@@ -54,7 +54,7 @@ class AidiffThreadsController < ApplicationController
     render json: @aidiff_thread.summarize_with_messages
   end
 
-  # POST /ai_diff/curriculum_courses
+  # POST /aidiff_threads/curriculum_courses
   def curriculum_courses
     unless validate_context?
       return render status: :bad_request, json: {}


### PR DESCRIPTION
After clicking a preset prompt, we want the focus to automatically go to the text box so the user doesn't have to click on it when creating a reply.

After (Note the ai diff is throwing 404s on my local env, but you can still see that it focuses on the text area after button click):

https://github.com/user-attachments/assets/b809a82b-88f2-426b-a079-7e0813e26926



## Links

- Jira: https://codedotorg.atlassian.net/browse/AITT-960
