### PR TITLE
Disable Some Overrides for Rails 5.2 Config Options

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -43,10 +43,6 @@ module Dashboard
     #
     # TODO infra: Figure out why, fix, and reenable.
     #
-    # added in Rails 5.2 (https://github.com/rails/rails/pull/28132)
-    config.action_dispatch.use_authenticated_cookie_encryption = false
-    # added in Rails 5.2 (https://github.com/rails/rails/pull/29263)
-    config.active_support.use_authenticated_message_encryption = false
     # added in Rails 6.0 (https://github.com/rails/rails/pull/32937)
     config.action_dispatch.use_cookies_with_metadata = false
 


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/46479, which updated *most* of our config values to use more-recent defaults, but included a few overrides for some values. In preparation for the upcoming upgrade to Rails 7, we'd like to remove those overrides.

This PR removes two of them; specifically, the overrides for two config values added in Rails 5.2. At the time, these config options caused authentication problems in our CI tests; I found the two PRs I used to run CI tests against these changes ([1](https://github.com/code-dot-org/code-dot-org/pull/47198), [2](https://github.com/code-dot-org/code-dot-org/pull/47199)), but unfortunately we no longer have access to the CI test results from that long ago so I'm not able to identify precisely which tests failed.

I'm also no longer able to reproduce the failures, either manually or in CI tests. It's possible something about the way we execute CI tests changed so as to obfuscate the original error, but I think it's more likely that the many changes that we've made to the way we handle cookies in the last few years incidentally resolved whatever sharp corner of our implementation was causing the error in the first place. I think at this point, these changes should be safe to enable.


## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->


Verified both locally and on an adhoc by starting up a server with these config options overridden and creating an account. I then removed the overrides, restarted the server, and verified that I remain logged in and can successfully log out then back in.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

We should plan to monitor zendesk following the DTP which includes this PR, just in case.
