### PR TITLE
Lab2: add student rubric tab to resource panel

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2983,6 +2983,8 @@
   "studentResources": "Student Resources",
   "studentResponses": "Student Responses",
   "studentResponse": "Student Response",
+  "studentRubricNoFeedback": "No feedback yet!",
+  "studentRubricTeacherFeedback": "Your teacher wrote:",
   "studentTableTeacherDemo": "Me",
   "studentUsStateUpdatesModal_title": "Set state for all students",
   "studentUsStateUpdatesModal_desc": "Please be sure to choose the correct state. For certain states, we may be required to obtain parental consent for student accounts. [**Learn more about parental consent**]({docURL})",

--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -13,6 +13,7 @@ import BrowserTextToSpeechWrapper from '@cdo/apps/sharedComponents/BrowserTextTo
 
 import ProjectContainer from '../projects/ProjectContainer';
 
+import RubricFABContainer from './components/rubrics/RubricFABContainer';
 import RubricWrapper from './components/rubrics/RubricWrapper';
 import DialogManager from './dialogs/DialogManager';
 import Lab2Wrapper from './Lab2Wrapper';
@@ -23,17 +24,19 @@ const Lab2: React.FunctionComponent = () => {
   return (
     <Provider store={getStore()}>
       <BrowserTextToSpeechWrapper>
-        <ThemeProvider>
-          <Lab2Wrapper>
-            <DialogManager>
-              <MetricsAdapter />
-              <ProjectContainer channelId={getStandaloneProjectId()}>
-                <LabViewsRenderer />
-              </ProjectContainer>
-              <RubricWrapper />
-            </DialogManager>
-          </Lab2Wrapper>
-        </ThemeProvider>
+        <RubricWrapper>
+          <ThemeProvider>
+            <Lab2Wrapper>
+              <DialogManager>
+                <MetricsAdapter />
+                <ProjectContainer channelId={getStandaloneProjectId()}>
+                  <LabViewsRenderer />
+                </ProjectContainer>
+                <RubricFABContainer />
+              </DialogManager>
+            </Lab2Wrapper>
+          </ThemeProvider>
+        </RubricWrapper>
       </BrowserTextToSpeechWrapper>
     </Provider>
   );

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -7,9 +7,12 @@ import React, {useMemo, useState} from 'react';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import AiTutor2Chat from '@cdo/apps/lab2/views/components/AiTutor2Chat';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import StudentRubricView from '@cdo/apps/lab2/views/components/rubrics/StudentRubricView';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {getTypedKeys} from '@cdo/apps/types/utils';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {useRubric} from '../../rubrics/RubricWrapper';
 import ForTeachersOnly from '../ForTeachersOnly';
 import Instructions, {InstructionsProps} from '../InstructionsV2';
 import NavigationArea from '../NavigationArea';
@@ -20,6 +23,7 @@ enum Tabs {
   Instructions = 'instructions',
   AiTutor = 'aiTutor',
   TeachersOnly = 'teachersOnly',
+  StudentRubric = 'studentRubric',
 }
 
 const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
@@ -28,6 +32,10 @@ const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
   [Tabs.TeachersOnly]: {
     title: commonI18n.forTeachersOnly(),
     icon: 'chalkboard-teacher',
+  },
+  [Tabs.StudentRubric]: {
+    title: 'Rubric',
+    icon: 'clipboard-list',
   },
 };
 
@@ -51,6 +59,10 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   ...instructionsProps
 }) => {
   const {theme} = useTheme();
+  const {showRubric} = useRubric();
+  const isParticipant = useAppSelector(
+    state => state.currentUser.userType === 'student'
+  );
   const [currentTab, setCurrentTab] = useState<Tabs>(Tabs.Instructions);
 
   // Build available tabs based on level information.
@@ -84,8 +96,12 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
       tabMap[Tabs.AiTutor] = <AiTutor2Chat hiddenContext={aiTutor2Context} />;
     }
 
