### PR TITLE
Hide donate in CSforALL header

### DIFF
--- a/frontend/apps/marketing/src/components/footerMui/config.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/config.tsx
@@ -9,11 +9,8 @@ export const SITE_LINKS = [
   {key: 'issues', label: 'Issues', href: '/issues'},
   {key: 'take-action', label: 'Take Action', href: '/take-action'},
   {key: 'hour-of-ai', label: 'Hour of AI', href: '/hour-of-ai'},
-  {
-    key: 'donate',
-    label: 'Donate',
-    href: 'https://donate.code.org/campaign/708610/donate',
-  },
+  // Marketing does not have permission to collect donations yet
+  //{ key: 'donate', label: 'Donate', href: 'https://donate.code.org/campaign/708610/donate',},
   {
     key: 'news-and-resources',
     label: 'News & Resources',

--- a/frontend/apps/marketing/src/components/header/csForAll/config.ts
+++ b/frontend/apps/marketing/src/components/header/csForAll/config.ts
@@ -97,7 +97,8 @@ export const TOP_LEVEL_LINKS: {linkList: LinkItemProps[]} = {
     createLinkItem(SHARED_LINKS.ISSUES, {typography: 'h4'}),
     createLinkItem(SHARED_LINKS.TAKE_ACTION, {typography: 'h4'}),
     createLinkItem(SHARED_LINKS.HOUR_OF_AI, {typography: 'h4'}),
-    createLinkItem(SHARED_LINKS.DONATE, {typography: 'h4'}),
+    // Marketing does not have permission to collect donations yet
+    //createLinkItem(SHARED_LINKS.DONATE, {typography: 'h4'}),
     createLinkItem(SHARED_LINKS.NEWS_AND_RESOURCES, {typography: 'h4'}),
   ],
 };
@@ -125,7 +126,7 @@ export const NEWS_AND_RESOURCES_LINKS: {linkList: LinkItemProps[]} = {
 };
 
 // Main Menu Desktop Configuration
-const [issuesLink, takeActionLink, hourOfAiLink, donateLink, newsLink] =
+const [issuesLink, takeActionLink, hourOfAiLink, newsLink] =
   TOP_LEVEL_LINKS.linkList;
 
 export const MAIN_MENU_DESKTOP_ITEMS = [
@@ -143,10 +144,11 @@ export const MAIN_MENU_DESKTOP_ITEMS = [
     type: 'button' as const,
     topLevelLink: hourOfAiLink,
   },
-  {
-    type: 'button' as const,
-    topLevelLink: donateLink,
-  },
+  // Marketing does not have permission to collect donations yet
+  //{
+  //type: 'button' as const,
+  //topLevelLink: donateLink,
+  //},
   {
     type: 'dropdown' as const,
     topLevelLink: newsLink,


### PR DESCRIPTION
Made this PR based on this one which Kelby set up yesterday: https://github.com/code-dot-org/code-dot-org/pull/67691

John said we need to remove Donate from the header as we don't have permission to collect donations yet. 

## Preview
### Full Header
<img width="100%" alt="full" src="https://github.com/user-attachments/assets/47589c95-d7a8-4ee9-8da2-1f34f2313ab6" />

### Hamburger Header
<img width="100%" src="https://github.com/user-attachments/assets/20ea6904-7da1-4e6a-9286-50bd35c2d7fc" />

### Footer
<img width="100%" alt="footer" src="https://github.com/user-attachments/assets/ca9405ad-9905-464b-a00c-00235f561228" />
