### PR TITLE
Temporarily Remove New `rubocop-factory_bot` Gem

### DIFF
--- a/.config/rubocop/config.yml
+++ b/.config/rubocop/config.yml
@@ -6,7 +6,6 @@ inherit_from:
   - blocklist.yml
 
 require:
-  - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails
   - rubocop-rails-accessibility

--- a/.config/rubocop/new.yml
+++ b/.config/rubocop/new.yml
@@ -12,14 +12,14 @@ Lint/MixedCaseRange: # new in 1.53
   Enabled: true
 Lint/RedundantRegexpQuantifiers: # new in 1.53
   Enabled: true
-FactoryBot/ConsistentParenthesesStyle:
-  Enabled: true
-FactoryBot/ExcessiveCreateList: # new in 2.25
-  Enabled: true
-FactoryBot/FactoryNameStyle: # new in 2.16
-  Enabled: true
-FactoryBot/IdSequence: # new in 2.24
-  Enabled: true
+# FactoryBot/ConsistentParenthesesStyle:
+#   Enabled: true
+# FactoryBot/ExcessiveCreateList: # new in 2.25
+#   Enabled: true
+# FactoryBot/FactoryNameStyle: # new in 2.16
+#   Enabled: true
+# FactoryBot/IdSequence: # new in 2.24
+#   Enabled: true
 Style/MapIntoArray: # new in 1.63
   Enabled: true
 Style/RedundantCurrentDirectoryInPath: # new in 1.53

--- a/.config/rubocop/todo.yml
+++ b/.config/rubocop/todo.yml
@@ -454,31 +454,31 @@ Style/TernaryParentheses:
 Style/TrailingUnderscoreVariable:
   Enabled: false
 
-# Offense count: 38
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, ExplicitOnly.
-# SupportedStyles: create_list, n_times
-FactoryBot/CreateList:
-  Enabled: false
+# # Offense count: 38
+# # This cop supports safe autocorrection (--autocorrect).
+# # Configuration parameters: EnforcedStyle, ExplicitOnly.
+# # SupportedStyles: create_list, n_times
+# FactoryBot/CreateList:
+#   Enabled: false
 
-# Offense count: 55
-# This cop supports safe autocorrection (--autocorrect).
-FactoryBot/FactoryClassName:
-  Enabled: false
+# # Offense count: 55
+# # This cop supports safe autocorrection (--autocorrect).
+# FactoryBot/FactoryClassName:
+#   Enabled: false
 
-# Offense count: 65
-FactoryBot/FactoryAssociationWithStrategy: # new in 2.23
-  Enabled: false
+# # Offense count: 65
+# FactoryBot/FactoryAssociationWithStrategy: # new in 2.23
+#   Enabled: false
 
-# Offense count: 111
-FactoryBot/AssociationStyle: # new in 2.23
-  Enabled: false
+# # Offense count: 111
+# FactoryBot/AssociationStyle: # new in 2.23
+#   Enabled: false
 
-# Offense count: 6
-FactoryBot/RedundantFactoryOption: # new in 2.23
-  Enabled: false
+# # Offense count: 6
+# FactoryBot/RedundantFactoryOption: # new in 2.23
+#   Enabled: false
 
-# Offense count: 44
-# This cop does not support safe autocorrection
-FactoryBot/SyntaxMethods: # new in 2.7
-  Enabled: false
+# # Offense count: 44
+# # This cop does not support safe autocorrection
+# FactoryBot/SyntaxMethods: # new in 2.7
+#   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -263,7 +263,6 @@ gem 'aws-sdk-secretsmanager'
 group :development, :staging, :levelbuilder, :test do
   gem 'haml_lint', require: false
   gem 'rubocop', '~> 1.28', require: false
-  gem 'rubocop-factory_bot', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rails-accessibility', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -814,8 +814,6 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.32.0)
       parser (>= 3.3.1.0)
-    rubocop-factory_bot (2.26.1)
-      rubocop (~> 1.61)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -1124,7 +1122,6 @@ DEPENDENCIES
   rmagick (~> 4.2.5)
   rspec
   rubocop (~> 1.28)
-  rubocop-factory_bot
   rubocop-performance
   rubocop-rails
   rubocop-rails-accessibility


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67117, which unfortunately broke our ability to install new gems on existing servers.

The breaking change has already been deployed, but [I've reverted it](https://github.com/code-dot-org/code-dot-org/pull/67639) and the revert has made its way through staging and test. Unfortunately, although the revert is in the build pipeline ready to be deployed so is [a PR which adds a new gem](https://github.com/code-dot-org/code-dot-org/pull/67451), which will unfortunately cause the build to fail before the revert gets picked up.

In order to avoid the next build breaking and also avoid the merge conflicts that would likely result from reverting the PR which adds the gem, I propose we keep the majority of its changes and undo only the addition of the new gem.

## Links

- Slack threads: [1](https://codedotorg.slack.com/archives/C03CK49G9/p1754688660259399), [2](https://codedotorg.slack.com/archives/C0T0PNTM3/p1754685502625799)

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

We should make sure this PR is included in the next DTP, or the build will fail.

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

Once https://github.com/code-dot-org/code-dot-org/pull/67639 has been deployed everywhere and it's again safe for us to add new Gemfile dependencies, we can revert this PR
