### PR TITLE
chore(marketing): update CSforAll News & Resources slugs

### DIFF
--- a/frontend/apps/marketing/src/components/footerMui/config.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/config.tsx
@@ -14,7 +14,7 @@ export const SITE_LINKS = [
   {
     key: 'news-and-resources',
     label: 'News & Resources',
-    href: '/news-and-resources',
+    href: '/news',
   },
   {key: 'privacy-policy', label: 'Privacy Policy', href: '/privacy-policy'},
 ];

--- a/frontend/apps/marketing/src/components/header/csForAll/config.ts
+++ b/frontend/apps/marketing/src/components/header/csForAll/config.ts
@@ -38,12 +38,8 @@ const SHARED_LINKS = {
     href: '/issues',
     label: 'Issues',
   },
-  NEWS: {
-    href: '/news',
-    label: 'News',
-  },
   NEWS_AND_RESOURCES: {
-    href: '/news-and-resources',
+    href: '/news',
     label: 'News & Resources',
   },
   PRIVACY_POLICY: {
@@ -120,11 +116,6 @@ export const TAKE_ACTION_LINKS: {linkList: LinkItemProps[]} = {
   ],
 };
 
-// Main Menu News & Resources Dropdown Links
-export const NEWS_AND_RESOURCES_LINKS: {linkList: LinkItemProps[]} = {
-  linkList: [createLinkItem(SHARED_LINKS.NEWS)],
-};
-
 // Main Menu Desktop Configuration
 const [issuesLink, takeActionLink, hourOfAiLink, newsLink] =
   TOP_LEVEL_LINKS.linkList;
@@ -150,8 +141,7 @@ export const MAIN_MENU_DESKTOP_ITEMS = [
   //topLevelLink: donateLink,
   //},
   {
-    type: 'dropdown' as const,
+    type: 'button' as const,
     topLevelLink: newsLink,
-    dropdownConfig: NEWS_AND_RESOURCES_LINKS,
   },
 ];


### PR DESCRIPTION
Updates the News & Resources slug to /news and removed dropdown in the Header. 

## Links
Jira ticket: [CMS-1004](https://codedotorg.atlassian.net/browse/CMS-1004)

----


https://github.com/user-attachments/assets/63001789-f05c-4932-a571-cf6d09017977

