### PR TITLE
Revert "Temporarily Remove New `rubocop-factory_bot` Gem"

### DIFF
--- a/.config/rubocop/config.yml
+++ b/.config/rubocop/config.yml
@@ -6,6 +6,7 @@ inherit_from:
   - blocklist.yml
 
 require:
+  - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails
   - rubocop-rails-accessibility

--- a/.config/rubocop/new.yml
+++ b/.config/rubocop/new.yml
@@ -12,14 +12,14 @@ Lint/MixedCaseRange: # new in 1.53
   Enabled: true
 Lint/RedundantRegexpQuantifiers: # new in 1.53
   Enabled: true
-# FactoryBot/ConsistentParenthesesStyle:
-#   Enabled: true
-# FactoryBot/ExcessiveCreateList: # new in 2.25
-#   Enabled: true
-# FactoryBot/FactoryNameStyle: # new in 2.16
-#   Enabled: true
-# FactoryBot/IdSequence: # new in 2.24
-#   Enabled: true
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: true
+FactoryBot/ExcessiveCreateList: # new in 2.25
+  Enabled: true
+FactoryBot/FactoryNameStyle: # new in 2.16
+  Enabled: true
+FactoryBot/IdSequence: # new in 2.24
+  Enabled: true
 Style/MapIntoArray: # new in 1.63
   Enabled: true
 Style/RedundantCurrentDirectoryInPath: # new in 1.53

--- a/.config/rubocop/todo.yml
+++ b/.config/rubocop/todo.yml
@@ -454,31 +454,31 @@ Style/TernaryParentheses:
 Style/TrailingUnderscoreVariable:
   Enabled: false
 
-# # Offense count: 38
-# # This cop supports safe autocorrection (--autocorrect).
-# # Configuration parameters: EnforcedStyle, ExplicitOnly.
-# # SupportedStyles: create_list, n_times
-# FactoryBot/CreateList:
-#   Enabled: false
+# Offense count: 38
+# This cop supports safe autocorrection (--autocorrect).
+# Configuration parameters: EnforcedStyle, ExplicitOnly.
+# SupportedStyles: create_list, n_times
+FactoryBot/CreateList:
+  Enabled: false
 
-# # Offense count: 55
-# # This cop supports safe autocorrection (--autocorrect).
-# FactoryBot/FactoryClassName:
-#   Enabled: false
+# Offense count: 55
+# This cop supports safe autocorrection (--autocorrect).
+FactoryBot/FactoryClassName:
+  Enabled: false
 
-# # Offense count: 65
-# FactoryBot/FactoryAssociationWithStrategy: # new in 2.23
-#   Enabled: false
+# Offense count: 65
+FactoryBot/FactoryAssociationWithStrategy: # new in 2.23
+  Enabled: false
 
-# # Offense count: 111
-# FactoryBot/AssociationStyle: # new in 2.23
-#   Enabled: false
+# Offense count: 111
+FactoryBot/AssociationStyle: # new in 2.23
+  Enabled: false
 
-# # Offense count: 6
-# FactoryBot/RedundantFactoryOption: # new in 2.23
-#   Enabled: false
+# Offense count: 6
+FactoryBot/RedundantFactoryOption: # new in 2.23
+  Enabled: false
 
-# # Offense count: 44
-# # This cop does not support safe autocorrection
-# FactoryBot/SyntaxMethods: # new in 2.7
-#   Enabled: false
+# Offense count: 44
+# This cop does not support safe autocorrection
+FactoryBot/SyntaxMethods: # new in 2.7
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -263,6 +263,7 @@ gem 'aws-sdk-secretsmanager'
 group :development, :staging, :levelbuilder, :test do
   gem 'haml_lint', require: false
   gem 'rubocop', '~> 1.28', require: false
+  gem 'rubocop-factory_bot', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rails-accessibility', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -814,6 +814,8 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.32.0)
       parser (>= 3.3.1.0)
+    rubocop-factory_bot (2.26.1)
+      rubocop (~> 1.61)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -1122,6 +1124,7 @@ DEPENDENCIES
   rmagick (~> 4.2.5)
   rspec
   rubocop (~> 1.28)
+  rubocop-factory_bot
   rubocop-performance
   rubocop-rails
   rubocop-rails-accessibility


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67641; a DTP including https://github.com/code-dot-org/code-dot-org/pull/67639 is deploying right now, so we can now safely install new gems again