### PR TITLE
Add check for csa-alt in assigned_csa?

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -191,6 +191,7 @@ class Section < ApplicationRecord
   ADD_STUDENT_RESTRICTED = 'restricted'.freeze
 
   CSA = 'csa'.freeze
+  CSA_ALT = 'csa-alt'.freeze
   CSA_PILOT_FACILITATOR = 'csa-pilot-facilitator'.freeze
 
   # A section can have five co-teachers, plus the owner, for a total of 6
@@ -689,7 +690,7 @@ class Section < ApplicationRecord
   # A section can be assigned a course (aka unit_group) without being assigned a script,
   # so we check both here.
   def assigned_csa?
-    script&.csa? || [CSA, CSA_PILOT_FACILITATOR].include?(unit_group&.family_name)
+    script&.csa? || [CSA, CSA_ALT, CSA_PILOT_FACILITATOR].include?(unit_group&.family_name)
   end
 
   def assigned_ai_chat?


### PR DESCRIPTION
There's a new family name for csa this year, `csa-alt`. If a section doesn't have a unit assigned, we fall back to checking family name to see if the user can access Java Lab. This adds a check for `csa-alt` in that method. We received a couple of Zendesk tickets where users couldn't access Java Lab for this reason.


## Links

- [Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1755614388324229)

## Testing story
Tested locally; before this change a user assigned to csa-alt but not assigned a unit got a message about not being assigned to a CSA section. Now they can run Java programs.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
