### PR TITLE
chore(redirect): do not redirect to code studio

### DIFF
--- a/frontend/apps/marketing/src/components/header/corporateSite/HeaderCorporateSite.tsx
+++ b/frontend/apps/marketing/src/components/header/corporateSite/HeaderCorporateSite.tsx
@@ -1,10 +1,14 @@
 'use client';
 
+import {getCookie} from 'cookies-next/client';
+
 import DSCOHeader, {
   getDefaultHeaderProps,
 } from '@code-dot-org/component-library/cms/header';
 
+import {getStage} from '@/config/stage';
 import {getStudioBaseUrl} from '@/config/studio';
+import {getCookieNameByStage} from '@/cookies/getCookie';
 import logoImage from '@public/images/cdo-logo-inverse.svg';
 import allProjectsImage from '@public/images/header-all-projects-icon.webp';
 import appLabImage from '@public/images/header-app-lab-icon.webp';
@@ -28,6 +32,12 @@ const defaultProps = getDefaultHeaderProps({
   studioUrl: getStudioBaseUrl(),
 });
 
-const Header: React.FC = () => <DSCOHeader {...defaultProps} />;
+const Header: React.FC = () => {
+  const isSignedIn = async (): Promise<boolean> => {
+    return !!getCookie(getCookieNameByStage('_user_type', getStage()));
+  };
+
+  return <DSCOHeader {...defaultProps} isSignedIn={isSignedIn} />;
+};
 
 export default Header;

--- a/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
@@ -168,25 +168,6 @@ describe('withLocale middleware', () => {
     );
   });
 
-  it('should redirect to dashboard if _user_type is set', async () => {
-    const request = {
-      nextUrl: {pathname: ''},
-      cookies: {get: jest.fn().mockReturnValue({value: '_user_type=student'})},
-      headers: {
-        get: jest.fn(),
-      },
-      url: 'https://code.marketing-sites.local',
-    } as unknown as NextRequest;
-
-    const response = await withLocale(next)(request, mockEvent);
-
-    expect(response).toBeInstanceOf(NextResponse);
-    expect(response?.headers.get('location')).toContain('studio.code.org');
-    expect(response?.headers.get('Cache-Control')).toEqual(
-      STALE_WHILE_REVALIDATE_ONE_HOUR,
-    );
-  });
-
   it('should handle paths with multiple segments correctly', async () => {
     const request = {
       url: 'https://test.code.org',

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -1,7 +1,7 @@
 import Negotiator from 'negotiator';
 import {NextFetchEvent, NextRequest} from 'next/server';
 
-import {Brand, getBrandFromHostname} from '@/config/brand';
+import {getBrandFromHostname} from '@/config/brand';
 import {
   getLocalizeJsLocaleFromDashboardLocale,
   SUPPORTED_LOCALE_CODES,
@@ -9,9 +9,7 @@ import {
   SupportedLocale,
 } from '@/config/locale';
 import {getStage} from '@/config/stage';
-import {getStudioBaseUrl} from '@/config/studio';
 import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
-import {getCookieNameByStage} from '@/cookies/getCookie';
 import {setLanguageCookie} from '@/middleware/i18n/setLanguageCookie';
 import {getCachedRedirectResponse} from '@/middleware/utils/getCachedRedirectResponse';
 
@@ -67,19 +65,6 @@ export const withLocale: MiddlewareFactory = next => {
       setLanguageCookie({response, maybeLocale, stage, brand, hostname});
 
       return response;
-    }
-
-    if (brand === Brand.CODE_DOT_ORG && isRootRoute) {
-      // If the _user_type cookie is set, then Dashboard successfully logged in the user which is an early indicator
-      // that the user is logged in right now. Therefore, send the user to Code Studio
-      // See: https://github.com/code-dot-org/code-dot-org/blob/3fad8bce055846378ae3da343da93a32acd4df8c/dashboard/config/initializers/devise.rb#L331
-      const userTypeCookie = request.cookies.get(
-        getCookieNameByStage('_user_type', stage),
-      );
-
-      if (userTypeCookie?.value) {
-        return getCachedRedirectResponse(getStudioBaseUrl());
-      }
     }
 
     const slug = isRootRoute ? '' : getContentfulSlug(pathParts);

--- a/frontend/apps/marketing/tests/e2e/home.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/home.spec.ts
@@ -21,25 +21,10 @@ test.describe('Home Page', () => {
   });
 
   test(
-    'should redirect / to dashboard if the _user_type cookie is set',
+    'should have a button to go to code studio (dashboard)',
     {tag: '@corporate'},
-    async ({page, browserName, context}) => {
+    async ({page, context}) => {
       test.skip(getSiteType() !== 'corporate', 'Only runs on corporate site');
-      test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-      const redirects: string[] = [];
-
-      // Capture all requests to track redirects
-      page.on('request', request => {
-        redirects.push(request.url());
-      });
-
-      await page.route('**://**studio.code.org**/', route => {
-        route.fulfill({
-          status: 200,
-          contentType: 'text/html',
-          body: '<html><body>Mocked Code Studio</body></html>',
-        });
-      });
 
       const marketingPage = new MarketingPage(page);
 
@@ -52,44 +37,15 @@ test.describe('Home Page', () => {
         },
       ]);
 
-      try {
-        await marketingPage.goto('/');
-      } catch {
-        // It's ok if an error occurs as dashboard may not be running
-      }
-
-      await expect.poll(() => redirects[1]).toContain('studio.code.org');
-    },
-  );
-
-  test(
-    'should redirect / to dashboard if the user is signed in (no cookies set)',
-    {tag: '@corporate'},
-    async ({page, browserName}) => {
-      test.skip(getSiteType() !== 'corporate', 'Only runs on corporate site');
-      test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-
-      const marketingPage = new MarketingPage(page);
-
-      await page.route('**/api/v1/users/signed_in', route =>
-        route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({is_signed_in: true}),
-        }),
-      );
-
-      await page.route('**://**studio.code.org**/', route => {
-        route.fulfill({
-          status: 200,
-          contentType: 'text/html',
-          body: '<html><body>Mocked Code Studio</body></html>',
-        });
-      });
-
       await marketingPage.goto('/');
 
-      await expect(page.getByText('Mocked Code Studio')).toBeVisible();
+      const studioButton = page.getByText('Go to Dashboard');
+
+      await expect(studioButton).toBeVisible();
+
+      await studioButton.click();
+
+      await expect(page).not.toHaveURL('/');
     },
   );
 });

