### PR TITLE
Revert "Revert "Add accessibility settings modal to other Blockly Labs""

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -83,6 +83,7 @@ import {
 import * as shareWarnings from './shareWarnings';
 import Sounds from './Sounds';
 import ChallengeDialog from './templates/ChallengeDialog';
+import SettingsModal from './templates/Settings';
 import VersionHistory from './templates/VersionHistory';
 import color from './util/color';
 import KeyHandler from './util/KeyHandler';
@@ -582,28 +583,8 @@ StudioApp.prototype.init = function (config) {
     );
   }
 
+  this.initSettingsUI();
   this.initVersionHistoryUI(config);
-
-  if (this.isUsingBlockly() && Blockly.contractEditor) {
-    Blockly.contractEditor.registerTestsFailedOnCloseHandler(
-      function () {
-        this.feedback_.showSimpleDialog({
-          headerText: undefined,
-          bodyText: msg.examplesFailedOnClose(),
-          cancelText: msg.ignore(),
-          confirmText: msg.tryAgain(),
-          onConfirm: null,
-          onCancel: function () {
-            Blockly.contractEditor.hideIfOpen();
-          },
-        });
-
-        // return true to indicate to blockly-core that we'll own closing the
-        // contract editor
-        return true;
-      }.bind(this)
-    );
-  }
 
   if (config.legacyShareStyle && config.hideSource) {
     this.setupLegacyShareView();
@@ -752,6 +733,19 @@ StudioApp.prototype.alertIfCompletedWhilePairing = function (config) {
   }
 };
 
+StudioApp.prototype.getSettingsHandler = function () {
+  return () => {
+    const contentDiv = document.createElement('div');
+    const dialog = this.createModalDialog({
+      contentDiv: contentDiv,
+      id: 'settings-modal',
+    });
+
+    ReactDOM.render(React.createElement(SettingsModal), contentDiv);
+    dialog.show();
+  };
+};
+
 StudioApp.prototype.getVersionHistoryHandler = function (config) {
   return () => {
     var contentDiv = document.createElement('div');
@@ -781,6 +775,13 @@ StudioApp.prototype.initTimeSpent = function () {
     this.silentlyReport.bind(this),
     1000
   );
+};
+
+StudioApp.prototype.initSettingsUI = function () {
+  const settingsButton = document.getElementById('settings-header');
+  if (settingsButton) {
+    dom.addClickTouchEvent(settingsButton, this.getSettingsHandler());
+  }
 };
 
 StudioApp.prototype.initVersionHistoryUI = function (config) {
@@ -2896,21 +2897,7 @@ StudioApp.prototype.setStartBlocks_ = function (config, loadLastAttempt) {
  * @param {AppOptionsConfig}
  */
 StudioApp.prototype.openFunctionDefinition_ = function (config) {
-  if (Blockly.contractEditor) {
-    Blockly.contractEditor.autoOpenWithLevelConfiguration({
-      autoOpenFunction: config.level.openFunctionDefinition,
-      contractCollapse: config.level.contractCollapse,
-      contractHighlight: config.level.contractHighlight,
-      examplesCollapse: config.level.examplesCollapse,
-      examplesHighlight: config.level.examplesHighlight,
-      definitionCollapse: config.level.definitionCollapse,
-      definitionHighlight: config.level.definitionHighlight,
-    });
-  } else {
-    Blockly.functionEditor.autoOpenFunction(
-      config.level.openFunctionDefinition
-    );
-  }
+  Blockly.functionEditor.autoOpenFunction(config.level.openFunctionDefinition);
 };
 
 /**

--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -7,9 +7,8 @@ import * as GoogleBlockly from 'blockly/core';
 import {commonI18n} from '@cdo/apps/types/locale';
 
 import LegacyDialog from '../../code-studio/LegacyDialog';
-import {Themes, MenuOptionStates, BLOCK_TYPES} from '../constants';
+import {MenuOptionStates, BLOCK_TYPES} from '../constants';
 import {ExtendedBlockSvg} from '../types';
-import {getBaseName, setWorkspaceTheme} from '../utils';
 
 // Some options are only available to levelbuilders via start mode.
 // Literal strings are used for display text instead of translatable strings
@@ -394,75 +393,6 @@ const registerAllBlocksUnmovable = function (weight: number) {
   );
 };
 
-const themes = [
-  {
-    name: Themes.MODERN,
-    label: commonI18n.blocklyModernTheme(),
-  },
-  {
-    name: Themes.HIGH_CONTRAST,
-    label: commonI18n.blocklyHighContrastTheme(),
-  },
-  {
-    name: Themes.PROTANOPIA,
-    label: commonI18n.blocklyProtanopiaTheme(),
-  },
-  {
-    name: Themes.DEUTERANOPIA,
-    label: commonI18n.blocklyDeuteranopiaTheme(),
-  },
-  {
-    name: Themes.TRITANOPIA,
-    label: commonI18n.blocklyTritanopiaTheme(),
-  },
-];
-/**
- * Change workspace theme to specified theme
- */
-const registerTheme = function (name: Themes, label: string, weight: number) {
-  const themeOption = {
-    displayText: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
-      return (
-        (isCurrentTheme(name, scope.workspace)
-          ? '✓ '
-          : `${commonI18n.enable()} `) + label
-      );
-    },
-    preconditionFn: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
-      if (Blockly.isJigsaw) {
-        // Jigsaw uses its own custom theme with an extra large font size.
-        // Blocks use hard-coded colors instead of styles, so switching
-        // palettes is not possible.
-        return MenuOptionStates.HIDDEN;
-      }
-      if (isCurrentTheme(name, scope.workspace)) {
-        return MenuOptionStates.DISABLED;
-      } else {
-        return MenuOptionStates.ENABLED;
-      }
-    },
-    callback: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
-      if (!scope.workspace) {
-        return;
-      }
-      setWorkspaceTheme(scope.workspace, name);
-    },
-    scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,
-    id: name + 'ThemeOption',
-    weight,
-  };
-  GoogleBlockly.ContextMenuRegistry.registry.register(themeOption);
-};
-
-function registerThemes(
-  weight: number,
-  themes: {name: Themes; label: string}[]
-) {
-  themes.forEach(theme => {
-    registerTheme(theme.name, theme.label, weight);
-  });
-}
-
 /**
  * Option to open help for a block.
  */
