### PR TITLE
Fix bug where teacher could never accept latest terms on new dashboard

### DIFF
--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -23,6 +23,9 @@
 - if current_user
   - if current_user.admin
     = render partial: 'home/admin'
+  - if current_user.teacher? && !current_user.accepted_latest_terms?
+    - current_user.update_user_tos_version_accept()
+    = render partial: 'layouts/implicit_new_user_terms_interstitial'
   - if Policies::Ai.ai_differentiation_enabled?(current_user)
     %div#ai-differentiation-fab-mount-point
 


### PR DESCRIPTION
Fixes bug reported in [zendesk](https://codeorg.zendesk.com/agent/tickets/549537).

We did not port over the accept terms interstitial from the v1 to the new homepage.

This PR simply adds the original terms dialog to the new homepage. We may want to replace this in the future.
After - note how the new homepage is in the background:
<img width="1181" height="441" alt="image" src="https://github.com/user-attachments/assets/c9256307-1af4-429a-907e-9999ecf96ab7" />

## Links
https://codeorg.zendesk.com/agent/tickets/549537
