### PR TITLE
Lab2 Resource Panel: update locale logic

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -411,9 +411,3 @@ export interface LabProps<
   levelProperties: T;
   initialSources?: U;
 }
-
-export interface LocaleProps {
-  localeUrl: string;
-  currentLocale: string;
-  localeOptions: {text: string; value: string}[];
-}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
@@ -2,10 +2,12 @@ import CloseButton from '@code-dot-org/component-library/closeButton';
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import {Heading2} from '@code-dot-org/component-library/typography';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {LocaleProps} from '@cdo/apps/lab2/types';
 import {Setting} from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
+import localization from '@cdo/apps/localization';
+import {LanguageInfo} from '@cdo/apps/localization/Localization';
 import {commonI18n} from '@cdo/apps/types/locale';
 
 import styles from './settings-panel.module.scss';
@@ -23,6 +25,19 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
   const {theme} = useTheme();
   // SimpleDropdown isn't themed properly, so we have to manually set the color.
   const dropdownColor = theme === 'Dark' ? 'white' : 'black';
+  // const currentLocale = useLocalization();
+  const [locale, setLocale] = useState<string>(localization.locale);
+  const [localeOptions, setLocaleOptions] = useState<LanguageInfo[]>(
+    localization.locales
+  );
+  console.log({localUrl: localeProps?.localeUrl});
+
+  useEffect(() => {
+    localization.on('change', info => {
+      setLocale(localization.locale);
+      setLocaleOptions(localization.locales);
+    });
+  }, [setLocale]);
 
   const handleLanguageChange = (
     event: React.ChangeEvent<HTMLSelectElement>
@@ -57,9 +72,9 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
             />
             <SimpleDropdown
               name="locale"
-              selectedValue={localeProps.currentLocale}
+              selectedValue={locale}
               onChange={handleLanguageChange}
-              items={localeProps.localeOptions}
+              items={localeOptions}
               labelText={commonI18n.language()}
               isLabelVisible={true}
               size="s"

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
@@ -4,7 +4,6 @@ import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import {Heading2} from '@code-dot-org/component-library/typography';
 import React, {useEffect, useState} from 'react';
 
-import {LocaleProps} from '@cdo/apps/lab2/types';
 import {Setting} from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import localization from '@cdo/apps/localization';
 import {LanguageInfo} from '@cdo/apps/localization/Localization';
@@ -14,13 +13,11 @@ import styles from './settings-panel.module.scss';
 interface SettingsPanelProps {
   settings: Setting[];
   closePanel: () => void;
-  localeProps?: LocaleProps;
 }
 
 const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
   settings,
   closePanel,
-  localeProps,
 }) => {
   const {theme} = useTheme();
   // SimpleDropdown isn't themed properly, so we have to manually set the color.
@@ -30,7 +27,6 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
   const [localeOptions, setLocaleOptions] = useState<LanguageInfo[]>(
     localization.locales
   );
-  console.log({localUrl: localeProps?.localeUrl});
 
   useEffect(() => {
     localization.on('change', info => {
@@ -57,33 +53,31 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
         />
       </div>
       <div className={styles.settingsList}>
-        {localeProps && (
-          <form
-            action={localeProps.localeUrl}
-            method="post"
-            style={{marginBottom: '0px'}}
-            data-notranslate=""
-            className={styles.languageForm}
-          >
-            <input
-              type="hidden"
-              name="user_return_to"
-              value={window.location.href}
-            />
-            <SimpleDropdown
-              name="locale"
-              selectedValue={locale}
-              onChange={handleLanguageChange}
-              items={localeOptions}
-              labelText={commonI18n.language()}
-              isLabelVisible={true}
-              size="s"
-              color={dropdownColor}
-              dropdownTextThickness="thin"
-              className={styles.dropdown}
-            />
-          </form>
-        )}
+        <form
+          action={'/locale'}
+          method="post"
+          style={{marginBottom: '0px'}}
+          data-notranslate=""
+          className={styles.languageForm}
+        >
+          <input
+            type="hidden"
+            name="user_return_to"
+            value={window.location.href}
+          />
+          <SimpleDropdown
+            name="locale"
+            selectedValue={locale}
+            onChange={handleLanguageChange}
+            items={localeOptions}
+            labelText={commonI18n.language()}
+            isLabelVisible={true}
+            size="s"
+            color={dropdownColor}
+            dropdownTextThickness="thin"
+            className={styles.dropdown}
+          />
+        </form>
         {settings.map(setting => (
           <SimpleDropdown
             key={setting.id}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
@@ -22,7 +22,6 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
   const {theme} = useTheme();
   // SimpleDropdown isn't themed properly, so we have to manually set the color.
   const dropdownColor = theme === 'Dark' ? 'white' : 'black';
-  // const currentLocale = useLocalization();
   const [locale, setLocale] = useState<string>(localization.locale);
   const [localeOptions, setLocaleOptions] = useState<LanguageInfo[]>(
     localization.locales

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
@@ -5,7 +5,7 @@ import {Heading2} from '@code-dot-org/component-library/typography';
 import React, {useEffect, useState} from 'react';
 
 import {Setting} from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
-import localization from '@cdo/apps/localization';
+import localization, {useLocalization} from '@cdo/apps/localization';
 import {LanguageInfo} from '@cdo/apps/localization/Localization';
 import {commonI18n} from '@cdo/apps/types/locale';
 
@@ -22,17 +22,16 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
   const {theme} = useTheme();
   // SimpleDropdown isn't themed properly, so we have to manually set the color.
   const dropdownColor = theme === 'Dark' ? 'white' : 'black';
-  const [locale, setLocale] = useState<string>(localization.locale);
+  const locale = useLocalization();
   const [localeOptions, setLocaleOptions] = useState<LanguageInfo[]>(
     localization.locales
   );
 
   useEffect(() => {
     localization.on('change', info => {
-      setLocale(localization.locale);
       setLocaleOptions(localization.locales);
     });
-  }, [setLocale]);
+  }, []);
 
   const handleLanguageChange = (
     event: React.ChangeEvent<HTMLSelectElement>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -8,13 +8,11 @@ import classNames from 'classnames';
 import React, {useMemo, useState} from 'react';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
-import {LocaleProps} from '@cdo/apps/lab2/types';
 import AiTutor2Chat from '@cdo/apps/lab2/views/components/AiTutor2Chat';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import StudentRubricView from '@cdo/apps/lab2/views/components/rubrics/StudentRubricView';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {getTypedKeys} from '@cdo/apps/types/utils';
-import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useRubric} from '../../rubrics/RubricWrapper';
@@ -56,13 +54,6 @@ const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
   },
 };
 
-function getLocaleProps() {
-  if (hasScriptData('script[data-localeProps]')) {
-    return getScriptData('localeProps') as LocaleProps;
-  }
-  return undefined;
-}
-
 type ResourcePanelProps = InstructionsProps & {
   className?: string;
   headerClassName?: string;
@@ -91,7 +82,6 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   );
   const [currentTab, setCurrentTab] = useState<Tabs>(Tabs.Instructions);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const localeProps = getLocaleProps();
 
   const levelId = instructionsProps.levelProperties.id;
 
@@ -169,27 +159,25 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
         </div>
         <div className={classNames(styles.bottomTabs)}>
           <ResourcePanelExtraLinks levelId={levelId} theme={theme} />
-          {(localeProps || settings) && (
-            <WithTooltip
-              tooltipProps={{
-                text: commonI18n.settings(),
-                tooltipId: 'tooltip-settings',
-                direction: 'onRight',
-                size: 'xs',
-                'data-theme': theme,
+          <WithTooltip
+            tooltipProps={{
+              text: commonI18n.settings(),
+              tooltipId: 'tooltip-settings',
+              direction: 'onRight',
+              size: 'xs',
+              'data-theme': theme,
+            }}
+          >
+            <button
+              type="button"
+              className={styles.bottomButton}
+              onClick={() => {
+                setIsSettingsOpen(!isSettingsOpen);
               }}
             >
-              <button
-                type="button"
-                className={styles.bottomButton}
-                onClick={() => {
-                  setIsSettingsOpen(!isSettingsOpen);
-                }}
-              >
-                <FontAwesomeV6Icon iconName={'gear'} />
-              </button>
-            </WithTooltip>
-          )}
+              <FontAwesomeV6Icon iconName={'gear'} />
+            </button>
+          </WithTooltip>
           <CopyrightButton theme={theme} />
         </div>
       </div>
@@ -206,7 +194,6 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
             <SettingsPanel
               settings={settings || []}
               closePanel={() => setIsSettingsOpen(false)}
-              localeProps={localeProps}
             />
           )}
         </PanelContainer>

--- a/dashboard/app/views/levels/_lab2.html.haml
+++ b/dashboard/app/views/levels/_lab2.html.haml
@@ -1,9 +1,3 @@
-:ruby
-  localeProps = {
-    localeUrl: locale_url,
-    currentLocale: locale,
-    localeOptions: locale_options.map { |(text, value)| { text: text, value: value } },
-  }
 #lab2-container
 
 - content_for(:head) do
@@ -22,5 +16,5 @@
   -# which we only use when optimizing our webpack build (ie, non-development environments).
   - if CDO.optimize_webpack_assets
     %script{src: webpack_asset_path('js/common.js')}
-  %script{src: webpack_asset_path("js/lab2.js"), data: {appoptions: app_options.to_json, localeProps: localeProps.to_json}}
+  %script{src: webpack_asset_path("js/lab2.js"), data: {appoptions: app_options.to_json}}
   %link{href: asset_path("css/lab2.css"), rel: 'stylesheet', type: 'text/css'}


### PR DESCRIPTION
This updates the resource panel to use the `localization` class to get locale information rather than using server-provided props. I confirmed with the platform team that these values are accurate.

There is a [useLocalization](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/localization/useLocalization.ts) hook we could use to get the current locale, but it doesn't also return the locale options, so I opted to make a custom onChange listener.


## Links

- Jira: [AFL-110](https://codedotorg.atlassian.net/browse/AFL-110)

## Testing story
I confirmed that the language settings work exactly as they did before.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
