### PR TITLE
Use new BYOW pre-survey as universal pre-survey

### DIFF
--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -60,7 +60,28 @@ module Pd
     #
     # If the pre-survey has been already completed, will redirect to thanks page.
     def new_pre_foorm
-      new_general_foorm(survey_names: PRE_SURVEY_CONFIG_PATHS, day: 0)
+      enrollment_code = params[:enrollmentCode]
+
+      workshop = nil
+      if enrollment_code
+        workshop = Pd::Enrollment.find_by(code: enrollment_code, user: current_user)&.workshop
+        unless workshop
+          render :invalid_enrollment_code
+          return false
+        end
+      else
+        workshop = Workshop.where(course: COURSE_BUILD_YOUR_OWN).enrolled_in_by(current_user)&.nearest
+        unless workshop
+          render :not_enrolled
+          return false
+        end
+      end
+
+      agenda = params[:agenda] || nil
+      # remove / from agenda url so module/1 => module1
+      agenda&.tr!("/", "")
+
+      render_survey_foorm(survey_name: PRE_SURVEY_CONFIG_PATHS[COURSE_BUILD_YOUR_OWN], workshop: workshop, session: nil, day: 0, workshop_agenda: agenda)
     end
 
     def new_facilitator_post_foorm(workshop)
@@ -80,7 +101,7 @@ module Pd
       should_have_attended = day != 0
       workshop = get_workshop_by_enrollment_or_course_and_subject(
         enrollment_code: enrollment_code,
-        course: [COURSE_CSD, COURSE_CSP, COURSE_CSA, COURSE_BUILD_YOUR_OWN],
+        course: [COURSE_CSD, COURSE_CSP, COURSE_CSA],
         subject: subject,
         should_have_attended: should_have_attended
       )

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -80,7 +80,7 @@ module Pd
       should_have_attended = day != 0
       workshop = get_workshop_by_enrollment_or_course_and_subject(
         enrollment_code: enrollment_code,
-        course: [COURSE_CSD, COURSE_CSP, COURSE_CSA],
+        course: [COURSE_CSD, COURSE_CSP, COURSE_CSA, COURSE_BUILD_YOUR_OWN],
         subject: subject,
         should_have_attended: should_have_attended
       )
@@ -111,23 +111,6 @@ module Pd
       else
         new_facilitator_post_foorm(workshop)
       end
-    end
-
-    # Display CSF201 (Deep Dive) pre-workshop survey using Foorm.
-    # GET workshop_survey/csf/pre201
-    def new_csf_pre201
-      # Find the closest CSF 201 workshop the current user enrolled in.
-      workshop = get_workshop_by_course_and_subject(
-        course: COURSE_CSF,
-        subject: SUBJECT_CSF_201,
-        should_have_attended: false
-      )
-
-      return unless workshop
-      return render :too_late unless workshop.state != STATE_ENDED
-
-      survey_name = PRE_SURVEY_CONFIG_PATHS[SUBJECT_CSF_201]
-      render_survey_foorm(survey_name: survey_name, workshop: workshop, session: nil, day: 0)
     end
 
     # Display CSF101 (Intro) post-workshop survey.
@@ -166,11 +149,6 @@ module Pd
 
     # GET /pd/workshop_survey/thanks
     def thanks
-    end
-
-    # Pre survey controller for academic year workshops
-    def new_ayw_pre
-      ayw_helper(survey_names: PRE_SURVEY_CONFIG_PATHS, day: 0)
     end
 
     def new_ayw_daily

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -162,11 +162,7 @@ class Pd::Enrollment < ApplicationRecord
 
   # Pre-workshop survey URL (if any)
   def pre_workshop_survey_url
-    if workshop.local_summer? || workshop.ayw?
-      url_for(action: 'new_pre_foorm', controller: 'pd/workshop_daily_survey', enrollmentCode: code)
-    elsif workshop.subject == Pd::Workshop::SUBJECT_CSF_201
-      CDO.studio_url "pd/workshop_survey/csf/pre201", CDO.default_scheme
-    end
+    url_for(action: 'new_pre_foorm', controller: 'pd/workshop_daily_survey', enrollmentCode: code)
   end
 
   def exit_survey_url

--- a/dashboard/lib/pd/workshop_survey_foorm_constants.rb
+++ b/dashboard/lib/pd/workshop_survey_foorm_constants.rb
@@ -32,7 +32,8 @@ module Pd
       SUBJECT_WORKSHOP_3 => 'surveys/pd/ayw_workshop_pre_survey',
       SUBJECT_WORKSHOP_4 => 'surveys/pd/ayw_workshop_pre_survey',
       SUBJECT_WORKSHOP_1_2 => 'surveys/pd/ayw_workshop_pre_survey',
