### PR TITLE
Only filter App Lab files when calling on libraries put/post endpoint

### DIFF
--- a/apps/test/unit/codebridge/utils/previewFileTypeTest.ts
+++ b/apps/test/unit/codebridge/utils/previewFileTypeTest.ts
@@ -15,7 +15,7 @@ describe('previewFileType', () => {
   });
 
   it('should use default preview file types if not provided', () => {
-    // Assuming defaultPreviewFileTypesArray includes 'html', 'css', and 'javascript'
+    // Assuming defaultPreviewFileTypesArray includes 'html'.
     expect(previewFileType('html')).toBe(true);
     expect(previewFileType('css')).toBe(false);
     expect(previewFileType('javascript')).toBe(false);

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -425,7 +425,7 @@ class FilesApi < Sinatra::Base
     # between their own projects -- skip this check for backpack files since the files are
     # only being used by a single user.
     # Backpack is used in Java Lab, Python Lab, and Web Lab 2, but not in App Lab.
-    if endpoint == 'libraries' && project_type == 'applab'
+    if endpoint == 'libraries' && project_type != 'backpack'
       begin
         share_failure = ShareFiltering.find_failure(body, request.locale)
       rescue StandardError => exception

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -21,12 +21,6 @@ class FilesApi < Sinatra::Base
 
   SOURCES_PUBLIC_CACHE_DURATION = 20.seconds
 
-  # These file types are not used in Applab, so they are safe to skip during the
-  # profanity check for libraries in put_file.
-  BACKPACK_PROGRAM_FILE_TYPES = ['.csv', '.java', '.py', '.txt']
-
-  DEFAULT_TOXICITY_THRESHOLD_USER_SOURCES = 0.3
-
   def get_bucket_impl(endpoint)
     case endpoint
     when 'animations'
@@ -266,7 +260,7 @@ class FilesApi < Sinatra::Base
     metadata = result[:metadata]
     abuse_score = [metadata['abuse_score'].to_i, metadata['abuse-score'].to_i].max
     project = Projects.new(get_storage_id).get(encrypted_channel_id)
-    project_type = project[:projectType]&.downcase
+    project_type = project[:projectType]&.downcase if project
     not_found if abuse_score >= SharedConstants::ABUSE_CONSTANTS.ABUSE_THRESHOLD && !can_view_flagged_assets?(encrypted_channel_id)
     not_found if profanity_privacy_violation?(filename, result[:body], project_type) && !can_view_flagged_assets?(encrypted_channel_id)
     not_found if code_projects_domain_root_route && !codeprojects_can_view?(encrypted_channel_id)
@@ -421,13 +415,17 @@ class FilesApi < Sinatra::Base
       quota_crossed_half_used(endpoint, encrypted_channel_id) if quota_crossed_half_used?(app_size, body.length)
     end
 
-    # Block libraries with PII/profanity from being published.
-    # Block main.json file from aichat lab flagged with profanity from being saved.
-    #
-    # The "backpack" feature uses libraries to allow students to share code
-    # between their own projects -- skip this check for .java and .py files, since in this use case
-    # the files are only being used by a single user.
-    if endpoint == 'libraries' && BACKPACK_PROGRAM_FILE_TYPES.exclude?(file_type)
+    unless project_type
+      project = Projects.new(get_storage_id).get(encrypted_channel_id)
+      project_type = project[:projectType]&.downcase if project
+    end
+
+    # Block App Lab libraries with PII/profanity from being published and shared with other users.
+    # The "backpack" feature uses the libraries endpoint to allow users to share code
+    # between their own projects -- skip this check for backpack files since the files are
+    # only being used by a single user.
+    # Backpack is used in Java Lab, Python Lab, and Web Lab 2, but not in App Lab.
+    if endpoint == 'libraries' && project_type == 'applab'
       begin
         share_failure = ShareFiltering.find_failure(body, request.locale)
       rescue StandardError => exception

--- a/dashboard/legacy/middleware/helpers/library_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/library_bucket.rb
@@ -7,7 +7,7 @@ class LibraryBucket < BucketHelper
   end
 
   def allowed_file_types
-    %w(.json .java .py .csv .txt)
+    %w(.json .java .py .csv .txt .js)
   end
 
   def cache_duration_seconds

--- a/dashboard/legacy/test/middleware/files_api_test_helper.rb
+++ b/dashboard/legacy/test/middleware/files_api_test_helper.rb
@@ -45,8 +45,10 @@ class FilesApiTestHelper
     last_response.body
   end
 
-  def put_object(filename, body = '', headers = {})
-    put "/v3/#{@endpoint}/#{@channel_id}/#{filename}", body, headers
+  def put_object(filename, body = '', headers = {}, query: nil)
+    path = "/v3/#{@endpoint}/#{@channel_id}/#{filename}"
+    path += "?#{query}" if query
+    put path, body, headers
     last_response.body
   end
 

--- a/dashboard/legacy/test/middleware/files_api_test_helper.rb
+++ b/dashboard/legacy/test/middleware/files_api_test_helper.rb
@@ -45,10 +45,8 @@ class FilesApiTestHelper
     last_response.body
   end
 
-  def put_object(filename, body = '', headers = {}, query: nil)
-    path = "/v3/#{@endpoint}/#{@channel_id}/#{filename}"
-    path += "?#{query}" if query
-    put path, body, headers
+  def put_object(filename, body = '', headers = {})
+    put "/v3/#{@endpoint}/#{@channel_id}/#{filename}", body, headers
     last_response.body
   end
 

--- a/dashboard/legacy/test/middleware/test_libraries.rb
+++ b/dashboard/legacy/test/middleware/test_libraries.rb
@@ -122,7 +122,7 @@ class LibrariesTest < FilesApiTestBase
     delete_all_library_versions(filename)
 
     # Upload a file
-    @api.put_object(filename, file_data, file_headers)
+    put "/v3/libraries/#{@channel_id}/#{filename}?project_type=applab", file_data, file_headers
     assert_equal 400, last_response.status
   end
 

--- a/dashboard/legacy/test/middleware/test_libraries.rb
+++ b/dashboard/legacy/test/middleware/test_libraries.rb
@@ -122,7 +122,7 @@ class LibrariesTest < FilesApiTestBase
     delete_all_library_versions(filename)
 
     # Upload a file
-    @api.put_object(filename, file_data, file_headers, query: 'project_type=applab')
+    @api.put_object(filename, file_data, file_headers)
     assert_equal 400, last_response.status
   end
 

--- a/dashboard/legacy/test/middleware/test_libraries.rb
+++ b/dashboard/legacy/test/middleware/test_libraries.rb
@@ -122,7 +122,7 @@ class LibrariesTest < FilesApiTestBase
     delete_all_library_versions(filename)
 
     # Upload a file
-    put "/v3/libraries/#{@channel_id}/#{filename}?project_type=applab", file_data, file_headers
+    @api.put_object(filename, file_data, file_headers, query: 'project_type=applab')
     assert_equal 400, last_response.status
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
We now support the Backpack feature in Java Lab, Python Lab, and Web Lab 2. Since files stored in the backpack are only used by the owner and not shared with others, we bypass PII/privacy filtering when adding/updaing files to the Backpack.

We continue to filter App Lab libraries that are intended to be shared with others.


## After update

I temporarily added print statements in `ShareFiltering`'s `find_failure` method.

Screencast video showing updating an App Lab library and then saving a `.js` file in Web Lab 2. You can see that `share_failure` 

https://github.com/user-attachments/assets/ccdcbb48-554b-4c2c-af8c-dcdeabd822d6



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/CT-1242

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
