### PR TITLE
chore(eyes): await expects to avoid flakiness

### DIFF
--- a/frontend/apps/marketing-storybook/stories/Button.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/Button.story.tsx
@@ -47,9 +47,9 @@ export const Emphasized: Story = {
   },
   play: async ({canvas}) => {
     const btn = canvas.getByRole('link', {name: 'Emphasized'});
-    expect(btn).toBeInTheDocument();
-    expect(btn).not.toHaveAttribute('target');
-    expect(btn.querySelector('svg')).not.toBeInTheDocument();
+    await expect(btn).toBeInTheDocument();
+    await expect(btn).not.toHaveAttribute('target');
+    await expect(btn.querySelector('svg')).not.toBeInTheDocument();
   },
 };
 
@@ -63,9 +63,9 @@ export const Primary: Story = {
   },
   play: async ({canvas}) => {
     const btn = canvas.getByRole('link', {name: 'Primary'});
-    expect(btn).toBeInTheDocument();
-    expect(btn).not.toHaveAttribute('target');
-    expect(btn.querySelector('svg')).not.toBeInTheDocument();
+    await expect(btn).toBeInTheDocument();
+    await expect(btn).not.toHaveAttribute('target');
+    await expect(btn.querySelector('svg')).not.toBeInTheDocument();
   },
 };
 
@@ -79,9 +79,9 @@ export const Secondary: Story = {
   },
   play: async ({canvas}) => {
     const btn = canvas.getByRole('link', {name: 'Secondary'});
-    expect(btn).toBeInTheDocument();
-    expect(btn).not.toHaveAttribute('target');
-    expect(btn.querySelector('svg')).not.toBeInTheDocument();
+    await expect(btn).toBeInTheDocument();
+    await expect(btn).not.toHaveAttribute('target');
+    await expect(btn.querySelector('svg')).not.toBeInTheDocument();
   },
 };
 
@@ -95,9 +95,9 @@ export const White: Story = {
   },
   play: async ({canvas}) => {
     const btn = canvas.getByRole('link', {name: 'White'});
-    expect(btn).toBeInTheDocument();
-    expect(btn).not.toHaveAttribute('target');
-    expect(btn.querySelector('svg')).not.toBeInTheDocument();
+    await expect(btn).toBeInTheDocument();
+    await expect(btn).not.toHaveAttribute('target');
+    await expect(btn.querySelector('svg')).not.toBeInTheDocument();
   },
 };
 
@@ -111,10 +111,10 @@ export const ExternalLink: Story = {
   },
   play: async ({canvas}) => {
     const btn = canvas.getByRole('link', {name: 'External Link'});
-    expect(btn).toBeInTheDocument();
-    expect(btn).toHaveAttribute('target', '_blank');
-    expect(btn).toHaveAttribute('rel', 'noopener noreferrer');
-    expect(btn.querySelector('svg')).toBeInTheDocument();
+    await expect(btn).toBeInTheDocument();
+    await expect(btn).toHaveAttribute('target', '_blank');
+    await expect(btn).toHaveAttribute('rel', 'noopener noreferrer');
+    await expect(btn.querySelector('svg')).toBeInTheDocument();
     btn.click();
   },
 };

--- a/frontend/apps/marketing-storybook/stories/Divider.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/Divider.story.tsx
@@ -33,7 +33,7 @@ export const Primary: Story = {
   },
   play: async ({canvas}) => {
     const separator = canvas.getByRole('separator');
-    expect(separator).toBeInTheDocument();
+    await expect(separator).toBeInTheDocument();
   },
 };
 
@@ -44,7 +44,7 @@ export const Strong: Story = {
   },
   play: async ({canvas}) => {
     const separator = canvas.getByRole('separator');
-    expect(separator).toBeInTheDocument();
+    await expect(separator).toBeInTheDocument();
   },
 };
 
@@ -58,6 +58,6 @@ export const White: Story = {
   },
   play: async ({canvas}) => {
     const separator = canvas.getByRole('separator');
-    expect(separator).toBeInTheDocument();
+    await expect(separator).toBeInTheDocument();
   },
 };

--- a/frontend/apps/marketing-storybook/stories/EditorialCard.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/EditorialCard.story.tsx
@@ -60,16 +60,16 @@ export const HorizontalWithImage: Story = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
     const headings = canvas.getAllByRole('heading');
