### PR TITLE
feat(workshops): add engagement survey category view

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Engagement.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Engagement.tsx
@@ -1,3 +1,79 @@
-import React from 'react';
+import {Box} from '@mui/material';
+import React, {useMemo} from 'react';
 
-export const Engagement = () => <div>Engagement</div>;
+import {
+  isQuestionType,
+  SurveyQuestions,
+} from '../../../../WorkshopFormTemplate/types';
+import {useWorkshopContext} from '../../../WorkshopLayout';
+import {FreeResponseCard} from '../../components/FreeResponseCard';
+import {ScoreCard} from '../../components/ScoreCard';
+import {MIN_RESPONSE_COUNT} from '../../constants';
+import {getQuestionDescription} from '../../helpers';
+
+import styles from '../../../workshop.module.scss';
+
+export const Engagement = () => {
+  const {surveys} = useWorkshopContext();
+
+  const questions: SurveyQuestions | undefined =
+    surveys?.surveys?.post_workshop?.categories?.engagement?.questions;
+
+  const likelyToRecommend = questions?.nps_self_paced_pd_byow;
+
+  const otherQuestionsEngagement = questions?.other_feedback_FR;
+
+  const likertQuestionRow = useMemo(() => {
+    if (!questions) return [];
+    return [questions.likelihood_other_pd, questions.rp_as_resource];
+  }, [questions]);
+
+  if (!questions) return null;
+
+  return (
+    <Box className={styles.surveyResultsContainer}>
+      <Box className={styles.cardRow}>
+        {isQuestionType(likelyToRecommend, 'promoter') && (
+          <ScoreCard
+            key={likelyToRecommend.question_name}
+            title={
+              likelyToRecommend.question_short_text ??
+              likelyToRecommend.question_text
+            }
+            description={getQuestionDescription(likelyToRecommend)}
+            footer={likelyToRecommend.question_sub_text}
+            score={likelyToRecommend.results.promoter_percentage}
+            responseCount={likelyToRecommend.results.total_responses}
+            minResponseCount={MIN_RESPONSE_COUNT}
+          />
+        )}
+        {likertQuestionRow.map(question =>
+          isQuestionType(question, 'likert') ? (
+            <ScoreCard
+              key={question.question_name}
+              title={question.question_short_text ?? question.question_text}
+              description={getQuestionDescription(question)}
+              footer={question.question_sub_text}
+              score={question.results.weighted_score}
+              responseCount={question.results.total_responses}
+              minResponseCount={MIN_RESPONSE_COUNT}
+            />
+          ) : null
+        )}
+      </Box>
+
+      <Box className={styles.cardRow}>
+        {isQuestionType(otherQuestionsEngagement, 'text') && (
+          <FreeResponseCard
+            title={
+              otherQuestionsEngagement.question_short_text ??
+              otherQuestionsEngagement.question_text
+            }
+            items={otherQuestionsEngagement.results.responses}
+            tagText={`${otherQuestionsEngagement.results.total_responses} Submitted`}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
This pull request significantly updates the `Engagement` component in the post-workshop survey dashboard to display actual engagement survey results instead of a placeholder. The component now fetches survey data from context, displays score cards for key engagement questions, and shows free-response feedback, improving the usefulness and interactivity of the survey results page.

**Survey results rendering improvements:**

* The `Engagement` component now retrieves engagement-related survey questions and results from the workshop context, replacing the static placeholder with dynamic content.
* Added logic to display a `ScoreCard` for the "likely to recommend" (NPS) question and for two Likert-scale questions, including score, response count, and minimum response threshold.
* Added a `FreeResponseCard` to display open-ended feedback responses, including a tag showing the total number of responses.


<img width="1263" height="624" alt="Screenshot 2025-08-21 at 1 08 11 PM" src="https://github.com/user-attachments/assets/cc960ca3-af65-4b93-a03a-8a8c2db763cc" />



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3444

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
