### PR TITLE
Use user's given_name and family_name if available for certificates

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -226,7 +226,11 @@ class Pd::Enrollment < ApplicationRecord
   # Convenience method for combining first and last name into a full name
   # @return [String] Combined first_name last_name
   def full_name
-    "#{first_name} #{last_name}".strip
+    if user&.given_name && user&.family_name
+      "#{user.given_name} #{user.family_name}"
+    else
+      "#{first_name} #{last_name}".strip
+    end
   end
 
   # Convenience method for setting first and last names from a full name
@@ -237,14 +241,6 @@ class Pd::Enrollment < ApplicationRecord
     first_name, last_name = value.split(' ', 2)
     write_attribute :first_name, first_name
     write_attribute :last_name, last_name || ''
-  end
-
-  # Maps enrollments to safe names
-  # @return [Array<Array<String, Pd::Enrollment>>] Array of tuples
-  #   representing the safe name and associated enrollment
-  def self.get_safe_names
-    # Use full name
-    all.map {|enrollment| [enrollment.full_name, enrollment]}
   end
 
   # TODO: Migrate existing school entries into schoolInfo and delete school column

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -248,7 +248,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert duplicate_enrollment.valid?
   end
 
-  test 'full_name' do
+  test 'setting full_name' do
     enrollment = create :pd_enrollment
     enrollment.full_name = 'SplitFirst SplitLast'
     assert_equal 'SplitFirst', enrollment.first_name
@@ -265,6 +265,24 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     enrollment.first_name = 'SeparateFirst'
     enrollment.last_name = 'SeparateLast'
     assert_equal 'SeparateFirst SeparateLast', enrollment.full_name
+  end
+
+  test 'getting full_name uses user given_name and family_name if available' do
+    user = create :user, given_name: "", family_name: ""
+    enrollment = create :pd_enrollment, user: user, first_name: "EnrollFirstName", last_name: "EnrollLastName"
+
+    # Uses enrollment name if both user.given_name and user.family_name are not available
+    assert_equal enrollment.full_name, 'EnrollFirstName EnrollLastName'
+
+    # Uses enrollment name if one of user.given_name or user.family_name is not available
+    user.update!(given_name: "UserFirstName")
+    assert_equal enrollment.full_name, 'EnrollFirstName EnrollLastName'
+    user.update!(given_name: "", family_name: "UserLastName")
+    assert_equal enrollment.full_name, 'EnrollFirstName EnrollLastName'
+
+    # Uses user given_name and family_name if both are available
+    user.update!(given_name: "UserFirstName", family_name: "UserLastName")
+    assert_equal enrollment.full_name, 'UserFirstName UserLastName'
   end
 
   test 'email format validation' do
@@ -442,16 +460,6 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     enrollment.validate
     assert_equal 'First', enrollment.first_name
     assert_equal 'Last', enrollment.last_name
-  end
-
-  test 'get safe names' do
-    enrollments = create_list :pd_enrollment, 5
-    safe_names = Pd::Enrollment.where(id: enrollments.pluck(:id)).order(:id).get_safe_names
-    assert_equal 5, safe_names.length
-
-    # each safe name is a tuple of the full name and the enrollment itself
-    expected = enrollments.map {|e| [e.full_name, e]}
-    assert_equal expected, safe_names
   end
 
   test 'school is deprecated' do


### PR DESCRIPTION
Use a user's `given_name` and `family_name` if available for certificates, otherwise still use the first and last names in the enrollment.

### If user has `given_name` and `family_name` set
![with user names](https://github.com/user-attachments/assets/5b5cb8f7-5aca-452c-8d5d-d80b2d30ee44)

### If user does not have `given_name` and `family_name` set
![no user names](https://github.com/user-attachments/assets/9cfca7f2-648f-4a35-9ede-f25f93db8ce5)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3406)

## Testing story
Local testing and adding a unit test.
