### PR TITLE
Modify redux for manage students page

### DIFF
--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -485,6 +485,7 @@ export default function manageStudents(state = initialState, action) {
             ...blankAddRow,
             loginType: action.loginType,
           },
+          ...state.studentData,
         },
         editingData: {
           [addRowId]: {
@@ -494,11 +495,20 @@ export default function manageStudents(state = initialState, action) {
         },
       };
     }
-    return {
+
+    let reduxState = {
       ...state,
       loginType: action.loginType,
       ...addRowInitialization,
     };
+
+    if (reduxState.studentData) {
+      Object.keys(reduxState.studentData).forEach(studentId => {
+        reduxState.studentData[studentId].loginType = action.loginType;
+      });
+    }
+    console.log(state, reduxState);
+    return reduxState;
   }
   if (action.type === SET_STUDENTS) {
     let studentData = {

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -507,7 +507,6 @@ export default function manageStudents(state = initialState, action) {
         reduxState.studentData[studentId].loginType = action.loginType;
       });
     }
-    console.log(state, reduxState);
     return reduxState;
   }
   if (action.type === SET_STUDENTS) {

--- a/apps/src/templates/teacherNavigation/PageHeader.tsx
+++ b/apps/src/templates/teacherNavigation/PageHeader.tsx
@@ -33,7 +33,8 @@ const skeletonSectionName = (
   </Typography>
 );
 
-const PageHeader: React.FC = () => {
+// const PageHeader: React.FC = () => {
+const PageHeader: React.FC<{urlSectionId: string}> = ({urlSectionId}) => {
   const isLoadingSectionData = useAppSelector(
     state => state.teacherSections.isLoadingSectionData
   );
@@ -49,9 +50,11 @@ const PageHeader: React.FC = () => {
 
   const dispatch = useAppDispatch();
   useEffect(() => {
-    if (selectedSection?.id)
-      dispatch(loadSectionStudentData(selectedSection.id));
-  }, [dispatch, selectedSection?.id]);
+    if (urlSectionId) {
+      dispatch(loadSectionStudentData(urlSectionId));
+    }
+  }, [dispatch, urlSectionId]);
+
   const studentData = useAppSelector(
     state => state.manageStudents?.studentData
   );

--- a/apps/src/templates/teacherNavigation/PageHeader.tsx
+++ b/apps/src/templates/teacherNavigation/PageHeader.tsx
@@ -33,7 +33,6 @@ const skeletonSectionName = (
   </Typography>
 );
 
-// const PageHeader: React.FC = () => {
 const PageHeader: React.FC<{urlSectionId: string}> = ({urlSectionId}) => {
   const isLoadingSectionData = useAppSelector(
     state => state.teacherSections.isLoadingSectionData

--- a/apps/src/templates/teacherNavigation/PageLayout.tsx
+++ b/apps/src/templates/teacherNavigation/PageLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Outlet} from 'react-router-dom';
+import {Outlet, useParams} from 'react-router-dom';
 
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -11,10 +11,11 @@ import styles from './teacher-navigation.module.scss';
 
 const PageLayout: React.FC = () => {
   const selectedSection = useAppSelector(selectedSectionSelector);
+  const urlSectionId = useParams().sectionId || '';
 
   return (
     <div className={styles.pageWithHeader}>
-      <PageHeader />
+      <PageHeader urlSectionId={urlSectionId} />
       {!!selectedSection && <Outlet />}
     </div>
   );

--- a/apps/src/templates/teacherNavigation/PageLayout.tsx
+++ b/apps/src/templates/teacherNavigation/PageLayout.tsx
@@ -11,7 +11,7 @@ import styles from './teacher-navigation.module.scss';
 
 const PageLayout: React.FC = () => {
   const selectedSection = useAppSelector(selectedSectionSelector);
-  const urlSectionId = useParams().sectionId || '';
+  const urlSectionId = useParams().sectionId || selectedSection?.id;
 
   return (
     <div className={styles.pageWithHeader}>

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -341,8 +341,10 @@ describe('ManageStudentsTable', () => {
     });
 
     it('renders correctly if loginType is picture', () => {
+      const store = getStore();
+      store.dispatch(setLoginType(SectionLoginType.picture));
       const wrapper = mount(
-        <Provider store={getStore()}>
+        <Provider store={store}>
           <ManageStudentsTable />
         </Provider>
       );


### PR DESCRIPTION
This fixes two things:

1. Sometimes the wrong log-in type would be shown in the `roster` table.  This occured when switching between sections using the dropdown that had different login types.  It would fix itself on refresh.
2. Phantom students would show up in new sections without students.  The phantom students frequently (maybe exclusively) came from "first ever created sections that were archived".   It also only occurred when going to the roster page from the teacher homepage.  It would fix itself on refresh. 

How it was fixed:

- This PR centers around two main fixes 1. get the `sectionId` from the URL and 2. modify the redux to add data rather than replace data.


## Links
- https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-2112
- https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-2115

## Testing story
Tested manually and updated tests