+    if (isParticipant && showRubric) {
+      tabMap[Tabs.StudentRubric] = <StudentRubricView />;
+    }
+
     return tabMap;
-  }, [instructionsProps, aiTutor2Context]);
+  }, [instructionsProps, aiTutor2Context, isParticipant, showRubric]);
 
   return (
     <div className={classNames(styles.resourcePanel, className)}>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -34,7 +34,7 @@ const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
     icon: 'chalkboard-teacher',
   },
   [Tabs.StudentRubric]: {
-    title: 'Rubric',
+    title: commonI18n.rubric(),
     icon: 'clipboard-list',
   },
 };

--- a/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
+++ b/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
@@ -1,0 +1,88 @@
+import React, {useMemo} from 'react';
+
+import {isLabLoading} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {useRubric} from './RubricWrapper';
+
+/**
+ * Lab2 container for the teacher-facing rubrics entrypoint {@link RubricFloatingActionButton}
+ * which provides rubric data from {@link useRubric} and provides student progress information from
+ * redux (as opposed to page script data which is only refreshed on page load.)
+ */
+const RubricFABContainer: React.FC = () => {
+  const {rubricData, showRubric, isLoading: isLoadingRubric} = useRubric();
+
+  const currentLevelName = useAppSelector(
+    state => state.lab.levelProperties?.name
+  );
+  const isTeacher = useAppSelector(state => state.currentUser.isTeacher);
+  const labLoading = useAppSelector(isLabLoading);
+  const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
+  const levelsWithProgress = useAppSelector(
+    state => state.teacherPanel.levelsWithProgress
+  );
+  const students = useAppSelector(
+    state => state.teacherSections.selectedStudents
+  );
+  const courseName = useAppSelector(state => state.progress.courseName);
+  const unitName = useAppSelector(state => state.progress.scriptName);
+
+  const studentLevelInfo = useMemo(() => {
+    const userLevel = levelsWithProgress?.find(
+      ul => ul.userId === viewAsUserId
+    );
+    const selectedStudent = students?.find(s => s.id === viewAsUserId);
+
+    if (!viewAsUserId || !userLevel || !selectedStudent) {
+      return;
+    }
+
+    return {
+      name: selectedStudent.name,
+      user_id: viewAsUserId,
+      timeSpent: userLevel.timeSpent,
+      attempts: userLevel.attempts,
+      lastAttempt: userLevel.updatedAt,
+    };
+  }, [viewAsUserId, levelsWithProgress, students]);
+
+  const reportingData = useMemo(
+    () => ({
+      unitName,
+      courseName,
+      levelName: currentLevelName,
+    }),
+    [unitName, courseName, currentLevelName]
+  );
+
+  if (
+    !isTeacher ||
+    !showRubric ||
+    labLoading ||
+    isLoadingRubric ||
+    !rubricData
+  ) {
+    return null;
+  }
+
+  const {rubric, canShowTaScoresAlert} = rubricData;
+
+  return (
+    // Force light mode for the rubric FAB and dialog as they are not fully themed currently.
+    <div data-theme="Light">
+      <RubricFloatingActionButton
+        rubric={rubric}
+        studentLevelInfo={studentLevelInfo}
+        reportingData={reportingData}
+        currentLevelName={currentLevelName}
+        aiEnabled={rubric.learningGoals?.some(lg => lg?.aiEnabled)}
+        canShowTaScoresAlert={canShowTaScoresAlert}
+        reloadOnStudentChange={false}
+      />
+    </div>
+  );
+};
+
+export default RubricFABContainer;

