### PR TITLE
Fix bug with LockedLessonUtils

### DIFF
--- a/apps/src/templates/sectionProgressV2/LockedLessonUtils.jsx
+++ b/apps/src/templates/sectionProgressV2/LockedLessonUtils.jsx
@@ -2,18 +2,41 @@ export const getLockedStatusPerStudent = (
   levelProgressByStudent,
   sortedStudents,
   lesson
-) =>
-  Object.fromEntries(
-    sortedStudents.map(student => [
-      student.id,
-      lesson.lockable &&
-        lesson.levels.every(
-          level =>
-            levelProgressByStudent[student.id] &&
-            levelProgressByStudent[student.id][level.id]?.locked
-        ),
-    ])
+) => {
+  if (!sortedStudents || sortedStudents.length === 0) {
+    return {};
+  }
+
+  if (
+    !lesson ||
+    !lesson.lockable ||
+    !lesson.levels ||
+    !levelProgressByStudent
+  ) {
+    return Object.fromEntries(
+      sortedStudents.map(student => [student.id, false])
+    );
+  }
+
+  return Object.fromEntries(
+    sortedStudents
+      .map(student => {
+        if (!student || student.id === undefined) {
+          return null;
+        }
+        return [
+          student.id,
+          lesson.lockable &&
+            lesson.levels.every(
+              level =>
+                levelProgressByStudent[student.id] &&
+                levelProgressByStudent[student.id][level.id]?.locked
+            ),
+        ];
+      })
+      .filter(entry => entry !== null)
   );
+};
 
 export const areAllLevelsLocked = lockedStatusPerStudent => {
   return Object.values(lockedStatusPerStudent).every(status => status);

--- a/apps/test/unit/templates/sectionProgressV2/LockedLessonUtilsTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LockedLessonUtilsTest.jsx
@@ -111,6 +111,77 @@ describe('LockedLessonUtils', () => {
       );
       expect(result).toEqual({1: false});
     });
+
+    it('is false when levelProgressByStudent is undefined', () => {
+      const lesson = {lockable: true, levels: [{id: 1}]};
+      const result = getLockedStatusPerStudent(undefined, [STUDENT_1], lesson);
+      expect(result).toEqual({1: false});
+    });
+
+    it('doesnt exist when student has no id', () => {
+      const lesson = {lockable: true, levels: [{id: 1}]};
+      const studentNoId = {name: 'Student No ID'};
+      const levelProgressByStudent = {
+        1: {1: {locked: true}},
+      };
+      const result = getLockedStatusPerStudent(
+        levelProgressByStudent,
+        [studentNoId],
+        lesson
+      );
+      expect(result).toEqual({});
+    });
+
+    it('is false when student is undefined', () => {
+      const lesson = {lockable: true, levels: [{id: 1}]};
+      const levelProgressByStudent = {
+        1: {1: {locked: true}},
+      };
+      const result = getLockedStatusPerStudent(
+        levelProgressByStudent,
+        [undefined],
+        lesson
+      );
+      expect(result).toEqual({});
+    });
+
+    it('is false when lesson has no lockable property', () => {
+      const lesson = {levels: [{id: 1}]};
+      const levelProgressByStudent = {
+        1: {1: {locked: true}},
+      };
+      const result = getLockedStatusPerStudent(
+        levelProgressByStudent,
+        [STUDENT_1],
+        lesson
+      );
+      expect(result).toEqual({1: false});
+    });
+
+    it('is false when lesson has no levels property', () => {
+      const lesson = {lockable: true};
+      const levelProgressByStudent = {
+        1: {1: {locked: true}},
+      };
+      const result = getLockedStatusPerStudent(
+        levelProgressByStudent,
+        [STUDENT_1],
+        lesson
+      );
+      expect(result).toEqual({1: false});
+    });
+
+    it('is false when lesson is undefined', () => {
+      const levelProgressByStudent = {
+        1: {1: {locked: true}},
+      };
+      const result = getLockedStatusPerStudent(
+        levelProgressByStudent,
+        [STUDENT_1],
+        undefined
+      );
+      expect(result).toEqual({1: false});
+    });
   });
 
   describe('areAllLevelsLocks', () => {


### PR DESCRIPTION
Original slack thread: https://codedotorg.slack.com/archives/C045UAX4WKH/p1755030126276399

We occasionally were seeing an error with the LockedLessonUtils function about a dereferenced undefined.

This PR adds checks for all arguments in the function and tests to make sure it accurately handles null or undefined arguments that get passed in.
<img width="560" height="720" alt="image" src="https://github.com/user-attachments/assets/3815b8b3-d8e0-42d3-abef-753839fe1a57" />
<img width="720" height="481" alt="image" src="https://github.com/user-attachments/assets/f51aa823-952a-4117-a9ca-c0355a52e0e3" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/TEACH-2132

## Testing story
Relying on unit tests
