### PR TITLE
fix(cache): disable cache if daisy chained cloudfront

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -312,7 +312,10 @@ Resources:
               - GET
               - HEAD
               - OPTIONS
-            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
+            CachePolicyId: !If
+              - IsCorporateSite
+              - 4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Managed-CachingDisabled (Disabled until this distribution becomes the main one instead of daisy chained)
+              - 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
             Compress: true
             PathPattern: /_next/*
             TargetOriginId: marketing-sites-static-assets-origin


### PR DESCRIPTION
In a daisy chained cloudfront configuration, if the inner cloudfront returns a cache control header on a 4xx, the outer will cache the response. This PR disables the cache if running in a daisy chained configuration and all caching is handled by the outer cloudfront.