### PR TITLE
update course_content/sync_in to use course version

### DIFF
--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -374,9 +374,19 @@ module I18n
               end
               script_strings.delete_if {|_, value| value.blank?}
 
-              name = "#{unit.name}.json"
-              i18n_source_file_path = File.join(I18N_SOURCE_DIR_PATH, get_unit_subdirectory(unit), name)
-              next if I18nScriptUtils.unit_directory_change?(I18N_SOURCE_DIR_PATH, i18n_source_file_path)
+              # We want to make sure to categorize HoC scripts as HoC scripts even if
+              # they have a version year, so this ordering is important
+              script_i18n_directory =
+                if script.in_initiative?('HOC')
+                  File.join(I18N_SOURCE_DIR_PATH, 'Hour of Code')
+                elsif script.get_course_version.blank? || script.get_course_version.key == CourseVersion::UNVERSIONED
+                  File.join(I18N_SOURCE_DIR_PATH, 'other')
+                else
+                  File.join(I18N_SOURCE_DIR_PATH, script.get_course_version.key)
+                end
+
+              source_file_path = File.join(script_i18n_directory, "#{script.name}.json")
+              next if I18nScriptUtils.unit_directory_change?(I18N_SOURCE_DIR_PATH, source_file_path)
 
               I18nScriptUtils.write_json_file(source_file_path, script_strings)
               redact_json_file(source_file_path)
@@ -452,26 +462,6 @@ module I18n
 
             redacted_data = RedactRestoreUtils.redact_data(redactable_data, REDACT_PLUGINS)
             I18nScriptUtils.write_json_file(source_path, source_data.deep_merge(redacted_data))
-          end
-
-          # Helper method to get the desired destination subdirectory of the given
-          # unit for the sync in. Note this may be a nested directory like "2021/csf"
-          # We want to make sure to categorize HoC scripts as HoC scripts even if
-          # they have a version year, so this ordering is important
-          private def get_unit_subdirectory(unit)
-            # special-case Hour of Code units.
-            return 'Hour of Code' if unit.in_initiative?('HOC')
-
-            # catchall for units without courses
-            return 'other' if unit.get_course_version.blank?
-
-            # special-case CSF and CSC; we want to group all CSF courses together and all CSC courses together,
-            # even though they all have different course offerings.
-            return File.join(unit.get_course_version.key, 'csf') if unit.csf?
-            return File.join(unit.get_course_version.key, 'csc') if unit.csc?
-
-            # base case
-            File.join(unit.get_course_version.key, unit.get_course_version.course_offering.key)
           end
         end
       end

--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -374,19 +374,9 @@ module I18n
               end
               script_strings.delete_if {|_, value| value.blank?}
 
-              # We want to make sure to categorize HoC scripts as HoC scripts even if
-              # they have a version year, so this ordering is important
-              script_i18n_directory =
-                if script.in_initiative?('HOC')
-                  File.join(I18N_SOURCE_DIR_PATH, 'Hour of Code')
-                elsif script.unversioned?
-                  File.join(I18N_SOURCE_DIR_PATH, 'other')
-                else
-                  File.join(I18N_SOURCE_DIR_PATH, script.version_year)
-                end
-
-              source_file_path = File.join(script_i18n_directory, "#{script.name}.json")
-              next if I18nScriptUtils.unit_directory_change?(I18N_SOURCE_DIR_PATH, source_file_path)
+              name = "#{unit.name}.json"
+              i18n_source_file_path = File.join(I18N_SOURCE_DIR_PATH, get_unit_subdirectory(unit), name)
+              next if I18nScriptUtils.unit_directory_change?(I18N_SOURCE_DIR_PATH, i18n_source_file_path)
 
               I18nScriptUtils.write_json_file(source_file_path, script_strings)
               redact_json_file(source_file_path)
@@ -462,6 +452,26 @@ module I18n
 
             redacted_data = RedactRestoreUtils.redact_data(redactable_data, REDACT_PLUGINS)
             I18nScriptUtils.write_json_file(source_path, source_data.deep_merge(redacted_data))
+          end
+
+          # Helper method to get the desired destination subdirectory of the given
+          # unit for the sync in. Note this may be a nested directory like "2021/csf"
+          # We want to make sure to categorize HoC scripts as HoC scripts even if
+          # they have a version year, so this ordering is important
+          private def get_unit_subdirectory(unit)
+            # special-case Hour of Code units.
+            return 'Hour of Code' if unit.in_initiative?('HOC')
+
+            # catchall for units without courses
+            return 'other' if unit.get_course_version.blank?
+
+            # special-case CSF and CSC; we want to group all CSF courses together and all CSC courses together,
+            # even though they all have different course offerings.
+            return File.join(unit.get_course_version.key, 'csf') if unit.csf?
+            return File.join(unit.get_course_version.key, 'csc') if unit.csc?
+
+            # base case
+            File.join(unit.get_course_version.key, unit.get_course_version.course_offering.key)
           end
         end
       end

--- a/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
@@ -87,6 +87,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     }
 
     script = Unit.new(name: 'unversioned-script')
+    course_version = FactoryBot.build_stubbed(:course_version, key: 'unversioned')
     script_level = ScriptLevel.new(progression: expected_string_level_progression)
     level = Level.new(encrypted: false)
 
@@ -98,7 +99,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     I18nScriptUtils.expects(:get_level_url_key).with(script, level).in_sequence(exec_seq).returns('expected_level_url')
     sync_in_instance.expects(:get_i18n_strings).with(level).in_sequence(exec_seq).returns(expected_level_i18n_strings)
     script.expects(:in_initiative?).with('HOC').in_sequence(exec_seq).returns(false)
