### PR TITLE
fix(yourschool): add suspense layer

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/AdoptionMap.tsx
+++ b/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/AdoptionMap.tsx
@@ -44,7 +44,7 @@ const DEFAULT_LAT = 39;
 const DEFAULT_ZOOM = 3;
 const MAP_POINT_ZOOM = 14;
 
-interface AdoptionMapMapProps {
+export interface AdoptionMapMapProps {
   school?: School | null;
   onTakeSurveyClick?: (school: School) => void;
 }
@@ -54,7 +54,9 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
   onTakeSurveyClick,
 }) => {
   const mapRef = useRef<MapRef>(null);
-  const tilesetUrlParam = useSearchParams()?.get('tileset');
+  const searchParams = useSearchParams();
+
+  const tilesetUrlParam = searchParams?.get('tileset');
   const mapTileset = tilesetUrlParam ?? MAP_TILESET_ID;
 
   const [mapLoaded, setMapLoaded] = useState(false);

--- a/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/AdoptionMap.tsx
+++ b/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/AdoptionMap.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import {useSearchParams} from 'next/navigation';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import Map, {
   FullscreenControl,
@@ -30,7 +31,7 @@ import './adoptionMap.scss';
 import styles from './adoptionMap.module.scss';
 
 // This constant is updated each year to the new census year tileset after its data is
-// confirmed using the update_census_mapbox script.
+// confirmed using the update_census_mapbox script and `tileset` URL parameter.
 const MAP_TILESET_ID = 'censustiles';
 
 const MAP_POINT_LAYER_ID = 'census';
@@ -53,6 +54,8 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
   onTakeSurveyClick,
 }) => {
   const mapRef = useRef<MapRef>(null);
+  const tilesetUrlParam = useSearchParams()?.get('tileset');
+  const mapTileset = tilesetUrlParam ?? MAP_TILESET_ID;
 
   const [mapLoaded, setMapLoaded] = useState(false);
   const [popupData, setPopupData] = useState<{
@@ -97,7 +100,7 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
       mapInstance.once('moveend', () => {
         let newPopupData;
 
-        const schoolPoint = mapInstance.querySourceFeatures(MAP_TILESET_ID, {
+        const schoolPoint = mapInstance.querySourceFeatures(mapTileset, {
           sourceLayer: MAP_POINT_LAYER_ID,
           filter: ['all', ['==', 'school_id', school.nces_id]],
         })[0];
@@ -217,13 +220,13 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
         <NavigationControl position="bottom-right" showCompass={false} />
 
         <Source
-          id={MAP_TILESET_ID}
+          id={mapTileset}
           type="vector"
-          url={`mapbox://codeorg.${MAP_TILESET_ID}`}
+          url={`mapbox://codeorg.${mapTileset}`}
         >
           <Layer
             id={NO_CS_SCHOOLS_LAYER_ID}
-            source={MAP_TILESET_ID}
+            source={mapTileset}
             source-layer={MAP_POINT_LAYER_ID}
             layout={{visibility: 'visible'}}
             type="circle"
@@ -250,7 +253,7 @@ const AdoptionMap: React.FC<AdoptionMapMapProps> = ({
           />
           <Layer
             id={CS_SCHOOLS_LAYER_ID}
-            source={MAP_TILESET_ID}
+            source={mapTileset}
             source-layer={MAP_POINT_LAYER_ID}
             layout={{visibility: 'visible'}}
             type="circle"

--- a/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/index.ts
+++ b/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/index.ts
@@ -1,3 +1,0 @@
-// Export the Component Definition for use in Contentful Studio
-export {AdoptionMapContentfulComponentDefinition} from './AdoptionMapContentfulDefinition';
-export {default} from './AdoptionMap';

--- a/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/index.tsx
+++ b/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/index.tsx
@@ -1,0 +1,15 @@
+// Export the Component Definition for use in Contentful Studio
+import {Suspense} from 'react';
+
+export {AdoptionMapContentfulComponentDefinition} from './AdoptionMapContentfulDefinition';
+import AdoptionMap from './AdoptionMap';
+
+const AdoptionMapSuspense = () => {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <AdoptionMap />
+    </Suspense>
+  );
+};
+
+export default AdoptionMapSuspense;

--- a/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/index.tsx
+++ b/frontend/apps/marketing/src/components/contentful/corporateSite/adoptionMap/index.tsx
@@ -2,12 +2,12 @@
 import {Suspense} from 'react';
 
 export {AdoptionMapContentfulComponentDefinition} from './AdoptionMapContentfulDefinition';
-import AdoptionMap from './AdoptionMap';
+import AdoptionMap, {AdoptionMapMapProps} from './AdoptionMap';
 
-const AdoptionMapSuspense = () => {
+const AdoptionMapSuspense = (props: AdoptionMapMapProps) => {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <AdoptionMap />
+    <Suspense fallback={<div aria-live="polite">Loading adoption map...</div>}>
+      <AdoptionMap {...props} />
     </Suspense>
   );
 };

--- a/frontend/apps/marketing/tests/e2e/your-school.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/your-school.spec.ts
@@ -1,0 +1,22 @@
+import {expect} from '@playwright/test';
+
+import {test} from './fixtures/base';
+import {MarketingPage} from './pom/marketing';
+import {getSiteType} from './utils/getSiteType';
+
+test.describe('Adoption Map', () => {
+  test(
+    'should be able to render the adoption map',
+    {tag: '@corporate'},
+    async ({page}) => {
+      test.skip(getSiteType() !== 'corporate', 'Only runs on corporate site');
+
+      const marketingPage = new MarketingPage(page);
+      await marketingPage.goto('/your-school');
+
+      const adoptionMap = page.getByRole('region', {name: 'Map'});
+
+      await expect(adoptionMap).toBeVisible();
+    },
+  );
+});

--- a/frontend/apps/marketing/tests/e2e/your-school.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/your-school.spec.ts
@@ -14,7 +14,7 @@ test.describe('Adoption Map', () => {
       const marketingPage = new MarketingPage(page);
       await marketingPage.goto('/your-school');
 
-      const adoptionMap = page.getByRole('region', {name: 'Map'});
+      const adoptionMap = page.getByRole('region', {name: 'Map', exact: true});
 
       await expect(adoptionMap).toBeVisible();
     },


### PR DESCRIPTION
The Your School map used `useSearchParams` which caused a production outage on the your school page. In production mode, this [error](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout) was thrown but not in dev. 

To address this, a react Suspense has been added to transition from SSR to CSR. Additionally, a lightweight UI test to ensure that the canvas is present has been added. Any further adoption map UI tests can be done later as part of Storybook.