### PR TITLE
Lab2 Dance: blockly workspace

### DIFF
--- a/apps/src/Globals.d.ts
+++ b/apps/src/Globals.d.ts
@@ -32,6 +32,11 @@ declare module '*.svg' {
   export = value;
 }
 
+declare module '*.gif' {
+  const value: string;
+  export = value;
+}
+
 // Modules without types
 declare module '@blockly/plugin-scroll-options';
 declare module '@blockly/keyboard-navigation';

--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -41,11 +41,11 @@ export const useInitialSources = (
 ) => {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const exemplarSources = levelProperties.exemplarSources as MultiFileSource;
+  const startSources = levelProperties.startSources as MultiFileSource;
   const {
     serializedMaze,
     miniApp,
     validationFile,
-    startSources,
     templateSources,
     predictSettings,
   } = levelProperties;

--- a/apps/src/dance/blockly/defaultSources.json
+++ b/apps/src/dance/blockly/defaultSources.json
@@ -1,0 +1,13 @@
+{
+  "source": {
+    "blocks": {
+      "blocks": [
+        {
+          "type": "Dancelab_whenSetup",
+          "deletable": false,
+          "movable": false
+        }
+      ]
+    }
+  }
+}

--- a/apps/src/dance/blockly/setup.ts
+++ b/apps/src/dance/blockly/setup.ts
@@ -1,31 +1,25 @@
+import * as blockUtils from '@cdo/apps/block_utils';
 import {BlockDefinition} from '@cdo/apps/blockly/types';
-import * as commonBlocks from '@cdo/apps/blocksCommon';
 import danceBlocks from '@cdo/apps/dance/blockly/blocks';
 
-const blockUtils = require('@cdo/apps/block_utils');
+let isBlocklyEnvironmentSetup = false;
 
-// Install common blocks for Dance Party Lab2.
-export function installCommonBlocks(
-  skin: string | undefined,
-  isK1: boolean | undefined
-) {
-  const blockInstallOptions = {
-    skin,
-    isK1,
-  };
-  commonBlocks.install(Blockly, blockInstallOptions);
+export function setupBlocklyEnvironment() {
+  if (isBlocklyEnvironmentSetup) {
+    return;
+  }
+  Blockly.cdoUtils.registerCustomProcedureBlocks();
+  delete Blockly.Blocks.procedures_defreturn;
+  delete Blockly.Blocks.procedures_ifreturn;
   Blockly.setInfiniteLoopTrap();
+  isBlocklyEnvironmentSetup = true;
 }
 
-// Install custom blocks for Dance Party Lab2.
-export function installDanceBlocks(
-  sharedBlocks: BlockDefinition[] | undefined
-) {
-  danceBlocks.install(Blockly);
-  const blocksByCategory = blockUtils.installCustomBlocks({
+export function installSharedBlocks(sharedBlocks: BlockDefinition[]) {
+  // @ts-expect-error needed to handle CommonJS export. Eventually this may be replaced by using Blockly JSON directly
+  blockUtils.installCustomBlocks({
     blockly: Blockly,
     blockDefinitions: sharedBlocks,
     customInputTypes: danceBlocks.customInputTypes,
   });
-  return blocksByCategory; // TODO: use when implementing pathway for toolbox editing for levelbuilders
 }

--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -72,6 +72,7 @@ export default class ProgramExecutor {
         resourceLoader: new ResourceLoader(ASSET_BASE),
         logger: metricsReporter,
       });
+    this.nativeAPI.reset();
     this.metricsReporter = metricsReporter;
   }
 
@@ -82,7 +83,7 @@ export default class ProgramExecutor {
     // TODO: Dance.js checks for unwanted top blocks and duplicate variables in for loops
     // before executing. We should do something similar here.
 
-    this.hooks = await this.compileAllCode(code || this.getCode());
+    this.hooks = await this.compileAllCode(code);
     if (!this.hooks.runUserSetup || !this.hooks.getCueList) {
       this.reportMissingHooks('runUserSetup', 'getCueList');
       return;
@@ -110,10 +111,7 @@ export default class ProgramExecutor {
    */
   async staticPreview(code: string) {
     this.reset();
-    this.hooks = await this.preloadSpritesAndCompileCode(
-      code || this.getCode(),
-      'runUserSetup'
-    );
+    this.hooks = await this.preloadSpritesAndCompileCode(code, 'runUserSetup');
     if (!this.hooks.runUserSetup) {
       this.reportMissingHooks('runUserSetup');
       return;
@@ -308,10 +306,5 @@ export default class ProgramExecutor {
     this.metricsReporter.logWarning(
       `Missing required hooks in compiled code: ${hooks.join(', ')}`
     );
-  }
-
-  // Temporary test code. TODO: Replace with code from Blockly workspace.
-  private getCode(): string {
-    return 'whenSetup(function () {\n  setBackgroundEffectWithPalette("kaleidoscope", "electronic");\n  setForegroundEffectExtended("raining_tacos");\n  makeNewDanceSpriteGroup(12, "ALIEN", "circle");\n  makeAnonymousDanceSprite("CAT", {x: 200, y: 200});\n});\n\natTimestamp(4, "measures", function () {\n  setBackgroundEffectWithPalette("disco_ball", "neon");\n  setForegroundEffectExtended("color_lights");\n  changeMoveEachLR(sprites, MOVES.Drop, -1);\n});\n';
   }
 }

--- a/apps/src/dance/lab2/utils/getInitialSources.ts
+++ b/apps/src/dance/lab2/utils/getInitialSources.ts
@@ -1,0 +1,43 @@
+import {START_BLOCKS} from '@cdo/apps/constants';
+import {
+  getAppOptionsEditBlocks,
+  getAppOptionsEditingExemplar,
+  getAppOptionsViewingExemplar,
+} from '@cdo/apps/lab2/projects/utils';
+import {LevelProperties, ProjectSources} from '@cdo/apps/lab2/types';
+
+const isStartMode = getAppOptionsEditBlocks() === START_BLOCKS;
+const isEditingExemplar = getAppOptionsEditingExemplar();
+const isViewingExemplar = getAppOptionsViewingExemplar();
+
+/**
+ * Computes which initial sources to present based on level and project information
+ */
+export default function <T extends ProjectSources>(
+  levelProperties: LevelProperties,
+  projectSources?: T
+) {
+  const startSources = levelProperties.startSources as T | undefined;
+  const templateSources = levelProperties.templateSources as T | undefined;
+  const exemplarSources = levelProperties.exemplarSources as T | undefined;
+  const predictSettings = levelProperties.predictSettings;
+
+  if (isStartMode) {
+    return startSources;
+  }
+
+  if (isEditingExemplar || isViewingExemplar) {
+    return exemplarSources;
+  }
+
+  if (
+    predictSettings?.isPredictLevel &&
+    !predictSettings?.codeEditableAfterSubmit
+  ) {
+    // Predict levels only use sources loaded from the server if the code is
+    // editable after submit, otherwise use the start sources.
+    return templateSources || startSources;
+  }
+
+  return projectSources || templateSources || startSources;
+}

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,8 +1,26 @@
+import {Events, WorkspaceSvg} from 'blockly/core';
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
+import {loadBlocksToWorkspace} from '@cdo/apps/blockly/addons/cdoUtils';
 import {saveReplayLog} from '@cdo/apps/code-studio/components/shareDialogRedux';
+import defaultSources from '@cdo/apps/dance/blockly/defaultSources.json';
+import {
+  installSharedBlocks,
+  setupBlocklyEnvironment,
+} from '@cdo/apps/dance/blockly/setup';
+import {
+  initSongs,
+  reducers,
+  setHasRun,
+  setIsRunning,
+  setRunIsStarting,
+  setSong,
+} from '@cdo/apps/dance/danceRedux';
+import {getFilterStatus} from '@cdo/apps/dance/songs';
 import SongSelector from '@cdo/apps/dance/SongSelector';
+import {DanceLevelProperties, DanceProjectSources} from '@cdo/apps/dance/types';
+import {setPageError} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {getIsShareView} from '@cdo/apps/lab2/projects/utils';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
@@ -13,20 +31,11 @@ import {registerReducers} from '@cdo/apps/redux';
 import AgeDialog from '@cdo/apps/templates/AgeDialog';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import loadingGif from '@cdo/static/dance/DancePartyLoading.gif';
 
-import {installCommonBlocks, installDanceBlocks} from '../../blockly/setup';
-import {
-  initSongs,
-  reducers,
-  setHasRun,
-  setIsRunning,
-  setRunIsStarting,
-  setSong,
-} from '../../danceRedux';
-import {getFilterStatus} from '../../songs';
-import {DanceLevelProperties, DanceProjectSources} from '../../types';
 import danceI18n from '../locale';
 import ProgramExecutor from '../ProgramExecutor';
+import getInitialSources from '../utils/getInitialSources';
 
 import DanceControls from './DanceControls';
 
@@ -43,7 +52,7 @@ registerReducers(reducers);
  */
 const DanceView: React.FunctionComponent<
   LabProps<DanceLevelProperties, DanceProjectSources>
-> = ({initialSources, levelProperties}) => {
+> = ({levelProperties, initialSources}) => {
   const dispatch = useAppDispatch();
 
   const isRunning = useAppSelector(state => state.dance.isRunning);
@@ -59,6 +68,7 @@ const DanceView: React.FunctionComponent<
   const isLoading = useAppSelector(state => state.dance.isLoading);
 
   const programExecutor = useRef<ProgramExecutor | null>(null);
+  const workspace = useRef<WorkspaceSvg | null>(null);
 
   const [filterOn, setFilterOn] = useState<boolean>(
     getFilterStatus(userType, under13)
@@ -81,6 +91,20 @@ const DanceView: React.FunctionComponent<
     [dispatch]
   );
 
+  const saveProject = (selectedSong: string, forceSave = false) => {
+    if (!workspace.current) {
+      return;
+    }
+    const blocksJson = Blockly.serialization.workspaces.save(workspace.current);
+    const sourcesToSave = {
+      selectedSong,
+      source: blocksJson,
+    };
+    Lab2Registry.getInstance()
+      .getProjectManager()
+      ?.save(sourcesToSave, forceSave);
+  };
+
   const runProgram = useCallback(async () => {
     if (!programExecutor.current || !currentSongMetadata) {
       return;
@@ -89,15 +113,21 @@ const DanceView: React.FunctionComponent<
     // Set the runIsStartingFlag to true while the run function is executing,
     // and set the isRunning flag to true once the run actually starts.
     dispatch(setRunIsStarting(true));
-    await programExecutor.current.execute('', currentSongMetadata);
+    programExecutor.current.reset();
+    await programExecutor.current.execute(
+      Blockly.getWorkspaceCode(),
+      currentSongMetadata
+    );
     dispatch(setRunIsStarting(false));
     dispatch(setIsRunning(true));
     dispatch(setHasRun(true));
-  }, [programExecutor, currentSongMetadata, dispatch]);
+    saveProject(selectedSong, true);
+  }, [programExecutor, currentSongMetadata, selectedSong, dispatch]);
 
   const resetProgram = useCallback(() => {
     programExecutor.current?.reset();
     dispatch(setIsRunning(false));
+    programExecutor.current?.staticPreview(Blockly.getWorkspaceCode());
   }, [programExecutor, dispatch]);
 
   const onPuzzleComplete = useCallback(
@@ -114,13 +144,31 @@ const DanceView: React.FunctionComponent<
     console.log('onEventsChanged');
   };
 
-  useEffect(() => {
-    installCommonBlocks(levelProperties.skin, levelProperties.isK1);
-  }, [levelProperties.skin, levelProperties.isK1]);
+  const onBlockSpaceChange = useCallback(
+    (e: Events.Abstract) => {
+      if (e.type !== Events.BLOCK_DRAG && e.type !== Events.BLOCK_CHANGE) {
+        return;
+      }
 
+      if (e.type === Events.BLOCK_DRAG && (e as Events.BlockDrag).isStart) {
+        return;
+      }
+
+      if (!isRunning) {
+        programExecutor.current?.staticPreview(Blockly.getWorkspaceCode());
+      }
+      saveProject(selectedSong);
+    },
+    [selectedSong, isRunning]
+  );
+
+  // Setup Blockly for dance party when first mounting.
+  useEffect(setupBlocklyEnvironment, []);
+
+  // Save project when selected song changes
   useEffect(() => {
-    installDanceBlocks(levelProperties.sharedBlocks);
-  }, [levelProperties.sharedBlocks]);
+    saveProject(selectedSong);
+  }, [selectedSong]);
 
   // Reset hasRun flag when level changes
   useEffect(() => {
@@ -143,6 +191,33 @@ const DanceView: React.FunctionComponent<
     );
   }, [levelProperties, initialSources, dispatch]);
 
+  // Set up the Blockly workspace when the level changes
+  useEffect(() => {
+    const blocklyDiv = document.getElementById(BLOCKLY_DIV_ID);
+    if (!blocklyDiv) {
+      dispatch(setPageError({errorMessage: 'Blockly div not found'}));
+      return;
+    }
+    if (levelProperties.sharedBlocks) {
+      installSharedBlocks(levelProperties.sharedBlocks);
+    }
+    workspace.current = Blockly.inject(blocklyDiv, {
+      toolbox: levelProperties.toolboxBlocks,
+    });
+
+    const sources =
+      getInitialSources(levelProperties, initialSources) || defaultSources;
+    loadBlocksToWorkspace(workspace.current, JSON.stringify(sources.source));
+
+    return () => workspace.current?.dispose();
+  }, [dispatch, initialSources, levelProperties]);
+
+  useEffect(() => {
+    workspace.current?.addChangeListener(onBlockSpaceChange);
+    return () => workspace.current?.removeChangeListener(onBlockSpaceChange);
+  }, [onBlockSpaceChange]);
+
+  // Set up the ProgramExecutor
   useEffect(() => {
     const {isProjectLevel, freePlay, customHelperLibrary, validationCode} =
       levelProperties;
@@ -214,7 +289,7 @@ const DanceView: React.FunctionComponent<
               )}
             >
               <img
-                src="//curriculum.code.org/images/DancePartyLoading.gif"
+                src={loadingGif}
                 className={moduleStyles.loadingGif}
                 alt={danceI18n.dancePartyLoading()}
               />

--- a/apps/src/dance/lab2/views/dance-view.module.scss
+++ b/apps/src/dance/lab2/views/dance-view.module.scss
@@ -15,6 +15,7 @@
   height: 400px;
   background-color: var(--background-neutral-secondary);
   position: relative;
+  border: 1px solid var(--borders-neutral-primary);
 }
 
 .workArea {
@@ -67,6 +68,7 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.1s ease-in;
+  background-color: white;
 
   &Show {
     opacity: 1;

--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -14,14 +14,14 @@ const BlocklySourceResponseValidator: ResponseValidator<
   ProjectSources
 > = response => {
   const blocklyValidator = (responseToValidate: Record<string, unknown>) => {
-    // Blockly sources are always stringified JSON.
-    let blocklySource;
-    try {
-      blocklySource = JSON.parse(
-        responseToValidate.source as string
-      ) as BlocklySource;
-    } catch (e) {
-      throw new ValidationError('Error parsing JSON: ' + e);
+    // Blockly sources can be stringified or plain JSON.
+    let blocklySource = responseToValidate.source as BlocklySource;
+    if (typeof responseToValidate.source === 'string') {
+      try {
+        blocklySource = JSON.parse(responseToValidate.source as string);
+      } catch (e) {
+        throw new ValidationError('Error parsing JSON: ' + e);
+      }
     }
     if (blocklySource.blocks === undefined) {
       throw missingFieldError('blocks');

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -61,8 +61,8 @@ export interface ProjectAndSources {
 
 // Represents the structure of the full project sources object (i.e. the main.json file)
 export interface ProjectSources {
-  // Source code can either be a string or a nested JSON object (for multi-file).
-  source: string | MultiFileSource;
+  // Source code can either be a string, Blockly JSON, or a nested JSON object (for multi-file).
+  source: string | Source;
   // Optional lab-specific configuration for this project
   labConfig?: LabConfig;
   // Add other properties (animations, html, etc) as needed.
@@ -86,28 +86,8 @@ export interface UpdateSourceOptions extends SaveSourceOptions {
 
 // -- BLOCKLY -- //
 
-export interface BlocklySource {
-  blocks: {
-    languageVersion: number;
-    blocks: BlocklyBlock[];
-  };
-  variables: BlocklyVariable[];
-}
-
-export interface BlocklyBlock {
-  type: string;
-  id: string;
-  x: number;
-  y: number;
-  next: {
-    block: BlocklyBlock;
-  };
-}
-
-export interface BlocklyVariable {
-  name: string;
-  id: string;
-}
+// Blockly JSON is currently typed as a generic object
+export type BlocklySource = {[key: string]: unknown};
 
 // -- MULTI-FILE -- //
 
@@ -187,7 +167,7 @@ export interface LevelProperties {
   isK1?: boolean;
   skin?: string;
   toolboxBlocks?: string;
-  startSources?: MultiFileSource;
+  startSources?: Source;
   templateSources?: MultiFileSource;
   sharedBlocks?: BlockDefinition[];
   validations?: Validation[];

--- a/apps/src/lab2/utils/isUsingResourcePanel.ts
+++ b/apps/src/lab2/utils/isUsingResourcePanel.ts
@@ -4,10 +4,9 @@ const LABS_WITHOUT_INSTRUCTIONS = [
   'bubble_choice',
   'panels',
   'standalone_video',
-  'dance', // Right now dance doesn't ever use the resource panel, but it may in the future.
 ];
 
-// Web Lab 2 uses the resource panel by default, otherwise we defer to the experiment flag.
+// Web Lab 2 and Lab2 Dance use the resource panel by default, otherwise we defer to the experiment flag.
 // TODO: Once all lab2 labs are using this version of instructions, this function may be better named
 // "isUsingInstructions", as the resource panel will be the instructions panel. Some labs do not use
 // instructions, such as Panels, we will need to keep this function to determine if the copyright/language
@@ -21,6 +20,7 @@ export function isUsingResourcePanel(
   }
   return (
     appName === 'weblab2' ||
+    appName === 'dance' ||
     experiments.isEnabledAllowingQueryString(experiments.LAB2_RESOURCE_PANEL)
   );
 }

--- a/apps/static/dance/DancePartyLoading.gif
+++ b/apps/static/dance/DancePartyLoading.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ba51210b79eeb30621d8eee09f232be309d46243886d786699e5b5129423657
+size 28640

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -183,7 +183,7 @@ describe('useInitialSources', () => {
       parsedDefaultSources,
     } = renderDefault(neighborhoodLevelProperties);
     const expectedSources = getExpectedMazeSources(
-      neighborhoodLevelProperties.startSources,
+      neighborhoodLevelProperties.startSources as MultiFileSource,
       neighborhoodLevelProperties.serializedMaze!,
       '1'
     );
@@ -211,7 +211,7 @@ describe('useInitialSources', () => {
       parsedDefaultSources,
     } = renderDefault(levelProperties);
     const expectedLevelSources = getExpectedMazeSources(
-      levelProperties.startSources,
+      levelProperties.startSources as MultiFileSource,
       levelProperties.serializedMaze!,
       '1'
     );

--- a/apps/test/unit/dance/lab2/ProgramExecutorTest.ts
+++ b/apps/test/unit/dance/lab2/ProgramExecutorTest.ts
@@ -199,7 +199,7 @@ describe('ProgramExecutor', () => {
 
   it('resets the native API on reset', () => {
     programExecutor.reset();
-    expect(nativeAPI.reset).to.have.been.calledOnce;
+    expect(nativeAPI.reset).to.have.been.calledTwice;
   });
 
   it('gets the replay log from the native API', () => {

--- a/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
+++ b/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
@@ -1,11 +1,12 @@
 <Dancelab>
   <config><![CDATA[{
+  "published": true,
   "game_id": 63,
-  "created_at": "2023-09-05T19:46:08.000Z",
+  "created_at": "2025-06-27T16:11:06.000Z",
   "level_num": "custom",
   "user_id": 182,
   "properties": {
-    "skin": "gamelab",
+    "skin": "dance",
     "helper_libraries": [
       "DanceLab"
     ],
@@ -24,7 +25,7 @@
     "hide_share_and_remix": "false",
     "disable_if_else_editing": "false",
     "include_shared_functions": "false",
-    "free_play": "false",
+    "free_play": "true",
     "hide_view_data_button": "false",
     "show_debug_watch": "false",
     "expand_debugger": "false",
@@ -34,50 +35,39 @@
     "pause_animations_by_default": "false",
     "hide_custom_blocks": "true",
     "use_default_sprites": "false",
-    "validation_code": "//after 1 measure, make sure there is a sprite. if not, fail immediately\r\nif (nativeAPI.getTime(\"measures\") > 1) {\r\n  if (sprites.length === 0) {\r\n    nativeAPI.fail(\"danceFeedbackNeedNewDancer\");\r\n  }\r\n}\r\n\r\nif (nativeAPI.getTime(\"measures\") > 2) {\r\n  nativeAPI.pass();\r\n}",
-    "default_song": "hammer",
+    "validation_code": "//after 1 measure, make sure there is a sprite. if not, fail immediately\r\nif (nativeAPI.getTime(\"measures\") > 1) {\r\n  if (sprites.length === 0) {\r\n    nativeAPI.fail(\"danceFeedbackNeedNewDancer\");\r\n  }\r\n}\r\n\r\nif (nativeAPI.getTime(\"measures\") > 17) {\r\n  nativeAPI.pass();\r\n}",
+    "default_song": "introtoshamstep_47SOUL",
     "long_instructions": "Let's get this moose dancing! Click the `\"dancer1\" do \"Floss\" forever` block onto the \"at 4 measures\" block to make him start flossing at the second measure.",
     "uses_lab2": true,
-    "preload_asset_list": null
+    "preload_asset_list": null,
+    "encrypted": "false",
+    "encrypted_examples": [
+
+    ],
+    "validation_enabled": "false",
+    "hide_pause_button": "false"
   },
-  "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:08.190-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"}]"
+  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:08.190-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"},{\"changed_at\":\"2025-08-20 23:36:05 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"skin\",\"validation_code\",\"default_song\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-20 23:41:21 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"free_play\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-22 22:53:47 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
+  "level_concept_difficulty": {
+  }
 }]]></config>
   <blocks>
     <start_blocks>
-      <xml>
-        <block type="Dancelab_whenSetupSong" movable="false">
-          <title name="SONG">"hammer"</title>
-          <statement name="DO">
-            <block type="Dancelab_makeNewDanceSprite">
-              <title name="COSTUME" config="&quot;CAT&quot;, &quot;MOOSE&quot;">"MOOSE"</title>
-              <title name="NAME">new_dancer</title>
-              <title name="LOCATION">{x: 200, y: 200}</title>
-            </block>
-          </statement>
-        </block>
+      <xml xmlns="https://developers.google.com/blockly/xml">
+        <block type="Dancelab_whenSetup" id="n2IvvYw0`dD^TvxCN_`K" deletable="false" movable="false" x="18" y="15"/>
       </xml>
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="Dancelab_makeNewDanceSprite">
-          <title name="COSTUME">"moose"</title>
-          <title name="NAME">dancer1</title>
-          <value name="LOCATION">
-            <block type="Dancelab_location_picker">
-              <title name="LOCATION">undefined</title>
-            </block>
-          </value>
+        <block type="Dancelab_makeAnonymousDanceSprite" id="1" x="54" y="185">
+          <field name="COSTUME" config="&quot;CAT&quot;,&quot;SLOTH&quot;">"CAT"</field>
+          <field name="LOCATION">{x: 200, y: 200}</field>
         </block>
-        <block type="Dancelab_changeMoveLR">
-          <title name="SPRITE">dancer1</title>
-          <title name="MOVE">6</title>
-          <title name="DIR">-1</title>
-        </block>
-        <block type="Dancelab_atTimestamp">
-          <title name="TIMESTAMP">4</title>
-          <title name="UNIT">"measures"</title>
+        <block type="Dancelab_changeMoveEachLR" id="|y+CWEBlleENO5MU(?yL" x="67" y="265">
+          <field name="GROUP" config="&quot;CAT&quot;,&quot;SLOTH&quot;">"CAT"</field>
+          <field name="MOVE">MOVES.Roll</field>
+          <field name="DIR">-1</field>
         </block>
       </xml>
     </toolbox_blocks>


### PR DESCRIPTION
Adds blockly workspace editing, and project editing/saving to Lab2 Dance. Thankfully much of the support work to get Blockly working was already done ahead of Dance AI HOC 2023, so this was pretty straightforward. I've made some intentional minor deviations from legacy dance in how we load and store blockly sources to better support JSON moving forward, that I'll note in PR comments directly.

<img width="1512" height="825" alt="Screenshot 2025-08-22 at 4 43 32 PM" src="https://github.com/user-attachments/assets/d13c811d-b2b6-469c-bb3e-65d584a4d5f2" />

## Testing story

Tested locally with Lab2 Dance allthethings.