-    script.expects(:unversioned?).in_sequence(exec_seq).returns(true)
+    script.expects(:get_course_version).at_least_once.in_sequence(exec_seq).returns(course_version)
     I18nScriptUtils.expects(:unit_directory_change?).with(expected_i18n_source_dir_path, expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
     I18nScriptUtils.expects(:write_json_file).with(expected_i18n_source_file_path, {'expected_level_url' => {'expected_script_string_key' => 'expected_script_string_value'}}).in_sequence(exec_seq)
     sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).in_sequence(exec_seq)
@@ -117,7 +118,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     exec_seq = sequence('execution')
 
     expected_i18n_source_dir_path = CDO.dir('i18n/locales/source/course_content')
-    expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'expected_version_year/versioned-script.json')
+    expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'expected-version-year/versioned-script.json')
     expected_string_level_progression = 'expected_progression_string'
     expected_block_categories = {'expected_block_category_key' => 'expected_block_category_value'}
     expected_variable_names = {'expected_variable_name_key' => 'expected_variable_name_value'}
@@ -129,7 +130,8 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
       'parameter_names'            => expected_parameter_names,
     }
 
-    script = Unit.new(name: 'versioned-script', version_year: 'expected_version_year')
+    script = Unit.new(name: 'versioned-script')
+    course_version = FactoryBot.build_stubbed(:course_version, key: 'expected-version-year')
     script_level = ScriptLevel.new(progression: expected_string_level_progression)
     level = Level.new(encrypted: false)
 
@@ -141,7 +143,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     I18nScriptUtils.expects(:get_level_url_key).with(script, level).in_sequence(exec_seq).returns('expected_level_url')
     sync_in_instance.expects(:get_i18n_strings).with(level).in_sequence(exec_seq).returns(expected_level_i18n_strings)
     script.expects(:in_initiative?).with('HOC').in_sequence(exec_seq).returns(false)
-    script.expects(:unversioned?).in_sequence(exec_seq).returns(false)
+    script.expects(:get_course_version).at_least_once.in_sequence(exec_seq).returns(course_version)
     I18nScriptUtils.expects(:unit_directory_change?).with(expected_i18n_source_dir_path, expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
     I18nScriptUtils.expects(:write_json_file).with(expected_i18n_source_file_path, {'expected_level_url' => {'expected_script_string_key' => 'expected_script_string_value'}}).in_sequence(exec_seq)
     sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).in_sequence(exec_seq)
@@ -155,12 +157,12 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     assert_equal expected_parameter_names, sync_in_instance.send(:parameter_strings)
   end
 
-  def test_level_content_preparation_of_script_with_changed_derectory
+  def test_level_content_preparation_of_script_with_changed_directory
     sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
     exec_seq = sequence('execution')
 
     expected_i18n_source_dir_path = CDO.dir('i18n/locales/source/course_content')
-    expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'expected_version_year/versioned-script.json')
+    expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'expected-version-year/versioned-script.json')
     expected_string_level_progression = 'expected_progression_string'
     expected_block_categories = {'expected_block_category_key' => 'expected_block_category_value'}
     expected_variable_names = {'expected_variable_name_key' => 'expected_variable_name_value'}
@@ -172,7 +174,8 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
       'parameter_names'            => expected_parameter_names,
     }
 
-    script = Unit.new(name: 'versioned-script', version_year: 'expected_version_year')
+    script = Unit.new(name: 'versioned-script')
+    course_version = FactoryBot.build_stubbed(:course_version, key: 'expected-version-year')
     script_level = ScriptLevel.new(progression: expected_string_level_progression)
     level = Level.new(encrypted: false)
 
@@ -184,7 +187,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     I18nScriptUtils.expects(:get_level_url_key).with(script, level).in_sequence(exec_seq).returns('expected_level_url')
     sync_in_instance.expects(:get_i18n_strings).with(level).in_sequence(exec_seq).returns(expected_level_i18n_strings)
     script.expects(:in_initiative?).with('HOC').in_sequence(exec_seq).returns(false)
-    script.expects(:unversioned?).in_sequence(exec_seq).returns(false)
+    script.expects(:get_course_version).at_least_once.in_sequence(exec_seq).returns(course_version)
     I18nScriptUtils.expects(:unit_directory_change?).with(expected_i18n_source_dir_path, expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
     I18nScriptUtils.expects(:write_json_file).with(expected_i18n_source_file_path, {'expected_level_url' => {'expected_script_string_key' => 'expected_script_string_value'}}).never
     sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).never


### PR DESCRIPTION
After the standalone unit migration earlier this year, the i18n sync is flooded with `[Destination directory for unit is attempting to change]` messages ([slack](https://codedotorg.slack.com/archives/C99KAHFK9/p1754926587386239)). This PR updates `course_content/sync_in.rb` to resolve most of those messages.

### Background
In [course_content/sync_in.rb](https://github.com/code-dot-org/code-dot-org/blob/5a14b3987b8de041c3773fcb2ab7acb05b80470d/bin/i18n/resources/dashboard/course_content/sync_in.rb#L379-L389), if a unit is `unversioned?`, it sets the directory to /other. Since all units are now in unit groups, all units will be `unversioned?`. But, I see in [curriculum_content/sync_in.rb](https://github.com/code-dot-org/code-dot-org/blob/584c88659a9a51fafc0a2cef3043db64f2a6af9a/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb#L77-L90), we use `get_course_version` , which would return the correct version year for a unit in a unit group.



## Testing story
Ran a test sync in locally to verify most of the messages are gone. 