--- a/frontend/packages/component-library/src/cms/header/__tests__/Header.test.tsx
+++ b/frontend/packages/component-library/src/cms/header/__tests__/Header.test.tsx
@@ -83,7 +83,15 @@ describe('Header Component', () => {
     const mockFetch = jest.fn(() => new Promise(() => {}));
     global.fetch = mockFetch as unknown as typeof fetch;
 
-    render(<Header {...defaultProps} />);
+    render(
+      <Header
+        {...defaultProps}
+        isSignedIn={jest.fn().mockImplementation(async () => {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+          return false;
+        })}
+      />,
+    );
 
     // check that the Loading button is rendered
     // and no other account buttons are rendered
@@ -105,13 +113,12 @@ describe('Header Component', () => {
   });
 
   it('renders correctly when user status is signed out', async () => {
-    const mockFetch = jest.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({is_signed_in: false}),
-    });
-    global.fetch = mockFetch;
-
-    render(<Header {...defaultProps} />);
+    render(
+      <Header
+        {...defaultProps}
+        isSignedIn={jest.fn().mockResolvedValue(false)}
+      />,
+    );
 
     // check that the Sign In and Create Account buttons are rendered
     // and no other account buttons are rendered
@@ -133,13 +140,12 @@ describe('Header Component', () => {
   });
 
   it('renders correctly when user status is signed in', async () => {
-    const mockFetch = jest.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({is_signed_in: true}),
-    });
-    global.fetch = mockFetch;
-
-    render(<Header {...defaultProps} />);
+    render(
+      <Header
+        {...defaultProps}
+        isSignedIn={jest.fn().mockResolvedValue(true)}
+      />,
+    );
 
     // check that the Go to Dashboard button is rendered
     // and no other account buttons are rendered
@@ -155,33 +161,6 @@ describe('Header Component', () => {
 
       const dashboardButton = screen.getByText('Go to Dashboard');
       expect(dashboardButton).toBeInTheDocument();
-    });
-
-    jest.restoreAllMocks();
-  });
-
-  it('renders correctly when there is an error fetching user status', async () => {
-    const mockFetch = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('Network error'));
-    global.fetch = mockFetch;
-
-    render(<Header {...defaultProps} />);
-
-    // check that the Sign In and Create account buttons are rendered
-    // and no other account buttons are rendered
-    await waitFor(() => {
-      const loadingButton = screen.queryByText('Loading');
-      expect(loadingButton).not.toBeInTheDocument();
-
-      const signInButton = screen.getByText('Sign In');
-      expect(signInButton).toBeInTheDocument();
-
-      const createAccountButton = screen.getByText('Create Account');
-      expect(createAccountButton).toBeInTheDocument();
-
-      const dashboardButton = screen.queryByText('Go to Dashboard');
-      expect(dashboardButton).not.toBeInTheDocument();
     });
 
     jest.restoreAllMocks();


### PR DESCRIPTION
This PR removes the ability to automatically redirect to Code Studio. Instead, the marketing app will check for the presence of a `_user_type` cookie and determine the appropriate call to action on the marketing page.

The header component is refactored to delegate the detection of signed in state to the consumer application via a callback.