--- a/apps/src/lab2/views/components/rubrics/RubricWrapper.tsx
+++ b/apps/src/lab2/views/components/rubrics/RubricWrapper.tsx
@@ -1,116 +1,87 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 import {getCurrentLesson} from '@cdo/apps/code-studio/progressReduxSelectors';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {isLabLoading} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
-import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
-import {RubricData} from '@cdo/apps/types/rubricTypes';
+import {getTaRubricFeedbackForStudent} from '@cdo/apps/templates/instructions/topInstructionsDataApi';
+import {RubricData, TeacherEvaluations} from '@cdo/apps/types/rubricTypes';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+interface RubricContextType {
+  showRubric: boolean;
+  isLoading: boolean;
+  rubricData?: RubricData;
+  teacherEvaluations?: TeacherEvaluations[];
+}
+
+const RubricContext = createContext<RubricContextType | null>(null);
+
+export function useRubric() {
+  const context = useContext(RubricContext);
+  if (!context) {
+    throw new Error('useRubric must be used within a RubricProvider');
+  }
+  return context;
+}
+
 /**
- * Lab2 wrapper around the teacher-facing rubrics entrypoint {@link RubricFloatingActionButton}
- * which loads the lesson rubric asynchronously and provides student progress information from
- * redux (as opposed to page script data which is only refreshed on page load.)
+ * Rubric context wrapper that loads the lesson rubric and teacher evaluations asynchronously.
  */
