### PR TITLE
Scroll to the end of chat threads when opening them

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -276,13 +276,16 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
   );
 
   // Scroll to bottom of content when a new message comes in
-  const chatWindowRef = useRef<HTMLDivElement>(null);
+  const chatWindowRef = useRef<HTMLImageElement>(null);
   useEffect(() => {
-    chatWindowRef.current?.lastElementChild?.scrollIntoView();
+    if (chatWindowRef.current) {
+      chatWindowRef.current?.scrollIntoView();
+    }
   }, [messageHistory]);
+
   return (
     <div className={style.chatContainer}>
-      <div className={style.chatContent} ref={chatWindowRef}>
+      <div className={style.chatContent}>
         {messageHistory.map((item: ChatItem, id: number) =>
           Array.isArray(item) ? (
             <AiDiffSuggestedPrompts
@@ -309,15 +312,17 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
             />
           )
         )}
-        <img
-          src="/blockly/media/aichat/typing-animation.gif"
-          alt={'Waiting for response'}
-          className={
-            isWaitingForResponse
-              ? style.waitingForResponse
-              : style.hideWaitingForResponse
-          }
-        />
+        <div ref={chatWindowRef}>
+          <img
+            src="/blockly/media/aichat/typing-animation.gif"
+            alt={'Waiting for response'}
+            className={
+              isWaitingForResponse
+                ? style.waitingForResponse
+                : style.hideWaitingForResponse
+            }
+          />
+        </div>
       </div>
       <AiDiffChatFooter
         onSubmit={onMessageSend}


### PR DESCRIPTION
Quick UI fix to make the chat UI scroll to the end of the chat messages when opening an old thread. This is to show the latest messages in the thread to continue the chat

## Testing story
No tests for this- tests for the threads UI will be in a separate PR

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
