### PR TITLE
AI Tutor: Update suggested prompt buttons with chip-like styling

### DIFF
--- a/apps/src/aichat/types/chatButton.ts
+++ b/apps/src/aichat/types/chatButton.ts
@@ -1,7 +1,19 @@
-import {AnalyticsProperties} from './analytics';
+import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
 
+import {AnalyticsProperties} from './analytics';
 export interface ChatButton {
   label: string;
   value: string;
   analyticsProperties?: AnalyticsProperties;
+  icon?: FontAwesomeV6IconProps;
 }
+
+export type ChatButtonClickHandler = (
+  userMessage: string,
+  analyticsProperties?: AnalyticsProperties
+) => void;
+export type ChatButtonProps = {
+  onClick: ChatButtonClickHandler;
+};
+
+export type ChatButtonComponent = React.ComponentType<ChatButtonProps>;

--- a/apps/src/aichat/types/chatButton.ts
+++ b/apps/src/aichat/types/chatButton.ts
@@ -12,6 +12,7 @@ export type ChatButtonClickHandler = (
   userMessage: string,
   analyticsProperties?: AnalyticsProperties
 ) => void;
+
 export type ChatButtonProps = {
   onClick: ChatButtonClickHandler;
 };

--- a/apps/src/aichat/types/chatButton.ts
+++ b/apps/src/aichat/types/chatButton.ts
@@ -1,7 +1,8 @@
 import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
 
 import {AnalyticsProperties} from './analytics';
