### PR TITLE
Temporarily disable musiclab timeline nav UI test

### DIFF
--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_timeline_nav.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_timeline_nav.feature
@@ -1,3 +1,5 @@
+# Temporarily skipping flaky test. Investigate and re-enable.
+@skip
 Feature: Musiclab timeline is keyboard navigable
 
 @no_mobile


### PR DESCRIPTION
Temporarily disabling due to flakiness.

## Links

Ticket to re-enable: https://codedotorg.atlassian.net/browse/SL-1372