### PR TITLE
fix(collections): resolve link for collections

### DIFF
--- a/frontend/apps/marketing-storybook/stories/collections/ActionBlockCollection.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/collections/ActionBlockCollection.story.tsx
@@ -2,8 +2,9 @@
 import ActionBlockCollection, {
   ActionBlockCollectionProps,
 } from '@/components/contentful/collections/actionBlockCollection/ActionBlockCollection';
+import {useInMemoryEntities} from '@contentful/experiences-sdk-react';
 import {Meta, StoryObj} from '@storybook/react';
-import {expect} from 'storybook/test';
+import {expect, within} from 'storybook/test';
 
 import ActionBlockCollectionAlphabeticalMock from './__mocks__/ActionBlockCollectionAlphabetical.json';
 import ActionBlockCollectionHiddenMock from './__mocks__/ActionBlockCollectionHidden.json';
@@ -17,6 +18,53 @@ const meta: Meta<ActionBlockCollectionProps> = {
 export default meta;
 
 type Story = StoryObj<ActionBlockCollectionProps>;
+const inMemoryEntities = useInMemoryEntities();
+
+inMemoryEntities.addEntities([
+  {
+    metadata: {
+      tags: [],
+      concepts: [],
+    },
+    sys: {
+      space: {
+        sys: {
+          type: 'Link',
+          linkType: 'Space',
+          id: '90t6bu6vlf76',
+        },
+      },
+      id: '49SifjEqSHArcx1iEiSw4o',
+      type: 'Entry',
+      createdAt: '2025-04-28T17:15:38.150Z',
+      updatedAt: '2025-07-02T20:12:46.258Z',
+      environment: {
+        sys: {
+          id: 'development',
+          type: 'Link',
+          linkType: 'Environment',
+        },
+      },
+      publishedVersion: 197,
+      revision: 2,
+      contentType: {
+        sys: {
+          type: 'Link',
+          linkType: 'ContentType',
+          id: 'link',
+        },
+      },
+      locale: 'en-US',
+    },
+    fields: {
+      linkName: '❌ [ENG] Secondary button test',
+      label: 'Secondary button test',
+      primaryTarget: '/ping',
+      isThisAnExternalLink: false,
+      ariaLabel: 'Secondary button test',
+    },
+  },
+]);
 
 export const SortedAlphabetically: Story = {
   args: ActionBlockCollectionAlphabeticalMock as any,
@@ -32,6 +80,18 @@ export const SortedAlphabetically: Story = {
     ];
     titles.forEach(title => {
       expect(canvas.getByText(title)).toBeInTheDocument();
+
+      // Self-Paced has secondary buttons
+      if (title.includes('Self-Paced')) {
+        const titleElement = canvas.getByText(title);
+        const parentDiv = titleElement.closest('div')?.parentElement;
+        expect(
+          parentDiv &&
+            within(parentDiv).getByRole('link', {
+              name: 'Secondary button test',
+            }),
+        ).toBeInTheDocument();
+      }
     });
     // Check that anchor links (buttons) are present
     const links = canvas.getAllByRole('link');

--- a/frontend/apps/marketing-storybook/stories/collections/LogoCollection.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/collections/LogoCollection.story.tsx
@@ -34,6 +34,10 @@ export const SortedAlphabetically: Story = {
       .getAllByRole('img')
       .map(img => img.getAttribute('alt'));
     expect(imgAlts).toEqual(titles);
+
+    // Check that "amazon logo" image is clickable using RTL syntax
+    const amazonLogoLink = canvas.getByRole('link', {name: /amazon logo/i});
+    expect(amazonLogoLink).toBeInTheDocument();
   },
 };
 
@@ -56,5 +60,9 @@ export const SortedManually: Story = {
     titles.forEach(title => {
       expect(imgAlts).toContain(title);
     });
+
+    // Check that "amazon logo" image is clickable using RTL syntax
+    const amazonLogoLink = canvas.getByRole('link', {name: /amazon logo/i});
+    expect(amazonLogoLink).toBeInTheDocument();
   },
 };

--- a/frontend/apps/marketing-storybook/stories/collections/PeopleCollection.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/collections/PeopleCollection.story.tsx
@@ -1,8 +1,9 @@
 import PeopleCollection, {
   PeopleCollectionProps,
 } from '@/components/contentful/collections/peopleCollection';
+import {useInMemoryEntities} from '@contentful/experiences-sdk-react';
 import {Meta, StoryObj} from '@storybook/react';
-import {expect} from 'storybook/test';
+import {expect, within} from 'storybook/test';
 
 import PeopleCollectionAlphabeticalMock from './__mocks__/PeopleCollectionAlphabetical.json';
 import PeopleCollectionHiddenMock from './__mocks__/PeopleCollectionHidden.json';
@@ -17,6 +18,54 @@ export default meta;
 
 type Story = StoryObj<PeopleCollectionProps>;
 
