### PR TITLE
Web Lab 2 preview improvements

### DIFF
--- a/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
@@ -118,7 +118,6 @@ const InnerHTMLPreview = () => {
 
   // TODOs:
   // Support other file types (images, etc.): https://codedotorg.atlassian.net/browse/CT-1255
-  // More robust file paths: https://codedotorg.atlassian.net/browse/CT-1256
   // Better regeneration logic: https://codedotorg.atlassian.net/browse/CT-1259
   useEffect(() => {
     if (source) {

--- a/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
@@ -1,5 +1,5 @@
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
-import {getFolderPath} from '@codebridge/utils';
+import {findFilePathByRelativePath, getFolderPath} from '@codebridge/utils';
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 
 import {MultiFileSource} from '@cdo/apps/lab2/types';
@@ -60,10 +60,10 @@ const InnerHTMLPreview = () => {
           setSource(data.source);
         }
       } else if (data.type === IframeMessageType.CHANGE_FILE_HREF) {
-        setCurrentFile(data.fileName);
+        setCurrentFile(data.filePath);
         // Tell the parent that we are changing the file, as this came from a link click.
         window.parent.postMessage(
-          {type: IframeMessageType.FILE_UPDATED, fileName: data.fileName},
+          {type: IframeMessageType.FILE_UPDATED, fileName: data.filePath},
           parentOrigin
         );
       } else if (data.type === IframeMessageType.CHANGE_FILE_URL_BAR) {
@@ -183,13 +183,19 @@ const InnerHTMLPreview = () => {
         });
         const fileLinks: NodeListOf<HTMLAnchorElement> =
           doc.querySelectorAll('a[href]');
+        const fullFileName = getFullyQualifiedFileName(
+          file.name,
+          file.folderId,
+          source.folders
+        );
         fileLinks.forEach(link => {
           const href = link.getAttribute('href');
           if (href?.endsWith('.html')) {
+            const filePath = findFilePathByRelativePath(href, fullFileName);
             link.setAttribute(
               'onclick',
               `event.preventDefault();
-              window.parent.postMessage({type: '${IframeMessageType.CHANGE_FILE_HREF}', fileName: '${href}'}, '${location.origin}');
+              window.parent.postMessage({type: '${IframeMessageType.CHANGE_FILE_HREF}', filePath: '${filePath}'}, '${location.origin}');
               return false;
             `
             );
@@ -197,11 +203,6 @@ const InnerHTMLPreview = () => {
         });
         const updatedContents = doc.documentElement.outerHTML;
         const blob = new Blob([updatedContents], {type: 'text/html'});
-        const fullFileName = getFullyQualifiedFileName(
-          file.name,
-          file.folderId,
-          source.folders
-        );
         files[fullFileName] = URL.createObjectURL(blob);
       });
       revokeAndSetFilesToBlobs(files);

--- a/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
@@ -1,10 +1,15 @@
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
-import {findFilePathByRelativePath, getFolderPath} from '@codebridge/utils';
+import {createBlobUrlForFile, getFolderPath} from '@codebridge/utils';
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 
 import {IframeMessageType} from './constants';
+import {
+  setContentSecurityPolicy,
+  updateLinksToHtmlFiles,
+  updateLinksToNonHtmlFiles,
+} from './htmlParsingHelpers';
 
 import moduleStyles from './styles/inner-html-preview.module.scss';
 const NOT_FOUND_FILE = 'NOT_FOUND';
@@ -121,86 +126,35 @@ const InnerHTMLPreview = () => {
       // Handle non-HTML files. These are just converted to Blobs.
       Object.values(source.files).forEach(file => {
         if (file.language !== 'html') {
-          let fileType = '';
-          if (file.language === 'css' || file.language === 'csv') {
-            fileType = `text/${file.language}`;
-          } else if (file.language === 'js') {
-            fileType = 'text/javascript';
-          } else {
-            // TODO: handle other file types, like images
-            fileType = file.language;
-          }
-          const blob = new Blob([file.contents], {type: fileType});
           const fullFileName = getFullyQualifiedFileName(
             file.name,
             file.folderId,
             source.folders
           );
-          files[fullFileName] = URL.createObjectURL(blob);
+          files[fullFileName] = createBlobUrlForFile(file);
         }
       });
-      // Handle HTML files. We replace src links to non-html files with blob URLs.
-      // We update links to other files with a click handler that will post a message to us
-      // to change the file.
+      // Handle HTML files. We do the following;
+      // 1. Set the Content Security Policy to allow requests to certain origins.
+      // 2. Replace src links to non-html files with blob URLs.
+      // 3. Update links to other files with a click handler that will post a message to us
+      //    to change the file.
       const htmlFiles = Object.values(source.files).filter(
         file => file.language === 'html'
       );
       htmlFiles.forEach(file => {
         const parser = new DOMParser();
         const doc = parser.parseFromString(file.contents, 'text/html');
-        // Remove any existing CSP meta tags, as we need to set our own.
-        const existingCspTags = doc.querySelectorAll(
-          'meta[http-equiv="Content-Security-Policy"]'
-        );
-        existingCspTags.forEach(tag => tag.remove());
 
-        const metaTag = doc.createElement('meta');
-        metaTag.setAttribute('http-equiv', 'Content-Security-Policy');
-        // TODO: Improve the list of allowed origins.
-        // https://codedotorg.atlassian.net/browse/CT-579
-        metaTag.setAttribute(
-          'content',
-          "connect-src 'self' http://numbersapi.com"
-        );
-
-        const head = doc.querySelector('head');
-        if (head) {
-          head.appendChild(metaTag);
-        }
-        const links = doc.querySelectorAll(
-          'link[rel="stylesheet"], script[src]'
-        );
-        links.forEach(link => {
-          const src = link.getAttribute('src') || link.getAttribute('href');
-          if (src && files[src]) {
-            const blobUrl = files[src];
-            if (link.tagName.toLowerCase() === 'link') {
-              link.setAttribute('href', blobUrl);
-            } else {
-              link.setAttribute('src', blobUrl);
-            }
-          }
-        });
-        const fileLinks: NodeListOf<HTMLAnchorElement> =
-          doc.querySelectorAll('a[href]');
         const fullFileName = getFullyQualifiedFileName(
           file.name,
           file.folderId,
           source.folders
         );
-        fileLinks.forEach(link => {
-          const href = link.getAttribute('href');
-          if (href?.endsWith('.html')) {
-            const filePath = findFilePathByRelativePath(href, fullFileName);
-            link.setAttribute(
-              'onclick',
-              `event.preventDefault();
-              window.parent.postMessage({type: '${IframeMessageType.CHANGE_FILE_HREF}', filePath: '${filePath}'}, '${location.origin}');
-              return false;
-            `
-            );
-          }
-        });
+
+        setContentSecurityPolicy(doc);
+        updateLinksToNonHtmlFiles(doc, files, fullFileName);
+        updateLinksToHtmlFiles(doc, fullFileName);
         const updatedContents = doc.documentElement.outerHTML;
         const blob = new Blob([updatedContents], {type: 'text/html'});
         files[fullFileName] = URL.createObjectURL(blob);

--- a/apps/src/codebridge/FilePreview/htmlParsingHelpers.ts
+++ b/apps/src/codebridge/FilePreview/htmlParsingHelpers.ts
@@ -1,0 +1,66 @@
+import {findFilePathByRelativePath} from '../utils';
+
+import {IframeMessageType} from './constants';
+
+// Remove any existing content security policy from the document, and
+// add a new Content Security Policy to the document to allow for certain
+// HTTP requests.
+export const setContentSecurityPolicy = (doc: Document) => {
+  // Remove any existing CSP meta tags, as we need to set our own.
+  const existingCspTags = doc.querySelectorAll(
+    'meta[http-equiv="Content-Security-Policy"]'
+  );
+  existingCspTags.forEach(tag => tag.remove());
+
+  const metaTag = doc.createElement('meta');
+  metaTag.setAttribute('http-equiv', 'Content-Security-Policy');
+  // TODO: Improve the list of allowed origins.
+  // https://codedotorg.atlassian.net/browse/CT-579
+  metaTag.setAttribute('content', "connect-src 'self' http://numbersapi.com");
+
+  const head = doc.querySelector('head');
+  if (head) {
+    head.appendChild(metaTag);
+  }
+};
+
+// Replace links to non-html files (css and js) with their appropriate blob URLs.
+export const updateLinksToNonHtmlFiles = (
+  doc: Document,
+  filesToBlobs: Record<string, string>,
+  fullFileName: string
+) => {
+  const links = doc.querySelectorAll('link[rel="stylesheet"], script[src]');
+  links.forEach(link => {
+    const src = link.getAttribute('src') || link.getAttribute('href');
+    if (src) {
+      const filePath = findFilePathByRelativePath(src, fullFileName);
+      const blobUrl = filesToBlobs[filePath];
+      if (blobUrl) {
+        if (link.tagName.toLowerCase() === 'link') {
+          link.setAttribute('href', blobUrl);
+        } else {
+          link.setAttribute('src', blobUrl);
+        }
+      }
+    }
+  });
+};
+
+export const updateLinksToHtmlFiles = (doc: Document, fullFileName: string) => {
+  const fileLinks: NodeListOf<HTMLAnchorElement> =
+    doc.querySelectorAll('a[href]');
+  fileLinks.forEach(link => {
+    const href = link.getAttribute('href');
+    if (href?.endsWith('.html')) {
+      const filePath = findFilePathByRelativePath(href, fullFileName);
+      link.setAttribute(
+        'onclick',
+        `event.preventDefault();
+        window.parent.postMessage({type: '${IframeMessageType.CHANGE_FILE_HREF}', filePath: '${filePath}'}, '${location.origin}');
+        return false;
+      `
+      );
+    }
+  });
+};

--- a/apps/src/codebridge/FilePreview/htmlParsingHelpers.ts
+++ b/apps/src/codebridge/FilePreview/htmlParsingHelpers.ts
@@ -25,6 +25,8 @@ export const setContentSecurityPolicy = (doc: Document) => {
 };
 
 // Replace links to non-html files (css and js) with their appropriate blob URLs.
+// We support <link> tags for CSS files and <script> tags for JavaScript files,
+// and support both relative and absolute paths.
 export const updateLinksToNonHtmlFiles = (
   doc: Document,
   filesToBlobs: Record<string, string>,
@@ -47,6 +49,8 @@ export const updateLinksToNonHtmlFiles = (
   });
 };
 
+// Update links to HTML files to include an onclick event. This will
+// send a message to the parent window telling it which file to navigate to.
 export const updateLinksToHtmlFiles = (doc: Document, fullFileName: string) => {
   const fileLinks: NodeListOf<HTMLAnchorElement> =
     doc.querySelectorAll('a[href]');

--- a/apps/src/codebridge/utils/createBlobUrlForFile.ts
+++ b/apps/src/codebridge/utils/createBlobUrlForFile.ts
@@ -1,5 +1,8 @@
 import {ProjectFile} from '../types';
 
+// Given a ProjectFile, create a Blob URL for it.
+// Currently explicitly supports css, csv, and js files,
+// otherwise the file type will be empty.
 export const createBlobUrlForFile = (file: ProjectFile): string => {
   // TODO: handle other file types, like images
   let fileType = '';

--- a/apps/src/codebridge/utils/createBlobUrlForFile.ts
+++ b/apps/src/codebridge/utils/createBlobUrlForFile.ts
@@ -1,0 +1,13 @@
+import {ProjectFile} from '../types';
+
+export const createBlobUrlForFile = (file: ProjectFile): string => {
+  // TODO: handle other file types, like images
+  let fileType = '';
+  if (file.language === 'css' || file.language === 'csv') {
+    fileType = `text/${file.language}`;
+  } else if (file.language === 'js') {
+    fileType = 'text/javascript';
+  }
+  const blob = new Blob([file.contents], {type: fileType});
+  return URL.createObjectURL(blob);
+};

--- a/apps/src/codebridge/utils/findFilePathByRelativePath.ts
+++ b/apps/src/codebridge/utils/findFilePathByRelativePath.ts
@@ -1,0 +1,32 @@
+export const findFilePathByRelativePath = (
+  filePath: string,
+  currentFile: string
+) => {
+  if (filePath.startsWith('/')) {
+    return filePath.substring(1); // remove leading slash
+  }
+  // Handle relative paths
+  const currentDir = currentFile.includes('/')
+    ? currentFile.substring(0, currentFile.lastIndexOf('/'))
+    : '';
+
+  // Split the new path into segments
+  const newPathSegments = filePath.split('/');
+
+  // If the path is relative, we will resolve it against the current directory.
+  // We start with the current directory split into segments, ignoring the current file name.
+  const resolvedPathSegments = currentDir ? currentDir.split('/') : [];
+
+  // Process each segment
+  for (const segment of newPathSegments) {
+    if (segment === '..') {
+      // Go up one directory
+      resolvedPathSegments.pop();
+    } else if (segment !== '.' && segment !== '') {
+      // Add segment (ignore current directory '.' and empty segments)
+      resolvedPathSegments.push(segment);
+    }
+  }
+
+  return resolvedPathSegments.join('/');
+};

--- a/apps/src/codebridge/utils/findFilePathByRelativePath.ts
+++ b/apps/src/codebridge/utils/findFilePathByRelativePath.ts
@@ -1,3 +1,7 @@
+// Given a file path and the current file (which is a full path), convert the file
+// path to a fully qualified path relative to the root folder. This supports both absolute
+// and relative paths.
+// The returned path will not have a leading slash.
 export const findFilePathByRelativePath = (
   filePath: string,
   currentFile: string
@@ -10,17 +14,14 @@ export const findFilePathByRelativePath = (
     ? currentFile.substring(0, currentFile.lastIndexOf('/'))
     : '';
 
-  // Split the new path into segments
   const newPathSegments = filePath.split('/');
-
   // If the path is relative, we will resolve it against the current directory.
   // We start with the current directory split into segments, ignoring the current file name.
   const resolvedPathSegments = currentDir ? currentDir.split('/') : [];
 
-  // Process each segment
   for (const segment of newPathSegments) {
-    if (segment === '..') {
-      // Go up one directory
+    if (segment === '..' && resolvedPathSegments.length > 0) {
+      // Go up one directory if we can. Ignore if at root.
       resolvedPathSegments.pop();
     } else if (segment !== '.' && segment !== '') {
       // Add segment (ignore current directory '.' and empty segments)

--- a/apps/src/codebridge/utils/index.ts
+++ b/apps/src/codebridge/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './analyticsReporterHelper';
 export * from './editableFileType';
+export * from './createBlobUrlForFile';
 export * from './isDuplicateFileName';
 export * from './isDuplicateFolderName';
 export * from './isValidFileName';

--- a/apps/src/codebridge/utils/index.ts
+++ b/apps/src/codebridge/utils/index.ts
@@ -6,6 +6,7 @@ export * from './isValidFileName';
 export * from './isValidFolderName';
 export * from './fileUtils';
 export * from './findFile';
+export * from './findFilePathByRelativePath';
 export * from './findFolder';
 export * from './getEmptyProject';
 export * from './getErrorMessage';

--- a/apps/test/unit/codebridge/utils/findFilePathByRelativePathTest.ts
+++ b/apps/test/unit/codebridge/utils/findFilePathByRelativePathTest.ts
@@ -1,0 +1,73 @@
+import {findFilePathByRelativePath} from '@cdo/apps/codebridge/utils/findFilePathByRelativePath';
+
+describe('findFilePathByRelativePath', () => {
+  it('returns an absolute path without leading slash', () => {
+    expect(
+      findFilePathByRelativePath('/path/to/file.html', 'current/index.html')
+    ).toBe('path/to/file.html');
+  });
+
+  it('handles root folder absolute paths', () => {
+    expect(findFilePathByRelativePath('/file.html', 'current/index.html')).toBe(
+      'file.html'
+    );
+  });
+
+  it('resolves relative path from root folder', () => {
+    expect(findFilePathByRelativePath('src/file.html', 'index.html')).toBe(
+      'src/file.html'
+    );
+  });
+
+  it('handles current directory references from root', () => {
+    expect(findFilePathByRelativePath('./file.html', 'index.html')).toBe(
+      'file.html'
+    );
+  });
+
+  it('resolves sibling file correctly', () => {
+    expect(
+      findFilePathByRelativePath('sibling.html', 'current/index.html')
+    ).toBe('current/sibling.html');
+  });
+
+  it('resolves current directory reference from a subdirectory', () => {
+    expect(
+      findFilePathByRelativePath('./file.html', 'current/index.html')
+    ).toBe('current/file.html');
+  });
+
+  it('resolves parent directory reference', () => {
+    expect(
+      findFilePathByRelativePath('../file.html', 'current/subdir/index.html')
+    ).toBe('current/file.html');
+  });
+
+  it('resolves complex path', () => {
+    expect(
+      findFilePathByRelativePath(
+        '../src/nested/../file.html',
+        'current/subdir/index.html'
+      )
+    ).toBe('current/src/file.html');
+  });
+
+  it('handles empty segments', () => {
+    expect(
+      findFilePathByRelativePath('src//file.html', 'current/index.html')
+    ).toBe('current/src/file.html');
+  });
+
+  it('handles multiple current directory references', () => {
+    expect(
+      findFilePathByRelativePath('././file.html', 'current/index.html')
+    ).toBe('current/file.html');
+  });
+
+  it('handles going above the root directory', () => {
+    // Extra .. should be ignored.
+    expect(findFilePathByRelativePath('../../file.html', 'index.html')).toBe(
+      'file.html'
+    );
+  });
+});


### PR DESCRIPTION
A couple improvements to the Web Lab 2 preview:
- Support any type of file path when linking between files (including html, css and js). Previously all file paths had to be absolute, now you can use relative paths.
- Refactor the html parsing logic into helpers to make it easier to read.


## Links

- Jira: [CT-1256](https://codedotorg.atlassian.net/browse/CT-1256)

## Testing story
Tested locally and added unit tests for the new routing logic.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
