### PR TITLE
Make Web Lab 2 panels all resizable

### DIFF
--- a/apps/src/codebridge/FilePreview/HTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreview.tsx
@@ -1,5 +1,6 @@
 import {ProjectFile} from '@codebridge/types';
 import {findFolder} from '@codebridge/utils';
+import classNames from 'classnames';
 import React, {useRef, useMemo} from 'react';
 
 import {MultiFileSource} from '@cdo/apps/lab2/types';
@@ -16,6 +17,7 @@ export const HTMLPreview = ({file}: HTMLPreviewProps) => {
   const {files, folders} = useAppSelector(
     state => state.lab2Project.projectSources?.source as MultiFileSource
   );
+  const isResizing = useAppSelector(state => state.lab2View.isResizing);
 
   const srcdoc = useMemo(() => {
     if (!file) {
@@ -51,7 +53,12 @@ export const HTMLPreview = ({file}: HTMLPreviewProps) => {
   }, [files, folders, file]);
 
   return (
-    <>
+    <div
+      className={classNames(
+        moduleStyles.previewContainer,
+        isResizing && moduleStyles.resizing
+      )}
+    >
       {file && (
         <iframe
           sandbox=""
@@ -64,6 +71,6 @@ export const HTMLPreview = ({file}: HTMLPreviewProps) => {
           className={moduleStyles.iframePreview}
         />
       )}
-    </>
+    </div>
   );
 };

--- a/apps/src/codebridge/FilePreview/styles/filePreview.module.scss
+++ b/apps/src/codebridge/FilePreview/styles/filePreview.module.scss
@@ -7,3 +7,15 @@
 .iframePreview {
   border: 2px solid var(--borders-neutral-primary);
 }
+
+.previewContainer {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+// While the preview is being resized, disable pointer events
+// so the resize handle can be used without interference.
+.resizing {
+  pointer-events: none;
+}

--- a/apps/src/codebridge/Workspace/HorizontalOutput.tsx
+++ b/apps/src/codebridge/Workspace/HorizontalOutput.tsx
@@ -5,7 +5,7 @@ import {throttle} from 'lodash';
 import React, {useRef, useState, useCallback, useMemo, useEffect} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
-import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
+import {logOnResize} from '@cdo/apps/lab2/utils/resizeUtils';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import BaseOutput from './BaseOutput';

--- a/apps/src/codebridge/Workspace/VerticalOutput.tsx
+++ b/apps/src/codebridge/Workspace/VerticalOutput.tsx
@@ -5,7 +5,7 @@ import {throttle} from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
-import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
+import {logOnResize} from '@cdo/apps/lab2/utils/resizeUtils';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import BaseOutput from './BaseOutput';

--- a/apps/src/lab2/hooks/useHorizontalLayout.ts
+++ b/apps/src/lab2/hooks/useHorizontalLayout.ts
@@ -2,12 +2,16 @@ import {throttle} from 'lodash';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
-import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
+import {
+  handleResizeEnd,
+  handleResizeStart,
+} from '@cdo/apps/lab2/utils/resizeUtils';
 import {RESIZE_BAR_SIZE_PX} from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import {
   ColumnPanelConfig,
   RowPanelConfig,
 } from '@cdo/apps/lab2/views/components/layout/types';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 // The top Y coordinate of the panel. This is the height of the main page header.
 const PANEL_TOP_COORDINATE = 50;
@@ -52,6 +56,7 @@ export const useHorizontalLayout = ({
     number | undefined
   >(rightBottomPanel.initialHeight);
   const rightmostPanelWidth = 300;
+  const dispatch = useAppDispatch();
 
   const {
     position: rawLeftPanelWidth,
@@ -63,10 +68,11 @@ export const useHorizontalLayout = ({
     initial: leftPanel.initialWidth,
     min: leftPanel.minWidth,
     onResizeStart: () =>
-      logOnResize(appName, {
+      handleResizeStart(dispatch, appName, {
         layout: 'horizontal',
         resizeBar: leftPanel.name,
       }),
+    onResizeEnd: () => handleResizeEnd(dispatch),
   });
   const {
     position: rawRightBottomPanelHeight,
@@ -79,10 +85,11 @@ export const useHorizontalLayout = ({
     min: rightBottomPanel.minHeight,
     reverse: true,
     onResizeStart: () =>
-      logOnResize(appName, {
+      handleResizeStart(dispatch, appName, {
         layout: 'horizontal',
         resizeBar: rightBottomPanel.name,
       }),
+    onResizeEnd: () => handleResizeEnd(dispatch),
   });
 
   const adjustRightPanelWidth = useCallback(() => {

--- a/apps/src/lab2/hooks/useVerticalLayout.ts
+++ b/apps/src/lab2/hooks/useVerticalLayout.ts
@@ -1,9 +1,13 @@
 import {useCallback, useEffect, useState} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
-import {logOnResize} from '@cdo/apps/lab2/utils/logOnResize';
+import {
+  handleResizeEnd,
+  handleResizeStart,
+} from '@cdo/apps/lab2/utils/resizeUtils';
 import {RESIZE_BAR_SIZE_PX} from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import {ColumnPanelConfig} from '@cdo/apps/lab2/views/components/layout/types';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 const TWO_RESIZE_BARS = RESIZE_BAR_SIZE_PX * 2;
 
@@ -36,6 +40,7 @@ export const useVerticalLayout = ({
   const [rightPanelWidth, setRightPanelWidth] = useState<number | undefined>(
     rightPanel.initialWidth
   );
+  const dispatch = useAppDispatch();
 
   const {
     position: rawLeftPanelWidth,
@@ -47,7 +52,11 @@ export const useVerticalLayout = ({
     initial: leftPanel.initialWidth,
     min: leftPanel.minWidth,
     onResizeStart: () =>
-      logOnResize(appName, {layout: 'vertical', resizeBar: leftPanel.name}),
+      handleResizeStart(dispatch, appName, {
+        layout: 'vertical',
+        resizeBar: leftPanel.name,
+      }),
+    onResizeEnd: () => handleResizeEnd(dispatch),
   });
   const {
     position: rawRightPanelWidth,
@@ -60,7 +69,11 @@ export const useVerticalLayout = ({
     min: rightPanel.minWidth,
     reverse: true,
     onResizeStart: () =>
-      logOnResize(appName, {layout: 'vertical', resizeBar: rightPanel.name}),
+      handleResizeStart(dispatch, appName, {
+        layout: 'vertical',
+        resizeBar: rightPanel.name,
+      }),
+    onResizeEnd: () => handleResizeEnd(dispatch),
   });
 
   const adjustWidths = useCallback(() => {

--- a/apps/src/lab2/redux/lab2ViewRedux.ts
+++ b/apps/src/lab2/redux/lab2ViewRedux.ts
@@ -8,12 +8,14 @@ export interface Lab2ViewState {
   consoleFontSizeKey: keyof typeof FontSize;
   editorFontSizeKey: keyof typeof FontSize;
   editorFontSizeLoaded: boolean;
+  isResizing: boolean;
 }
 
 const initialState: Lab2ViewState = {
   consoleFontSizeKey: 'Small',
   editorFontSizeKey: 'Small',
   editorFontSizeLoaded: false,
+  isResizing: false,
 };
 
 // THUNKS
@@ -63,10 +65,17 @@ const lab2ViewSlice = createSlice({
     setEditorFontSizeLoaded(state, action: PayloadAction<boolean>) {
       state.editorFontSizeLoaded = action.payload;
     },
+    setIsResizing(state, action: PayloadAction<boolean>) {
+      state.isResizing = action.payload;
+    },
   },
 });
 
-export const {setConsoleFontSize, setEditorFontSize, setEditorFontSizeLoaded} =
-  lab2ViewSlice.actions;
+export const {
+  setConsoleFontSize,
+  setEditorFontSize,
+  setEditorFontSizeLoaded,
+  setIsResizing,
+} = lab2ViewSlice.actions;
 
 export default lab2ViewSlice.reducer;

--- a/apps/src/lab2/utils/resizeUtils.ts
+++ b/apps/src/lab2/utils/resizeUtils.ts
@@ -1,5 +1,20 @@
+import {setIsResizing} from '@cdo/apps/lab2/redux/lab2ViewRedux';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {AppDispatch} from '@cdo/apps/util/reduxHooks';
+
+export const handleResizeStart = (
+  dispatch: AppDispatch,
+  labType?: string,
+  payload?: Record<string, string>
+) => {
+  logOnResize(labType, payload);
+  dispatch(setIsResizing(true));
+};
+
+export const handleResizeEnd = (dispatch: AppDispatch) => {
+  dispatch(setIsResizing(false));
+};
 
 export const logOnResize = (
   labType?: string,

--- a/apps/src/weblab2/layout/HorizontalLayout.tsx
+++ b/apps/src/weblab2/layout/HorizontalLayout.tsx
@@ -71,10 +71,6 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
             />
           </>
         )}
-        {/* TODO: Make the panels resizable vertically. The iframe in FilePreview makes it so you
-         can only drag left, not right (something about the mouse events getting 
-         captured by the preview?).
-         Ticket: https://codedotorg.atlassian.net/browse/CT-1125 */}
         <div
           className={moduleStyles.flexColumn}
           style={{width: rightPanelWidth}}

--- a/apps/src/weblab2/layout/HorizontalLayout.tsx
+++ b/apps/src/weblab2/layout/HorizontalLayout.tsx
@@ -27,6 +27,8 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
     rightBottomPanelHeight,
     rightBottomPanelSeparatorProps,
     rightBottomPanelDragging,
+    leftPanelSeparatorProps,
+    leftPanelDragging,
   } = useHorizontalLayout({
     leftPanel: {
       minWidth: isProjectLevel ? 0 : MIN_INFO_PANEL_WIDTH,
@@ -57,10 +59,17 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
     >
       <div className={moduleStyles.layoutContainer}>
         {!isProjectLevel && (
-          <InfoPanel
-            style={{width: leftPanelWidth}}
-            className={moduleStyles.flexShrink0}
-          />
+          <>
+            <InfoPanel
+              style={{width: leftPanelWidth}}
+              className={moduleStyles.flexShrink0}
+            />
+            <ResizeBar
+              isVertical={true}
+              separatorProps={leftPanelSeparatorProps}
+              isDragging={leftPanelDragging}
+            />
+          </>
         )}
         {/* TODO: Make the panels resizable vertically. The iframe in FilePreview makes it so you
          can only drag left, not right (something about the mouse events getting 

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -24,6 +24,8 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
     rightPanelWidth,
     leftPanelSeparatorProps,
     leftPanelDragging,
+    rightPanelSeparatorProps,
+    rightPanelDragging,
   } = useVerticalLayout({
     leftPanel: {
       minWidth: isProjectLevel ? 0 : MIN_INFO_PANEL_WIDTH,
@@ -72,6 +74,11 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
          can only drag left, not right (something about the mouse events getting 
          captured by the preview?) 
          Ticket: https://codedotorg.atlassian.net/browse/CT-1125 */}
+        <ResizeBar
+          isVertical={true}
+          separatorProps={rightPanelSeparatorProps}
+          isDragging={rightPanelDragging}
+        />
         <div
           style={{width: rightPanelWidth}}
           className={moduleStyles.shrinkAndGrow}

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -70,10 +70,6 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
           style={{width: middlePanelWidth}}
           className={moduleStyles.shrinkAndGrow}
         />
-        {/* TODO: Make right panel resizable. The iframe in FilePreview makes it so you
-         can only drag left, not right (something about the mouse events getting 
-         captured by the preview?) 
-         Ticket: https://codedotorg.atlassian.net/browse/CT-1125 */}
         <ResizeBar
           isVertical={true}
           separatorProps={rightPanelSeparatorProps}


### PR DESCRIPTION
Web Lab 2 panels were only partially resizable because any resizing that could cause the mouse to go over the preview iframe would cause the mouse events to get captured by the preview and resizing to stop working and behave unpredictably (see screen recording). There was actually a simple fix for this; set a redux value while we are resizing and disable pointer events on the iframe while that happens.
We could extend this to disable pointer events elsewhere too; I have noticed when you are resizing and mouse over certain text on the screen (such as file names in the file browser, panel header text), it will get highlighted, which looks a bit janky.

This updates involves the soon-to-be-deprecated file preview (in favor of a more robust version), but the work that will need to be redone is just the work to check the redux value and add the disabled pointer events class when `isResizing` is true. The rest of the work will carry over, so this felt worth doing now.

## Behavior without disabling pointer events
This behavior is not live, but is why we initially did not have all the resize bars set up in Web Lab 2.

https://github.com/user-attachments/assets/1bc4222d-fcac-4629-a004-7017983ffeb3

## Behavior now

https://github.com/user-attachments/assets/2bcf85cf-91cd-4ad7-8a63-baf1707b018c



## Links

- Jira: [CT-1125](https://codedotorg.atlassian.net/browse/CT-1125)

## Testing story
Tested locally.


## Follow-up work
[CT-1254](https://codedotorg.atlassian.net/browse/CT-1254) tracks the nice-to-have follow up to disable highlighting of text while we are resizing. You can see text get highlighted while resizing in the screen recording



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
