### PR TITLE
Add footer landmark

### DIFF
--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -7,7 +7,7 @@
 - options[:loc_prefix] = "footer."
 - footer_contents = Cdo::Footer.get_footer_contents(options)
 
-.navbar-static-top.footer
+%footer.navbar-static-top.footer
   .container{ style: 'padding: 10px;' + (full_width ? 'margin: auto' : '') }
     .row
       .span9{style: (full_width ? 'max-width: 80%;' : '')}


### PR DESCRIPTION
Our footer should be contained in a landmark for keyboard navigability. 
This will bring us closer to WCAG compliance.
This PR switches the footer wrapper from `<div>` to `<footer>`

## Links
- Jira: [P20-1553](https://codedotorg.atlassian.net/browse/P20-1553)

## Testing story
### Before:
<img width="1728" height="676" alt="Screenshot 2025-08-07 at 15 13 28" src="https://github.com/user-attachments/assets/9560761d-c0e6-440e-b876-ead42e9c5cfb" />

### After:
<img width="1728" height="676" alt="Screenshot 2025-08-07 at 15 28 35" src="https://github.com/user-attachments/assets/f72c919a-d7ab-4f65-973b-8691eb3121a9" />


## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