-      SUBJECT_WORKSHOP_3_4 => 'surveys/pd/ayw_workshop_pre_survey'
+      SUBJECT_WORKSHOP_3_4 => 'surveys/pd/ayw_workshop_pre_survey',
+      COURSE_BUILD_YOUR_OWN => '/surveys/pd/build_your_own_workshop_teachers_pre_survey'
     }
 
     TEST_PARTICIPANT_SURVEY_CONFIG_PATHS = [

--- a/dashboard/lib/pd/workshop_survey_foorm_constants.rb
+++ b/dashboard/lib/pd/workshop_survey_foorm_constants.rb
@@ -33,7 +33,7 @@ module Pd
       SUBJECT_WORKSHOP_4 => 'surveys/pd/ayw_workshop_pre_survey',
       SUBJECT_WORKSHOP_1_2 => 'surveys/pd/ayw_workshop_pre_survey',
       SUBJECT_WORKSHOP_3_4 => 'surveys/pd/ayw_workshop_pre_survey',
-      COURSE_BUILD_YOUR_OWN => '/surveys/pd/build_your_own_workshop_teachers_pre_survey'
+      COURSE_BUILD_YOUR_OWN => 'surveys/pd/build_your_own_workshop_teachers_pre_survey'
     }
 
     TEST_PARTICIPANT_SURVEY_CONFIG_PATHS = [

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -33,46 +33,6 @@ module Pd
       assert_response :not_found
     end
 
-    test 'pre-workshop survey displays not enrolled message when not enrolled' do
-      sign_in unenrolled_teacher
-      get '/pd/workshop_survey/day/0'
-      assert_response :success
-      assert_not_enrolled
-    end
-
-    test 'pre-workshop foorm survey displays not enrolled message when not enrolled' do
-      sign_in unenrolled_teacher
-      get '/pd/workshop_pre_survey'
-      assert_response :success
-      assert_not_enrolled
-    end
-
-    test 'pre-workshop foorm survey shows thanks when a response exists' do
-      setup_summer_workshop
-      existing_survey = create(:daily_workshop_day_0_foorm_submission,
-        :answers_high,
-        form_name: "surveys/pd/summer_workshop_pre_survey"
-)
-      create(:day_0_workshop_foorm_submission,
-        foorm_submission: existing_survey,
-        pd_workshop: @summer_workshop,
-        user: @enrolled_summer_teacher
-)
-
-      sign_in @enrolled_summer_teacher
-      get '/pd/workshop_pre_survey'
-      assert_thanks
-    end
-
-    test 'pre-workshop foorm survey displays foorm when enrolled' do
-      setup_summer_workshop
-
-      sign_in @enrolled_summer_teacher
-      get '/pd/workshop_pre_survey'
-      assert_template :new_general_foorm
-      assert_response :success
-    end
-
     test 'post-workshop foorm survey displays foorm when enrolled and attended' do
       setup_summer_workshop
 
@@ -190,18 +150,36 @@ module Pd
     end
 
     test 'pre workshop survey without a valid enrollment code renders invalid enrollment code' do
-      setup_summer_workshop
-      sign_in @enrolled_summer_teacher
+      teacher = create(:teacher)
+      byo_workshop = create(:byo_workshop)
+      create(:pd_enrollment, workshop: byo_workshop, user: teacher)
+
+      sign_in teacher
       get '/pd/workshop_survey/day/0?enrollmentCode=invalid_enrollment_code'
       assert_template :invalid_enrollment_code
     end
 
     test 'pre workshop survey with a valid enrollment code but wrong user renders invalid enrollment code' do
-      setup_summer_workshop
-      summer_enrollment2 = create(:pd_enrollment, :from_user, workshop: @summer_workshop)
-      sign_in @enrolled_summer_teacher
-      get "/pd/workshop_survey/day/0?enrollmentCode=#{summer_enrollment2.code}"
+      teacher1 = create(:teacher)
+      teacher2 = create(:teacher)
+      byo_workshop = create(:byo_workshop)
+      create(:pd_enrollment, workshop: byo_workshop, user: teacher1)
+      teacher2_enrollment = create(:pd_enrollment, workshop: byo_workshop, user: teacher2)
+
+      sign_in teacher1
+      get "/pd/workshop_survey/day/0?enrollmentCode=#{teacher2_enrollment.code}"
       assert_template :invalid_enrollment_code
+    end
+
+    test 'pre workshop survey with valid enrollment code and valid user returns byow pre survey' do
+      teacher = create(:teacher)
+      byo_workshop = create(:byo_workshop)
+      teacher_enrollment = create(:pd_enrollment, workshop: byo_workshop, user: teacher)
+
+      sign_in teacher
+      get "/pd/workshop_survey/day/0?enrollmentCode=#{teacher_enrollment.code}"
+      assert_response :success
+      assert_template :new_general_foorm
     end
 
     test 'foorm pre workshop survey without a valid enrollment code renders invalid enrollment code' do
@@ -265,73 +243,6 @@ module Pd
       get "/pd/workshop_survey/csf/post101/#{@csf101_enrollment.code}"
       assert_response :success
       assert_no_attendance
-    end
-
-    test 'csf pre201 survey: unauthenticated teacher is redirected to sign-in' do
-      get '/pd/workshop_survey/csf/pre201'
-      assert_response :redirect
-      assert_redirected_to_sign_in
-    end
-
-    test 'csf pre201 survey: unenrolled teacher gets not_enrolled msg' do
-      sign_in unenrolled_teacher
-      get '/pd/workshop_survey/csf/pre201'
-
-      assert_response :success
-      assert_not_enrolled
-    end
-
-    test 'csf pre201 survey: enrolled teacher in ended workshop gets too-late msg' do
-      setup_csf201_ended_workshop
-      teacher = create(:teacher)
-      create(:pd_enrollment, user: teacher, workshop: @csf201_ended_workshop)
-
-      sign_in teacher
-      get '/pd/workshop_survey/csf/pre201'
-
-      assert_response :success
-      assert_closed
-    end
-
-    test 'csf pre201 survey: enrolled teacher in unended workshop gets survey' do
-      setup_csf201_not_started_workshop
-      teacher = create(:teacher)
-      create(:pd_enrollment, user: teacher, workshop: @csf201_not_started_workshop)
-
-      sign_in teacher
-      get '/pd/workshop_survey/csf/pre201'
-
-      assert_response :success
-      assert_template :new_general_foorm
-
-      submit_params = prop('submitParams')
-      assert_equal @csf201_not_started_workshop.id, submit_params['pd_workshop_id']
-    end
-
-    test 'csf pre201 survey: teacher already submitted survey does not gets survey again' do
-      setup_csf201_not_started_workshop
-      teacher = create(:teacher)
-      create(:pd_enrollment, user: teacher, workshop: @csf201_not_started_workshop)
-
-      _, latest_version = ::Foorm::Form.get_questions_and_latest_version_for_name(PRE_SURVEY_CONFIG_PATHS[SUBJECT_CSF_201])
-      ::Foorm::Submission.create(
-        id: FAKE_SUBMISSION_ID,
-        form_name: PRE_SURVEY_CONFIG_PATHS[SUBJECT_CSF_201],
-        form_version: latest_version,
-        answers: {}
-      )
-
-      WorkshopSurveyFoormSubmission.create(
-        foorm_submission_id: FAKE_SUBMISSION_ID,
-        user_id: teacher.id,
-        pd_workshop_id: @csf201_not_started_workshop.id,
-        day: 0
-      )
-
-      sign_in teacher
-      get '/pd/workshop_survey/csf/pre201'
-
-      assert_thanks
     end
 
     test 'csf post201 survey: redirect to sign-in page if teacher did not authenticate' do
@@ -413,18 +324,6 @@ module Pd
       assert_select 'h1', text: 'Thank you for submitting today’s survey.'
     end
 
-    test 'AYW1 pre-survey link shows foorm survey' do
-      setup_academic_year_workshop
-      sign_in @enrolled_academic_year_teacher
-
-      pre_survey_links = %w(/pd/AYW1/pre /pd/AYW1/pre/module/1 /pd/AYW1/pre/module/2)
-      pre_survey_links.each do |link|
-        get link
-        assert_response :success
-        assert_template :new_general_foorm
-      end
-    end
-
     test 'AYW1 post-survey link shows foorm survey for attended teacher' do
       setup_academic_year_workshop
       sign_in @enrolled_academic_year_teacher
@@ -454,15 +353,6 @@ module Pd
       end
     end
 
-    test 'AYW1_2 pre-survey link shows foorm survey' do
-      setup_two_day_academic_year_workshop
-      sign_in @enrolled_two_day_academic_year_teacher
-
-      get '/pd/AYW1_2/pre'
-      assert_response :success
-      assert_template :new_general_foorm
-    end
-
     test 'AYW1_2 post-survey link shows foorm survey for attended teacher' do
       setup_two_day_academic_year_workshop
       sign_in @enrolled_two_day_academic_year_teacher
@@ -475,15 +365,6 @@ module Pd
       get '/pd/AYW1_2/post/in_person'
       assert_response :success
       assert_template :new_general_foorm
-    end
-
-    test 'User cannot access AYW survey if they are not enrolled' do
-      setup_two_day_academic_year_workshop
-      sign_in @enrolled_two_day_academic_year_teacher
-
-      # two day workshop enrollee should not be able to load 1 day survey
-      get '/pd/AYW1/pre'
-      assert_not_enrolled
     end
 
     private def setup_summer_workshop

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -33,6 +33,51 @@ module Pd
       assert_response :not_found
     end
 
+    test 'pre-workshop survey displays not enrolled message when not enrolled' do
+      sign_in unenrolled_teacher
+      get '/pd/workshop_survey/day/0'
+      assert_response :success
+      assert_not_enrolled
+    end
+
+    test 'pre-workshop foorm survey displays not enrolled message when not enrolled' do
+      sign_in unenrolled_teacher
+      get '/pd/workshop_pre_survey'
+      assert_response :success
+      assert_not_enrolled
+    end
+
+    test 'pre-workshop foorm survey shows thanks when a response exists' do
+      teacher = create(:teacher)
+      byo_workshop = create(:byo_workshop)
+      create(:pd_enrollment, workshop: byo_workshop, user: teacher)
+
+      existing_survey = create(:daily_workshop_day_0_foorm_submission,
+        :answers_high,
+        form_name: "surveys/pd/build_your_own_workshop_teachers_pre_survey"
+      )
+      create(:day_0_workshop_foorm_submission,
+        foorm_submission: existing_survey,
+        pd_workshop: byo_workshop,
+        user: teacher
+      )
+
+      sign_in teacher
+      get '/pd/workshop_pre_survey'
+      assert_thanks
+    end
+
+    test 'pre-workshop foorm survey displays foorm when enrolled' do
+      teacher = create(:teacher)
+      byo_workshop = create(:byo_workshop)
+      create(:pd_enrollment, workshop: byo_workshop, user: teacher)
+
+      sign_in teacher
+      get '/pd/workshop_pre_survey'
+      assert_template :new_general_foorm
+      assert_response :success
+    end
+
     test 'post-workshop foorm survey displays foorm when enrolled and attended' do
       setup_summer_workshop
 

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -101,21 +101,13 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     csp_summer_workshop = build(:csp_summer_workshop)
     csp_summer_workshop_enrollment = build(:pd_enrollment, workshop: csp_summer_workshop)
 
-    csp_academic_year_workshop = build(:csp_academic_year_workshop)
-    csp_academic_year_workshop_enrollment = build(:pd_enrollment, workshop: csp_academic_year_workshop)
-
-    csf_deep_dive_workshop = build(:csf_deep_dive_workshop)
-    csf_201_workshop_enrollment = build(:pd_enrollment, workshop: csf_deep_dive_workshop)
-
-    csf_intro_workshop = build(:csf_intro_workshop)
-    csf_intro_workshop_enrollment = build(:pd_enrollment, workshop: csf_intro_workshop)
+    byo_workshop = build(:byo_workshop)
+    byo_workshop_enrollment = build(:pd_enrollment, workshop: byo_workshop)
 
     assert_equal "/pd/workshop_pre_survey?enrollmentCode=#{csp_summer_workshop_enrollment.code}",
       URI(csp_summer_workshop_enrollment.pre_workshop_survey_url).path + '?' + URI(csp_summer_workshop_enrollment.pre_workshop_survey_url).query
-    assert_equal "/pd/workshop_pre_survey?enrollmentCode=#{csp_academic_year_workshop_enrollment.code}",
-      URI(csp_academic_year_workshop_enrollment.pre_workshop_survey_url).path + '?' + URI(csp_academic_year_workshop_enrollment.pre_workshop_survey_url).query
-    assert_equal '/pd/workshop_survey/csf/pre201', URI(csf_201_workshop_enrollment.pre_workshop_survey_url).path
-    assert_nil csf_intro_workshop_enrollment.pre_workshop_survey_url
+    assert_equal "/pd/workshop_pre_survey?enrollmentCode=#{byo_workshop_enrollment.code}",
+      URI(byo_workshop_enrollment.pre_workshop_survey_url).path + '?' + URI(byo_workshop_enrollment.pre_workshop_survey_url).query
   end
 
   test 'exit_survey_url' do


### PR DESCRIPTION
This PR unifies all workshops to now use the same pre-workshop survey (the BYOW survey). This has a lot of potential for scope creep since there's a lot of cleanup that could be done, so I tried to do some in the areas I was already in but kept it timeboxed since this was a blocker on the new MailJet emails which I believe are a higher priority. I did my best to keep method names the same and preserve constants so that legacy content and tests still works. With that being said, I did find a couple now-unused methods (and their respective tests) so I removed those since they were relevant to this work and no longer needed.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3483)
(this will also inherently solve another Jira ticket ([Add new pre-survey to workshop confirmation, 10 day and 3 day emails](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3452)), since they do/will use the `pre_workshop_survey_url` method to retrieve the URL)

## Testing story
Updating unit tests.
