### PR TITLE
Disallow LAUSD email domains during signup

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1073,7 +1073,6 @@
   "displayName": "Display name",
   "documentation": "Documentation",
   "documentationBug": "Found a bug in the documentation? Let us know at [support@code.org](mailto:support@code.org).",
-  "domainDisallowed": "{domain} emails disallowed from logging in with email and password.",
   "done": "Done",
   "dontForget": "Don't forget",
   "doSomething": "do something",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1073,6 +1073,7 @@
   "displayName": "Display name",
   "documentation": "Documentation",
   "documentationBug": "Found a bug in the documentation? Let us know at [support@code.org](mailto:support@code.org).",
+  "domainDisallowed": "{domain} emails disallowed from logging in with email and password.",
   "done": "Done",
   "dontForget": "Don't forget",
   "doSomething": "do something",

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -51,7 +51,8 @@ const getUserType = () => {
 const LoginTypeSelection: React.FunctionComponent<{
   isSignedOut: boolean;
   passwordMinLength: number;
-}> = ({isSignedOut, passwordMinLength}) => {
+  emailDomainDisallowed?: object;
+}> = ({isSignedOut, passwordMinLength, emailDomainDisallowed}) => {
   const [userType, setUserType] = useState(getUserType());
   const [password, setPassword] = useState('');
   const [passwordIcon, setPasswordIcon] = useState(X_ICON);
@@ -167,6 +168,18 @@ const LoginTypeSelection: React.FunctionComponent<{
     logUserLoginType('email');
     if (!isEmail(email)) {
       setEmailErrorMessage(i18n.censusInvalidEmail());
+      setShowEmailError(true);
+      return;
+    }
+    // Check if the email domain is in the disallowed list. Some districts
+    // require students to log in through their LMS, so we disallow those
+    // domains from logging in with an email and password.
+    const emailDomain = email.split('@')[1];
+    if (
+      Array.isArray(emailDomainDisallowed) &&
+      emailDomainDisallowed.includes(emailDomain)
+    ) {
+      setEmailErrorMessage(i18n.domainDisallowed({domain: emailDomain}));
       setShowEmailError(true);
       return;
     }

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -51,8 +51,7 @@ const getUserType = () => {
 const LoginTypeSelection: React.FunctionComponent<{
   isSignedOut: boolean;
   passwordMinLength: number;
-  emailDomainDisallowed?: object;
-}> = ({isSignedOut, passwordMinLength, emailDomainDisallowed}) => {
+}> = ({isSignedOut, passwordMinLength}) => {
   const [userType, setUserType] = useState(getUserType());
   const [password, setPassword] = useState('');
   const [passwordIcon, setPasswordIcon] = useState(X_ICON);
@@ -171,18 +170,6 @@ const LoginTypeSelection: React.FunctionComponent<{
       setShowEmailError(true);
       return;
     }
-    // Check if the email domain is in the disallowed list. Some districts
-    // require students to log in through their LMS, so we disallow those
-    // domains from logging in with an email and password.
-    const emailDomain = email.split('@')[1];
-    if (
-      Array.isArray(emailDomainDisallowed) &&
-      emailDomainDisallowed.includes(emailDomain)
-    ) {
-      setEmailErrorMessage(i18n.domainDisallowed({domain: emailDomain}));
-      setShowEmailError(true);
-      return;
-    }
     const submitLoginTypeParams = {
       user: {
         email: email,
@@ -200,10 +187,17 @@ const LoginTypeSelection: React.FunctionComponent<{
         },
         body: JSON.stringify(submitLoginTypeParams),
       });
-      // We are currently only intentionally surfacing errors for duplicate emails
       if (!response.ok) {
-        setEmailErrorMessage(i18n.duplicate_email_error_message());
-        setShowEmailError(true);
+        // Handle disallowed email domains
+        if (response.status === 403) {
+          const res = await response.json();
+          setEmailErrorMessage(res.error);
+          setShowEmailError(true);
+        } else {
+          // We are currently only intentionally surfacing errors for duplicate emails
+          setEmailErrorMessage(i18n.duplicate_email_error_message());
+          setShowEmailError(true);
+        }
         return;
       }
       navigateToHref(finishAccountUrl);

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -188,7 +188,8 @@ const LoginTypeSelection: React.FunctionComponent<{
         body: JSON.stringify(submitLoginTypeParams),
       });
       if (!response.ok) {
-        // Handle disallowed email domains
+        // Handle disallowed email domains. We return a 403 status code from the server
+        // in this case.
         if (response.status === 403) {
           const res = await response.json();
           setEmailErrorMessage(res.error);

--- a/apps/src/sites/studio/pages/devise/registrations/login_type.js
+++ b/apps/src/sites/studio/pages/devise/registrations/login_type.js
@@ -8,12 +8,10 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 $(document).ready(() => {
   const isSignedOut = getScriptData('isSignedOut');
   const passwordMinLength = getScriptData('passwordMinLength');
-  const emailDomainDisallowed = getScriptData('emailDomainDisallowed');
   ReactDOM.render(
     <LoginTypeSelection
       isSignedOut={isSignedOut}
       passwordMinLength={passwordMinLength}
-      emailDomainDisallowed={emailDomainDisallowed}
     />,
     document.getElementById('login-type-selection')
   );

--- a/apps/src/sites/studio/pages/devise/registrations/login_type.js
+++ b/apps/src/sites/studio/pages/devise/registrations/login_type.js
@@ -8,10 +8,12 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 $(document).ready(() => {
   const isSignedOut = getScriptData('isSignedOut');
   const passwordMinLength = getScriptData('passwordMinLength');
+  const emailDomainDisallowed = getScriptData('emailDomainDisallowed');
   ReactDOM.render(
     <LoginTypeSelection
       isSignedOut={isSignedOut}
       passwordMinLength={passwordMinLength}
+      emailDomainDisallowed={emailDomainDisallowed}
     />,
     document.getElementById('login-type-selection')
   );

--- a/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
+++ b/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
@@ -348,6 +348,82 @@ describe('LoginTypeSelection', () => {
     fetchSpy.restore();
   });
 
+  it('trying to use a disallowed email domain displays disallowed domain error message', async () => {
+    const fetchSpy = sinon.stub(window, 'fetch');
+    const disallowedDomainMessage =
+      'Emails from test.com are not allowed to sign up with email and password.';
+    fetchSpy.returns(
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: disallowedDomainMessage,
+          }),
+          {
+            status: 403,
+          }
+        )
+      )
+    );
+
+    await waitFor(() => {
+      renderDefault();
+    });
+
+    // Set up create account button onClick jest function
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.create_my_account(),
+    }) as HTMLButtonElement;
+    const handleClick = jest.fn();
+    finishSignUpButton.onclick = handleClick;
+
+    // Fill in required fields with disallowed domain
+    const email = 'user@test.com';
+    const password = 'password';
+    const emailInput = screen.getByLabelText(locale.email_address());
+    const passwordInput = screen.getByLabelText(locale.password());
+    const confirmPasswordInput = screen.getByLabelText(
+      locale.confirm_password()
+    );
+    const beginSignUpParams = {
+      user: {
+        email: email,
+        password: password,
+        password_confirmation: password,
+        user_type: UserTypes.STUDENT, // Testing with student but should be same for teacher
+      },
+    };
+
+    fireEvent.change(emailInput, {
+      target: {value: email},
+    });
+    fireEvent.change(passwordInput, {target: {value: password}});
+    fireEvent.change(confirmPasswordInput, {target: {value: password}});
+    await waitFor(() => {
+      expect(finishSignUpButton).not.toBeDisabled();
+    });
+
+    // Click create account button
+    fireEvent.click(finishSignUpButton);
+
+    await waitFor(() => {
+      // Verify the button's click handler was called
+      expect(handleClick).toHaveBeenCalled();
+
+      // Verify the button's fetch method was called
+      expect(fetchSpy).toHaveBeenCalled;
+      const fetchCall = fetchSpy.getCall(0);
+      expect(fetchCall.args[0]).toEqual('/users/begin_sign_up');
+      expect(fetchCall.args[1]?.body).toEqual(
+        JSON.stringify(beginSignUpParams)
+      );
+
+      // Verify the user sees the disallowed domain error message
+      screen.getByText(disallowedDomainMessage);
+    });
+
+    fetchSpy.restore();
+  });
+
   it('clicks the create account button when Enter is pressed if the button is enabled', async () => {
     const fetchSpy = sinon.stub(window, 'fetch');
     fetchSpy.returns(Promise.resolve(new Response()));

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -37,6 +37,13 @@ class RegistrationsController < Devise::RegistrationsController
   # Submit step 1 of the signup process for creating an email/password account.
   #
   def begin_sign_up
+    domain = params[:user][:email].split('@')[1] if params[:user][:email].present?
+    if Policies::Devise::DisallowedDomains::DISALLOWED_DOMAINS.include?(domain)
+      render json: {
+        error: I18n.t('devise.registrations.disallowed_domain', domain: domain)
+      }, status: :forbidden
+      return
+    end
     @user = User.new(begin_sign_up_params)
     @user.country_code = @country_code
     @user.validate_for_finish_sign_up
@@ -64,7 +71,6 @@ class RegistrationsController < Devise::RegistrationsController
   def login_type
     @is_signed_out = current_user.nil?
     @user_type = params[:user_type]
-    @email_domain_disallowed = Policies::Devise::DisallowedDomains::DISALLOWED_DOMAINS
     view_options(full_width: true, responsive_content: true)
     render 'login_type'
   end

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -38,7 +38,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def begin_sign_up
     domain = params[:user][:email].split('@')[1] if params[:user][:email].present?
-    if Policies::Devise::EmailDomains.disallowed_domains.include?(domain)
+    if Policies::Devise::EmailDomains::DISALLOWED_DOMAINS.include?(domain)
       render json: {
         error: I18n.t('devise.registrations.disallowed_domain', domain: domain)
       }, status: :forbidden

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -5,7 +5,7 @@ require_relative '../../../shared/middleware/helpers/experiments'
 require 'metrics/events'
 require 'policies/lti'
 require 'queries/lti'
-require 'policies/devise/disallowed_domains'
+require 'policies/devise/email_domains'
 
 class RegistrationsController < Devise::RegistrationsController
   before_action :require_no_authentication, only: [:account_type, :login_type, :finish_student_account, :finish_teacher_account, :new, :create, :cancel]
@@ -38,7 +38,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def begin_sign_up
     domain = params[:user][:email].split('@')[1] if params[:user][:email].present?
-    if Policies::Devise::DisallowedDomains::DISALLOWED_DOMAINS.include?(domain)
+    if Policies::Devise::EmailDomains.disallowed_domains.include?(domain)
       render json: {
         error: I18n.t('devise.registrations.disallowed_domain', domain: domain)
       }, status: :forbidden

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -5,6 +5,7 @@ require_relative '../../../shared/middleware/helpers/experiments'
 require 'metrics/events'
 require 'policies/lti'
 require 'queries/lti'
+require 'policies/devise/disallowed_domains'
 
 class RegistrationsController < Devise::RegistrationsController
   before_action :require_no_authentication, only: [:account_type, :login_type, :finish_student_account, :finish_teacher_account, :new, :create, :cancel]
@@ -63,6 +64,7 @@ class RegistrationsController < Devise::RegistrationsController
   def login_type
     @is_signed_out = current_user.nil?
     @user_type = params[:user_type]
+    @email_domain_disallowed = Policies::Devise::DisallowedDomains::DISALLOWED_DOMAINS
     view_options(full_width: true, responsive_content: true)
     render 'login_type'
   end

--- a/dashboard/app/views/devise/registrations/login_type.haml
+++ b/dashboard/app/views/devise/registrations/login_type.haml
@@ -1,5 +1,5 @@
 = render 'devise/registrations/sign_up_locale'
 
-%script{src: webpack_asset_path('js/devise/registrations/login_type.js'), data: {isSignedOut: @is_signed_out.to_json, passwordMinLength: User.password_min_length(@user_type, @country_code).to_json}}
+%script{src: webpack_asset_path('js/devise/registrations/login_type.js'), data: {isSignedOut: @is_signed_out.to_json, passwordMinLength: User.password_min_length(@user_type, @country_code).to_json, emailDomainDisallowed: @email_domain_disallowed.to_json}}
 
 #login-type-selection

--- a/dashboard/app/views/devise/registrations/login_type.haml
+++ b/dashboard/app/views/devise/registrations/login_type.haml
@@ -1,5 +1,5 @@
 = render 'devise/registrations/sign_up_locale'
 
-%script{src: webpack_asset_path('js/devise/registrations/login_type.js'), data: {isSignedOut: @is_signed_out.to_json, passwordMinLength: User.password_min_length(@user_type, @country_code).to_json, emailDomainDisallowed: @email_domain_disallowed.to_json}}
+%script{src: webpack_asset_path('js/devise/registrations/login_type.js'), data: {isSignedOut: @is_signed_out.to_json, passwordMinLength: User.password_min_length(@user_type, @country_code).to_json}}
 
 #login-type-selection

--- a/dashboard/config/locales/devise/en.yml
+++ b/dashboard/config/locales/devise/en.yml
@@ -32,6 +32,7 @@ en:
       updated: "Your password was changed successfully. You are now signed in."
       updated_not_active: "Your password was changed successfully."
     registrations:
+      disallowed_domain: "Emails from %{domain} are not allowed to sign up with email and password. Please use your LMS to sign in."
       destroyed: "Bye! Your account was successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."

--- a/dashboard/lib/policies/devise/disallowed_domains.rb
+++ b/dashboard/lib/policies/devise/disallowed_domains.rb
@@ -1,7 +1,7 @@
 class Policies::Devise::DisallowedDomains
+  # TODO: consider using a regex to match subdomains
   DISALLOWED_DOMAINS = [
     'mymail.lausd.net',
     'lausd.net',
-    'lausd.org',
   ].freeze
 end

--- a/dashboard/lib/policies/devise/disallowed_domains.rb
+++ b/dashboard/lib/policies/devise/disallowed_domains.rb
@@ -1,7 +1,0 @@
-class Policies::Devise::DisallowedDomains
-  # TODO: consider using a regex to match subdomains
-  DISALLOWED_DOMAINS = [
-    'mymail.lausd.net',
-    'lausd.net',
-  ].freeze
-end

--- a/dashboard/lib/policies/devise/disallowed_domains.rb
+++ b/dashboard/lib/policies/devise/disallowed_domains.rb
@@ -1,0 +1,7 @@
+class Policies::Devise::DisallowedDomains
+  DISALLOWED_DOMAINS = [
+    'mymail.lausd.net',
+    'lausd.net',
+    'lausd.org',
+  ].freeze
+end

--- a/dashboard/lib/policies/devise/email_domains.rb
+++ b/dashboard/lib/policies/devise/email_domains.rb
@@ -1,8 +1,6 @@
 class Policies::Devise::EmailDomains
-  def self.disallowed_domains
-    [
-      'mymail.lausd.net',
-      'lausd.net',
-    ].freeze
-  end
+  DISALLOWED_DOMAINS = [
+    'mymail.lausd.net',
+    'lausd.net',
+  ].freeze
 end

--- a/dashboard/lib/policies/devise/email_domains.rb
+++ b/dashboard/lib/policies/devise/email_domains.rb
@@ -1,0 +1,8 @@
+class Policies::Devise::EmailDomains
+  def self.disallowed_domains
+    [
+      'mymail.lausd.net',
+      'lausd.net',
+    ].freeze
+  end
+end

--- a/dashboard/test/integration/registration/email_test.rb
+++ b/dashboard/test/integration/registration/email_test.rb
@@ -56,6 +56,32 @@ module RegistrationsControllerTests
       created_user&.destroy!
     end
 
+    test "user with disallowed domain in new sign-up" do
+      email = "user@testdomain.com"
+      # Mock the disallowed domains to include a test domain
+      original_domains = Policies::Devise::DisallowedDomains::DISALLOWED_DOMAINS
+      test_domains = ['testdomain.com']
+
+      # Stub the constant to return our test domain
+      Policies::Devise::DisallowedDomains.const_set(:DISALLOWED_DOMAINS, test_domains.freeze)
+
+      post '/users/begin_sign_up', params: {
+        user: {
+          email: email,
+          password: 'mypassword',
+          password_confirmation: 'mypassword',
+          user_type: User::TYPE_STUDENT, # user type doesn't matter for this test
+        }
+      }
+
+      assert_response :forbidden
+      assert_match /Emails from testdomain.com are not allowed to sign up with email and password. Please use your LMS to sign in./, @response.body
+      refute PartialRegistration.in_progress? session
+    ensure
+      # Restore the original constant
+      Policies::Devise::DisallowedDomains.const_set(:DISALLOWED_DOMAINS, original_domains)
+    end
+
     private def finish_email_sign_up(user_type, email)
       params = finish_sign_up_params({user_type: user_type, email: email})
       post '/users', params: params

--- a/dashboard/test/integration/registration/email_test.rb
+++ b/dashboard/test/integration/registration/email_test.rb
@@ -59,11 +59,10 @@ module RegistrationsControllerTests
     test "user with disallowed domain in new sign-up" do
       email = "user@testdomain.com"
       # Mock the disallowed domains to include a test domain
-      original_domains = Policies::Devise::DisallowedDomains::DISALLOWED_DOMAINS
-      test_domains = ['testdomain.com']
+      test_domains = ['testdomain.com'].freeze
 
       # Stub the constant to return our test domain
-      Policies::Devise::DisallowedDomains.const_set(:DISALLOWED_DOMAINS, test_domains.freeze)
+      Policies::Devise::EmailDomains.stubs(:disallowed_domains).returns(test_domains)
 
       post '/users/begin_sign_up', params: {
         user: {
@@ -77,9 +76,6 @@ module RegistrationsControllerTests
       assert_response :forbidden
       assert_match /Emails from testdomain.com are not allowed to sign up with email and password. Please use your LMS to sign in./, @response.body
       refute PartialRegistration.in_progress? session
-    ensure
-      # Restore the original constant
-      Policies::Devise::DisallowedDomains.const_set(:DISALLOWED_DOMAINS, original_domains)
     end
 
     private def finish_email_sign_up(user_type, email)

--- a/dashboard/test/integration/registration/email_test.rb
+++ b/dashboard/test/integration/registration/email_test.rb
@@ -7,6 +7,7 @@ module RegistrationsControllerTests
   #
   class EmailTest < ActionDispatch::IntegrationTest
     include OmniauthCallbacksControllerTests::Utils
+    include Minitest::RSpecMocks
 
     setup do
       stub_firehose
@@ -56,26 +57,29 @@ module RegistrationsControllerTests
       created_user&.destroy!
     end
 
-    test "user with disallowed domain in new sign-up" do
-      email = "user@testdomain.com"
-      # Mock the disallowed domains to include a test domain
-      test_domains = ['testdomain.com'].freeze
+    describe "disallowed email domain" do
+      let(:disallowed_domains) {['testdomain.com']}
+      let(:email) {"user@#{disallowed_domains.first}"}
 
-      # Stub the constant to return our test domain
-      Policies::Devise::EmailDomains.stubs(:disallowed_domains).returns(test_domains)
+      before do
+        stub_const('Policies::Devise::EmailDomains::DISALLOWED_DOMAINS', disallowed_domains)
 
-      post '/users/begin_sign_up', params: {
-        user: {
-          email: email,
-          password: 'mypassword',
-          password_confirmation: 'mypassword',
-          user_type: User::TYPE_STUDENT, # user type doesn't matter for this test
+        post '/users/begin_sign_up', params: {
+          user: {
+            email: email,
+            password: 'mypassword',
+            password_confirmation: 'mypassword',
+            user_type: User::TYPE_STUDENT
+          }
         }
-      }
+      end
 
-      assert_response :forbidden
-      assert_match /Emails from testdomain.com are not allowed to sign up with email and password. Please use your LMS to sign in./, @response.body
-      refute PartialRegistration.in_progress? session
+      it "forbids sign up" do
+        _(response.status).must_equal 403
+        _(response.body).must_match(
+          /Emails from #{Regexp.escape(disallowed_domains.first)} are not allowed to sign up with email and password\. Please use your LMS to sign in\./
+        )
+      end
     end
 
     private def finish_email_sign_up(user_type, email)


### PR DESCRIPTION
This PR adds functionality to disallow users with an LAUSD email domain from signing up via email/password. This is a requirement for supporting LAUSD, and could likely be a requirement from other districts in the future.

<img width="1517" height="844" alt="Screenshot 2025-08-21 at 1 19 29 PM" src="https://github.com/user-attachments/assets/a0b4d387-b55f-4643-85c3-cc792e57f97e" />

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/P20-1579

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
