### PR TITLE
remove MIGRATE_STANDALONE_UNITS env var references

### DIFF
--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -28,10 +28,8 @@ class CourseVersion < ApplicationRecord
   has_many :vocabularies
   has_many :reference_guides
 
-  unless ENV.fetch('MIGRATE_STANDALONE_UNITS', nil)
-    attr_readonly :content_root_type
-    attr_readonly :content_root_id
-  end
+  attr_readonly :content_root_type
+  attr_readonly :content_root_id
 
   KEY_CHAR_RE = /[a-z0-9\-]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -238,7 +238,7 @@ class UnitGroup < ApplicationRecord
         ugu.position = index + 1
         unit.update!(published_state: nil, instruction_type: nil, participant_audience: nil, instructor_audience: nil, is_course: false, pilot_experiment: nil, skip_name_format_validation: true)
         unit.update!(original_unit_group_id: id, skip_name_format_validation: true) if unit.original_unit_group.nil?
-        unit.course_version&.destroy unless ENV.fetch('MIGRATE_STANDALONE_UNITS', nil)
+        unit.course_version&.destroy
 
         unit.reload
         unit.write_script_json


### PR DESCRIPTION
As part of the cleanup process related to standalone units, we need to remove references to the migration in the code.



## Links

- Jira: [TEACH-1884](https://codedotorg.atlassian.net/browse/TEACH-1884)

