### PR TITLE
Fix bug with progress header showing (legacy) incorrectly 

### DIFF
--- a/apps/src/templates/teacherNavigation/PageHeader.tsx
+++ b/apps/src/templates/teacherNavigation/PageHeader.tsx
@@ -70,7 +70,7 @@ const PageHeader: React.FC = () => {
         path => matchPath(path.absoluteUrl, location.pathname) !== null
       )?.label || 'unknown path';
 
-    if (result === 'Progress' && !showProgressV2) {
+    if (result === 'Progress' && showProgressV2 === 'legacy') {
       return i18n.progressLegacy();
     }
     return result;


### PR DESCRIPTION
Progress (legacy) is supposed to show up when the user is on the v1 progress page.

Currently it shows up when a user has not selected the v1 or v2 page before.
