### PR TITLE
Revert "CMS-953: Move DCDO mocking test endpoint to Dashboard (#67437)"

### DIFF
--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -450,15 +450,4 @@ class TestController < ApplicationController
     Services::ChildAccount.grant_permission_request!(permission_request)
     head :ok
   end
-
-  # Endpoint for testing DCDO mocking.
-  # @see /dashboard/test/ui/features/dcdo_mocking.feature
-  def get_dcdo
-    render json: {
-      fetched: DCDO.get('dcdo_mocking_test', nil),
-      stored: DCDO.instance_variable_get(:@datastore_cache)&.
-        instance_variable_get(:@datastore)&.
-        get('dcdo_mocking_test'),
-    }
-  end
 end

--- a/dashboard/test/ui/features/dcdo_mocking.feature
+++ b/dashboard/test/ui/features/dcdo_mocking.feature
@@ -1,23 +1,34 @@
+@pegasus_content
 Feature: DCDO mocking
   Scenario: Using a cookie to mock DCDO
-    Given I am on "http://studio.code.org/api/test/get_dcdo"
-    Then response json key "stored" has value "null"
-    And response json key "fetched" has value "null"
+    Given I am on "http://code.org/test_dcdo"
+    Then element "#fetched_dcdo_value" has text "nil"
 
     # Tests mocking of DCDO
-    When I use a cookie to mock the DCDO key "dcdo_mocking_test" as "mocked"
-    And I am on "http://studio.code.org/api/test/get_dcdo"
-    Then response json key "stored" has value "null"
-    And response json key "fetched" has value ""mocked""
+    When I use a cookie to mock the DCDO key "test_dcdo_on_pegasus" as "mocked"
+    And I reload the page
+    Then element "#fetched_dcdo_value" has text "\"mocked\""
 
     # Tests re-mocking of DCDO
-    When I use a cookie to mock the DCDO key "dcdo_mocking_test" as "{"dcdo":"re-mocked"}"
-    And I am on "http://studio.code.org/api/test/get_dcdo"
-    Then response json key "stored" has value "null"
-    And response json key "fetched" has value "{"dcdo":"re-mocked"}"
+    When I use a cookie to mock the DCDO key "test_dcdo_on_pegasus" as "{"dcdo":"re-mocked"}"
+    And I reload the page
+    Then element "#fetched_dcdo_value" has text "{\"dcdo\"=>\"re-mocked\"}"
 
     # Tests cleaning of DCDO
     When I delete the cookie named "DCDO"
-    And I am on "http://studio.code.org/api/test/get_dcdo"
-    Then response json key "stored" has value "null"
-    And response json key "fetched" has value "null"
+    And I reload the page
+    Then element "#fetched_dcdo_value" has text "nil"
+
+  Scenario: DCDO mocked on the "studio.code.org" domain is also available on the "code.org" domain
+    Given I am on "http://studio.code.org"
+    And I use a cookie to mock the DCDO key "test_dcdo_on_pegasus" as "mocked"
+
+    When I am on "http://code.org/test_dcdo"
+    Then element "#fetched_dcdo_value" has text "\"mocked\""
+
+  Scenario: DCDO mocked on the "hourofcode.com" domain is not available on the "code.org" domain
+    Given I am on "http://hourofcode.com/us"
+
+    When I use a cookie to mock the DCDO key "test_dcdo_on_pegasus" as "mocked"
+    And I am on "http://code.org/test_dcdo"
+    Then element "#fetched_dcdo_value" has text "nil"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1575,11 +1575,6 @@ Then /^page text does (not )?contain "([^"]*)"$/ do |negation, text|
   expect(body_text.include?(text)).to eq(negation.nil?)
 end
 
-Then /^response json key "([^"]*)" has value "(.*)"$/ do |key, value|
-  response_json = @browser.find_element(:css, 'body').text
-  expect(response_json).to include(%Q["#{key}":#{value}])
-end
-
 Then /^I click selector "([^"]*)" (\d+(?:\.\d*)?) times?$/ do |selector, times|
   step_list = []
   times.to_i.times do

--- a/pegasus/sites.v3/code.org/public/test_dcdo.haml
+++ b/pegasus/sites.v3/code.org/public/test_dcdo.haml
@@ -1,0 +1,2 @@
+#fetched_dcdo_value= DCDO.get('test_dcdo_on_pegasus', nil).inspect
+#raw_dcdo_value= DCDO.instance_variable_get('@datastore_cache')&.instance_variable_get('@datastore')&.get('test_dcdo_on_pegasus')&.inspect


### PR DESCRIPTION
This reverts commit 0c661367788e9b98981f97ea0c4a8254b10fe724.

