### PR TITLE
fix: use shortName cookie

### DIFF
--- a/frontend/apps/marketing/src/components/header/corporateSite/HeaderCorporateSite.tsx
+++ b/frontend/apps/marketing/src/components/header/corporateSite/HeaderCorporateSite.tsx
@@ -34,7 +34,7 @@ const defaultProps = getDefaultHeaderProps({
 
 const Header: React.FC = () => {
   const isSignedIn = async (): Promise<boolean> => {
-    return !!getCookie(getCookieNameByStage('_user_type', getStage()));
+    return !!getCookie(getCookieNameByStage('_shortName', getStage()));
   };
 
   return <DSCOHeader {...defaultProps} isSignedIn={isSignedIn} />;

--- a/frontend/apps/marketing/tests/e2e/home.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/home.spec.ts
@@ -30,7 +30,7 @@ test.describe('Home Page', () => {
 
       await context.addCookies([
         {
-          name: getCookieNameByStage('_user_type', getAppStageFromTestStage()),
+          name: getCookieNameByStage('_shortName', getAppStageFromTestStage()),
           path: '/',
           domain: `.${marketingPage.getCookieDomain()}`,
           value: 'student',


### PR DESCRIPTION
The `_user_type` cookie is HTTP only, instead use the `shortName` cookie which is available to the DOM.