### PR TITLE
Fix `update_cookbook_versions` Script for new Bundle Install

### DIFF
--- a/cookbooks/update_cookbook_versions
+++ b/cookbooks/update_cookbook_versions
@@ -34,5 +34,7 @@ Chef::Config.chef_repo_path = Chef::Config.find_chef_repo_path(__dir__)
 Chef::LocalMode.with_server_connectivity do
   require 'chef/server_api'
   cookbooks = Chef::ServerAPI.new(Chef::Config[:chef_server_url]).get('/cookbooks')
-  cookbooks.each_key {|path| update_metadata path}
+  cookbooks.each_key do |path|
+    update_metadata(path) if path.start_with?('cdo-')
+  end
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67155, which included a change to `cookbooks/Berksfile` to only treat subdirectories starting with `cdo-` as cookbooks (see [this comment](https://github.com/code-dot-org/code-dot-org/pull/66536#pullrequestreview-2977321948) for details).

Unfortunately, because the `update_cookbook_versions` script only executes in the staging environment I missed it in my testing. This PR represents a quick fix-forward to bring that script in line with our updated logic.

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Verified locally that with this change in place I can successfully execute the script even with a local `cookbooks/vendor/bundle` directory.