### PR TITLE
Mitigate Levelbuilder memory leak by restarting activejob workers regularly

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -83,6 +83,8 @@
     if node.chef_environment == 'levelbuilder'
       cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      # mitigate memory leaks by restarting ActiveJob workers occasionally
+      cronjob at:'* */12 * * *', do:deploy_dir('bin', 'restart-active-job-workers')
     end
 
 


### PR DESCRIPTION
We are seeing levelbuilder hang regularly after memory usage maxes out. The sawtooth pattern in memory usage is reset when we DTL - which is when ActiveJob workers are restarted. This restarts the workers every 12 hours, instead of only every 24 during the week and not at all on weekends.

<img width="1653" height="679" alt="image" src="https://github.com/user-attachments/assets/6009d94f-82c3-483e-8d82-792b33c5e104" />




## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
