### PR TITLE
Ceara/aitt 1037 display old thread

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -235,7 +235,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
             id: json.message_id,
           };
 
-          // logging here because on the first user message the threadID is null
+          // logging here because on the first user message the threadID is 0
           // we only get a threadID initialized in the response
           if (localThreadId === 0) {
             threadFetchCallback();

--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -74,6 +74,7 @@ const AIDIFF_CHAT_COMPLETION = 'chat_completion';
 
 interface AiDiffChatProps {
   context: Context;
+  threadMessages?: ChatItem[];
   scriptName?: string;
   chatResponseCallback?: () => void;
   initialChatMessage?: string;
@@ -81,10 +82,12 @@ interface AiDiffChatProps {
   disableEndButtons?: boolean;
   curriculumCourses?: string[];
   threadFetchCallback?: () => void;
+  threadId?: number;
 }
 
 const AiDiffChat: React.FC<AiDiffChatProps> = ({
   context,
+  threadMessages = [],
   scriptName,
   chatResponseCallback = () => {},
   initialChatMessage = INITIAL_CHAT_MESSAGE,
@@ -94,6 +97,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
   disableEndButtons = false,
   curriculumCourses = [],
   threadFetchCallback = () => {},
+  threadId = 0,
 }) => {
   const reportingData = React.useMemo(() => {
     return {
@@ -106,7 +110,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
 
   const [suggestionPage, setSuggestionPage] = useState(0);
 
-  const [threadId, setThreadId] = useState(null);
+  const [localThreadId, setLocalThreadId] = useState(threadId);
 
   const viewAsUserId = useAppSelector(
     state => state.progress?.viewAsUserId || undefined
@@ -120,14 +124,18 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
     additionalPrompts.push(DEBUG_THIS_CODE, IMPROVE_THIS_CODE);
   }
 
-  const [messageHistory, setMessageHistory] = useState<ChatItem[]>([
-    {
-      role: Role.ASSISTANT,
-      chatMessageText: initialChatMessage,
-      status: Status.OK,
-    },
-    suggestedPrompts.concat(additionalPrompts),
-  ]);
+  const [messageHistory, setMessageHistory] = useState<ChatItem[]>(
+    threadMessages.length > 0
+      ? threadMessages
+      : [
+          {
+            role: Role.ASSISTANT,
+            chatMessageText: initialChatMessage,
+            status: Status.OK,
+          },
+          suggestedPrompts.concat(additionalPrompts),
+        ]
+  );
 
   const onMessageSend = (message: string) => {
     const newUserMessage = {
@@ -198,20 +206,20 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
     (prompt: string, isPreset: boolean, presetChipText: string | null) => {
       setIsWaitingForResponse(true);
 
-      if (threadId !== null) {
-        sendChatEvent(Role.USER, prompt, isPreset, threadId);
+      if (localThreadId !== 0) {
+        sendChatEvent(Role.USER, prompt, isPreset, localThreadId);
       }
 
       const endpoint =
-        threadId === null
+        localThreadId === 0
           ? `${AIDIFF_THREADS_ENDPOINT}`
-          : `${AIDIFF_THREADS_ENDPOINT}/${threadId}/${AIDIFF_CHAT_COMPLETION}`;
+          : `${AIDIFF_THREADS_ENDPOINT}/${localThreadId}/${AIDIFF_CHAT_COMPLETION}`;
 
       const body = JSON.stringify({
         inputText: prompt,
         isPreset,
         presetChipText,
-        ...(threadId === null ? {context} : {}),
+        ...(localThreadId === 0 ? {context} : {}),
         ...(context.type === AiDiffContext.LEVEL ? {viewAsUserId} : {}),
       });
 
@@ -229,7 +237,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
 
           // logging here because on the first user message the threadID is null
           // we only get a threadID initialized in the response
-          if (threadId === null) {
+          if (localThreadId === 0) {
             threadFetchCallback();
             sendChatEvent(Role.USER, prompt, isPreset, json.thread_id);
           }
@@ -241,7 +249,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
             json.thread_id
           );
           if (json.thread_id) {
-            setThreadId(json.thread_id);
+            setLocalThreadId(json.thread_id);
           }
           setMessageHistory(prevMessages => [...prevMessages, newAiMessage]);
         })
@@ -252,12 +260,13 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         });
     },
     [
+      localThreadId,
       context,
-      threadId,
       viewAsUserId,
-      chatResponseCallback,
       sendChatEvent,
       threadFetchCallback,
+      setLocalThreadId,
+      chatResponseCallback,
     ]
   );
 

--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -90,7 +90,10 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
         data-testid="draggable-test-id"
         id="draggable-id"
         className={
-          showSidebar ? style.aiDiffContainerWide : style.aiDiffContainer
+          showSidebar &&
+          !(!hasCompletedAiDifferentiationWelcome && showWelcomeExperience) //don't use wide container for welcome
+            ? style.aiDiffContainerWide
+            : style.aiDiffContainer
         }
         style={open ? undefined : {display: 'none'}}
       >

--- a/apps/src/aiDifferentiation/AiDiffSidebar.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSidebar.tsx
@@ -11,7 +11,7 @@ import styles from './ai-differentiation.module.scss';
 interface AiDiffSidebarProps {
   threads?: ChatThread[];
   selectedThreadId?: number;
-  threadSelectCallback?: () => void;
+  threadSelectCallback?: (thread: number) => void;
 }
 
 const now = new Date();
@@ -51,11 +51,10 @@ const ThreadItem: React.FC<{
 const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
   threads = [],
   selectedThreadId,
-  threadSelectCallback,
+  threadSelectCallback = () => {},
 }) => {
-  const [selectedChat, setSelectedChat] = React.useState<number>(0);
   const handleListItemClick = (chatId: number) => {
-    setSelectedChat(chatId);
+    threadSelectCallback(chatId);
   };
 
   const todayChats = threads.filter(thread => {
@@ -89,7 +88,7 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
           size="m"
           type="primary"
           iconLeft={{iconName: 'plus'}}
-          onClick={() => console.log('Add new chat thread')}
+          onClick={() => threadSelectCallback(0)}
           text={commonI18n.aiDifferentiation_new_chat()}
           className={styles.sidebarButton}
         />
@@ -102,7 +101,7 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
                   <ThreadItem
                     key={chat.id}
                     chat={chat}
-                    selected={chat.id === selectedChat}
+                    selected={chat.id === selectedThreadId}
                     onClick={() => handleListItemClick(chat.id)}
                   />
                 ))}
@@ -115,7 +114,7 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
                   <ThreadItem
                     key={chat.id}
                     chat={chat}
-                    selected={chat.id === selectedChat}
+                    selected={chat.id === selectedThreadId}
                     onClick={() => handleListItemClick(chat.id)}
                   />
                 ))}
