### PR TITLE
feat(workshops): add survey card empty states

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/WorkshopLayout.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/WorkshopLayout.tsx
@@ -18,6 +18,7 @@ import {FacilitatorSelection} from './components/FacilitatorSelection';
 import {SurveyCategorySelection} from './components/SurveyCategorySelection';
 import {SurveyTypeSelection} from './components/SurveyTypeSelection';
 import {WorkshopTabs} from './components/WorkshopTabs';
+import {NoSurveyResponses} from './surveys/components/NoSurveyResponses';
 import {WorkshopLayoutProps, WorkshopContextValue} from './types';
 
 import styles from './workshop.module.scss';
@@ -88,6 +89,16 @@ export const WorkshopLayout: FC<WorkshopLayoutProps> = ({
     '/surveys/post/facilitators'
   );
 
+  const showNoSurveyResponses = useMemo(() => {
+    if (showPostSurveyCategorySelection) {
+      return !surveysLoading && !surveys?.surveys?.post_workshop;
+    }
+  }, [
+    showPostSurveyCategorySelection,
+    surveys?.surveys?.post_workshop,
+    surveysLoading,
+  ]);
+
   // TODO: https://codedotorg.atlassian.net/browse/ACQ-3438
   const handleDownload = () => {};
 
@@ -135,6 +146,7 @@ export const WorkshopLayout: FC<WorkshopLayoutProps> = ({
         {showFacilitatorSelection && <FacilitatorSelection />}
       </nav>
       <main>
+        {showNoSurveyResponses && <NoSurveyResponses />}
         <Outlet />
       </main>
     </WorkshopContext.Provider>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/EmptyState.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/EmptyState.tsx
@@ -1,0 +1,39 @@
+import Image, {ImageProps} from '@code-dot-org/component-library/image';
+import {
+  BodyThreeText,
+  BodyTwoText,
+  StrongText,
+} from '@code-dot-org/component-library/typography';
+import {Box} from '@mui/material';
+import classNames from 'classnames';
+import React, {FC} from 'react';
+
+import styles from '../../workshop.module.scss';
+
+export interface EmptyStateProps {
+  imageProps: ImageProps;
+  title: string;
+  description: string;
+  large?: boolean;
+}
+
+export const EmptyState: FC<EmptyStateProps> = ({
+  imageProps,
+  title,
+  description,
+  large,
+}) => {
+  return (
+    <Box
+      className={classNames(styles.emptyStateContainer, {
+        [styles.large]: large,
+      })}
+    >
+      <Image className={styles.emptyStateImage} {...imageProps} />
+      <BodyTwoText noMargin>
+        <StrongText>{title}</StrongText>
+      </BodyTwoText>
+      <BodyThreeText noMargin>{description}</BodyThreeText>
+    </Box>
+  );
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/EmptyState.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/EmptyState.tsx
@@ -29,7 +29,9 @@ export const EmptyState: FC<EmptyStateProps> = ({
         [styles.large]: large,
       })}
     >
-      <Image className={styles.emptyStateImage} {...imageProps} />
+      {/* empty state images generally do not convey additional meaning. 
+      using alt="" by default so screen readers will ignore the image */}
+      <Image className={styles.emptyStateImage} alt="" {...imageProps} />
       <BodyTwoText noMargin>
         <StrongText>{title}</StrongText>
       </BodyTwoText>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FollowUpRequestedCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FollowUpRequestedCard.tsx
@@ -1,4 +1,3 @@
-import Tags from '@code-dot-org/component-library/tags';
 import {
   BodyThreeText,
   Heading2,
@@ -8,21 +7,26 @@ import {Card, CardContent, Box, CardHeader} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC} from 'react';
 
-import noResponsesText from '@cdo/static/pd/no-responses-text.png';
+import noResponsesEmail from '@cdo/static/pd/no-responses-email.png';
 
 import {EmptyState} from './EmptyState';
 
 import styles from '../../workshop.module.scss';
 
-interface FreeResponseCardProps {
-  title: string;
-  tagText?: string;
-  items: string[];
+interface FollowUp {
+  name: string;
+  email: string;
 }
 
-export const FreeResponseCard: FC<FreeResponseCardProps> = ({
+interface FollowUpRequestedCardProps {
+  title: string;
+  description: string;
+  items: FollowUp[];
+}
+
+export const FollowUpRequestedCard: FC<FollowUpRequestedCardProps> = ({
   title,
-  tagText,
+  description,
   items,
 }) => {
   return (
@@ -30,40 +34,36 @@ export const FreeResponseCard: FC<FreeResponseCardProps> = ({
       className={classNames(
         styles.card,
         styles.questionCard,
-        styles.freeResponse
+        styles.multiSelect
       )}
     >
       <CardHeader
         className={styles.cardHeader}
         title={
-          <Box className={styles.cardHeaderRow}>
+          <>
             <Heading2 visualAppearance="body-one" noMargin>
               <StrongText>{title}</StrongText>
             </Heading2>
-            {tagText && (
-              <Tags
-                size="s"
-                tagsList={[{label: tagText}]}
-                className={classNames(styles.workshopTag, styles.questionTag)}
-              />
-            )}
-          </Box>
+            <BodyThreeText noMargin className={styles.subHeader}>
+              {description}
+            </BodyThreeText>
+          </>
         }
       />
       <CardContent className={styles.cardContent}>
         {items.length > 0 ? (
-          <Box className={styles.textCardContainer}>
+          <Box className={styles.column}>
             {items.map(item => (
-              <Box key={item} className={styles.textCard}>
-                <BodyThreeText noMargin>{item}</BodyThreeText>
+              <Box key={item.email}>
+                {/* TODO: https://codedotorg.atlassian.net/browse/ACQ-3460 render result rows */}
               </Box>
             ))}
           </Box>
         ) : (
           <EmptyState
-            title="No responses submitted yet."
-            description="Responses will appear here once participants complete the survey."
-            imageProps={{src: noResponsesText}}
+            title="No teachers requested follow-up support."
+            description="All participants feel confident proceeding independently."
+            imageProps={{src: noResponsesEmail}}
           />
         )}
       </CardContent>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/MultiSelectCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/MultiSelectCard.tsx
@@ -7,7 +7,11 @@ import {Card, CardContent, Box, CardHeader} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC, useEffect, useState} from 'react';
 
+import noResponsesBars from '@cdo/static/pd/no-responses-bars.png';
+
 import {MultiSelectBreakdown} from '../../../WorkshopFormTemplate/types';
+
+import {EmptyState} from './EmptyState';
 
 import styles from '../../workshop.module.scss';
 
@@ -50,21 +54,29 @@ export const MultiSelectCard: FC<MultiSelectCardProps> = ({
         }
       />
       <CardContent className={styles.cardContent}>
-        <Box className={styles.column}>
-          {items.map(item => (
-            <Box key={item.label}>
-              <BodyThreeText noMargin>
-                <StrongText>{item.label}</StrongText>
-              </BodyThreeText>
-              <Box className={styles.barRow}>
-                <PercentageBar percentage={item.percentage} />
-                <BodyThreeText noMargin className={styles.barLabel}>{`${
-                  item.count
-                }${barLabel ? ` ${barLabel}` : ''}`}</BodyThreeText>
+        {items.length > 0 ? (
+          <Box className={styles.column}>
+            {items.map(item => (
+              <Box key={item.label}>
+                <BodyThreeText noMargin>
+                  <StrongText>{item.label}</StrongText>
+                </BodyThreeText>
+                <Box className={styles.barRow}>
+                  <PercentageBar percentage={item.percentage} />
+                  <BodyThreeText noMargin className={styles.barLabel}>{`${
+                    item.count
+                  }${barLabel ? ` ${barLabel}` : ''}`}</BodyThreeText>
+                </Box>
               </Box>
-            </Box>
-          ))}
-        </Box>
+            ))}
+          </Box>
+        ) : (
+          <EmptyState
+            title="No data available yet."
+            description="Check back after responses are submitted."
+            imageProps={{src: noResponsesBars}}
+          />
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/NoSurveyResponses.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/NoSurveyResponses.tsx
@@ -1,0 +1,25 @@
+import {Box, Card, CardContent} from '@mui/material';
+import React from 'react';
+
+import noResponsesText from '@cdo/static/pd/no-responses-text.png';
+
+import {EmptyState} from './EmptyState';
+
+import styles from '../../workshop.module.scss';
+
+export const NoSurveyResponses = () => {
+  return (
+    <Box className={styles.surveyResultsContainer}>
+      <Card className={styles.card}>
+        <CardContent className={styles.cardContent}>
+          <EmptyState
+            title="No survey responses submitted yet."
+            description="Results will appear here once participants complete the survey."
+            imageProps={{src: noResponsesText}}
+            large
+          />
+        </CardContent>
+      </Card>
+    </Box>
+  );
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
@@ -1,7 +1,5 @@
-import {Box, Card, CardContent} from '@mui/material';
+import {Box} from '@mui/material';
 import React, {useMemo} from 'react';
-
-import noResponsesText from '@cdo/static/pd/no-responses-text.png';
 
 import {
   isQuestionType,
@@ -9,7 +7,6 @@ import {
   SurveyQuestions,
 } from '../../../../WorkshopFormTemplate/types';
 import {useWorkshopContext} from '../../../WorkshopLayout';
-import {EmptyState} from '../../components/EmptyState';
 import {FollowUpRequestedCard} from '../../components/FollowUpRequestedCard';
 import {FreeResponseCard} from '../../components/FreeResponseCard';
 import {MultiSelectCard} from '../../components/MultiSelectCard';
@@ -75,70 +72,57 @@ export const Implementation = () => {
     return '';
   };
 
+  if (!questions) return null;
+
   return (
     <Box className={styles.surveyResultsContainer}>
-      {!questions ? (
-        <Card className={styles.card}>
-          <CardContent className={styles.cardContent}>
-            <EmptyState
-              title="No survey responses submitted yet."
-              description="Results will appear here once participants complete the survey."
-              imageProps={{src: noResponsesText}}
-              large
+      <Box className={styles.cardRow}>
+        {likertQuestionRow.map(question =>
+          isQuestionType(question, 'likert') ? (
+            <ScoreCard
+              key={question.question_name}
+              title={question.question_short_text ?? question.question_text}
+              description={getDescription(question)}
+              footer={question.question_sub_text}
+              score={question.results.weighted_score}
+              responseCount={question.results.total_responses}
+              minResponseCount={MIN_RESPONSE_COUNT}
             />
-          </CardContent>
-        </Card>
-      ) : (
-        <>
-          <Box className={styles.cardRow}>
-            {likertQuestionRow.map(question =>
-              isQuestionType(question, 'likert') ? (
-                <ScoreCard
-                  key={question.question_name}
-                  title={question.question_short_text ?? question.question_text}
-                  description={getDescription(question)}
-                  footer={question.question_sub_text}
-                  score={question.results.weighted_score}
-                  responseCount={question.results.total_responses}
-                  minResponseCount={MIN_RESPONSE_COUNT}
-                />
-              ) : null
-            )}
-          </Box>
+          ) : null
+        )}
+      </Box>
 
-          <Box className={styles.cardRow}>
-            {isQuestionType(barriersToImplementation, 'multiSelect') && (
-              <MultiSelectCard
-                title={
-                  barriersToImplementation.question_short_text ??
-                  barriersToImplementation.question_text
-                }
-                description={getDescription(barriersToImplementation)}
-                items={barriersItems}
-                barLabel="Teachers"
-              />
-            )}
-            <FollowUpRequestedCard
-              items={[]}
-              title="Follow-up requested"
-              description=""
-            />
-          </Box>
+      <Box className={styles.cardRow}>
+        {isQuestionType(barriersToImplementation, 'multiSelect') && (
+          <MultiSelectCard
+            title={
+              barriersToImplementation.question_short_text ??
+              barriersToImplementation.question_text
+            }
+            description={getDescription(barriersToImplementation)}
+            items={barriersItems}
+            barLabel="Teachers"
+          />
+        )}
+        <FollowUpRequestedCard
+          items={[]}
+          title="Follow-up requested"
+          description=""
+        />
+      </Box>
 
-          <Box className={styles.cardRow}>
-            {isQuestionType(otherQuestionsImplementation, 'text') && (
-              <FreeResponseCard
-                title={
-                  otherQuestionsImplementation.question_short_text ??
-                  otherQuestionsImplementation.question_text
-                }
-                items={otherQuestionsImplementation.results.responses}
-                tagText={`${otherQuestionsImplementation.results.total_responses} Submitted`}
-              />
-            )}
-          </Box>
-        </>
-      )}
+      <Box className={styles.cardRow}>
+        {isQuestionType(otherQuestionsImplementation, 'text') && (
+          <FreeResponseCard
+            title={
+              otherQuestionsImplementation.question_short_text ??
+              otherQuestionsImplementation.question_text
+            }
+            items={otherQuestionsImplementation.results.responses}
+            tagText={`${otherQuestionsImplementation.results.total_responses} Submitted`}
+          />
+        )}
+      </Box>
     </Box>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
@@ -1,5 +1,7 @@
-import {Box} from '@mui/material';
+import {Box, Card, CardContent} from '@mui/material';
 import React, {useMemo} from 'react';
+
+import noResponsesText from '@cdo/static/pd/no-responses-text.png';
 
 import {
   isQuestionType,
@@ -7,6 +9,8 @@ import {
   SurveyQuestions,
 } from '../../../../WorkshopFormTemplate/types';
 import {useWorkshopContext} from '../../../WorkshopLayout';
+import {EmptyState} from '../../components/EmptyState';
+import {FollowUpRequestedCard} from '../../components/FollowUpRequestedCard';
 import {FreeResponseCard} from '../../components/FreeResponseCard';
 import {MultiSelectCard} from '../../components/MultiSelectCard';
 import {ScoreCard} from '../../components/ScoreCard';
@@ -60,60 +64,81 @@ export const Implementation = () => {
       isQuestionType(question, 'multiSelect') &&
       question.question_name === 'barriers_implementation_curriculum'
     ) {
+      if (question.results.total_respondents === 0) {
+        return '';
+      }
       const numWithBarriers =
-        (question.results.total_respondents ?? 0) -
-        (question.results.breakdown?.none?.count ?? 0);
+        question.results.total_respondents -
+        (question.results.breakdown.none?.count ?? 0);
       return `${numWithBarriers} teachers reported at least 1 or more barriers to implementation`;
     }
     return '';
   };
 
-  if (!questions) return null;
-
   return (
     <Box className={styles.surveyResultsContainer}>
-      <Box className={styles.cardRow}>
-        {likertQuestionRow.map(question =>
-          isQuestionType(question, 'likert') ? (
-            <ScoreCard
-              key={question.question_name}
-              title={question.question_short_text ?? question.question_text}
-              description={getDescription(question)}
-              footer={question.question_sub_text}
-              score={question.results.weighted_score}
-              responseCount={question.results.total_responses}
-              minResponseCount={MIN_RESPONSE_COUNT}
+      {!questions ? (
+        <Card className={styles.card}>
+          <CardContent className={styles.cardContent}>
+            <EmptyState
+              title="No survey responses submitted yet."
+              description="Results will appear here once participants complete the survey."
+              imageProps={{src: noResponsesText}}
+              large
             />
-          ) : null
-        )}
-      </Box>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <Box className={styles.cardRow}>
+            {likertQuestionRow.map(question =>
+              isQuestionType(question, 'likert') ? (
+                <ScoreCard
+                  key={question.question_name}
+                  title={question.question_short_text ?? question.question_text}
+                  description={getDescription(question)}
+                  footer={question.question_sub_text}
+                  score={question.results.weighted_score}
+                  responseCount={question.results.total_responses}
+                  minResponseCount={MIN_RESPONSE_COUNT}
+                />
+              ) : null
+            )}
+          </Box>
 
-      <Box className={styles.cardRow}>
-        {isQuestionType(barriersToImplementation, 'multiSelect') && (
-          <MultiSelectCard
-            title={
-              barriersToImplementation.question_short_text ??
-              barriersToImplementation.question_text
-            }
-            description={getDescription(barriersToImplementation)}
-            items={barriersItems}
-            barLabel="Teachers"
-          />
-        )}
-      </Box>
+          <Box className={styles.cardRow}>
+            {isQuestionType(barriersToImplementation, 'multiSelect') && (
+              <MultiSelectCard
+                title={
+                  barriersToImplementation.question_short_text ??
+                  barriersToImplementation.question_text
+                }
+                description={getDescription(barriersToImplementation)}
+                items={barriersItems}
+                barLabel="Teachers"
+              />
+            )}
+            <FollowUpRequestedCard
+              items={[]}
+              title="Follow-up requested"
+              description=""
+            />
+          </Box>
 
-      <Box className={styles.cardRow}>
-        {isQuestionType(otherQuestionsImplementation, 'text') && (
-          <FreeResponseCard
-            title={
-              otherQuestionsImplementation.question_short_text ??
-              otherQuestionsImplementation.question_text
-            }
-            items={otherQuestionsImplementation.results.responses}
-            tagText={`${otherQuestionsImplementation.results.total_responses} Submitted`}
-          />
-        )}
-      </Box>
+          <Box className={styles.cardRow}>
+            {isQuestionType(otherQuestionsImplementation, 'text') && (
+              <FreeResponseCard
+                title={
+                  otherQuestionsImplementation.question_short_text ??
+                  otherQuestionsImplementation.question_text
+                }
+                items={otherQuestionsImplementation.results.responses}
+                tagText={`${otherQuestionsImplementation.results.total_responses} Submitted`}
+              />
+            )}
+          </Box>
+        </>
+      )}
     </Box>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
@@ -85,6 +85,7 @@ div.card {
 
   div.cardContent {
     padding: 0.75rem 1rem 1rem;
+    flex: 1;
   }
 
   .divider {
@@ -466,5 +467,24 @@ div.card {
         grid-template-columns: repeat(3, 1fr);
       }
     }
+  }
+}
+
+.emptyStateContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 0;
+  width: 100%;
+
+  &.large {
+    padding: 5rem 0;
+  }
+
+  .emptyStateImage {
+    width: auto;
+    height: 8.75rem;
+    margin-bottom: 1rem;
   }
 }

--- a/apps/static/pd/no-responses-bars.png
+++ b/apps/static/pd/no-responses-bars.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52693b196b3a49c829b899ed18cb35983b6255d64143d8417ae37c704baadf6f
+size 7619

--- a/apps/static/pd/no-responses-email.png
+++ b/apps/static/pd/no-responses-email.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3a405a3ebac6583263ed690ed76b552df84d37e7b0c0cbe4c7d3273ec70dac6
+size 5593

--- a/apps/static/pd/no-responses-text.png
+++ b/apps/static/pd/no-responses-text.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e5a4d5fb55cbcf8d3321af2d4ea839b488d62df1eb817c4376c6a0a6e03dcf6
+size 5733

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/surveys/components/EmptyStateTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/surveys/components/EmptyStateTest.tsx
@@ -1,0 +1,59 @@
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {EmptyState} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshops/surveys/components/EmptyState';
+
+describe('EmptyState', () => {
+  const defaultProps = {
+    imageProps: {
+      src: 'path/to/image.png',
+      // Note: No alt text here to test the default case.
+    },
+    title: 'No Data Available',
+    description: 'There are no responses to display for this question yet.',
+  };
+
+  const renderComponent = (props = {}) => {
+    return render(<EmptyState {...defaultProps} {...props} />);
+  };
+
+  it('renders the title and description', () => {
+    renderComponent();
+
+    expect(screen.getByText('No Data Available')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'There are no responses to display for this question yet.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  describe('image rendering', () => {
+    it('renders a decorative image with an empty alt attribute by default', () => {
+      renderComponent();
+
+      // Find the image by its role. Since the alt text is empty,
+      // it has no accessible name.
+      const image = screen.getByRole('img');
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute('src', 'path/to/image.png');
+      expect(image).toHaveAttribute('alt', '');
+    });
+
+    it('allows overriding the alt attribute for an informative image', () => {
+      renderComponent({
+        imageProps: {
+          src: 'path/to/image.png',
+          alt: 'An informative description.', // Provide an explicit alt text
+        },
+      });
+
+      // Find the image by its accessible name (the alt text).
+      const image = screen.getByRole('img', {
+        name: 'An informative description.',
+      });
+      expect(image).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a reusable `EmptyState` component for displaying consistent "no data" or "empty" UI states in the workshop survey dashboard. It refactors multiple survey components to use this new component, adds themed images for empty states, and ensures accessibility best practices. The update also introduces a new card for follow-up requests and improves the layout and styling for empty states.

**Key changes:**

### Empty State Component & Usage

- Added a new `EmptyState` component (`EmptyState.tsx`) to standardize the display of empty or no-response states, including support for custom images, titles, descriptions, and accessibility via alt text.
- Refactored `FreeResponseCard`, `MultiSelectCard`, and `FollowUpRequestedCard` components to use the new `EmptyState` for displaying when there are no responses, each with a context-appropriate image and message.
- Introduced a `NoSurveyResponses` component that uses `EmptyState` to show a prominent message when there are no survey responses at all, and integrated it into the main workshop layout.

### Visuals & Styling

- Added new static images (`no-responses-text.png`, `no-responses-bars.png`, `no-responses-email.png`) for use in empty state illustrations. 
- Updated SCSS styles to support the new empty state layouts, including sizing, alignment, and padding for the empty state container and images. 

### Survey Results Enhancements

- Added a `FollowUpRequestedCard` to the post-survey implementation section, currently displaying an empty state when no teachers have requested follow-up. 
- Improved logic in the implementation summary to skip summary text when there are no respondents for a question.

### Testing

- Added a unit test for the `EmptyState` component to verify correct rendering of titles, descriptions, and image accessibility features.<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

<img width="1338" height="1228" alt="Screenshot 2025-08-19 at 2 59 16 PM" src="https://github.com/user-attachments/assets/ca6f1eda-51f5-4019-9e05-f266d3691bea" />

<img width="1492" height="772" alt="Screenshot 2025-08-19 at 2 17 37 PM" src="https://github.com/user-attachments/assets/f9491d30-324e-4b4d-9585-3789bb8e9ca9" />

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
