### PR TITLE
add section setup started event to new homepage

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
@@ -4,6 +4,8 @@ import SegmentedButtons from '@code-dot-org/component-library/segmentedButtons';
 import {Heading4} from '@code-dot-org/component-library/typography';
 import React from 'react';
 
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
@@ -35,6 +37,15 @@ export const Header: React.FC<HeaderProps> = ({
     dispatch(beginEditingSection());
   }
 
+  const onSectionCreateButtonClick = () => {
+    analyticsReporter.sendEvent(
+      EVENTS.SECTION_SETUP_STARTED,
+      {},
+      PLATFORMS.BOTH
+    );
+    dispatch(beginEditingSection());
+  };
+
   return (
     <div>
       <Heading4>{i18n.classSections()}</Heading4>
@@ -62,7 +73,7 @@ export const Header: React.FC<HeaderProps> = ({
           <Button
             iconLeft={{iconName: 'plus', iconStyle: 'solid'}}
             text={i18n.newClassSection()}
-            onClick={() => dispatch(beginEditingSection())}
+            onClick={() => onSectionCreateButtonClick()}
             size="s"
             className={styles.createSectionButton}
           />

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
@@ -73,7 +73,7 @@ export const Header: React.FC<HeaderProps> = ({
           <Button
             iconLeft={{iconName: 'plus', iconStyle: 'solid'}}
             text={i18n.newClassSection()}
-            onClick={() => onSectionCreateButtonClick()}
+            onClick={onSectionCreateButtonClick}
             size="s"
             className={styles.createSectionButton}
           />

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -55,6 +55,22 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
     schoolType: existingSchoolInfo?.school_type,
   });
 
+  React.useEffect(() => {
+    if (schoolInfoInterstitialOpen) {
+      analyticsReporter.sendEvent(
+        EVENTS.SCHOOL_INTERSTITIAL_SHOW,
+        {},
+        PLATFORMS.BOTH
+      );
+    } else if (schoolInfoConfirmationOpen) {
+      analyticsReporter.sendEvent(
+        EVENTS.UPDATE_SCHOOL_INFO_DIALOG_SHOWN,
+        {},
+        PLATFORMS.BOTH
+      );
+    }
+  }, [schoolInfoInterstitialOpen, schoolInfoConfirmationOpen]);
+
   const existingSchoolName =
     existingSchoolInfo?.school_name || i18n.schoolInfoDialogDescriptionNoName();
 


### PR DESCRIPTION
This update adds the section setup started analytics event to the new teacher homepage. The event is triggered when the teacher clicks the new section button.

It also adds missing events to the school info drawer to be triggered when the drawer is shown.

https://github.com/user-attachments/assets/32f6950e-626c-478b-a1b4-76c3cc73dead


## Links
- Jira: [TEACH-2102](https://codedotorg.atlassian.net/browse/TEACH-2102)
## Testing story
No additional tests added

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
