### PR TITLE
Lab2: tabbed instructions for Python Lab

### DIFF
--- a/apps/src/codebridge/InfoPanel/InfoPanel.tsx
+++ b/apps/src/codebridge/InfoPanel/InfoPanel.tsx
@@ -9,10 +9,13 @@ import {
   setHasValidated,
 } from '@cdo/apps/lab2/redux/systemRedux';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
+import ForTeachersOnly from '@cdo/apps/lab2/views/components/Instructions/ForTeachersOnly';
 import InstructionsV2 from '@cdo/apps/lab2/views/components/Instructions/InstructionsV2';
+import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi';
+import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {UserLevelInteractions} from '@cdo/generated-scripts/sharedConstants';
 
@@ -20,8 +23,6 @@ import {useCodebridgeContext} from '../codebridgeContext';
 import CodebridgeRegistry from '../CodebridgeRegistry';
 import {getSystemMessage} from '../Console/MessageHelpers';
 import {sendCodebridgeAnalyticsEvent} from '../utils/analyticsReporterHelper';
-
-import ForTeachersOnly from './ForTeachersOnly';
 
 import moduleStyles from './styles/info-panel.module.scss';
 
@@ -49,8 +50,13 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
   style,
   className,
 }) => {
-  const {levelProperties, onRun, onStop, AiTutor2ResponseView} =
-    useCodebridgeContext();
+  const {
+    levelProperties,
+    onRun,
+    onStop,
+    AiTutor2ResponseView,
+    aiTutor2Context,
+  } = useCodebridgeContext();
   const {
     mapReference,
     referenceLinks,
@@ -177,6 +183,32 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
     }
   };
 
+  if (
+    experiments.isEnabledAllowingQueryString(experiments.LAB2_RESOURCE_PANEL)
+  ) {
+    return (
+      <div style={style} className={className}>
+        <ResourcePanel
+          isRunning={isRunning}
+          hasRun={hasRun}
+          hasEdited={hasEdited}
+          validationSettings={{
+            onValidate: handleValidate,
+            onStopValidation: handleStopValidation,
+            isValidating,
+            isValidateDisabled: !hasLoadedEnvironment || isRunning,
+          }}
+          AiTutor2ResponseView={AiTutor2ResponseView}
+          className={moduleStyles.instructionsContainer}
+          headerClassName={moduleStyles.infoPanelHeader}
+          levelProperties={levelProperties}
+          requireRun={true}
+          aiTutor2Context={aiTutor2Context}
+        />
+      </div>
+    );
+  }
+
   return (
     <div style={style} className={className}>
       <PanelContainer
@@ -221,7 +253,7 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
             requireRun={true}
           />
         ) : (
-          <ForTeachersOnly />
+          <ForTeachersOnly levelProperties={levelProperties} />
         )}
       </PanelContainer>
     </div>

--- a/apps/src/lab2/views/components/Instructions/ForTeachersOnly.tsx
+++ b/apps/src/lab2/views/components/Instructions/ForTeachersOnly.tsx
@@ -1,15 +1,18 @@
-import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import React from 'react';
 
-import PredictSolution from '@cdo/apps/lab2/views/components/Instructions/PredictSolution';
+import {LevelProperties} from '@cdo/apps/lab2/types';
 import TeacherOnlyMarkdown from '@cdo/apps/templates/instructions/TeacherOnlyMarkdown';
 
