### PR TITLE
chore(marketing): update CSforAll Header and Footer links

### DIFF
--- a/frontend/apps/marketing/src/components/footerMui/config.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/config.tsx
@@ -6,7 +6,7 @@ export const COPYRIGHT_TEXT = 'All rights reserved';
 
 // Main site links
 export const SITE_LINKS = [
-  {key: 'issues', label: 'Issues', href: '/issues'},
+  {key: 'initiatives', label: 'Initiatives', href: '/initiatives'},
   {key: 'take-action', label: 'Take Action', href: '/take-action'},
   {key: 'hour-of-ai', label: 'Hour of AI', href: '/hour-of-ai'},
   // Marketing does not have permission to collect donations yet
@@ -24,13 +24,13 @@ export const SOCIAL_LINKS = [
   {
     key: 'x-twitter',
     label: 'X',
-    href: 'https://x.com/codeorg',
+    href: 'https://x.com/csforall',
     icon: <XIcon />,
   },
   {
     key: 'linkedin',
     label: 'LinkedIn',
-    href: 'https://linkedin.com/company/code-org',
+    href: 'https://www.linkedin.com/company/csforall',
     icon: <Linkedin />,
   },
 ];

--- a/frontend/apps/marketing/src/components/header/csForAll/config.ts
+++ b/frontend/apps/marketing/src/components/header/csForAll/config.ts
@@ -34,9 +34,9 @@ const SHARED_LINKS = {
     href: '/hour-of-ai',
     label: 'Hour of AI',
   },
-  ISSUES: {
-    href: '/issues',
-    label: 'Issues',
+  INITIATIVES: {
+    href: '/initiatives',
+    label: 'Initiatives',
   },
   NEWS_AND_RESOURCES: {
     href: '/news',
@@ -90,7 +90,7 @@ export const CALL_TO_ACTION: {callToAction: CallToActionProps} = {
 // Top Level Links used in Main Menu Desktop and Drawer
 export const TOP_LEVEL_LINKS: {linkList: LinkItemProps[]} = {
   linkList: [
-    createLinkItem(SHARED_LINKS.ISSUES, {typography: 'h4'}),
+    createLinkItem(SHARED_LINKS.INITIATIVES, {typography: 'h4'}),
     createLinkItem(SHARED_LINKS.TAKE_ACTION, {typography: 'h4'}),
     createLinkItem(SHARED_LINKS.HOUR_OF_AI, {typography: 'h4'}),
     // Marketing does not have permission to collect donations yet
@@ -99,11 +99,11 @@ export const TOP_LEVEL_LINKS: {linkList: LinkItemProps[]} = {
   ],
 };
 
-// Main Menu Issues Dropdown Links
-export const ISSUES_LINKS: {linkList: LinkItemProps[]} = {
+// Main Menu Initiatives Dropdown Links
+export const INITIATIVES_LINKS: {linkList: LinkItemProps[]} = {
   linkList: [
-    createLinkItem(SHARED_LINKS.CS_IS_EVERYTHING),
     createLinkItem(SHARED_LINKS.UNLOCK8),
+    createLinkItem(SHARED_LINKS.CS_IS_EVERYTHING),
     createLinkItem(SHARED_LINKS.TEACH_AI),
   ],
 };
@@ -117,14 +117,14 @@ export const TAKE_ACTION_LINKS: {linkList: LinkItemProps[]} = {
 };
 
 // Main Menu Desktop Configuration
-const [issuesLink, takeActionLink, hourOfAiLink, newsLink] =
+const [initiativesLink, takeActionLink, hourOfAiLink, newsLink] =
   TOP_LEVEL_LINKS.linkList;
 
 export const MAIN_MENU_DESKTOP_ITEMS = [
   {
     type: 'dropdown' as const,
-    topLevelLink: issuesLink,
-    dropdownConfig: ISSUES_LINKS,
+    topLevelLink: initiativesLink,
+    dropdownConfig: INITIATIVES_LINKS,
   },
   {
     type: 'dropdown' as const,


### PR DESCRIPTION
Updates the following on the CSforAll Header and Footer:
- Change the Nav section label from 'Issues' to 'Initiatives'
- Reorder dropdown items to move 'Unlock8' above 'CS is Everything'
- Update footer social icons to link to CSforAll’s channels 

## Links
Jira ticket: [CMS-1005](https://codedotorg.atlassian.net/browse/CMS-1005)

----


https://github.com/user-attachments/assets/bce85b9b-199c-4832-9b85-752afefd9087

