### PR TITLE
Fix lesson numbering duplication on lesson dropdown

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
@@ -37,11 +37,7 @@ const LinkOption: React.FC<LinkElementProps> = ({
     <li>
       {isTeacherDashboard ? (
         <Link
-          id={
-            url.includes('lesson')
-              ? `ui-test-lesson-${label.replace(' ', '-')}`
-              : `ui-test-unit-${label.replace(' ', '-')}`
-          }
+          id={`ui-test-${label.replace(' ', '-')}`}
           to={url}
           className={styles.dropdownMenuItem}
           onClick={() => {

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
@@ -37,7 +37,11 @@ const LinkOption: React.FC<LinkElementProps> = ({
     <li>
       {isTeacherDashboard ? (
         <Link
-          id={`ui-test-${label.replace(' ', '-')}`}
+          id={
+            value.includes('lesson')
+              ? `ui-test-lesson-${label.replace(' ', '-')}`
+              : `ui-test-unit-${label.replace(' ', '-')}`
+          }
           to={url}
           className={styles.dropdownMenuItem}
           onClick={() => {

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
@@ -38,7 +38,7 @@ const LinkOption: React.FC<LinkElementProps> = ({
       {isTeacherDashboard ? (
         <Link
           id={
-            value.includes('lesson')
+            url.includes('lesson')
               ? `ui-test-lesson-${label.replace(' ', '-')}`
               : `ui-test-unit-${label.replace(' ', '-')}`
           }
@@ -60,7 +60,11 @@ const LinkOption: React.FC<LinkElementProps> = ({
         </Link>
       ) : (
         <a
-          id={`ui-test-${label.replaceAll(' ', '-').replaceAll(':', '')}`}
+          id={
+            url.includes('lesson')
+              ? `ui-test-lesson-${label.replace(' ', '-')}`
+              : `ui-test-unit-${label.replace(' ', '-')}`
+          }
           className={styles.dropdownMenuItem}
           href={url}
           onClick={() => {

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
@@ -37,7 +37,7 @@ const LinkOption: React.FC<LinkElementProps> = ({
     <li>
       {isTeacherDashboard ? (
         <Link
-          id={`ui-test-${label.replace(' ', '-')}`}
+          id={`ui-test-${label.replaceAll(' ', '-')}`}
           to={url}
           className={styles.dropdownMenuItem}
           onClick={() => {
@@ -58,8 +58,8 @@ const LinkOption: React.FC<LinkElementProps> = ({
         <a
           id={
             url.includes('lesson')
-              ? `ui-test-lesson-${label.replace(' ', '-')}`
-              : `ui-test-unit-${label.replace(' ', '-')}`
+              ? `ui-test-lesson-${label.replaceAll(' ', '-')}`
+              : `ui-test-unit-${label.replaceAll(' ', '-')}`
           }
           className={styles.dropdownMenuItem}
           href={url}

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -81,7 +81,7 @@ class SectionsController < ApplicationController
               script_lesson_path(unit, lesson)
             end
           {
-            text: 'Lesson ' + lesson.relative_position.to_s + ': ' + lesson.localized_name,
+            text: lesson.localized_title,
             value: path,
           }
         end

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -297,7 +297,7 @@ class SectionsControllerTest < ActionController::TestCase
     get :retrieve_lessons_for_dropdown, params: {id: @flappy_section.id}
     assert_response :success
     response_json = JSON.parse(@response.body)
-    assert_equal response_json, [{"text"=>"Flappy Code", "value"=>"/courses/flappy/units/1"}, {"text"=>"Lesson 1: Flappy Code", "value"=>"/courses/flappy/units/1/lessons/1/levels/1"}]
+    assert_equal response_json, [{"text"=>"Flappy Code", "value"=>"/courses/flappy/units/1"}, {"text"=>"Flappy Code", "value"=>"/courses/flappy/units/1/lessons/1/levels/1"}]
   end
 
   describe '#retrieve_lessons_for_dropdown' do
@@ -335,7 +335,7 @@ class SectionsControllerTest < ActionController::TestCase
     end
 
     it 'returns lesson name' do
-      _(response_lesson[:text]).must_equal "Lesson #{lesson.relative_position}: #{lesson.localized_name}"
+      _(response_lesson[:text]).must_equal lesson.localized_title
     end
 
     it 'returns lesson path' do

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v2.feature
@@ -81,7 +81,7 @@ Scenario: Teacher can delete a section from the section options dropdown
     And I wait until element "#course-content-dropdown-Untitled-Section" is visible
     And element "#course-content-dropdown-Untitled-Section" has text "Course: AI for Oceans"
     Then I click "#go-to-lesson-dropdown-button" once it exists
-    And I click "#ui-test-Lesson-1-AI-for-Oceans" once it exists
+    And I click "#ui-test-AI-for-Oceans" once it exists
     Then I wait until element "a:contains(AI for Oceans)" is visible
 
   Scenario: Teacher can access section roster from the "Add students" button on the section card

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v2.feature
@@ -81,7 +81,7 @@ Scenario: Teacher can delete a section from the section options dropdown
     And I wait until element "#course-content-dropdown-Untitled-Section" is visible
     And element "#course-content-dropdown-Untitled-Section" has text "Course: AI for Oceans"
     Then I click "#go-to-lesson-dropdown-button" once it exists
-    And I click "#ui-test-AI-for-Oceans" once it exists
+    And I click "#ui-test-lesson-AI-for-Oceans" once it exists
     Then I wait until element "a:contains(AI for Oceans)" is visible
 
   Scenario: Teacher can access section roster from the "Add students" button on the section card


### PR DESCRIPTION
This update fixes an error on the lesson dropdown on the new teacher homepage that caused lesson numbers to be duplicated in each listing.

Before:
<img width="995" height="787" alt="Screenshot 2025-07-23 141255" src="https://github.com/user-attachments/assets/6308103d-bb3a-4a94-b399-a049d7c71e01" />

After:
<img width="504" height="938" alt="image" src="https://github.com/user-attachments/assets/56636d62-f036-4667-ac7c-bcc7446ec82c" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 
[TEACH-2125](https://codedotorg.atlassian.net/browse/TEACH-2125)

## Testing story
No new tests needed

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