-const ForTeachersOnly: React.FunctionComponent = () => {
-  const {levelProperties} = useCodebridgeContext();
+import PredictSolution from './PredictSolution';
+
+const ForTeachersOnly: React.FC<{
+  levelProperties: LevelProperties;
+  className?: string;
+}> = ({levelProperties, className}) => {
   const {teacherMarkdown, predictSettings} = levelProperties;
 
   return (
-    <div>
+    <div className={className}>
       <PredictSolution predictSettings={predictSettings} />
       <TeacherOnlyMarkdown content={teacherMarkdown} hideContainer={true} />
     </div>

--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -46,6 +46,8 @@ export interface InstructionsProps {
   /** If the lab requires the user to click run in order to continue.
    * Only applies to non-validated levels. */
   requireRun?: boolean;
+  /** If the navigation area should be hidden. */
+  hideNavigation?: boolean;
 }
 
 interface ValidationSettings {
@@ -73,6 +75,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   fixedDarkBackground,
   AiTutor2ResponseView,
   overrideTheme,
+  hideNavigation = false,
   ...feedbackProps
 }) => {
   const validationResults = useAppSelector(
@@ -168,11 +171,13 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
             <PredictQuestionRunPrompt />
           </>
         )}
-        <NavigationArea
-          {...feedbackProps}
-          levelProperties={levelProperties}
-          handleInstructionsTextClick={handleInstructionsTextClick}
-        />
+        {!hideNavigation && (
+          <NavigationArea
+            {...feedbackProps}
+            levelProperties={levelProperties}
+            handleInstructionsTextClick={handleInstructionsTextClick}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -1,0 +1,129 @@
+import {useTheme} from '@code-dot-org/component-library/common/contexts';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {WithTooltip} from '@code-dot-org/component-library/tooltip';
+import classNames from 'classnames';
+import React, {useMemo, useState} from 'react';
+
+import {queryParams} from '@cdo/apps/code-studio/utils';
+import {commonI18n} from '@cdo/apps/types/locale';
+import {getTypedKeys} from '@cdo/apps/types/utils';
+
+import AiTutor2Chat from '../../AiTutor2Chat';
+import PanelContainer from '../../PanelContainer';
+import ForTeachersOnly from '../ForTeachersOnly';
+import Instructions, {InstructionsProps} from '../InstructionsV2';
+import NavigationArea from '../NavigationArea';
+
+import styles from './styles.module.scss';
+
+enum Tabs {
+  Instructions = 'instructions',
+  AiTutor = 'aiTutor',
+  TeachersOnly = 'teachersOnly',
+}
+
+const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
+  [Tabs.Instructions]: {title: commonI18n.instructions(), icon: 'info-circle'},
+  [Tabs.AiTutor]: {title: commonI18n.aiTutor(), icon: 'robot'},
+  [Tabs.TeachersOnly]: {
+    title: commonI18n.forTeachersOnly(),
+    icon: 'chalkboard-teacher',
+  },
+};
+
+type ResourcePanelProps = InstructionsProps & {
+  className?: string;
+  headerClassName?: string;
+  aiTutor2Context?: string;
+};
+
+/**
+ * Display various instructional resources for the level as tabs.
+ */
+const ResourcePanel: React.FC<ResourcePanelProps> = ({
+  className,
+  headerClassName,
+  aiTutor2Context,
+  ...instructionsProps
+}) => {
+  const {theme} = useTheme();
+  const [currentTab, setCurrentTab] = useState<Tabs>(Tabs.Instructions);
+
+  // Build available tabs based on level information.
+  const availableTabs = useMemo(() => {
+    const tabMap: {[key in Tabs]?: React.ReactNode} = {};
+    const levelProperties = instructionsProps.levelProperties;
+
+    if (levelProperties.longInstructions) {
+      tabMap[Tabs.Instructions] = (
+        <Instructions {...instructionsProps} hideNavigation />
+      );
+    }
+
+    if (
+      levelProperties.teacherMarkdown ||
+      levelProperties.predictSettings?.solution
+    ) {
+      tabMap[Tabs.TeachersOnly] = (
+        <ForTeachersOnly
+          levelProperties={levelProperties}
+          className={styles.panelContent}
+        />
+      );
+    }
+
+    if (
+      (levelProperties.aiTutor2Available ||
+        queryParams('show-ai-tutor2') === 'true') &&
+      aiTutor2Context
+    ) {
+      tabMap[Tabs.AiTutor] = <AiTutor2Chat hiddenContext={aiTutor2Context} />;
+    }
+
+    return tabMap;
+  }, [instructionsProps, aiTutor2Context]);
+
+  return (
+    <div className={classNames(styles.resourcePanel, className)}>
+      <div className={styles.sidebar}>
+        <div className={styles.tabs}>
+          {getTypedKeys(availableTabs).map(tab => (
+            <WithTooltip
+              tooltipProps={{
+                text: tabInfo[tab].title,
+                tooltipId: `tooltip-${tab}`,
+                direction: 'onRight',
+                size: 'xs',
+                'data-theme': theme,
+              }}
+            >
+              <button
+                type="button"
+                className={classNames(
+                  styles.tabButton,
+                  tab === currentTab && styles.selected
+                )}
+                onClick={() => setCurrentTab(tab)}
+                key={tab}
+              >
+                <FontAwesomeV6Icon iconName={tabInfo[tab].icon} />
+              </button>
+            </WithTooltip>
+          ))}
+        </div>
+      </div>
+      <div className={classNames(styles.panels)}>
+        <PanelContainer
+          id={currentTab}
+          headerContent={tabInfo[currentTab].title}
+          headerClassName={headerClassName}
+        >
+          {availableTabs[currentTab]}
+          <NavigationArea {...instructionsProps} />
+        </PanelContainer>
+      </div>
+    </div>
+  );
+};
+
+export default ResourcePanel;

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -5,11 +5,11 @@ import classNames from 'classnames';
 import React, {useMemo, useState} from 'react';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
+import AiTutor2Chat from '@cdo/apps/lab2/views/components/AiTutor2Chat';
+import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {getTypedKeys} from '@cdo/apps/types/utils';
 
-import AiTutor2Chat from '../../AiTutor2Chat';
-import PanelContainer from '../../PanelContainer';
 import ForTeachersOnly from '../ForTeachersOnly';
 import Instructions, {InstructionsProps} from '../InstructionsV2';
 import NavigationArea from '../NavigationArea';

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -1,0 +1,61 @@
+@import 'color.scss';
+@import '../../../../../mixins.scss';
+
+.resourcePanel {
+  display: flex;
+  background-color: var(--background-neutral-secondary);
+  height: 100%;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .tabs {
+    margin-top: 2rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tabButton {
+    @include remove-button-styles;
+    height: 2rem;
+    width: 2rem;
+    margin-left: 5px;
+    border: 1px solid var(--borders-neutral-primary);
+    border-right: none;
+    border-radius: 4px 0 0 4px;
+    background-color: var(--background-neutral-secondary);
+
+    // Overwrite default button styles.
+    &:active {
+      border: 1px solid var(--borders-neutral-primary) !important;
+      border-right: none !important;
+    }
+
+    &.selected {
+      background-color: var(--background-neutral-primary);
+    }
+
+    i {
+      color: var(--text-neutral-secondary);
+      font-size: 14px;
+    }
+  }
+}
+
+.panels {
+  display: flex;
+  opacity: 1;
+  flex-direction: column;
+  flex: 1;
+  // Space for absolutely positioned footer.
+  // Remove when footer buttons are moved to sidebar.
+  margin-bottom: 45px;
+}
+
+.panelContent {
+  background-color: var(--background-neutral-primary);
+  height: 100%;
+}

--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -11,6 +11,7 @@ import {useHorizontalLayout} from '@cdo/apps/lab2/hooks/useHorizontalLayout';
 import AiTutor2Chat from '@cdo/apps/lab2/views/components/AiTutor2Chat';
 import ResizeBar from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import moduleStyles from '@cdo/apps/lab2/views/components/layout/layout.module.scss';
@@ -19,7 +20,11 @@ const MIN_RIGHT_PANEL_WIDTH = 300;
 const MIN_LEFT_PANEL_WIDTH = 150;
 const MIN_OUTPUT_HEIGHT = 120;
 const MIN_EDITOR_HEIGHT = 200;
-const INITIAL_INFO_PANEL_WIDTH = 300;
+const INITIAL_INFO_PANEL_WIDTH = experiments.isEnabledAllowingQueryString(
+  experiments.LAB2_RESOURCE_PANEL
+)
+  ? 330
+  : 300;
 const INITIAL_OUTPUT_HEIGHT = 300;
 const INITIAL_OUTPUT_HEIGHT_WIDGET = 800;
 const PROJECT_FOOTER_HEIGHT = 56;
@@ -33,9 +38,13 @@ const HorizontalLayout: React.FunctionComponent<LayoutProps> = ({
   );
   const {aiTutor2Context, levelProperties} = useCodebridgeContext();
 
+  // AI Tutor 2 is shown in the resource panel if enabled.
   const showAiTutor2 =
-    levelProperties.aiTutor2Available ||
-    queryParams('show-ai-tutor2') === 'true';
+    !experiments.isEnabledAllowingQueryString(
+      experiments.LAB2_RESOURCE_PANEL
+    ) &&
+    (levelProperties.aiTutor2Available ||
+      queryParams('show-ai-tutor2') === 'true');
 
   const {
     leftPanelWidth,

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -66,6 +66,8 @@ experiments.MODULARITY = 'modularity';
 experiments.LOCALIZEJS = 'localizejs';
 // Use the new lab2 instructions panel
 experiments.LAB2_INSTRUCTIONS_V2 = 'lab2-instructions-v2';
+// Use the new lab2 tabbed resource panel
+experiments.LAB2_RESOURCE_PANEL = 'lab2-resource-panel';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
This adds a new "tabbed" instructions experience to Python Lab as described [here](https://docs.google.com/document/d/1e8MlvVGbeBlKE0WJwMm87qTmTPXNHPJfuOtUbPxbrUo/edit?tab=t.0#heading=h.8hybj8rt0eob) in the hopes of better surfacing instructional content, colocating related information, and reducing popups/overlay over the workspace. Named "Resource Panel" in code to differentiate it from instructions (but open to other naming ideas!) 

This is currently gated behind an experiment flag (`lab2-resource-panel`) that can be enabled with `enableExperiments=lab2-resource-panel` (saves to local storage and keeps the experiment enable for future sessions) or `lab2-resource-panel=true` (doesn't save to local storage).

<img width="1513" height="824" alt="Screenshot 2025-08-06 at 1 29 48 PM" src="https://github.com/user-attachments/assets/6938d9a9-2a82-47e7-ba4d-e819507c5ed0" />
<img width="1511" height="825" alt="Screenshot 2025-08-06 at 1 30 03 PM" src="https://github.com/user-attachments/assets/18ce06d3-4959-4299-b5f6-d629587e5c69" />

https://github.com/user-attachments/assets/2a742491-24aa-4c96-bdd9-70654799395b

## Links

- Spec: https://docs.google.com/document/d/1e8MlvVGbeBlKE0WJwMm87qTmTPXNHPJfuOtUbPxbrUo/edit?tab=t.0#heading=h.8hybj8rt0eob

## Testing story
- Tested locally on a variety of Python Lab levels.

## Follow-up work
- Add this to AI Chat and Music Lab
- Add Student Rubrics as a tab