### PR TITLE
Python Lab: remove feedback button

### DIFF
--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -35,14 +35,6 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
   ) as MultiFileSource | undefined;
   const files = source?.files || {};
 
-  const feedbackTooltipProps: TooltipProps = {
-    text: commonI18n.feedback(),
-    direction: 'onBottom',
-    tooltipId: 'feedback-tooltip',
-    size: 'xs',
-    hideTail: true,
-  };
-
   const documentationTooltipProps: TooltipProps = {
     text: commonI18n.documentation(),
     direction: 'onBottom',
@@ -110,20 +102,6 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
       )}
       {!isWidgetView && (
         <VersionHistoryButton startSources={startSources} appName={appName} />
-      )}
-      {appName === 'pythonlab' && (
-        <WithTooltip tooltipProps={feedbackTooltipProps}>
-          <LinkButton
-            isIconOnly
-            icon={{iconStyle: 'solid', iconName: 'commenting'}}
-            href={'https://forms.gle/Z4FsGMFzE4NrFp369'}
-            ariaLabel={commonI18n.feedback()}
-            size={'xs'}
-            type={'tertiary'}
-            color={'black'}
-            target="_blank"
-          />
-        </WithTooltip>
       )}
       {/* For now, only python lab supports documentation */}
       {appName === 'pythonlab' && (


### PR DESCRIPTION
We had a workspace header button in Python Lab that linked to a google form. We are ready to remove this.



## Links

- Jira: [LABS-1546](https://codedotorg.atlassian.net/browse/LABS-1546)

## Testing story
Confirmed the button is gone and everything still works as expected.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
