### PR TITLE
chore(marketing): hide Hour of AI link on CSforAll Header and Footer

### DIFF
--- a/frontend/apps/marketing/src/components/footerMui/config.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/config.tsx
@@ -8,7 +8,8 @@ export const COPYRIGHT_TEXT = 'All rights reserved';
 export const SITE_LINKS = [
   {key: 'issues', label: 'Issues', href: '/issues'},
   {key: 'take-action', label: 'Take Action', href: '/take-action'},
-  {key: 'hour-of-ai', label: 'Hour of AI', href: '/hour-of-ai'},
+  // TODO - Put back later https://codedotorg.atlassian.net/browse/CMS-998
+  // {key: 'hour-of-ai', label: 'Hour of AI', href: '/hour-of-ai'},
   {
     key: 'donate',
     label: 'Donate',

--- a/frontend/apps/marketing/src/components/header/csForAll/config.ts
+++ b/frontend/apps/marketing/src/components/header/csForAll/config.ts
@@ -30,11 +30,10 @@ const SHARED_LINKS = {
     href: '/',
     label: 'Home',
   },
-  // TODO - Put back later https://codedotorg.atlassian.net/browse/CMS-998
-  // HOUR_OF_AI: {
-  //   href: '/hour-of-ai',
-  //   label: 'Hour of AI',
-  // },
+  HOUR_OF_AI: {
+    href: '/hour-of-ai',
+    label: 'Hour of AI',
+  },
   ISSUES: {
     href: '/issues',
     label: 'Issues',

--- a/frontend/apps/marketing/src/components/header/csForAll/config.ts
+++ b/frontend/apps/marketing/src/components/header/csForAll/config.ts
@@ -30,10 +30,11 @@ const SHARED_LINKS = {
     href: '/',
     label: 'Home',
   },
-  HOUR_OF_AI: {
-    href: '/hour-of-ai',
-    label: 'Hour of AI',
-  },
+  // TODO - Put back later https://codedotorg.atlassian.net/browse/CMS-998
+  // HOUR_OF_AI: {
+  //   href: '/hour-of-ai',
+  //   label: 'Hour of AI',
+  // },
   ISSUES: {
     href: '/issues',
     label: 'Issues',
@@ -96,7 +97,8 @@ export const TOP_LEVEL_LINKS: {linkList: LinkItemProps[]} = {
   linkList: [
     createLinkItem(SHARED_LINKS.ISSUES, {typography: 'h4'}),
     createLinkItem(SHARED_LINKS.TAKE_ACTION, {typography: 'h4'}),
-    createLinkItem(SHARED_LINKS.HOUR_OF_AI, {typography: 'h4'}),
+    // TODO - Put back later https://codedotorg.atlassian.net/browse/CMS-998
+    // createLinkItem(SHARED_LINKS.HOUR_OF_AI, {typography: 'h4'}),
     createLinkItem(SHARED_LINKS.DONATE, {typography: 'h4'}),
     createLinkItem(SHARED_LINKS.NEWS_AND_RESOURCES, {typography: 'h4'}),
   ],
@@ -128,7 +130,7 @@ export const NEWS_AND_RESOURCES_LINKS: {linkList: LinkItemProps[]} = {
 };
 
 // Main Menu Desktop Configuration
-const [issuesLink, takeActionLink, hourOfAiLink, donateLink, newsLink] =
+const [issuesLink, takeActionLink, donateLink, newsLink] =
   TOP_LEVEL_LINKS.linkList;
 
 export const MAIN_MENU_DESKTOP_ITEMS = [
@@ -142,10 +144,11 @@ export const MAIN_MENU_DESKTOP_ITEMS = [
     topLevelLink: takeActionLink,
     dropdownConfig: TAKE_ACTION_LINKS,
   },
-  {
-    type: 'button' as const,
-    topLevelLink: hourOfAiLink,
-  },
+  // TODO - Put back later https://codedotorg.atlassian.net/browse/CMS-998
+  // {
+  //   type: 'button' as const,
+  //   topLevelLink: hourOfAiLink,
+  // },
   {
     type: 'button' as const,
     topLevelLink: donateLink,


### PR DESCRIPTION
Hides the Hour of AI link in the Header and Footer on CSforAll. 

## Links
Jira ticket: [CMS-995](https://codedotorg.atlassian.net/browse/CMS-995)

## Followup
Put this back before launch: [CMS-998](https://codedotorg.atlassian.net/browse/CMS-998)

----


https://github.com/user-attachments/assets/9452f5f8-0657-4ed9-b88d-e97de827774d