-    expect(headings.length).toBe(4);
-    headings.forEach((h: HTMLElement) =>
-      expect(h.textContent).toMatch(/Editorial Card/),
-    );
+    await expect(headings.length).toBe(4);
+    for (const h of headings) {
+      await expect(h.textContent).toMatch(/Editorial Card/);
+    }
     const links = canvas.getAllByRole('link', {name: 'Editorial Card Link'});
-    expect(links.length).toBe(4);
-    links.forEach((link: HTMLElement) => {
-      expect(link).toHaveAttribute('href', '/editorial-card-test');
-      expect(link.textContent).toBe('Editorial Card Link');
-    });
+    await expect(links.length).toBe(4);
+    for (const link of links) {
+      await expect(link).toHaveAttribute('href', '/editorial-card-test');
+      await expect(link.textContent).toBe('Editorial Card Link');
+    }
   },
 };
 
@@ -91,16 +91,16 @@ export const VerticalWithImage: Story = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
     const headings = canvas.getAllByRole('heading');
-    expect(headings.length).toBe(3);
-    headings.forEach((h: HTMLElement) =>
-      expect(h.textContent).toMatch(/Editorial Card/),
-    );
+    await expect(headings.length).toBe(3);
+    for (const h of headings) {
+      await expect(h.textContent).toMatch(/Editorial Card/);
+    }
     const links = canvas.getAllByRole('link', {name: 'Editorial Card Link'});
-    expect(links.length).toBe(3);
-    links.forEach((link: HTMLElement) => {
-      expect(link).toHaveAttribute('href', '/editorial-card-test');
-      expect(link.textContent).toBe('Editorial Card Link');
-    });
+    await expect(links.length).toBe(3);
+    for (const link of links) {
+      await expect(link).toHaveAttribute('href', '/editorial-card-test');
+      await expect(link.textContent).toBe('Editorial Card Link');
+    }
   },
 };
 
@@ -122,18 +122,17 @@ export const VerticalWithIcon: Story = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
     const headings = canvas.getAllByRole('heading');
-    expect(headings.length).toBe(3);
-    headings.forEach((h: HTMLElement) =>
-      expect(h.textContent).toMatch(/Editorial Card/),
-    );
+    await expect(headings.length).toBe(3);
+    for (const h of headings) {
+      await expect(h.textContent).toMatch(/Editorial Card/);
+    }
     const links = canvas.getAllByRole('link', {name: 'Editorial Card Link'});
-    expect(links.length).toBe(3);
-    links.forEach((link: HTMLElement) => {
-      expect(link).toHaveAttribute('href', '/editorial-card-test');
-      expect(link.textContent).toBe('Editorial Card Link');
-    });
-    // Icon test: check for svg or i tag
+    await expect(links.length).toBe(3);
+    for (const link of links) {
+      await expect(link).toHaveAttribute('href', '/editorial-card-test');
+      await expect(link.textContent).toBe('Editorial Card Link');
+    }
     const icons = canvasElement.querySelectorAll('svg, i');
-    expect(icons.length).toBeGreaterThanOrEqual(3);
+    await expect(icons.length).toBeGreaterThanOrEqual(3);
   },
 };

