### PR TITLE
fix(redirect): do not redirect in supported locales

### DIFF
--- a/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
@@ -229,4 +229,29 @@ describe('withLocale middleware', () => {
       expect.anything(),
     );
   });
+
+  it('should not infinitely redirect for non-corporate brands when locale is unsupported', async () => {
+    // Simulate CSForAll brand by setting a non-code.org host
+    const request = {
+      url: 'https://csforall.org/en-US/home',
+      nextUrl: {
+        pathname: '/en-US/home',
+        url: 'https://csforall.org/en-US/home',
+      },
+      cookies: {get: jest.fn(() => ({value: 'unsupported-locale'}))},
+      headers: {get: jest.fn().mockReturnValue('csforall.org')},
+    } as unknown as NextRequest;
+
+    (getContentfulSlug as jest.Mock).mockReturnValue('home');
+
+    const response = await withLocale(next)(request, mockEvent);
+
+    expect(response?.headers).toBeUndefined();
+    // Should not set language_ cookie for non-code.org brands
+    expect(cookieMock.set).not.toHaveBeenCalledWith(
+      'language_',
+      expect.anything(),
+      expect.anything(),
+    );
+  });
 });

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -60,30 +60,30 @@ export const withLocale: MiddlewareFactory = next => {
     // It is an empty string here because when a call is made to Contentful, `/` is automatically prepended
     const isRootRoute = pathParts.length === 0;
 
-    if (brand === Brand.CODE_DOT_ORG) {
-      if (SUPPORTED_LOCALES_SET.has(maybeLocale)) {
-        // If the first part of the path is a supported locale or there are no subpaths, we don't need to redirect
-        const response = await next(request, event);
+    if (SUPPORTED_LOCALES_SET.has(maybeLocale)) {
+      // If the first part of the path is a supported locale or there are no subpaths, we don't need to redirect
+      const response = await next(request, event);
 
+      if (brand === Brand.CODE_DOT_ORG) {
         response.cookies.set('language_', getDashboardLocale(maybeLocale), {
           path: '/',
           domain: stage === 'production' ? '.code.org' : undefined,
         });
-
-        return response;
       }
 
-      if (isRootRoute) {
-        // If the _user_type cookie is set, then Dashboard successfully logged in the user which is an early indicator
-        // that the user is logged in right now. Therefore, send the user to Code Studio
-        // See: https://github.com/code-dot-org/code-dot-org/blob/3fad8bce055846378ae3da343da93a32acd4df8c/dashboard/config/initializers/devise.rb#L331
-        const userTypeCookie = request.cookies.get(
-          getCookieNameByStage('_user_type', stage),
-        );
+      return response;
+    }
 
-        if (userTypeCookie?.value) {
-          return getCachedRedirectResponse(getStudioBaseUrl());
-        }
+    if (brand === Brand.CODE_DOT_ORG && isRootRoute) {
+      // If the _user_type cookie is set, then Dashboard successfully logged in the user which is an early indicator
+      // that the user is logged in right now. Therefore, send the user to Code Studio
+      // See: https://github.com/code-dot-org/code-dot-org/blob/3fad8bce055846378ae3da343da93a32acd4df8c/dashboard/config/initializers/devise.rb#L331
+      const userTypeCookie = request.cookies.get(
+        getCookieNameByStage('_user_type', stage),
+      );
+
+      if (userTypeCookie?.value) {
+        return getCachedRedirectResponse(getStudioBaseUrl());
       }
     }
 


### PR DESCRIPTION
Fixes an infinite redirect loop where the site does not stop redirecting because the supported locale code early return was wrapped in the code.org specific brand check.