@@ -128,7 +127,7 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
                   <ThreadItem
                     key={chat.id}
                     chat={chat}
-                    selected={chat.id === selectedChat}
+                    selected={chat.id === selectedThreadId}
                     onClick={() => handleListItemClick(chat.id)}
                   />
                 ))}
@@ -141,7 +140,7 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
                   <ThreadItem
                     key={chat.id}
                     chat={chat}
-                    selected={chat.id === selectedChat}
+                    selected={chat.id === selectedThreadId}
                     onClick={() => handleListItemClick(chat.id)}
                   />
                 ))}

--- a/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
+++ b/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
@@ -4,7 +4,13 @@ import HttpClient from '../util/HttpClient';
 
 import AiDiffChat from './AiDiffChat';
 import AiDiffSidebar from './AiDiffSidebar';
-import {ChatThread, chatThreadValidator, Context} from './types';
+import {
+  ChatItem,
+  ChatThread,
+  chatThreadValidator,
+  chatThreadMessagesValidator,
+  Context,
+} from './types';
 
 import style from './ai-differentiation.module.scss';
 
@@ -22,6 +28,8 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
   showSidebar,
 }) => {
   const [threads, setThreads] = useState<ChatThread[]>();
+  const [threadMessages, setThreadMessages] = useState<ChatItem[]>();
+  const [threadId, setThreadId] = useState<number>(0);
 
   async function asyncFetchThreads(): Promise<ChatThread[]> {
     const response = await HttpClient.fetchJson<ChatThread[]>(
@@ -48,14 +56,47 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
     }
   }, [showSidebar, fetchThreads]);
 