--- a/frontend/apps/marketing-storybook/stories/FAQAccordion.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/FAQAccordion.story.tsx
@@ -18,18 +18,15 @@ type Story = StoryObj<FAQAccordionContentfulProps>;
 export const FilledOut: Story = {
   args: FAQAccordionMock as FAQAccordionContentfulProps,
   play: async ({canvas}) => {
-    // Check for all three FAQ questions
     const questions = ['FAQ Text', 'FAQ Lists', 'FAQ Links'];
     for (const q of questions) {
       const summary = canvas.getByRole('button', {name: q});
       await expect(summary).toBeInTheDocument();
       await userEvent.click(summary);
-      // Find the closest MuiAccordion-root ancestor and cast to HTMLElement
       const accordionRoot = summary.closest(
         '.MuiAccordion-root',
       ) as HTMLElement | null;
       await expect(accordionRoot).toBeTruthy();
-      // Use within to get the region inside this accordion
       const region = within(accordionRoot!).getByRole('region', {hidden: true});
       await expect(region).toBeInTheDocument();
       if (q === 'FAQ Text') {
@@ -37,7 +34,6 @@ export const FilledOut: Story = {
       } else if (q === 'FAQ Lists') {
         await expect(region).toHaveTextContent('Ordered Item 3');
       } else if (q === 'FAQ Links') {
-        // Find the Bold Italic link inside the region
         const boldItalicLink = within(region).getByRole('link', {
           name: 'Bold Italic link',
         });
@@ -49,7 +45,6 @@ export const FilledOut: Story = {
       }
     }
 
-    // De-focus
     const storybookRoot = document.getElementById('storybook-root');
     await userEvent.click(storybookRoot!);
   },

--- a/frontend/apps/marketing-storybook/stories/IconHighlight.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/IconHighlight.story.tsx
@@ -34,16 +34,16 @@ export const FilledOut: Story = {
     const heading = canvas.getByRole('heading', {
       name: /Icon Highlight Heading/i,
     });
-    expect(heading).toBeInTheDocument();
+    await expect(heading).toBeInTheDocument();
 
     // Check text
     const text = canvas.getByText(/Icon Highlight\s*Multiline Text/i);
-    expect(text).toBeInTheDocument();
+    await expect(text).toBeInTheDocument();
 
     // Check link
     const link = canvas.getByRole('link', {name: /Editorial Card Link/i});
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', '/editorial-card-test');
-    expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toBeInTheDocument();
+    await expect(link).toHaveAttribute('href', '/editorial-card-test');
+    await expect(link).toHaveAttribute('target', '_blank');
   },
 };

--- a/frontend/apps/marketing-storybook/stories/Link.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/Link.story.tsx
@@ -39,21 +39,21 @@ export const Playground: Story = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function testLinkMatrix(canvas: any, size: string, color: string) {
+async function testLinkMatrix(canvas: any, size: string, color: string) {
   for (const isLinkExternal of isLinkExternals) {
     for (const removeMarginBottom of removeMarginBottoms) {
       const linkText = `Link | size: ${size} | color: ${color} | external: ${isLinkExternal} | removeMarginBottom: ${removeMarginBottom}`;
       const link = canvas.getByRole('link', {name: linkText});
-      expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute('href', 'about:blank');
+      await expect(link).toBeInTheDocument();
+      await expect(link).toHaveAttribute('href', 'about:blank');
       if (isLinkExternal) {
-        expect(link).toHaveAttribute('target', '_blank');
-        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-        expect(link.querySelector('svg')).toBeInTheDocument();
+        await expect(link).toHaveAttribute('target', '_blank');
+        await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        await expect(link.querySelector('svg')).toBeInTheDocument();
       } else {
-        expect(link).not.toHaveAttribute('target');
-        expect(link).not.toHaveAttribute('rel');
-        expect(link.querySelector('svg')).not.toBeInTheDocument();
+        await expect(link).not.toHaveAttribute('target');
+        await expect(link).not.toHaveAttribute('rel');
+        await expect(link.querySelector('svg')).not.toBeInTheDocument();
       }
     }
   }
@@ -81,7 +81,7 @@ export const LinkXSPrimary: Story = {
     </div>
   ),
   play: async ({canvas}) => {
-    testLinkMatrix(canvas, 'xs', 'primary');
+    await testLinkMatrix(canvas, 'xs', 'primary');
   },
 };
 
@@ -110,7 +110,7 @@ export const LinkXSWhite: Story = {
     </div>
   ),
   play: async ({canvas}) => {
-    testLinkMatrix(canvas, 'xs', 'white');
+    await testLinkMatrix(canvas, 'xs', 'white');
   },
 };
 
@@ -136,7 +136,7 @@ export const LinkSPrimary: Story = {
     </div>
   ),
   play: async ({canvas}) => {
-    testLinkMatrix(canvas, 's', 'primary');
+    await testLinkMatrix(canvas, 's', 'primary');
   },
 };
 
@@ -165,7 +165,7 @@ export const LinkSWhite: Story = {
     </div>
   ),
   play: async ({canvas}) => {
-    testLinkMatrix(canvas, 's', 'white');
+    await testLinkMatrix(canvas, 's', 'white');
   },
 };
 
@@ -191,7 +191,7 @@ export const LinkMPrimary: Story = {
     </div>
   ),
   play: async ({canvas}) => {
-    testLinkMatrix(canvas, 'm', 'primary');
+    await testLinkMatrix(canvas, 'm', 'primary');
   },
 };
 
@@ -220,7 +220,7 @@ export const LinkMWhite: Story = {
     </div>
   ),
   play: async ({canvas}) => {
-    testLinkMatrix(canvas, 'm', 'white');
+    await testLinkMatrix(canvas, 'm', 'white');
   },
 };
 
