### PR TITLE
chore(localization): update lang list

### DIFF
--- a/frontend/apps/marketing/src/components/footer/common/utils.ts
+++ b/frontend/apps/marketing/src/components/footer/common/utils.ts
@@ -1,15 +1,17 @@
 import {usePathname, useRouter} from 'next/navigation';
 
+import {getLocalizeJsLocaleFromSupportedLocale} from '@/config/locale';
+
 export const useFooterLocalization = () => {
   const pathname = usePathname();
   const router = useRouter();
   const handleLanguageChange = (localeCode: string) => {
     const newPathName = pathname.replace(
-      /^\/([a-z]{2}(-[A-Z]{2})?)(?=\/|$)/,
+      /^\/([a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*)(?=\/|$)/,
       `/${localeCode}`,
     );
     router.push(newPathName);
-    Localize.setLanguage(localeCode);
+    Localize.setLanguage(getLocalizeJsLocaleFromSupportedLocale(localeCode));
   };
   return {handleLanguageChange};
 };

--- a/frontend/apps/marketing/src/components/footer/corporateSite/FooterCorporateSite.tsx
+++ b/frontend/apps/marketing/src/components/footer/corporateSite/FooterCorporateSite.tsx
@@ -1,6 +1,6 @@
 'use client';
 import {Brand} from '@/config/brand';
-import {LOCALIZE_JS_CONFIG_MAP} from '@/config/locale';
+import {SUPPORTED_LOCALES_CONFIG} from '@/config/locale';
 
 import {GlobalFooterProps} from '../common/types';
 import {useFooterLocalization} from '../common/utils';
@@ -29,7 +29,7 @@ const FooterCSforAll = ({locale}: GlobalFooterProps) => {
       {...defaultProps}
       onLanguageChange={handleLanguageChange}
       selectedLocaleCode={locale}
-      languages={LOCALIZE_JS_CONFIG_MAP}
+      languages={SUPPORTED_LOCALES_CONFIG}
       imageLink={IMAGE_LINK_CORPORATE_SITE}
     />
   );

--- a/frontend/apps/marketing/src/components/footer/csForAll/FooterCSforAll.tsx
+++ b/frontend/apps/marketing/src/components/footer/csForAll/FooterCSforAll.tsx
@@ -1,6 +1,6 @@
 'use client';
 import {Brand} from '@/config/brand';
-import {LOCALIZE_JS_CONFIG_MAP} from '@/config/locale';
+import {SUPPORTED_LOCALES_CONFIG} from '@/config/locale';
 
 import {GlobalFooterProps} from '../common/types';
 import {useFooterLocalization} from '../common/utils';
@@ -28,7 +28,7 @@ const FooterCSforAll = ({locale}: GlobalFooterProps) => {
       {...defaultProps}
       onLanguageChange={handleLanguageChange}
       selectedLocaleCode={locale}
-      languages={LOCALIZE_JS_CONFIG_MAP}
+      languages={SUPPORTED_LOCALES_CONFIG}
     />
   );
 };

--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -24,14 +24,15 @@ export enum SupportedLocale {
   'zh-Hant' = 'zh-Hant',
 }
 
