### PR TITLE
Web Lab 2: support basic image upload

### DIFF
--- a/apps/src/codebridge/Editor/Editor.tsx
+++ b/apps/src/codebridge/Editor/Editor.tsx
@@ -82,10 +82,11 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
   }, [file?.language, langMapping]);
 
   if (file && viewableImageFileType(file.language)) {
-    const base64 = window.btoa(file.contents);
+    // const base64 = window.btoa(file.contents);
     return (
       <div>
-        <img src={`data:image/png;base64,${base64}`} alt={file.name} />
+        {/*<img src={`data:image/png;base64,${base64}`} alt={file.name} />*/}
+        <img src={file.contents} alt={file.name} />
       </div>
     );
   }

--- a/apps/src/codebridge/Editor/Editor.tsx
+++ b/apps/src/codebridge/Editor/Editor.tsx
@@ -82,11 +82,9 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
   }, [file?.language, langMapping]);
 
   if (file?.url && viewableImageFileType(file.language)) {
-    // const base64 = window.btoa(file.contents);
     return (
       <div>
-        {/*<img src={`data:image/png;base64,${base64}`} alt={file.name} />*/}
-        <img src={file?.url} alt={file.name} />
+        <img src={file.url} alt={file.name} />
       </div>
     );
   }

--- a/apps/src/codebridge/Editor/Editor.tsx
+++ b/apps/src/codebridge/Editor/Editor.tsx
@@ -81,12 +81,12 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
     }
   }, [file?.language, langMapping]);
 
