### PR TITLE
feat(ui-tests): add CSForAll UI tests

### DIFF
--- a/.github/actions/frontend/marketing/ui-tests/action.yml
+++ b/.github/actions/frontend/marketing/ui-tests/action.yml
@@ -33,6 +33,10 @@ inputs:
   PR_HEAD_REF:
     description: "The head ref of the pull request."
     required: false
+  SITE_TYPE:
+    description: "The type of site being tested. Defaults to 'corporate'."
+    default: "corporate"
+    required: false
 
 runs:
   using: composite
@@ -50,6 +54,7 @@ runs:
         APPLICATION_BASE_ADDRESS=${{ inputs.APPLICATION_BASE_ADDRESS }}
         BRANCHED_TESTING_ENABLED=${{ inputs.BRANCHED_TESTING_ENABLED }}
         PR_HEAD_REF=${{ inputs.PR_HEAD_REF }}
+        SITE_TYPE=${{ inputs.SITE_TYPE }}
         " >> .env
 
     - name: UI Tests

--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -129,7 +129,6 @@ jobs:
   ui-tests:
     runs-on: ubuntu-24.04
     environment: marketing-sites-${{ inputs.ENVIRONMENT_TYPE }}-${{ inputs.SITE_TYPE }}
-    if: ${{ inputs.SITE_TYPE == 'corporate' }}
     needs:
       - deploy
 
@@ -164,6 +163,7 @@ jobs:
           APPLICATION_BASE_ADDRESS: "${{ vars.APPLICATION_SUBDOMAIN_NAME }}.${{ vars.APPLICATION_BASE_DOMAIN }}"
           DRAFT_MODE_TOKEN: ${{ secrets.DRAFT_MODE_TOKEN }}
           GITHUB_ENVIRONMENT_NAME: ${{ env.GITHUB_ENVIRONMENT_NAME }}
+          SITE_TYPE: ${{ inputs.SITE_TYPE }}
           SHARD_INDEX: ${{ matrix.shardIndex }}
           SHARD_TOTAL: ${{ matrix.shardTotal }}
 

--- a/frontend/apps/marketing/src/config/host.ts
+++ b/frontend/apps/marketing/src/config/host.ts
@@ -1,6 +1,13 @@
 import {Brand} from '@/config/brand';
 import {Stage} from '@/config/stage';
 
+const ALLOWED_PRODUCTION_CANONICAL_HOSTNAMES: {[brand in Brand]: Set<string>} =
+  {
+    [Brand.CODE_DOT_ORG]: new Set(['code.org', 'aiday.org']),
+    [Brand.CS_FOR_ALL]: new Set(['csforall.org']),
+    [Brand.HOUR_OF_CODE]: new Set(['hourofcode.com']),
+  };
+
 /**
  * Returns the localhost domain
  */
@@ -51,4 +58,15 @@ export function getCanonicalHostname(brand: Brand, stage: Stage) {
     case 'production':
       return getProductionCanonicalRootDomain(brand);
   }
+}
+
+export function isAllowedProductionCanonicalHostname(
+  brand: Brand,
+  hostname: string | null,
+): boolean {
+  if (hostname == null) {
+    return false;
+  }
+
+  return ALLOWED_PRODUCTION_CANONICAL_HOSTNAMES[brand].has(hostname);
 }

--- a/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
@@ -222,12 +222,6 @@ describe('withLocale middleware', () => {
 
     SUPPORTED_LOCALES_SET.add('zh-TW' as SupportedLocale);
     await withLocale(next)(request, mockEvent);
-
-    expect(cookieMock.set).not.toHaveBeenCalledWith(
-      'language_',
-      expect.anything(),
-      expect.anything(),
-    );
   });
 
   it('should not infinitely redirect for non-corporate brands when locale is unsupported', async () => {
@@ -247,11 +241,5 @@ describe('withLocale middleware', () => {
     const response = await withLocale(next)(request, mockEvent);
 
     expect(response?.headers).toBeUndefined();
-    // Should not set language_ cookie for non-code.org brands
-    expect(cookieMock.set).not.toHaveBeenCalledWith(
-      'language_',
-      expect.anything(),
-      expect.anything(),
-    );
   });
 });

