### PR TITLE
Fix AI Chat levelbuilder upload

### DIFF
--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -102,8 +102,10 @@ class LevelStarterAssetsController < ApplicationController
         upload_tempfile = LevelStarterAssetsHelper.try_resize_file(upload.tempfile, file_ext, MAX_DIMENSION_PIXELS_AI_CHAT)
       end
 
-      head :payload_too_large if upload_tempfile.size > MAX_FILE_SIZE_AI_CHAT
-      return nil
+      if upload_tempfile.size > MAX_FILE_SIZE_AI_CHAT
+        head :payload_too_large
+        return nil
+      end
     end
 
     {

--- a/dashboard/app/helpers/level_starter_assets_helper.rb
+++ b/dashboard/app/helpers/level_starter_assets_helper.rb
@@ -5,7 +5,7 @@ module LevelStarterAssetsHelper
 
   def self.try_resize_file(file, extension, max_dimension_px)
     # Resizing takes a lot of compute power.
-    # If we're given an image higher than 20MB (), don't attempt to resize.
+    # If we're given an image higher than 20MB, don't attempt to resize.
     # Since this is intended to be a levelbuilder-specific helper (ie, low volume/levelbuilder machine), it may be safe to increase this limit.
     if ([".jpg", ".jpeg", ".png"].include? extension.downcase) && (file.length < MAX_RESIZE_SIZE)
       image = MiniMagick::Image.read(file, extension)


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67732 thanks to this [handy comment from Copilot](https://github.com/code-dot-org/code-dot-org/pull/67732/files/97d1088df470ae8e02819aed14d4029c279bdb5b#r2298219959).

A "quick refactor" 🤦 involving an early return applied to levelbuilder uploads on AI Chat levels was being applied regardless of whether the upload size was too large or not.