### PR TITLE
Export Measures of Learning tables to Redshift

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -90,6 +90,9 @@ cron:
     remove_column: [feedback]
 - dashboard.learning_goal_ai_evaluation_feedbacks:
     remove_column: [other_content]
+- dashboard.skills
+- dashboard.levels_skills
+- dashboard.student_work_evaluation_summaries
 - dashboard.rubrics
 - dashboard.rubric_ai_evaluations
 - dashboard.learning_goals


### PR DESCRIPTION
Edit the replication task to add three tables that are required for the Measures of Learning work. Note that there are 3 tables here, all of which contain only non-PII content. There is no PII in any of these three tables. 

## Links
- [https://codedotorg.atlassian.net/browse/DATAOPS-1410](https://codedotorg.atlassian.net/browse/DATAOPS-1410)
