### PR TITLE
Web Lab 2: add css color picker

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -237,6 +237,7 @@
     "@react-bootstrap/pagination": "^1.0.0",
     "@react-pdf/renderer": "3.4.4",
     "@reduxjs/toolkit": "^1.9.3",
+    "@replit/codemirror-css-color-picker": "^6.3.0",
     "@selectize/selectize": "^0.15.2",
     "@statsig/js-client": "^3.12.2",
     "@statsig/session-replay": "^3.12.2",

--- a/apps/src/Globals.d.ts
+++ b/apps/src/Globals.d.ts
@@ -41,3 +41,4 @@ declare module '@blockly/field-colour';
 declare module '@cdo/locale';
 declare module '@code-dot-org/maze';
 declare module 'eslint-linter-browserify';
+declare module '@replit/codemirror-css-color-picker';

--- a/apps/src/codebridge/Editor/Editor.tsx
+++ b/apps/src/codebridge/Editor/Editor.tsx
@@ -4,7 +4,12 @@ import {esLint} from '@codemirror/lang-javascript';
 import {LanguageSupport} from '@codemirror/language';
 import {linter, lintGutter} from '@codemirror/lint';
 import {Extension} from '@codemirror/state';
+import {EditorView} from '@codemirror/view';
 import js from '@eslint/js';
+import {
+  colorPicker,
+  wrapperClassName,
+} from '@replit/codemirror-css-color-picker';
 import * as eslint from 'eslint-linter-browserify';
 import globals from 'globals';
 import React, {useCallback, useMemo} from 'react';
@@ -58,6 +63,16 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
 
         extensions.push(linter(esLint(new eslint.Linter(), config)));
         extensions.push(lintGutter());
+      } else if (file.language === 'css') {
+        // Add css color picker and remove white outline from color indicator.
+        extensions.push(colorPicker);
+        extensions.push(
+          EditorView.theme({
+            [`.${wrapperClassName}`]: {
+              outlineColor: 'transparent',
+            },
+          })
+        );
       }
 
       return extensions;

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -6478,6 +6478,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@replit/codemirror-css-color-picker@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "@replit/codemirror-css-color-picker@npm:6.3.0"
+  peerDependencies:
+    "@codemirror/language": ^6.0.0
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.0.0
+  checksum: 10/ae3895ba7dedd8c4f3d19d4cf8772161d7857a7941a5f795cb086255e593d1b538fbca2402998cb8e8998bb2a694b3f82381f68eced7913351f38b356a80532b
+  languageName: node
+  linkType: hard
+
 "@restart/hooks@npm:^0.4.9":
   version: 0.4.9
   resolution: "@restart/hooks@npm:0.4.9"
@@ -10901,6 +10912,7 @@ __metadata:
     "@react-bootstrap/pagination": "npm:^1.0.0"
     "@react-pdf/renderer": "npm:3.4.4"
     "@reduxjs/toolkit": "npm:^1.9.3"
+    "@replit/codemirror-css-color-picker": "npm:^6.3.0"
     "@selectize/selectize": "npm:^0.15.2"
     "@statsig/js-client": "npm:^3.12.2"
     "@statsig/session-replay": "npm:^3.12.2"


### PR DESCRIPTION
This add's replit's codemirror color picker extension to css files in the Web Lab 2 editor. This extension uses the browser native color-picker. Most of our users are on Chrome/Edge and will see Chrome's simple, native color picker. On Firefox they will see a more complex color picker, and on Safari they will see a grid of colors, with the option to open up the same complex color picker as Firefox.

##  Screen recordings/Screen shots

### Chrome
Edge should be the same, but I don't have a windows computer to confirm. 

https://github.com/user-attachments/assets/66dd6d72-9cc2-47b6-aa12-ab49f74db2af

### Firefox

https://github.com/user-attachments/assets/6cea499e-e223-4479-b391-d9c3454246a9

### Safari
<img width="263" height="238" alt="Screenshot 2025-08-04 at 11 27 07 AM" src="https://github.com/user-attachments/assets/15e0b58c-0bfb-4a3d-804f-f77758977079" />

If you click "show colors" you get the same picker as Firefox.

## Links

- Jira: [CT-590](https://codedotorg.atlassian.net/browse/CT-590), [CT-589](https://codedotorg.atlassian.net/browse/CT-589)

## Testing story
Tested locally. Jamila confirmed that on a windows computer the Chrome and Firefox pickers on replit looked the same as what I see on a Mac.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
