### PR TITLE
fix(eyes): deflake background tests

### DIFF
--- a/frontend/apps/marketing-storybook/stories/Divider.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/Divider.story.tsx
@@ -50,7 +50,7 @@ export const Strong: Story = {
 
 export const White: Story = {
   globals: {
-    backgrounds: {value: 'dark'},
+    sectionBackground: 'dark',
   },
   args: {
     color: 'white',

--- a/frontend/apps/marketing-storybook/stories/Link.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/Link.story.tsx
@@ -87,7 +87,7 @@ export const LinkXSPrimary: Story = {
 
 export const LinkXSWhite: Story = {
   globals: {
-    backgrounds: {value: 'dark'},
+    sectionBackground: 'dark',
   },
   render: () => (
     <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
@@ -142,7 +142,7 @@ export const LinkSPrimary: Story = {
 
 export const LinkSWhite: Story = {
   globals: {
-    backgrounds: {value: 'dark'},
+    sectionBackground: 'dark',
   },
   render: () => (
     <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
@@ -197,7 +197,7 @@ export const LinkMPrimary: Story = {
 
 export const LinkMWhite: Story = {
   globals: {
-    backgrounds: {value: 'dark'},
+    sectionBackground: 'dark',
   },
   render: () => (
     <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
@@ -252,7 +252,7 @@ export const LinkLPrimary: Story = {
 
 export const LinkLWhite: Story = {
   globals: {
-    backgrounds: {value: 'dark'},
+    sectionBackground: 'dark',
   },
   render: () => (
     <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>


### PR DESCRIPTION
The tests were using both a Storybook dark mode AND section dark which caused some flakiness when loading in the dark mode on different areas. This deflakes it by having a consistent dark mode on the section component for these CMS components.