### PR TITLE
fix remaining unit.course_version references

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -219,11 +219,11 @@ class Section < ApplicationRecord
   end
 
   def course_offering_id
-    unit_group ? unit_group&.course_version&.course_offering&.id : script&.course_version&.course_offering&.id
+    unit_group ? unit_group&.course_version&.course_offering&.id : script&.get_course_version&.course_offering&.id
   end
 
   def course_display_name
-    unit_group ? unit_group&.course_version&.localized_title : script&.course_version&.localized_title
+    unit_group ? unit_group&.course_version&.localized_title : script&.get_course_version&.localized_title
   end
 
   def workshop_section?
@@ -410,7 +410,7 @@ class Section < ApplicationRecord
         code: code,
         course_display_name: course_display_name,
         course_offering_id: course_offering_id,
-        course_version_id: unit_group ? unit_group&.course_version&.id : script&.course_version&.id,
+        course_version_id: unit_group ? unit_group&.course_version&.id : script&.get_course_version&.id,
         unit_id: script_id,
         course_id: course_id,
         hidden: hidden,
@@ -462,7 +462,7 @@ class Section < ApplicationRecord
         },
         course: {
           course_offering_id: course_offering_id,
-          version_id: unit_group ? unit_group&.course_version&.id : script&.course_version&.id,
+          version_id: unit_group ? unit_group&.course_version&.id : script&.get_course_version&.id,
           unit_id: unit_group ? script_id : nil,
           lesson_extras_available: script.try(:lesson_extras_available),
           text_to_speech_enabled: script.try(:text_to_speech_enabled?),
@@ -534,7 +534,7 @@ class Section < ApplicationRecord
           participant_type: participant_type,
           course_display_name: course_display_name,
           course_offering_id: course_offering_id,
-          course_version_id: unit_group ? unit_group&.course_version&.id : script&.course_version&.id,
+          course_version_id: unit_group ? unit_group&.course_version&.id : script&.get_course_version&.id,
           unit_id: unit_group ? script_id : nil,
           unitPosition: unit_group_unit&.position,
           course_id: course_id,

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -501,6 +501,56 @@ class SectionTest < ActiveSupport::TestCase
     end
   end
 
+  test 'concise_summarize: deprecated section with a script assigned but no course' do
+    unit_group = create(:single_unit_course, name: 'somecourse', version_year: '1991', family_name: 'some-family')
+    unit = unit_group.first_unit
+    CourseOffering.add_course_offering(unit_group)
+
+    Timecop.freeze(Time.zone.now) do
+      section = create(:section, script: unit, unit_group: nil)
+
+      expected = {
+        id: section.id,
+        name: section.name,
+        courseVersionName: 'somecourse',
+        unitName: unit.name,
+        unitPosition: 1,
+        isAssignedStandaloneCourse: false,
+        login_type: "email",
+        grades: nil,
+        providerManaged: false,
+        lesson_extras: false,
+        pairing_allowed: true,
+        tts_autoplay_enabled: false,
+        sharing_disabled: false,
+        studentCount: 0,
+        code: section.code,
+        course_display_name: unit_group.course_version.localized_title,
+        course_offering_id: unit_group.course_version.course_offering.id,
+        course_version_id: unit_group.course_version.id,
+        unit_id: unit.id,
+        course_id: unit_group.id,
+        hidden: false,
+        restrict_section: false,
+        post_milestone_disabled: false,
+        code_review_expires_at: nil,
+        is_assigned_csa: false,
+        participant_type: 'student',
+        sectionInstructors: [{id: section.section_instructors[0].id, status: "active", instructor_name: section.teacher.name, instructor_email: section.teacher.email}],
+        sync_enabled: nil,
+        ai_tutor_enabled: false,
+        avatar_color: nil,
+        avatar_emoji: nil,
+        at_risk_age_gated_date: nil,
+        at_risk_age_gated_us_state: nil
+      }
+      # Compare created_at separately because the object's created_at microseconds
+      # don't match Time.zone.now's microseconds (different levels of precision)
+      assert_equal Time.zone.now.change(sec: 0), section.created_at.change(sec: 0)
+      assert_equal expected, section.concise_summarize.except!(:createdAt)
+    end
+  end
+
   test 'concise_summarize: section with a single-unit course assigned' do
     # Use an existing script so that it has a translation
     script = Unit.find_by_name('jigsaw')
@@ -817,6 +867,24 @@ class SectionTest < ActiveSupport::TestCase
     assert_equal true, summarized_section[:is_assigned_single_unit_course]
   end
 
+  test 'selected_section_summarize: deprecated section with a script assigned but no course' do
+    single_unit_course = create(:single_unit_course)
+    single_unit = single_unit_course.first_unit
+    section = create(:section, script: single_unit)
+    CourseOffering.add_course_offering(single_unit_course)
+
+    summarized_section = section.selected_section_summarize
+    expected_script_info = {
+      id: single_unit.id,
+      name: single_unit.name,
+      project_sharing: single_unit.project_sharing
+    }
+
+    assert_equal single_unit_course.course_version.course_offering.id, summarized_section[:course][:course_offering_id]
+    assert_equal expected_script_info, summarized_section[:script]
+    assert_equal true, summarized_section[:is_assigned_single_unit_course]
+  end
+
   test 'selected_section_summarize: section with students' do
     section = create(:section, script: nil, unit_group: nil)
     student1 = create(:follower, section: section).student_user
@@ -912,6 +980,67 @@ class SectionTest < ActiveSupport::TestCase
         restrict_section: false,
         is_assigned_csa: false,
         is_assigned_single_unit_course: false,
+        post_milestone_disabled: false,
+        code_review_expires_at: nil,
+        sectionInstructors: [{id: section.section_instructors[0].id, status: "active", instructor_name: section.teacher.name, instructor_email: section.teacher.email}],
+        primaryInstructor: {email: section.teacher.email, name: section.teacher.name, ltiRosterSyncEnabled: nil},
+        sync_enabled: nil,
+        ai_tutor_enabled: false,
+        at_risk_age_gated_date: nil,
+        at_risk_age_gated_us_state: nil,
+        avatar_color: nil,
+        avatar_emoji: nil,
+      }
+      # Compare created_at separately because the object's created_at microseconds
+      # don't match Time.zone.now's microseconds (different levels of precision)
+      assert_equal Time.zone.now.change(sec: 0), section.created_at.change(sec: 0)
+      assert_equal expected, section.summarize.except!(:createdAt)
+    end
+  end
+
+  test 'summarize: deprecated section with a script assigned but no course' do
+    unit_group = create(:single_unit_course, name: 'somecourse', version_year: '1991', family_name: 'some-family')
+    unit = unit_group.first_unit
+    CourseOffering.add_course_offering(unit_group)
+
+    Timecop.freeze(Time.zone.now) do
+      section = create(:section, script: unit, unit_group: nil)
+
+      expected = {
+        id: section.id,
+        name: section.name,
+        teacherName: section.teacher.name,
+        linkToProgress: "//test-studio.code.org/teacher_dashboard/sections/#{section.id}/progress",
+        assignedTitle: 'somecourse',
+        linkToAssigned: '/courses/somecourse',
+        currentUnitTitle: unit.name,
+        linkToCurrentUnit: "/courses/somecourse/units/1",
+        courseVersionName: 'somecourse',
+        numberOfStudents: 0,
+        linkToStudents: "//test-studio.code.org/teacher_dashboard/sections/#{section.id}/manage_students",
+        code: section.code,
+        lesson_extras: false,
+        pairing_allowed: true,
+        tts_autoplay_enabled: false,
+        sharing_disabled: false,
+        login_type: "email",
+        login_type_name: "Email",
+        participant_type: 'student',
+        course_display_name: unit_group.course_version.localized_title,
+        course_offering_id: unit_group.course_version.course_offering.id,
+        course_version_id: unit_group.course_version.id,
+        unit_id: unit.id,
+        unitPosition: 1,
+        course_id: unit_group.id,
+        script: {id: unit.id, name: unit.name, project_sharing: nil},
+        studentCount: 0,
+        grades: nil,
+        providerManaged: false,
+        hidden: false,
+        students: [],
+        restrict_section: false,
+        is_assigned_csa: false,
+        is_assigned_single_unit_course: true,
         post_milestone_disabled: false,
         code_review_expires_at: nil,
         sectionInstructors: [{id: section.section_instructors[0].id, status: "active", instructor_name: section.teacher.name, instructor_email: section.teacher.email}],


### PR DESCRIPTION
After removing the CourseVersion association from the Unit model, there was a report of an incident where the homepage was resulting in Sad Bee. Some investigation showed that the user had a section where there was a `script_id`, but no `course_id`, causing a missed reference to script.course_version to be called. This PR changes `script.course_version` to `script.get_course_version`



## Links
Slack thread reporting incident: https://codedotorg.slack.com/archives/C045UAX4WKH/p1755286955987729

## Testing story
verified that the error is resolved on the home page when a user has a section with a script_id but no course_id


## Follow-up work
We should investigate backfilling sections that have a script_id but no course_id
Jira: [TEACH-2146](https://codedotorg.atlassian.net/browse/TEACH-2146)


