### PR TITLE
Stop proliferation of levelbuilder sourceUrls in level animation JSON

### DIFF
--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -7,6 +7,7 @@ import {
 } from '@cdo/apps/assetManagement/animationLibraryApi';
 import {PICKER_TYPE} from '@cdo/apps/p5lab/AnimationPicker/AnimationPicker';
 import AnimationPickerBody from '@cdo/apps/p5lab/AnimationPicker/AnimationPickerBody.jsx';
+import {getSerializedAnimationList} from '@cdo/apps/p5lab/shapes';
 import color from '@cdo/apps/util/color';
 import {createUuid} from '@cdo/apps/utils';
 
@@ -165,7 +166,13 @@ export default class SelectStartAnimations extends React.Component {
           {this.displayAnimationPickerBody(this.state.libraryManifest)}
         </div>
         <h2>Generated Animation JSON:</h2>
-        <p>{JSON.stringify({orderedKeys, propsByKey})}</p>
+        <pre className={moduleStyles.jsonPre}>
+          {JSON.stringify(
+            getSerializedAnimationList({orderedKeys, propsByKey}),
+            null,
+            2
+          )}
+        </pre>
       </React.Fragment>
     );
   }

--- a/apps/src/code-studio/assets/select-start-animations.module.scss
+++ b/apps/src/code-studio/assets/select-start-animations.module.scss
@@ -7,3 +7,9 @@
     opacity: 1;
   }
 }
+
+.jsonPre {
+  max-height: 300px;
+  overflow: auto;
+  white-space: pre;
+}

--- a/apps/src/p5lab/redux/animationList.js
+++ b/apps/src/p5lab/redux/animationList.js
@@ -941,12 +941,28 @@ export function animationSourceUrl(key, props, channelId) {
 export function withAbsoluteSourceUrls(serializedList, channelId) {
   let list = _.cloneDeep(serializedList);
   list.orderedKeys.forEach(key => {
-    let props = list.propsByKey[key];
+    const props = list.propsByKey[key];
 
-    const relativeUrl = animationSourceUrl(key, props, channelId);
-    const sourceLocation = document.createElement('a');
-    sourceLocation.href = relativeUrl;
-    props.sourceUrl = sourceLocation.href;
+    const rawUrl = props.sourceUrl || animationSourceUrl(key, props, channelId);
+    let updatedUrl = rawUrl;
+
+    // Unwrap proxy if present
+    const proxyPrefix = '/media?u=';
+    if (rawUrl?.includes(proxyPrefix)) {
+      const encoded = rawUrl.split(proxyPrefix)[1];
+      updatedUrl = decodeURIComponent(encoded);
+    }
+
+    // Use relative URL for animation library URLs
+    if (updatedUrl.includes('v1/animation-library/')) {
+      props.sourceUrl = updatedUrl.split('code.org')[1] || updatedUrl;
+      return;
+    }
+
+    // Convert others to absolute URL (retaining original host)
+    const url = document.createElement('a');
+    url.href = updatedUrl;
+    props.sourceUrl = url.href;
   });
   return list;
 }

--- a/apps/src/p5lab/shapes.js
+++ b/apps/src/p5lab/shapes.js
@@ -254,3 +254,19 @@ export function throwIfSerializedAnimationListIsInvalid(
     knownNames[name] = true;
   }
 }
+
+/**
+ * @param {!SerializedAnimationList} serializedAnimationList
+ * @throws {Error} if the includes an unsupported sourceUrl.
+ */
+export function throwIfDisallowedAnimationSourceUrl(serializedAnimationList) {
+  const {propsByKey} = serializedAnimationList;
+  for (const animationKey in propsByKey) {
+    const sourceUrl = propsByKey[animationKey]['sourceUrl'];
+    if (sourceUrl?.startsWith('https://levelbuilder-studio.code.org/')) {
+      throw new Error(
+        `levelbuilder sourceUrl for "${propsByKey[animationKey]['name']}" is not allowed.`
+      );
+    }
+  }
+}

--- a/apps/src/sites/studio/pages/levels/editors/fields/_animation.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_animation.js
@@ -1,7 +1,10 @@
 import $ from 'jquery';
 
 import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