--- a/frontend/apps/marketing/src/middleware/i18n/__tests__/setLanguageCookie.test.ts
+++ b/frontend/apps/marketing/src/middleware/i18n/__tests__/setLanguageCookie.test.ts
@@ -1,0 +1,97 @@
+import {NextResponse} from 'next/server';
+
+import {Brand} from '@/config/brand';
+import {SupportedLocale} from '@/config/locale';
+import {Stage} from '@/config/stage';
+
+import {setLanguageCookie} from '../setLanguageCookie';
+
+type MockResponse = {
+  cookies: {
+    set: jest.Mock;
+  };
+};
+
+describe('setLanguageCookie', () => {
+  let response: MockResponse;
+
+  beforeEach(() => {
+    response = {
+      cookies: {
+        set: jest.fn(),
+      },
+    };
+  });
+
+  it('sets cookie with domain for production CODE_DOT_ORG and allowed hostname', () => {
+    setLanguageCookie({
+      response: response as unknown as NextResponse,
+      maybeLocale: SupportedLocale['en-US'],
+      stage: 'production' as Stage,
+      brand: Brand.CODE_DOT_ORG,
+      hostname: 'code.org',
+    });
+    expect(response.cookies.set).toHaveBeenCalledWith(
+      'language_',
+      SupportedLocale['en-US'],
+      expect.objectContaining({
+        path: '/',
+        domain: '.code.org',
+      }),
+    );
+  });
+
+  it('sets cookie with root domain for production CODE_DOT_ORG and disallowed hostname', () => {
+    setLanguageCookie({
+      response: response as unknown as NextResponse,
+      maybeLocale: SupportedLocale['en-US'],
+      stage: 'production' as Stage,
+      brand: Brand.CODE_DOT_ORG,
+      hostname: 'notallowed.com',
+    });
+    expect(response.cookies.set).toHaveBeenCalledWith(
+      'language_',
+      SupportedLocale['en-US'],
+      expect.objectContaining({
+        path: '/',
+        domain: '.code.org',
+      }),
+    );
+  });
+
+  it('sets cookie without domain for non-production stage', () => {
+    setLanguageCookie({
+      response: response as unknown as NextResponse,
+      maybeLocale: SupportedLocale['en-US'],
+      stage: 'development' as Stage,
+      brand: Brand.CODE_DOT_ORG,
+      hostname: 'code.org',
+    });
+    expect(response.cookies.set).toHaveBeenCalledWith(
+      'language_',
+      SupportedLocale['en-US'],
+      expect.objectContaining({
+        path: '/',
+        domain: undefined,
+      }),
+    );
+  });
+
+  it('sets cookie without domain for non corporate brand', () => {
+    setLanguageCookie({
+      response: response as unknown as NextResponse,
+      maybeLocale: SupportedLocale['en-US'],
+      stage: 'production' as Stage,
+      brand: Brand.CS_FOR_ALL,
+      hostname: 'csforall.org',
+    });
+    expect(response.cookies.set).toHaveBeenCalledWith(
+      'language_',
+      SupportedLocale['en-US'],
+      expect.objectContaining({
+        path: '/',
+        domain: undefined,
+      }),
+    );
+  });
+});

