### PR TITLE
Lab2: tabbed instructions for Music Lab

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -36,6 +36,7 @@ type ResourcePanelProps = InstructionsProps & {
   headerClassName?: string;
   aiTutor2Context?: string;
   rightHeaderContent?: React.ReactNode;
+  includeFooterSpacing?: boolean;
 };
 
 /**
@@ -46,6 +47,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   headerClassName,
   aiTutor2Context,
   rightHeaderContent,
+  includeFooterSpacing = true,
   ...instructionsProps
 }) => {
   const {theme} = useTheme();
@@ -114,7 +116,12 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
           ))}
         </div>
       </div>
-      <div className={classNames(styles.panels)}>
+      <div
+        className={classNames(
+          styles.panels,
+          includeFooterSpacing && styles.footerSpacing
+        )}
+      >
         <PanelContainer
           id={currentTab}
           headerContent={tabInfo[currentTab].title}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -50,9 +50,12 @@
   opacity: 1;
   flex-direction: column;
   flex: 1;
-  // Space for absolutely positioned footer.
-  // Remove when footer buttons are moved to sidebar.
-  margin-bottom: 45px;
+
+  &.footerSpacing {
+    // Space for absolutely positioned footer.
+    // Remove when footer buttons are moved to sidebar.
+    margin-bottom: 45px;
+  }
 }
 
 .panelContent {

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -20,6 +20,7 @@ import {LevelProperties} from '@cdo/apps/lab2/types';
 import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import InstructionsV2 from '@cdo/apps/lab2/views/components/Instructions/InstructionsV2';
+import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
 import ProjectTemplateWorkspaceIconV2 from '@cdo/apps/templates/ProjectTemplateWorkspaceIconV2';
@@ -339,60 +340,88 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
               moduleStyles.instructionsSide
             )}
           >
-            <PanelContainer
-              id="instructions-panel"
-              headerContent={musicI18n.panelHeaderInstructions()}
-              hideHeaders={hideHeaders}
-            >
-              {useNewInstructions ? (
-                <InstructionsV2
-                  isRunning={isPlaying}
-                  handleInstructionsTextClick={onInstructionsTextClick}
-                  bottomComponent={
-                    exemplarPlayerInsideInstructions &&
-                    showExemplarPlayer && (
-                      <ExemplarPlayerView
-                        playbackEvents={exemplarPlaybackEvents}
-                        title={exemplarSettings.playerTitle!}
-                        player={player}
-                        insideInstructions={exemplarPlayerInsideInstructions}
-                      />
-                    )
-                  }
-                  hasRun={hasRun}
-                  hasEdited={hasEdited}
-                  fixedDarkBackground={true}
-                  overrideTheme={'Light'}
-                  levelProperties={levelProperties}
-                />
-              ) : (
-                <Instructions
-                  isRunning={isPlaying}
-                  handleInstructionsTextClick={onInstructionsTextClick}
-                  bottomComponent={
-                    exemplarPlayerInsideInstructions &&
-                    showExemplarPlayer && (
-                      <ExemplarPlayerView
-                        playbackEvents={exemplarPlaybackEvents}
-                        title={exemplarSettings.playerTitle!}
-                        player={player}
-                        insideInstructions={exemplarPlayerInsideInstructions}
-                      />
-                    )
-                  }
-                  hasRun={hasRun}
-                  hasEdited={hasEdited}
-                />
-              )}
-              {!exemplarPlayerInsideInstructions && showExemplarPlayer && (
-                <ExemplarPlayerView
-                  playbackEvents={exemplarPlaybackEvents}
-                  title={exemplarSettings.playerTitle!}
-                  player={player}
-                  insideInstructions={exemplarPlayerInsideInstructions}
-                />
-              )}
-            </PanelContainer>
+            {experiments.isEnabledAllowingQueryString(
+              experiments.LAB2_RESOURCE_PANEL
+            ) ? (
+              <ResourcePanel
+                isRunning={isPlaying}
+                handleInstructionsTextClick={onInstructionsTextClick}
+                bottomComponent={
+                  exemplarPlayerInsideInstructions &&
+                  showExemplarPlayer && (
+                    <ExemplarPlayerView
+                      playbackEvents={exemplarPlaybackEvents}
+                      title={exemplarSettings.playerTitle!}
+                      player={player}
+                      insideInstructions={exemplarPlayerInsideInstructions}
+                    />
+                  )
+                }
+                hasRun={hasRun}
+                hasEdited={hasEdited}
+                fixedDarkBackground={true}
+                overrideTheme={'Light'}
+                includeFooterSpacing={false}
+                levelProperties={levelProperties}
+                headerClassName={moduleStyles.panelContainerHeader}
+              />
+            ) : (
+              <PanelContainer
+                id="instructions-panel"
+                headerContent={musicI18n.panelHeaderInstructions()}
+                hideHeaders={hideHeaders}
+                headerClassName={moduleStyles.panelContainerHeader}
+              >
+                {useNewInstructions ? (
+                  <InstructionsV2
+                    isRunning={isPlaying}
+                    handleInstructionsTextClick={onInstructionsTextClick}
+                    bottomComponent={
+                      exemplarPlayerInsideInstructions &&
+                      showExemplarPlayer && (
+                        <ExemplarPlayerView
+                          playbackEvents={exemplarPlaybackEvents}
+                          title={exemplarSettings.playerTitle!}
+                          player={player}
+                          insideInstructions={exemplarPlayerInsideInstructions}
+                        />
+                      )
+                    }
+                    hasRun={hasRun}
+                    hasEdited={hasEdited}
+                    fixedDarkBackground={true}
+                    overrideTheme={'Light'}
+                    levelProperties={levelProperties}
+                  />
+                ) : (
+                  <Instructions
+                    isRunning={isPlaying}
+                    handleInstructionsTextClick={onInstructionsTextClick}
+                    bottomComponent={
+                      exemplarPlayerInsideInstructions &&
+                      showExemplarPlayer && (
+                        <ExemplarPlayerView
+                          playbackEvents={exemplarPlaybackEvents}
+                          title={exemplarSettings.playerTitle!}
+                          player={player}
+                          insideInstructions={exemplarPlayerInsideInstructions}
+                        />
+                      )
+                    }
+                    hasRun={hasRun}
+                    hasEdited={hasEdited}
+                  />
+                )}
+                {!exemplarPlayerInsideInstructions && showExemplarPlayer && (
+                  <ExemplarPlayerView
+                    playbackEvents={exemplarPlaybackEvents}
+                    title={exemplarSettings.playerTitle!}
+                    player={player}
+                    insideInstructions={exemplarPlayerInsideInstructions}
+                  />
+                )}
+              </PanelContainer>
+            )}
           </div>
         )}
 

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -363,7 +363,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 overrideTheme={'Light'}
                 includeFooterSpacing={false}
                 levelProperties={levelProperties}
-                headerClassName={moduleStyles.panelContainerHeader}
+                headerClassName={moduleStyles.headerWithBorder}
               />
             ) : (
               <PanelContainer
@@ -440,7 +440,13 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 hideChaff={hideChaff}
               />
             }
-            headerClassName={moduleStyles.panelContainerHeader}
+            headerClassName={
+              experiments.isEnabledAllowingQueryString(
+                experiments.LAB2_RESOURCE_PANEL
+              )
+                ? moduleStyles.headerWithBorder
+                : moduleStyles.panelContainerHeader
+            }
           >
             {isStartMode && (
               <div

--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -95,7 +95,11 @@ $default-spacing: 2px;
 }
 
 .panelContainerHeader {
-  border-bottom: 1px solid var(--borders-neutral-primary)
+  margin-bottom: 2px;
+}
+
+.headerWithBorder {
+  border-bottom: 1px solid var(--borders-neutral-primary);
 }
 
 .advancedControlsContainer {

--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -95,7 +95,7 @@ $default-spacing: 2px;
 }
 
 .panelContainerHeader {
-  margin-bottom: 2px;
+  border-bottom: 1px solid var(--borders-neutral-primary)
 }
 
 .advancedControlsContainer {


### PR DESCRIPTION
Adds the new tabbed instructions "Resource Panel" introduced in https://github.com/code-dot-org/code-dot-org/pull/67585 to Music Lab. I added borders for the top two panel headers to match styling, but kept the Timeline and Controls panel headers without borders as per https://codedotorg.slack.com/archives/C04TH8400AU/p1754669418994849. As with Python Lab, this is gated behind a lab2-resource-panel experiment flag.

<img width="1512" height="825" alt="Screenshot 2025-08-08 at 12 47 59 PM" src="https://github.com/user-attachments/assets/f8de7255-4587-4735-8002-addb49716e49" />
<img width="1512" height="824" alt="Screenshot 2025-08-08 at 12 51 54 PM" src="https://github.com/user-attachments/assets/aa0130e4-d617-4b98-b5ec-84f8355fe3bc" />

## Testing story

- Tested locally on Music Lab levels.