### PR TITLE
AI Chat / Tutor: Split Statsig Metrics

### DIFF
--- a/apps/src/aichat/redux/index.ts
+++ b/apps/src/aichat/redux/index.ts
@@ -14,6 +14,7 @@ export {
   setStartingAiCustomizations,
   setStudentChatHistory,
   setUserHasAichatAccess,
+  setClientType,
   setViewMode,
   addStagedFile,
   stagedFileUploadFinished,

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -23,6 +23,7 @@ import {
   PendingChatMessage,
   ChatAsset,
   SaveError,
+  AiChatClientType,
 } from '../types';
 import {
   DEFAULT_VISIBILITIES,
@@ -33,6 +34,7 @@ import {validateModelId} from '../views/modelCustomization/utils';
 import {AichatState} from './state';
 
 const initialState: AichatState = {
+  clientType: undefined,
   chatEventsPast: [],
   chatEventsCurrent: [],
   chatMessagePending: undefined,
@@ -102,6 +104,10 @@ const aichatSlice = createSlice({
     },
     setUserHasAichatAccess: (state, action: PayloadAction<boolean>) => {
       state.userHasAichatAccess = action.payload;
+    },
+
+    setClientType(state, action: PayloadAction<AiChatClientType>) {
+      state.clientType = action.payload;
     },
     removeUpdateMessage: (state, action: PayloadAction<number>) => {
       const modelUpdateMessageInfo = getUpdateMessageLocation(
@@ -370,6 +376,7 @@ export const {
   setStudentChatHistory,
   setOwnChatHistory,
   setUserHasAichatAccess,
+  setClientType,
   setViewMode,
   addStagedFile,
   stagedFileUploadFinished,

--- a/apps/src/aichat/redux/state.ts
+++ b/apps/src/aichat/redux/state.ts
@@ -9,9 +9,11 @@ import {
   SaveType,
   ServerChatEvent,
   ViewMode,
+  AiChatClientType,
 } from '../types';
 
 export interface AichatState {
+  clientType?: AiChatClientType;
   // Content from previous chat sessions that we track purely for visibility to the user
   // and do not send to the model as history.
   chatEventsPast: ChatEvent[];

--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -11,6 +11,14 @@ export const sendAnalytics =
   (dispatch: AppDispatch, getState: () => RootState) => {
     const userHasAichatAccess = getState().aichat.userHasAichatAccess;
     if (userHasAichatAccess || skipAccessCheck) {
-      analyticsReporter.sendEvent(event, properties, PLATFORMS.BOTH);
+      const propertiesWithClientType = {
+        ...properties,
+        clientType: getState().aichat.clientType,
+      };
+      analyticsReporter.sendEvent(
+        event,
+        propertiesWithClientType,
+        PLATFORMS.BOTH
+      );
     }
   };

--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -2,6 +2,7 @@ import {PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {RootState} from '@cdo/apps/types/redux';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
+import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
 
 // This thunk sends aichat analytics events to Amplitude and Statsig.
 // The event is sent for authorized users and if skipAccessCheck is true,
@@ -9,16 +10,27 @@ import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 export const sendAnalytics =
   (event: string, properties: object, skipAccessCheck = false) =>
   (dispatch: AppDispatch, getState: () => RootState) => {
+    const clientType = getState().aichat.clientType;
     const userHasAichatAccess = getState().aichat.userHasAichatAccess;
-    if (userHasAichatAccess || skipAccessCheck) {
+
+    // Only check `userHasAichatAccess` for AI Chat.
+    if (
+      clientType !== AiChatClientTypes.AI_CHAT_LAB ||
+      userHasAichatAccess ||
+      skipAccessCheck
+    ) {
       const propertiesWithClientType = {
         ...properties,
-        clientType: getState().aichat.clientType,
+        clientType,
       };
       analyticsReporter.sendEvent(
         event,
         propertiesWithClientType,
-        PLATFORMS.BOTH
+
+        // Only log to Amplitude for AI Chat otherwise just log to Statsig.
+        clientType === AiChatClientTypes.AI_CHAT_LAB
+          ? PLATFORMS.BOTH
+          : PLATFORMS.STATSIG
       );
     }
   };

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -99,6 +99,7 @@ export const submitChatContents = createAsyncThunk(
           fileCount,
           fileCountImage,
           fileCountPdf,
+          clientType,
         })
       );
     } catch (error) {

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -25,6 +25,7 @@ import {
   ChatAsset,
   ModelParameters,
   AiChatClientType,
+  AnalyticsProperties,
 } from '../../types';
 import {getNewRemoveId} from '../utils';
 
@@ -44,14 +45,21 @@ export const submitChatContents = createAsyncThunk(
       clientType: AiChatClientType;
       hiddenContext?: string;
       assets?: ChatAsset[];
+      analyticsProperties?: AnalyticsProperties;
     },
     thunkAPI
   ) => {
     const dispatch = thunkAPI.dispatch as AppDispatch;
     const state = thunkAPI.getState() as RootState;
     const chatEventsCurrent = state.aichat.chatEventsCurrent;
-    const {text, hiddenContext, assets, modelParameters, clientType} =
-      newUserMessageInput;
+    const {
+      text,
+      hiddenContext,
+      assets,
+      modelParameters,
+      clientType,
+      analyticsProperties,
+    } = newUserMessageInput;
 
     // Clear any staged files if present (used with multimodal models)
     thunkAPI.dispatch(clearStagedFiles());
@@ -100,6 +108,7 @@ export const submitChatContents = createAsyncThunk(
           fileCountImage,
           fileCountPdf,
           clientType,
+          ...analyticsProperties,
         })
       );
     } catch (error) {

--- a/apps/src/aichat/types/analytics.ts
+++ b/apps/src/aichat/types/analytics.ts
@@ -1,0 +1,5 @@
+/*
+ * Type to map from an event property name to a value.  This is used to pass analytics data to
+ * Statsig and Amplitude where the exact key (name) and data type isn't known ahead of time.
+ **/
+export type AnalyticsProperties = {[name: string]: string | number | boolean};

--- a/apps/src/aichat/types/chatButton.ts
+++ b/apps/src/aichat/types/chatButton.ts
@@ -1,4 +1,7 @@
+import {AnalyticsProperties} from './analytics';
+
 export interface ChatButton {
   label: string;
   value: string;
+  analyticsProperties?: AnalyticsProperties;
 }

--- a/apps/src/aichat/types/index.ts
+++ b/apps/src/aichat/types/index.ts
@@ -4,3 +4,4 @@ export * from './chatEvents';
 export * from './customizations';
 export * from './levelProperties';
 export * from './toxicity';
+export * from './analytics';

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -19,6 +19,7 @@ import {
   clearStagedFiles,
   fetchUserChatHistory,
   selectAllVisibleMessages,
+  setClientType,
   setNewChatSession,
 } from '../redux';
 import {findChangedProperties, getNewRemoveId} from '../redux/utils';
@@ -147,6 +148,10 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       );
     }
   }, [dispatch, currentUserId, currentLevelId, selectedStudent]);
+
+  useEffect(() => {
+    dispatch(setClientType(clientType));
+  }, [dispatch, clientType]);
 
   const selectedStudentName =
     selectedStudent && getShortName(selectedStudent.name);

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -5,7 +5,12 @@ import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/Us
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {submitChatContents} from '../redux';
-import {AiChatClientType, ChatButton, ModelParameters} from '../types';
+import {
+  AiChatClientType,
+  ChatButton,
+  ModelParameters,
+  AnalyticsProperties,
+} from '../types';
 
 import moduleStyles from './UserChatMessageEditor.module.scss';
 
@@ -49,7 +54,7 @@ const UserChatMessageEditor: React.FunctionComponent<
   const disabled = isWaitingForChatResponse || saveInProgress || uploadsPending;
 
   const handleSubmit = useCallback(
-    (userMessage: string) => {
+    (userMessage: string, analyticsProperties?: AnalyticsProperties) => {
       if (!disabled) {
         dispatch(
           submitChatContents({
@@ -57,6 +62,7 @@ const UserChatMessageEditor: React.FunctionComponent<
             modelParameters,
             clientType,
             hiddenContext,
+            analyticsProperties,
             assets:
               multimodalAvailable && chatAssets.length > 0
                 ? chatAssets
@@ -93,7 +99,9 @@ const UserChatMessageEditor: React.FunctionComponent<
               key={button.label}
               aria-label={button.label}
               id="button-hint"
-              onClick={() => handleSubmit(button.value)}
+              onClick={() =>
+                handleSubmit(button.value, button.analyticsProperties)
+              }
               text={button.label}
               size="s"
               type="secondary"

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {clearChatMessages} from '@cdo/apps/aichat/redux';
-import {ModelParameters} from '@cdo/apps/aichat/types';
+import {ChatButton, ModelParameters} from '@cdo/apps/aichat/types';
 import ChatWorkspace from '@cdo/apps/aichat/views/ChatWorkspace';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
@@ -19,18 +19,27 @@ const MODEL_PARAMETERS: ModelParameters = {
 };
 
 // Some pre-canned chat buttons.
-const CHAT_BUTTONS = [
+const CHAT_BUTTONS: ChatButton[] = [
   {
     label: 'example',
     value: 'Can you give me an example?',
+    analyticsProperties: {
+      cannedPrompt: 'example',
+    },
   },
   {
     label: 'hint',
     value: 'Can you give me a hint?',
+    analyticsProperties: {
+      cannedPrompt: 'hint',
+    },
   },
   {
     label: 'doc',
     value: 'Can you give me some documentation?',
+    analyticsProperties: {
+      cannedPrompt: 'doc',
+    },
   },
 ];
 


### PR DESCRIPTION
This PR separates/differentiates logging for AI Tutor by:

- Only logging to Statsig, where AI Chat logs to Amplitude as well
- Adding a `clientType` parameter (0=Chat, 1=Tutor, 2=Flow) to all student logs
- Adds a `cannedPrompt` parameter for the `User submits aichat request successfully` event
- Updates all AI Chat Statsig dashboards to filter only AI Chat events. 

<img width="797" height="587" alt="Screenshot 2025-08-12 at 12 08 20 PM" src="https://github.com/user-attachments/assets/fe50dc5e-7d70-4346-a90f-ae19eac7ee26" />

## Details 

All “Exploring with Generative AI Unit” [dashboards on Statsig](https://console.statsig.com/6uqJc02CIZP7hHowwYO7AS/dashboards/6KvjXDkhlAtxzOKMjHCYOM?type=relative&offset_days=0&label=Last+30+days&window_size=30) were updated to filter for `clientType` of `0` or `empty` (so events sent before the change are supported)

<img width="307" height="147" alt="Screenshot 2025-08-12 at 10 34 39 AM" src="https://github.com/user-attachments/assets/5f678265-cceb-417f-9540-493ef2222cf2" />

Here is the list of all dashbaords that were updated:

- Total users sending chats 
- Unique users updating AI chat
- Levels that folks are successfully chatting with the chatbot
- Unique users updating the chatbot
- Unique Users sending AI chats
- Successful AI chats sent
- Levels where users are attempting to access the chatbot without the right permissions (was broken due to incomplete metric name - fixed)
- Users attempting to access the chatbot without the right permissions  (was broken due to incomplete metric name - fixed)
- Unique users updating temperature
- Most Common Temperature Changes
- How often do student update temp on each level?
- How often do students update system prompts on each level?
- Unique users updating system prompt
- How often do students update retrieval on each level?
- Unique users updating retrieval context
- Unique users updating retrieval
- Most Common Model Changes
- How often do student update model type on each level?
- New Chart Widget
- Usage of chat features

<img width="1400" height="740" alt="Screenshot 2025-08-12 at 10 51 19 AM" src="https://github.com/user-attachments/assets/5139d8f3-8d55-4a49-b913-e95031c115ca" />


## Links

This is the student facing part of this [Jira Ticket](https://codedotorg.atlassian.net/issues/?jql=labels%20%3D%20%22milestone3%22&selectedIssue=LABS-1503).  The teacher facing part should be handled with @cnbrenci's work which reused the existing AI Tutor teacher management and should already do the necessary logging. 


## Testing story
This change does not add any tests as it is only focused on logging.


## Follow-up work

Next steps would be to add dashboards for the AI Tutor data that is logged.

## Privacy
While logging has privacy concerns, the only new data that is logged is which client (AI Tutor vs. AI Chat) or which canned prompt ("doc", "example", "hint") was used.
