### PR TITLE
Web Lab 2: allow levels to appear in bubble choice levels

### DIFF
--- a/dashboard/app/views/levels/editors/_weblab2.html.haml
+++ b/dashboard/app/views/levels/editors/_weblab2.html.haml
@@ -1,5 +1,6 @@
 = render partial: 'levels/editors/fields/long_instructions', locals: {f: f}
 = render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
+= render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/weblab2_fields', locals: {f: f}
 
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}


### PR DESCRIPTION
Allows Web Lab 2 levels to appear in bubble choice levels.

## Links

- Jira: https://codedotorg.atlassian.net/browse/CT-1245

## Testing story

Tested adding a Web Lab level (with a markdown description) to a bubble choice level. Tested both the lab2 version of bubble choice as well as legacy bubble choice.