### PR TITLE
Remove course versions with non unit group content roots

### DIFF
--- a/dashboard/db/migrate/20250812140655_remove_old_course_version_instances.rb
+++ b/dashboard/db/migrate/20250812140655_remove_old_course_version_instances.rb
@@ -1,0 +1,10 @@
+class RemoveOldCourseVersionInstances < ActiveRecord::Migration[6.1]
+  def up
+    if Rails.env.development?
+      CourseVersion.where.not(content_root_type: 'UnitGroup').delete_all
+    end
+  end
+
+  def down
+  end
+end

--- a/dashboard/db/migrate/20250812140655_remove_old_course_version_instances.rb
+++ b/dashboard/db/migrate/20250812140655_remove_old_course_version_instances.rb
@@ -1,7 +1,8 @@
 class RemoveOldCourseVersionInstances < ActiveRecord::Migration[6.1]
   def up
     if Rails.env.development?
-      CourseVersion.where.not(content_root_type: 'UnitGroup').delete_all
+      deleted_count = CourseVersion.where.not(content_root_type: 'UnitGroup').delete_all
+      puts "Deleted #{deleted_count} CourseVersion records."
     end
   end
 

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_08_05_233618) do
+ActiveRecord::Schema.define(version: 2025_08_12_140655) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
With the removal of `content_root_type` (#67601), an issue with outdated CourseVersion entries was surfaced.
There are no any bad entries in staging, test, levelbuilder or production, but it could affect developers with databases that are 3+ years old. This PR removes any CourseVersions in development environments with a `content_root_type` that is not a `UnitGroup`.


## Links
Initial PR: #67601

## Testing story
Tested the migration locally


## Follow-up work
1. Merge  #67601
2. Merge the db migration PR
