### PR TITLE
feat(marketing): enable cache for sites other than corporate

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -42,6 +42,7 @@ Parameters:
 
 Conditions:
   IsProductionEnvironment: !Equals [!Ref EnvironmentType, production]
+  IsCorporateSite: !Equals [ !Ref SiteType, corporate ]
 
 Mappings:
   # Cloudfront Mappings
@@ -205,7 +206,10 @@ Resources:
           TargetOriginId: marketing-sites-application-origin
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
-          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Managed-CachingDisabled (Disabled until this distribution becomes the main one instead of daisy chained)
+          CachePolicyId: !If
+            - IsCorporateSite
+            - 4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Managed-CachingDisabled (Disabled until this distribution becomes the main one instead of daisy chained)
+            - !Ref ApplicationCachingPolicy
           OriginRequestPolicyId: "216adef6-5c7f-47e4-b989-5492eafa07d3" # AllViewer
           FunctionAssociations:
             - EventType: viewer-response


### PR DESCRIPTION
This PR automatically enables caching using the predefined caching policy if the site type is other than the corporate website.

Tested and verified on `csforall.marketing-sites.dev-code.org/en-US`