### PR TITLE
[All Labs] Making match levels keyboard navigable

### DIFF
--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -105,7 +105,15 @@ export default class Match {
   //   * answers are only droppable on slots within the same container
   //   * answers cannot be dragged outside of the container.
   initMatch() {
-    $(this.container).find('.mainblock .match_answers li.answer').draggable({
+    const answers = $(this.container).find(
+      '.mainblock .match_answers li.answer'
+    );
+
+    // Make answers focusable and draggable via keyboard
+    answers
+      .attr('tabindex', '0') // Make focusable
+      .on('keydown', event => this.handleAnswerKeydown(event));
+    answers.draggable({
       revert: 'invalid',
       stack: '.answer',
       containment: this.container,
@@ -120,6 +128,118 @@ export default class Match {
     }
 
     this.enableSounds = this.standalone;
+  }
+
+  handleAnswerKeydown(event) {
+    const answer = $(event.currentTarget);
+    const slots = $(this.container).find('.mainblock .match_slots li');
+
+    switch (event.key) {
+      case 'Enter':
+      case ' ': // Select the answer
+        event.preventDefault();
+
+        if (answer.hasClass('selected')) {
+          // Deselect the answer
+          answer.removeClass('selected'); // Remove visual feedback
+          this.selectedAnswer = null; // Clear the selected answer
+          slots.attr('tabindex', '-1'); // Make slots not focusable
+          answer.focus(); // Keep focus on the answer
+        } else {
+          // Select the answer
+          answer.addClass('selected'); // Add visual feedback
+          this.selectedAnswer = answer; // Store the selected answer
+          slots.each((index, slot) => {
+            const $slot = $(slot);
+            const existingAnswer = $slot.data('currentAnswer');
+
+            if (existingAnswer) {
+              // If the slot contains an answer, remove it from the tab order
+              $slot.attr('tabindex', '-1');
+            } else {
+              // If the slot is empty, make it focusable
+              $slot.attr('tabindex', '0');
+            }
+          });
+          slots.first().focus(); // Move focus to the first slot
+          this.enableFocusTrap(slots); // Enable focus trap for slots
+        }
+        break;
+
+      case 'ArrowDown': // Move focus to the next answer
+        event.preventDefault();
+        answer.next().focus();
+        break;
+
+      case 'ArrowUp': // Move focus to the previous answer
+        event.preventDefault();
+        answer.prev().focus();
+        break;
+
+      case 'Escape': // Deselect the answer or remove it from the slot
+        event.preventDefault();
+
+        if (this.selectedAnswer) {
+          // Deselect the currently selected answer
+          this.selectedAnswer.removeClass('selected'); // Remove visual feedback
+          this.selectedAnswer = null; // Clear the selected answer
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  enableFocusTrap(slots) {
+    const firstSlot = slots.first();
+    const lastSlot = slots.last();
+
+    const handleKeydown = event => {
+      if (event.key === 'ArrowUp' || (event.key === 'Tab' && event.shiftKey)) {
+        event.preventDefault();
+        // Move focus to the previous slot or loop to the last slot
+        if ($(event.currentTarget).is(firstSlot)) {
+          lastSlot.focus();
+        } else {
+          $(event.currentTarget).prev().focus();
+        }
+      } else if (event.key === 'ArrowDown' || event.key === 'Tab') {
+        event.preventDefault();
+        // Move focus to the next slot or loop to the first slot
+        if ($(event.currentTarget).is(lastSlot)) {
+          firstSlot.focus();
+        } else {
+          $(event.currentTarget).next().focus();
+        }
+      } else if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        // Drop the selected answer into the slot
+        const slot = $(event.currentTarget);
+        if (this.selectedAnswer) {
+          this.moveAnswerToSlot(slot, this.selectedAnswer);
+          this.selectedAnswer.removeClass('selected'); // Remove visual feedback
+          this.selectedAnswer = null; // Clear the selection
+          slots.attr('tabindex', '-1'); // Disable focusability for slots
+
+          // Disable the focus trap
+          slots.off('keydown', handleKeydown);
+          $('body').focus();
+        }
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        // Deselect the answer and move focus to the top of the page
+        if (this.selectedAnswer) {
+          this.selectedAnswer.removeClass('selected'); // Remove visual feedback
+          this.selectedAnswer = null; // Clear the selected answer
+        }
+        slots.attr('tabindex', '-1'); // Disable focusability for slots
+        // Disable the focus trap
+        slots.off('keydown', handleKeydown);
+        $('body').focus(); // Move focus to the top of the page
+      }
+    };
+    slots.on('keydown', handleKeydown);
   }
 
   // set up the central list of empty slots.

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -214,6 +214,7 @@ export default class Match {
         if (isFromDifferentSlot) {
           console.log('manually calling drop handler');
           // Simulate drag locations
+          /*
           const $container = $('.draggablecolumn');
           const containerOffset = $container.offset();
           const itemOffset = existingElement.offset();
@@ -226,7 +227,7 @@ export default class Match {
             top: relativeTop,
             left: relativeLeft,
             zIndex: 1000,
-          });
+          });*/
           // Simulate the drop call
           const dropHandler = existingElement.data('ui-droppable').options.drop;
 
@@ -244,8 +245,9 @@ export default class Match {
         }
         this.selectedAnswer = null;
 
-        // Disable focusability for slots
-        slots.attr('tabindex', '-1');
+        // Disable focusability for empty slots
+        const emptySlots = $(this.container).find('.emptyslot');
+        emptySlots.attr('tabindex', '-1');
 
         // Disable the focus trap and move focus back to the body, deselecting any selected ansers
         $('.answer.selected').removeClass('selected');
@@ -259,7 +261,8 @@ export default class Match {
           this.selectedAnswer = null; // Clear the selected answer
         }
         $('.submitButton').focus();
-        slots.attr('tabindex', '-1'); // Disable focusability for slots
+        const emptySlots = $(this.container).find('.emptyslot');
+        emptySlots.attr('tabindex', '-1'); // Disable focusability for empty slots
       }
     };
     slots.on('keydown', handleKeydown);

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -109,7 +109,7 @@ export default class Match {
       '.mainblock .match_answers li.answer'
     );
 
-    // Make answers focusable and draggable via keyboard
+    // Make answers focusable and set up keyboard navigation
     answers
       .attr('tabindex', '0') // Make focusable
       .on('keydown', event => this.handleAnswerKeydown(event));
@@ -132,7 +132,7 @@ export default class Match {
 
   handleAnswerKeydown(event) {
     const answer = $(event.currentTarget);
-    const slots = $(this.container).find('.mainblock .match_slots li');
+    const slots = $(this.container).find('.ui-droppable');
 
     switch (event.key) {
       case 'Enter':
@@ -141,28 +141,16 @@ export default class Match {
 
         if (answer.hasClass('selected')) {
           // Deselect the answer
-          answer.removeClass('selected'); // Remove visual feedback
-          this.selectedAnswer = null; // Clear the selected answer
-          slots.attr('tabindex', '-1'); // Make slots not focusable
-          answer.focus(); // Keep focus on the answer
+          answer.removeClass('selected');
+          this.selectedAnswer = null;
+          slots.attr('tabindex', '-1');
         } else {
-          // Select the answer
-          answer.addClass('selected'); // Add visual feedback
-          this.selectedAnswer = answer; // Store the selected answer
-          slots.each((index, slot) => {
-            const $slot = $(slot);
-            const existingAnswer = $slot.data('currentAnswer');
-
-            if (existingAnswer) {
-              // If the slot contains an answer, remove it from the tab order
-              $slot.attr('tabindex', '-1');
-            } else {
-              // If the slot is empty, make it focusable
-              $slot.attr('tabindex', '0');
-            }
-          });
-          slots.first().focus(); // Move focus to the first slot
-          this.enableFocusTrap(slots); // Enable focus trap for slots
+          // Select the answer and make slots focusable, move focus to first one
+          answer.addClass('selected');
+          this.selectedAnswer = answer;
+          slots.attr('tabindex', '0');
+          slots.first().focus();
+          this.enableSlotNavigation(slots);
         }
         break;
 
@@ -176,9 +164,8 @@ export default class Match {
         answer.prev().focus();
         break;
 
-      case 'Escape': // Deselect the answer or remove it from the slot
+      case 'Escape': // Deselect the answer
         event.preventDefault();
-
         if (this.selectedAnswer) {
           // Deselect the currently selected answer
           this.selectedAnswer.removeClass('selected'); // Remove visual feedback
@@ -191,7 +178,7 @@ export default class Match {
     }
   }
 
-  enableFocusTrap(slots) {
+  enableSlotNavigation(slots) {
     const firstSlot = slots.first();
     const lastSlot = slots.last();
 
@@ -214,18 +201,56 @@ export default class Match {
         }
       } else if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
-        // Drop the selected answer into the slot
         const slot = $(event.currentTarget);
-        if (this.selectedAnswer) {
-          this.moveAnswerToSlot(slot, this.selectedAnswer);
-          this.selectedAnswer.removeClass('selected'); // Remove visual feedback
-          this.selectedAnswer = null; // Clear the selection
-          slots.attr('tabindex', '-1'); // Disable focusability for slots
+        const incomingAnswer = $(this.selectedAnswer);
+        const existingElement = $(event.target);
 
-          // Disable the focus trap
-          slots.off('keydown', handleKeydown);
-          $('body').focus();
+        // This is to find out if the answer is being moved from an existing slot,
+        // as in not from the answer bank on the right.
+        const isFromDifferentSlot =
+          $(incomingAnswer).closest('.match_slots').length === 1;
+        console.log('is from a different slot:', isFromDifferentSlot);
+        // We only want to do a swap if the answer is coming from a different slot
+        if (isFromDifferentSlot) {
+          console.log('manually calling drop handler');
+          // Simulate drag locations
+          const $container = $('.draggablecolumn');
+          const containerOffset = $container.offset();
+          const itemOffset = existingElement.offset();
+
+          const relativeTop = itemOffset.top - containerOffset.top;
+          const relativeLeft = itemOffset.left - containerOffset.left;
+
+          existingElement.css({
+            position: 'absolute',
+            top: relativeTop,
+            left: relativeLeft,
+            zIndex: 1000,
+          });
+          // Simulate the drop call
+          const dropHandler = existingElement.data('ui-droppable').options.drop;
+
+          // Create mock event and ui
+          const fakeEvent = $.Event('drop', {target: existingElement[0]});
+          const ui = {draggable: incomingAnswer};
+
+          // Manually call the drop function
+          dropHandler.call(existingElement[0], fakeEvent, ui);
+        } else if ($(existingElement).hasClass('answer')) {
+          // We do nothing if there's already an answer
+        } else {
+          // Place the incoming answer into the slot
+          this.moveAnswerToSlot(slot, incomingAnswer);
         }
+        this.selectedAnswer = null;
+
+        // Disable focusability for slots
+        slots.attr('tabindex', '-1');
+
+        // Disable the focus trap and move focus back to the body, deselecting any selected ansers
+        $('.answer.selected').removeClass('selected');
+        slots.off('keydown', handleKeydown);
+        $('.submitButton').focus();
       } else if (event.key === 'Escape') {
         event.preventDefault();
         // Deselect the answer and move focus to the top of the page
@@ -233,10 +258,8 @@ export default class Match {
           this.selectedAnswer.removeClass('selected'); // Remove visual feedback
           this.selectedAnswer = null; // Clear the selected answer
         }
+        $('.submitButton').focus();
         slots.attr('tabindex', '-1'); // Disable focusability for slots
-        // Disable the focus trap
-        slots.off('keydown', handleKeydown);
-        $('body').focus(); // Move focus to the top of the page
       }
     };
     slots.on('keydown', handleKeydown);

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -130,22 +130,32 @@ export default class Match {
     this.enableSounds = this.standalone;
   }
 
+  // A method for the 'answer options' that start in the right-most column.
+  // Allows answers to be selected and deselected with the keyboard and moved
+  // between using arrow keys.
   handleAnswerKeydown(event) {
     const answer = $(event.currentTarget);
     const slots = $(this.container).find('.ui-droppable');
 
     switch (event.key) {
+      // Enter and spacebar are used to select an answer
       case 'Enter':
-      case ' ': // Select the answer
+      case ' ':
         event.preventDefault();
-
+        // If there is a different answer already selected and it is not the same as the current one,
+        // ignore this key event.
+        if (this.selectedAnswer && this.selectedAnswer !== answer) {
+          return;
+        }
+        // In this case, clicking on the selected answer should deselect it, moving the user out of
+        // move mode (as in, make the slots not tab navigable again).
         if (answer.hasClass('selected')) {
-          // Deselect the answer
           answer.removeClass('selected');
           this.selectedAnswer = null;
           slots.attr('tabindex', '-1');
         } else {
-          // Select the answer and make slots focusable, move focus to first one
+          // We are selecting a new answer, which means we want to make the slots tab navigable and move
+          // focus there so a user can choose where this answer should be dropped.
           answer.addClass('selected');
           this.selectedAnswer = answer;
           slots.attr('tabindex', '0');
@@ -164,12 +174,11 @@ export default class Match {
         answer.prev().focus();
         break;
 
-      case 'Escape': // Deselect the answer
+      case 'Escape': // Deselect the answer and remove visual feedback
         event.preventDefault();
         if (this.selectedAnswer) {
-          // Deselect the currently selected answer
-          this.selectedAnswer.removeClass('selected'); // Remove visual feedback
-          this.selectedAnswer = null; // Clear the selected answer
+          this.selectedAnswer.removeClass('selected');
+          this.selectedAnswer = null;
         }
         break;
 
@@ -178,94 +187,91 @@ export default class Match {
     }
   }
 
+  // This enables tab navigation for the 'slots' or 'droppable' components. This becomes a
+  // bit confusing because answers can be become 'droppables' once they have been placed in
+  // a slot. That is, both keyDown functions can be called at once if a user is dropping an answer
+  // into a slot that already has an answer. There is logic near line 147 to prevent the second
+  // keyboard nav handler call and keep the action focused here.
   enableSlotNavigation(slots) {
     const firstSlot = slots.first();
     const lastSlot = slots.last();
 
     const handleKeydown = event => {
-      if (event.key === 'ArrowUp' || (event.key === 'Tab' && event.shiftKey)) {
-        event.preventDefault();
-        // Move focus to the previous slot or loop to the last slot
-        if ($(event.currentTarget).is(firstSlot)) {
-          lastSlot.focus();
-        } else {
-          $(event.currentTarget).prev().focus();
+      if (this.selectedAnswer) {
+        if (
+          event.key === 'ArrowUp' ||
+          (event.key === 'Tab' && event.shiftKey)
+        ) {
+          event.preventDefault();
+          // Move focus to the previous slot or loop to the last slot
+          if ($(event.currentTarget).is(firstSlot)) {
+            lastSlot.focus();
+          } else {
+            $(event.currentTarget).prev().focus();
+          }
+        } else if (event.key === 'ArrowDown' || event.key === 'Tab') {
+          event.preventDefault();
+          // Move focus to the next slot or loop to the first slot
+          if ($(event.currentTarget).is(lastSlot)) {
+            firstSlot.focus();
+          } else {
+            $(event.currentTarget).next().focus();
+          }
+        } else if (event.key === 'Enter' || event.key === ' ') {
+          // Here is the bulk of this function: a user is trying to place an answer into a slot!
+          event.preventDefault();
+          const slot = $(event.currentTarget);
+          const incomingAnswer = $(this.selectedAnswer);
+          const existingElement = $(event.target);
+
+          // This is to find out if the answer is being moved from an existing slot,
+          // as in not from the answer bank on the right.
+          const isFromDifferentSlot =
+            $(incomingAnswer).closest('.match_slots').length === 1;
+          // We only want to do a swap if the answer is coming from a different slot
+          if (isFromDifferentSlot) {
+            // Simulate the drop call
+            const dropHandler =
+              existingElement.data('ui-droppable').options.drop;
+
+            // Create mock event and ui
+            const fakeEvent = $.Event('drop', {target: existingElement[0]});
+            const ui = {draggable: incomingAnswer};
+
+            // Manually call the drop function
+            dropHandler.call(existingElement[0], fakeEvent, ui);
+          } else if ($(existingElement).hasClass('answer')) {
+            // We do nothing if the answer is coming from the bank on the far right
+            // and there's already an answer
+          } else {
+            // We are moving an answer from the far right into a brand new slot, so
+            // place the incoming answer into the slot!
+            this.moveAnswerToSlot(slot, incomingAnswer);
+          }
+          // Now, we have moved or rejected the answer move, so call cleanup function.
+          this.cleanupSelectionsAndSlots();
+          slots.off('keydown', handleKeydown);
+        } else if (event.key === 'Escape') {
+          // We are abandoning an answer positioning: call cleanup function.
+          event.preventDefault();
+          this.cleanupSelectionsAndSlots();
+          slots.off('keydown', handleKeydown);
         }
-      } else if (event.key === 'ArrowDown' || event.key === 'Tab') {
-        event.preventDefault();
-        // Move focus to the next slot or loop to the first slot
-        if ($(event.currentTarget).is(lastSlot)) {
-          firstSlot.focus();
-        } else {
-          $(event.currentTarget).next().focus();
-        }
-      } else if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        const slot = $(event.currentTarget);
-        const incomingAnswer = $(this.selectedAnswer);
-        const existingElement = $(event.target);
-
-        // This is to find out if the answer is being moved from an existing slot,
-        // as in not from the answer bank on the right.
-        const isFromDifferentSlot =
-          $(incomingAnswer).closest('.match_slots').length === 1;
-        console.log('is from a different slot:', isFromDifferentSlot);
-        // We only want to do a swap if the answer is coming from a different slot
-        if (isFromDifferentSlot) {
-          console.log('manually calling drop handler');
-          // Simulate drag locations
-          /*
-          const $container = $('.draggablecolumn');
-          const containerOffset = $container.offset();
-          const itemOffset = existingElement.offset();
-
-          const relativeTop = itemOffset.top - containerOffset.top;
-          const relativeLeft = itemOffset.left - containerOffset.left;
-
-          existingElement.css({
-            position: 'absolute',
-            top: relativeTop,
-            left: relativeLeft,
-            zIndex: 1000,
-          });*/
-          // Simulate the drop call
-          const dropHandler = existingElement.data('ui-droppable').options.drop;
-
-          // Create mock event and ui
-          const fakeEvent = $.Event('drop', {target: existingElement[0]});
-          const ui = {draggable: incomingAnswer};
-
-          // Manually call the drop function
-          dropHandler.call(existingElement[0], fakeEvent, ui);
-        } else if ($(existingElement).hasClass('answer')) {
-          // We do nothing if there's already an answer
-        } else {
-          // Place the incoming answer into the slot
-          this.moveAnswerToSlot(slot, incomingAnswer);
-        }
-        this.selectedAnswer = null;
-
-        // Disable focusability for empty slots
-        const emptySlots = $(this.container).find('.emptyslot');
-        emptySlots.attr('tabindex', '-1');
-
-        // Disable the focus trap and move focus back to the body, deselecting any selected ansers
-        $('.answer.selected').removeClass('selected');
-        slots.off('keydown', handleKeydown);
-        $('.submitButton').focus();
-      } else if (event.key === 'Escape') {
-        event.preventDefault();
-        // Deselect the answer and move focus to the top of the page
-        if (this.selectedAnswer) {
-          this.selectedAnswer.removeClass('selected'); // Remove visual feedback
-          this.selectedAnswer = null; // Clear the selected answer
-        }
-        $('.submitButton').focus();
-        const emptySlots = $(this.container).find('.emptyslot');
-        emptySlots.attr('tabindex', '-1'); // Disable focusability for empty slots
       }
     };
     slots.on('keydown', handleKeydown);
+  }
+
+  // This method is a helper to clear a selected answer, remove tab navigability
+  // of the slots, and move focus back to the submit button.
+  cleanupSelectionsAndSlots() {
+    if (this.selectedAnswer) {
+      this.selectedAnswer.removeClass('selected');
+      this.selectedAnswer = null;
+    }
+    $('.submitButton').focus();
+    const emptySlots = $(this.container).find('.emptyslot');
+    emptySlots.attr('tabindex', '-1');
   }
 
   // set up the central list of empty slots.

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2611,6 +2611,15 @@ a.download-video {
     background-color: $white;
     border-color: $lighter_cyan;
   }
+  .answer:focus {
+    outline: 2px solid $dark_charcoal;
+  }
+  .answer.selected {
+    background-color: $teal;
+  }
+  .slot:focus {
+    outline: 2px solid $lighter_cyan;
+  }
   .answer.ui-draggable:hover {
     border-color: $light_green;
     cursor: move;

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -3,7 +3,7 @@
 
   - if standalone && !level.properties['options'].try(:[], 'hide_submit')
     .buttons
-      %a.btn.btn-large.btn-primary.next-lesson.submitButton
+      %button.btn.btn-large.btn-primary.next-lesson.submitButton
         =t('submit')
 
   %br/

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -3,7 +3,7 @@
 
   - if standalone && !level.properties['options'].try(:[], 'hide_submit')
     .buttons
-      %button.btn.btn-large.btn-primary.next-lesson.submitButton
+      %button.btn.btn-large.btn-primary.next-lesson.submitButton{style: "margin: 0;"}
         =t('submit')
 
   %br/


### PR DESCRIPTION
The logic on this page was already a bit confusing and I know the keynav is a lot to read through. I added ample comments so hopefully each case is followable!!

Thanks @edcodedotorg for helping me work through the bug with the swap case!

Some nice features I've built in:

1. The slots are not tab navigable until an answer is selected to be moved. Once that answer is placed in a slot, they become not tab navigable again.
2. When an answer has been selected, the user can only navigate through the potential slots so they do not get lost mid-move on the rest of the page. 
3. Slots can be moved between using the arrow keys or tabs, and they loop back around to the start (again, maintaining the focus trap).
4. To exit that move, the user can press escape and the focus will move back up to the submit button
5. When an answer is selected, focus automatically moves to the first slot.
6. When an answer is placed, focus moves back to the submit button (only one move away from the answer list, but obviously cleared out of the match area)
7. You can also navigate between the answers using arrow keys, and they stop at the top and bottom answers (no trap here- the user should then still be able to navigate the rest of the page with the tab key as they have not yet selected an answer)
8. The animation for the swap remains, even though you are not quite 'dragging' with a keyboard move.

Potential for followup work (the whole area could use a rewrite):

I followed the rules of the existing drag and drop via mouse, namely: 
  `// The container limits this as follows:
  //   * only elements within the container are marked draggable / droppable
  //   * answers are only droppable on slots within the same container
  //   * answers cannot be dragged outside of the container.`

This means a user cannot move a new answer into a slot that already has an answer. Additionally, a user cannot remove or 'clear' an answer- they can only move it to another slot. This matches the mouse behavior, though is confusing.

I took this screen recording before removing the new 5px button margin. That is fixed, but the functionality remains the same!

https://github.com/user-attachments/assets/4648ee87-fd9d-456d-8870-e8cd7cd1d805




## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1339

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
