### PR TITLE
Fast follow- updating non unique ids to classes

### DIFF
--- a/apps/src/music/views/Keybed.tsx
+++ b/apps/src/music/views/Keybed.tsx
@@ -6,7 +6,7 @@ import {getNoteName, isBlackKey} from '../utils/Notes';
 
 import moduleStyles from './keybed.module.scss';
 
-const keyId = 'keyId';
+const keyClass = 'keyClass';
 
 interface KeybedProps {
   numOctaves: number;
@@ -98,7 +98,7 @@ const Key: React.FunctionComponent<KeyProps> = ({
 }: KeyProps) => {
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const keyElements = Array.from(
-      document.querySelectorAll<HTMLElement>(`#${keyId}`)
+      document.querySelectorAll<HTMLElement>(`.${keyClass}`)
     );
     const currentIndex = keyElements.indexOf(event.currentTarget);
     if (event.key === 'ArrowRight') {
@@ -132,8 +132,8 @@ const Key: React.FunctionComponent<KeyProps> = ({
 
   return (
     <div
-      id={keyId}
       className={classNames(
+        keyClass,
         moduleStyles.key,
         isDisabled && moduleStyles.disabled,
         isSelected && moduleStyles.selected,

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -22,7 +22,7 @@ import {
 } from '../redux/musicRedux';
 
 import usePlaybackUpdate from './hooks/usePlaybackUpdate';
-import {TimelineElementId} from './TimelineElement';
+import {TimelineElementClass} from './TimelineElement';
 import TimelineSampleEvents from './TimelineSampleEvents';
 import TimelineSimple2Events from './TimelineSimple2Events';
 import {useMusicSelector} from './types';
@@ -114,7 +114,7 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
   }, []);
 
   const timelineElements = Array.from(
-    document.querySelectorAll<HTMLElement>(`#${TimelineElementId}`)
+    document.querySelectorAll<HTMLElement>(`.${TimelineElementClass}`)
   );
 
   const onKeyDown = useCallback(

--- a/apps/src/music/views/TimelineElement.tsx
+++ b/apps/src/music/views/TimelineElement.tsx
@@ -13,7 +13,7 @@ import SoundStyle from '../utils/SoundStyle';
 
 import moduleStyles from './timeline.module.scss';
 
-export const TimelineElementId = 'timeline-element';
+export const TimelineElementClass = 'timeline-element';
 
 interface TimelineElementProps {
   eventData: PlaybackEvent;
@@ -68,12 +68,12 @@ const TimelineElement: React.FunctionComponent<TimelineElementProps> = ({
 
   return (
     <button
-      id={TimelineElementId}
       tabIndex={-1}
       type="button"
       onKeyDown={onKeyDown}
       aria-label={friendlyLabel}
       className={classNames(
+        TimelineElementClass,
         moduleStyles.timelineElement,
         SoundStyle[soundType]?.classNameBackground,
         SoundStyle[soundType]?.classNameBorder,

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -20,7 +20,7 @@ Scenario Outline: Dragging play sound block
   And I wait until element "[data-id='when-run-block']" is visible
 
   # There should be no music timeline entry yet.
-  And element "#timeline-element" is not visible
+  And element ".timeline-element" is not visible
 
   # Open the first category.
   And I press the first ".blocklyTreeRow" element
@@ -29,7 +29,7 @@ Scenario Outline: Dragging play sound block
   Then I drag block "play_sound_at_current_location_simple2" to block "when-run-block"
 
   # There should now be a music timeline entry.
-  And element "#timeline-element" is visible
+  And element ".timeline-element" is visible
 
   # Click the field inside the attached "play sound" block.
   And I click block field "[data-id='when-run-block'] > [data-id='play_sound_at_current_location_simple2'] > .blocklyEditableField"
@@ -47,7 +47,7 @@ Scenario Outline: Dragging play sound block
   And I wait until element "#sounds-panel" is not visible
 
   # There should still be a music timeline entry.
-  And element "#timeline-element" is visible
+  And element ".timeline-element" is visible
 
 Examples:
   | url                                                       | test_name               |


### PR DESCRIPTION
This is a fast follow to [making the keybed navigable](https://github.com/code-dot-org/code-dot-org/pull/67391). The keynav queries the elements by id, but the ids were not unique. I've moved those to classes in both the timelineElement case and the keybed case, so that we are not violating that rule. 

Thanks for catching this @sanchitmalhotra126 !

I tested both were still navigable here:


https://github.com/user-attachments/assets/cd0f648f-0d69-4f59-91ed-d43b20380612




## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1341

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
