### PR TITLE
[AI Tutor] Update default model to gemini flash 2.5

### DIFF
--- a/apps/src/lab2/ai/ai-tutor-model-id.ts
+++ b/apps/src/lab2/ai/ai-tutor-model-id.ts
@@ -8,9 +8,9 @@ const modelQueryParam = queryParams('aitutor2-model');
 export type AiChatModelIdType = ValueOf<typeof AiChatModelIds>;
 
 // Only use modelQueryParam as modelId if it is a valid id, otherwise set to default
-// of Gemini 2.0 Flash.
+// of Gemini 2.5 Flash.
 export const aiTutorModelId = Object.values(AiChatModelIds).includes(
   modelQueryParam as AiChatModelIdType
 )
   ? (modelQueryParam as AiChatModelIdType)
-  : AiChatModelIds.GEMINI_2_0_FLASH;
+  : AiChatModelIds.GEMINI_2_5_FLASH;


### PR DESCRIPTION
Update the default model for AI Tutor to gemini flash 2.5


[LABS-1554 Update to Gemini Flash 2.5](https://codedotorg.atlassian.net/browse/LABS-1554?atlOrigin=eyJpIjoiNDNjYzNlMTI0ODc4NDM0NmI0ZWI1ZmFmYzQ4MTk0NGIiLCJwIjoiaiJ9)