+const inMemoryEntities = useInMemoryEntities();
+
+inMemoryEntities.addEntities([
+  {
+    metadata: {
+      tags: [],
+      concepts: [],
+    },
+    sys: {
+      space: {
+        sys: {
+          type: 'Link',
+          linkType: 'Space',
+          id: '90t6bu6vlf76',
+        },
+      },
+      id: '5CznPyR4ZsbIkhpwSaUxoe',
+      type: 'Entry',
+      createdAt: '2025-04-28T17:15:38.051Z',
+      updatedAt: '2025-07-02T20:13:06.538Z',
+      environment: {
+        sys: {
+          id: 'development',
+          type: 'Link',
+          linkType: 'Environment',
+        },
+      },
+      publishedVersion: 42,
+      revision: 4,
+      contentType: {
+        sys: {
+          type: 'Link',
+          linkType: 'ContentType',
+          id: 'link',
+        },
+      },
+      locale: 'en-US',
+    },
+    fields: {
+      linkName: '❌ [ENG] External link button test',
+      label: 'External link button test',
+      primaryTarget: 'about:blank',
+      isThisAnExternalLink: true,
+      ariaLabel: 'External link button test',
+    },
+  },
+]);
+
 export const SortedAlphabetically: Story = {
   args: PeopleCollectionAlphabeticalMock,
   play: async ({canvas}) => {
@@ -29,6 +78,13 @@ export const SortedAlphabetically: Story = {
       }
       if (person.fields.bio) {
         expect(canvas.getByText(person.fields.bio)).toBeInTheDocument();
+      }
+      if (person.fields.personalLink) {
+        const heading = canvas.getByRole('heading', {name: person.fields.name});
+        const parentDiv = heading.closest('div');
+        expect(
+          within(parentDiv!).getByRole('link', {name: 'Visit personal page'}),
+        ).toBeInTheDocument();
       }
     }
   },
@@ -47,6 +103,13 @@ export const SortedManually: Story = {
       if (person.fields.bio) {
         expect(canvas.getByText(person.fields.bio)).toBeInTheDocument();
       }
+      if (person.fields.personalLink) {
+        const heading = canvas.getByRole('heading', {name: person.fields.name});
+        const parentDiv = heading.closest('div');
+        expect(
+          within(parentDiv!).getByRole('link', {name: 'Visit personal page'}),
+        ).toBeInTheDocument();
+      }
     }
   },
 };
@@ -63,6 +126,13 @@ export const HiddenImages: Story = {
       }
       if (person.fields.bio) {
         expect(canvas.getByText(person.fields.bio)).toBeInTheDocument();
+      }
+      if (person.fields.personalLink) {
+        const heading = canvas.getByRole('heading', {name: person.fields.name});
+        const parentDiv = heading.closest('div');
+        expect(
+          within(parentDiv!).getByRole('link', {name: 'Visit personal page'}),
+        ).toBeInTheDocument();
       }
     }
   },

--- a/frontend/apps/marketing/src/components/contentful/collections/logoCollection/LogoCollection.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/logoCollection/LogoCollection.tsx
@@ -78,8 +78,11 @@ const LogoCollection: React.FC<LogoCollectionProps> = ({
       const resolvedLogoImage = inMemoryEntities.maybeResolveLink(
         logoImage,
       ) as ExperienceAsset;
+      const resolvedPrimaryLinkRef = inMemoryEntities.maybeResolveLink(
+        primaryLinkRef,
+      ) as LinkEntry;
 
-      const url = primaryLinkRef?.fields?.primaryTarget || '';
+      const url = resolvedPrimaryLinkRef?.fields?.primaryTarget || '';
       const getImage = () => (
         <img
           src={getAbsoluteImageUrl(resolvedLogoImage)}

--- a/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/PeopleCollection.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/peopleCollection/PeopleCollection.tsx
@@ -84,6 +84,9 @@ const PeopleCollection: React.FC<PeopleCollectionProps> = ({
       const resolvedImage = inMemoryEntities.maybeResolveLink(
         image,
       ) as ExperienceAsset;
+      const resolvedPersonalLink = inMemoryEntities.maybeResolveLink(
+        personalLink,
+      ) as LinkEntry;
 
       return {
         id: name,
@@ -125,11 +128,11 @@ const PeopleCollection: React.FC<PeopleCollectionProps> = ({
                 {bio}
               </Typography>
             )}
-            {personalLink && (
+            {resolvedPersonalLink && (
               <Box sx={styles.personalLink}>
                 <Link
                   size="s"
-                  href={personalLink?.fields?.primaryTarget}
+                  href={resolvedPersonalLink?.fields?.primaryTarget}
                   isLinkExternal
                   removeMarginBottom
                 >


### PR DESCRIPTION
During the contentful sdk v2 upgrade, I missed the need to resolve the links for the collection components. This causes the links to miss an href breaking the links. This affected the people and logo collections.