### PR TITLE
Remove aiEvaluationApi's dependency on aiTutor/chatApi since aiTutor/chatApi is going away.

### DIFF
--- a/apps/src/aiEvaluation/aiEvaluationApi.ts
+++ b/apps/src/aiEvaluation/aiEvaluationApi.ts
@@ -1,7 +1,9 @@
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import {AiEvaluationTypes} from '@cdo/generated-scripts/sharedConstants';
-
-import {OpenaiChatCompletionMessage} from '../aiTutor/chatApi';
+import {
+  AiEvaluationTypes,
+  AiInteractionStatus,
+} from '@cdo/generated-scripts/sharedConstants';
 
 import {logStudentWorkEvaluations} from './studentWorkEvaluationsApi';
 
@@ -85,6 +87,21 @@ const EVALUATE_URL = '/openai/evaluate';
 
 type ValueOf<T> = T[keyof T];
 type EvaluationType = ValueOf<typeof AiEvaluationTypes>;
+// These are the possible statuses returned by ShareFiltering.find_failure
+enum ShareFilterStatus {
+  Email = 'email',
+  Phone = 'phone',
+  Address = 'address',
+  Profanity = 'profanity',
+}
+type OpenaiChatCompletionMessage = {
+  status?: ValueOf<typeof AiInteractionStatus>;
+  role: Role;
+  content: string;
+  // Only used in case of PII or profanity violation
+  flagged_content?: string;
+  safety_status?: ShareFilterStatus;
+};
 
 export async function evaluationFromOpenAI(
   studentWork?: string | Record<string, string>,

--- a/apps/src/aiTutor/chatApi.ts
+++ b/apps/src/aiTutor/chatApi.ts
@@ -131,7 +131,7 @@ export async function getChatCompletionMessage(
   }
 }
 
-export type OpenaiChatCompletionMessage = {
+type OpenaiChatCompletionMessage = {
   status?: AITutorInteractionStatusValue;
   role: Role;
   content: string;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Just a small bit I want to merge separately from the big removal PR (#67631) given that it touches another feature.


## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Relying on drone

