### PR TITLE
Change Default Instance Type When Cloning a Database Cluster

### DIFF
--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -15,7 +15,7 @@ module Cdo
     def self.clone_cluster(
       source_cluster_id: CDO.db_cluster_id,
       clone_cluster_id: "#{source_cluster_id}-clone",
-      instance_type: 'db.r5.large',
+      instance_type: 'db.r7i.xlarge',
       max_attempts: 30,  # It takes ~15 minutes to clone the production cluster, so default to 30 minutes.
       delay: 60
     )

--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -15,6 +15,8 @@ module Cdo
     def self.clone_cluster(
       source_cluster_id: CDO.db_cluster_id,
       clone_cluster_id: "#{source_cluster_id}-clone",
+      # We currently standardize on the `r7i` family. The `xlarge` instance type is likely the smallest that can operate on
+      # a clone of the production cluster, which is the most common usage of this method.
       instance_type: 'db.r7i.xlarge',
       max_attempts: 30,  # It takes ~15 minutes to clone the production cluster, so default to 30 minutes.
       delay: 60

--- a/lib/rake/rds.rake
+++ b/lib/rake/rds.rake
@@ -3,12 +3,13 @@ require lib_dir 'cdo/data/logging/rake_task_event_logger'
 include TimedTaskWithLogging
 
 namespace :rds do
-  # Provide all 3 arguments
-  # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav INSTANCE_ID=db.r7i.large
-  # Use default 'db.r7i.xlarge' instance type
-  # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav
-  # Use default clone id (suffix source cluster id with '-clone')
-  # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster
+  # Provide all 3 arguments:
+  #   bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav INSTANCE_ID=db.r7i.large
+  # Use default 'db.r7i.xlarge' instance type, which is likely the smallest that can operate on a clone of the
+  # production cluster, which is the most common usage of this task:
+  #   bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav
+  # Use default clone id (suffix source cluster id with '-clone'):
+  #   bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster
   desc 'Clone SOURCE_CLUSTER_ID to optional CLONE_CLUSTER_ID with optional INSTANCE_TYPE.'
   timed_task_with_logging :clone_cluster do
     options = {

--- a/lib/rake/rds.rake
+++ b/lib/rake/rds.rake
@@ -4,8 +4,8 @@ include TimedTaskWithLogging
 
 namespace :rds do
   # Provide all 3 arguments
-  # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav INSTANCE_ID=db.r4.4xlarge
-  # Use default 'db.r4.large' instance type
+  # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav INSTANCE_ID=db.r7i.large
+  # Use default 'db.r7i.xlarge' instance type
   # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav
   # Use default clone id (suffix source cluster id with '-clone')
   # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster


### PR DESCRIPTION
Change helper methods that clone an Aurora cluster to use a newer and slightly larger database instance type, particularly because we're typically cloning the production database and should have more memory available for the large datasets. We're standardizing for now on the `r7i` family.

## Testing story

`bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=autoscale-prod-cluster CLONE_CLUSTER_ID=production-clone-test`



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
