### PR TITLE
chore(marketing): remove Hero Banner component from CSforall

### DIFF
--- a/frontend/apps/marketing/src/contentful/registration/csforall/index.ts
+++ b/frontend/apps/marketing/src/contentful/registration/csforall/index.ts
@@ -40,9 +40,6 @@ import FAQAccordion, {
 import Heading, {
   HeadingContentfulComponentDefinition,
 } from '@/components/contentful/heading';
-import HeroBanner, {
-  HeroBannerContentfulComponentDefinition,
-} from '@/components/contentful/heroBanner';
 import IconHighlight, {
   IconHighlightContentfulComponentDefinition,
 } from '@/components/contentful/iconHighlight';
@@ -138,13 +135,6 @@ const contentfulRegistration = {
     {
       component: Heading,
       definition: HeadingContentfulComponentDefinition,
-    },
-    {
-      component: HeroBanner,
-      definition: HeroBannerContentfulComponentDefinition,
-      options: {
-        wrapContainerWidth: '100%',
-      },
     },
     {
       component: IconHighlight,


### PR DESCRIPTION
Removes the Hero Banner component from the CSforAll site since they can be built using patterns that allow for more flexibility.

## Links
Jira ticket: [CMS-984](https://codedotorg.atlassian.net/browse/CMS-984)