-  if (file && viewableImageFileType(file.language)) {
+  if (file?.url && viewableImageFileType(file.language)) {
     // const base64 = window.btoa(file.contents);
     return (
       <div>
         {/*<img src={`data:image/png;base64,${base64}`} alt={file.name} />*/}
-        <img src={file.contents} alt={file.name} />
+        <img src={file?.url} alt={file.name} />
       </div>
     );
   }

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -14,7 +14,10 @@ import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-type UseFileUploaderArgs = Omit<FileUploaderProps, 'sendAnalyticsEvent'> & {
+type UseFileUploaderArgs = Omit<
+  FileUploaderProps,
+  'sendAnalyticsEvent' | 'channelId'
+> & {
   validFileTypes?: string[];
 };
 
@@ -28,9 +31,8 @@ export const useFileUploader = (
   const files = useAppSelector(
     state => (state.lab2Project.projectSources?.source as MultiFileSource).files
   );
-  const channelId = useAppSelector(
-    state => state.lab.channel && state.lab.channel.id
-  );
+  const channelId =
+    useAppSelector(state => state.lab.channel && state.lab.channel.id) || '';
 
   const sendAnalyticsEvent = useCallback(
     (eventName: string, payload: Record<string, string>) => {

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -70,10 +70,8 @@ export const useFileUploader = (
     [folderId, files, isStartMode, validationFile, validFileTypes]
   );
 
-  const getExternalFileName = useCallback(
-    (fileName: string) => `/folder-${folderId}-file-${fileName}`,
-    [folderId]
-  );
+  const getExternalFileName = (fileName: string) =>
+    `/folder-${folderId}-file-${fileName}`;
 
   return useLab2FileUploader({
     sendAnalyticsEvent,

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -13,7 +13,6 @@ import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {createUuid} from '@cdo/apps/utils';
 
 type UseFileUploaderArgs = Omit<FileUploaderProps, 'sendAnalyticsEvent'> & {
   validFileTypes?: string[];
@@ -71,14 +70,10 @@ export const useFileUploader = (
     [folderId, files, isStartMode, validationFile, validFileTypes]
   );
 
-  const getExternalFileName = (fileName: string) =>
-    `${createUuid()}-${fileName}`;
-
   return useLab2FileUploader({
     sendAnalyticsEvent,
     validateFileName,
     channelId,
-    getExternalFileName,
     ...lab2FileUploaderArgs,
   });
 };

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -12,6 +12,7 @@ import {
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 type UseFileUploaderArgs = Omit<FileUploaderProps, 'sendAnalyticsEvent'> & {
@@ -52,7 +53,7 @@ export const useFileUploader = (
     [appName]
   );
 
-  const {validFileTypes, ...lab2FileUploaderArgs} = args;
+  const {validFileTypes, callback, ...lab2FileUploaderArgs} = args;
   const validateFileName = useCallback(
     (fileName: string) => {
       return validateCodebridgeFileName({
@@ -67,9 +68,22 @@ export const useFileUploader = (
     [folderId, files, isStartMode, validationFile, validFileTypes]
   );
 
+  const uploadToExternalSource = async (file: File) => {
+    // return something with URL?
+    // If the file is not a text file, upload to S3
+    // await HttpClient.put(buildAssetUrl(asset), file);
+    // we don't have channelId here
+    const url = `/v3/assets/3H-AyPf3huzbPZ9mTPK4qw/${file.name}`;
+    await HttpClient.put(url, file);
+    return url;
+  };
+
   return useLab2FileUploader({
+    callback,
     sendAnalyticsEvent,
     validateFileName,
+    externalSourceFileTypes: ['png'],
+    uploadToExternalSource,
     ...lab2FileUploaderArgs,
   });
 };

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -70,11 +70,16 @@ export const useFileUploader = (
     [folderId, files, isStartMode, validationFile, validFileTypes]
   );
 
+  const getExternalFileName = useCallback(
+    (fileName: string) => `/folder-${folderId}-file-${fileName}`,
+    [folderId]
+  );
+
   return useLab2FileUploader({
     sendAnalyticsEvent,
     validateFileName,
     channelId,
-    folderId,
+    getExternalFileName,
     ...lab2FileUploaderArgs,
   });
 };

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -12,7 +12,6 @@ import {
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 type UseFileUploaderArgs = Omit<FileUploaderProps, 'sendAnalyticsEvent'> & {
@@ -56,7 +55,7 @@ export const useFileUploader = (
     [appName]
   );
 
-  const {validFileTypes, callback, ...lab2FileUploaderArgs} = args;
+  const {validFileTypes, ...lab2FileUploaderArgs} = args;
   const validateFileName = useCallback(
     (fileName: string) => {
       return validateCodebridgeFileName({
@@ -71,18 +70,11 @@ export const useFileUploader = (
     [folderId, files, isStartMode, validationFile, validFileTypes]
   );
 
-  const uploadToAssetsBucket = async (file: File) => {
-    const url = `/v3/assets/${channelId}/${file.name}`;
-    await HttpClient.put(url, file);
-    return url;
-  };
-
   return useLab2FileUploader({
-    callback,
     sendAnalyticsEvent,
     validateFileName,
-    externalSourceFileTypes: ['png'],
-    uploadToExternalSource: uploadToAssetsBucket,
+    channelId,
+    folderId,
     ...lab2FileUploaderArgs,
   });
 };

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -13,6 +13,7 @@ import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {createUuid} from '@cdo/apps/utils';
 
 type UseFileUploaderArgs = Omit<FileUploaderProps, 'sendAnalyticsEvent'> & {
   validFileTypes?: string[];
@@ -71,7 +72,7 @@ export const useFileUploader = (
   );
 
   const getExternalFileName = (fileName: string) =>
-    `/folder-${folderId}-file-${fileName}`;
+    `${createUuid()}-${fileName}`;
 
   return useLab2FileUploader({
     sendAnalyticsEvent,

--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -29,6 +29,9 @@ export const useFileUploader = (
   const files = useAppSelector(
     state => (state.lab2Project.projectSources?.source as MultiFileSource).files
   );
+  const channelId = useAppSelector(
+    state => state.lab.channel && state.lab.channel.id
+  );
 
   const sendAnalyticsEvent = useCallback(
     (eventName: string, payload: Record<string, string>) => {
@@ -68,12 +71,8 @@ export const useFileUploader = (
     [folderId, files, isStartMode, validationFile, validFileTypes]
   );
 
-  const uploadToExternalSource = async (file: File) => {
-    // return something with URL?
-    // If the file is not a text file, upload to S3
-    // await HttpClient.put(buildAssetUrl(asset), file);
-    // we don't have channelId here
-    const url = `/v3/assets/3H-AyPf3huzbPZ9mTPK4qw/${file.name}`;
+  const uploadToAssetsBucket = async (file: File) => {
+    const url = `/v3/assets/${channelId}/${file.name}`;
     await HttpClient.put(url, file);
     return url;
   };
@@ -83,7 +82,7 @@ export const useFileUploader = (
     sendAnalyticsEvent,
     validateFileName,
     externalSourceFileTypes: ['png'],
-    uploadToExternalSource,
+    uploadToExternalSource: uploadToAssetsBucket,
     ...lab2FileUploaderArgs,
   });
 };

--- a/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
@@ -44,6 +44,7 @@ export const useHandleFileUpload = (
         return;
       }
 
+      // this is what actually updates the project files (in Redux and triggering save to S3)
       dispatch(createNewFileThunk({fileName, folderId, contents}));
       sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_UPLOAD_FILE, appName, {
         fileName,

--- a/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
@@ -54,11 +54,9 @@ export const useHandleFileUpload = (
 
       if (url) {
         dispatch(createNewExternalFileThunk({fileName, folderId, url}));
-        return;
+      } else {
+        dispatch(createNewFileThunk({fileName, folderId, contents}));
       }
-      // this is what actually updates the project files (in Redux and triggering save to S3)
-      // add createNewExternalFileThunk to the project files?
-      dispatch(createNewFileThunk({fileName, folderId, contents}));
       sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_UPLOAD_FILE, appName, {
         fileName,
       });

--- a/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
@@ -6,7 +6,10 @@ import {useCallback} from 'react';
 
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
-import {createNewFileThunk} from '@cdo/apps/lab2/redux/lab2ProjectReduxThunks';
+import {
+  createNewFileThunk,
+  createNewExternalFileThunk,
+} from '@cdo/apps/lab2/redux/lab2ProjectReduxThunks';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
@@ -21,7 +24,12 @@ export const useHandleFileUpload = (
 
   const dialogControl = useDialogControl();
   return useCallback(
-    async (fileName: string, contents: string, folderIdArg: unknown) => {
+    (
+      fileName: string,
+      contents: string,
+      url?: string,
+      folderIdArg?: unknown
+    ) => {
       const folderId = folderIdArg as FolderId;
 
       const validationError = validateFileName({
@@ -44,13 +52,10 @@ export const useHandleFileUpload = (
         return;
       }
 
-      // need to check against a list of files types we want to upload to s3
-      // need to actually get project id somehow
-      // if (file) {
-      //   const url = `/v3/assets/3H-AyPf3huzbPZ9mTPK4qw/${fileName}`;
-      //   await HttpClient.put(url, file);
-      // }
-
+      if (url) {
+        dispatch(createNewExternalFileThunk({fileName, folderId, url}));
+        return;
+      }
       // this is what actually updates the project files (in Redux and triggering save to S3)
       // add createNewExternalFileThunk to the project files?
       dispatch(createNewFileThunk({fileName, folderId, contents}));

--- a/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/useHandleFileUpload.ts
@@ -21,7 +21,7 @@ export const useHandleFileUpload = (
 
   const dialogControl = useDialogControl();
   return useCallback(
-    (fileName: string, contents: string, folderIdArg: unknown) => {
+    async (fileName: string, contents: string, folderIdArg: unknown) => {
       const folderId = folderIdArg as FolderId;
 
       const validationError = validateFileName({
@@ -44,7 +44,15 @@ export const useHandleFileUpload = (
         return;
       }
 
+      // need to check against a list of files types we want to upload to s3
+      // need to actually get project id somehow
+      // if (file) {
+      //   const url = `/v3/assets/3H-AyPf3huzbPZ9mTPK4qw/${fileName}`;
+      //   await HttpClient.put(url, file);
+      // }
+
       // this is what actually updates the project files (in Redux and triggering save to S3)
+      // add createNewExternalFileThunk to the project files?
       dispatch(createNewFileThunk({fileName, folderId, contents}));
       sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_UPLOAD_FILE, appName, {
         fileName,

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -161,10 +161,11 @@ export const useFileUploader = ({
       } else {
         try {
           if (!channelId) {
-            throw new Error('channelId required for file upload');
+            throw new Error('channelId required for file upload.');
           }
 
-          const url = `/v3/assets/${channelId}/${createUuid()}`;
+          const fileType = file.name.split('.')[1];
+          const url = `/v3/assets/${channelId}/${createUuid()}.${fileType}`;
           await HttpClient.put(url, file);
           sendAnalyticsEvent(analyticsEvents.UPLOAD_SUCCEEDED, {
             name: file.name,

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -19,6 +19,7 @@ export type FileUploaderProps = {
     callbackArgs?: unknown
   ) => void;
   errorCallback: (error: string, callbackArgs?: unknown) => void;
+  channelId: string;
   validateFileName?: (fileName: string) => string | undefined;
   multiple?: boolean;
   validMimeTypes?: string[];
@@ -26,7 +27,6 @@ export type FileUploaderProps = {
     eventName: analyticsEvents,
     payload: Record<string, string>
   ) => void;
-  channelId?: string;
 };
 
 const bufferToString = (buffer: ArrayBuffer) => {
@@ -91,10 +91,10 @@ export const useFileUploader = ({
   callback,
   errorCallback,
   validMimeTypes,
+  channelId,
   validateFileName = () => undefined,
   sendAnalyticsEvent = () => {},
   multiple = true,
-  channelId = '',
 }: FileUploaderProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const callbackArgs = useRef<unknown>();
@@ -159,9 +159,8 @@ export const useFileUploader = ({
         };
       } else {
         try {
-          // Better error handling?
           if (!channelId) {
-            return;
+            throw new Error('channelId required for file upload');
           }
 
           const url = `/v3/assets/${channelId}/${createUuid()}`;
@@ -173,7 +172,6 @@ export const useFileUploader = ({
           callback(file.name, '', url, callbackArgs.current);
         } catch (error) {
           if (error instanceof Error) {
-            // what to do in error case?
             handleError(error);
           }
         }

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -25,8 +25,8 @@ export type FileUploaderProps = {
     eventName: analyticsEvents,
     payload: Record<string, string>
   ) => void;
-  folderId?: string;
   channelId?: string;
+  getExternalFileName?: (fileName: string) => string;
 };
 
 const bufferToString = (buffer: ArrayBuffer) => {
@@ -95,12 +95,19 @@ export const useFileUploader = ({
   sendAnalyticsEvent = () => {},
   multiple = true,
   channelId = '',
-  folderId = '',
+  getExternalFileName,
 }: FileUploaderProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const callbackArgs = useRef<unknown>();
 
   const changeHandler = useCallback(() => {
+    const handleError = (error: Error) => {
+      sendAnalyticsEvent(analyticsEvents.UPLOAD_FAILED, {
+        error: error.message,
+      });
+      errorCallback(error.message, callbackArgs.current);
+    };
+
     Array.from(inputRef.current?.files || []).forEach(async file => {
       const fileNameErrorMessage = validateFileName(file.name);
       if (fileNameErrorMessage) {
@@ -121,13 +128,46 @@ export const useFileUploader = ({
         return;
       }
 
-      const reader = new FileReader();
       if (file.type.match(/^text/)) {
+        const reader = new FileReader();
         reader.readAsText(file);
+
+        reader.onload = () => {
+          if (!reader.result) {
+            callback(file.name, '', undefined, callbackArgs.current);
+          } else {
+            const result =
+              typeof reader.result === 'string'
+                ? reader.result
+                : bufferToString(reader.result);
+            sendAnalyticsEvent(analyticsEvents.UPLOAD_SUCCEEDED, {
+              name: file.name,
+              type: file.type,
+            });
+            callback(
+              file.name,
+              result as string,
+              undefined,
+              callbackArgs.current
+            );
+          }
+        };
+
+        reader.onerror = () => {
+          if (reader.error) {
+            handleError(reader.error);
+          }
+        };
       } else {
         try {
-          // handle if channel ID missing?
-          const url = `/v3/assets/${channelId}/${folderId}-${file.name}`;
+          // Better error handling?
+          if (!getExternalFileName || !channelId) {
+            return;
+          }
+
+          const url = `/v3/assets/${channelId}/${getExternalFileName(
+            file.name
+          )}`;
           await HttpClient.put(url, file);
           sendAnalyticsEvent(analyticsEvents.UPLOAD_SUCCEEDED, {
             name: file.name,
@@ -136,44 +176,11 @@ export const useFileUploader = ({
           callback(file.name, '', url, callbackArgs.current);
         } catch (error) {
           if (error instanceof Error) {
-            sendAnalyticsEvent(analyticsEvents.UPLOAD_FAILED, {
-              error: error.message,
-            });
-            errorCallback(error.message, callbackArgs.current);
+            handleError(error);
           }
         }
         // what to do in error case?
-        return;
       }
-
-      reader.onload = () => {
-        if (!reader.result) {
-          callback(file.name, '', undefined, callbackArgs.current);
-        } else {
-          const result =
-            typeof reader.result === 'string'
-              ? reader.result
-              : bufferToString(reader.result);
-          sendAnalyticsEvent(analyticsEvents.UPLOAD_SUCCEEDED, {
-            name: file.name,
-            type: file.type,
-          });
-          callback(
-            file.name,
-            result as string,
-            undefined,
-            callbackArgs.current
-          );
-        }
-      };
-      reader.onerror = () => {
-        if (reader.error) {
-          sendAnalyticsEvent(analyticsEvents.UPLOAD_FAILED, {
-            error: reader.error.message,
-          });
-          errorCallback(reader.error.message, callbackArgs.current);
-        }
-      };
     });
   }, [
     validMimeTypes,
@@ -182,7 +189,7 @@ export const useFileUploader = ({
     errorCallback,
     callback,
     channelId,
-    folderId,
+    getExternalFileName,
   ]);
 
   return useMemo(

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useMemo, useRef} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import HttpClient from '@cdo/apps/util/HttpClient';
 
 export const enum analyticsEvents {
   UPLOAD_FAILED = 'UPLOAD_FAILED',
@@ -24,8 +25,8 @@ export type FileUploaderProps = {
     eventName: analyticsEvents,
     payload: Record<string, string>
   ) => void;
-  externalSourceFileTypes?: string[];
-  uploadToExternalSource?: (file: File) => Promise<string>;
+  folderId?: string;
+  channelId?: string;
 };
 
 const bufferToString = (buffer: ArrayBuffer) => {
@@ -93,8 +94,8 @@ export const useFileUploader = ({
   validateFileName = () => undefined,
   sendAnalyticsEvent = () => {},
   multiple = true,
-  externalSourceFileTypes = [],
-  uploadToExternalSource = undefined,
+  channelId = '',
+  folderId = '',
 }: FileUploaderProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const callbackArgs = useRef<unknown>();
@@ -120,17 +121,14 @@ export const useFileUploader = ({
         return;
       }
 
-      // NOTE: this is multifile, API supports one at a time?
-      // I feel like we have to mess with the internals (this is lab2 code)
-      // because we're talking about changing the core way that files are saved to a project.
-      // This currently just returns file contents as a string, which is not what we want.
-      // We want to write the file to S3 AND store the url somewhere.
-      if (
-        externalSourceFileTypes.includes(file.name.split('.')[1]) &&
-        uploadToExternalSource
-      ) {
+      const reader = new FileReader();
+      if (file.type.match(/^text/)) {
+        reader.readAsText(file);
+      } else {
         try {
-          const url = await uploadToExternalSource(file);
+          // handle if channel ID missing?
+          const url = `/v3/assets/${channelId}/${folderId}-${file.name}`;
+          await HttpClient.put(url, file);
           sendAnalyticsEvent(analyticsEvents.UPLOAD_SUCCEEDED, {
             name: file.name,
             type: file.type,
@@ -146,13 +144,6 @@ export const useFileUploader = ({
         }
         // what to do in error case?
         return;
-      }
-
-      const reader = new FileReader();
-      if (file.type.match(/^text/)) {
-        reader.readAsText(file);
-      } else {
-        reader.readAsArrayBuffer(file);
       }
 
       reader.onload = () => {
@@ -190,8 +181,8 @@ export const useFileUploader = ({
     sendAnalyticsEvent,
     errorCallback,
     callback,
-    externalSourceFileTypes,
-    uploadToExternalSource,
+    channelId,
+    folderId,
   ]);
 
   return useMemo(

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback, useMemo, useRef} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
-import HttpClient from '@cdo/apps/util/HttpClient';
 
 export const enum analyticsEvents {
   UPLOAD_FAILED = 'UPLOAD_FAILED',
@@ -24,6 +23,8 @@ export type FileUploaderProps = {
     eventName: analyticsEvents,
     payload: Record<string, string>
   ) => void;
+  externalSourceFileTypes?: string[];
+  uploadToExternalSource?: (file: File) => Promise<string>;
 };
 
 const bufferToString = (buffer: ArrayBuffer) => {
@@ -91,6 +92,8 @@ export const useFileUploader = ({
   validateFileName = () => undefined,
   sendAnalyticsEvent = () => {},
   multiple = true,
+  externalSourceFileTypes = [],
+  uploadToExternalSource = undefined,
 }: FileUploaderProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const callbackArgs = useRef<unknown>();
@@ -115,18 +118,32 @@ export const useFileUploader = ({
         );
         return;
       }
+
       // NOTE: this is multifile, API supports one at a time?
       // I feel like we have to mess with the internals (this is lab2 code)
       // because we're talking about changing the core way that files are saved to a project.
       // This currently just returns file contents as a string, which is not what we want.
       // We want to write the file to S3 AND store the url somewhere.
-      if (!file.type.match(/^text/)) {
-        // If the file is not a text file, upload to S3
-        // await HttpClient.put(buildAssetUrl(asset), file);
-        // we don't have channelId here
-        const url = `/v3/assets/3H-AyPf3huzbPZ9mTPK4qw/${file.name}`;
-        await HttpClient.put(url, file);
-        callback(file.name, url, callbackArgs.current);
+      if (
+        externalSourceFileTypes.includes(file.name.split('.')[1]) &&
+        uploadToExternalSource
+      ) {
+        try {
+          const url = await uploadToExternalSource(file);
+          sendAnalyticsEvent(analyticsEvents.UPLOAD_SUCCEEDED, {
+            name: file.name,
+            type: file.type,
+          });
+          callback(file.name, url, callbackArgs.current);
+        } catch (error) {
+          if (error instanceof Error) {
+            sendAnalyticsEvent(analyticsEvents.UPLOAD_FAILED, {
+              error: error.message,
+            });
+            errorCallback(error.message, callbackArgs.current);
+          }
+        }
+        // what to do in error case?
         return;
       }
 
@@ -167,6 +184,8 @@ export const useFileUploader = ({
     sendAnalyticsEvent,
     errorCallback,
     callback,
+    externalSourceFileTypes,
+    uploadToExternalSource,
   ]);
 
   return useMemo(

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -65,7 +65,7 @@ const isValidMimeType = (
 
 /**
  * A custom hook that provides functionality for file uploads,
- * including validation, reading, and handling callbacks.
+ * including validation, reading, uploading to S3 for non-text files, and handling callbacks.
  *
  * @param props An object containing configuration options for the hook.
  *
@@ -74,6 +74,7 @@ const isValidMimeType = (
  * @property props.errorCallback - A function to be called with an error message if the upload fails.
  * @property props.validMimeTypes - An optional array of strings representing the allowed MIME types for uploaded files.
  *                                  If not provided, the hook will validate against the internal defaultMimeTypes array
+ * @property props.channelId - Required so that we can upload non-text files to S3.
  * @property props.sendAnalyticsEvent - An optional function that will be called with analytics data. It will generated analytics events for
                                         analyticsEvents.UPLOAD_UNACCEPTED_FILE, analyticsEvents.UPLOAD_FAILED, and analyticsEvents.UPLOAD_SUCCEEDED.
                                         Map them to your own analytics events. The second argument will be a record with more info, as Record<string, string>

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -13,6 +13,7 @@ export type FileUploaderProps = {
   callback: (
     filename: string,
     contents: string,
+    uploadUrl?: string,
     callbackArgs?: unknown
   ) => void;
   errorCallback: (error: string, callbackArgs?: unknown) => void;
@@ -134,7 +135,7 @@ export const useFileUploader = ({
             name: file.name,
             type: file.type,
           });
-          callback(file.name, url, callbackArgs.current);
+          callback(file.name, '', url, callbackArgs.current);
         } catch (error) {
           if (error instanceof Error) {
             sendAnalyticsEvent(analyticsEvents.UPLOAD_FAILED, {
@@ -156,7 +157,7 @@ export const useFileUploader = ({
 
       reader.onload = () => {
         if (!reader.result) {
-          callback(file.name, '', callbackArgs.current);
+          callback(file.name, '', undefined, callbackArgs.current);
         } else {
           const result =
             typeof reader.result === 'string'
@@ -166,7 +167,12 @@ export const useFileUploader = ({
             name: file.name,
             type: file.type,
           });
-          callback(file.name, result as string, callbackArgs.current);
+          callback(
+            file.name,
+            result as string,
+            undefined,
+            callbackArgs.current
+          );
         }
       };
       reader.onerror = () => {

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useMemo, useRef} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import HttpClient from '@cdo/apps/util/HttpClient';
 
 export const enum analyticsEvents {
   UPLOAD_FAILED = 'UPLOAD_FAILED',
@@ -74,6 +75,7 @@ const isValidMimeType = (
                                         analyticsEvents.UPLOAD_UNACCEPTED_FILE, analyticsEvents.UPLOAD_FAILED, and analyticsEvents.UPLOAD_SUCCEEDED.
                                         Map them to your own analytics events. The second argument will be a record with more info, as Record<string, string>
                                         If the function is not provided, then no analytics will be tracked
+ * @property props.multiple - Optionally disable multiple file uploads. Defaults to true.
  *
  * @returns An object containing the following properties:
  *
@@ -94,7 +96,7 @@ export const useFileUploader = ({
   const callbackArgs = useRef<unknown>();
 
   const changeHandler = useCallback(() => {
-    Array.from(inputRef.current?.files || []).forEach(file => {
+    Array.from(inputRef.current?.files || []).forEach(async file => {
       const fileNameErrorMessage = validateFileName(file.name);
       if (fileNameErrorMessage) {
         errorCallback(fileNameErrorMessage, callbackArgs.current);
@@ -111,6 +113,20 @@ export const useFileUploader = ({
           codebridgeI18n.invalidFileType({fileType: file.type || fileType}),
           callbackArgs.current
         );
+        return;
+      }
+      // NOTE: this is multifile, API supports one at a time?
+      // I feel like we have to mess with the internals (this is lab2 code)
+      // because we're talking about changing the core way that files are saved to a project.
+      // This currently just returns file contents as a string, which is not what we want.
+      // We want to write the file to S3 AND store the url somewhere.
+      if (!file.type.match(/^text/)) {
+        // If the file is not a text file, upload to S3
+        // await HttpClient.put(buildAssetUrl(asset), file);
+        // we don't have channelId here
+        const url = `/v3/assets/3H-AyPf3huzbPZ9mTPK4qw/${file.name}`;
+        await HttpClient.put(url, file);
+        callback(file.name, url, callbackArgs.current);
         return;
       }
 

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -176,10 +176,10 @@ export const useFileUploader = ({
           callback(file.name, '', url, callbackArgs.current);
         } catch (error) {
           if (error instanceof Error) {
+            // what to do in error case?
             handleError(error);
           }
         }
-        // what to do in error case?
       }
     });
   }, [

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useMemo, useRef} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import HttpClient from '@cdo/apps/util/HttpClient';
+import {createUuid} from '@cdo/apps/utils';
 
 export const enum analyticsEvents {
   UPLOAD_FAILED = 'UPLOAD_FAILED',
@@ -26,7 +27,6 @@ export type FileUploaderProps = {
     payload: Record<string, string>
   ) => void;
   channelId?: string;
-  getExternalFileName?: (fileName: string) => string;
 };
 
 const bufferToString = (buffer: ArrayBuffer) => {
@@ -95,7 +95,6 @@ export const useFileUploader = ({
   sendAnalyticsEvent = () => {},
   multiple = true,
   channelId = '',
-  getExternalFileName,
 }: FileUploaderProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const callbackArgs = useRef<unknown>();
@@ -161,13 +160,11 @@ export const useFileUploader = ({
       } else {
         try {
           // Better error handling?
-          if (!getExternalFileName || !channelId) {
+          if (!channelId) {
             return;
           }
 
-          const url = `/v3/assets/${channelId}/${getExternalFileName(
-            file.name
-          )}`;
+          const url = `/v3/assets/${channelId}/${createUuid()}`;
           await HttpClient.put(url, file);
           sendAnalyticsEvent(analyticsEvents.UPLOAD_SUCCEEDED, {
             name: file.name,
@@ -189,7 +186,6 @@ export const useFileUploader = ({
     errorCallback,
     callback,
     channelId,
-    getExternalFileName,
   ]);
 
   return useMemo(

--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -93,8 +93,8 @@ const projectSlice = createSlice({
       state,
       action: PayloadAction<{
         fileName: string;
-        folderId?: FolderId;
         url: string;
+        folderId?: FolderId;
       }>
     ) {
       if (state.projectSources?.source) {

--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -90,6 +90,30 @@ const projectSlice = createSlice({
         state.hasEdited = true;
       }
     },
+    createNewExternalFile(
+      state,
+      action: PayloadAction<{
+        fileName: string;
+        folderId?: FolderId;
+        url: string;
+      }>
+    ) {
+      if (state.projectSources?.source) {
+        const source = state.projectSources.source as MultiFileSource;
+        const newFileId = createNewFileHelper(
+          source,
+          action.payload.fileName,
+          action.payload.folderId,
+          undefined,
+          action.payload.url
+        );
+        state.projectSources = {
+          ...state.projectSources,
+          source: newFileId,
+        };
+        state.hasEdited = true;
+      }
+    },
     renameFile(
       state,
       action: PayloadAction<{fileId: FileId; newName: string}>
@@ -396,6 +420,7 @@ export const {
   setSource,
   setProjectTooLarge,
   createNewFile,
+  createNewExternalFile,
   renameFile,
   saveFile,
   setFileType,

--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -74,6 +74,7 @@ const projectSlice = createSlice({
         fileName: string;
         folderId?: FolderId;
         contents?: string;
+        url?: string;
       }>
     ) {
       if (state.projectSources?.source) {

--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -74,7 +74,6 @@ const projectSlice = createSlice({
         fileName: string;
         folderId?: FolderId;
         contents?: string;
-        url?: string;
       }>
     ) {
       if (state.projectSources?.source) {

--- a/apps/src/lab2/redux/lab2ProjectReduxThunks.ts
+++ b/apps/src/lab2/redux/lab2ProjectReduxThunks.ts
@@ -21,6 +21,7 @@ import {
   setProjectSource,
   setViewingOldVersion,
   createNewFile,
+  createNewExternalFile,
   renameFile,
   saveFile,
   setFileType,
@@ -161,6 +162,9 @@ function makeFileOperationThunk<P>(
 }
 // Generate all thunks in one line each
 export const createNewFileThunk = makeFileOperationThunk(createNewFile);
+export const createNewExternalFileThunk = makeFileOperationThunk(
+  createNewExternalFile
+);
 export const renameFileThunk = makeFileOperationThunk(renameFile);
 export const saveFileThunk = makeFileOperationThunk(saveFile);
 export const setFileTypeThunk = makeFileOperationThunk(setFileType);

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -132,6 +132,7 @@ export interface ProjectFile {
   active?: boolean;
   folderId: string;
   type?: ProjectFileType;
+  url?: string;
 }
 
 /**

--- a/apps/src/lab2/utils/multiFileSourceEditUtils.ts
+++ b/apps/src/lab2/utils/multiFileSourceEditUtils.ts
@@ -24,20 +24,27 @@ export const createNewFileHelper = (
   source: MultiFileSource,
   fileName: string,
   folderId: FolderId = DEFAULT_FOLDER_ID,
-  contents: string = ''
+  contents: string = '',
+  url?: string
 ): MultiFileSource => {
   const fileId = getNextFileId(Object.values(source.files));
   const newSource = {...source, files: {...source.files}};
   const [, extension] = fileName.split('.');
   const defaultContents = `Add your changes to ${fileName}`;
 
-  newSource.files[fileId] = {
+  const file: ProjectFile = {
     id: fileId,
     name: fileName,
     language: extension || 'html',
     contents: contents || defaultContents,
     folderId,
   };
+
+  if (url) {
+    file.url = url; // If a URL is provided, add it to the file object.
+  }
+
+  newSource.files[fileId] = file;
 
   return activateFileHelper(newSource, fileId);
 };

--- a/apps/src/lab2/utils/multiFileSourceEditUtils.ts
+++ b/apps/src/lab2/utils/multiFileSourceEditUtils.ts
@@ -7,6 +7,7 @@ import {
   MultiFileSource,
   ProjectFile,
 } from '@cdo/apps/lab2/types';
+import HttpClient from '@cdo/apps/util/HttpClient';
 
 import {
   getNextFileId,
@@ -137,6 +138,10 @@ export const deleteFileHelper = (
   const fileToBeDeleted = newSource.files[fileId];
   delete newSource.files[fileId];
 
+  if (fileToBeDeleted.url) {
+    HttpClient.delete(fileToBeDeleted.url);
+  }
+
   const newActiveFileId = getNewActiveFileId(source, fileToBeDeleted);
   if (newActiveFileId) {
     newSource.files[newActiveFileId] = {
@@ -206,7 +211,12 @@ export const deleteFolderHelper = (
     newSource.files = {...newSource.files};
     Object.values(newSource.files)
       .filter(f => files.has(f.id))
-      .forEach(f => delete newSource.files[f.id]);
+      .forEach(f => {
+        delete newSource.files[f.id];
+        if (f.url) {
+          HttpClient.delete(f.url);
+        }
+      });
     if (newSource.openFiles) {
       // Delete files from the list of open files.
       newSource.openFiles = newSource.openFiles.filter(

--- a/apps/src/lab2/utils/multiFileSourceEditUtils.ts
+++ b/apps/src/lab2/utils/multiFileSourceEditUtils.ts
@@ -36,12 +36,12 @@ export const createNewFileHelper = (
     id: fileId,
     name: fileName,
     language: extension || 'html',
-    contents: contents || defaultContents,
+    contents: url ? '' : contents || defaultContents,
     folderId,
   };
 
   if (url) {
-    file.url = url; // If a URL is provided, add it to the file object.
+    file.url = url;
   }
 
   newSource.files[fileId] = file;

--- a/apps/src/lab2/utils/multiFileSourceEditUtils.ts
+++ b/apps/src/lab2/utils/multiFileSourceEditUtils.ts
@@ -1,5 +1,6 @@
 import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
 import {getOpenFileIds} from '@cdo/apps/codebridge/utils';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {getActiveFileForSource} from '@cdo/apps/lab2/projects/utils';
 import {
   FileId,
@@ -139,7 +140,15 @@ export const deleteFileHelper = (
   delete newSource.files[fileId];
 
   if (fileToBeDeleted.url) {
-    HttpClient.delete(fileToBeDeleted.url);
+    try {
+      // We don't wait for the deletion to complete because a user's project doesn't depend on the completion of the operation.
+      // In the case of a failure, we just end up with an orphaned file in S3.
+      HttpClient.delete(fileToBeDeleted.url);
+    } catch (error) {
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .logError('Error deleting project asset from S3', error as Error);
+    }
   }
 
   const newActiveFileId = getNewActiveFileId(source, fileToBeDeleted);
@@ -214,7 +223,18 @@ export const deleteFolderHelper = (
       .forEach(f => {
         delete newSource.files[f.id];
         if (f.url) {
-          HttpClient.delete(f.url);
+          try {
+            // We don't wait for the deletion to complete because a user's project doesn't depend on the completion of the operation.
+            // In the case of a failure, we just end up with an orphaned file in S3.
+            HttpClient.delete(f.url);
+          } catch (error) {
+            Lab2Registry.getInstance()
+              .getMetricsReporter()
+              .logError(
+                'Error deleting project asset (as part of folder deletion) from S3',
+                error as Error
+              );
+          }
         }
       });
     if (newSource.openFiles) {

--- a/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
+++ b/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
@@ -18,6 +18,7 @@ import reducer, {
   rearrangeFiles,
   resetProjectMetadata,
   Lab2ProjectState,
+  createNewExternalFile,
 } from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {
   MultiFileSource,
@@ -141,6 +142,75 @@ describe('lab2ProjectRedux', () => {
       const state = reducer(
         initialState,
         createNewFile({fileName: 'newFile.txt'})
+      );
+
+      expect(state).toEqual(initialState);
+    });
+  });
+
+  describe('createNewExternalFile', () => {
+    it('should create a new external file in root folder', () => {
+      const fileUrl = '/v3/assets/channelId/abc-def.png';
+      const initialProjectSources = createMockProjectSources();
+      const initialStateWithSources = {
+        ...initialState,
+        projectSources: initialProjectSources,
+      };
+
+      const state = reducer(
+        initialStateWithSources,
+        createNewExternalFile({
+          fileName: 'image.png',
+          url: fileUrl,
+        })
+      );
+
+      const source = state.projectSources!.source as MultiFileSource;
+      const newFiles = Object.values(source.files);
+      const newFile = newFiles.find(f => f.name === 'image.png');
+
+      expect(newFile).toBeDefined();
+      expect(newFile?.folderId).toBe(DEFAULT_FOLDER_ID);
+      expect(newFile?.contents).toBe('');
+      expect(newFile?.url).toBe(fileUrl);
+      expect(newFile?.language).toBe('png');
+      expect(state.hasEdited).toBe(true);
+    });
+
+    it('should create a new external file in specific folder', () => {
+      const fileUrl = '/v3/assets/channelId/abc-def.png';
+      const initialProjectSources = createMockProjectSources();
+      const initialStateWithSources = {
+        ...initialState,
+        projectSources: initialProjectSources,
+      };
+
+      const state = reducer(
+        initialStateWithSources,
+        createNewExternalFile({
+          fileName: 'image.png',
+          url: fileUrl,
+          folderId: '1',
+        })
+      );
+
+      const source = state.projectSources!.source as MultiFileSource;
+      const newFiles = Object.values(source.files);
+      const newFile = newFiles.find(f => f.name === 'image.png');
+
+      expect(newFile).toBeDefined();
+      expect(newFile?.folderId).toBe('1');
+      expect(newFile?.contents).toBe('');
+      expect(newFile?.url).toBe(fileUrl);
+      expect(newFile?.language).toBe('png');
+      expect(state.hasEdited).toBe(true);
+    });
+
+    it('should not create file when project sources is undefined', () => {
+      const fileUrl = '/v3/assets/channelId/abc-def.png';
+      const state = reducer(
+        initialState,
+        createNewExternalFile({fileName: 'image.png', url: fileUrl})
       );
 
       expect(state).toEqual(initialState);


### PR DESCRIPTION
Adds initial support for image uploads in Web Lab 2, with images saved to S3 via our Assets API.

This PR updates the general lab2 `useFileUploader` hook so that any time it sees a non-text file, it uploads the image to S3. Text files continue to function as they have previously, with the file being read and returned so that it can be added to the project's main.json file. For image files, an entry is still added to main.json that includes a new `url` property.

https://github.com/user-attachments/assets/d10f7863-6146-40c0-874d-dcee461a88a1

## Links

- Jira: https://codedotorg.atlassian.net/browse/CT-585

## Testing story

I tested manually that I could:
- upload image files with the same name in different folders.
- delete individual images as well as folders containing images, and in either case, the images were deleted from S3.
- add/edit existing text files (.html, etc)

## Follow-up work

We'll next make image uploads and available to levelbuilders via start mode, and we'll also want to restrict the file types that can be uploaded.
