### PR TITLE
Ceara/aitt fix new thread behavior

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -1,4 +1,10 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
@@ -83,6 +89,7 @@ interface AiDiffChatProps {
   curriculumCourses?: string[];
   threadFetchCallback?: () => void;
   threadId?: number;
+  setThreadId?: Dispatch<SetStateAction<number>>;
 }
 
 const AiDiffChat: React.FC<AiDiffChatProps> = ({
@@ -98,6 +105,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
   curriculumCourses = [],
   threadFetchCallback = () => {},
   threadId = 0,
+  setThreadId = () => {},
 }) => {
   const reportingData = React.useMemo(() => {
     return {
@@ -252,6 +260,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
           );
           if (json.thread_id) {
             setLocalThreadId(json.thread_id);
+            setThreadId(json.thread_id);
           }
           setMessageHistory(prevMessages => [...prevMessages, newAiMessage]);
         })
@@ -272,6 +281,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
       threadFetchCallback,
       setLocalThreadId,
       chatResponseCallback,
+      setThreadId,
     ]
   );
 

--- a/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
+++ b/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
@@ -30,6 +30,7 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
   const [threads, setThreads] = useState<ChatThread[]>();
   const [threadMessages, setThreadMessages] = useState<ChatItem[]>();
   const [threadId, setThreadId] = useState<number>(0);
+  const [keyId, setKeyId] = useState<number>(0);
 
   async function asyncFetchThreads(): Promise<ChatThread[]> {
     const response = await HttpClient.fetchJson<ChatThread[]>(
@@ -70,14 +71,24 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
       if (thread === 0) {
         setThreadMessages([]);
         setThreadId(thread);
+        // changing the keyId resets the component state.
+        // if key is already 0 (i.e. starting a new thread from a new thread)
+        // then we need to alternate to a different key value to reset state
+        // -1 is safe because it won't accidentally match a threadID value
+        if (keyId === 0) {
+          setKeyId(-1);
+        } else {
+          setKeyId(thread);
+        }
       } else {
         asyncFetchThreadMessages(thread).then(response => {
           setThreadMessages(response.messages);
           setThreadId(thread);
+          setKeyId(thread);
         });
       }
     },
-    [setThreadMessages]
+    [setThreadMessages, keyId]
   );
 
   return (
@@ -95,8 +106,9 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
         curriculumCourses={curriculumCourses}
         threadFetchCallback={showSidebar ? fetchThreads : () => {}}
         threadMessages={threadMessages}
-        key={threadId}
+        key={keyId}
         threadId={threadId}
+        setThreadId={setThreadId}
       />
     </div>
   );


### PR DESCRIPTION
This is a fix for a bug @MollyPeredo noted where you couldn't create a new thread using the "New thread" button if you are still in a thread started with the new thread button.

This is because we previously set the key for the chat component as 0 for a new thread and the thread id for old threads. We set the key when switching threads to re-set the State of the chat component to clear the message history and reset it from params. On a new thread with key == 0, we don't reset the key to the newly created threadID because we want to keep the messagehistory and view as-is.  The key remained until switching threads from the sidebar, which cause problems when trying to create a new thread from a previous new thread, because both keys are 0.

This change just alternates 0 and -1 as keys for new threads. -1 is used so it won't accidentally clash with a real thread ID.

Video:

https://github.com/user-attachments/assets/c0911d37-059f-4cc7-a0f5-ae44fb6b4e77

## Links
slack thread about bug: https://codedotorg.slack.com/archives/C050HE4QDHR/p1755200424919449?thread_ts=1755196263.126769&cid=C050HE4QDHR
Included in jira ticket: https://codedotorg.atlassian.net/browse/AITT-1115

## Testing story
Previous non-thread tests are passing

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