@@ -246,7 +246,7 @@ export const LinkLPrimary: Story = {
     </div>
   ),
   play: async ({canvas}) => {
-    testLinkMatrix(canvas, 'l', 'primary');
+    await testLinkMatrix(canvas, 'l', 'primary');
   },
 };
 
@@ -275,6 +275,6 @@ export const LinkLWhite: Story = {
     </div>
   ),
   play: async ({canvas}) => {
-    testLinkMatrix(canvas, 'l', 'white');
+    await testLinkMatrix(canvas, 'l', 'white');
   },
 };

--- a/frontend/apps/marketing-storybook/stories/Section.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/Section.story.tsx
@@ -59,7 +59,7 @@ const createStory = (background: SectionBackground): Story => ({
         for (const divider of dividers) {
           const sectionText = `Section | background: ${background} | padding: ${padding} | theme: ${themeOpt} | divider: ${divider}`;
           const section = canvas.getByText(sectionText);
-          expect(section).toBeInTheDocument();
+          await expect(section).toBeInTheDocument();
         }
       }
     }

--- a/frontend/apps/marketing-storybook/stories/SimpleList.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/SimpleList.story.tsx
@@ -20,9 +20,9 @@ export const Basic: StoryObj<SimpleListContentfulProps> = {
   play: async ({canvas}) => {
     // Check that all list items are rendered
     const items = await canvas.findAllByText(/List Item/);
-    expect(items.length).toBeGreaterThan(0);
+    await expect(items.length).toBeGreaterThan(0);
     // Check that the first item text is present
-    expect(await canvas.findByText('List Item 1')).toBeInTheDocument();
+    await expect(await canvas.findByText('List Item 1')).toBeInTheDocument();
   },
 };
 
@@ -41,9 +41,9 @@ export const Smile: StoryObj<SimpleListContentfulProps> = {
     const foundSmile = smileIcons.some(icon =>
       (icon as HTMLElement).classList.contains('fa-smile'),
     );
-    expect(foundSmile).toBe(true);
+    await expect(foundSmile).toBe(true);
     // Check that all list items are rendered
     const items = await canvas.findAllByText(/List Item/);
-    expect(items.length).toBeGreaterThan(0);
+    await expect(items.length).toBeGreaterThan(0);
   },
 };

--- a/frontend/apps/marketing-storybook/stories/TabGroup.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/TabGroup.story.tsx
@@ -20,14 +20,11 @@ export const FilledOut: StoryObj<typeof TabGroup> = {
   },
   args: TabGroupMock as any,
   play: async ({canvas}) => {
-    // Check that all tab labels are rendered
     const tabLabels = await canvas.findAllByRole('tab');
-    expect(tabLabels.length).toBeGreaterThan(0);
-    // Click each tab and check its content
+    await expect(tabLabels.length).toBeGreaterThan(0);
     for (const tab of tabLabels) {
       tab.click();
       const labelText = tab.textContent;
-      // Helper to filter out elements under <details>
       const getVisibleText = async (text: string) => {
         const all = await canvas.findAllByText(text);
         return all.find(el => {
@@ -40,22 +37,22 @@ export const FilledOut: StoryObj<typeof TabGroup> = {
         });
       };
       if (labelText === 'Test Item Image and Button') {
-        expect(
+        await expect(
           await getVisibleText('With image and button'),
         ).toBeInTheDocument();
       } else if (labelText === 'Test Item Text Only') {
-        expect(await getVisibleText('Text Only')).toBeInTheDocument();
-        expect(
+        await expect(await getVisibleText('Text Only')).toBeInTheDocument();
+        await expect(
           await getVisibleText('Without image, without button'),
         ).toBeInTheDocument();
       } else if (labelText === 'Test Item Button') {
-        expect(await getVisibleText('With Button')).toBeInTheDocument();
-        expect(
+        await expect(await getVisibleText('With Button')).toBeInTheDocument();
+        await expect(
           await getVisibleText('Without image, with button'),
         ).toBeInTheDocument();
       } else if (labelText === 'Test Item Image') {
-        expect(await getVisibleText('With Image')).toBeInTheDocument();
-        expect(
+        await expect(await getVisibleText('With Image')).toBeInTheDocument();
+        await expect(
           await getVisibleText('With image, without button'),
         ).toBeInTheDocument();
       }


### PR DESCRIPTION
The promise returned by `expect` was not being awaited causing flakiness in eyes runs due to the test not waiting for the story to complete before capturing images.