@@ -551,15 +481,6 @@ function clearShadowState(block: GoogleBlockly.Block) {
   });
 }
 
-function isCurrentTheme(
-  theme: Themes,
-  workspace: GoogleBlockly.WorkspaceSvg | undefined
-) {
-  return (
-    getBaseName(workspace?.getTheme().name as Themes) === getBaseName(theme)
-  );
-}
-
 /**
  * Unregister some default options. We do this either because the options are needlessly
  * advanced for our target users or because the options have undesired impacts.
@@ -626,7 +547,6 @@ function registerCustomWorkspaceOptions() {
 
   // Custom workspace options. We increment the weight for each so they are automatically
   // sorted in the order listed here. The ++ incrementation happens after the value is accessed.
-  registerThemes(nextWeight++, themes);
   registerAllBlocksUndeletable(nextWeight++);
   registerAllBlocksUneditable(nextWeight++);
   registerAllBlocksUnmovable(nextWeight++);

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -89,7 +89,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('BlockValueType');
   blocklyWrapper.wrapReadOnlyProperty('common_locale');
   blocklyWrapper.wrapReadOnlyProperty('Connection');
-  blocklyWrapper.wrapReadOnlyProperty('contractEditor');
   blocklyWrapper.wrapReadOnlyProperty('createSvgElement');
   blocklyWrapper.wrapReadOnlyProperty('Css');
   blocklyWrapper.wrapReadOnlyProperty('disableVariableEditing');

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -185,7 +185,6 @@ export const READ_ONLY_PROPERTIES = [
   'ConnectionType',
   'ContextMenu',
   'ContextMenuRegistry',
-  'contractEditor',
   'createBlockDefinitionsFromJsonArray',
   'Css',
   'Cursor',

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -77,6 +77,10 @@ export function setupApp(appOptions) {
         );
       }
 
+      if (appSupportsSettings(appOptions.app, appOptions.droplet)) {
+        $('#settings-header').show();
+      }
+
       if (
         appOptions.level.projectTemplateLevelName ||
         appOptions.app === 'applab' ||
@@ -234,6 +238,28 @@ export function setupApp(appOptions) {
   // stopped being able to use the user agent on the server, and thus try
   // to have the same logic on the client.
   appOptions.noPadding = userAgentParser.isMobile();
+}
+
+/**
+ * Checks if the given app name supports settings.
+ * Currently this is just Blockly labs that support changing the Blockly theme.
+ * @param {string} appName
+ * @param {boolean} droplet
+ * @returns {boolean}
+ */
+function appSupportsSettings(appName, droplet) {
+  const supportedApps = [
+    'bounce',
+    'craft',
+    'dance',
+    'flappy',
+    'poetry',
+    'spritelab',
+    'studio',
+    'turtle',
+  ];
+  // Star Wars Edit Code is considered 'studio' but does not use Blockly.
+  return supportedApps.includes(appName) && !droplet;
 }
 
 /**

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -235,6 +235,14 @@ class CodeWorkspace extends React.Component {
               isRtl={isRtl}
               isMinecraft={props.isMinecraft}
             />
+            <PaneButton
+              id="settings-header"
+              headerHasFocus={hasFocus}
+              iconClass="fa fa-cog"
+              label={'Settings'}
+              isRtl={isRtl}
+              isMinecraft={props.isMinecraft}
+            />
             <PaneSection id="workspace-header">
               {props.showProjectTemplateWorkspaceIcon && (
                 <ProjectTemplateWorkspaceIcon />

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -178,6 +178,9 @@ export const PaneButton = Radium(function (props) {
 
   function onKeyDownWrapper(event) {
     const {onClick} = props;
+    if (!onClick) {
+      return;
+    }
     if (
       event.key === ' ' ||
       event.key === 'Enter' ||

--- a/apps/src/templates/Settings.jsx
+++ b/apps/src/templates/Settings.jsx
@@ -1,0 +1,59 @@
+import SimpleDropdown from '@code-dot-org/component-library/dropdown/simpleDropdown';
+import React, {useState, useEffect} from 'react';
+
+import {BLOCKLY_THEME, Themes} from '@cdo/apps/blockly/constants';
+import commonI18n from '@cdo/locale';
+
+import {setAllWorkspacesTheme} from '../blockly/utils';
+import UserPreferences from '../lib/util/UserPreferences';
+
+import styles from './settings.module.scss';
+
+const themeOptions = [
+  {value: Themes.MODERN, text: commonI18n.blocklyModernTheme()},
+  {value: Themes.HIGH_CONTRAST, text: commonI18n.blocklyHighContrastTheme()},
+  {value: Themes.PROTANOPIA, text: commonI18n.blocklyProtanopiaTheme()},
+  {value: Themes.DEUTERANOPIA, text: commonI18n.blocklyDeuteranopiaTheme()},
+  {value: Themes.TRITANOPIA, text: commonI18n.blocklyTritanopiaTheme()},
+];
+
+const SettingsModal = () => {
+  const [selectedTheme, setSelectedTheme] = useState(undefined);
+
+  useEffect(() => {
+    new UserPreferences()
+      .getBlocklyTheme(() => ({
+        blockly: localStorage.getItem(BLOCKLY_THEME) || Themes.MODERN,
+      }))
+      .then(theme => setSelectedTheme(theme));
+  }, []);
+
+  const handleChange = value => {
+    const theme = Blockly.themes[value];
+    if (theme) {
+      setSelectedTheme(value);
+      setAllWorkspacesTheme(theme, Blockly.getMainWorkspace()?.getTheme());
+      new UserPreferences().setBlocklyTheme(value, () =>
+        localStorage.setItem(BLOCKLY_THEME, value)
+      );
+    }
+  };
+
+  return (
+    <div className="modal-content" style={{margin: 0}}>
+      <h5 className="dialog-title">{commonI18n.settings()}</h5>
+      <div className={styles.settingsRow}>
+        <p>{commonI18n.blocklyTheme()}</p>
+        <SimpleDropdown
+          name="theme"
+          items={themeOptions}
+          selectedValue={selectedTheme}
+          onChange={e => handleChange(e.target.value)}
+          isLabelVisible={false}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SettingsModal;

--- a/apps/src/templates/Settings.jsx
+++ b/apps/src/templates/Settings.jsx
@@ -1,4 +1,3 @@
-import SimpleDropdown from '@code-dot-org/component-library/dropdown/simpleDropdown';
 import React, {useState, useEffect} from 'react';
 
 import {BLOCKLY_THEME, Themes} from '@cdo/apps/blockly/constants';
@@ -44,13 +43,16 @@ const SettingsModal = () => {
       <h5 className="dialog-title">{commonI18n.settings()}</h5>
       <div className={styles.settingsRow}>
         <p>{commonI18n.blocklyTheme()}</p>
-        <SimpleDropdown
-          name="theme"
-          items={themeOptions}
-          selectedValue={selectedTheme}
+        <select
+          value={selectedTheme}
           onChange={e => handleChange(e.target.value)}
-          isLabelVisible={false}
-        />
+        >
+          {themeOptions.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.text}
+            </option>
+          ))}
+        </select>
       </div>
     </div>
   );

--- a/apps/src/templates/settings.module.scss
+++ b/apps/src/templates/settings.module.scss
@@ -1,0 +1,6 @@
+.settingsRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+}

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1042,6 +1042,11 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
   }
 }
 
+// Hidden by default. Manually shown for Blockly labs only (loadApp.js)
+#settings-header {
+  display: none;
+}
+
 #versions-header {
   display: none;
 }


### PR DESCRIPTION
Second attempt of: 
- https://github.com/code-dot-org/code-dot-org/pull/67470

Replaces the `<SimpleDropdown/>` with a common `<select/>` which somehow prevents certain text in the Teacher panel from becoming aligned incorrectly. https://github.com/code-dot-org/code-dot-org/pull/67508/commits/5393912f6fa47dee43a384a99f76d5125d827373

Before:
<img width="1333" height="540" alt="image" src="https://github.com/user-attachments/assets/0b6eee26-ed58-4c05-9ea5-d92e3924fe91" />

After:
<img width="356" height="446" alt="image" src="https://github.com/user-attachments/assets/3ae4b9dc-8cff-4848-869f-c3302d07b781" />

Note that the text `Sort by:` in the teacher panel is once again centered as expected. 