### PR TITLE
Fix `switch-to-deployment-mode` on New Servers

### DIFF
--- a/cookbooks/cdo-ruby/recipes/switch-to-deployment-mode.rb
+++ b/cookbooks/cdo-ruby/recipes/switch-to-deployment-mode.rb
@@ -7,6 +7,8 @@
 root_dir = File.join(node[:home], node.chef_environment)
 ['', 'dashboard', 'cookbooks'].each do |subdir|
   project_dir = File.join(root_dir, subdir)
+  next unless Dir.exist?(project_dir)
+
   bundle_dir = File.join(project_dir, '.bundle')
   vendor_dir = File.join(project_dir, 'vendor/bundle')
 


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67155, which added some logic to prepare our web application for an upcoming switch to the way we install gems.

When testing that change, I was so focused on making sure it will apply cleanly to our existing persistent managed servers that I neglected to verify that it will also work when spinning a new server up from scratch! Unfortunately, this new logic assumes that we've already cloned the repository by the time it executes, which is trivially true for existing servers but not true at all for new ones.

Specifically, two of the new resources ([1](https://github.com/code-dot-org/code-dot-org/blob/9fb834549db595b08b94f4037243844f1d9d8922/cookbooks/cdo-ruby/recipes/switch-to-deployment-mode.rb#L32), [2](https://github.com/code-dot-org/code-dot-org/blob/9fb834549db595b08b94f4037243844f1d9d8922/cookbooks/cdo-ruby/recipes/switch-to-deployment-mode.rb#L41)) will attempt to execute their commands from within the project directory, which will fail if it does not exist. The simple fix is to check whether that directory exists before proceeding, rather than assuming it will.

## Links

[Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1754083477652899)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Spun up a new adhoc on this branch, and verified that it provisioned successfully