--- a/frontend/apps/marketing/src/middleware/i18n/setLanguageCookie.ts
+++ b/frontend/apps/marketing/src/middleware/i18n/setLanguageCookie.ts
@@ -1,0 +1,37 @@
+import {NextResponse} from 'next/server';
+
+import {Brand} from '@/config/brand';
+import {
+  getProductionCanonicalRootDomain,
+  isAllowedProductionCanonicalHostname,
+} from '@/config/host';
+import {getDashboardLocale, SupportedLocale} from '@/config/locale';
+import {Stage} from '@/config/stage';
+
+interface SetLanguageCookieParams {
+  response: NextResponse;
+  maybeLocale: SupportedLocale;
+  stage: Stage;
+  brand: Brand;
+  hostname: string | null;
+}
+
+export const setLanguageCookie = ({
+  response,
+  maybeLocale,
+  stage,
+  brand,
+  hostname,
+}: SetLanguageCookieParams) => {
+  const cookieDomain = isAllowedProductionCanonicalHostname(brand, hostname)
+    ? hostname
+    : getProductionCanonicalRootDomain(brand);
+
+  response.cookies.set('language_', getDashboardLocale(maybeLocale), {
+    path: '/',
+    domain:
+      stage === 'production' && brand === Brand.CODE_DOT_ORG // Only set the domain for the corporate website
+        ? `.${cookieDomain}`
+        : undefined,
+  });
+};

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -4,7 +4,6 @@ import {NextFetchEvent, NextRequest} from 'next/server';
 import {Brand, getBrandFromHostname} from '@/config/brand';
 import {
   getLocalizeJsLocaleFromDashboardLocale,
-  getDashboardLocale,
   SUPPORTED_LOCALE_CODES,
   SUPPORTED_LOCALES_SET,
   SupportedLocale,
@@ -13,6 +12,7 @@ import {getStage} from '@/config/stage';
 import {getStudioBaseUrl} from '@/config/studio';
 import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
 import {getCookieNameByStage} from '@/cookies/getCookie';
+import {setLanguageCookie} from '@/middleware/i18n/setLanguageCookie';
 import {getCachedRedirectResponse} from '@/middleware/utils/getCachedRedirectResponse';
 
 import {MiddlewareFactory} from './types';
@@ -64,12 +64,7 @@ export const withLocale: MiddlewareFactory = next => {
       // If the first part of the path is a supported locale or there are no subpaths, we don't need to redirect
       const response = await next(request, event);
 
-      if (brand === Brand.CODE_DOT_ORG) {
-        response.cookies.set('language_', getDashboardLocale(maybeLocale), {
-          path: '/',
-          domain: stage === 'production' ? '.code.org' : undefined,
-        });
-      }
+      setLanguageCookie({response, maybeLocale, stage, brand, hostname});
 
       return response;
     }
@@ -104,17 +99,14 @@ export const withLocale: MiddlewareFactory = next => {
     const redirectUrl = new URL(localizedPath, request.url);
     const response = getCachedRedirectResponse(redirectUrl);
 
-    if (brand === Brand.CODE_DOT_ORG) {
-      // Set the language cookie if discovered via Accept-Language header
-      response.cookies.set(
-        'language_',
-        getDashboardLocale(locale as SupportedLocale),
-        {
-          path: '/',
-          domain: getStage() === 'production' ? '.code.org' : undefined,
-        },
-      );
-    }
+    // Set the language cookie if discovered via Accept-Language header
+    setLanguageCookie({
+      response,
+      maybeLocale: locale as SupportedLocale,
+      stage,
+      brand,
+      hostname,
+    });
 
     return response;
   };

--- a/frontend/apps/marketing/tests/e2e/README.md
+++ b/frontend/apps/marketing/tests/e2e/README.md
@@ -10,6 +10,11 @@ The E2E tests are designed to ensure that the marketing application behaves as e
 
 To run the full set of tests locally, an [Applitools Eyes API Key](https://applitools.com/tutorials/getting-started/retrieve-api-key) is needed. Define `APPLITOOLS_API_KEY` in `marketing/.env` to use.
 
+You will also want a copy of `marketing/.env` for each site to copy the UI test experience to:
+
+1. `marketing/.env.corporate`: The Corporate website environment variables
+2. `marketing/.env.csforall`: The CSForAll environment variables
+
 ## Running Tests
 
 ### Against a local server
@@ -57,7 +62,7 @@ To update the "All The Things" page, execute the fork command which will take th
 To create a fork:
 
 ```bash
-yarn test:ui:fork
+yarn test:ui:fork --env .env.corporate
 ```
 
 ### Updating the source control snapshot
@@ -65,21 +70,21 @@ yarn test:ui:fork
 To download a copy of the "All The Things" page to source control:
 
 ```bash
-yarn test:ui:update-snapshot --environment <development|test|production>
+yarn test:ui:update-snapshot --env .env.corporate --environment <development|test|production>
 ```
 
 If working on a fork and you want to update the version control version, specify the source entry id:
 
 ```bash
-yarn test:ui:update-snapshot --environment development --source-entry-id <fork experience entry id>
+yarn test:ui:update-snapshot --env .env.corporate --environment development --source-entry-id <fork experience entry id>
 ```
 
 ### Updating "All The Things" on Contentful from source control
 
-To upload the source control version of "All the Things" to Contentful:
+To upload the source control version of "All the Things" to Contentful. **Be sure to repeat for other site types.**
 
 ```bash
-yarn test:ui:publish-snapshot --environment <development|test|production>
+yarn test:ui:publish-snapshot --env .env.corporate --environment <development|test|production>
 ```
 
 This will save "All The Things", open up the experience in the associated environment and publish the page if it looks correct.
@@ -91,7 +96,7 @@ This will save "All The Things", open up the experience in the associated enviro
 1. Create a new fork (see [Forking](#forking) section above):
 
 ```bash
-yarn test:ui:fork
+yarn test:ui:fork --env .env.corporate
 ```
 
 2. Make updates on the forked page in Contentful.
@@ -103,27 +108,27 @@ yarn test:ui:fork
 
 4. Once the PR is merged, update your workspace with `staging`.
 
-5. Publish the updated snapshot in the `development` environment:
+5. Publish the updated snapshot in the `development` environment to the corporate site (repeat for other site types):
 
 ```bash
-yarn test:ui:publish-snapshot --environment development
+yarn test:ui:publish-snapshot --env .env.corporate --environment development
 ```
 
 6. Open the development output link in the terminal in Contentful, and Publish the experience.
 
-7. Publish the updated snapshot in the `test` environment:
+7. Publish the updated snapshot in the `test` environment (repeat for other site types):
 
 ```bash
-yarn test:ui:publish-snapshot --environment test
+yarn test:ui:publish-snapshot --env .env.corporate --environment test
 ```
 
-8. Publish the updated snapshot in the `production` environment:
+8. Publish the updated snapshot in the `production` environment (repeat for other site types):
 
 ```bash
-yarn test:ui:publish-snapshot --environment production
+yarn test:ui:publish-snapshot --env .env.corporate --environment production
 ```
 
-9. Publish updated `production` version of the All The Things page in Contentful.
+9. Publish updated `production` version of the All The Things page in Contentful. Repeat for other site types.
 
 10. **If you're adding a new component:** add the component to the Section Types on `/apps/marketing/tests/e2e/pom/all-the-things.ts` and add unit and Eyes tests to `/apps/marketing/tests/e2e/all-the-things.spec.ts`. Create/merge a PR with these tests.
 

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -6,8 +6,9 @@ import {test} from './fixtures/base';
 import {AllTheThingsPage} from './pom/all-the-things';
 import {type Section} from './pom/all-the-things';
 import {MarketingPage} from './pom/marketing';
+import {getSiteType} from './utils/getSiteType';
 
-test.describe('All the things UI e2e test', () => {
+test.describe(`[${getSiteType()}] All the things`, () => {
   test.describe('a11y', () => {
     test('should have no accessibility violations', async ({page}) => {
       const allTheThingsPage = new AllTheThingsPage(page, {locale: 'en-US'});
@@ -166,7 +167,7 @@ test.describe('All the things UI e2e test', () => {
       'OpenGraph Description',
     );
     expect(await allTheThingsPage.getOpenGraph('image')).toMatch(
-      /https:\/\/contentful-images\.code\.org\/90t6bu6vlf76\/4hXiOPiRlCXpmtypRNOZqc\/(.*)\/engineering-only-opengraph-default\.png\?fm=webp/,
+      /https:\/\/contentful-images\.code\.org\/(.*)\/4hXiOPiRlCXpmtypRNOZqc\/(.*)\/engineering-only-opengraph-default\.png\?fm=webp/,
     );
     expect(await allTheThingsPage.getOpenGraph('type')).toBe('website');
   });

--- a/frontend/apps/marketing/tests/e2e/home.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/home.spec.ts
@@ -4,6 +4,7 @@ import {getCookieNameByStage} from '@/cookies/getCookie';
 
 import {test} from './fixtures/base';
 import {MarketingPage} from './pom/marketing';
+import {getSiteType} from './utils/getSiteType';
 import {getAppStageFromTestStage} from './utils/stage';
 
 test.describe('Home Page', () => {
@@ -19,73 +20,76 @@ test.describe('Home Page', () => {
     await page.waitForURL('**/en-US');
   });
 
-  test('should redirect / to dashboard if the _user_type cookie is set', async ({
-    page,
-    browserName,
-    context,
-  }) => {
-    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    const redirects: string[] = [];
+  test(
+    'should redirect / to dashboard if the _user_type cookie is set',
+    {tag: '@corporate'},
+    async ({page, browserName, context}) => {
+      test.skip(getSiteType() !== 'corporate', 'Only runs on corporate site');
+      test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+      const redirects: string[] = [];
 
-    // Capture all requests to track redirects
-    page.on('request', request => {
-      redirects.push(request.url());
-    });
-
-    await page.route('**://**studio.code.org**/', route => {
-      route.fulfill({
-        status: 200,
-        contentType: 'text/html',
-        body: '<html><body>Mocked Code Studio</body></html>',
+      // Capture all requests to track redirects
+      page.on('request', request => {
+        redirects.push(request.url());
       });
-    });
 
-    const marketingPage = new MarketingPage(page);
+      await page.route('**://**studio.code.org**/', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: '<html><body>Mocked Code Studio</body></html>',
+        });
+      });
 
-    await context.addCookies([
-      {
-        name: getCookieNameByStage('_user_type', getAppStageFromTestStage()),
-        path: '/',
-        domain: `.${marketingPage.getCookieDomain()}`,
-        value: 'student',
-      },
-    ]);
+      const marketingPage = new MarketingPage(page);
 
-    try {
+      await context.addCookies([
+        {
+          name: getCookieNameByStage('_user_type', getAppStageFromTestStage()),
+          path: '/',
+          domain: `.${marketingPage.getCookieDomain()}`,
+          value: 'student',
+        },
+      ]);
+
+      try {
+        await marketingPage.goto('/');
+      } catch {
+        // It's ok if an error occurs as dashboard may not be running
+      }
+
+      await expect.poll(() => redirects[1]).toContain('studio.code.org');
+    },
+  );
+
+  test(
+    'should redirect / to dashboard if the user is signed in (no cookies set)',
+    {tag: '@corporate'},
+    async ({page, browserName}) => {
+      test.skip(getSiteType() !== 'corporate', 'Only runs on corporate site');
+      test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+
+      const marketingPage = new MarketingPage(page);
+
+      await page.route('**/api/v1/users/signed_in', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({is_signed_in: true}),
+        }),
+      );
+
+      await page.route('**://**studio.code.org**/', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: '<html><body>Mocked Code Studio</body></html>',
+        });
+      });
+
       await marketingPage.goto('/');
-    } catch {
-      // It's ok if an error occurs as dashboard may not be running
-    }
 
-    await expect.poll(() => redirects[1]).toContain('studio.code.org');
-  });
-
-  test('should redirect / to dashboard if the user is signed in (no cookies set)', async ({
-    page,
-    browserName,
-  }) => {
-    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-
-    const marketingPage = new MarketingPage(page);
-
-    await page.route('**/api/v1/users/signed_in', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({is_signed_in: true}),
-      }),
-    );
-
-    await page.route('**://**studio.code.org**/', route => {
-      route.fulfill({
-        status: 200,
-        contentType: 'text/html',
-        body: '<html><body>Mocked Code Studio</body></html>',
-      });
-    });
-
-    await marketingPage.goto('/');
-
-    await expect(page.getByText('Mocked Code Studio')).toBeVisible();
-  });
+      await expect(page.getByText('Mocked Code Studio')).toBeVisible();
+    },
+  );
 });

--- a/frontend/apps/marketing/tests/e2e/utils/getSiteType.ts
+++ b/frontend/apps/marketing/tests/e2e/utils/getSiteType.ts
@@ -1,0 +1,3 @@
+export function getSiteType() {
+  return process.env.SITE_TYPE ?? 'corporate';
+}


### PR DESCRIPTION
This PR adds a header which allows UI tests to override the brand to allow the same "All the Things" code that is in the Code.org space to be used for CSForAll to eliminate the need to maintain multiple experiences and sync them together.

To accomplish this, the All the Things updater script now accepts a flag, `--env` which allows switching between different spaces. 