### PR TITLE
[ACQ-3471] Hide the translation icon on self paced pl cards

### DIFF
--- a/apps/src/templates/courseOfferings/courseCard/CourseOfferingCard.tsx
+++ b/apps/src/templates/courseOfferings/courseCard/CourseOfferingCard.tsx
@@ -51,7 +51,7 @@ const CourseOfferingCard: React.FC<CourseOfferingCardProps> = ({
     school_subject,
     cs_topic,
     image,
-    is_translated,
+    // is_translated,
   } = courseOffering;
 
   const translatedSubjectsAndTopicsTitlesArray = useMemo(() => {
@@ -132,9 +132,10 @@ const CourseOfferingCard: React.FC<CourseOfferingCardProps> = ({
                   <Tags size="s" tagsList={courseSubjectsAndTopicsTagsList} />
                 )}
 
-                {is_translated && (
-                  <FontAwesomeV6Icon iconName="language" iconStyle="solid" />
-                )}
+                {/* TODO: [ACQ-3475] Make this work correctly */}
+                {/*{is_translated && (*/}
+                {/*  <FontAwesomeV6Icon iconName="language" iconStyle="solid" />*/}
+                {/*)}*/}
               </div>
               <Heading4 noMargin className={moduleStyles.courseTitle}>
                 {display_name}

--- a/apps/src/templates/courseOfferings/courseCard/CourseOfferingCard.tsx
+++ b/apps/src/templates/courseOfferings/courseCard/CourseOfferingCard.tsx
@@ -51,6 +51,7 @@ const CourseOfferingCard: React.FC<CourseOfferingCardProps> = ({
     school_subject,
     cs_topic,
     image,
+    // TODO: [ACQ-3475]: uncomment this
     // is_translated,
   } = courseOffering;
 


### PR DESCRIPTION
## [ACQ-3471] Hide the translation icon on self paced pl cards
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
<img width="1000" height="815" alt="Знімок екрана 2025-08-15 о 12 11 20" src="https://github.com/user-attachments/assets/6aa8d7e5-6d99-4760-a65b-6383c3640df4" />



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [ACQ-3471](https://codedotorg.atlassian.net/browse/ACQ-3471)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
