### PR TITLE
Revert "Revert "Teach-1949/remove content root type references""

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -232,21 +232,14 @@ export default function CurriculumQuickAssign({
 
       const courseVersionId = sectionCourse.versionId;
       const courseVersion = courseVersions[courseVersionId];
-      const isStandaloneUnit = courseVersion.type === 'Unit';
 
-      let targetUnit;
-
-      if (isStandaloneUnit) {
-        targetUnit = Object.values(courseVersion.units)[0];
-      } else if (sectionCourse.unitId) {
-        targetUnit = courseVersion.units[sectionCourse.unitId];
-      }
+      let targetUnit = courseVersion.units[sectionCourse.unitId];
 
       const updateSectionData = {
         displayName: course.display_name,
         courseOfferingId: course.id,
         versionId: courseVersionId,
-        unitId: isStandaloneUnit ? null : sectionCourse.unitId,
+        unitId: sectionCourse.unitId,
         lessonExtrasAvailable: targetUnit?.lesson_extras_available,
         textToSpeechEnabled: targetUnit?.text_to_speech_enabled,
       };

--- a/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
@@ -288,7 +288,7 @@ const assignmentsForSection = (courseOfferings, section) => {
       ];
     if (courseVersion) {
       assignments.push(courseVersion);
-      if (section.unitId && courseVersion.type === 'UnitGroup') {
+      if (section.unitId) {
         if (courseVersion.units[section.unitId]) {
           assignments.push(courseVersion.units[section.unitId]);
         }

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -314,24 +314,16 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
       course_version = CourseVersion.find_by_id(params[:course_version_id])
       return head :bad_request unless course_version
 
-      case course_version.content_root_type
-      when 'UnitGroup'
-        course_id = course_version.content_root_id
-        @course = UnitGroup.get_from_cache(course_id)
-        return head :bad_request unless @course
-        return head :forbidden unless @course.course_assignable?(current_user)
-        @unit = if @course.single_unit_course?
-                  @course.units_for_user(current_user).first
-                else
-                  params[:unit_id] ? Unit.get_from_cache(params[:unit_id]) : nil
-                end
-        return head :bad_request if @unit && @course && @unit.unit_groups.exclude?(@course)
-      when 'Unit'
-        unit_id = course_version.content_root_id
-        @unit = Unit.get_from_cache(unit_id)
-        return head :bad_request unless @unit
-        return head :forbidden unless @unit.course_assignable?(current_user)
-      end
+      course_id = course_version.content_root_id
+      @course = UnitGroup.get_from_cache(course_id)
+      return head :bad_request unless @course
+      return head :forbidden unless @course.course_assignable?(current_user)
+      @unit = if @course.single_unit_course?
+                @course.units_for_user(current_user).first
+              else
+                params[:unit_id] ? Unit.get_from_cache(params[:unit_id]) : nil
+              end
+      return head :bad_request if @unit && @course && @unit.unit_groups.exclude?(@course)
     else
       # Should not get a unit_id unless also get a course version which is course
       return head :bad_request if params[:unit_id]

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -90,8 +90,6 @@ class CourseOffering < ApplicationRecord
     end
 
     if content_root.is_course?
-      raise "family_name must be set, since is_course is true, for: #{content_root.name}" if content_root.family_name.nil_or_empty?
-
       offering = CourseOffering.find_or_create_by!(key: content_root.family_name) do |co|
         co.display_name = content_root.family_name if co.display_name.nil_or_empty?
       end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -33,7 +33,7 @@
 class CourseOffering < ApplicationRecord
   include Curriculum::SharedCourseConstants
 
-  has_many :course_versions, -> {where(content_root_type: ['UnitGroup', 'Unit'])}
+  has_many :course_versions
   belongs_to :self_paced_pl_course_offering, class_name: 'CourseOffering', optional: true
 
   has_and_belongs_to_many :pd_workshops, class_name: 'Pd::Workshop', join_table: :course_offerings_pd_workshops, association_foreign_key: 'pd_workshop_id'
@@ -116,7 +116,7 @@ class CourseOffering < ApplicationRecord
   def latest_published_version(locale_code = 'en-us')
     locale_str = locale_code&.to_s
     unless locale_str&.start_with?('en')
-      latest_stable_version = any_version_is_unit? ? Unit.latest_stable_version(key, locale: locale_str) : UnitGroup.latest_stable_version(key, locale: locale_str)
+      latest_stable_version = UnitGroup.latest_stable_version(key, locale: locale_str)
       return latest_stable_version.course_version unless latest_stable_version.nil?
     end
 
@@ -136,17 +136,7 @@ class CourseOffering < ApplicationRecord
   end
 
   def course_id
-    return unless latest_published_version&.content_root_type == 'UnitGroup'
-    latest_published_version.content_root.id
-  end
-
-  def script_id
-    return unless latest_published_version&.content_root_type == 'Unit'
-    latest_published_version.content_root.id
-  end
-
-  def standalone_unit?
-    latest_published_version&.content_root_type == 'Unit'
+    latest_published_version&.content_root&.id
   end
 
   def self.should_cache?
@@ -332,7 +322,7 @@ class CourseOffering < ApplicationRecord
     locale_str = locale_code&.to_s
     return true if locale_str&.start_with?('en')
 
-    latest_stable_version = any_version_is_unit? ? Unit.latest_stable_version(key, locale: locale_str) : UnitGroup.latest_stable_version(key, locale: locale_str)
+    latest_stable_version = UnitGroup.latest_stable_version(key, locale: locale_str)
     !latest_stable_version.nil?
   end
 
@@ -377,8 +367,6 @@ class CourseOffering < ApplicationRecord
       course_version_id: latest_published_version(locale_code)&.id,
       course_id: course_id,
       course_offering_id: id,
-      script_id: script_id,
-      is_standalone_unit: standalone_unit?,
       is_translated: translated?(locale_code),
       description: description,
       professional_learning_program: professional_learning_program,
@@ -453,10 +441,6 @@ class CourseOffering < ApplicationRecord
 
   def units_included_in_any_version?(unit_ids)
     course_versions.any? {|cv| cv.included_in_units?(unit_ids)}
-  end
-
-  def any_version_is_unit?
-    course_versions.any? {|cv| cv.content_root_type == 'Unit'}
   end
 
   def csd?

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -75,20 +75,20 @@ class CourseOffering < ApplicationRecord
     'Rubric'
   ]
   # Seeding method for creating / updating / deleting a CourseOffering and CourseVersion for the given
-  # potential content root, i.e. a Unit or UnitGroup.
+  # potential content root, i.e. a UnitGroup.
   #
   # Examples:
   #
-  # coursea-2019.script represents the content root for Course A, Version 2019.
-  # Therefore, it should contain "is_course true", which will cause this method to create the
-  # corresponding CourseOffering and CourseVersion objects.
-  #
   # csp1-2019.script does not represent a content root (the root for CSP, Version 2019 is a UnitGroup).
-  # Therefore, it does not contain "is_course true". so this method will not create any new objects.
+  # Therefore, this method will not create any new objects.
   #
   # This method will also delete CourseOfferings and/or CourseVersions that were previously associated with
   # the content_root, if appropriate. See CourseVersion#add_course_version for details.
   def self.add_course_offering(content_root)
+    unless content_root.is_a?(UnitGroup)
+      raise "cannot create CourseOffering for content root #{content_root.name} that is not a UnitGroup"
+    end
+
     if content_root.is_course?
       raise "family_name must be set, since is_course is true, for: #{content_root.name}" if content_root.family_name.nil_or_empty?
 

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -90,6 +90,8 @@ class CourseOffering < ApplicationRecord
     end
 
     if content_root.is_course?
+      raise "family_name must be set, since is_course is true, for: #{content_root.name}" if content_root.family_name.nil_or_empty?
+
       offering = CourseOffering.find_or_create_by!(key: content_root.family_name) do |co|
         co.display_name = content_root.family_name if co.display_name.nil_or_empty?
       end

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -42,15 +42,10 @@ class CourseVersion < ApplicationRecord
   UNVERSIONED = 'unversioned'.freeze
 
   def units
-    content_root_type == 'UnitGroup' ? content_root.default_units : [content_root]
+    content_root.default_units
   end
 
-  # "Interface" for content_root:
-  #
-  # is_course? - used during seeding to determine whether this object represents the content root for a CourseVersion.
-  #   For example, this should return True for the CourseA-2019 Unit and the CSP-2019 UnitGroup. This should return
-  #   False for the CSP1-2019 Unit.
-  belongs_to :content_root, polymorphic: true, optional: true
+  belongs_to :content_root, class_name: "UnitGroup", optional: true
 
   alias_attribute :version_year, :key
 
@@ -83,18 +78,14 @@ class CourseVersion < ApplicationRecord
   end
 
   # Seeding method for creating / updating / deleting the CourseVersion for the given
-  # potential content root, i.e. a Unit or UnitGroup.
+  # potential content root, i.e. a UnitGroup.
   #
   # Examples:
-  #
-  # coursea-2019.script represents the content root for Course A, Version 2019.
-  # Therefore, it should contain "is_course true", which will cause this method to create the
-  # corresponding CourseVersion object.
   #
   # csp1-2019.script does not represent a content root (the root for CSP, Version 2019 is a UnitGroup).
   # Therefore, it does not contain "is_course true". so this method will not create a CourseVersion object for it.
   def self.add_course_version(course_offering, content_root)
-    if content_root.is_course?
+    if content_root.is_a?(UnitGroup)
       raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
 
       course_version = CourseVersion.find_or_initialize_by(
@@ -102,10 +93,12 @@ class CourseVersion < ApplicationRecord
         key: content_root.version_year,
         display_name: content_root.version_year,
         content_root: content_root,
+        content_root_type: content_root.class.name
       )
       course_version.published_state = content_root.published_state
     else
-      course_version = nil
+      # If content_root is not a UnitGroup, then we cannot create a CourseVersion.
+      raise "cannot create CourseVersion for content root #{content_root.name} that is not a UnitGroup"
     end
 
     # Check if we should prevent saving the new course version:
@@ -140,16 +133,16 @@ class CourseVersion < ApplicationRecord
   end
 
   def all_standards_url
-    content_root_type == 'UnitGroup' ? standards_course_path(content_root) : standards_script_path(content_root)
+    standards_course_path(content_root)
   end
 
   def self.should_cache?
     Unit.should_cache?
   end
 
-  def self.course_offering_keys(content_root_type)
-    Rails.cache.fetch("course_version/course_offering_keys/#{content_root_type}", force: !should_cache?) do
-      CourseVersion.includes(:course_offering).where(content_root_type: content_root_type).filter_map {|cv| cv.course_offering&.key}.uniq.sort
+  def self.course_offering_keys
+    Rails.cache.fetch("course_version/course_offering_keys", force: !should_cache?) do
+      CourseVersion.includes(:course_offering).filter_map {|cv| cv.course_offering&.key}.uniq.sort
     end
   end
 
@@ -188,11 +181,9 @@ class CourseVersion < ApplicationRecord
   # See fakeCoursesWithProgress in teacherDashboardTestHelpers.js for an example of what
   # the resulting data looks like
   def self.courses_for_unit_selector(unit_ids, user)
-    standalone_units = Unit.joins(:course_version).where(id: unit_ids).map {|u| u.course_version.course_offering&.summarize_for_unit_selector(unit_ids)}.compact.uniq
-
-    unit_groups =  Unit.joins(unit_groups: :course_version).where(id: unit_ids).where(course_version: {content_root_type: 'UnitGroup'}).flat_map {|u| u.unit_groups.map(&:course_version)}.select {|cv| cv.course_assignable?(user)}.map(&:summarize_for_unit_selector).uniq
-
-    standalone_units.concat(unit_groups).sort_by {|c| c[:display_name]}
+    Unit.joins(unit_groups: :course_version).where(id: unit_ids).
+        flat_map {|u| u.unit_groups.map(&:course_version)}.select {|cv| cv.course_assignable?(user)}.
+        map(&:summarize_for_unit_selector).uniq.sort_by {|c| c[:display_name]}
   end
 
   def summarize_for_assignment_dropdown(user, locale_code)
@@ -201,11 +192,10 @@ class CourseVersion < ApplicationRecord
       {
         id: id,
         key: key,
-        version_year: content_root_type == 'UnitGroup' ? content_root.localized_version_title : display_name,
+        version_year: content_root.localized_version_title,
         content_root_id: content_root.id,
         name: content_root.localized_title,
         path: content_root.link,
-        type: content_root_type,
         is_stable: stable?,
         is_recommended: recommended?(locale_code),
         locales: content_root.supported_locale_names,

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -85,7 +85,11 @@ class CourseVersion < ApplicationRecord
   # csp1-2019.script does not represent a content root (the root for CSP, Version 2019 is a UnitGroup).
   # Therefore, it does not contain "is_course true". so this method will not create a CourseVersion object for it.
   def self.add_course_version(course_offering, content_root)
-    if content_root.is_a?(UnitGroup)
+    unless content_root.is_a?(UnitGroup)
+      raise "cannot create CourseVersion for content root #{content_root.name} that is not a UnitGroup"
+    end
+
+    if content_root.is_course?
       raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
 
       course_version = CourseVersion.find_or_initialize_by(
@@ -97,8 +101,7 @@ class CourseVersion < ApplicationRecord
       )
       course_version.published_state = content_root.published_state
     else
-      # If content_root is not a UnitGroup, then we cannot create a CourseVersion.
-      raise "cannot create CourseVersion for content root #{content_root.name} that is not a UnitGroup"
+      course_version = nil
     end
 
     # Check if we should prevent saving the new course version:

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -90,6 +90,8 @@ class CourseVersion < ApplicationRecord
     end
 
     if content_root.is_course?
+      raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
+
       course_version = CourseVersion.find_or_initialize_by(
         course_offering: course_offering,
         key: content_root.version_year,

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -90,8 +90,6 @@ class CourseVersion < ApplicationRecord
     end
 
     if content_root.is_course?
-      raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
-
       course_version = CourseVersion.find_or_initialize_by(
         course_offering: course_offering,
         key: content_root.version_year,

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -787,7 +787,6 @@ class Lesson < ApplicationRecord
     # that may be used in the sort block below.
     load_params = {
       script: [
-        :course_version,
         {
           unit_group_units: {
             unit_group: :course_version
@@ -814,7 +813,7 @@ class Lesson < ApplicationRecord
     # and course offering. In the future, when curriulum_umbrella moves to
     # CourseOffering, this implementation will need to change to be more like
     # related_lessons.
-    lessons = Lesson.eager_load(script: :course_version).
+    lessons = Lesson.eager_load(:script).
       where("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella).
       where(key: key).
       # This SQL string is not at risk for injection vulnerabilites because

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -69,7 +69,6 @@ class Unit < ApplicationRecord
   has_many :unit_group_units, foreign_key: 'script_id', dependent: :destroy
   has_many :unit_groups, through: :unit_group_units
   belongs_to :original_unit_group, class_name: 'UnitGroup', optional: true
-  has_one :course_version, as: :content_root, dependent: :destroy
 
   scope(
     :with_associated_models, lambda do
@@ -100,11 +99,6 @@ class Unit < ApplicationRecord
           },
           {
             unit_group_units: :unit_group
-          },
-          {
-            course_version: {
-              course_offering: :course_versions
-            }
           }
         ]
       )
@@ -121,7 +115,6 @@ class Unit < ApplicationRecord
               unit_group: :course_version
             }
           },
-          :course_version,
           :lesson_groups,
           {
             lessons: [
@@ -362,7 +355,7 @@ class Unit < ApplicationRecord
 
     def family_names
       Rails.cache.fetch('script/family_names', force: !Unit.should_cache?) do
-        (CourseVersion.course_offering_keys('Unit') + ScriptConstants::DEPRECATED_FAMILY_NAMES).uniq.sort
+        ScriptConstants::DEPRECATED_FAMILY_NAMES.sort
       end
     end
 
@@ -1211,7 +1204,7 @@ class Unit < ApplicationRecord
     end
   end
 
-  def clone_migrated_unit(new_name, new_level_suffix: nil, destination_unit_group_name: nil, destination_professional_learning_course: nil, version_year: nil, family_name:  nil)
+  def clone_migrated_unit(new_name, new_level_suffix: nil, destination_unit_group_name: nil, destination_professional_learning_course: nil)
     raise 'Unit name has already been taken' if Unit.find_by_name(new_name) || File.exist?(Unit.script_json_filepath(new_name))
 
     if destination_professional_learning_course.nil? && old_professional_learning_course?
@@ -1237,7 +1230,6 @@ class Unit < ApplicationRecord
         copied_unit.announcements = nil
         copied_unit.name = new_name
 
-        copied_unit.is_course = destination_unit_group.nil? && destination_professional_learning_course.nil?
         copied_unit.published_state = destination_unit_group.nil? ? Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development : nil
         copied_unit.instruction_type = destination_unit_group.nil? ? get_instruction_type : nil
         copied_unit.participant_audience = destination_unit_group.nil? ? get_participant_audience : nil
@@ -1253,12 +1245,6 @@ class Unit < ApplicationRecord
           UnitGroupUnit.create!(unit_group: destination_unit_group, script: copied_unit, position: destination_unit_group.default_units.length + 1)
           copied_unit.update!(original_unit_group: destination_unit_group)
           copied_unit.reload
-        else
-          raise "Must supply version year if new unit will be a standalone unit" unless version_year
-          copied_unit.version_year = version_year
-          raise "Must supply family name if new unit will be a standalone unit" unless family_name
-          copied_unit.family_name = family_name
-          CourseOffering.add_course_offering(copied_unit)
         end
 
         copied_unit.save! if copied_unit.changed?
@@ -1696,11 +1682,9 @@ class Unit < ApplicationRecord
     include_lessons = false
     summary = summarize(include_lessons, unit_group_unit: original_unit_group_unit)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
-    summary[:courseOfferingEditPath] = edit_course_offering_path(course_version&.course_offering&.key) if course_version
-    summary[:missingRequiredDeviceCompatibilities] = course_version&.course_offering&.missing_required_device_compatibility?
-    summary[:coursePublishedState] = unit_group ? unit_group.published_state : published_state
-    summary[:unitPublishedState] = unit_group ? published_state : nil
-    summary[:isCSDCourseOffering] = unit_group&.course_version&.course_offering&.csd?
+    summary[:coursePublishedState] = original_unit_group ? original_unit_group.published_state : published_state
+    summary[:unitPublishedState] = original_unit_group ? published_state : nil
+    summary[:isCSDCourseOffering] = original_unit_group&.course_version&.course_offering&.csd?
     summary[:allowMajorCurriculumChanges] = allow_major_curriculum_changes?
     summary
   end
@@ -1798,22 +1782,15 @@ class Unit < ApplicationRecord
   end
 
   # Returns summary object of all the course versions that an instructor can
-  # assign or all the launched versions a participant can view. 'course_assignable'
-  # will always return false for participants so they will fall into the second check for
-  # launched and can_view_version?. For instructors if course_assignable? is false then
-  # launched will also be false.
-  def summarize_course_versions(user = nil, locale_code = 'en-us', unit_group: nil)
-    unit_group ||= original_unit_group
-
-    return {} if unit_group && !unit_group.single_unit_course?
-
+  # assign or all the launched versions a participant can view. A unit can no
+  # longer have course versions, so this method will only return course versions
+  # for single-unit courses.
+  def summarize_course_versions(user = nil, locale_code = 'en-us', unit_group: original_unit_group)
     if unit_group&.single_unit_course?
       return unit_group.summarize_course_versions(user, locale_code)
     end
 
-    all_course_versions = course_version&.course_offering&.course_versions
-    course_versions_for_user = all_course_versions&.select {|cv| cv.course_assignable?(user) || (cv.launched? && cv.can_view_version?(user, locale: locale_code))}
-    course_versions_for_user&.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
+    {}
   end
 
   def self.clear_cache
@@ -1961,12 +1938,11 @@ class Unit < ApplicationRecord
     unit_group_units.find {|ugu| ugu.unit_group == original_unit_group}
   end
 
-  # If this unit is a standalone unit, returns its CourseVersion. Otherwise,
-  # if this unit belongs to a UnitGroup, returns the UnitGroup's CourseVersion,
+  # If this unit belongs to a UnitGroup, returns the UnitGroup's CourseVersion
   # if there is one.
   # @return [CourseVersion]
   def get_course_version
-    course_version || unit_group&.course_version
+    unit_group&.course_version
   end
 
   # If a script is in a unit group, use that unit group's published state. If not, use the script's published_state

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -42,7 +42,7 @@ class UnitGroup < ApplicationRecord
   has_and_belongs_to_many :resources, join_table: :unit_groups_resources
   has_many :unit_groups_student_resources, dependent: :destroy
   has_many :student_resources, through: :unit_groups_student_resources, source: :resource
-  has_one :course_version, as: :content_root, dependent: :destroy
+  has_one :course_version, foreign_key: 'content_root_id', dependent: :destroy
 
   scope(
     :with_associated_models, lambda do
@@ -238,7 +238,6 @@ class UnitGroup < ApplicationRecord
         ugu.position = index + 1
         unit.update!(published_state: nil, instruction_type: nil, participant_audience: nil, instructor_audience: nil, is_course: false, pilot_experiment: nil, skip_name_format_validation: true)
         unit.update!(original_unit_group_id: id, skip_name_format_validation: true) if unit.original_unit_group.nil?
-        unit.course_version&.destroy
 
         unit.reload
         unit.write_script_json
@@ -282,7 +281,7 @@ class UnitGroup < ApplicationRecord
   end
 
   def self.family_names
-    CourseVersion.course_offering_keys('UnitGroup')
+    CourseVersion.course_offering_keys
   end
 
   # A course that the general public can assign. Has been soft or

--- a/dashboard/db/migrate/20250812140655_remove_old_course_version_instances.rb
+++ b/dashboard/db/migrate/20250812140655_remove_old_course_version_instances.rb
@@ -1,8 +1,7 @@
 class RemoveOldCourseVersionInstances < ActiveRecord::Migration[6.1]
   def up
     if Rails.env.development?
-      deleted_count = CourseVersion.where.not(content_root_type: 'UnitGroup').delete_all
-      puts "Deleted #{deleted_count} CourseVersion records."
+      execute "DELETE FROM course_versions WHERE content_root_type != 'UnitGroup'"
     end
   end
 

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -160,7 +160,7 @@ class CoursesControllerTest < ActionController::TestCase
     get :show, params: {course_name: 'csp'}
     assert_redirected_to '/courses/csp-2019'
 
-    Rails.cache.delete("course_version/course_offering_keys/UnitGroup")
+    Rails.cache.delete("course_version/course_offering_keys")
     offering = create(:course_offering, key: 'csd')
     ug2018 = create(:unit_group, name: 'csd-2018', family_name: 'csd', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
     create(:course_version, course_offering: offering, content_root: ug2018, key: '2018')
@@ -183,7 +183,7 @@ class CoursesControllerTest < ActionController::TestCase
   end
 
   test "get_unit_group for family name with no stable versions does not redirect" do
-    Rails.cache.delete("course_version/course_offering_keys/UnitGroup")
+    Rails.cache.delete("course_version/course_offering_keys")
     offering = create(:course_offering, key: 'csd')
     ug2020 = create(:unit_group, name: 'csd-2020', family_name: 'csd', version_year: '2020', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
     create(:course_version, course_offering: offering, content_root: ug2020, key: '2020')
@@ -193,7 +193,7 @@ class CoursesControllerTest < ActionController::TestCase
   end
 
   test 'redirect to latest standards in course family' do
-    Rails.cache.delete("course_version/course_offering_keys/UnitGroup")
+    Rails.cache.delete("course_version/course_offering_keys")
 
     offering = create(:course_offering, key: 'csp')
     ug2018 = create(:unit_group, name: 'csp-2018', family_name: 'csp', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -862,7 +862,7 @@ class LessonsControllerTest < ActionController::TestCase
   end
 
   test 'update lesson with new resources' do
-    course_version = create(:course_version, content_root: @lesson.script)
+    course_version = create(:course_version, content_root: @course)
     resource = create(:resource, course_version: course_version)
 
     sign_in @levelbuilder
@@ -873,7 +873,7 @@ class LessonsControllerTest < ActionController::TestCase
   end
 
   test 'update lesson removing and adding resources' do
-    course_version = create(:course_version, content_root: @lesson.script)
+    course_version = create(:course_version, content_root: @course)
     resource_to_keep = create(:resource, course_version: course_version)
     resource_to_add = create(:resource, course_version: course_version)
     resource_to_remove = create(:resource, course_version: course_version)
@@ -892,7 +892,7 @@ class LessonsControllerTest < ActionController::TestCase
   end
 
   test 'update lesson by removing and adding vocabularies' do
-    course_version = create(:course_version, content_root: @lesson.script)
+    course_version = create(:course_version, content_root: @course)
     vocab_to_keep = create(:vocabulary, course_version: course_version)
     vocab_to_remove = create(:vocabulary, course_version: course_version)
     vocab_to_add = create(:vocabulary, course_version: course_version)

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -873,10 +873,10 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    unit = create(:script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta, is_migrated: true)
+    unit = create(:single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta).first_unit
     stub_file_writes(unit.name)
 
-    course_version = create(:course_version, content_root: unit)
+    course_version = create(:course_version, content_root: unit.original_unit_group)
     teacher_resources = [
       create(:resource, course_version: course_version),
       create(:resource, course_version: course_version),
@@ -899,10 +899,10 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    unit = create(:script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta, is_migrated: true)
+    unit = create(:single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta).first_unit
     stub_file_writes(unit.name)
 
-    course_version = create(:course_version, content_root: unit)
+    course_version = create(:course_version, content_root: unit.original_unit_group)
     student_resources = [
       create(:resource, course_version: course_version),
       create(:resource, course_version: course_version)
@@ -1001,7 +1001,6 @@ class ScriptsControllerTest < ActionController::TestCase
       instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
       tts: 'on',
       project_sharing: 'on',
-      is_course: 'on',
       peer_reviews_to_complete: 1,
       curriculum_path: 'fake_curriculum_path',
       family_name: 'fake-family-z',

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -38,6 +38,7 @@ FactoryBot.define do
     sequence(:key) {|n| "202#{n - 1}"}
     sequence(:display_name) {|n| "2#{n - 1}-2#{n}"}
     association :course_offering
+    content_root_type {'UnitGroup'}
     with_unit_group
 
     trait :with_unit_group do

--- a/dashboard/test/lib/services/i18n/curriculum_sync_utils/serializers_test.rb
+++ b/dashboard/test/lib/services/i18n/curriculum_sync_utils/serializers_test.rb
@@ -11,28 +11,6 @@ class Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializerT
         'details'    => 'announcement_details',
         'buttonText' => 'announcement_buttonText',
       ],
-      course_version: FactoryBot.build(
-        :course_version,
-        key: 'script_course_version_key',
-        course_offering: FactoryBot.build(
-          :course_offering,
-          key: 'script_course_offering_key'
-        ),
-        reference_guides: FactoryBot.build_list(
-          :reference_guide, 1,
-          key:          'reference_guide_key',
-          display_name: 'reference_guide_display_name',
-          content:      'reference_guide_content',
-          course_version: FactoryBot.build(
-            :course_version,
-            key: 'reference_guide_course_version_key',
-            course_offering: FactoryBot.build(
-              :course_offering,
-              key: 'reference_guide_course_offering_key'
-            )
-          )
-        ),
-      ),
       resources: FactoryBot.build_list(
         :resource, 1,
         key:  'resource_key',
@@ -128,12 +106,6 @@ class Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializerT
             name: 'student_resource_name',
             url:  'student_resource_url',
             type: 'student_resource_type'
-          }
-        },
-        reference_guides: {
-          URI('https://studio.code.org/courses/script_course_offering_key-script_course_version_key/guides/reference_guide_key') => {
-            display_name: 'reference_guide_display_name',
-            content:      'reference_guide_content'
           }
         },
         lessons: {

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -64,7 +64,6 @@ module Services
 
     test 'seed script in unit group' do
       script = create_script_tree
-      refute script.course_version
       assert script.original_unit_group.course_version
       assert script.original_unit_group.id, script.original_unit_group_id
       script.freeze
@@ -93,7 +92,6 @@ module Services
     # a particular machine.
     test 'seed script not yet in unit group' do
       script = create_script_tree
-      refute script.course_version
       assert script.unit_group.course_version
 
       # Capture the json while resources are still present. This test checks

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -619,7 +619,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
       let(:lesson) {create(:lesson, script: pl_unit, lesson_group: lesson_group)}
 
       before do
-        create(:course_version, content_root: pl_unit)
+        create(:course_version, content_root: pl_unit.original_unit_group)
 
         3.times do
           sublevels << create(:level)
@@ -652,7 +652,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
       let(:lesson) {create(:lesson, script: pl_unit, lesson_group: lesson_group)}
 
       before do
-        create(:course_version, content_root: pl_unit)
+        create(:course_version, content_root: pl_unit.original_unit_group)
 
         game_level.contained_level_names = ['free response level']
         game_level.save!

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -99,19 +99,6 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert_equal 1, CourseOffering.find_by(key: old_offering_key).course_versions.length # old CourseOffering should have 1 version left
   end
 
-  test "add_course_offering does nothing if is_course is false for unit" do
-    num_course_offerings = CourseOffering.count
-    num_course_versions = CourseVersion.count
-    content_root = create(:unit)
-
-    offering = CourseOffering.add_course_offering(content_root)
-
-    assert_nil offering
-    assert_nil content_root.course_version
-    assert_equal num_course_offerings, CourseOffering.count
-    assert_equal num_course_versions, CourseVersion.count
-  end
-
   test "throws exception if removing course version of course that prevent course version change" do
     course = create(:unit_group, family_name: 'family', version_year: '2000')
     CourseOffering.add_course_offering(course)
@@ -680,10 +667,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
 
   test 'missing_required_device_compatibility? returns false for pl course offerings' do
     pl_co = create(:course_offering)
-    pl_course = create(
-      :single_unit_course,
-      :pl_course
-    ).first_unit
+    pl_course = create(:single_unit_course, :pl_course)
     create(:course_version, content_root: pl_course, course_offering: pl_co)
     co = create(:course_offering, self_paced_pl_course_offering: pl_co)
 
@@ -1022,8 +1006,8 @@ class CourseOfferingTest < ActiveSupport::TestCase
   end
 
   test 'finds corresponding offerings for pl course' do
-    pl_course_offering = create(:course_offering)
-    pl_course = create(:single_unit_course, :pl_course).first_unit
+    pl_course_offering =create(:course_offering)
+    pl_course = create(:single_unit_course, :pl_course)
     create(:course_version, content_root: pl_course, course_offering: pl_course_offering)
 
     course_offering = create(:course_offering, self_paced_pl_course_offering: pl_course_offering)
@@ -1039,7 +1023,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
 
   test 'pl_for_elementary_school? returns true if non-pl offering is targeted at elementary' do
     pl_course_offering = create(:course_offering)
-    pl_course = create(:single_unit_course, :pl_course).first_unit
+    pl_course = create(:single_unit_course, :pl_course)
     create(:course_version, content_root: pl_course, course_offering: pl_course_offering)
 
     non_pl_course_offering = create(:course_offering, grade_levels: 'K,1,2,3,4,5', self_paced_pl_course_offering: pl_course_offering)
@@ -1050,7 +1034,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
 
   test 'pl_for_elementary_school? returns false if non-pl offering is not targeted at elementary' do
     pl_course_offering = create(:course_offering)
-    pl_course = create(:single_unit_course, :pl_course).first_unit
+    pl_course = create(:single_unit_course, :pl_course)
     create(:course_version, content_root: pl_course, course_offering: pl_course_offering)
 
     non_pl_course_offering = create(:course_offering, grade_levels: '9,10,11,12', self_paced_pl_course_offering: pl_course_offering)

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -225,16 +225,6 @@ class CourseVersionTest < ActiveSupport::TestCase
     assert_nil CourseVersion.find_by(course_offering: offering, key: '2050') # old CourseVersion should be deleted
   end
 
-  test "add_course_version does nothing for script without CourseVersion if is_course is false" do
-    offering = create(:course_offering)
-    script = create(:script, family_name: 'csz', version_year: '2050')
-    course_version = CourseVersion.add_course_version(offering, script)
-
-    assert_nil course_version
-    assert_nil script.course_version
-    assert_nil CourseVersion.find_by(course_offering: offering, key: '2050')
-  end
-
   test "cannot destroy course version if it has resources" do
     course_version = create(:course_version)
     create(:resource, course_version: course_version)

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -663,7 +663,7 @@ class LessonTest < ActiveSupport::TestCase
     # of related_lessons, so that the count is not artificially reduced by
     # anything being cached from the call to related_lessons.
     summaries = nil
-    assert_queries(10) do
+    assert_queries(9) do
       summaries = lesson1.summarize_related_lessons
     end
 
@@ -689,7 +689,7 @@ class LessonTest < ActiveSupport::TestCase
     create(:lesson, script: script2, key: 'foo')
 
     lesson1.reload
-    assert_queries(4) do
+    assert_queries(3) do
       assert_equal [], lesson1.related_lessons
     end
   end

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -553,7 +553,7 @@ class SectionTest < ActiveSupport::TestCase
   test 'concise_summarize: section with a coteacher' do
     # Use an existing script so that it has a translation
     script = Unit.find_by_name('jigsaw')
-    CourseOffering.add_course_offering(script)
+    CourseOffering.add_course_offering(script.original_unit_group)
 
     Timecop.freeze(Time.zone.now) do
       section = create(:section)
@@ -993,7 +993,7 @@ class SectionTest < ActiveSupport::TestCase
   test 'summarize: section with a coteacher' do
     # Use an existing script so that it has a translation
     script = Unit.find_by_name('jigsaw')
-    CourseOffering.add_course_offering(script)
+    CourseOffering.add_course_offering(script.original_unit_group)
 
     Timecop.freeze(Time.zone.now) do
       section = create(:section)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -72,7 +72,6 @@ class UnitTest < ActiveSupport::TestCase
     UnitGroup.course_cache
 
     CourseVersion.stubs(:should_cache?).returns true
-    CourseVersion.course_offering_keys('Unit')
 
     CourseOffering.all.pluck(:key).each do |key|
       CourseOffering.get_from_cache(key)
@@ -2355,7 +2354,10 @@ class UnitTest < ActiveSupport::TestCase
       create(:script_level, levels: [level1], script: @single_unit, lesson: lesson, activity_section: activity_section, activity_section_position: 1)
       create(:script_level, levels: [level2], script: @single_unit, lesson: lesson, activity_section: activity_section, activity_section_position: 2)
 
-      cloned_unit = @single_unit.clone_migrated_unit('single-unit-2022', version_year: '2022', family_name: 'csf')
+      single_unit_course_2022 = create(:unit_group, name: 'single-unit-course-2022')
+      create(:course_version, course_offering: @single_unit_course_offering, content_root: single_unit_course_2022, key: "2022", display_name: "2022")
+
+      cloned_unit = @single_unit.clone_migrated_unit('single-unit-2022', destination_unit_group_name: 'single-unit-course-2022')
       assert_equal [level1, level2], cloned_unit.levels
     end
 
@@ -2370,15 +2372,20 @@ class UnitTest < ActiveSupport::TestCase
       create(:script_level, levels: [level1], script: @single_unit, lesson: lesson, activity_section: activity_section, activity_section_position: 1)
       create(:script_level, levels: [level2], script: @single_unit, lesson: lesson, activity_section: activity_section, activity_section_position: 2)
 
-      cloned_unit = @single_unit.clone_migrated_unit('single-unit-2022', new_level_suffix: '2022', version_year: '2022', family_name: 'csf')
+      single_unit_course_2022 = create(:unit_group, name: 'single-unit-course-2022')
+      create(:course_version, course_offering: @single_unit_course_offering, content_root: single_unit_course_2022, key: "2022", display_name: "2022")
+
+      cloned_unit = @single_unit.clone_migrated_unit('single-unit-2022', destination_unit_group_name: 'single-unit-course-2022', new_level_suffix: '2022')
       refute_equal [level1, level2], cloned_unit.levels
     end
 
     test 'can copy teacher and student resources' do
       @single_unit.resources = [create(:resource)]
       @single_unit.student_resources = [create(:resource)]
+      single_unit_course_2022 = create(:unit_group, name: 'single-unit-course-2022')
+      create(:course_version, course_offering: @single_unit_course_offering, content_root: single_unit_course_2022, key: "2022", display_name: "2022")
 
-      cloned_unit = @single_unit.clone_migrated_unit('single-unit-2022', version_year: '2022', family_name: 'csf')
+      cloned_unit = @single_unit.clone_migrated_unit('single-unit-2022', destination_unit_group_name: 'single-unit-course-2022')
       assert_equal 1, cloned_unit.resources.count
       assert_equal 1, cloned_unit.student_resources.count
       refute_equal @single_unit.resources[0], cloned_unit.resources[0]
@@ -2409,17 +2416,6 @@ class UnitTest < ActiveSupport::TestCase
       assert_equal 1, cloned_unit.get_course_version.reference_guides.count
     end
 
-    test 'can copy a script without a course version' do
-      source_unit = create(:script)
-      lesson = create(:lesson, script: source_unit)
-      create(:lesson_group, script: source_unit, lessons: [lesson])
-
-      cloned_unit = source_unit.clone_migrated_unit('cloned-unit', family_name: 'family-name', version_year: 'unversioned')
-      assert_equal 1, cloned_unit.lesson_groups.count
-      assert_equal 1, cloned_unit.lessons.count
-      refute_nil cloned_unit.get_course_version
-    end
-
     test 'clone raises exception if deeper learning course is being copied to a non-deeper learning course' do
       raise = assert_raises do
         @deeper_learning_unit.clone_migrated_unit('my-name')
@@ -2437,7 +2433,7 @@ class UnitTest < ActiveSupport::TestCase
     test 'clone raises exception if script name has already been taken' do
       create(:script, name: 'my-name')
       raise = assert_raises do
-        @single_unit.clone_migrated_unit('my-name', version_year: '2022')
+        @single_unit.clone_migrated_unit('my-name')
       end
       assert_equal 'Unit name has already been taken', raise.message
     end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67736 (restores #67601)

The PR had to be reverted because of an issue seeding while building staging ([slack](https://codedotorg.slack.com/archives/C03CK8E51/p1755119079096769)). The issue was the existence of UnitGroups that don't have a `family_name` or `version_year`. The changes in this PR restore the behavior for these types of UnitGroups while still disallowing Units to be content roots of CourseVersions/CourseOfferings

## Testing Story
Re-verified:
- [x] section creation
- [x] assignment
- [x]  navigation through a course
- [x]  student progress
- [x] creating a unit
- [x] creating a unit group
- [x] seeding from scratch
- [x] seeding on top of existing db