-type LocalizeJsConfig = {
+type SupportedLocaleConfig = {
   value: SupportedLocale;
   text: string;
   isRTL: boolean;
 };
 
-// The following are LocalizeJS language codes and map 1:1. They are replicated here to ensure compatability in SSR.
-export const LOCALIZE_JS_CONFIG_MAP: LocalizeJsConfig[] = [
+// The following are BCP-47 language codes supported by the marketing app.
+// When updating languages here, ensure they are valid BCP 47 codes
+export const SUPPORTED_LOCALES_CONFIG: SupportedLocaleConfig[] = [
   {value: SupportedLocale['en-US'], text: 'English', isRTL: false},
   {value: SupportedLocale['es'], text: 'Español (LATAM)', isRTL: false},
   {value: SupportedLocale['es-ES'], text: 'Español (España)', isRTL: false},
@@ -57,7 +58,7 @@ export const LOCALIZE_JS_CONFIG_MAP: LocalizeJsConfig[] = [
   {value: SupportedLocale['zh-Hant'], text: '繁體字', isRTL: false},
 ];
 
-// Map of supported BCP 47 locale codes to LocalizeJS locale codes
+// Map of application supported BCP 47 locale codes to LocalizeJS locale codes
 // When selecting languages here, ensure they are valid BCP 47 codes
 // LocalizeJS has a variety of language codes but we standardize them to ensure compatability with our systems.
 const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
@@ -66,7 +67,7 @@ const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
   cs: 'cs',
   de: 'de',
   'es-ES': 'es', // Localize has es-ES as es
-  es: 'es-LA', // es-LA is not a valid ISO code, but this is what Localize uses.
+  es: 'es-LA', // Latin America Spanish is es-LA in Localize
   fa: 'fa',
   fr: 'fr',
   hi: 'hi',
@@ -83,17 +84,17 @@ const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
   th: 'th',
   tr: 'tr',
   'zh-Hans': 'zh-Hans',
-  'zh-Hant': 'zh-TW',
+  'zh-Hant': 'zh-TW', // Localize has zh-Hant as zh-TW
 };
 
-// Map of LocalizeJS locale codes to Dashboard (studio.code.org) locale codes
-const DASHBOARD_LOCALE_MAP: Record<string, string> = {
+// Map of BCP-47 application supported locale codes to Dashboard (studio.code.org) locale codes
+const DASHBOARD_LOCALE_MAP: Record<SupportedLocale, string> = {
   'en-US': 'en-US',
   ar: 'ar-SA',
   cs: 'cs-CZ',
   de: 'de-DE',
-  es: 'es-ES',
-  'es-LA': 'es-MX',
+  'es-ES': 'es-ES',
+  es: 'es-MX',
   fa: 'fa-IR',
   fr: 'fr-FR',
   hi: 'hi-IN',
@@ -113,46 +114,53 @@ const DASHBOARD_LOCALE_MAP: Record<string, string> = {
   'zh-Hant': 'zh-TW',
 };
 
-const LOCALIZEJS_LOCALE_MAP: Record<string, SupportedLocale | undefined> =
-  Object.fromEntries(
-    Object.entries(DASHBOARD_LOCALE_MAP).map(([key, value]) => [value, key]),
-  );
+const DASHBOARD_LOCALE_TO_SUPPORTED_LOCALE_MAP: Record<
+  string,
+  SupportedLocale
+> = Object.fromEntries(
+  Object.entries(DASHBOARD_LOCALE_MAP).map(([key, value]) => [
+    value,
+    key as SupportedLocale,
+  ]),
+);
 
-export const SUPPORTED_LOCALE_CODES = LOCALIZE_JS_CONFIG_MAP.map(
+export const SUPPORTED_LOCALE_CODES = SUPPORTED_LOCALES_CONFIG.map(
   locale => locale.value,
 );
 export const SUPPORTED_LOCALES_SET = new Set(SUPPORTED_LOCALE_CODES);
 
 export const SUPPORTED_LOCALES_MAP = new Map(
-  LOCALIZE_JS_CONFIG_MAP.map(locale => [locale.value, locale]),
+  SUPPORTED_LOCALES_CONFIG.map(locale => [locale.value, locale]),
 );
 
 /**
  * Returns the LocalizeJS locale code for a given BCP 47 locale code.
- * @param bcp47Code - The BCP 47 locale code to convert.
+ * @param supportedLocale - The BCP 47 supported locale code to convert.
  */
-export function getLocalizeJsLocaleFromBCP47(bcp47Code: string) {
-  return LOCALIZEJS_LOCALE[bcp47Code as SupportedLocale] || 'en';
+export function getLocalizeJsLocaleFromSupportedLocale(
+  supportedLocale: SupportedLocale,
+) {
+  return LOCALIZEJS_LOCALE[supportedLocale as SupportedLocale] || 'en';
 }
 
 /**
  * Returns the Dashboard (studio.code.org) locale code for a given LocalizeJS locale code.
- * @param localizeJsLocale - The LocalizeJS locale code to convert.
+ * @param supportedLocale - The marketing app locale code to convert.
  */
-export function getDashboardLocale(localizeJsLocale: SupportedLocale): string {
-  return DASHBOARD_LOCALE_MAP[localizeJsLocale] || 'en-US';
+export function getDashboardLocale(supportedLocale: SupportedLocale): string {
+  return DASHBOARD_LOCALE_MAP[supportedLocale] || 'en-US';
 }
 
 /**
- * Returns the LocalizeJS locale code for a given Dashboard (studio.code.org) locale code.
+ * Returns the BCP-47 marketing app locale code for a given Dashboard (studio.code.org) locale code.
  * @param dashboardLocale - The Dashboard (studio.code.org) locale code to convert.
  */
-export function getLocalizeJsLocaleFromDashboardLocale(
+export function getSupportedLocaleFromDashboardLocale(
   dashboardLocale: string | undefined,
 ): SupportedLocale | undefined {
   if (!dashboardLocale) {
     return undefined;
   }
 
-  return LOCALIZEJS_LOCALE_MAP[dashboardLocale];
+  return DASHBOARD_LOCALE_TO_SUPPORTED_LOCALE_MAP[dashboardLocale];
 }

--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -65,8 +65,8 @@ const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
   ar: 'ar',
   cs: 'cs',
   de: 'de',
-  'es-ES': 'es-ES',
-  es: 'es',
+  'es-ES': 'es', // Localize has es-ES as es
+  es: 'es-LA', // es-LA is not a valid ISO code, but this is what Localize uses.
   fa: 'fa',
   fr: 'fr',
   hi: 'hi',
@@ -87,13 +87,13 @@ const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
 };
 
 // Map of LocalizeJS locale codes to Dashboard (studio.code.org) locale codes
-const DASHBOARD_LOCALE_MAP: Record<SupportedLocale, string | undefined> = {
+const DASHBOARD_LOCALE_MAP: Record<string, string> = {
   'en-US': 'en-US',
   ar: 'ar-SA',
   cs: 'cs-CZ',
   de: 'de-DE',
-  'es-ES': 'es-ES',
-  es: 'es',
+  es: 'es-ES',
+  'es-LA': 'es-MX',
   fa: 'fa-IR',
   fr: 'fr-FR',
   hi: 'hi-IN',

--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -138,7 +138,7 @@ export const SUPPORTED_LOCALES_MAP = new Map(
  * @param supportedLocale - The BCP 47 supported locale code to convert.
  */
 export function getLocalizeJsLocaleFromSupportedLocale(
-  supportedLocale: SupportedLocale,
+  supportedLocale: SupportedLocale | string,
 ) {
   return LOCALIZEJS_LOCALE[supportedLocale as SupportedLocale] || 'en';
 }

--- a/frontend/apps/marketing/src/config/locale.ts
+++ b/frontend/apps/marketing/src/config/locale.ts
@@ -4,7 +4,7 @@ export enum SupportedLocale {
   cs = 'cs',
   de = 'de',
   'es-ES' = 'es-ES',
-  'es-LA' = 'es-LA', // Latin America Spanish
+  'es' = 'es', // Latin America Spanish
   fa = 'fa',
   fr = 'fr',
   hi = 'hi',
@@ -20,8 +20,8 @@ export enum SupportedLocale {
   te = 'te',
   th = 'th',
   tr = 'tr',
-  'zh-CN' = 'zh-CN',
-  'zh-TW' = 'zh-TW',
+  'zh-Hans' = 'zh-Hans',
+  'zh-Hant' = 'zh-Hant',
 }
 
 type LocalizeJsConfig = {
@@ -33,7 +33,7 @@ type LocalizeJsConfig = {
 // The following are LocalizeJS language codes and map 1:1. They are replicated here to ensure compatability in SSR.
 export const LOCALIZE_JS_CONFIG_MAP: LocalizeJsConfig[] = [
   {value: SupportedLocale['en-US'], text: 'English', isRTL: false},
-  {value: SupportedLocale['es-LA'], text: 'Español (LATAM)', isRTL: false},
+  {value: SupportedLocale['es'], text: 'Español (LATAM)', isRTL: false},
   {value: SupportedLocale['es-ES'], text: 'Español (España)', isRTL: false},
   {value: SupportedLocale['ar'], text: 'العربية', isRTL: true},
   {value: SupportedLocale['cs'], text: 'Čeština', isRTL: false},
@@ -53,18 +53,20 @@ export const LOCALIZE_JS_CONFIG_MAP: LocalizeJsConfig[] = [
   {value: SupportedLocale['te'], text: 'తెలుగు', isRTL: false},
   {value: SupportedLocale['th'], text: 'ภาษาไทย', isRTL: false},
   {value: SupportedLocale['tr'], text: 'Türkçe', isRTL: false},
-  {value: SupportedLocale['zh-CN'], text: '简体字', isRTL: false},
-  {value: SupportedLocale['zh-TW'], text: '繁體字', isRTL: false},
+  {value: SupportedLocale['zh-Hans'], text: '简体字', isRTL: false},
+  {value: SupportedLocale['zh-Hant'], text: '繁體字', isRTL: false},
 ];
 
 // Map of supported BCP 47 locale codes to LocalizeJS locale codes
+// When selecting languages here, ensure they are valid BCP 47 codes
+// LocalizeJS has a variety of language codes but we standardize them to ensure compatability with our systems.
 const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
   'en-US': 'en',
   ar: 'ar',
   cs: 'cs',
   de: 'de',
   'es-ES': 'es-ES',
-  'es-LA': 'es-MX',
+  es: 'es',
   fa: 'fa',
   fr: 'fr',
   hi: 'hi',
@@ -80,8 +82,8 @@ const LOCALIZEJS_LOCALE: {[locale in SupportedLocale]: string} = {
   te: 'te',
   th: 'th',
   tr: 'tr',
-  'zh-CN': 'zh-CN',
-  'zh-TW': 'zh-TW',
+  'zh-Hans': 'zh-Hans',
+  'zh-Hant': 'zh-TW',
 };
 
 // Map of LocalizeJS locale codes to Dashboard (studio.code.org) locale codes
@@ -91,7 +93,7 @@ const DASHBOARD_LOCALE_MAP: Record<SupportedLocale, string | undefined> = {
   cs: 'cs-CZ',
   de: 'de-DE',
   'es-ES': 'es-ES',
-  'es-LA': 'es-MX',
+  es: 'es',
   fa: 'fa-IR',
   fr: 'fr-FR',
   hi: 'hi-IN',
@@ -107,8 +109,8 @@ const DASHBOARD_LOCALE_MAP: Record<SupportedLocale, string | undefined> = {
   te: 'te-IN',
   th: 'th-TH',
   tr: 'tr-TR',
-  'zh-CN': 'zh-CN',
-  'zh-TW': 'zh-TW',
+  'zh-Hans': 'zh-CN',
+  'zh-Hant': 'zh-TW',
 };
 
 const LOCALIZEJS_LOCALE_MAP: Record<string, SupportedLocale | undefined> =

--- a/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withLocale.test.ts
@@ -1,11 +1,7 @@
 import {NextRequest, NextFetchEvent, NextResponse} from 'next/server';
 
 import {STALE_WHILE_REVALIDATE_ONE_HOUR} from '@/cache/constants';
-import {
-  SUPPORTED_LOCALE_CODES,
-  SUPPORTED_LOCALES_SET,
-  SupportedLocale,
-} from '@/config/locale';
+import {SUPPORTED_LOCALE_CODES, SupportedLocale} from '@/config/locale';
 import {getStage} from '@/config/stage';
 import {getContentfulSlug} from '@/contentful/slug/getContentfulSlug';
 
@@ -38,13 +34,12 @@ describe('withLocale middleware', () => {
 
   it('should not redirect if the path contains a supported locale', async () => {
     const request = {
-      nextUrl: {pathname: '/zh-TW/home'},
+      nextUrl: {pathname: '/zh-Hant/home'},
       cookies: {get: jest.fn()},
       headers: {get: jest.fn()},
       response: {cookies: {set: jest.fn()}},
     } as unknown as NextRequest;
 
-    SUPPORTED_LOCALES_SET.add('zh-TW' as SupportedLocale);
     await withLocale(next)(request, mockEvent);
 
     expect(next).toHaveBeenCalledWith(request, mockEvent);
@@ -61,14 +56,13 @@ describe('withLocale middleware', () => {
 
   it('should not redirect if the path contains a supported locale - development', async () => {
     const request = {
-      nextUrl: {pathname: '/zh-TW/home'},
+      nextUrl: {pathname: '/zh-Hant/home'},
       cookies: {get: jest.fn()},
       headers: {get: jest.fn()},
       response: {cookies: {set: jest.fn()}},
     } as unknown as NextRequest;
     (getStage as jest.Mock).mockReturnValue('production');
 
-    SUPPORTED_LOCALES_SET.add('zh-TW' as SupportedLocale);
     await withLocale(next)(request, mockEvent);
 
     expect(next).toHaveBeenCalledWith(request, mockEvent);
@@ -91,14 +85,13 @@ describe('withLocale middleware', () => {
       headers: {get: jest.fn()},
     } as unknown as NextRequest;
 
-    SUPPORTED_LOCALES_SET.add('zh-TW' as SupportedLocale);
     (getContentfulSlug as jest.Mock).mockReturnValue('home');
 
     const response = await withLocale(next)(request, mockEvent);
 
     expect(response).toBeInstanceOf(NextResponse);
     expect(response?.headers.get('location')).toBe(
-      'https://test.code.org/zh-TW/home',
+      'https://test.code.org/zh-Hant/home',
     );
     expect(response?.headers.get('Cache-Control')).toEqual(
       STALE_WHILE_REVALIDATE_ONE_HOUR,
@@ -111,18 +104,18 @@ describe('withLocale middleware', () => {
       nextUrl: {pathname: '/home', url: 'https://test.code.org/home'},
       cookies: {get: jest.fn()},
       headers: {
-        get: jest.fn().mockReturnValue('zh-TW;q=0.9'),
+        get: jest.fn().mockReturnValue('zh-Hant;q=0.9'),
       },
     } as unknown as NextRequest;
 
-    SUPPORTED_LOCALE_CODES.push('zh-TW' as SupportedLocale);
+    SUPPORTED_LOCALE_CODES.push('zh-Hant' as SupportedLocale);
     (getContentfulSlug as jest.Mock).mockReturnValue('home');
 
     const response = await withLocale(next)(request, mockEvent);
 
     expect(response).toBeInstanceOf(NextResponse);
     expect(response?.headers.get('location')).toBe(
-      'https://test.code.org/zh-TW/home',
+      'https://test.code.org/zh-Hant/home',
     );
     expect(response?.headers.get('Cache-Control')).toEqual(
       STALE_WHILE_REVALIDATE_ONE_HOUR,
@@ -155,7 +148,7 @@ describe('withLocale middleware', () => {
       nextUrl: {pathname: '/'},
       cookies: {get: jest.fn()},
       headers: {
-        get: jest.fn().mockReturnValue('zh-TW, en-US;q=0.9'),
+        get: jest.fn().mockReturnValue('zh-Hant, en-US;q=0.9'),
       },
       url: 'https://code.marketing-sites.local',
     } as unknown as NextRequest;
@@ -164,7 +157,7 @@ describe('withLocale middleware', () => {
 
     expect(response).toBeInstanceOf(NextResponse);
     expect(response?.headers.get('location')).toBe(
-      'https://code.marketing-sites.local/zh-TW',
+      'https://code.marketing-sites.local/zh-Hant',
     );
   });
 
@@ -179,7 +172,6 @@ describe('withLocale middleware', () => {
       headers: {get: jest.fn()},
     } as unknown as NextRequest;
 
-    SUPPORTED_LOCALES_SET.add('zh-TW' as SupportedLocale);
     (getContentfulSlug as jest.Mock).mockReturnValue(
       'engineering/all-the-things',
     );
@@ -188,20 +180,19 @@ describe('withLocale middleware', () => {
 
     expect(response).toBeInstanceOf(NextResponse);
     expect(response?.headers.get('location')).toBe(
-      'https://test.code.org/zh-TW/engineering/all-the-things',
+      'https://test.code.org/zh-Hant/engineering/all-the-things',
     );
   });
 
   it('should not set language_ cookie or redirect to studio base url when brand is not CODE_DOT_ORG', async () => {
     const request = {
-      nextUrl: {pathname: '/zh-TW/home'},
+      nextUrl: {pathname: '/zh-Hant/home'},
       cookies: {get: jest.fn()},
       headers: {get: jest.fn().mockReturnValue('csforall.org')},
       response: {cookies: {set: jest.fn()}},
-      url: 'https://not-code.org/zh-TW/home',
+      url: 'https://not-code.org/zh-Hant/home',
     } as unknown as NextRequest;
 
-    SUPPORTED_LOCALES_SET.add('zh-TW' as SupportedLocale);
     await withLocale(next)(request, mockEvent);
   });
 

--- a/frontend/apps/marketing/src/middleware/__tests__/withRedirects.test.ts
+++ b/frontend/apps/marketing/src/middleware/__tests__/withRedirects.test.ts
@@ -195,13 +195,13 @@ describe('withRedirects middleware', () => {
       status: 404,
       json: async () => ({}),
     });
-    // CODE_DOT_ORG brand triggers a brand redirect for /es/engineering/all-the-things
-    const req = makeRequest('/es/engineering/all-the-things');
+    // CODE_DOT_ORG brand triggers a brand redirect for /es-LA/engineering/all-the-things
+    const req = makeRequest('/es-LA/engineering/all-the-things');
     const response = await withRedirects(next)(req, event);
     // Should return a redirect response (not call next) for this brand/path
     expect(response?.status).toBe(308);
     expect(response?.headers.get('Location')).toBe(
-      'http://localhost:3000/es-LA/engineering/all-the-things',
+      'http://localhost:3000/es/engineering/all-the-things',
     );
   });
 
@@ -210,11 +210,11 @@ describe('withRedirects middleware', () => {
       status: 200,
       json: async () => ({redirectEntry: null}),
     });
-    const req = makeRequest('/es/engineering/all-the-things');
+    const req = makeRequest('/es-LA/engineering/all-the-things');
     const response = await withRedirects(next)(req, event);
     expect(response?.status).toBe(308);
     expect(response?.headers.get('Location')).toBe(
-      'http://localhost:3000/es-LA/engineering/all-the-things',
+      'http://localhost:3000/es/engineering/all-the-things',
     );
   });
 
@@ -242,6 +242,21 @@ describe('withRedirects middleware', () => {
           ETag: 'mocked-etag',
         },
       }),
+    );
+  });
+
+  it('redirects zh-TW to zh-Hant on the corporate site', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      status: 404,
+      json: async () => ({}),
+    });
+    // CODE_DOT_ORG brand triggers a brand redirect for /es-LA/engineering/all-the-things
+    const req = makeRequest('/zh-TW/engineering/all-the-things');
+    const response = await withRedirects(next)(req, event);
+    // Should return a redirect response (not call next) for this brand/path
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get('Location')).toBe(
+      'http://localhost:3000/zh-Hant/engineering/all-the-things',
     );
   });
 });

--- a/frontend/apps/marketing/src/middleware/redirects/__tests__/index.test.ts
+++ b/frontend/apps/marketing/src/middleware/redirects/__tests__/index.test.ts
@@ -18,14 +18,26 @@ describe('getBrandRedirects', () => {
     expect(result).toBeUndefined();
   });
 
-  it('redirects /es to /es-LA', () => {
+  it('redirects /es-LA to /es', () => {
     const request = makeMockRequest(
-      '/es/engineering/all-the-things',
+      '/es-LA/engineering/all-the-things',
       'http://localhost:3000',
     );
     const result = getBrandRedirects(Brand.CODE_DOT_ORG, request);
     expect(result?.headers.get('Location')).toEqual(
-      'http://localhost:3000/es-LA/engineering/all-the-things',
+      'http://localhost:3000/es/engineering/all-the-things',
+    );
+    expect(result?.status).toEqual(308);
+  });
+
+  it('redirects /zh-TW to /zh-Hant', () => {
+    const request = makeMockRequest(
+      '/zh-TW/engineering/all-the-things',
+      'http://localhost:3000',
+    );
+    const result = getBrandRedirects(Brand.CODE_DOT_ORG, request);
+    expect(result?.headers.get('Location')).toEqual(
+      'http://localhost:3000/zh-Hant/engineering/all-the-things',
     );
     expect(result?.status).toEqual(308);
   });

--- a/frontend/apps/marketing/src/middleware/redirects/corporate/__tests__/index.test.ts
+++ b/frontend/apps/marketing/src/middleware/redirects/corporate/__tests__/index.test.ts
@@ -26,20 +26,20 @@ function createMockRequest(pathname: string, origin = 'https://example.com') {
 describe('getRedirects', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('redirects /es to /es-LA', () => {
-    const req = createMockRequest('/es');
+  it('redirects /es-LA to /es', () => {
+    const req = createMockRequest('/es-LA');
     getRedirects(req);
     expect(getCachedRedirectResponse).toHaveBeenCalledWith(
-      new URL('/es-LA/', req.nextUrl.origin),
+      new URL('/es', req.nextUrl.origin),
       {status: 308},
     );
   });
 
-  it('redirects /es/foo/bar to /es-LA/foo/bar', () => {
-    const req = createMockRequest('/es/foo/bar');
+  it('redirects /es-LA/foo/bar to /es/foo/bar', () => {
+    const req = createMockRequest('/es-LA/foo/bar');
     getRedirects(req);
     expect(getCachedRedirectResponse).toHaveBeenCalledWith(
-      new URL('/es-LA/foo/bar', req.nextUrl.origin),
+      new URL('/es/foo/bar', req.nextUrl.origin),
       {status: 308},
     );
   });

--- a/frontend/apps/marketing/src/middleware/redirects/corporate/index.ts
+++ b/frontend/apps/marketing/src/middleware/redirects/corporate/index.ts
@@ -9,11 +9,23 @@ export function getRedirects(request: NextRequest) {
 
   const maybeLocale = pathParts[0];
 
-  // Permanently redirect /es to /es-LA
+  // Permanently redirect /es-LA to /es
   // Code may be removed after January 2026 (to allow time for SEO crawlers to update)
-  if (maybeLocale === 'es') {
+  if (maybeLocale === 'es-LA') {
     const restOfPath = pathParts.slice(1).join('/');
-    const redirectUrl = new URL(`/es-LA/${restOfPath}`, request.nextUrl.origin);
+    const redirectUrl = new URL(`/es/${restOfPath}`, request.nextUrl.origin);
+
+    return getCachedRedirectResponse(redirectUrl, {status: 308});
+  }
+
+  // Permanently redirect /zh-TW to /zh-Hant
+  // Code may be removed after January 2026 (to allow time for SEO crawlers to update)
+  if (maybeLocale === 'zh-TW') {
+    const restOfPath = pathParts.slice(1).join('/');
+    const redirectUrl = new URL(
+      `/zh-Hant/${restOfPath}`,
+      request.nextUrl.origin,
+    );
 
     return getCachedRedirectResponse(redirectUrl, {status: 308});
   }

--- a/frontend/apps/marketing/src/middleware/withLocale.ts
+++ b/frontend/apps/marketing/src/middleware/withLocale.ts
@@ -3,7 +3,7 @@ import {NextFetchEvent, NextRequest} from 'next/server';
 
 import {getBrandFromHostname} from '@/config/brand';
 import {
-  getLocalizeJsLocaleFromDashboardLocale,
+  getSupportedLocaleFromDashboardLocale,
   SUPPORTED_LOCALE_CODES,
   SUPPORTED_LOCALES_SET,
   SupportedLocale,
@@ -16,7 +16,7 @@ import {getCachedRedirectResponse} from '@/middleware/utils/getCachedRedirectRes
 import {MiddlewareFactory} from './types';
 
 function getLanguageFromCookie(request: NextRequest) {
-  const cookieLocale = getLocalizeJsLocaleFromDashboardLocale(
+  const cookieLocale = getSupportedLocaleFromDashboardLocale(
     request.cookies.get('language_')?.value,
   );
   return cookieLocale !== undefined && SUPPORTED_LOCALES_SET.has(cookieLocale)

--- a/frontend/apps/marketing/src/providers/localize/LocalizeLoader.tsx
+++ b/frontend/apps/marketing/src/providers/localize/LocalizeLoader.tsx
@@ -2,7 +2,7 @@
 import Script from 'next/script';
 
 import {Brand} from '@/config/brand';
-import {getLocalizeJsLocaleFromBCP47} from '@/config/locale';
+import {getLocalizeJsLocaleFromSupportedLocale} from '@/config/locale';
 import {getLocalizePath, getProjectId} from '@/config/localize';
 
 /**
@@ -67,7 +67,7 @@ const LocalizeLoader = ({
               key: projectId!,
               autodetectLanguage: true,
               rememberLanguage: false, // use the locale in the URL instead
-              defaultLanguage: getLocalizeJsLocaleFromBCP47(locale),
+              defaultLanguage: getLocalizeJsLocaleFromSupportedLocale(locale),
               disableWidget: true, // use our own language dropdown
               // Block classes that match developer mode Next.js overlays
               blockedClasses: [

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -73,13 +73,13 @@ test.describe(`[${getSiteType()}] All the things`, () => {
           name: 'language_',
           path: '/',
           domain: `.${allTheThingsPage.getCookieDomain()}`,
-          value: 'zh-TW',
+          value: 'zh-Hant',
         },
       ]);
 
       await allTheThingsPage.goto('/engineering/all-the-things');
 
-      await page.waitForURL('**/zh-TW/engineering/all-the-things');
+      await page.waitForURL('**/zh-Hant/engineering/all-the-things');
     });
 
     test.use({
@@ -121,16 +121,16 @@ test.describe(`[${getSiteType()}] All the things`, () => {
       );
       const allTheThingsPage = new MarketingPage(page);
 
-      await allTheThingsPage.goto('/zh-TW/engineering/all-the-things');
+      await allTheThingsPage.goto('/zh-Hant/engineering/all-the-things');
 
-      // The middleware should send us back to /zh-TW with the language_ cookie set via the previous visit
+      // The middleware should send us back to /zh-Hant with the language_ cookie set via the previous visit
       await allTheThingsPage.goto('/engineering/all-the-things');
-      await page.waitForURL('**/zh-TW/engineering/all-the-things');
+      await page.waitForURL('**/zh-Hant/engineering/all-the-things');
     });
 
     test.describe('accept-language header', () => {
       test.use({
-        locale: 'zh-TW',
+        locale: 'zh-Hant',
       });
 
       test('redirects to localized page via accept-language', async ({
@@ -144,7 +144,7 @@ test.describe(`[${getSiteType()}] All the things`, () => {
         const allTheThingsPage = new MarketingPage(page);
         await allTheThingsPage.goto('/engineering/all-the-things');
 
-        await page.waitForURL('**/zh-TW/engineering/all-the-things');
+        await page.waitForURL('**/zh-Hant/engineering/all-the-things');
       });
     });
   });

--- a/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/all-the-things.spec.ts
@@ -73,7 +73,7 @@ test.describe(`[${getSiteType()}] All the things`, () => {
           name: 'language_',
           path: '/',
           domain: `.${allTheThingsPage.getCookieDomain()}`,
-          value: 'zh-Hant',
+          value: 'zh-TW',
         },
       ]);
 

--- a/frontend/apps/marketing/tests/e2e/i18n.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/i18n.spec.ts
@@ -1,0 +1,26 @@
+import {expect} from '@playwright/test';
+
+import {EXPECTED_LOCALIZATION_STRINGS} from './config/i18n';
+import {test} from './fixtures/base';
+import {AllTheThingsPage} from './pom/all-the-things';
+
+test.describe('i18n', () => {
+  test('should switch language using language dropdown', async ({page}) => {
+    const allTheThingsPage = new AllTheThingsPage(page, {locale: 'en-US'});
+    await allTheThingsPage.goto();
+    await page.waitForURL('**/en-US/engineering/all-the-things**');
+
+    const languageDropdown = page.locator(
+      '[aria-label="Language selection dropdown"]',
+    );
+    await expect(languageDropdown).toBeVisible();
+
+    await languageDropdown.selectOption('ar');
+
+    await page.waitForURL('**/ar/engineering/all-the-things');
+
+    await expect(
+      page.getByText(EXPECTED_LOCALIZATION_STRINGS['ar'].longText),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Aligns the language list with the global supported languages, particularly to better match BCP-47 standards.

1. Rename `es-LA` to `es`
2. Change `zh-CN` to `zh-Hans`
3. Change `zh-TW` to `zh-Hant`

Aligns languages to specification [here](https://docs.google.com/spreadsheets/d/18YRsmQXIQ99AnGvNNKew54oQp9pWw3nIzijYAkbSnsE/edit?gid=785053768#gid=785053768)