+  async function asyncFetchThreadMessages(thread: number): Promise<ChatThread> {
+    const response = await HttpClient.fetchJson<ChatThread>(
+      `/aidiff_threads/${thread}`,
+      {},
+      chatThreadMessagesValidator
+    );
+    return response.value;
+  }
+
+  const fetchThreadMessages = useCallback(
+    (thread: number) => {
+      if (thread === 0) {
+        setThreadMessages([]);
+        setThreadId(thread);
+      } else {
+        asyncFetchThreadMessages(thread).then(response => {
+          setThreadMessages(response.messages);
+          setThreadId(thread);
+        });
+      }
+    },
+    [setThreadMessages]
+  );
+
   return (
     <div className={style.aiDiffWorkspace}>
-      {showSidebar && <AiDiffSidebar threads={threads} />}
+      {showSidebar && (
+        <AiDiffSidebar
+          threads={threads}
+          selectedThreadId={threadId}
+          threadSelectCallback={fetchThreadMessages}
+        />
+      )}
       <AiDiffChat
         context={context}
         scriptName={scriptName}
         curriculumCourses={curriculumCourses}
         threadFetchCallback={showSidebar ? fetchThreads : () => {}}
+        threadMessages={threadMessages}
+        key={threadId}
+        threadId={threadId}
       />
     </div>
   );

--- a/apps/src/aiDifferentiation/types.ts
+++ b/apps/src/aiDifferentiation/types.ts
@@ -1,5 +1,8 @@
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
-import {AiDiffContext} from '@cdo/generated-scripts/sharedConstants';
+import {
+  AiDiffContext,
+  AiInteractionStatus,
+} from '@cdo/generated-scripts/sharedConstants';
 
 import {ResponseValidator} from '../util/HttpClient';
 
@@ -25,6 +28,15 @@ type ServerChatThread = {
   messages?: [ChatItem];
 };
 
+type ServerChatMessage = {
+  id: number;
+  role: string;
+  content: string;
+  updated_at: Date;
+  is_preset: boolean;
+  preset_chip_text: string;
+};
+
 export type ChatThread = {
   id: number;
   title: string;
@@ -43,6 +55,24 @@ export type Context = {
   courseId?: number;
   viewAsUserId?: number;
 };
+
+function messageValidatorHelper(
+  response: Record<string, unknown> | unknown[]
+): ChatTextMessage {
+  if (Array.isArray(response)) {
+    throw new Error('Source response should be an object (received array).');
+  }
+  const serverMsg = response as ServerChatMessage;
+  return {
+    role: serverMsg.role,
+    chatMessageText:
+      serverMsg.is_preset && serverMsg.preset_chip_text
+        ? serverMsg.preset_chip_text
+        : serverMsg.content,
+    status: AiInteractionStatus.OK,
+    id: serverMsg.id,
+  } as ChatTextMessage;
+}
 
 const chatThreadValidator: ResponseValidator<ChatThread[]> = bodyJson => {
   if (!Array.isArray(bodyJson)) {
@@ -73,4 +103,22 @@ const chatThreadValidator: ResponseValidator<ChatThread[]> = bodyJson => {
   return threads;
 };
 
+const chatThreadMessagesValidator: ResponseValidator<ChatThread> = bodyJson => {
+  const serverThread = bodyJson as ServerChatThread;
+  const serverMessages = serverThread.messages as ChatTextMessage[];
+
+  const messages: ChatTextMessage[] = serverMessages.map(serverMessage => {
+    return messageValidatorHelper(serverMessage);
+  });
+
+  return {
+    id: serverThread.id,
+    title: serverThread.title,
+    updatedAt: new Date(serverThread.updated_at),
+    contextType: serverThread.context_type,
+    messages: messages,
+  } as ChatThread;
+};
+
 export {chatThreadValidator};
+export {chatThreadMessagesValidator};


### PR DESCRIPTION
Adds a fetch to get previous chat messages based on threadID, and allows the user to select threads from the sidebar to display that thread's messages in the chat and continue the chat by calling `chat_completion` with that thread's ID. Also enables the "New Chat" button to display the intro text and prompt chips and create a new thread. Creating a new thread re-fetches the threads list so it shows up in the sidebar.

- Adds a validator to types to convert the server messages in json to `ChatTextMessage`
- Puts the threadId and setter useState in the Workspace and passes them as params to the sidebar and chat components
- Passes messages array to the Chat component to display old thread messages
- Adds the threadId as a key for the Chat component to reset the component state when switching threads
- Misc change to use the narrow container width for the welcome flow even if the sidebar experiment is enabled

Video:

https://github.com/user-attachments/assets/36f07206-69cf-4790-8bc0-99ad2c634463

## Links
- https://codedotorg.atlassian.net/browse/AITT-1038
- https://codedotorg.atlassian.net/browse/AITT-1037
- https://codedotorg.atlassian.net/browse/AITT-1036
- https://codedotorg.atlassian.net/browse/AITT-1039

## Testing story
This is hidden behind the experiment flag and previous tests pass. I want to merge this now so Tess can experiment with it now and add tests for it in a separate PR


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
