### PR TITLE
feat(storybook): add dark mode testing

### DIFF
--- a/frontend/apps/marketing-storybook/.storybook/preview.ts
+++ b/frontend/apps/marketing-storybook/.storybook/preview.ts
@@ -1,3 +1,6 @@
+import {sectionBackground} from '@/components/contentful/section/Section';
+import cdoTheme from '@/themes/code.org';
+import csforallTheme from '@/themes/csforall';
 import {useInMemoryEntities} from '@contentful/experiences-sdk-react';
 import {CssBaseline, ThemeProvider} from '@mui/material';
 import {withThemeFromJSXProvider} from '@storybook/addon-themes';
@@ -6,9 +9,9 @@ import {loadFonts, injectFontAwesome} from '@code-dot-org/fonts';
 
 import '@code-dot-org/fonts/brands/code.org/index.css';
 import '@code-dot-org/fonts/brands/CSForAll/index.css';
-import cdoTheme from '../../marketing/src/themes/code.org';
-import csforallTheme from '../../marketing/src/themes/csforall';
+
 import './preview.module.scss';
+import SectionDecorator from '../decorators/SectionDecorator';
 
 injectFontAwesome();
 
@@ -617,6 +620,7 @@ export const decorators = [
     Provider: ThemeProvider,
     GlobalStyles: CssBaseline,
   }),
+  SectionDecorator,
 ];
 
 const preview = {
@@ -640,6 +644,21 @@ const preview = {
         },
       },
     },
+  },
+  globalTypes: {
+    sectionBackground: {
+      description: 'Contentful section background',
+      toolbar: {
+        title: 'Section Background',
+        icon: 'moon',
+        items: Object.values(sectionBackground),
+        dynamicTitle: true,
+      },
+    },
+  },
+
+  initialGlobals: {
+    sectionBackground: 'primary',
   },
 };
 export const loaders = document.fonts ? [fontLoader] : [];

--- a/frontend/apps/marketing-storybook/.storybook/preview.ts
+++ b/frontend/apps/marketing-storybook/.storybook/preview.ts
@@ -1,9 +1,5 @@
 import {sectionBackground} from '@/components/contentful/section/Section';
-import cdoTheme from '@/themes/code.org';
-import csforallTheme from '@/themes/csforall';
 import {useInMemoryEntities} from '@contentful/experiences-sdk-react';
-import {CssBaseline, ThemeProvider} from '@mui/material';
-import {withThemeFromJSXProvider} from '@storybook/addon-themes';
 
 import {loadFonts, injectFontAwesome} from '@code-dot-org/fonts';
 
@@ -11,6 +7,7 @@ import '@code-dot-org/fonts/brands/code.org/index.css';
 import '@code-dot-org/fonts/brands/CSForAll/index.css';
 
 import './preview.module.scss';
+import MuiDecorator from '../decorators/MuiDecorator';
 import SectionDecorator from '../decorators/SectionDecorator';
 
 injectFontAwesome();
@@ -610,18 +607,7 @@ const fontLoader = async () => {
   };
 };
 
