### PR TITLE
Fix breaking bug when hitting save and continue from section creation

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
@@ -9,7 +9,10 @@ import i18n from '@cdo/locale';
 
 import AddSectionDialog from '../../teacherDashboard/AddSectionDialog';
 import RosterDialog from '../../teacherDashboard/RosterDialog';
-import {beginEditingSection} from '../../teacherDashboard/teacherSectionsRedux';
+import {
+  beginCreatingSection,
+  beginEditingSection,
+} from '../../teacherDashboard/teacherSectionsRedux';
 
 import {ArchiveAllModal} from './ArchiveAllModal';
 import {ArchivedToggleOption} from './TeacherHomepage';
@@ -30,10 +33,12 @@ export const Header: React.FC<HeaderProps> = ({
   const [archiveAllModalOpen, setArchiveAllModalOpen] =
     React.useState<boolean>(false);
 
-  const searchParams = new URLSearchParams(window.location.search);
-  if (searchParams.get('openAddSectionDialog') === 'true') {
-    dispatch(beginEditingSection());
-  }
+  React.useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    if (searchParams.get('openAddSectionDialog') === 'true') {
+      dispatch(beginCreatingSection());
+    }
+  }, [dispatch]);
 
   return (
     <div>

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
@@ -9,10 +9,7 @@ import i18n from '@cdo/locale';
 
 import AddSectionDialog from '../../teacherDashboard/AddSectionDialog';
 import RosterDialog from '../../teacherDashboard/RosterDialog';
-import {
-  beginCreatingSection,
-  beginEditingSection,
-} from '../../teacherDashboard/teacherSectionsRedux';
+import {beginEditingSection} from '../../teacherDashboard/teacherSectionsRedux';
 
 import {ArchiveAllModal} from './ArchiveAllModal';
 import {ArchivedToggleOption} from './TeacherHomepage';
@@ -36,7 +33,7 @@ export const Header: React.FC<HeaderProps> = ({
   React.useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);
     if (searchParams.get('openAddSectionDialog') === 'true') {
-      dispatch(beginCreatingSection());
+      dispatch(beginEditingSection());
     }
   }, [dispatch]);
 


### PR DESCRIPTION
Fixes bug reported in [zendesk](https://codeorg.zendesk.com/agent/tickets/549659)
<img width="1696" height="511" alt="image" src="https://github.com/user-attachments/assets/125708d8-7c8b-4307-b763-215f1379dac4" />

Fix:
https://github.com/user-attachments/assets/7138166e-e558-49af-a8f9-9149484aa132


The `dispatch(beginEditingSection()` was happening before react loaded and dispatch was available. Wrapping in a useEffect only calls it once and calls it after redux is appropriately loaded.

## Links
[zendesk](https://codeorg.zendesk.com/agent/tickets/549659)