### PR TITLE
Deflake Weblab Redirects Test

### DIFF
--- a/dashboard/test/integration/redirects_test.rb
+++ b/dashboard/test/integration/redirects_test.rb
@@ -158,8 +158,13 @@ class RedirectsTest < ActionDispatch::IntegrationTest
   end
 
   test 'redirects weblab code studio share link to codeprojects' do
-    get "//projects/weblab/abcdef"
-    assert_redirected_to "https://#{CDO.codeprojects_hostname}/abcdef/"
+    # This route is defined based on the value of `CDO.dashboard_hostname` at
+    # initialization time, so we must undo the stub that test_helper adds at
+    # runtime for this to resolve.
+    CDO.unstub(:override_dashboard)
+
+    get "http://#{CDO.dashboard_hostname}/projects/weblab/abcdef"
+    assert_redirected_to "http://#{CDO.codeprojects_hostname}/abcdef/"
   end
 
   test 'redirects to /courses/ from /s/' do


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67771. The `RedirectsTest` fix in that PR was not quite adequate; with it in place, the test goes from consistently failing to only occasionally failing.

Specifically, the underlying problem with the test is that in [my WIP unified Drone config](https://github.com/code-dot-org/code-dot-org/pull/67635) we set an `override_dashboard` value in `locals.yml` so that UI and unit tests will work consistently. That means that when we define the route this test is exercising, we do so with the overridden value: https://github.com/code-dot-org/code-dot-org/blob/98565c50f6e0c9210fbe542c64821afc893641ec/dashboard/config/routes.rb#L327-L328

Unfortunately, we also stub out overrides in the test helper before running tests (but, importantly, *after* initializing routes): https://github.com/code-dot-org/code-dot-org/blob/98565c50f6e0c9210fbe542c64821afc893641ec/dashboard/test/test_helper.rb#L41-L42

This means that this test when run in isolation will always fail in any environment which is configured with a dashboard overrides. I'm not entirely sure why it occasionally passes when run as part of a complete test suite, but I'd guess that some other test is leaking state changes, and the flakiness is a result of random ordering.

Either way, the fix is to update the test to explicitly use the configuration used at initialization rather than accepting the stub.

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Verified locally that with this fix in place, the test consistently passes when run in isolation in an environment in which it was formerly consistently failing.

Also verified in Drone that with this fix in place, the new unified Drone config consistently passes all unit tests.

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

I believe this is the last prerequisite necessary for us to begin taking advantage of a unified Drone config

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