-export const decorators = [
-  withThemeFromJSXProvider({
-    themes: {
-      'code.org': cdoTheme,
-      csforall: csforallTheme,
-    },
-    defaultTheme: 'code.org',
-    Provider: ThemeProvider,
-    GlobalStyles: CssBaseline,
-  }),
-  SectionDecorator,
-];
+export const decorators = [SectionDecorator, MuiDecorator];
 
 const preview = {
   parameters: {

--- a/frontend/apps/marketing-storybook/applitools.config.cjs
+++ b/frontend/apps/marketing-storybook/applitools.config.cjs
@@ -6,6 +6,20 @@
 // Used in DevContainers, see `.devcontainer/frontend/Dockerfile`
 const isDocker = !!process.env.IS_DOCKER || !!process.env.CI;
 
+const variationMatrix = {
+  'code.org': {theme: 'code.org', sectionBackground: ['primary', 'dark']},
+  csforall: {theme: 'csforall', sectionBackground: ['primary']},
+};
+
+const variations = Object.entries(variationMatrix).flatMap(
+  ([, {theme, sectionBackground}]) =>
+    sectionBackground.map(bg => ({
+      queryParams: {
+        globals: `theme:${theme};sectionBackground:${bg}`,
+      },
+    })),
+);
+
 module.exports = {
   concurrency: 5,
   showLogs: !!process.env.APPLITOOLS_SHOW_LOGS,
@@ -24,12 +38,5 @@ module.exports = {
       ? ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
       : [],
   },
-  variations: [
-    {
-      queryParams: {globals: 'theme:code.org'},
-    },
-    {
-      queryParams: {globals: 'theme:csforall'},
-    },
-  ],
+  variations,
 };

--- a/frontend/apps/marketing-storybook/decorators/MuiDecorator.tsx
+++ b/frontend/apps/marketing-storybook/decorators/MuiDecorator.tsx
@@ -1,0 +1,14 @@
+import cdoTheme from '@/themes/code.org';
+import csforallTheme from '@/themes/csforall';
+import {CssBaseline, ThemeProvider} from '@mui/material';
+import {withThemeFromJSXProvider} from '@storybook/addon-themes';
+
+export default withThemeFromJSXProvider({
+  themes: {
+    'code.org': cdoTheme,
+    csforall: csforallTheme,
+  },
+  defaultTheme: 'code.org',
+  Provider: ThemeProvider,
+  GlobalStyles: CssBaseline,
+});

--- a/frontend/apps/marketing-storybook/decorators/SectionDecorator.tsx
+++ b/frontend/apps/marketing-storybook/decorators/SectionDecorator.tsx
@@ -1,0 +1,12 @@
+import Section from '@/components/contentful/section';
+import {StoryContext, StoryFn} from '@storybook/nextjs-vite';
+
+const SectionDecorator = (Story: StoryFn, context: StoryContext) => {
+  return (
+    <Section background={context.globals.sectionBackground}>
+      <Story />
+    </Section>
+  );
+};
+
+export default SectionDecorator;

--- a/frontend/apps/marketing-storybook/decorators/SectionDecorator.tsx
+++ b/frontend/apps/marketing-storybook/decorators/SectionDecorator.tsx
@@ -2,6 +2,10 @@ import Section from '@/components/contentful/section';
 import {StoryContext, StoryFn} from '@storybook/nextjs-vite';
 
 const SectionDecorator = (Story: StoryFn, context: StoryContext) => {
+  if (context.parameters.disableSectionDecorator) {
+    return <Story />;
+  }
+
   return (
     <Section background={context.globals.sectionBackground}>
       <Story />

--- a/frontend/apps/marketing-storybook/stories/Section.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/Section.story.tsx
@@ -6,6 +6,9 @@ const meta: Meta<typeof Section> = {
   title: 'Marketing/Section',
   component: Section,
   tags: ['autodocs', 'marketing'],
+  parameters: {
+    disableSectionDecorator: true,
+  },
 };
 export default meta;
 type Story = StoryObj<typeof Section>;

--- a/frontend/apps/marketing-storybook/tsconfig.json
+++ b/frontend/apps/marketing-storybook/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@code-dot-org/lint-config/typescript/tsconfig.react.json",
-  "include": [".storybook/**/*", "stories/**/*"],
+  "include": [".storybook/**/*", "stories/**/*", "decorators/*"],
   "compilerOptions": {
     "paths": {
       "@/*": ["../../apps/marketing/src/*"],


### PR DESCRIPTION
This PR adds the ability for Eyes to perform dark mode testing on components. This works by adding a `Section` decoration on all marketing components and a new toolbar option which allows you to select the applicable background (`primary` being default).

When eyes runs, the dark variation is added for the `code.org` theme.

<img width="314" height="464" alt="image" src="https://github.com/user-attachments/assets/941505ae-d9e3-4bc0-9d06-513892a0adc2" />
