### PR TITLE
feat(hsts): enable hsts on marketing sites

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -166,7 +166,8 @@ Resources:
       FunctionConfig:
         Comment: Adds Cache-Control if not present
         Runtime: cloudfront-js-2.0
-  # For immutable static assets (hashed assets like JS/CSS files), ensure that the Cache-Control header is set to immutable
+  # Default response headers policy for the marketing sites
+  # This policy sets the Strict-Transport-Security header to ensure that the site is only served over HTTPS
   DefaultResponseHeadersPolicy:
     Type: AWS::CloudFront::ResponseHeadersPolicy
     Properties:
@@ -178,7 +179,7 @@ Resources:
             AccessControlMaxAgeSec: 31536000
             IncludeSubdomains: false
             Override: false
-  # Sets HSTS (HTTP Strict Transport Security) security headers for immutable static assets
+  # For immutable static assets (hashed assets like JS/CSS files), ensure that the Cache-Control header is set to immutable
   ImmutableStaticAssetsResponseHeadersPolicy:
     Type: AWS::CloudFront::ResponseHeadersPolicy
     Properties:

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -178,7 +178,7 @@ Resources:
             AccessControlMaxAgeSec: 31536000
             IncludeSubdomains: false
             Override: false
-  # For immutable static assets (hashed assets like JS/CSS files), ensure that the Cache-Control header is set to immutable
+  # Sets HSTS (HTTP Strict Transport Security) security headers for immutable static assets
   ImmutableStaticAssetsResponseHeadersPolicy:
     Type: AWS::CloudFront::ResponseHeadersPolicy
     Properties:

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -167,6 +167,18 @@ Resources:
         Comment: Adds Cache-Control if not present
         Runtime: cloudfront-js-2.0
   # For immutable static assets (hashed assets like JS/CSS files), ensure that the Cache-Control header is set to immutable
+  DefaultResponseHeadersPolicy:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: !Sub "${AWS::StackName}-Default-ResponseHeader-Policy"
+        Comment: "Marketing Sites default response headers policy"
+        SecurityHeadersConfig:
+          StrictTransportSecurity:
+            AccessControlMaxAgeSec: 31536000
+            IncludeSubdomains: false
+            Override: false
+  # For immutable static assets (hashed assets like JS/CSS files), ensure that the Cache-Control header is set to immutable
   ImmutableStaticAssetsResponseHeadersPolicy:
     Type: AWS::CloudFront::ResponseHeadersPolicy
     Properties:
@@ -178,6 +190,11 @@ Resources:
             - Header: cache-control
               Override: false # Do not override the cache control from the origin if it is available
               Value: public, max-age=31536000, immutable
+        SecurityHeadersConfig:
+          StrictTransportSecurity:
+            AccessControlMaxAgeSec: 31536000
+            IncludeSubdomains: false
+            Override: false
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -211,6 +228,7 @@ Resources:
             - 4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Managed-CachingDisabled (Disabled until this distribution becomes the main one instead of daisy chained)
             - !Ref ApplicationCachingPolicy
           OriginRequestPolicyId: "216adef6-5c7f-47e4-b989-5492eafa07d3" # AllViewer
+          ResponseHeadersPolicyId: !Ref DefaultResponseHeadersPolicy
           FunctionAssociations:
             - EventType: viewer-response
               FunctionARN: !GetAtt ViewerResponseCloudFrontFunction.FunctionARN
@@ -243,6 +261,7 @@ Resources:
               - DELETE
             CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Managed-CachingDisabled (APIs are not cached)
             OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3 # AllViewer
+            ResponseHeadersPolicyId: !Ref DefaultResponseHeadersPolicy
             PathPattern: /api/*
             TargetOriginId: marketing-sites-application-origin
             ViewerProtocolPolicy: redirect-to-https

--- a/frontend/apps/marketing/tests/e2e/security.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/security.spec.ts
@@ -7,7 +7,7 @@ import {isDeployedStage} from './utils/stage';
 test.describe('Security Tests', () => {
   test('should have HSTS headers', async ({page, browserName}) => {
     test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    test.skip(isDeployedStage(), 'Only runs in deployed mode');
+    test.skip(!isDeployedStage(), 'Only runs in deployed mode');
 
     const allTheThingsPage = new AllTheThingsPage(page, {locale: 'en-US'});
     const response = await allTheThingsPage.goto();
@@ -19,7 +19,7 @@ test.describe('Security Tests', () => {
 
   test('should redirect http to https', async ({page, browserName}) => {
     test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    test.skip(isDeployedStage(), 'Only runs in deployed mode');
+    test.skip(!isDeployedStage(), 'Only runs in deployed mode');
 
     const allTheThingsPage = new AllTheThingsPage(page, {locale: 'en-US'});
     const plainTextPath = allTheThingsPage

--- a/frontend/apps/marketing/tests/e2e/security.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/security.spec.ts
@@ -1,0 +1,32 @@
+import {expect} from '@playwright/test';
+
+import {test} from './fixtures/base';
+import {AllTheThingsPage} from './pom/all-the-things';
+import {getTestStage} from './utils/stage';
+
+test.describe('Security Tests', () => {
+  test('should have HSTS headers', async ({page, browserName}) => {
+    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
+
+    const allTheThingsPage = new AllTheThingsPage(page, {locale: 'en-US'});
+    const response = await allTheThingsPage.goto();
+
+    expect(response?.headers()['strict-transport-security']).toBe(
+      'max-age=31536000',
+    );
+  });
+
+  test('should redirect http to https', async ({page, browserName}) => {
+    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
+
+    const allTheThingsPage = new AllTheThingsPage(page, {locale: 'en-US'});
+    const plainTextPath = allTheThingsPage
+      .getBasePath()
+      .replace('https', 'http');
+
+    await page.goto(plainTextPath);
+    expect(page.url()).toBe(allTheThingsPage.getBasePath());
+  });
+});

--- a/frontend/apps/marketing/tests/e2e/security.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/security.spec.ts
@@ -2,12 +2,12 @@ import {expect} from '@playwright/test';
 
 import {test} from './fixtures/base';
 import {AllTheThingsPage} from './pom/all-the-things';
-import {getTestStage} from './utils/stage';
+import {isDeployedStage} from './utils/stage';
 
 test.describe('Security Tests', () => {
   test('should have HSTS headers', async ({page, browserName}) => {
     test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
+    test.skip(isDeployedStage(), 'Only runs in deployed mode');
 
     const allTheThingsPage = new AllTheThingsPage(page, {locale: 'en-US'});
     const response = await allTheThingsPage.goto();
@@ -19,7 +19,7 @@ test.describe('Security Tests', () => {
 
   test('should redirect http to https', async ({page, browserName}) => {
     test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
+    test.skip(isDeployedStage(), 'Only runs in deployed mode');
 
     const allTheThingsPage = new AllTheThingsPage(page, {locale: 'en-US'});
     const plainTextPath = allTheThingsPage

--- a/frontend/apps/marketing/tests/e2e/utils/stage.ts
+++ b/frontend/apps/marketing/tests/e2e/utils/stage.ts
@@ -30,3 +30,7 @@ export function getAppStageFromTestStage() {
       throw new Error(`Invalid stage: ${stage}`);
   }
 }
+
+export function isDeployedStage() {
+  return getAppStageFromTestStage() !== 'development';
+}


### PR DESCRIPTION
This PR adds strict HSTS headers to the cloudfront distribution copying the same ones that are on studio.code.org. It also adds a UI test to ensure these headers exist on deploy and that the HTTP -> HTTPS redirect is occurring.

Tested and verified on `csforall.marketing-sites.dev-code.org/en-US`