-export interface ChatButton {
+
+export interface ChatButtonData {
   label: string;
   value: string;
   analyticsProperties?: AnalyticsProperties;

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -26,7 +26,7 @@ import {findChangedProperties, getNewRemoveId} from '../redux/utils';
 import {
   AiChatClientType,
   ChatAsset,
-  ChatButton,
+  ChatButtonComponent,
   ModelParameters,
 } from '../types';
 import {getAssetUrl, getShortName} from '../utils';
@@ -42,7 +42,7 @@ import moduleStyles from './chatWorkspace.module.scss';
 interface ChatWorkspaceProps {
   modelParameters: ModelParameters;
   clientType: AiChatClientType;
-  chatButtons?: ChatButton[];
+  chatButtons?: ChatButtonComponent[];
   hiddenContext?: string;
   onClear: () => void;
 

--- a/apps/src/aichat/views/UserChatMessageEditor.module.scss
+++ b/apps/src/aichat/views/UserChatMessageEditor.module.scss
@@ -1,7 +1,9 @@
 .chatButtonsContainer {
   display: flex;
   flex-direction: row;
-  gap: 10px;
+  flex-wrap: wrap;
+  row-gap: 8px;
+  column-gap: 5px;
   align-items: center;
   padding: 0 10px;
 }

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -1,4 +1,3 @@
-import {Button} from '@code-dot-org/component-library/button';
 import React, {useCallback, useEffect, useRef} from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
@@ -7,7 +6,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {submitChatContents} from '../redux';
 import {
   AiChatClientType,
-  ChatButton,
+  ChatButtonComponent,
   ModelParameters,
   AnalyticsProperties,
 } from '../types';
@@ -18,7 +17,7 @@ interface UserChatMessageEditorProps {
   modelParameters: ModelParameters;
   clientType: AiChatClientType;
   editorContainerClassName?: string;
-  chatButtons?: ChatButton[];
+  chatButtons?: ChatButtonComponent[];
   hiddenContext?: string;
   multimodalAvailable?: boolean;
 }
@@ -94,19 +93,8 @@ const UserChatMessageEditor: React.FunctionComponent<
     <>
       {chatButtons && (
         <div className={moduleStyles.chatButtonsContainer}>
-          {chatButtons.map(button => (
-            <Button
-              key={button.label}
-              aria-label={button.label}
-              id="button-hint"
-              onClick={() =>
-                handleSubmit(button.value, button.analyticsProperties)
-              }
-              text={button.label}
-              size="s"
-              type="secondary"
-              color="gray"
-            />
+          {chatButtons.map(ChatButton => (
+            <ChatButton onClick={handleSubmit} />
           ))}
         </div>
       )}

--- a/apps/src/lab2/views/components/AiTutor2Chat.module.scss
+++ b/apps/src/lab2/views/components/AiTutor2Chat.module.scss
@@ -9,3 +9,26 @@
     margin-top: auto;
   }
 }
+
+/* Multiple classes used to increase specifity to override default DSCO styles */
+.chatButton.chatButton.chatButton {
+  padding: .25rem .65rem;
+  border-radius: 50rem;
+  gap: 4px;
+  
+  > .icon {
+    width: 1rem;
+  }
+
+  > .icon-code {
+    color: var(--text-success-primary);
+  }
+
+  > .icon-lightbulb {
+    color: var(--accent-orange-50);
+  }
+
+  > .icon-file-code {
+    color: var(--text-info-primary);
+  }
+}

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -4,7 +4,11 @@ import classNames from 'classnames';
 import React, {useEffect} from 'react';
 
 import {clearChatMessages} from '@cdo/apps/aichat/redux';
-import {ModelParameters, ChatButtonClickHandler} from '@cdo/apps/aichat/types';
+import {
+  ModelParameters,
+  ChatButtonClickHandler,
+  ChatButtonData,
+} from '@cdo/apps/aichat/types';
 import ChatWorkspace from '@cdo/apps/aichat/views/ChatWorkspace';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
@@ -20,15 +24,15 @@ const systemPrompt = shouldShowCopyCode
   ? `You are an AI Computer Science Tutor that supports students through scaffolded learning, metacognitive reflection, and problem-solving strategies. Target the reading age of an American 7th grader. By default, when a student asks a question, you should respond with a clarifying question, a small hint, or a reflective nudge—to help them take the next step without solving the task for them. Do not give them the whole answer directly. If the student appears frustrated, you may include syntax, code, or pseudocode. When sharing code meant to be copied into the student's solution, ask them where they think the code should be copied to, so that the student will have to think about where the code fits in the solution. If the student explicitly asks for a HINT, provide a tip that nudges them forward to take the next step. If they ask for an EXAMPLE, give a short (1–3 line) conceptual code snippet from a different context that illustrates the relevant idea without solving the actual task. If they request DOCUMENTATION, share 1–3 concise and relevant references formatted with a clear keyword, short explanation and example code. Always work within the provided instructions, student code, and question, and tailor your support to encourage confidence, independence, and thoughtful programming.`
   : `You are an AI Computer Science Tutor that supports students through scaffolded learning, metacognitive reflection, and problem-solving strategies. Target the reading age of an American 7th grader. By default, when a student asks a question, you should respond with a clarifying question, a small hint, or a reflective nudge—to help them take the next step without solving the task for them. Do not give them the answer directly. If the student appears frustrated, you may include syntax or pseudocode. If the student explicitly asks for a HINT, provide a tip that nudges them forward to take the next step. If they ask for an EXAMPLE, give a short (1–3 line) conceptual code snippet from a different context that illustrates the relevant idea without solving the actual task. If they request DOCUMENTATION, share 1–3 concise and relevant references formatted with a clear keyword, short explanation and example code. Always work within the provided instructions, student code, and question, and tailor your support to encourage confidence, independence, and thoughtful programming.`;
 
-const MODEL_PARAMETERS: ModelParameters = {
+const modelParameters: ModelParameters = {
   systemPrompt,
   selectedModelId: aiTutorModelId,
   temperature: 0.5,
   retrievalContexts: [],
-};
+} as const;
 
 // Some pre-canned chat buttons.
-const chatButtonData = [
+const chatButtonData: ChatButtonData[] = [
   {
     label: 'Give an example',
     value: 'Can you give me an example?',
@@ -59,7 +63,7 @@ const chatButtonData = [
       iconName: 'file-code',
     },
   },
-];
+] as const;
 
 const chatButtons = chatButtonData.map(
   button =>
@@ -110,7 +114,7 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
     <div className={moduleStyles.container}>
       <ChatWorkspace
         clientType={AiChatClientTypes.AI_TUTOR}
-        modelParameters={MODEL_PARAMETERS}
+        modelParameters={modelParameters}
         chatButtons={chatButtons}
         hiddenContext={hiddenContext}
         onClear={() => {

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -1,7 +1,10 @@
+import {Button} from '@code-dot-org/component-library/button';
+import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import classNames from 'classnames';
 import React, {useEffect} from 'react';
 
 import {clearChatMessages} from '@cdo/apps/aichat/redux';
-import {ChatButton, ModelParameters} from '@cdo/apps/aichat/types';
+import {ModelParameters, ChatButtonClickHandler} from '@cdo/apps/aichat/types';
 import ChatWorkspace from '@cdo/apps/aichat/views/ChatWorkspace';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
@@ -25,30 +28,64 @@ const MODEL_PARAMETERS: ModelParameters = {
 };
 
 // Some pre-canned chat buttons.
-const CHAT_BUTTONS: ChatButton[] = [
+const chatButtonData = [
   {
-    label: 'example',
+    label: 'Give an example',
     value: 'Can you give me an example?',
     analyticsProperties: {
       cannedPrompt: 'example',
     },
+    icon: {
+      iconName: 'code',
+    },
   },
   {
-    label: 'hint',
+    label: 'Give a hint',
     value: 'Can you give me a hint?',
     analyticsProperties: {
       cannedPrompt: 'hint',
     },
+    icon: {
+      iconName: 'lightbulb',
+    },
   },
   {
-    label: 'doc',
+    label: 'Show documentation',
     value: 'Can you give me some documentation?',
     analyticsProperties: {
       cannedPrompt: 'doc',
     },
+    icon: {
+      iconName: 'file-code',
+    },
   },
 ];
 
+const chatButtons = chatButtonData.map(
+  button =>
+    ({onClick}: {onClick: ChatButtonClickHandler}) =>
+      (
+        <Button
+          className={moduleStyles.chatButton}
+          key={button.label}
+          aria-label={button.label}
+          iconLeft={
+            {
+              ...button.icon,
+              className: classNames({
+                [moduleStyles['icon']]: true,
+                [moduleStyles[`icon-${button.icon?.iconName}`]]: button.icon,
+              }),
+            } as FontAwesomeV6IconProps
+          }
+          onClick={() => onClick(button.value, button.analyticsProperties)}
+          text={button.label}
+          size="s"
+          type="secondary"
+          color="black"
+        />
+      )
+);
 interface AiTutor2ChatProps {
   hiddenContext: string;
 }
@@ -74,7 +111,7 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
       <ChatWorkspace
         clientType={AiChatClientTypes.AI_TUTOR}
         modelParameters={MODEL_PARAMETERS}
-        chatButtons={CHAT_BUTTONS}
+        chatButtons={chatButtons}
         hiddenContext={hiddenContext}
         onClear={() => {
           dispatch(clearChatMessages());


### PR DESCRIPTION
This PR updates AI Tutor's suggested prompt buttons with chip-like (rounded corner) styling and icons.  

We initially thought we would use our DSCO chip components but we stuck with buttons because:

1. It turns out our [chip component doesn't seem to support icons](https://code-dot-org.github.io/code-dot-org/component-library-storybook/?path=/docs/designsystem-chips--docs&globals=backgrounds.value:transparent;backgrounds.grid:!undefined) 
2. It looks like chips [aren't meant to be used over buttons](https://m2.material.io/components/chips#action-chips) where they appear "persistently and consistently" (at least according to Material Design)


https://github.com/user-attachments/assets/7925c878-1165-419c-bcb1-27e269e49627


## Links

The Jira ticket is [here](https://codedotorg.atlassian.net/browse/LABS-1521?atlOrigin=eyJpIjoiNGZmM2E4YzM4MTQ1NDhiMTk3YWI0MDMyOWI0MzE1YjkiLCJwIjoiaiJ9) and the Figma files are [here](https://www.figma.com/design/fl4LaT3JTEu0Ruze2vRqRv/AI-Tutor-MVP?node-id=2641-18198&p=f&t=GC6skhr0EIf0Ov8r-0).

## Testing story
This PR only ultimately affects styling so it does not introduce any new tests.

## Implementation Details

This PR changes how we pass in the extra buttons to `/apps/src/aichat/views/UserChatMessageEditor.tsx`. Previously the data to populate the buttons was passed as an object via an extra `chatButtons` prop and it looks like AI Tutor is the only place that passes this to `UserChatMessageEditor`.  I initially just updated this object to have an icon:

```
{
 label: 'Give an example',
 value: 'Can you give me an example?',
 analyticsProperties: {
  cannedPrompt: 'example',
 },
 icon:{
  iconName: 'code',
 },
},
```

But this pushed a bunch of styling down to `UserChatMessageEditor.module.css`  that was really specific to this use case.  I decided to change the `chatButtons` prop to accept an array of React components instead of the simple object. This allows us to do all the AI Tutor specific styling, locally in the AI Tutor specific file: `apps/src/lab2/views/components/AiTutor2Chat.module.scss`
