### PR TITLE
Revert "use cached unit group units in single_unit_course? helper"

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -630,7 +630,7 @@ class UnitGroup < ApplicationRecord
   # rubocop:enable Naming/PredicateName
 
   def single_unit_course?
-    cached.default_unit_group_units.one?
+    default_unit_group_units.one?
   end
 
   def first_unit

--- a/dashboard/test/controllers/congrats_controller_test.rb
+++ b/dashboard/test/controllers/congrats_controller_test.rb
@@ -30,7 +30,7 @@ class CongratsControllerTest < ActionController::TestCase
 
     Unit.stubs(:should_cache?).returns(true)
 
-    assert_cached_queries(1) do
+    assert_cached_queries(0) do
       # Reset @view_options before each request to avoid FrozenError on retries
       @controller.instance_variable_set(:@view_options, nil)
       get :index, params: {s: Base64.urlsafe_encode64(hoc_course.name)}

--- a/dashboard/test/integration/caching_test.rb
+++ b/dashboard/test/integration/caching_test.rb
@@ -22,7 +22,7 @@ class CachingTest < ActionDispatch::IntegrationTest
   end
 
   test "should get other hoc course unit overview" do
-    assert_cached_queries(0) do
+    assert_cached_queries(1) do
       get "/courses/#{@other_hoc_course.name}/units/1"
     end
     assert_response :success


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67540 because query counts on test do not match those in drone