-const RubricWrapper: React.FC = () => {
-  const rubricPath = useAppSelector(state => {
-    const rubricId = getCurrentLesson(state)?.rubric?.id;
-    if (rubricId) {
-      return `/rubrics/${rubricId}`;
-    }
-  });
-  const currentLevelName = useAppSelector(
-    state => state.lab.levelProperties?.name
-  );
-  const isTeacher = useAppSelector(state => state.currentUser.isTeacher);
-  const showRubric = useAppSelector(
-    state => state.lab.levelProperties?.showRubric
-  );
-  const labLoading = useAppSelector(isLabLoading);
-  const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
-  const levelsWithProgress = useAppSelector(
-    state => state.teacherPanel.levelsWithProgress
-  );
-  const students = useAppSelector(
-    state => state.teacherSections.selectedStudents
-  );
-  const courseName = useAppSelector(state => state.progress.courseName);
-  const unitName = useAppSelector(state => state.progress.scriptName);
-
-  const studentLevelInfo = useMemo(() => {
-    const userLevel = levelsWithProgress?.find(
-      ul => ul.userId === viewAsUserId
-    );
-    const selectedStudent = students?.find(s => s.id === viewAsUserId);
-
-    if (!viewAsUserId || !userLevel || !selectedStudent) {
-      return;
-    }
-
-    return {
-      name: selectedStudent.name,
-      user_id: viewAsUserId,
-      timeSpent: userLevel.timeSpent,
-      attempts: userLevel.attempts,
-      lastAttempt: userLevel.updatedAt,
-    };
-  }, [viewAsUserId, levelsWithProgress, students]);
-
-  const reportingData = useMemo(
-    () => ({
-      unitName,
-      courseName,
-      levelName: currentLevelName,
-    }),
-    [unitName, courseName, currentLevelName]
-  );
+const RubricWrapper: React.FC<{children: React.ReactNode}> = ({children}) => {
+  const rubricId = useAppSelector(state => getCurrentLesson(state)?.rubric?.id);
+  const showRubric =
+    useAppSelector(state => state.lab.levelProperties?.showRubric) || false;
 
   const [rubricData, setRubricData] = useState<RubricData>();
-  const [isLoadingRubric, setIsLoadingRubric] = useState(false);
+  const [teacherEvaluations, setTeacherEvaluations] =
+    useState<TeacherEvaluations[]>();
+  const [isLoading, setIsLoading] = useState(false);
 
-  useEffect(() => {
-    if (!rubricPath) {
+  const loadRubricAndEvaluations = useCallback(async () => {
+    if (!rubricId) {
       return;
     }
 
     setRubricData(undefined);
-    setIsLoadingRubric(true);
-    HttpClient.fetchJson<RubricData>(rubricPath)
-      .then(response => setRubricData(response.value))
-      .catch(error =>
-        Lab2Registry.getInstance()
-          .getMetricsReporter()
-          .logError(`Error fetching rubric data`, error)
-      )
-      .finally(() => setIsLoadingRubric(false));
-  }, [rubricPath]);
+    setTeacherEvaluations(undefined);
+    setIsLoading(true);
 
-  if (
-    !isTeacher ||
-    !showRubric ||
-    labLoading ||
-    isLoadingRubric ||
-    !rubricData
-  ) {
-    return null;
-  }
+    try {
+      const rubricDataResponse = await HttpClient.fetchJson<RubricData>(
+        `/rubrics/${rubricId}`
+      );
+      const teacherEvaluationsResponse = await getTaRubricFeedbackForStudent(
+        rubricId
+      );
+      setRubricData(rubricDataResponse.value);
+      setTeacherEvaluations(
+        teacherEvaluationsResponse.value as TeacherEvaluations[]
+      );
+    } catch (error) {
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .logError(`Error fetching rubric data`, error as Error);
+    }
 
-  const {rubric, canShowTaScoresAlert} = rubricData;
+    setIsLoading(false);
+  }, [rubricId]);
+
+  useEffect(() => {
+    loadRubricAndEvaluations();
+  }, [loadRubricAndEvaluations]);
 
   return (
-    // Force light mode for the rubric FAB and dialog as they are not fully themed currently.
-    <div data-theme="Light">
-      <RubricFloatingActionButton
-        rubric={rubric}
-        studentLevelInfo={studentLevelInfo}
-        reportingData={reportingData}
-        currentLevelName={currentLevelName}
-        aiEnabled={rubric.learningGoals?.some(lg => lg?.aiEnabled)}
-        canShowTaScoresAlert={canShowTaScoresAlert}
-        reloadOnStudentChange={false}
-      />
-    </div>
+    <RubricContext.Provider
+      value={{showRubric, isLoading, rubricData, teacherEvaluations}}
+    >
+      {children}
+    </RubricContext.Provider>
   );
 };
 

--- a/apps/src/lab2/views/components/rubrics/StudentRubricView.tsx
+++ b/apps/src/lab2/views/components/rubrics/StudentRubricView.tsx
@@ -1,0 +1,171 @@
+// Student-facing rubric view inside Lab2 panel
+
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {
+  BodyFourText,
+  BodyThreeText,
+  BodyTwoText,
+} from '@code-dot-org/component-library/typography';
+import classNames from 'classnames';
+import React, {useEffect, useState} from 'react';
+
+import ProgressRing from '@cdo/apps/templates/rubrics/ProgressRing';
+import {UNDERSTANDING_LEVEL_STRINGS} from '@cdo/apps/templates/rubrics/rubricHelpers';
+import {commonI18n} from '@cdo/apps/types/locale';
+import {EvidenceLevel} from '@cdo/apps/types/rubricTypes';
+
+import {useRubric} from './RubricWrapper';
+
+import styles from './styles.module.scss';
+
+const StudentRubricView: React.FC = () => {
+  const {rubricData, teacherEvaluations, isLoading} = useRubric();
+  const [currentGoalIndex, setCurrentGoalIndex] = useState(0);
+
+  if (isLoading) {
+    return (
+      <div className={styles.rubricContainer}>
+        <div className={styles.loadingSpinner}>
+          <FontAwesomeV6Icon iconName="spinner" animationType="spin" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!rubricData?.rubric?.learningGoals) {
+    return null;
+  }
+
+  const learningGoals = rubricData.rubric.learningGoals;
+
+  const switchGoal = (direction: -1 | 1) => {
+    const numGoals = learningGoals.length;
+    setCurrentGoalIndex((currentGoalIndex + direction + numGoals) % numGoals);
+  };
+
+  const currentLearningGoal = learningGoals[currentGoalIndex];
+  const currentEvaluation = teacherEvaluations
+    ? teacherEvaluations[currentGoalIndex]
+    : undefined;
+
+  if (!currentLearningGoal) {
+    return null;
+  }
+
+  return (
+    <div className={styles.rubricContainer}>
+      <div className={styles.goalSwitcher}>
+        <button
+          className={styles.goalSwitcherButton}
+          type="button"
+          onClick={() => switchGoal(-1)}
+        >
+          <FontAwesomeV6Icon iconName="angle-left" />
+        </button>
+        <ProgressRing
+          className={styles.progressRing}
+          learningGoals={learningGoals}
+          currentLearningGoal={currentGoalIndex}
+          understandingLevels={teacherEvaluations?.map(evaluation =>
+            evaluation.understanding === null ? -1 : evaluation.understanding
+          )}
+          radius={30}
+          stroke={4}
+        />
+        <button
+          className={styles.goalSwitcherButton}
+          type="button"
+          onClick={() => switchGoal(1)}
+        >
+          <FontAwesomeV6Icon iconName="angle-right" />
+        </button>
+      </div>
+      <BodyTwoText className={styles.learningGoalHeader}>
+        {currentLearningGoal.learningGoal}
+      </BodyTwoText>
+      <div className={styles.scrollContainer}>
+        <div className={styles.feedbackContainer}>
+          <BodyFourText className={styles.feedbackHeader}>
+            <i>
+              {!!currentEvaluation?.feedback
+                ? commonI18n.studentRubricTeacherFeedback()
+                : commonI18n.studentRubricNoFeedback()}
+            </i>
+          </BodyFourText>
+          {currentEvaluation?.feedback && (
+            <div className={styles.teacherFeedback}>
+              <BodyThreeText>{currentEvaluation?.feedback}</BodyThreeText>
+            </div>
+          )}
+        </div>
+        <div className={styles.evidenceLevelsContainer}>
+          {currentLearningGoal.evidenceLevels?.map((evidenceLevel, index) => {
+            // InferProps allows evidenceLevel to be null, but if the array is defined
+            // we can assume evidenceLevel is not null.
+            const el = evidenceLevel as EvidenceLevel;
+            return (
+              <EvidenceLevelView
+                key={index}
+                {...el}
+                selected={currentEvaluation?.understanding === el.understanding}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface EvidenceLevelViewProps extends EvidenceLevel {
+  selected: boolean;
+}
+
+const EvidenceLevelView: React.FC<EvidenceLevelViewProps> = ({
+  understanding,
+  teacherDescription,
+  selected,
+}) => {
+  const [collapsed, setCollapsed] = useState(!selected);
+
+  useEffect(() => {
+    setCollapsed(!selected);
+  }, [selected]);
+
+  return (
+    <div
+      className={classNames(
+        styles.evidenceLevelContainer,
+        selected && styles.evidenceLevelContainerSelected
+      )}
+    >
+      <div className={styles.header} onClick={() => setCollapsed(!collapsed)}>
+        <div
+          className={classNames(
+            styles.bubble,
+            selected && styles.bubbleSelected
+          )}
+        />
+        <BodyTwoText>
+          {
+            (UNDERSTANDING_LEVEL_STRINGS as {[level: number]: string})[
+              understanding
+            ]
+          }
+        </BodyTwoText>
+      </div>
+      <div
+        className={classNames(
+          styles.descriptionContainer,
+          collapsed && styles.descriptionContainerCollapsed
+        )}
+      >
+        <BodyThreeText className={classNames(styles.description)}>
+          {teacherDescription}
+        </BodyThreeText>
+      </div>
+    </div>
+  );
+};
+
+export default StudentRubricView;

--- a/apps/src/lab2/views/components/rubrics/styles.module.scss
+++ b/apps/src/lab2/views/components/rubrics/styles.module.scss
@@ -1,0 +1,140 @@
+@import '@code-dot-org/component-library-styles/primitiveColors';
+@import '@code-dot-org/component-library-styles/colors';
+@import '../../../../mixins.scss';
+
+.rubricContainer {
+  display: flex;
+  padding: 10px;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  background-color: var(--background-neutral-primary);
+  overflow: hidden;
+}
+
+.loadingSpinner {
+  margin: auto;
+  > i {
+    font-size: 30px;
+  }
+}
+
+.scrollContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  padding-left: 8px;
+  padding-right: 16px;
+  padding-bottom: 16px;
+}
+
+.goalSwitcher {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+}
+
+.progressRing {
+  fill: var(--text-neutral-primary);
+}
+
+.goalSwitcherButton {
+  @include remove-button-styles;
+  color: var(--text-neutral-primary);
+
+  i {
+    color: var(--text-neutral-primary);
+  }
+}
+
+.learningGoalHeader {
+  margin: 0;
+  text-align: center;
+}
+
+.feedbackContainer {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.teacherFeedback {
+  border: 1px solid var(--text-neutral-quaternary);
+  border-radius: 4px;
+  padding: 16px;
+  background-color: var(--background-neutral-secondary);
+  p {
+    margin: 0;
+  }
+}
+
+.feedbackHeader {
+  text-align: center;
+}
+
+.evidenceLevelsContainer {
+  margin-top: 16px;
+}
+
+.evidenceLevelContainer {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border: 1px solid var(--text-neutral-quaternary);
+
+  &Selected {
+    border-color: var(--borders-brand-teal-primary);
+    background-color: var(--background-brand-teal-extra-light);
+  }
+
+  &:first-child {
+    border-radius: 8px 8px 0 0;
+  }
+
+  &:last-child {
+    border-radius: 0 0 8px 8px;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  .header {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    .bubble {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      border: 1px solid var(--text-neutral-quaternary);
+
+      &Selected {
+        border-color: var(--borders-brand-teal-primary);
+        background-color: var(--background-brand-teal-primary);
+      }
+    }
+  }
+
+  .descriptionContainer {
+    transition: max-height 0.5s ease-in-out, opacity 0.5s ease-in-out;
+    max-height: 500px;
+    opacity: 1;
+
+    &Collapsed {
+      max-height: 0;
+      opacity: 0;
+      overflow: hidden;
+    }
+
+    .description {
+      margin-top: 8px;
+    }
+  }
+}

--- a/apps/src/templates/rubrics/RubricContainer.story.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.story.jsx
@@ -25,6 +25,7 @@ const createRubricContainerStore = () => {
 const rubricLevelName = 'free_play_level';
 
 const defaultRubric = {
+  id: 1,
   lesson: {
     position: 3,
     name: 'Testing',

--- a/apps/src/templates/rubrics/rubricShapes.jsx
+++ b/apps/src/templates/rubrics/rubricShapes.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 export const evidenceLevelShape = PropTypes.shape({
-  understanding: PropTypes.number,
+  understanding: PropTypes.number.isRequired,
   teacherDescription: PropTypes.string,
 });
 
@@ -14,6 +14,7 @@ export const learningGoalShape = PropTypes.shape({
 });
 
 export const rubricShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
   learningGoals: PropTypes.arrayOf(learningGoalShape),
   lesson: PropTypes.shape({
     position: PropTypes.number,

--- a/apps/src/types/rubricTypes.ts
+++ b/apps/src/types/rubricTypes.ts
@@ -21,3 +21,8 @@ export interface RubricData {
   rubric: Rubric;
   canShowTaScoresAlert: boolean;
 }
+export interface TeacherEvaluations {
+  id: number;
+  feedback: string | null;
+  understanding: number | null;
+}


### PR DESCRIPTION
Adds a new student-facing rubric panel to the tabbed instructions in lab2. This is adapted from an [earlier prototype](https://github.com/code-dot-org/code-dot-org/pull/65999) so the UI isn't necessary final, but we expect to refine this as we test this out with students and teachers.

To support this, I reworked the RubricWrapper into an actual context wrapper that just loads the rubric data, so that the student-facing rubric view and the FAB container can both access it.

<img width="1511" height="824" alt="Screenshot 2025-08-12 at 10 07 12 AM" src="https://github.com/user-attachments/assets/9f46346f-8cf7-4c4b-884d-4439ddb12811" />

## Testing story

Tested locally on a Music Lab lesson with a rubric