### PR TITLE
fix(marketing): stop page shift caused by Header dropdowns

### DIFF
--- a/frontend/apps/marketing/src/components/header/csForAll/DropdownMenu.tsx
+++ b/frontend/apps/marketing/src/components/header/csForAll/DropdownMenu.tsx
@@ -102,6 +102,7 @@ const DropdownMenu: React.FC<MenuListProps> = ({id, buttonLabel, linkList}) => {
         }}
         elevation={0}
         disableAutoFocusItem
+        disableScrollLock
         sx={styles.menu}
       >
         {linkList?.map(({label, href, typography = 'body3', ...linkProps}) => (


### PR DESCRIPTION
Fixes an issue on some browsers where 15px of padding was being added to the page body when a dropdown in the Header was opened. See [this post](https://stackoverflow.com/questions/60682426/material-ui-adds-padding-to-the-body-tag-when-a-dialog-is-opened) for more context.

## Links
Jira ticket: [CMS-985](https://codedotorg.atlassian.net/browse/CMS-985)
Slack convo: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1754422947503229?thread_ts=1754420011.764699&cid=C07UW4ED66Q)