### PR TITLE
Web Lab 2: always use the new resource panel

### DIFF
--- a/apps/src/codebridge/InfoPanel/InfoPanel.tsx
+++ b/apps/src/codebridge/InfoPanel/InfoPanel.tsx
@@ -88,6 +88,10 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
   const hasLoadedEnvironment = useAppSelector(
     state => state.lab2System.loadedCodeEnvironment
   );
+  // Web Lab 2 uses the resource panel by default, otherwise we defer to the experiment flag.
+  const useResourcePanel =
+    appName === 'weblab2' ||
+    experiments.isEnabledAllowingQueryString(experiments.LAB2_RESOURCE_PANEL);
 
   useEffect(() => {
     // For now, always include Instructions panel.
@@ -183,9 +187,7 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
     }
   };
 
-  if (
-    experiments.isEnabledAllowingQueryString(experiments.LAB2_RESOURCE_PANEL)
-  ) {
+  if (useResourcePanel) {
     return (
       <div style={style} className={className}>
         <ResourcePanel


### PR DESCRIPTION
This updates web lab 2 to always use the new resource panel. Web Lab 2 is in development and the resource panel is what we want to use eventually, so it makes sense to not need an experiment flag for web lab 2. Python Lab is unchanged.



## Links

- Jira: [CT-1266](https://codedotorg.atlassian.net/browse/CT-1266)

## Testing story
Confirmed locally that Web Lab 2 uses the new panel by default but Python Lab does not.


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
