### PR TITLE
Revert "Revert "Update preview codeprojects origin""

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -858,6 +858,9 @@ Outputs:
   PegasusURL:
     Value: "https://<%=subdomain%>"
     Description: Pegasus URL
+  PreviewCodeprojectsURL:
+    Description: Codeprojects URL
+    Value: !Ref CodeprojectsPreviewRecord
 # display information about how to ssh to console if this is a single instance adhoc environment
 <% if rack_env?(:adhoc) && !frontends -%>
   SSHServerName:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -860,7 +860,7 @@ Outputs:
     Description: Pegasus URL
   PreviewCodeprojectsURL:
     Description: Codeprojects URL
-    Value: !Ref CodeprojectsPreviewRecord
+    Value: !Sub preview.${CodeprojectsBaseDomainName}
 # display information about how to ssh to console if this is a single instance adhoc environment
 <% if rack_env?(:adhoc) && !frontends -%>
   SSHServerName:

--- a/aws/cloudformation/components/codeprojects_resources.yml.erb
+++ b/aws/cloudformation/components/codeprojects_resources.yml.erb
@@ -71,16 +71,15 @@ CodeprojectsCertificate:
       - DomainName: !Sub bramble-download.${CodeprojectsBaseDomainName}
         HostedZoneId: !Ref CodeprojectsHostedZoneId
 
-CodeprojectsRecords:
-  Type: AWS::Route53::RecordSetGroup
+CodeprojectsPreviewRecord:
+  Type: AWS::Route53::RecordSet
   Properties:
     HostedZoneId: !Ref CodeprojectsHostedZoneId
-    RecordSets:
-      - Name: !Sub preview.${CodeprojectsBaseDomainName}
-        Type: A
-        AliasTarget:
-          DNSName: !GetAtt CodeprojectsCloudFrontDistribution.DomainName
-          HostedZoneId: Z2FDTNDATAQYW2
+    Name: !Sub preview.${CodeprojectsBaseDomainName}
+    Type: A
+    AliasTarget:
+      DNSName: !GetAtt CodeprojectsCloudFrontDistribution.DomainName
+      HostedZoneId: Z2FDTNDATAQYW2
 
 # Codeprojects CloudFront Distribution
 CodeprojectsCloudFrontDistribution:
@@ -95,7 +94,7 @@ CodeprojectsCloudFrontDistribution:
         - !Sub preview.${CodeprojectsBaseDomainName}
       Origins:
         - Id: DashboardOrigin
-          DomainName: <%= load_balancer ? '!GetAtt ALB.DNSName' : '!Sub ${DashboardSubdomainName}.${BaseDomainName}' %>
+          DomainName: <%= cdn_enabled ? subdomain('origin') : '!Sub ${DashboardSubdomainName}.${BaseDomainName}' %>
           CustomOriginConfig:
             OriginProtocolPolicy: https-only
             OriginSSLProtocols:

--- a/aws/cloudformation/components/codeprojects_resources.yml.erb
+++ b/aws/cloudformation/components/codeprojects_resources.yml.erb
@@ -71,15 +71,16 @@ CodeprojectsCertificate:
       - DomainName: !Sub bramble-download.${CodeprojectsBaseDomainName}
         HostedZoneId: !Ref CodeprojectsHostedZoneId
 
-CodeprojectsPreviewRecord:
-  Type: AWS::Route53::RecordSet
+CodeprojectsRecords:
+  Type: AWS::Route53::RecordSetGroup
   Properties:
     HostedZoneId: !Ref CodeprojectsHostedZoneId
-    Name: !Sub preview.${CodeprojectsBaseDomainName}
-    Type: A
-    AliasTarget:
-      DNSName: !GetAtt CodeprojectsCloudFrontDistribution.DomainName
-      HostedZoneId: Z2FDTNDATAQYW2
+    RecordSets:
+      - Name: !Sub preview.${CodeprojectsBaseDomainName}
+        Type: A
+        AliasTarget:
+          DNSName: !GetAtt CodeprojectsCloudFrontDistribution.DomainName
+          HostedZoneId: Z2FDTNDATAQYW2
 
 # Codeprojects CloudFront Distribution
 CodeprojectsCloudFrontDistribution:


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67913

The first attempt at this change was replacing a RecordSetGroup with a Record, but the way cloudformation works is that new resources are created before removed resources are deleted. This resulted in an attempt to create a duplicate record. That was simply a tidiness refactor that's not necessary, so I've remove that and just kept the core change, which is the update to the preview codeprojects origin.