### PR TITLE
run i18n tests when rails models change

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -36,7 +36,7 @@ require 'cdo/shared_constants'
 require 'cdo/shared_constants/curriculum/shared_course_constants'
 require 'ruby-progressbar'
 
-# A sequence of Levels
+# A sequence of Lessons
 class Unit < ApplicationRecord
   self.table_name = 'scripts'
 

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -36,7 +36,7 @@ require 'cdo/shared_constants'
 require 'cdo/shared_constants/curriculum/shared_course_constants'
 require 'ruby-progressbar'
 
-# A sequence of Lessons
+# A sequence of Levels
 class Unit < ApplicationRecord
   self.table_name = 'scripts'
 

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -425,7 +425,17 @@ namespace :test do
 
     desc 'Runs lib tests if lib might have changed from staging.'
     timed_task_with_logging :bin do
-      run_tests_if_changed('bin', ['Gemfile', 'Gemfile.lock', 'deployment.rb', 'bin/**/*']) do
+      run_tests_if_changed(
+        'bin',
+        [
+          'Gemfile',
+          'Gemfile.lock',
+          'deployment.rb',
+          'bin/**/*',
+          # i18n tests depend on curriculum models
+          'dashboard/app/models/**/*'
+        ]
+      ) do
         TestRunUtils.run_bin_tests
       end
     end


### PR DESCRIPTION
Fix for an issue where bin / i18n tests do not run when certain files they depend on are modified. for context, see:
- PR which passed drone but broke i18n tests: https://github.com/code-dot-org/code-dot-org/pull/67746
- DTT failure: https://codedotorg.slack.com/archives/C03CM903Y/p1755268559350189
-  i18n test fix: https://github.com/code-dot-org/code-dot-org/pull/67780

## Testing story

confirmed that modification to a rails model file is enough to trigger the bin tests to run in drone:
```
[test] Files affecting bin          tests *modified* from origin/staging. Starting tests. Changed files:
--
[test]
dashboard/app/models/unit.rb
lib/rake/test.rake
[test] Running bin tests...
```



## Follow-up work
* bin tests take 6 minutes to run, and may not depend on all rails model files. a possible follow-up would be to try to further restrict which files should trigger the bin tests.