### PR TITLE
Speculative fix: Add react and reactdom to window of preview.codeprojects.org

### DIFF
--- a/apps/src/sites/studio/pages/codeprojects_preview/show.js
+++ b/apps/src/sites/studio/pages/codeprojects_preview/show.js
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom';
 
 import InnerHTMLPreview from '@cdo/apps/codebridge/FilePreview/InnerHTMLPreview';
 
+window.React = require('react');
+window.ReactDOM = require('react-dom');
+
 document.addEventListener('DOMContentLoaded', () => {
   ReactDOM.render(
     <InnerHTMLPreview />,


### PR DESCRIPTION
This is a speculative fix to an issue we are seeing where `preview.codeprojects.org` is not loading properly on prod. The working theory is that React isn't loaded properly. This adds both React and ReactDOM to the window object for `preview.codeprojects.org`. This follows the existing pattern in [code-studio.js](https://github.com/code-dot-org/code-dot-org/blob/c031ee348e4c13f7b95dc30d88e7350038f8ca32/apps/src/sites/studio/pages/code-studio.js#L43-L44), which is not loaded on this page but is loaded on all of our other pages.


## Links

- Jira: [AFL-34](https://codedotorg.atlassian.net/browse/AFL-34)

## Testing story
This is impossible to test, because local works fine! I confirmed local still works with this change. `preview.codeprojects.org` also redirects to login on non-local, non-prod envs, so I can't test on an adhoc.




## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
