### PR TITLE
feat(marketing): add Manage Cookies link in CSforAll Footer

### DIFF
--- a/frontend/apps/marketing/src/components/footerMui/FooterMui.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/FooterMui.tsx
@@ -11,7 +11,13 @@ import NativeSelect from '@mui/material/NativeSelect';
 import Stack from '@mui/material/Stack';
 import {styled} from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import {AnchorHTMLAttributes, HTMLAttributes, Key, ReactNode} from 'react';
+import {
+  AnchorHTMLAttributes,
+  HTMLAttributes,
+  Key,
+  ReactNode,
+  MouseEvent,
+} from 'react';
 
 import {isExternalLink} from '@/components/common/utils';
 import {Brand} from '@/config/brand';
@@ -20,6 +26,7 @@ export interface SiteLink extends AnchorHTMLAttributes<HTMLAnchorElement> {
   key: Key;
   label: string;
   href: string;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
 }
 
 export interface SocialLink extends AnchorHTMLAttributes<HTMLAnchorElement> {
@@ -102,21 +109,23 @@ const FooterMui: React.FC<FooterProps> = ({
         >
           {/* Site Links */}
           <FooterLinks className="site-links" aria-label="Site links">
-            {siteLinks?.map(({key, label, href}) => (
+            {siteLinks?.map(({key, label, href, onClick, ...linkProps}) => (
               <ListItem key={key}>
                 <FooterLink
                   href={href}
                   variant="body4"
                   target={
-                    isExternalLink(href, brand, 'production')
+                    !onClick && isExternalLink(href, brand, 'production')
                       ? '_blank'
                       : undefined
                   }
                   rel={
-                    isExternalLink(href, brand, 'production')
+                    !onClick && isExternalLink(href, brand, 'production')
                       ? 'noopener noreferrer'
                       : undefined
                   }
+                  onClick={onClick}
+                  {...linkProps}
                 >
                   {label}
                 </FooterLink>

--- a/frontend/apps/marketing/src/components/footerMui/FooterMui.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/FooterMui.tsx
@@ -115,12 +115,14 @@ const FooterMui: React.FC<FooterProps> = ({
                   href={href}
                   variant="body4"
                   target={
-                    !onClick && isExternalLink(href, brand, 'production')
+                    typeof onClick !== 'function' &&
+                    isExternalLink(href, brand, 'production')
                       ? '_blank'
                       : undefined
                   }
                   rel={
-                    !onClick && isExternalLink(href, brand, 'production')
+                    typeof onClick !== 'function' &&
+                    isExternalLink(href, brand, 'production')
                       ? 'noopener noreferrer'
                       : undefined
                   }

--- a/frontend/apps/marketing/src/components/footerMui/__tests__/FooterMui.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/__tests__/FooterMui.tsx
@@ -1,8 +1,15 @@
 import XIcon from '@mui/icons-material/X';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import {Brand} from '@/config/brand';
+
 import Footer, {FooterProps, SiteLink, SocialLink} from '../FooterMui';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+}));
 
 describe('FooterMui', () => {
   const siteLinks: SiteLink[] = [
@@ -10,6 +17,18 @@ describe('FooterMui', () => {
       key: 'siteLink',
       label: 'Site Link Label',
       href: '/site-link',
+    },
+    {
+      key: 'manage-cookies',
+      label: 'Manage Cookies',
+      href: '/cookies',
+      onClick: (e: {preventDefault: () => void}) => {
+        if (window?.OneTrust) {
+          e.preventDefault();
+          // Displays the OneTrust cookie dialog
+          window.OneTrust.ToggleInfoDisplay();
+        }
+      },
     },
   ];
   const socialLinks: SocialLink[] = [
@@ -30,8 +49,8 @@ describe('FooterMui', () => {
   const renderFooterContainer = (props: Partial<FooterProps> = {}) => {
     render(
       <Footer
+        {...{siteLinks, socialLinks, copyright, brand: Brand.CS_FOR_ALL}}
         {...props}
-        {...{siteLinks, socialLinks, copyright}}
         onLanguageChange={mockLanguageChange}
         languages={languages}
       />,
@@ -78,5 +97,42 @@ describe('FooterMui', () => {
     // Simulate changing the language
     await userEvent.selectOptions(languageSelect, 'es');
     expect(mockLanguageChange).toHaveBeenCalledWith('es');
+  });
+
+  it('opens OneTrust cookie dialog when "Manage Cookies" is clicked', () => {
+    window.OneTrust = {
+      ToggleInfoDisplay: jest.fn(),
+      OnConsentChanged: jest.fn(),
+      IsAlertBoxClosedAndValid: jest.fn(),
+    };
+
+    renderFooterContainer();
+
+    const manageCookiesLink = screen.getByText('Manage Cookies');
+    const preventDefaultSpy = jest.fn();
+
+    manageCookiesLink.addEventListener('click', e => {
+      e.preventDefault = preventDefaultSpy;
+    });
+    fireEvent.click(manageCookiesLink);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(window.OneTrust.ToggleInfoDisplay).toHaveBeenCalled();
+  });
+
+  it('does not call ToggleInfoDisplay when OneTrust is not available', () => {
+    window.OneTrust = undefined;
+
+    renderFooterContainer();
+
+    const manageCookiesLink = screen.getByText('Manage Cookies');
+    const preventDefaultSpy = jest.fn();
+
+    manageCookiesLink.addEventListener('click', e => {
+      e.preventDefault = preventDefaultSpy;
+    });
+    fireEvent.click(manageCookiesLink);
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/apps/marketing/src/components/footerMui/config.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/config.tsx
@@ -21,7 +21,7 @@ export const SITE_LINKS = [
     key: 'manage-cookies',
     label: 'Manage Cookies',
     href: '/cookies',
-    onClick: (e: {preventDefault: () => void}) => {
+    onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
       if (window?.OneTrust) {
         e.preventDefault();
         // Displays the OneTrust cookie dialog

--- a/frontend/apps/marketing/src/components/footerMui/config.tsx
+++ b/frontend/apps/marketing/src/components/footerMui/config.tsx
@@ -17,6 +17,18 @@ export const SITE_LINKS = [
     href: '/news',
   },
   {key: 'privacy-policy', label: 'Privacy Policy', href: '/privacy-policy'},
+  {
+    key: 'manage-cookies',
+    label: 'Manage Cookies',
+    href: '/cookies',
+    onClick: (e: {preventDefault: () => void}) => {
+      if (window?.OneTrust) {
+        e.preventDefault();
+        // Displays the OneTrust cookie dialog
+        window.OneTrust.ToggleInfoDisplay();
+      }
+    },
+  },
 ];
 
 // Social media links


### PR DESCRIPTION
Adds a Manage Cookies link to the CSforAll Footer that shows a OneTrust popup if it's not blocked and goes to the csforall.org/cookies page if OneTrust is blocked.

## Links
Jira ticket: [CMS-993](https://codedotorg.atlassian.net/browse/CMS-993)

## Testing story
Added unit tests similar to the Code.org ones added [here](https://github.com/code-dot-org/code-dot-org/pull/66682/files#diff-26b175c73a748f53b37be5919339e09d1d5d51150ffc96db21893e19b74b0666).

----


https://github.com/user-attachments/assets/19c3d959-8520-4baf-8642-7d5a8318aac8

