### PR TITLE
Revert "Revert "Making mult choice levels keyboard navigable""

### DIFF
--- a/apps/src/code-studio/levels/multi.js
+++ b/apps/src/code-studio/levels/multi.js
@@ -218,7 +218,9 @@ Multi.prototype.lockAnswers = function () {
   if (this.allowMultipleAttempts) {
     return;
   }
-  $('#' + this.id + ' .answerbutton').addClass('lock-answers');
+  $('#' + this.id + ' .answerbutton')
+    .addClass('lock-answers')
+    .attr('tabindex', '-1');
   $('#reset-predict-progress-button')?.prop('disabled', false);
 };
 

--- a/dashboard/app/views/levels/_dialog.html.haml
+++ b/dashboard/app/views/levels/_dialog.html.haml
@@ -14,7 +14,7 @@
       %a.btn.btn-large.btn-primary.nextPageButton
         =t('next_page')
     - else
-      %a.btn.btn-large.btn-primary.next-lesson.submitButton{style: !!local_assigns[:show_next_page_link] ? 'display:none' : nil}
+      %button.btn.btn-large.btn-primary.next-lesson.submitButton{style: !!local_assigns[:show_next_page_link] ? 'display:none' : nil}
         =t('submit')
       -# This button is unhidden in _dialog.js if the user has already submitted
       - if @level.properties['submittable'] && !Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)

--- a/dashboard/app/views/levels/_dialog.html.haml
+++ b/dashboard/app/views/levels/_dialog.html.haml
@@ -14,7 +14,7 @@
       %a.btn.btn-large.btn-primary.nextPageButton
         =t('next_page')
     - else
-      %button.btn.btn-large.btn-primary.next-lesson.submitButton{style: !!local_assigns[:show_next_page_link] ? 'display:none' : nil}
+      %button.btn.btn-large.btn-primary.next-lesson.submitButton{style: "#{!!local_assigns[:show_next_page_link] ? 'display:none;' : ''} margin-left: 0;"}
         =t('submit')
       -# This button is unhidden in _dialog.js if the user has already submitted
       - if @level.properties['submittable'] && !Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)

--- a/dashboard/app/views/levels/_dialog.html.haml
+++ b/dashboard/app/views/levels/_dialog.html.haml
@@ -14,7 +14,7 @@
       %a.btn.btn-large.btn-primary.nextPageButton
         =t('next_page')
     - else
-      %button.btn.btn-large.btn-primary.next-lesson.submitButton{style: "#{!!local_assigns[:show_next_page_link] ? 'display:none;' : ''} margin-left: 0;"}
+      %button.btn.btn-large.btn-primary.next-lesson.submitButton{style: "#{!!local_assigns[:show_next_page_link] ? 'display:none;' : ''} margin: 0;"}
         =t('submit')
       -# This button is unhidden in _dialog.js if the user has already submitted
       - if @level.properties['submittable'] && !Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -70,7 +70,7 @@
           -# When LevelGroup-hosted, with students (or teachers doing PD), set all answers false before rendering page.
           - correct = include_multi_answers?(standalone) ? answer['correct'] : false
           - answer_class = "answerbutton " + (use_tight_layout ? "" : "btn")
-          %div{class: answer_class, style: "display: inline-block; height: #{height}", correct: "#{correct}", index: "#{i}"}
+          %button{class: answer_class, style: "display: inline-block; height: #{height}", correct: "#{correct}", index: "#{i}"}
             .item-mark{id: "unchecked_#{i}"}
               .fa{class: unchecked_class}
             .item-mark{id: "checked_#{i}", style: 'display: none;'}

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -70,7 +70,7 @@
           -# When LevelGroup-hosted, with students (or teachers doing PD), set all answers false before rendering page.
           - correct = include_multi_answers?(standalone) ? answer['correct'] : false
           - answer_class = "answerbutton " + (use_tight_layout ? "" : "btn")
-          %button{class: answer_class, style: "display: inline-block; height: #{height}", correct: "#{correct}", index: "#{i}"}
+          %button{class: answer_class, style: "display: inline-block; margin-left: 0", correct: "#{correct}", index: "#{i}"}
             .item-mark{id: "unchecked_#{i}"}
               .fa{class: unchecked_class}
             .item-mark{id: "checked_#{i}", style: 'display: none;'}

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -340,10 +340,10 @@ Given 'I start a self-paced PL course' do
     And I wait until element "a[title='Level 3 Lesson Instructor In Training Levels']" is visible
     Then I click selector "a[title='Level 3 Lesson Instructor In Training Levels']"
     When I am on "http://studio.code.org/courses/alltheselfpacedplthings/units/1/lessons/1/levels/3"
-    Then I wait until element "a:contains(Submit)" is visible
-    When I click selector "a:contains(Submit)"
+    Then I wait until element "button:contains(Submit)" is visible
+    When I click selector "button:contains(Submit)"
     Then I wait until I am on "http://studio.code.org/courses/alltheselfpacedplthings/units/1/lessons/1/levels/4"
-    And I wait until element "a:contains(Submit)" is visible
+    And I wait until element "button:contains(Submit)" is visible
   GHERKIN
 end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67815

Attempting again while explicitly removing the automatic margin left that gets added in with buttons.

That way, the submit button and answer buttons are still aligned on the left. I kept the top margin for the answer buttons (removing meant they all get squished), but also removed the top margin for the submit so the space is maintained between the answer selections and the submit button on the bottom.

These were the eyes failures from the first attempt:

<img width="1372" height="686" alt="Screenshot 2025-08-19 at 1 04 31 PM" src="https://github.com/user-attachments/assets/92418d52-acc1-4df5-94a2-08ee386e6061" />

<img width="1340" height="576" alt="Screenshot 2025-08-19 at 1 07 45 PM" src="https://github.com/user-attachments/assets/722f5491-95da-4fe9-91f8-4bdb78aea129" />

This is all the allthethings levels now (plus extras from the relevant eyes tests above):

<img width="825" height="762" alt="Screenshot 2025-08-19 at 1 02 43 PM" src="https://github.com/user-attachments/assets/870dcbda-e24a-4217-b843-979b2ceec01e" />
<img width="1099" height="534" alt="Screenshot 2025-08-20 at 2 09 07 PM" src="https://github.com/user-attachments/assets/7ed8dfa0-5e37-4eb5-a247-e15a35a34e3d" />
<img width="1114" height="524" alt="Screenshot 2025-08-20 at 2 08 43 PM" src="https://github.com/user-attachments/assets/045f2720-614c-435c-9f6b-d5c29c391b2d" />
<img width="843" height="697" alt="Screenshot 2025-08-20 at 2 08 34 PM" src="https://github.com/user-attachments/assets/a4d8b080-7743-4e9a-abc7-46c265431e0f" />
