### PR TITLE
modify when studentData is set

### DIFF
--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -1021,7 +1021,7 @@ export const loadSectionStudentData = sectionId => {
           const convertedStudentData = convertStudentServerData(
             studentData,
             state.loginType,
-            sectionId
+            parseInt(sectionId)
           );
           dispatch(setStudents(convertedStudentData));
         })

--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -46,9 +46,7 @@ export const asyncLoadSelectedSection = async (
 
   return response
     .then(r => r.json())
-    .then(sectionData =>
-      setSelectedSectionData(sectionData, parseInt(sectionId))
-    )
+    .then(sectionData => setSelectedSectionData(sectionData, sectionId))
     .then(() => getStore().dispatch(finishLoadingSectionData()))
     .catch(error => {
       analyticsReporter.sendEvent(EVENTS.SECTION_LOAD_FAILURE, {
@@ -61,7 +59,7 @@ export const asyncLoadSelectedSection = async (
 export const setSelectedSectionData = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sectionData: any,
-  sectionId?: number
+  sectionId?: string
 ) => {
   getStore().dispatch(
     setStudentsForCurrentSection(sectionData.id, sectionData.students)

--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -35,7 +35,6 @@ export const asyncLoadSelectedSection = async (
 
   getStore().dispatch(startLoadingSectionData());
   getStore().dispatch(selectSection(sectionId));
-  getStore().dispatch(loadSectionStudentData(sectionId));
 
   const response = fetch(`/dashboardapi/section/${sectionId}`, {
     method: 'GET',
@@ -47,7 +46,7 @@ export const asyncLoadSelectedSection = async (
 
   return response
     .then(r => r.json())
-    .then(setSelectedSectionData)
+    .then(sectionData => setSelectedSectionData(sectionData, sectionId))
     .then(() => getStore().dispatch(finishLoadingSectionData()))
     .catch(error => {
       analyticsReporter.sendEvent(EVENTS.SECTION_LOAD_FAILURE, {
@@ -57,8 +56,11 @@ export const asyncLoadSelectedSection = async (
     });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const setSelectedSectionData = (sectionData: any) => {
+export const setSelectedSectionData = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sectionData: any,
+  sectionId?: string
+) => {
   getStore().dispatch(
     setStudentsForCurrentSection(sectionData.id, sectionData.students)
   );
@@ -78,4 +80,8 @@ export const setSelectedSectionData = (sectionData: any) => {
   getStore().dispatch(setRosterProviderName(sectionData.login_type_name));
 
   getStore().dispatch(updateSelectedSection(sectionData));
+
+  if (sectionId) {
+    getStore().dispatch(loadSectionStudentData(sectionId));
+  }
 };

--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -46,7 +46,9 @@ export const asyncLoadSelectedSection = async (
 
   return response
     .then(r => r.json())
-    .then(sectionData => setSelectedSectionData(sectionData, sectionId))
+    .then(sectionData =>
+      setSelectedSectionData(sectionData, parseInt(sectionId))
+    )
     .then(() => getStore().dispatch(finishLoadingSectionData()))
     .catch(error => {
       analyticsReporter.sendEvent(EVENTS.SECTION_LOAD_FAILURE, {
@@ -59,7 +61,7 @@ export const asyncLoadSelectedSection = async (
 export const setSelectedSectionData = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sectionData: any,
-  sectionId?: string
+  sectionId?: number
 ) => {
   getStore().dispatch(
     setStudentsForCurrentSection(sectionData.id, sectionData.students)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
You will still notice a "double load" when switching sections.  This, as best I can tell, is from the fact we call `loadSectionStudentData` twice - once for the `PageHeader` and a second time in the `selectedSectionLoader`.   The useEffect in PageHeader is there, I believe to be able to get the "under age 13" warning to pop up.  Ideally we would only use loadSectionStudentData once - and realistically, I am concerned that loading it twice might make the "Under 13" banner inaccurate... but I haven't investigated that too much yet.