### PR TITLE
add beginGoogleImportRosterFlow back to teacherSectionsRedux.ts

### DIFF
--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
@@ -1153,6 +1153,16 @@ const importUrlByProvider: {[key: string]: string} = {
 } as const;
 
 /**
+ * Start the process of importing a section from Google Classroom by opening
+ * the RosterDialog and loading the list of classrooms available for import.
+ */
+export const beginGoogleImportRosterFlow =
+  () => (dispatch: ThunkDispatch<RootState, undefined, AnyAction>) => {
+    dispatch(setRosterProvider(OAuthSectionTypes.google_classroom));
+    dispatch(beginImportRosterFlow());
+  };
+
+/**
  * Import the course with the given courseId from a third-party provider
  * (like Google Classroom or Clever), creating a new section. If the course
  * in question has already been imported, update the existing section already


### PR DESCRIPTION
This PR adds `beginGoogleImportRosterFlow` to `teacherSectionsRedux.ts` after not being converted from `teacherSectionsRedux.js` in https://github.com/code-dot-org/code-dot-org/pull/61597. Since that PR, there has been a bug where the Google Classrooms roster dialog doesn't stay open after authorizing Google.
<img width="800" height="553" alt="Screenshot 2025-08-13 at 4 10 35 PM" src="https://github.com/user-attachments/assets/9d8eaa48-8d0a-4aba-a4ce-3c5a20831b4a" />

It came to the surface when we got a Zendesk ticket where a user was confused about the Google Classroom roster syncing progress. More information can be found at the Jira ticket below.

## Links
- Jira: https://codedotorg.atlassian.net/browse/P20-1570

## Testing story
Manually verified that the dialog stays open after returning from authorizing Google. 

