### PR TITLE
Lab2: tabbed instructions in AI Chat

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -18,12 +18,14 @@ import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LabProps} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils';
 import InstructionsV2 from '@cdo/apps/lab2/views/components/Instructions/InstructionsV2';
+import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import ProjectTemplateWorkspaceIconV2 from '@cdo/apps/templates/ProjectTemplateWorkspaceIconV2';
 import {commonI18n} from '@cdo/apps/types/locale';
+import experiments from '@cdo/apps/util/experiments';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
@@ -334,27 +336,51 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
           {viewMode === ViewMode.EDIT && (
             <>
               <div className={moduleStyles.instructionsArea}>
-                <PanelContainer
-                  id="aichat-instructions-panel"
-                  headerContent={commonI18n.instructions()}
-                  className={moduleStyles.panelContainer}
-                  headerClassName={moduleStyles.panelHeader}
-                  rightHeaderContent={renderInstructionsHeaderRight(
-                    isUserTeacher,
-                    () => {
-                      dispatch(setShowModalType(ModalTypes.TEACHER_ONBOARDING));
-                    }
-                  )}
-                >
-                  <InstructionsV2
-                    className={moduleStyles.instructions}
+                {experiments.isEnabledAllowingQueryString(
+                  experiments.LAB2_RESOURCE_PANEL
+                ) ? (
+                  <ResourcePanel
+                    className={moduleStyles.panelContainer}
+                    headerClassName={moduleStyles.panelHeader}
                     /** AI Chat doesn't have a traditional "run" state, so this is always false. */
                     isRunning={false}
                     hasRun={hasSentMessage}
                     hasEdited={hasUpdatedCustomizations}
                     levelProperties={levelProperties}
+                    rightHeaderContent={renderInstructionsHeaderRight(
+                      isUserTeacher,
+                      () => {
+                        dispatch(
+                          setShowModalType(ModalTypes.TEACHER_ONBOARDING)
+                        );
+                      }
+                    )}
                   />
-                </PanelContainer>
+                ) : (
+                  <PanelContainer
+                    id="aichat-instructions-panel"
+                    headerContent={commonI18n.instructions()}
+                    className={moduleStyles.panelContainer}
+                    headerClassName={moduleStyles.panelHeader}
+                    rightHeaderContent={renderInstructionsHeaderRight(
+                      isUserTeacher,
+                      () => {
+                        dispatch(
+                          setShowModalType(ModalTypes.TEACHER_ONBOARDING)
+                        );
+                      }
+                    )}
+                  >
+                    <InstructionsV2
+                      className={moduleStyles.instructions}
+                      /** AI Chat doesn't have a traditional "run" state, so this is always false. */
+                      isRunning={false}
+                      hasRun={hasSentMessage}
+                      hasEdited={hasUpdatedCustomizations}
+                      levelProperties={levelProperties}
+                    />
+                  </PanelContainer>
+                )}
               </div>
               {!allFieldsHidden && (
                 <div className={moduleStyles.customizationArea}>

--- a/apps/src/aichat/views/aichatView.module.scss
+++ b/apps/src/aichat/views/aichatView.module.scss
@@ -58,10 +58,9 @@ $column-min-width: 200px;
 }
 
 .panelContainer {
-  border: 1px $light_gray_200 solid;
+  border: 1px solid var(--borders-neutral-primary);
   border-radius: $border-radius;
   box-sizing: border-box;
-  background: $white;
 }
 
 .panelHeader {

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -36,7 +36,7 @@ $default-spacing: 4px;
   flex: 1;
   overflow: hidden;
   flex-direction: column;
-  background: $light_white;
+  background: var(--background-neutral-primary);
 
   .tabsContainer {
     background-color: var(--background-neutral-tertiary);

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -35,6 +35,7 @@ type ResourcePanelProps = InstructionsProps & {
   className?: string;
   headerClassName?: string;
   aiTutor2Context?: string;
+  rightHeaderContent?: React.ReactNode;
 };
 
 /**
@@ -44,6 +45,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   className,
   headerClassName,
   aiTutor2Context,
+  rightHeaderContent,
   ...instructionsProps
 }) => {
   const {theme} = useTheme();
@@ -117,6 +119,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
           id={currentTab}
           headerContent={tabInfo[currentTab].title}
           headerClassName={headerClassName}
+          rightHeaderContent={rightHeaderContent}
         >
           {availableTabs[currentTab]}
           <NavigationArea {...instructionsProps} />


### PR DESCRIPTION
Adds the new tabbed instructions "Resource Panel" introduced in https://github.com/code-dot-org/code-dot-org/pull/67585 to AI Chat Lab. Also fixes a few colors that were using hardcoded/legacy constants. As with Python Lab, this is gated behind a `lab2-resource-panel` experiment flag.

<img width="1511" height="826" alt="Screenshot 2025-08-07 at 11 10 48 AM" src="https://github.com/user-attachments/assets/38892b3d-fb2b-4761-8478-5ad05d8108da" />

## Testing story

Tested locally on AI Chat levels.