### PR TITLE
Teach 1830/remove standalone unit language from levelbuilder

### DIFF
--- a/apps/src/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -17,9 +17,6 @@ export default class CourseVersionPublishingEditor extends Component {
     updateVersionYear: PropTypes.func.isRequired,
     families: PropTypes.arrayOf(PropTypes.string).isRequired,
     versionYearOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
-    isCourse: PropTypes.bool,
-    updateIsCourse: PropTypes.func,
-    showIsCourseSelector: PropTypes.bool,
     initialPublishedState: PropTypes.string.isRequired,
     publishedState: PropTypes.oneOf(Object.values(PublishedState)).isRequired,
     updatePublishedState: PropTypes.func.isRequired,
@@ -110,99 +107,67 @@ export default class CourseVersionPublishingEditor extends Component {
   render() {
     return (
       <div>
-        {this.props.showIsCourseSelector && (
+        <div>
           <label>
-            Is a Standalone Unit
-            <input
-              className="isCourseCheckbox"
-              type="checkbox"
-              checked={this.props.isCourse}
-              disabled={this.props.preventCourseVersionChange}
-              style={styles.checkbox}
-              onChange={this.props.updateIsCourse}
-            />
-            {this.props.familyName && (
-              <HelpTip>
-                <p>
-                  If checked, indicates that this Unit represents a standalone
-                  unit. Examples of such Units include CourseA-F, Express, and
-                  Pre-Express.
-                </p>
-              </HelpTip>
+            Family Name
+            <select
+              value={this.state.selectedFamilyName}
+              style={styles.dropdown}
+              className="familyNameSelector"
+              disabled={
+                this.props.preventCourseVersionChange ||
+                !!this.state.newFamilyName
+              }
+              onChange={this.onFamilyNameSelect}
+            >
+              <option value="">(None)</option>
+              {this.props.families.map(familyOption => (
+                <option key={familyOption} value={familyOption}>
+                  {familyOption}
+                </option>
+              ))}
+            </select>
+            {!this.props.preventCourseVersionChange && (
+              <span>
+                or{' '}
+                <input
+                  type="text"
+                  value={this.state.newFamilyName}
+                  style={styles.smallInput}
+                  onChange={this.handleNewFamilyNameChange}
+                />
+              </span>
             )}
-            {!this.props.familyName && (
-              <HelpTip>
-                <p>
-                  You must select a family name in order to mark something as a
-                  standalone unit.
-                </p>
-              </HelpTip>
-            )}
+            <HelpTip>
+              <p>
+                The family name is used to group together courses that are
+                different version years of the same course so that users can be
+                redirected between different version years. Family names should
+                only contain letters, numbers, and dashes.
+              </p>
+            </HelpTip>
           </label>
-        )}
-
-        {this.props.isCourse && (
-          <div>
-            <label>
-              Family Name
-              <select
-                value={this.state.selectedFamilyName}
-                style={styles.dropdown}
-                className="familyNameSelector"
-                disabled={
-                  this.props.preventCourseVersionChange ||
-                  !!this.state.newFamilyName
-                }
-                onChange={this.onFamilyNameSelect}
-              >
-                <option value="">(None)</option>
-                {this.props.families.map(familyOption => (
-                  <option key={familyOption} value={familyOption}>
-                    {familyOption}
-                  </option>
-                ))}
-              </select>
-              {!this.props.preventCourseVersionChange && (
-                <span>
-                  or{' '}
-                  <input
-                    type="text"
-                    value={this.state.newFamilyName}
-                    style={styles.smallInput}
-                    onChange={this.handleNewFamilyNameChange}
-                  />
-                </span>
-              )}
-              <HelpTip>
-                <p>
-                  The family name is used to group together courses that are
-                  different version years of the same course so that users can
-                  be redirected between different version years. Family names
-                  should only contain letters, numbers, and dashes.
-                </p>
-              </HelpTip>
-            </label>
-            <label>
-              Version Year
-              <select
-                value={this.props.versionYear}
-                style={styles.dropdown}
-                className="versionYearSelector"
-                onChange={event =>
-                  this.props.updateVersionYear(event.target.value)
-                }
-                disabled={this.props.preventCourseVersionChange}
-              >
-                <option value="">(None)</option>
-                {this.props.versionYearOptions.map(year => (
-                  <option key={year} value={year}>
-                    {year}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-        )}
+          <label>
+            Version Year
+            <select
+              value={this.props.versionYear}
+              style={styles.dropdown}
+              className="versionYearSelector"
+              onChange={event =>
+                this.props.updateVersionYear(event.target.value)
+              }
+              disabled={this.props.preventCourseVersionChange}
+            >
+              <option value="">(None)</option>
+              {this.props.versionYearOptions.map(year => (
+                <option key={year} value={year}>
+                  {year}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        )
         <label>
           Published State
           <select

--- a/apps/src/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -167,7 +167,6 @@ export default class CourseVersionPublishingEditor extends Component {
             </select>
           </label>
         </div>
-        )
         <label>
           Published State
           <select

--- a/apps/src/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/levelbuilder/course-editor/CourseEditor.js
@@ -375,7 +375,6 @@ class CourseEditor extends Component {
               this.props.initialVersionYear !== '' ||
               this.props.initialFamilyName !== ''
             }
-            isCourse
             courseOfferingEditorLink={this.props.courseOfferingEditorLink}
           />
         </CollapsibleEditorSection>

--- a/apps/src/levelbuilder/course-editor/ResourcesEditor.js
+++ b/apps/src/levelbuilder/course-editor/ResourcesEditor.js
@@ -30,9 +30,7 @@ export default class ResourcesEditor extends Component {
     if (!this.props.courseVersionId) {
       return (
         <strong>
-          Cannot add resources to migrated unit without course version. A unit
-          must belong to a course or have 'Is a Standalone Unit' checked to have
-          a course version.
+          A unit must belong to a course in order to add resources.
         </strong>
       );
     }

--- a/apps/src/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -404,9 +404,7 @@ class LessonEditor extends Component {
                 />
               ) : (
                 <h4>
-                  A unit must be in a course version, i.e. a unit must belong to
-                  a course or have 'Is a Standalone Course' checked, in order to
-                  add resources.
+                  A unit must belong to a course in order to add resources.
                 </h4>
               )}
             </CollapsibleEditorSection>
@@ -421,11 +419,7 @@ class LessonEditor extends Component {
                   courseVersionId={unitInfo.courseVersionId}
                 />
               ) : (
-                <h4>
-                  A unit must be in a course version, i.e. a unit must belong to
-                  a course or have 'Is a Standalone Course' checked, in order to
-                  add vocabulary.
-                </h4>
+                <h4>A unit belong to a course in order to add vocabulary.</h4>
               )}
             </CollapsibleEditorSection>
 

--- a/apps/src/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -419,7 +419,9 @@ class LessonEditor extends Component {
                   courseVersionId={unitInfo.courseVersionId}
                 />
               ) : (
-                <h4>A unit belong to a course in order to add vocabulary.</h4>
+                <h4>
+                  A unit must belong to a course in order to add vocabulary.
+                </h4>
               )}
             </CollapsibleEditorSection>
 

--- a/apps/src/levelbuilder/unit-editor/NewUnitForm.jsx
+++ b/apps/src/levelbuilder/unit-editor/NewUnitForm.jsx
@@ -6,7 +6,6 @@ import HelpTip from '@cdo/apps/sharedComponents/HelpTip';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 
 export default function NewUnitForm(props) {
-  const [isCourse, setIsCourse] = useState('');
   const [submitDialogOpen, setSubmitDialogOpen] = useState(false);
 
   const savingDetailsAndButton = React.useCallback(
@@ -58,68 +57,21 @@ export default function NewUnitForm(props) {
   return (
     <form action="/s" method="post">
       <RailsAuthenticityToken />
-      <label>
-        Is this unit going to be a standalone unit or part of a course with
-        multiple units?
-        <select
-          style={styles.dropdown}
-          value={isCourse}
-          className="isCourseSelector"
-          onChange={e => setIsCourse(e.target.value)}
-        >
-          <option key={'empty'} value={''}>
-            {''}
-          </option>
-          <option key={'multi-unit'} value={'false'}>
-            {'Part of a course'}
-          </option>
-          <option key={'single-unit'} value={'true'}>
-            {'Standalone unit'}
-          </option>
-        </select>
-        <HelpTip>
-          <p>
-            Standalone units are designed to exist on their own. Use this when
-            the unit won't appear inside of a Course with /courses/ in the URL.
-          </p>
-          <p>
-            Units inside a course can be found within a Course that has a
-            /courses/ URL and shares resources between other units in that
-            course.
-          </p>
-          <p>
-            For example: How AI Works is a standalone unit, but CSD Unit 1 is
-            contained within the CSD course.
-          </p>
-        </HelpTip>
-      </label>
-      {isCourse === 'true' && (
-        <div>
-          <p>
-            To create a standalone unit, please{' '}
-            <a href="/courses/new">create a new course</a> first. Then, come
-            back to this page and create a unit that is "Part of a Course" which
-            has the same name (url slug) as the course.
-          </p>
-        </div>
-      )}
-      {isCourse === 'false' && (
-        <div>
-          <label>
-            Unit Slug
-            <HelpTip>
-              <p>
-                The unit slug is used to create the link to the unit. It is in
-                the format of studio.code.org/s/unit-slug-here. A unit slug can
-                only contain lowercase letters, numbers and dashes. Once you set
-                the slug it can not be updated.
-              </p>
-            </HelpTip>
-            <input name="script[name]" />
-          </label>
-          {savingDetailsAndButton()}
-        </div>
-      )}
+      <div>
+        <label>
+          Unit Slug
+          <HelpTip>
+            <p>
+              The unit slug is used to create the link to the unit. It is in the
+              format of studio.code.org/s/unit-slug-here. A unit slug can only
+              contain lowercase letters, numbers and dashes. Once you set the
+              slug it can not be updated.
+            </p>
+          </HelpTip>
+          <input name="script[name]" />
+        </label>
+        {savingDetailsAndButton()}
+      </div>
       {submitDialog()}
     </form>
   );

--- a/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
@@ -37,7 +37,7 @@ import {linkWithQueryParams, navigateToHref} from '@cdo/apps/utils';
 import {lessonGroupShape} from './shapes';
 
 /**
- * Component for editing units in unit_groups or stand alone courses
+ * Component for editing units
  */
 class UnitEditor extends React.Component {
   static propTypes = {
@@ -95,7 +95,6 @@ class UnitEditor extends React.Component {
     isLevelbuilder: PropTypes.bool,
     initialTts: PropTypes.bool,
     hasCourse: PropTypes.bool,
-    initialIsCourse: PropTypes.bool,
     initialShowCalendar: PropTypes.bool,
     initialWeeklyInstructionalMinutes: PropTypes.number,
     isMigrated: PropTypes.bool,
@@ -126,7 +125,6 @@ class UnitEditor extends React.Component {
       ttsDialogOpen: false,
       familyName: this.props.initialFamilyName,
       savedFamilyName: this.props.initialFamilyName,
-      isCourse: this.props.initialIsCourse,
       showCalendar: this.props.initialShowCalendar,
       weeklyInstructionalMinutes:
         this.props.initialWeeklyInstructionalMinutes || '',
@@ -223,16 +221,6 @@ class UnitEditor extends React.Component {
           'Please provide a positive number of instructional minutes per week in Unit Calendar Settings.',
       });
       return;
-    } else if (
-      this.state.isCourse &&
-      ((this.state.versionYear !== '' && this.state.familyName === '') ||
-        (this.state.versionYear === '' && this.state.familyName !== ''))
-    ) {
-      this.setState({
-        isSaving: false,
-        error: 'Please set both version year and family name.',
-      });
-      return;
     }
 
     if (
@@ -255,7 +243,6 @@ class UnitEditor extends React.Component {
     let dataToSave = {
       name: this.props.name,
       family_name: this.state.familyName,
-      is_course: this.state.isCourse,
       show_calendar: this.state.showCalendar,
       weekly_instructional_minutes: parseInt(
         this.state.weeklyInstructionalMinutes

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -82,10 +82,6 @@ export default function initPage(unitEditorData) {
         versionYearOptions={unitEditorData.version_year_options}
         isLevelbuilder={unitEditorData.is_levelbuilder}
         initialTts={scriptData.tts}
-        /* isCourse controls whether this Script/Unit is intended to be the root of a CourseOffering version.
-         * hasCourse indicates whether this Script/Unit is part of a UnitGroup. These two in theory should be
-         * complements, but currently (August 2020) they are not, so they are separate fields for now. */
-        initialIsCourse={scriptData.is_course}
         hasCourse={unitEditorData.has_course}
         initialShowCalendar={scriptData.showCalendar}
         initialWeeklyInstructionalMinutes={

--- a/apps/test/unit/levelbuilder/CourseVersionPublishingEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/CourseVersionPublishingEditorTest.jsx
@@ -9,14 +9,12 @@ describe('CourseVersionPublishingEditor', () => {
     updatePilotExperiment,
     updateFamilyName,
     updatePublishedState,
-    updateVersionYear,
-    updateIsCourse;
+    updateVersionYear;
 
   beforeEach(() => {
     updatePilotExperiment = jest.fn();
     updateFamilyName = jest.fn();
     updateVersionYear = jest.fn();
-    updateIsCourse = jest.fn();
     updatePublishedState = jest.fn();
     defaultProps = {
       pilotExperiment: null,
@@ -25,7 +23,6 @@ describe('CourseVersionPublishingEditor', () => {
       updatePilotExperiment,
       updateFamilyName,
       updateVersionYear,
-      updateIsCourse,
       updatePublishedState,
       families: ['family1', 'family2', 'family3'],
       versionYearOptions: ['1990', '1991', '1992'],
@@ -277,27 +274,16 @@ describe('CourseVersionPublishingEditor', () => {
     const wrapper = shallow(
       <CourseVersionPublishingEditor
         {...defaultProps}
-        showIsCourseSelector
-        isCourse
         preventCourseVersionChange
       />
     );
-    expect(wrapper.find('.isCourseCheckbox').props().disabled).toBe(true);
     expect(wrapper.find('.familyNameSelector').props().disabled).toBe(true);
     expect(wrapper.find('.versionYearSelector').props().disabled).toBe(true);
   });
 
-  it('hides family name and version year selectors if isCourse is false', () => {
+  it('shows family name and version year selectors', () => {
     const wrapper = shallow(
-      <CourseVersionPublishingEditor {...defaultProps} isCourse={false} />
-    );
-    expect(wrapper.find('.familyNameSelector').length).toBe(0);
-    expect(wrapper.find('.versionYearSelector').length).toBe(0);
-  });
-
-  it('shows family name and version year selectors when isCourse is true', () => {
-    const wrapper = shallow(
-      <CourseVersionPublishingEditor {...defaultProps} isCourse />
+      <CourseVersionPublishingEditor {...defaultProps} />
     );
     expect(wrapper.find('.familyNameSelector').length).toBe(1);
     expect(wrapper.find('.versionYearSelector').length).toBe(1);
@@ -305,7 +291,7 @@ describe('CourseVersionPublishingEditor', () => {
 
   it('disables family name selector if inputting new family name', () => {
     const wrapper = shallow(
-      <CourseVersionPublishingEditor {...defaultProps} isCourse />
+      <CourseVersionPublishingEditor {...defaultProps} />
     );
     wrapper
       .instance()

--- a/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -542,7 +542,7 @@ describe('UnitEditor', () => {
     });
 
     it('saves successfully if unit is not a course and only version year is set', () => {
-      const wrapper = createWrapper({initialIsCourse: false});
+      const wrapper = createWrapper();
 
       const unitEditor = wrapper.find('UnitEditor');
       unitEditor.setState({
@@ -584,121 +584,6 @@ describe('UnitEditor', () => {
       //check that last saved message is showing
       expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
       server.restore();
-    });
-
-    it('shows error when version year is set but family name is not', () => {
-      sinon.stub($, 'ajax');
-      const wrapper = createWrapper({initialIsCourse: true});
-
-      const unitEditor = wrapper.find('UnitEditor');
-      unitEditor.setState({
-        versionYear: '1991',
-        familyName: '',
-      });
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
-      saveAndKeepEditingButton.simulate('click');
-
-      expect($.ajax).to.not.have.been.called;
-
-      expect(unitEditor.state().isSaving).to.equal(false);
-      expect(unitEditor.state().error).to.equal(
-        'Please set both version year and family name.'
-      );
-
-      expect(
-        wrapper
-          .find('.saveBar')
-          .contains(
-            'Error Saving: Please set both version year and family name.'
-          )
-      ).to.be.true;
-
-      $.ajax.restore();
-    });
-
-    it('saves successfully when moving standalone unit out of in development if professional learning course', () => {
-      sinon.stub(window, 'confirm').callsFake(() => true);
-      const wrapper = createWrapper({initialIsCourse: false, hasCourse: false});
-
-      const unitEditor = wrapper.find('UnitEditor');
-      unitEditor.setState({
-        publishedState: 'beta',
-        deeperLearningCourse: 'new-pl-course',
-      });
-
-      let returnData = {scriptPath: '/s/test-unit'};
-      let server = sinon.fakeServer.create();
-      server.respondWith('PUT', `/s/1`, [
-        200,
-        {'Content-Type': 'application/json'},
-        JSON.stringify(returnData),
-      ]);
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
-      saveAndKeepEditingButton.simulate('click');
-
-      // check that the spinner is showing
-      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
-      expect(unitEditor.state().isSaving).to.equal(true);
-
-      clock = sinon.useFakeTimers(new Date('2020-12-01'));
-      const expectedLastSaved = Date.now();
-      server.respond();
-      clock.tick(50);
-
-      unitEditor.update();
-      expect(utils.navigateToHref).to.not.have.been.called;
-      expect(unitEditor.state().isSaving).to.equal(false);
-      expect(unitEditor.state().lastSaved).to.equal(expectedLastSaved);
-      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
-      //check that last saved message is showing
-      expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
-      server.restore();
-      window.confirm.restore();
-    });
-
-    it('shows error when family name is set but version year is not', () => {
-      sinon.stub($, 'ajax');
-      const wrapper = createWrapper({initialIsCourse: true});
-
-      const unitEditor = wrapper.find('UnitEditor');
-      unitEditor.setState({
-        versionYear: '',
-        familyName: 'new-family-name',
-      });
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
-      saveAndKeepEditingButton.simulate('click');
-
-      expect($.ajax).to.not.have.been.called;
-
-      expect(unitEditor.state().isSaving).to.equal(false);
-      expect(unitEditor.state().error).to.equal(
-        'Please set both version year and family name.'
-      );
-
-      expect(
-        wrapper
-          .find('.saveBar')
-          .contains(
-            'Error Saving: Please set both version year and family name.'
-          )
-      ).to.be.true;
-
-      $.ajax.restore();
     });
 
     it('can save and close', () => {

--- a/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -6,12 +6,7 @@ import {Provider} from 'react-redux';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
-import {
-  PublishedState,
-  InstructionType,
-  InstructorAudience,
-  ParticipantAudience,
-} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
+import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import createResourcesReducer, {
   initResources,
 } from '@cdo/apps/levelbuilder/lesson-editor/resourcesEditorRedux';
@@ -74,17 +69,11 @@ describe('UnitEditor', () => {
       locales: [],
       name: 'test-unit',
       unitFamilies: [],
-      versionYearOptions: [],
-      initialFamilyName: '',
-      initialVersionYear: '',
       initialProjectSharing: false,
       initialLocales: [],
       isMigrated: false,
       initialPublishedState: PublishedState.in_development,
       initialHideWithinCourse: false,
-      initialInstructionType: InstructionType.teacher_led,
-      initialInstructorAudience: InstructorAudience.teacher,
-      initialParticipantAudience: ParticipantAudience.student,
       initialSupportedLocales: [],
       initialTopicTags: [],
       hasCourse: false,

--- a/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -6,7 +6,12 @@ import {Provider} from 'react-redux';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
-import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
+import {
+  PublishedState,
+  InstructionType,
+  InstructorAudience,
+  ParticipantAudience,
+} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import createResourcesReducer, {
   initResources,
 } from '@cdo/apps/levelbuilder/lesson-editor/resourcesEditorRedux';
@@ -69,11 +74,17 @@ describe('UnitEditor', () => {
       locales: [],
       name: 'test-unit',
       unitFamilies: [],
+      versionYearOptions: [],
+      initialFamilyName: '',
+      initialVersionYear: '',
       initialProjectSharing: false,
       initialLocales: [],
       isMigrated: false,
       initialPublishedState: PublishedState.in_development,
       initialHideWithinCourse: false,
+      initialInstructionType: InstructionType.teacher_led,
+      initialInstructorAudience: InstructorAudience.teacher,
+      initialParticipantAudience: ParticipantAudience.student,
       initialSupportedLocales: [],
       initialTopicTags: [],
       hasCourse: false,

--- a/apps/test/unit/levelbuilder/unit-editor/NewUnitFormTest.jsx
+++ b/apps/test/unit/levelbuilder/unit-editor/NewUnitFormTest.jsx
@@ -1,4 +1,4 @@
-import {mount, shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
 import NewUnitForm from '@cdo/apps/levelbuilder/unit-editor/NewUnitForm';
@@ -24,87 +24,15 @@ describe('NewUnitFormTest', () => {
     };
   });
 
-  it('can not create a new standalone unit', () => {
-    const wrapper = mount(<NewUnitForm {...defaultProps} />);
-    expect(wrapper.find('button').length).toBe(0);
-    expect(wrapper.find('NewCourseFields').length).toBe(0);
-    expect(wrapper.find('.isCourseSelector').length).toBe(1);
-
-    wrapper
-      .find('.isCourseSelector')
-      .simulate('change', {target: {value: 'true'}});
-
-    expect(wrapper.text()).toContain(
-      'To create a standalone unit, please create a new course first.'
-    );
-  });
-
   it('can create a new unit for multi unit course', () => {
     const wrapper = shallow(<NewUnitForm {...defaultProps} />);
-    expect(wrapper.find('div.savingDetailsAndButton').length).toBe(0);
-    expect(wrapper.find('NewCourseFields').length).toBe(0);
-    expect(wrapper.find('.isCourseSelector').length).toBe(1);
-
-    wrapper
-      .find('.isCourseSelector')
-      .simulate('change', {target: {value: 'false'}});
-
     expect(wrapper.find('NewCourseFields').length).toBe(0);
     expect(wrapper.find('div.savingDetailsAndButton').length).toBe(1);
     expect(wrapper.find('[name="script[name]"]').length).toBe(1);
-  });
-
-  it('resetting isCourseSelector hides standalone unit instruction text', () => {
-    const wrapper = shallow(<NewUnitForm {...defaultProps} />);
-    expect(wrapper.find('div.savingDetailsAndButton').length).toBe(0);
-    expect(wrapper.find('NewCourseFields').length).toBe(0);
-    expect(wrapper.find('.isCourseSelector').length).toBe(1);
-
-    wrapper
-      .find('.isCourseSelector')
-      .simulate('change', {target: {value: 'true'}});
-
-    expect(wrapper.text()).toContain(
-      'To create a standalone unit, please create a new course first.'
-    );
-
-    wrapper.find('.isCourseSelector').simulate('change', {target: {value: ''}});
-
-    expect(wrapper.text()).not.toContain(
-      'To create a standalone unit, please create a new course first.'
-    );
-  });
-
-  it('resetting isCourseSelector hides save button', () => {
-    const wrapper = shallow(<NewUnitForm {...defaultProps} />);
-    expect(wrapper.find('div.savingDetailsAndButton').length).toBe(0);
-    expect(wrapper.find('NewCourseFields').length).toBe(0);
-    expect(wrapper.find('.isCourseSelector').length).toBe(1);
-
-    wrapper
-      .find('.isCourseSelector')
-      .simulate('change', {target: {value: 'false'}});
-
-    expect(wrapper.find('NewCourseFields').length).toBe(0);
-    expect(wrapper.find('div.savingDetailsAndButton').length).toBe(1);
-    expect(wrapper.find('[name="script[name]"]').length).toBe(1);
-
-    wrapper.find('.isCourseSelector').simulate('change', {target: {value: ''}});
-
-    expect(wrapper.find('NewCourseFields').length).toBe(0);
-    expect(wrapper.find('div.savingDetailsAndButton').length).toBe(0);
-    expect(wrapper.find('[name="script[name]"]').length).toBe(0);
   });
 
   it('hitting save opens submit confirmation dialog', () => {
     const wrapper = shallow(<NewUnitForm {...defaultProps} />);
-    expect(wrapper.find('div.savingDetailsAndButton').length).toBe(0);
-    expect(wrapper.find('NewCourseFields').length).toBe(0);
-    expect(wrapper.find('.isCourseSelector').length).toBe(1);
-
-    wrapper
-      .find('.isCourseSelector')
-      .simulate('change', {target: {value: 'false'}});
 
     expect(wrapper.find('BaseDialog').props().isOpen).toBe(false);
 

--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/new_unit_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/new_unit_page.feature
@@ -4,9 +4,7 @@ Feature: Using the New Unit Page
   Scenario: Create a new unit
     Given I create a levelbuilder named "Levi"
     And I am on "http://studio.code.org/s/new"
-    And I wait until element ".isCourseSelector" is visible
 
-    When I select the "Part of a course" option in dropdown with class "isCourseSelector"
     And I wait until element "input[name='script[name]']" is visible
     And I enter a temp unit name
     And I click "button[type='button']"


### PR DESCRIPTION
This PR removes references to standalone units when creating and editing units and courses.
|                            | Before                                                                                                                                                             | After                                                                                                                                                             |
|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| New Unit                   | <img width="1004" height="189" alt="Screenshot 2025-08-04 at 10 05 58 AM" src="https://github.com/user-attachments/assets/8f3fb1bd-f854-4fc7-8fba-2e7b5ccd4003" /> | <img width="560" height="222" alt="Screenshot 2025-08-04 at 10 21 39 AM" src="https://github.com/user-attachments/assets/88295640-a40a-4560-a184-6ad3d8bae880" /> |
| Edit Unit/Course Resources | <img width="990" height="278" alt="unit-edit-resources" src="https://github.com/user-attachments/assets/606a59e5-2d24-4899-8461-d41840e482a5" />                   | <img width="649" height="278" alt="Screenshot 2025-08-04 at 10 20 37 AM" src="https://github.com/user-attachments/assets/08028dec-a150-4192-a19d-5f0d4ae2866b" /> |
| Edit Lesson                | <img width="1129" height="261" alt="lesson-edit" src="https://github.com/user-attachments/assets/089631b8-3645-44f7-8b64-a909a1ac698a" />                          | <img width="507" height="245" alt="Screenshot 2025-08-04 at 10 22 00 AM" src="https://github.com/user-attachments/assets/e435558e-b97c-4da6-8f81-21aedbd26648" /> |

## Links
- Jira: [TEACH-1830](https://codedotorg.atlassian.net/browse/TEACH-1830)


## Testing story
- `UnitEditorTest.jsx`, `NewUnitFormTest.jsx`, `CourseVersionPublishingEditorTest.jsx` and `new_unit_page.feature` updated to reflect the above changes


## Follow-up work
We need to remove some more backend references to properties that are no longer associated with units
- Cleanup Unit Edit Page: [TEACH-1761](https://codedotorg.atlassian.net/browse/TEACH-1761)
