### PR TITLE
Lab2 Dance: playback & program execution

### DIFF
--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -80,8 +80,6 @@ export const initSongs = createAsyncThunk(
       onSongUnavailable,
     } = payload;
 
-    await new Promise(resolve => setTimeout(resolve, 3000));
-
     // Check for a user-specified manifest file.
     const userManifest = queryParams('manifest') as string;
 
@@ -141,7 +139,6 @@ export const setSong = createAsyncThunk(
     },
     {dispatch, getState}
   ) => {
-    await new Promise(resolve => setTimeout(resolve, 3000));
     const {songId, onAuthError, onSongSelected} = payload;
     const state = getState() as {dance: DanceState};
     const {selectedSong: lastSongId, songData} = state.dance;

--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -29,8 +29,13 @@ export interface DanceState {
   aiOutput?: DanceAiModalOutputType;
   aiModalOpenedFromFlyout: boolean;
   // Fields below are used only by Lab2 Dance
+  /** If the program is currently running */
   isRunning: boolean;
+  /** Metadata for the currently selected song */
   currentSongMetadata: SongMetadata | undefined;
+  /** If a load is in progress */
+  isLoading: boolean;
+  hasRun: boolean;
 }
 
 const initialState: DanceState = {
@@ -42,6 +47,8 @@ const initialState: DanceState = {
   aiModalOpenedFromFlyout: false,
   isRunning: false,
   currentSongMetadata: undefined,
+  isLoading: false,
+  hasRun: false,
 };
 
 // THUNKS
@@ -72,6 +79,8 @@ export const initSongs = createAsyncThunk(
       onSongSelected,
       onSongUnavailable,
     } = payload;
+
+    await new Promise(resolve => setTimeout(resolve, 3000));
 
     // Check for a user-specified manifest file.
     const userManifest = queryParams('manifest') as string;
@@ -132,6 +141,7 @@ export const setSong = createAsyncThunk(
     },
     {dispatch, getState}
   ) => {
+    await new Promise(resolve => setTimeout(resolve, 3000));
     const {songId, onAuthError, onSongSelected} = payload;
     const state = getState() as {dance: DanceState};
     const {selectedSong: lastSongId, songData} = state.dance;
@@ -207,6 +217,36 @@ const danceSlice = createSlice({
       state.currentAiModalBlockId = undefined;
       state.aiModalOpenedFromFlyout = false;
     },
+    setIsRunning: (state, action: PayloadAction<boolean>) => {
+      state.isRunning = action.payload;
+    },
+    setHasRun: (state, action: PayloadAction<boolean>) => {
+      state.hasRun = action.payload;
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(initSongs.pending, state => {
+      state.isLoading = true;
+    });
+    builder.addCase(initSongs.fulfilled, state => {
+      state.isLoading = false;
+    });
+    builder.addCase(initSongs.rejected, state => {
+      state.isLoading = false;
+      // TODO: Handle error. Should we bubble this up to Lab2 and show the
+      // error modal? Or should we handle internally and retry?
+    });
+    builder.addCase(setSong.pending, state => {
+      state.isLoading = true;
+    });
+    builder.addCase(setSong.fulfilled, state => {
+      state.isLoading = false;
+    });
+    builder.addCase(setSong.rejected, state => {
+      state.isLoading = false;
+      // TODO: Handle error. Should we bubble this up to Lab2 and show the
+      // error modal? Or should we handle internally and retry?
+    });
   },
 });
 
@@ -218,5 +258,7 @@ export const {
   setAiOutput,
   openAiModal,
   closeAiModal,
+  setIsRunning,
+  setHasRun,
 } = danceSlice.actions;
 export const reducers = {dance: danceSlice.reducer};

--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -57,7 +57,7 @@ export default class ProgramExecutor {
       nativeAPI ||
       new DanceParty({
         onPuzzleComplete,
-        playSound: this.playSong,
+        playSound: this.playSong.bind(this),
         recordReplayLog,
         showMeasureLabel: !isReadOnlyWorkspace,
         onHandleEvents: (currentFrameEvents: object[]) =>
@@ -81,7 +81,7 @@ export default class ProgramExecutor {
     // TODO: Dance.js checks for unwanted top blocks and duplicate variables in for loops
     // before executing. We should do something similar here.
 
-    this.hooks = await this.compileAllCode(code);
+    this.hooks = await this.compileAllCode(code || this.getCode());
     if (!this.hooks.runUserSetup || !this.hooks.getCueList) {
       this.reportMissingHooks('runUserSetup', 'getCueList');
       return;
@@ -109,7 +109,10 @@ export default class ProgramExecutor {
    */
   async staticPreview(code: string) {
     this.reset();
-    this.hooks = await this.preloadSpritesAndCompileCode(code, 'runUserSetup');
+    this.hooks = await this.preloadSpritesAndCompileCode(
+      code || this.getCode(),
+      'runUserSetup'
+    );
     if (!this.hooks.runUserSetup) {
       this.reportMissingHooks('runUserSetup');
       return;
@@ -304,5 +307,10 @@ export default class ProgramExecutor {
     this.metricsReporter.logWarning(
       `Missing required hooks in compiled code: ${hooks.join(', ')}`
     );
+  }
+
+  // Temporary test code. TODO: Replace with code from Blockly workspace.
+  private getCode(): string {
+    return 'whenSetup(function () {\n  setBackgroundEffectWithPalette("kaleidoscope", "electronic");\n  setForegroundEffectExtended("raining_tacos");\n  makeNewDanceSpriteGroup(12, "ALIEN", "circle");\n  makeAnonymousDanceSprite("CAT", {x: 200, y: 200});\n});\n\natTimestamp(4, "measures", function () {\n  setBackgroundEffectWithPalette("disco_ball", "neon");\n  setForegroundEffectExtended("color_lights");\n  changeMoveEachLR(sprites, MOVES.Drop, -1);\n});\n';
   }
 }

--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -57,7 +57,8 @@ export default class ProgramExecutor {
       nativeAPI ||
       new DanceParty({
         onPuzzleComplete,
-        playSound: this.playSong.bind(this),
+        playSound: (...args: Parameters<typeof this.playSong>) =>
+          this.playSong(...args),
         recordReplayLog,
         showMeasureLabel: !isReadOnlyWorkspace,
         onHandleEvents: (currentFrameEvents: object[]) =>

--- a/apps/src/dance/lab2/locale.ts
+++ b/apps/src/dance/lab2/locale.ts
@@ -1,0 +1,13 @@
+/**
+ * A TypeScript wrapper for the Dance locale object which casts
+ * it to the {@link Locale} type.
+ */
+import {Locale} from '@cdo/apps/types/locale';
+
+import * as danceMsg from '../locale';
+
+const typedDanceMsg = danceMsg as Locale<
+  typeof import('@cdo/i18n/dance/en_us.json')
+>;
+
+export default typedDanceMsg;

--- a/apps/src/dance/lab2/views/DanceControls.tsx
+++ b/apps/src/dance/lab2/views/DanceControls.tsx
@@ -1,0 +1,41 @@
+import {Button} from '@code-dot-org/component-library/button';
+import React from 'react';
+
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import moduleStyles from './dance-view.module.scss';
+
+interface DanceControlsProps {
+  onRun: () => void;
+  onReset: () => void;
+}
+
+/**
+ * Control buttons for Lab2 Dance Party. Manages flags related to
+ * running and loading the program.
+ */
+const DanceControls: React.FunctionComponent<DanceControlsProps> = ({
+  onRun,
+  onReset,
+}) => {
+  const isRunning = useAppSelector(state => state.dance.isRunning);
+  const disabled = useAppSelector(
+    state => state.dance.isLoading || state.dance.runIsStarting
+  );
+
+  const props = isRunning
+    ? {
+        text: 'Reset',
+        onClick: onReset,
+        iconLeft: {iconName: 'rotate-right'},
+      }
+    : {text: 'Run', onClick: onRun, iconLeft: {iconName: 'play'}};
+
+  return (
+    <div className={moduleStyles.controlsContainer}>
+      <Button {...props} disabled={disabled} />
+    </div>
+  );
+};
+
+export default DanceControls;

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,9 +1,12 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
+import {saveReplayLog} from '@cdo/apps/code-studio/components/shareDialogRedux';
 import SongSelector from '@cdo/apps/dance/SongSelector';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {getIsShareView} from '@cdo/apps/lab2/projects/utils';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LabProps} from '@cdo/apps/lab2/types';
-import InstructionsV2 from '@cdo/apps/lab2/views/components/Instructions/InstructionsV2';
+import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {registerReducers} from '@cdo/apps/redux';
 import AgeDialog from '@cdo/apps/templates/AgeDialog';
@@ -11,9 +14,19 @@ import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {installCommonBlocks, installDanceBlocks} from '../../blockly/setup';
-import {initSongs, reducers, setSong} from '../../danceRedux';
+import {
+  initSongs,
+  reducers,
+  setHasRun,
+  setIsRunning,
+  setRunIsStarting,
+  setSong,
+} from '../../danceRedux';
 import {getFilterStatus} from '../../songs';
 import {DanceLevelProperties, DanceProjectSources} from '../../types';
+import ProgramExecutor from '../ProgramExecutor';
+
+import DanceControls from './DanceControls';
 
 import moduleStyles from './dance-view.module.scss';
 
@@ -32,12 +45,70 @@ const DanceView: React.FunctionComponent<
   const dispatch = useAppDispatch();
 
   const isRunning = useAppSelector(state => state.dance.isRunning);
+  const userType = useAppSelector(state => state.currentUser.userType);
+  const under13 = useAppSelector(state => state.currentUser.under13);
+  const selectedSong = useAppSelector(state => state.dance.selectedSong);
+  const songData = useAppSelector(state => state.dance.songData);
+  const readonlyWorkspace = useAppSelector(isReadOnlyWorkspace);
+  const currentSongMetadata = useAppSelector(
+    state => state.dance.currentSongMetadata
+  );
+  const hasRun = useAppSelector(state => state.dance.hasRun);
+
+  const programExecutor = useRef<ProgramExecutor | null>(null);
+
+  const [filterOn, setFilterOn] = useState<boolean>(
+    getFilterStatus(userType, under13)
+  );
 
   const onAuthError = (songId: string) => {
+    // TODO: Show page error if necessary
     Lab2Registry.getInstance().getMetricsReporter().logWarning({
       message: 'Error loading song',
       songId,
     });
+  };
+
+  const turnOffFilter = useCallback(() => setFilterOn(false), []);
+
+  const onSetSong = useCallback(
+    (songId: string) => {
+      dispatch(setSong({songId, onAuthError}));
+    },
+    [dispatch]
+  );
+
+  const runProgram = useCallback(async () => {
+    if (!programExecutor.current || !currentSongMetadata) {
+      return;
+    }
+
+    // Set the runIsStartingFlag to true while the run function is executing,
+    // and set the isRunning flag to true once the run actually starts.
+    dispatch(setRunIsStarting(true));
+    await programExecutor.current.execute('', currentSongMetadata);
+    dispatch(setRunIsStarting(false));
+    dispatch(setIsRunning(true));
+    dispatch(setHasRun(true));
+  }, [programExecutor, currentSongMetadata, dispatch]);
+
+  const resetProgram = useCallback(() => {
+    programExecutor.current?.reset();
+    dispatch(setIsRunning(false));
+  }, [programExecutor, dispatch]);
+
+  const onPuzzleComplete = useCallback(
+    (result: boolean, message: string) => {
+      resetProgram();
+      // TODO: Handle puzzle complete.
+      console.log(`onPuzzleComplete! pass?: ${result} message: ${message}`);
+    },
+    [resetProgram]
+  );
+
+  const onEventsChanged = () => {
+    // TODO: Save project thumbnail when events change.
+    console.log('onEventsChanged');
   };
 
   useEffect(() => {
@@ -47,6 +118,11 @@ const DanceView: React.FunctionComponent<
   useEffect(() => {
     installDanceBlocks(levelProperties.sharedBlocks);
   }, [levelProperties.sharedBlocks]);
+
+  // Reset hasRun flag when level changes
+  useEffect(() => {
+    dispatch(setHasRun(false));
+  }, [levelProperties.id, dispatch]);
 
   // Initialize song manifest and load initial song when level loads.
   useEffect(() => {
@@ -64,28 +140,67 @@ const DanceView: React.FunctionComponent<
     );
   }, [levelProperties, initialSources, dispatch]);
 
-  const userType = useAppSelector(state => state.currentUser.userType);
-  const under13 = useAppSelector(state => state.currentUser.under13);
-  const [filterOn, setFilterOn] = useState<boolean>(
-    getFilterStatus(userType, under13)
-  );
-  const turnOffFilter = useCallback(() => setFilterOn(false), []);
+  useEffect(() => {
+    const {isProjectLevel, freePlay, customHelperLibrary, validationCode} =
+      levelProperties;
+    // record a replay log (and generate a video) for both project levels and any
+    // course levels that have sharing enabled
+    const recordReplayLog = isProjectLevel || freePlay || false;
+    programExecutor.current = new ProgramExecutor(
+      DANCE_VISUALIZATION_ID,
+      onPuzzleComplete,
+      readonlyWorkspace,
+      recordReplayLog,
+      Lab2Registry.getInstance().getMetricsReporter(),
+      customHelperLibrary,
+      validationCode,
+      onEventsChanged
+    );
 
-  const selectedSong = useAppSelector(state => state.dance.selectedSong);
-  const songData = useAppSelector(state => state.dance.songData);
-  const onSetSong = useCallback(
-    (songId: string) => {
-      dispatch(setSong({songId, onAuthError}));
-    },
-    [dispatch]
-  );
+    if (recordReplayLog) {
+      dispatch(saveReplayLog(programExecutor.current.getReplayLog()));
+    }
 
-  // TODO: Don't show AgeDialog if in share mode. Share view is currently
-  // not supported for Lab2.
+    return () => {
+      programExecutor.current?.destroy();
+    };
+  }, [
+    levelProperties,
+    dispatch,
+    programExecutor,
+    onPuzzleComplete,
+    readonlyWorkspace,
+  ]);
+
   return (
     <div id="dance-lab" className={moduleStyles.danceLab}>
-      <AgeDialog turnOffFilter={turnOffFilter} />
-      <div className={moduleStyles.visualizationArea}>
+      {!getIsShareView() && <AgeDialog turnOffFilter={turnOffFilter} />}
+      <ResourcePanel
+        isRunning={isRunning}
+        hasRun={hasRun}
+        // Always passing true for now; update when Blockly workspace is set up.
+        hasEdited={true}
+        levelProperties={levelProperties}
+        headerClassName={moduleStyles.panelHeader}
+        className={moduleStyles.instructionsArea}
+      />
+      <div className={moduleStyles.divider} />
+      <PanelContainer
+        id="dance-workspace-panel"
+        headerContent={commonI18n.workspaceHeaderShort()}
+        className={moduleStyles.workspaceArea}
+        headerClassName={moduleStyles.panelHeader}
+      >
+        <div id={BLOCKLY_DIV_ID} />
+      </PanelContainer>
+
+      <div className={moduleStyles.divider} />
+      <PanelContainer
+        id="visualization"
+        headerContent="Dance Party!"
+        headerClassName={moduleStyles.panelHeader}
+        className={moduleStyles.visualizationArea}
+      >
         <div className={moduleStyles.visualizationColumn}>
           <SongSelector
             enableSongSelection={!isRunning}
@@ -99,31 +214,9 @@ const DanceView: React.FunctionComponent<
             id={DANCE_VISUALIZATION_ID}
             className={moduleStyles.visualization}
           />
+          <DanceControls onRun={runProgram} onReset={resetProgram} />
         </div>
-      </div>
-      <div className={moduleStyles.workArea}>
-        <PanelContainer
-          id="dance-instructions-panel"
-          headerContent={commonI18n.instructions()}
-          className={moduleStyles.instructionsArea}
-        >
-          <InstructionsV2
-            layout="horizontal"
-            isRunning={isRunning}
-            // Always passing true for now; update when resuming work on Lab2 Dance.
-            hasRun={true}
-            hasEdited={true}
-            levelProperties={levelProperties}
-          />
-        </PanelContainer>
-        <PanelContainer
-          id="dance-workspace-panel"
-          headerContent={commonI18n.workspaceHeaderShort()}
-          className={moduleStyles.workspaceArea}
-        >
-          <div id={BLOCKLY_DIV_ID} />
-        </PanelContainer>
-      </div>
+      </PanelContainer>
     </div>
   );
 };

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {saveReplayLog} from '@cdo/apps/code-studio/components/shareDialogRedux';
@@ -54,6 +55,7 @@ const DanceView: React.FunctionComponent<
     state => state.dance.currentSongMetadata
   );
   const hasRun = useAppSelector(state => state.dance.hasRun);
+  const isLoading = useAppSelector(state => state.dance.isLoading);
 
   const programExecutor = useRef<ProgramExecutor | null>(null);
 
@@ -186,16 +188,6 @@ const DanceView: React.FunctionComponent<
       />
       <div className={moduleStyles.divider} />
       <PanelContainer
-        id="dance-workspace-panel"
-        headerContent={commonI18n.workspaceHeaderShort()}
-        className={moduleStyles.workspaceArea}
-        headerClassName={moduleStyles.panelHeader}
-      >
-        <div id={BLOCKLY_DIV_ID} />
-      </PanelContainer>
-
-      <div className={moduleStyles.divider} />
-      <PanelContainer
         id="visualization"
         headerContent="Dance Party!"
         headerClassName={moduleStyles.panelHeader}
@@ -213,9 +205,31 @@ const DanceView: React.FunctionComponent<
           <div
             id={DANCE_VISUALIZATION_ID}
             className={moduleStyles.visualization}
-          />
+          >
+            <div
+              className={classNames(
+                moduleStyles.loading,
+                isLoading && moduleStyles.loadingShow
+              )}
+            >
+              <img
+                src="//curriculum.code.org/images/DancePartyLoading.gif"
+                className={moduleStyles.loadingGif}
+                alt={'' /** TODO: Sort out Dance locale */}
+              />
+            </div>
+          </div>
           <DanceControls onRun={runProgram} onReset={resetProgram} />
         </div>
+      </PanelContainer>
+      <div className={moduleStyles.divider} />
+      <PanelContainer
+        id="dance-workspace-panel"
+        headerContent={commonI18n.workspaceHeaderShort()}
+        className={moduleStyles.workspaceArea}
+        headerClassName={moduleStyles.panelHeader}
+      >
+        <div id={BLOCKLY_DIV_ID} />
       </PanelContainer>
     </div>
   );

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../danceRedux';
 import {getFilterStatus} from '../../songs';
 import {DanceLevelProperties, DanceProjectSources} from '../../types';
+import danceI18n from '../locale';
 import ProgramExecutor from '../ProgramExecutor';
 
 import DanceControls from './DanceControls';
@@ -215,7 +216,7 @@ const DanceView: React.FunctionComponent<
               <img
                 src="//curriculum.code.org/images/DancePartyLoading.gif"
                 className={moduleStyles.loadingGif}
-                alt={'' /** TODO: Sort out Dance locale */}
+                alt={danceI18n.dancePartyLoading()}
               />
             </div>
           </div>

--- a/apps/src/dance/lab2/views/constants.scss
+++ b/apps/src/dance/lab2/views/constants.scss
@@ -1,3 +1,0 @@
-// TODO: Should this move up to Lab2 components?
-
-$visualization-size: 400px;

--- a/apps/src/dance/lab2/views/dance-view.module.scss
+++ b/apps/src/dance/lab2/views/dance-view.module.scss
@@ -14,6 +14,7 @@
   width: 400px;
   height: 400px;
   background-color: var(--background-neutral-secondary);
+  position: relative;
 }
 
 .workArea {
@@ -53,5 +54,26 @@
 .verticalFlex {
   display: flex;
   flex-direction: column;
-  flex:0;
+  flex: 0;
+}
+
+.loading {
+  position: absolute;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  height: 100%;
+  width: 100%;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s ease-in;
+
+  &Show {
+    opacity: 1;
+  }
+
+  .loadingGif {
+    width: 100px;
+    height: 100px;
+  }
 }

--- a/apps/src/dance/lab2/views/dance-view.module.scss
+++ b/apps/src/dance/lab2/views/dance-view.module.scss
@@ -1,17 +1,8 @@
-@import 'color.scss';
-@import './constants.scss';
-
 .danceLab {
   height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: row;
-  gap: 2px;
-}
-
-.visualizationArea {
-  flex: 0;
-  height: 100%;
-  background-color: $neutral_dark10;
 }
 
 .visualizationColumn {
@@ -20,9 +11,9 @@
 
 .visualization {
   // TODO: support resizing
-  width: $visualization-size;
-  height: $visualization-size;
-  background-color: $neutral_white;
+  width: 400px;
+  height: 400px;
+  background-color: var(--background-neutral-secondary);
 }
 
 .workArea {
@@ -33,8 +24,34 @@
 
 .instructionsArea {
   flex: 0;
+  min-width: 25%;
+}
+
+.visualizationArea {
+  flex: 0;
+  background-color: var(--background-neutral-primary);
 }
 
 .workspaceArea {
   flex: 1;
+}
+
+.panelHeader {
+  border-bottom: 1px solid var(--borders-neutral-primary);
+}
+
+.divider {
+  width: 1px;
+  height: 100%;
+  background-color: var(--background-neutral-quaternary);
+}
+
+.controlsContainer {
+  margin: 5px 0;
+}
+
+.verticalFlex {
+  display: flex;
+  flex-direction: column;
+  flex:0;
 }

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -223,6 +223,8 @@ export interface LevelProperties {
   type?: string;
   starterAssets?: {[key: string]: string};
   showRubric?: boolean;
+  customHelperLibrary?: string;
+  validationCode?: string;
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/dashboard/app/views/levels/_lab2.html.haml
+++ b/dashboard/app/views/levels/_lab2.html.haml
@@ -7,6 +7,7 @@
   %script{src: webpack_asset_path("js/#{js_locale}/codebridge_locale.js")}
   %script{src: webpack_asset_path("js/#{js_locale}/lab2_locale.js")}
   %script{src: webpack_asset_path("js/#{js_locale}/pythonlab_locale.js")}
+  %script{src: webpack_asset_path("js/#{js_locale}/dance_locale.js")}
   %script{src: webpack_asset_path('js/googleblockly.js')}
   -# To use css linting in Web Lab 2, uncomment this line. This is commented out because this is a prototype
   -# feature and we aren't ready to have it imported for every lab2 lab yet.

--- a/dashboard/config/levels/custom/dance/Dance Lab2 Showcase.level
+++ b/dashboard/config/levels/custom/dance/Dance Lab2 Showcase.level
@@ -1,7 +1,8 @@
 <Dancelab>
   <config><![CDATA[{
+  "published": true,
   "game_id": 63,
-  "created_at": "2024-05-08T22:32:24.000Z",
+  "created_at": "2025-06-27T16:11:06.000Z",
   "level_num": "custom",
   "user_id": 182,
   "properties": {
@@ -34,18 +35,22 @@
     "pause_animations_by_default": "false",
     "hide_custom_blocks": "true",
     "use_default_sprites": "false",
-    "validation_code": "//after 1 measure, make sure there is a sprite. if not, fail immediately\r\nif (nativeAPI.getTime(\"measures\") > 1) {\r\n  if (sprites.length === 0) {\r\n    nativeAPI.fail(\"danceFeedbackNeedNewDancer\");\r\n  }\r\n}\r\n\r\nif (nativeAPI.getTime(\"measures\") > 2) {\r\n  nativeAPI.pass();\r\n}",
+    "validation_code": "//after 1 measure, make sure there is a sprite. if not, fail immediately\r\nif (nativeAPI.getTime(\"measures\") > 1) {\r\n  if (sprites.length === 0) {\r\n    nativeAPI.fail(\"danceFeedbackNeedNewDancer\");\r\n  }\r\n}\r\n\r\nif (nativeAPI.getTime(\"measures\") > 17) {\r\n  nativeAPI.pass();\r\n}",
     "default_song": "introtoshamstep_47SOUL",
     "long_instructions": "Let's get this moose dancing! Click the `\"dancer1\" do \"Floss\" forever` block onto the \"at 4 measures\" block to make him start flossing at the second measure.",
     "uses_lab2": true,
     "encrypted": "false",
     "validation_enabled": "false",
     "hide_pause_button": "false",
-    "preload_asset_list": null
+    "preload_asset_list": null,
+    "encrypted_examples": [
+
+    ]
   },
-  "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2024-05-08T15:32:24.484-07:00\",\"changed\":[\"cloned from \\\"Dance Lab2 Level 1\\\"\"],\"cloned_from\":\"Dance Lab2 Level 1\"}]"
+  "audit_log": "[{\"changed_at\":\"2024-05-08T15:32:24.484-07:00\",\"changed\":[\"cloned from \\\"Dance Lab2 Level 1\\\"\"],\"cloned_from\":\"Dance Lab2 Level 1\"},{\"changed_at\":\"2025-08-18 22:38:46 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"validation_code\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-18 22:43:16 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"validation_code\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
+  "level_concept_difficulty": {
+  }
 }]]></config>
   <blocks>
     <start_blocks>


### PR DESCRIPTION
This enables code execution and playback on Lab2 Dance. There's a fair bit of finesse, cleanup, and follow-up work, but other than that, this just leaves setting the blockly workspace as the next big chunk of work for finishing porting dance party to lab2.

<img width="1512" height="826" alt="Screenshot 2025-08-18 at 4 13 07 PM" src="https://github.com/user-attachments/assets/6c15a33f-0c69-4a86-ad5f-77ae72da1a58" />

## Testing story

- Tested on Dance allthethings lab2 level


## Follow-up work

- Blockly workspace
- Better error handling/UI
- Handle puzzle complete/progress reporting
- Resizing
- UI and layout
- Theming
- Check if we still need:
  - Replay log (for video export which is currently unsupported and broken)
  - Validation code (as opposed to newer lab2 validation system)