### PR TITLE
[MusicLab] Adding back in blocklyActiveFocus outline

### DIFF
--- a/apps/src/blockly/addons/cdoCss.ts
+++ b/apps/src/blockly/addons/cdoCss.ts
@@ -12,6 +12,10 @@ export default function initializeCss(blocklyWrapper: BlocklyWrapperType) {
       padding: 0px;
       margin: 0px;
     }
+    .blocklyActiveFocus:focus-visible {
+      outline: -webkit-focus-ring-color auto 5px;
+      border-radius: 2px;
+    }
     .blocklyFieldGrid .blocklyFieldGridItem img {
       opacity: 1;
       object-fit: contain;


### PR DESCRIPTION
This reapplies some styles that I [should have implemented differently the first time](https://github.com/code-dot-org/code-dot-org/pull/66429/files). That is, I picked up the blocklyActiveFocus here, but applied it when elements were focused, not using 'focus-visible' (as in, focused via keyboard). That meant that the focus outline was appearing during click events as well, which was a regression. This time, I'm reapplying it for only focus-visible. 



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
