### PR TITLE
fix-i18n-course-version-test-failures

### DIFF
--- a/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb
@@ -45,7 +45,7 @@ module I18n
             # Eager loads Unit resources needed for Curriculum i18n data serialization,
             # see: Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializer
             @translatable_units ||= Unit.where(name: ScriptConstants::TRANSLATEABLE_UNITS).includes(
-              :resources, :student_resources, course_version: :reference_guides,
+              :resources, :student_resources,
               lessons: [:objectives, :resources, :vocabularies, {lesson_activities: :activity_sections}],
             )
           end

--- a/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
@@ -38,7 +38,7 @@ describe I18n::Resources::Dashboard::CurriculumContent::SyncIn do
 
     let(:course_version_key) {'expected-course-version-key'}
     let(:course_offering_key) {'expected-course-offering-key'}
-    let(:unit_course_version) do
+    let(:course_version) do
       FactoryBot.build(
         :course_version,
         key: course_version_key,
@@ -50,12 +50,14 @@ describe I18n::Resources::Dashboard::CurriculumContent::SyncIn do
     end
 
     let(:unit_name) {'expected-unit-name'}
-    let(:unit) {FactoryBot.create(:unit, name: unit_name, course_version: unit_course_version)}
+    let(:unit) {FactoryBot.create(:unit, name: unit_name)}
+    let(:unit_group) {FactoryBot.create(:single_unit_course, unit: unit, course_version: course_version)}
 
     before do
       unit.stubs(:in_initiative?).with('HOC').returns(false)
       unit.stubs(:csf?).returns(false)
       unit.stubs(:csc?).returns(false)
+      unit.stubs(:get_course_version).returns(course_version)
     end
 
     it 'returns the unit subdirectory path based on course_version and course_offering keys' do
@@ -83,7 +85,7 @@ describe I18n::Resources::Dashboard::CurriculumContent::SyncIn do
     end
 
     context 'when the init does not have a course version' do
-      let(:unit_course_version) {nil}
+      let(:course_version) {nil}
 
       it 'returns subdirectory path for "other" units' do
         assert_equal 'other', unit_subdirectory


### PR DESCRIPTION
Some i18n tests are failing due to the change with course_versions. This PR fixes those tests


## Links
Failed DTT: https://codedotorg.slack.com/archives/C03CM903Y/p1755268559350189

## Testing story
All bin tests passing locally


