### PR TITLE
Adding unit_group_id column to user_levels table

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -17,6 +17,7 @@
 #  time_spent       :integer
 #  deleted_at       :datetime
 #  properties       :text(65535)
+#  unit_group_id    :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20250805233618_add_unit_group_to_user_levels.rb
+++ b/dashboard/db/migrate/20250805233618_add_unit_group_to_user_levels.rb
@@ -1,0 +1,5 @@
+class AddUnitGroupToUserLevels < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_levels, :unit_group_id, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_07_29_223547) do
+ActiveRecord::Schema.define(version: 2025_08_05_233618) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2392,6 +2392,7 @@ ActiveRecord::Schema.define(version: 2025_07_29_223547) do
     t.integer "time_spent"
     t.datetime "deleted_at"
     t.text "properties"
+    t.integer "unit_group_id"
     t.index ["user_id", "script_id", "level_id", "deleted_at"], name: "index_user_levels_unique", unique: true
   end
 


### PR DESCRIPTION
The RED team wants to to know the UnitGroup a student was in when they made progress on a level. To achieve this, we will add the unit_group_id to UserLevel. UserLevels are created/updated whenever a student makes progress on a particular Level in a Unit.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/TEACH-2088)

## Testing story
* Recently added the unit_group_id to the UserScripts table which also has millions of rows. It happened instantly without any issue, so I think its safe to expect this to be fine too.



## Deployment strategy
* Monitor the DTP when this goes out to verify the migration happens smoothly.


## Follow-up work
* Future tasks will focus on populating this column

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
