### PR TITLE
fix(cache): store cache-control on s3

### DIFF
--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -94,6 +94,8 @@ jobs:
 
           echo "Uploading static assets to $BUCKET_NAME"
 
+          # Upload to S3 and set the cache control for these static assets to be immutable.
+          # More details: https://nextjs.org/docs/app/guides/self-hosting#automatic-caching
           aws s3 sync static/ "s3://$BUCKET_NAME/_next/static" --quiet --cache-control "public, max-age=31536000, immutable"
 
       - name: "[${{ env.GITHUB_ENVIRONMENT_NAME }}] Deploy Marketing App to AWS"

--- a/.github/workflows/marketing-app-deploy-to-environment.yml
+++ b/.github/workflows/marketing-app-deploy-to-environment.yml
@@ -94,7 +94,7 @@ jobs:
 
           echo "Uploading static assets to $BUCKET_NAME"
 
-          aws s3 sync static/ "s3://$BUCKET_NAME/_next/static" --quiet
+          aws s3 sync static/ "s3://$BUCKET_NAME/_next/static" --quiet --cache-control "public, max-age=31536000, immutable"
 
       - name: "[${{ env.GITHUB_ENVIRONMENT_NAME }}] Deploy Marketing App to AWS"
         working-directory: ./frontend/apps/marketing/cicd/3-app

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -218,23 +218,6 @@ Resources:
             AccessControlMaxAgeSec: 31536000
             IncludeSubdomains: false
             Override: false
-  # For immutable static assets (hashed assets like JS/CSS files), ensure that the Cache-Control header is set to immutable
-  ImmutableStaticAssetsResponseHeadersPolicy:
-    Type: AWS::CloudFront::ResponseHeadersPolicy
-    Properties:
-      ResponseHeadersPolicyConfig:
-        Name: !Sub "${AWS::StackName}-Assets-ResponseHeader-Policy"
-        Comment: "Ensure immutable static assets have Cache-Control header set to immutable"
-        CustomHeadersConfig:
-          Items:
-            - Header: cache-control
-              Override: false # Do not override the cache control from the origin if it is available
-              Value: public, max-age=31536000, immutable
-        SecurityHeadersConfig:
-          StrictTransportSecurity:
-            AccessControlMaxAgeSec: 31536000
-            IncludeSubdomains: false
-            Override: false
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -320,7 +303,7 @@ Resources:
             PathPattern: /_next/*
             TargetOriginId: marketing-sites-static-assets-origin
             ViewerProtocolPolicy: redirect-to-https
-            ResponseHeadersPolicyId: !Ref ImmutableStaticAssetsResponseHeadersPolicy
+            ResponseHeadersPolicyId: !Ref DefaultResponseHeadersPolicy
 
   ####################################
   # Load Balancer Resources          #


### PR DESCRIPTION
This PR changes the cache-control mechanism for S3 assets from being set on Cloudfront indiscriminatly via a response header override to being stored in S3 as a Cache-Control metadata header.

Previously, the response header always added `Cache-Control` regardless of the origin response code which leads to circumstances where a 4xx or 5xx is cached (if Cloudfront caches that status code).

Now, S3 will be responsible for setting `Cache-Control`, for which it will only respond with `Cache-Control` if the file was successfuly retrieved (as it will be in that file's metadata).

This was tested on `csforall.marketing-sites.dev-code.org`.