### PR TITLE
Stop Linting `haml` in Third-party Gems

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -199,5 +199,7 @@ linters:
 exclude:
 - '/**/pegasus/test/fixtures/**/*.haml'
 - 'pegasus/test/fixtures/**/*.haml'
+- 'vendor/**/*' # don't lint third-party code
+- '*/vendor/**/*'
 require:
 - './tools/customLinters/haml_lint_only_allowed_characters.rb'


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67465

Apparently some of our third-party gems also include haml templates :facepalm: 

## Links

[Build log](https://s3.console.aws.amazon.com/s3/object/cdo-build-logs?prefix=staging/20250731T173023%2B0000)

## Testing story

As before; made this change locally on the staging server and ran `RAILS_ENV=staging RACK_ENV=staging bundle exec haml-lint dashboard pegasus shared`