-import {throwIfSerializedAnimationListIsInvalid} from '@cdo/apps/p5lab/shapes';
+import {
+  throwIfDisallowedAnimationSourceUrl,
+  throwIfSerializedAnimationListIsInvalid,
+} from '@cdo/apps/p5lab/shapes';
 
 const VALID_COLOR = 'black';
 const INVALID_COLOR = '#d00';
@@ -17,6 +20,7 @@ $(document).ready(function () {
       if (json.length > 0) {
         const animationList = JSON.parse(json);
         throwIfSerializedAnimationListIsInvalid(animationList);
+        throwIfDisallowedAnimationSourceUrl(animationList);
       }
       levelStartAnimationsValidationDiv.text('Animations JSON appears valid.');
       levelStartAnimationsValidationDiv.css('color', VALID_COLOR);

--- a/apps/test/unit/p5lab/redux/animationListTest.js
+++ b/apps/test/unit/p5lab/redux/animationListTest.js
@@ -715,7 +715,7 @@ describe('animationList', function () {
       });
     });
 
-    it('Uses media proxy for non-curriculum.code.org absolute URLs', function () {
+    it('Does not use media proxy for absolute URLs', function () {
       const serializedList = {
         orderedKeys: ['foo'],
         propsByKey: {
@@ -728,7 +728,7 @@ describe('animationList', function () {
         orderedKeys: ['foo'],
         propsByKey: {
           foo: {
-            sourceUrl: `${document.location.origin}/media?u=http%3A%2F%2Fhost.com%2Fsome-absolute-url`,
+            sourceUrl: `http://host.com/some-absolute-url`,
           },
         },
       });


### PR DESCRIPTION
Last week, @breville [shared an issue](https://codedotorg.slack.com/archives/C03DBDN67B7/p1754883134040929) of a level on `test` failing to load animations. This coincided with `levelbuilder` being down. Our p5 levels (Game Lab, Sprite Lab) support a custom animation JSON field. This level, and many others have animations with a levelbuilder URL in their `sourceUrl`, which causes an undesirable dependency. For example, the level at https://test-studio.code.org/courses/coursee-2019/units/1/lessons/9/levels/6?noautoplay=true&no_redirect=true depends upon the image at https://levelbuilder-studio.code.org/api/v1/animation-library/wzaShBj3E3JC6ynAQTv56K3MIRlpF19i/category_characters/kid_outline.png

Before fixing existing levels with this problem, this branch aims to prevent it from happening more. I looked at the two ways that levelbuilders are known to author this JSON. I also added some validation to explicitly prevent a level from being saved if it contains a levelbuilder URL in its animation JSON.

## Extra Links Option
The older of the two methods for authoring animation JSON is also the most flexible. Using the link, the author can view the full animation JSON for any level or project simply by visiting it. They can then copy and paste it into other levels.  This is available on all environments to users with sufficient privileges.

Currently, this pop-up shows absolute URLs. If you add animation from the library to a project on levelbuilder, you might see something like:
```
"name": "kid_outline_1",
      "sourceUrl": "https://levelbuilder-studio.code.org/api/v1/animation-library/spritelab/9j7wtr58woBSBVOZqrWQ66Msi.JqL6vF/category_people/kid_outline.png",
```
If this gets pasted into a level file which is loaded on another environment, we wrap it our media proxy to make sure it can be loaded without a CORS violation. At that point you might see something like:

```
"name": "kid_outline_1",
      "sourceUrl": "https://studio.code.org/media?u=https%3A%2F%2Flevelbuilder-studio.code.org%2Fapi%2Fv1%2Fanimation-library%2F9j7wtr58woBSBVOZqrWQ66Msi.JqL6vF%2Fcategory_people%2Fkid_outline.png"
```

The relative URL we should actually show in both of these cases is just `/api/v1/animation-library/spritelab/9j7wtr58woBSBVOZqrWQ66Msi.JqL6vF/category_people/kid_outline.png`
However, this is only safe because `/api/v1/animation-library/` tells us it's a library animation. These relative links should be available on any environment (prod/test/levelbuilder/localhost), and because they're relative, the lab won't need to proxy them.

If the animation is not from the library, we still need the full absolute URL. This includes images at images.code.org and curriculum.code.org (seldom used, but supported), or studio links that include `v3/animations` in the path. 

The `v3/animations` path is for animations that were created (drawn or uploaded) or modified on the environment itself, ie. using the Piskel editor in Game Lab or Sprite Lab. A relative path will only work on the environment where the image exists in this case, so we need to save the full URL. *This does imply the undesirable dependency still exists*, but the only way around that is to update the levels themselves. This is follow-up work.



Changes:
1. Proxy unwrap
If we detect that the URL includes our proxy prefix, we'll split the URL and decode it, displaying the original URL.

2. Preserving relative URLs for animation library assets
If the path indicates it's a library asset, we'll split it at the domain (e.g. levelbuilder-studio.code.org or studio.code.org) and just return the later part.

3. Absolute URLs for non-library assets
If it's not a library asset, we guarantee a properly formatter URL based on the current environment. This is the pre-existing anchor tag logic and is only used when `props.sourceUrl` doesn't exist and we end up with a raw relative URL. This is the path we'd take for animations that uploaded directly into the project, for example.

## Screenshots
The screenshots compare the JSON for two animations, one created by the user and one from the library (a bear).
<img width="215" height="437" alt="image" src="https://github.com/user-attachments/assets/1cf85f60-3741-4578-acfd-26b9126998c0" />


### Before (Production)
The user animation has a full production link with version. The bear animation url is also absolute and includes a proxied version of the animation's actual source URL.
<img width="564" height="670" alt="image" src="https://github.com/user-attachments/assets/8752f0e5-7e1a-4bca-82d1-42aa212aa44e" />

### Before (Levelbuilder)
Same as above, except the absolute URL for includes levelbuilder-studio.
<img width="568" height="682" alt="image" src="https://github.com/user-attachments/assets/09c39ce6-edeb-48d2-8ba0-8047b641038f" />

### After (Localhost)
The user animation still has a full URL, out of necessity. The bear animation has a simple relative URL for the un-proxied original source. If added to a level, this will work equally well on any environment without creating a cross-environment dependency.
<img width="568" height="796" alt="image" src="https://github.com/user-attachments/assets/12a80577-fce5-4ee6-9111-461ed8a35ada" />

## Lesson Edit Page
The lesson edit page includes a JSON field for specify animations. Even with the changes above, it's possible that we will still need to show a levelbuilder URL - if the user created the image on the levelbuilder environment. It's also possible to type anything into this field, so it makes sense that we should validate against the URLs we want to prevent. 

We were already validating for malformed JSON so it was straight-forward to add a check for source URLs that include `https://levelbuilder-studio.code.org`

<img width="798" height="565" alt="image" src="https://github.com/user-attachments/assets/b53fb65d-e004-4dd2-9ff1-ce8953ce2ba5" />

### Asset Management tools
Levelbuilder has a set of tools available (at `/sprites`) which allow authors to upload/replace animations, create new JSON blobs for levels, and to update Sprite Lab's default costumes and backgrounds. Fortunately, the relevant tool ("Generate Animation JSON for a level" `/sprites/select_start_animations`) only provides relative URLs already. No functional changes were needed here but I did take the opportunity to add some nicer formatting to the output text.

**Before:**
<img width="2036" height="406" alt="image (341)" src="https://github.com/user-attachments/assets/4cf2255a-e07f-47b3-aba9-b0676eb0b2c4" />

**After:**
<img width="1846" height="702" alt="image (342)" src="https://github.com/user-attachments/assets/d05e74ec-0645-49bd-b372-f511e504eefe" />

@katiejofr supported these changes:
> YES! For sure. I have needed to sift through that raw text before to find something. It would be much better if it were formatted



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/SL-1374

## Testing story

I had to update one test case to reflect that `withAbsoluteSourceUrls` no longer returns proxied URLs for absolute URLs. This function is only used for the pop-up that provides authors with the JSON to copy. It doesn't change any actual app functionality.


<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

Audit and update all p5 levels that currently have a levelbuilder dependency.


## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
