### PR TITLE
Add deletion_warning_email_sent_at column to user_data_retention_statuses

### DIFF
--- a/dashboard/app/models/user/data_retention_status.rb
+++ b/dashboard/app/models/user/data_retention_status.rb
@@ -12,9 +12,10 @@
 #
 # Indexes
 #
-#  index_user_data_retention_statuses_on_anonymized_at    (anonymized_at)
-#  index_user_data_retention_statuses_on_pii_scrubbed_at  (pii_scrubbed_at)
-#  index_user_data_retention_statuses_on_user_id          (user_id)
+#  index_user_data_retention_statuses_on_anonymized_at          (anonymized_at)
+#  index_user_data_retention_statuses_on_pii_scrubbed_at        (pii_scrubbed_at)
+#  index_user_data_retention_statuses_on_user_id                (user_id)
+#  index_user_data_retention_statuses_on_warning_email_sent_at  (deletion_warning_email_sent_at)
 #
 class User::DataRetentionStatus < ApplicationRecord
   belongs_to :user, -> {with_deleted}

--- a/dashboard/app/models/user/data_retention_status.rb
+++ b/dashboard/app/models/user/data_retention_status.rb
@@ -2,12 +2,13 @@
 #
 # Table name: user_data_retention_statuses
 #
-#  id              :bigint           not null, primary key
-#  user_id         :integer          not null
-#  pii_scrubbed_at :datetime
-#  anonymized_at   :datetime
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
+#  id                             :bigint           not null, primary key
+#  user_id                        :integer          not null
+#  pii_scrubbed_at                :datetime
+#  anonymized_at                  :datetime
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  deletion_warning_email_sent_at :datetime
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20250821182723_add_deletion_warning_email_sent_at_to_user_data_retention_statuses.rb
+++ b/dashboard/db/migrate/20250821182723_add_deletion_warning_email_sent_at_to_user_data_retention_statuses.rb
@@ -1,0 +1,5 @@
+class AddDeletionWarningEmailSentAtToUserDataRetentionStatuses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_data_retention_statuses, :deletion_warning_email_sent_at, :datetime
+  end
+end

--- a/dashboard/db/migrate/20250821182723_add_deletion_warning_email_sent_at_to_user_data_retention_statuses.rb
+++ b/dashboard/db/migrate/20250821182723_add_deletion_warning_email_sent_at_to_user_data_retention_statuses.rb
@@ -1,5 +1,6 @@
 class AddDeletionWarningEmailSentAtToUserDataRetentionStatuses < ActiveRecord::Migration[6.1]
   def change
     add_column :user_data_retention_statuses, :deletion_warning_email_sent_at, :datetime
+    add_index :user_data_retention_statuses, :deletion_warning_email_sent_at, name: "index_user_data_retention_statuses_on_warning_email_sent_at"
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_08_15_132016) do
+ActiveRecord::Schema.define(version: 2025_08_21_182723) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2337,12 +2337,13 @@ ActiveRecord::Schema.define(version: 2025_08_15_132016) do
     t.index ["unit_group_id", "resource_id"], name: "index_ug_student_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "user_data_retention_statuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_data_retention_statuses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "pii_scrubbed_at"
     t.datetime "anonymized_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deletion_warning_email_sent_at"
     t.index ["anonymized_at"], name: "index_user_data_retention_statuses_on_anonymized_at"
     t.index ["pii_scrubbed_at"], name: "index_user_data_retention_statuses_on_pii_scrubbed_at"
     t.index ["user_id"], name: "index_user_data_retention_statuses_on_user_id"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -2337,7 +2337,7 @@ ActiveRecord::Schema.define(version: 2025_08_21_182723) do
     t.index ["unit_group_id", "resource_id"], name: "index_ug_student_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "user_data_retention_statuses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_data_retention_statuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "pii_scrubbed_at"
     t.datetime "anonymized_at"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -2345,6 +2345,7 @@ ActiveRecord::Schema.define(version: 2025_08_21_182723) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "deletion_warning_email_sent_at"
     t.index ["anonymized_at"], name: "index_user_data_retention_statuses_on_anonymized_at"
+    t.index ["deletion_warning_email_sent_at"], name: "index_user_data_retention_statuses_on_warning_email_sent_at"
     t.index ["pii_scrubbed_at"], name: "index_user_data_retention_statuses_on_pii_scrubbed_at"
     t.index ["user_id"], name: "index_user_data_retention_statuses_on_user_id"
   end


### PR DESCRIPTION
This PR adds `deletion_warning_email_sent_at` column to `user_data_retention_statuses` table to track when a user has been emailed about their inactive account.
- Adds a datetime column to `user_data_retention_statuses`.
- Tracks when a user is emailed about account deletion due to inactivity. Reusable if the user signs in after email has already been sent and another three years elapse.


## Links
- Jira: [here](https://codedotorg.atlassian.net/browse/P20-1493)

## Follow-up work
Use this field for our inactive teacher query for those who should be emailed.
