### PR TITLE
fix(marketing): fixes CSforAll Header dropdown link width and gap

### DIFF
--- a/frontend/apps/marketing/src/components/header/csForAll/DropdownMenu.tsx
+++ b/frontend/apps/marketing/src/components/header/csForAll/DropdownMenu.tsx
@@ -5,6 +5,8 @@ import Box from '@mui/material/Box';
 import Menu from '@mui/material/Menu';
 import {useState} from 'react';
 
+import {isExternalLink} from '@/components/common/utils';
+import {Brand} from '@/config/brand';
 import theme from '@/themes/csforall';
 
 import {buttonStyles} from './common/styles';
@@ -17,6 +19,8 @@ export interface MenuListProps {
   buttonLabel: string;
   /** The list of links to display in the menu */
   linkList?: LinkItemProps[];
+  /** Brand for the links, used with external links */
+  brand?: Brand;
 }
 
 const styles = {
@@ -31,12 +35,14 @@ const styles = {
       paddingTop: 0,
       paddingBottom: theme.spacing(1),
       minWidth: '200px',
+      gap: theme.spacing(0),
     },
   },
   menuItem: {
     marginBlock: theme.spacing(0.5),
     fontSize: theme.typography.body3.fontSize,
     transition: 'all 0.2s ease',
+    width: '100%',
     '&:hover, &:focus': {
       backgroundColor: alpha(theme.palette.primary.main, 0.1),
       borderRadius: theme.shape.borderRadius,
@@ -56,7 +62,12 @@ const styles = {
   },
 };
 
-const DropdownMenu: React.FC<MenuListProps> = ({id, buttonLabel, linkList}) => {
+const DropdownMenu: React.FC<MenuListProps> = ({
+  id,
+  buttonLabel,
+  linkList,
+  brand = Brand.CS_FOR_ALL,
+}) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
@@ -113,6 +124,16 @@ const DropdownMenu: React.FC<MenuListProps> = ({id, buttonLabel, linkList}) => {
             href={href}
             disableRipple
             sx={styles.menuItem}
+            target={
+              href && isExternalLink(href, brand, 'production')
+                ? '_blank'
+                : undefined
+            }
+            rel={
+              href && isExternalLink(href, brand, 'production')
+                ? 'noopener noreferrer'
+                : undefined
+            }
           >
             {label}
           </MenuItem>

--- a/frontend/apps/marketing/src/components/header/csForAll/__tests__/DropdownMenu.test.tsx
+++ b/frontend/apps/marketing/src/components/header/csForAll/__tests__/DropdownMenu.test.tsx
@@ -6,6 +6,7 @@ const linkList = [
   {label: 'Home', href: '/home'},
   {label: 'About', href: '/about'},
   {label: 'Contact', href: '/contact'},
+  {label: 'External', href: 'https://example.com', external: true},
 ];
 
 const defaultProps: MenuListProps = {
@@ -43,6 +44,15 @@ describe('DropdownMenu', () => {
     linkList.forEach(link => {
       expect(screen.getByText(link.label)).toBeInTheDocument();
     });
+  });
+
+  it('renders external link with correct target and rel', () => {
+    render(<DropdownMenu {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', {name: /menu/i}));
+    const externalLink = screen.getByRole('menuitem', {name: /external/i});
+    expect(externalLink).toHaveAttribute('href', 'https://example.com');
+    expect(externalLink).toHaveAttribute('target', '_blank');
+    expect(externalLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('does not render menu items if linkList is empty', () => {

--- a/frontend/apps/marketing/src/components/header/csForAll/config.ts
+++ b/frontend/apps/marketing/src/components/header/csForAll/config.ts
@@ -67,7 +67,7 @@ const SHARED_LINKS = {
     label: 'Unlock8',
   },
   UNLOCK8_PETITION: {
-    href: '/open-letter-unlock-8',
+    href: '/unlock8/open-letter',
     label: 'Unlock8 Petition',
   },
 } as const;

--- a/frontend/apps/marketing/src/components/header/csForAll/config.ts
+++ b/frontend/apps/marketing/src/components/header/csForAll/config.ts
@@ -121,10 +121,7 @@ export const TAKE_ACTION_LINKS: {linkList: LinkItemProps[]} = {
 
 // Main Menu News & Resources Dropdown Links
 export const NEWS_AND_RESOURCES_LINKS: {linkList: LinkItemProps[]} = {
-  linkList: [
-    createLinkItem(SHARED_LINKS.ABOUT),
-    createLinkItem(SHARED_LINKS.NEWS),
-  ],
+  linkList: [createLinkItem(SHARED_LINKS.NEWS)],
 };
 
 // Main Menu Desktop Configuration


### PR DESCRIPTION
Fixes issues with the width and spacing on dropdown menu link lists on the CSforAll Header. Also adds external link support, updates the Unlock8 Petition slug, and removes the About link from the News & Resources dropdown for launch.

## Links
Jira ticket: [CMS-997](https://codedotorg.atlassian.net/browse/CMS-997)

## Testing story
Tested locally and added unit test for external link logic

## Followup
We will add UI and Eyes tests for the Header: [CMS-991](https://codedotorg.atlassian.net/browse/CMS-991)

-----


https://github.com/user-attachments/assets/7ee4f9c8-8dde-460c-98b1-5275c67667a9

