### PR TITLE
Stop Linting Third-party Gems 

### DIFF
--- a/.config/rubocop/config.yml
+++ b/.config/rubocop/config.yml
@@ -24,6 +24,8 @@ AllCops:
     - 'apps/**/*'
     - 'dashboard/db/schema.rb'
     - 'pegasus/test/test_string.rb' # Parser does not support non-utf8 escape sequences
+    - 'vendor/**/*' # don't lint third-party code
+    - '*/vendor/**/*'
   DisplayCopNames: true
   TargetRubyVersion: 3.3
 

--- a/cookbooks/Berksfile
+++ b/cookbooks/Berksfile
@@ -19,9 +19,7 @@ Chef::Config.chef_repo_path = Chef::Config.find_chef_repo_path(__dir__)
 Chef::LocalMode.with_server_connectivity do
   require 'chef/server_api'
   cookbooks = Chef::ServerAPI.new(Chef::Config[:chef_server_url]).get('/cookbooks')
-  cookbooks.keys.select do |path|
-    path.start_with? 'cdo-'
-  end.each do |path|
-    cookbook path, path: path
+  cookbooks.keys.each do |path|
+    cookbook(path, path: path) if path.start_with?('cdo-')
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67155, which starts installing gems into some local `vendor/bundle` directories in deployment mode. These directories are being `gitignore`d, but also need to be ignored by Rubocop.

Also fix one genuine lint failure.


## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Updated these files manually on staging and verified that `RAILS_ENV=staging RACK_ENV=staging bundle exec rubocop --parallel` passes successfully. I then reverted the changes.
