### PR TITLE
Revert "Revert "Revert "Revert "Install Bundled Gems in Deployment Mode""""

### DIFF
--- a/.github/actions/install-test-variables/action.yml
+++ b/.github/actions/install-test-variables/action.yml
@@ -6,7 +6,6 @@ runs:
     - name: Setup locals
       run: |
           echo "
-          bundler_use_sudo: false
           cloudfront_key_pair_id: $CLOUDFRONT_KEY_PAIR_ID
           cloudfront_private_key: \"$CLOUDFRONT_PRIVATE_KEY\"
           ignore_eyes_mismatches: true

--- a/.github/workflows/dev_test_docker.yml
+++ b/.github/workflows/dev_test_docker.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Setup locals
         run: |
           echo "
-          bundler_use_sudo: false
           cloudfront_key_pair_id: $CLOUDFRONT_KEY_PAIR_ID
           cloudfront_private_key: \"$CLOUDFRONT_PRIVATE_KEY\"
           ignore_eyes_mismatches: true

--- a/.github/workflows/run_ui_tests.yml
+++ b/.github/workflows/run_ui_tests.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
             echo "
             properties_encryption_key: $PROPERTIES_ENCRYPTION_KEY
-            bundler_use_sudo: false
             cloudfront_key_pair_id: $CLOUDFRONT_KEY_PAIR_ID
             cloudfront_private_key: \"$CLOUDFRONT_PRIVATE_KEY\"
             saucelabs_username: $SAUCE_USERNAME

--- a/bin/oneoff/update_ubuntu/02-postupdate.sh
+++ b/bin/oneoff/update_ubuntu/02-postupdate.sh
@@ -13,8 +13,9 @@ apt upgrade --yes;
 # Reinstall rmagick to resolve the error:
 #   This installation of RMagick was configured with ImageMagick 6.9.10 but
 #   ImageMagick 6.9.11-60 is in use.
-bundle exec gem uninstall rmagick;
-bundle install;
+# Bundle should be run as local rather than root user
+sudo -u ubuntu bundle exec gem uninstall rmagick;
+sudo -u ubuntu bundle install;
 
 # Run a regular build once we're done to get everything working again!
 echo "after the server reboots, kick off a regular build with something like 'start-build'";

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -490,10 +490,6 @@ disable_s3_image_uploads: false
 
 channels_api_secret: !Secret
 
-# Whether to prefix bundler commands with 'sudo'.
-# It may be useful to set this false when doing local development on Linux.
-bundler_use_sudo: <%=chef_managed%>
-
 daemon: <%=name == 'production-daemon'%>
 image_optim: <%=chef_managed && !ci_test%>
 

--- a/cookbooks/cdo-apps/recipes/bundle_bootstrap.rb
+++ b/cookbooks/cdo-apps/recipes/bundle_bootstrap.rb
@@ -20,7 +20,9 @@ env = {
   # http://bundler.io/man/bundle-config.1.html
   'BUNDLE_IGNORE_CONFIG' => '1',
   # Avoid writing 'remembered options' to the default local config (./bundle/config).
-  'BUNDLE_APP_CONFIG' => "#{Chef::Config[:file_cache_path]}/.bundle"
+  'BUNDLE_APP_CONFIG' => "#{Chef::Config[:file_cache_path]}/.bundle",
+  # Install gems to vendor/bundle as per https://bundler.io/guides/deploying.html
+  'BUNDLE_DEPLOYMENT' => 'true',
 }
 node.default['cdo-apps']['bundle_env'] = env
 directory(env['BUNDLE_APP_CONFIG']) {owner user; group user}
@@ -28,16 +30,24 @@ directory(env['BUNDLE_APP_CONFIG']) {owner user; group user}
 # Export bundler environment to project root config ($HOME/$REPO/.bundle/config).
 # Used in case we run 'bundle' manually without the provided environment.
 directory("#{root}/.bundle") {owner user; group user}
-
 file "#{root}/.bundle/config" do
   owner user
   group user
   content env.to_yaml
 end
 
-execute 'bundle-install' do
-  command 'bundle install'
+# Run initial bundle install
+execute 'bundle install' do
   cwd root
   environment node['cdo-apps']['bundle_env']
-  not_if 'bundle check', cwd: root
+  group user
+  user user
+  # Temporarily disable the conditional check so that we always run bundle
+  # install on every build. This will help us avoid the chicken-egg problem we
+  # otherwise get when we try to rely on a Ruby-initiated process to switch
+  # from running bundle install as root to running as local user.
+  #
+  # TODO infra: reenable this check once we have switched over all existing
+  # persistent managed servers to the new bundle install.
+  # not_if 'bundle check', cwd: root
 end

--- a/cookbooks/cdo-nginx/test/cookbooks/nginx_test/recipes/default.rb
+++ b/cookbooks/cdo-nginx/test/cookbooks/nginx_test/recipes/default.rb
@@ -47,6 +47,8 @@ end
 
 execute "bundle install" do
   cwd "/home/#{node[:current_user]}"
+  user node[:current_user]
+  group node[:current_user]
 end
 
 service 'nginx_test' do

--- a/cookbooks/cdo-ruby/recipes/switch-to-deployment-mode.rb
+++ b/cookbooks/cdo-ruby/recipes/switch-to-deployment-mode.rb
@@ -34,13 +34,4 @@ root_dir = File.join(node[:home], node.chef_environment)
     cwd project_dir
     not_if {Dir.exist?(vendor_dir)}
   end
-
-  # Finally, undo the change to the config file. We'll reenable this setting on
-  # a future build.
-  execute "reset deployment config" do
-    command 'bundle config unset deployment'
-    user node[:user]
-    cwd project_dir
-    only_if "grep DEPLOYMENT #{File.join(bundle_dir, 'config')}"
-  end
 end

--- a/docker/ci/scripts/prepare_ui_tests.sh
+++ b/docker/ci/scripts/prepare_ui_tests.sh
@@ -17,7 +17,6 @@ echo "
 build_apps: true
 build_dashboard: true
 build_pegasus: true
-bundler_use_sudo: false
 cloudfront_key_pair_id: $CLOUDFRONT_KEY_PAIR_ID
 cloudfront_private_key: \"$CLOUDFRONT_PRIVATE_KEY\"
 dashboard_db_reader: \"mysql://readonly@localhost/dashboard_test\"

--- a/docker/ci/scripts/prepare_unit_tests.sh
+++ b/docker/ci/scripts/prepare_unit_tests.sh
@@ -16,7 +16,6 @@ echo "
 build_apps: true
 build_dashboard: true
 build_pegasus: true
-bundler_use_sudo: false
 cloudfront_key_pair_id: $CLOUDFRONT_KEY_PAIR_ID
 cloudfront_private_key: \"$CLOUDFRONT_PRIVATE_KEY\"
 dashboard_db_reader: \"mysql://readonly@localhost/dashboard_test\"

--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -121,15 +121,12 @@ module RakeUtils
   def self.bundle_install(*args)
     without = CDO.rack_envs - [CDO.rack_env]
     run_bundle_command('config set --local without', *without)
+    run_bundle_command('config set --local deployment \'true\'') if CDO.chef_managed
     run_bundle_command('install --quiet --jobs', nproc, *args)
   end
 
   def self.run_bundle_command(*args)
-    if CDO.bundler_use_sudo
-      sudo('bundle', *args)
-    else
-      system('bundle', *args)
-    end
+    system('bundle', *args)
   end
 
   def self.python_venv_install

--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -94,10 +94,8 @@ module RakeUtils
   # Changes the Bundler environment to the specified directory for the specified block.
   # Runs bundle_install ensuring dependencies are up to date.
   def self.with_bundle_dir(dir)
-    # Using `with_clean_env` is recommended when shelling out to a different bundle (ref:
-    # http://bundler.io/man/bundle-exec.1.html#Shelling-out), but `with_clean_env` is
-    # deprecated in favor of `with_unbundled_env` (ref:
-    # https://bundler.io/v2.1/whats_new.html#helper-deprecations) so use that instead.
+    # Using `with_unbundled_env` is recommended when shelling out to a different bundle.
+    # Ref: https://bundler.io/man/bundle-exec.1.html#Shelling-out
     Bundler.with_unbundled_env do
       ENV['AWS_DEFAULT_REGION'] ||= CDO.aws_region
       Dir.chdir(dir) do
@@ -126,7 +124,11 @@ module RakeUtils
   end
 
   def self.run_bundle_command(*args)
-    system('bundle', *args)
+    # Using `with_unbundled_env` is recommended when shelling out to a different bundle.
+    # Ref: https://bundler.io/man/bundle-exec.1.html#Shelling-out
+    Bundler.with_unbundled_env do
+      system('bundle', *args)
+    end
   end
 
   def self.python_venv_install

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -9,10 +9,6 @@
 #pardot_private_key: localoverride
 #openai_student_learning_api_key: localoverride
 
-# Whether to prefix bundler commands with 'sudo'.
-# It may be useful to set this false when doing local development on Linux.
-#bundler_use_sudo: false
-
 
 # Causes dashboard-server to run pegasus as middleware, starting both in a
 # single command.  This is preferred (and default) in development mode.


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67639, re-reapplying https://github.com/code-dot-org/code-dot-org/pull/66536

The last attempt applied successfully at first, but a subsequent build revealed that it introduced a circular dependency problem when trying to process Gemfile changes.

Specifically, in order to successfully run a bundle operation which processes a Gemfile change from within a Ruby processes started within the bundle environment, it's important to spawn the subshell without any of the `BUNDLE_*` environment variables set by the original process. Bundle [provides a `with_unbundled_env` helper for doing so](https://bundler.io/man/bundle-exec.1.html#Shelling-out), but we weren't using it; we were instead running all bundle operations with `sudo`, which has a side effect of stripping out *all* environment variables.

Since we are now running `bundle install` without `sudo`, we need to make sure to use `with_unbundled_env` instead.

## Links

[Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1754688660259399)

## Testing Story

Tested on an adhoc; I first verified that without [this fix](https://github.com/code-dot-org/code-dot-org/pull/67642/commits/a01ab3fb875d3720bb38d05b02325ff8f7ff284b), the adhoc will fail to install a new gem in the same way our build pipeline servers failed. I then verified that with the fix in place, the adhoc can successfully install a new gem.