### PR TITLE
Web Lab 2: allow submittable levels

### DIFF
--- a/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
+++ b/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
@@ -27,6 +27,7 @@ interface NavigationButtonProps {
   hasEdited: boolean;
   className?: string;
   size?: ComponentSizeXSToL;
+  requireRun?: boolean;
 }
 
 const NavigationButton: React.FC<NavigationButtonProps> = ({
@@ -35,23 +36,30 @@ const NavigationButton: React.FC<NavigationButtonProps> = ({
   hasEdited,
   className,
   size,
+  requireRun,
 }) => {
-  return levelProperties.submittable ? (
-    <SubmitButton
-      levelId={levelProperties.id}
-      appName={levelProperties.appName}
-      disableEditRunForSubmission={levelProperties.disableEditRunForSubmission}
-      disableRunForSubmission={levelProperties.appName === 'weblab2'}
-      hasRun={hasRun}
-      hasEdited={hasEdited}
-      className={className}
-    />
-  ) : (
+  if (levelProperties.submittable) {
+    return (
+      <SubmitButton
+        levelId={levelProperties.id}
+        appName={levelProperties.appName}
+        disableEditRunForSubmission={
+          levelProperties.disableEditRunForSubmission
+        }
+        hasRun={hasRun}
+        hasEdited={hasEdited}
+        className={className}
+      />
+    );
+  }
+
+  return (
     <ContinueButton
       className={className}
       size={size}
       hasRun={hasRun}
       isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
+      requireRun={requireRun}
     />
   );
 };
@@ -61,6 +69,7 @@ interface ContinueButtonProps {
   size?: ComponentSizeXSToL;
   isPredictLevel?: boolean;
   hasRun?: boolean;
+  requireRun?: boolean;
 }
 
 /**
@@ -71,6 +80,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
   size,
   isPredictLevel,
   hasRun,
+  requireRun,
 }) => {
   const dispatch = useAppDispatch();
   const hasNextLevel = useAppSelector(
@@ -96,7 +106,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
     } else if (hasConditions) {
       return validationSatisfied;
     } else {
-      return hasRun;
+      return !requireRun || hasRun;
     }
   }, [
     hasRun,
@@ -104,6 +114,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
     isPredictLevel,
     hasSubmittedPredictResponse,
     validationSatisfied,
+    requireRun,
   ]);
 
   const text = hasNextLevel ? commonI18n.continue() : commonI18n.finish();
@@ -137,7 +148,6 @@ interface SubmitButtonProps {
   hasRun: boolean;
   hasEdited: boolean;
   disableEditRunForSubmission?: boolean;
-  disableRunForSubmission?: boolean;
   className?: string;
 }
 
@@ -150,7 +160,6 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
   hasRun,
   hasEdited,
   disableEditRunForSubmission = false,
-  disableRunForSubmission = false,
   className,
 }) => {
   const hasSubmitted = useAppSelector(
@@ -161,10 +170,7 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
   );
 
   const enabled =
-    disableEditRunForSubmission ||
-    (disableRunForSubmission && hasEdited) ||
-    hasSubmitted ||
-    (hasRun && hasEdited);
+    disableEditRunForSubmission || hasSubmitted || (hasRun && hasEdited);
   const buttonText = hasSubmitted ? commonI18n.unsubmit() : commonI18n.submit();
 
   const dialogControl = useDialogControl();

--- a/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
+++ b/apps/src/lab2/views/components/Instructions/NavigationButton.tsx
@@ -27,7 +27,6 @@ interface NavigationButtonProps {
   hasEdited: boolean;
   className?: string;
   size?: ComponentSizeXSToL;
-  requireRun?: boolean;
 }
 
 const NavigationButton: React.FC<NavigationButtonProps> = ({
@@ -36,30 +35,23 @@ const NavigationButton: React.FC<NavigationButtonProps> = ({
   hasEdited,
   className,
   size,
-  requireRun,
 }) => {
-  if (levelProperties.submittable) {
-    return (
-      <SubmitButton
-        levelId={levelProperties.id}
-        appName={levelProperties.appName}
-        disableEditRunForSubmission={
-          levelProperties.disableEditRunForSubmission
-        }
-        hasRun={hasRun}
-        hasEdited={hasEdited}
-        className={className}
-      />
-    );
-  }
-
-  return (
+  return levelProperties.submittable ? (
+    <SubmitButton
+      levelId={levelProperties.id}
+      appName={levelProperties.appName}
+      disableEditRunForSubmission={levelProperties.disableEditRunForSubmission}
+      disableRunForSubmission={levelProperties.appName === 'weblab2'}
+      hasRun={hasRun}
+      hasEdited={hasEdited}
+      className={className}
+    />
+  ) : (
     <ContinueButton
       className={className}
       size={size}
       hasRun={hasRun}
       isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
-      requireRun={requireRun}
     />
   );
 };
@@ -69,7 +61,6 @@ interface ContinueButtonProps {
   size?: ComponentSizeXSToL;
   isPredictLevel?: boolean;
   hasRun?: boolean;
-  requireRun?: boolean;
 }
 
 /**
@@ -80,7 +71,6 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
   size,
   isPredictLevel,
   hasRun,
-  requireRun,
 }) => {
   const dispatch = useAppDispatch();
   const hasNextLevel = useAppSelector(
@@ -106,7 +96,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
     } else if (hasConditions) {
       return validationSatisfied;
     } else {
-      return !requireRun || hasRun;
+      return hasRun;
     }
   }, [
     hasRun,
@@ -114,7 +104,6 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
     isPredictLevel,
     hasSubmittedPredictResponse,
     validationSatisfied,
-    requireRun,
   ]);
 
   const text = hasNextLevel ? commonI18n.continue() : commonI18n.finish();
@@ -148,6 +137,7 @@ interface SubmitButtonProps {
   hasRun: boolean;
   hasEdited: boolean;
   disableEditRunForSubmission?: boolean;
+  disableRunForSubmission?: boolean;
   className?: string;
 }
 
@@ -160,6 +150,7 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
   hasRun,
   hasEdited,
   disableEditRunForSubmission = false,
+  disableRunForSubmission = false,
   className,
 }) => {
   const hasSubmitted = useAppSelector(
@@ -170,7 +161,10 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
   );
 
   const enabled =
-    disableEditRunForSubmission || hasSubmitted || (hasRun && hasEdited);
+    disableEditRunForSubmission ||
+    (disableRunForSubmission && hasEdited) ||
+    hasSubmitted ||
+    (hasRun && hasEdited);
   const buttonText = hasSubmitted ? commonI18n.unsubmit() : commonI18n.submit();
 
   const dialogControl = useDialogControl();

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -4,12 +4,13 @@ import {css} from '@codemirror/lang-css';
 import {html} from '@codemirror/lang-html';
 import {javascript} from '@codemirror/lang-javascript';
 import {LanguageSupport} from '@codemirror/language';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
+import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
 import {LabProps, MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
 
 import {useSource} from '../codebridge/hooks/useSource';
-import {useAppSelector} from '../util/reduxHooks';
+import {useAppSelector, useAppDispatch} from '../util/reduxHooks';
 
 import HorizontalLayout from './layout/HorizontalLayout';
 import VerticalLayout from './layout/VerticalLayout';
@@ -68,6 +69,18 @@ const Weblab2View: React.FC<
   const hasSource = useAppSelector(
     state => !!state.lab2Project.projectSources?.source
   );
+
+  // Since there's no run button in Weblab2, set it to true by default
+  // to enable the Submit button on edit on submittable levels.
+  // Set back to false on unmount in case we switch to a different level type.
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch(setHasRun(true));
+
+    return () => {
+      dispatch(setHasRun(false));
+    };
+  }, [dispatch]);
 
   return (
     <div className={moduleStyles.weblab2Container}>

--- a/dashboard/app/models/levels/ailab.rb
+++ b/dashboard/app/models/levels/ailab.rb
@@ -30,7 +30,6 @@ class Ailab < Level
     start_sources
     hide_share_and_remix
     is_project_level
-    submittable
     mode
     dynamic_instructions
   )

--- a/dashboard/app/models/levels/panels.rb
+++ b/dashboard/app/models/levels/panels.rb
@@ -28,7 +28,6 @@ class Panels < Level
   serialized_attrs %w(
     hide_share_and_remix
     is_project_level
-    submittable
     background
     level_data
     panels

--- a/dashboard/app/models/levels/weblab2.rb
+++ b/dashboard/app/models/levels/weblab2.rb
@@ -32,6 +32,7 @@ class Weblab2 < Level
     encrypted_exemplar_sources
     submittable
     validation_enabled
+    disable_edit_run_for_submission
   )
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
@@ -5,15 +5,14 @@
   Special Level Types
 
 #special-levels.in.collapse
-  -# Dance and Spritelab are special types of Gamelab levels
-  - if @level.is_a?(Gamelab) || @level.is_a?(Applab) || @level.is_a?(Weblab) || @level.is_a?(FreeResponse) || @level.is_a?(Javalab) || @level.is_a?(Pythonlab) || @level.is_a?(Music) || @level.is_a?(Aichat)
+  - if @level.respond_to?(:submittable)
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :submittable, description: "Submittable"}
     %p
       If checked, students with teachers can "submit" a solution for
       grading. Submitting a solution means that it is marked as
       submitted and they can no longer edit it (unless a teacher returns
       it).
-    - if @level.is_a?(Pythonlab) || @level.is_a?(Music) || @level.is_a?(Aichat)
+    - if @level.is_a?(Pythonlab) || @level.is_a?(Music) || @level.is_a?(Aichat) || @level.is_a?(Weblab2)
       = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :disable_edit_run_for_submission, description: "Disable Edit and Run Requirement for Submission"}
       %p
         By default, submittable levels require the student to edit and


### PR DESCRIPTION
Adds the option to mark a Web Lab 2 level as as submittable.

As a bit of cleanup, I made the `submittable` checkbox visible for level types that are configured to be submittable.

The only two level types that list submittable as a serialized property but weren't in the list of levels where this UI is shown are `ailab` and `panels`. I looked in the level directories for those two level types and saw no mention of submittable being set, so I think it is safe to remove.


## Links

- Jira: https://codedotorg.atlassian.net/browse/CT-1248

## Testing story

Tested manually that on a Web Lab 2 level with `submittable` set to true that the Submit button a) started disabled, b) became enabled once edited, and c) I got a popup to submit it on click. On page reload, the "Unsubmit" button appeared. 

I also tested that switching between a Web Lab 2 and another Lab2 level (eg, Python Lab) in the same lesson that the `hasRun` flag was reset appropriately.