### PR TITLE
Add policy method for special LTI deployments

### DIFF
--- a/dashboard/app/models/lti_deployment.rb
+++ b/dashboard/app/models/lti_deployment.rb
@@ -17,4 +17,8 @@
 class LtiDeployment < ApplicationRecord
   belongs_to :lti_integration
   has_and_belongs_to_many :lti_user_identities
+
+  def restricted?
+    Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(id)
+  end
 end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -16,7 +16,7 @@ class Policies::Lti
 
   module DeploymentConfiguration
     RESTRICTED_DEPLOYMENTS = [
-      288 # LAUSD
+      223 # LAUSD
     ]
   end
 

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -14,6 +14,12 @@ class Policies::Lti
     ].freeze
   end
 
+  module DeploymentConfiguration
+    RESTRICTED_DEPLOYMENTS = [
+      288 # LAUSD
+    ]
+  end
+
   ALL_SCOPES = AccessTokenScopes.constants.map do |scope|
     AccessTokenScopes.const_get(scope)
   end
@@ -214,5 +220,12 @@ class Policies::Lti
 
   def self.account_linking?(session, user)
     session[:lms_landing].present? && only_lti_auth?(user) && !user.lms_landing_opted_out
+  end
+
+  # Check if the user is part of a deployment with special restrictions
+  def self.restricted_user?(user)
+    user.lti_user_identities.any? do |identity|
+      identity.lti_deployments.any?(&:restricted?)
+    end
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -2054,6 +2054,33 @@ FactoryBot.define do
     subject {"subject"}
     lti_integration {create(:lti_integration)}
     user {create(:student)}
+    
+    # Let callers optionally pass deployments to attach after creation
+    transient do
+      attach_deployments {[]} # accept one or many deployments
+    end
+
+    after(:create) do |identity, evaluator|
+      Array(evaluator.attach_deployments).compact.each do |dep|
+        identity.lti_deployments << dep
+      end
+    end
+
+    # Convenience trait that creates one deployment (linked to same integration)
+    trait :with_deployment do
+      after(:create) do |identity, _|
+        identity.lti_deployments << create(:lti_deployment, lti_integration: identity.lti_integration)
+      end
+    end
+
+    # Add multiple deployments
+    trait :with_deployments do
+      transient { deployment_count { 2 } }
+      after(:create) do |identity, evaluator|
+        deps = create_list(:lti_deployment, evaluator.deployment_count, lti_integration: identity.lti_integration)
+        identity.lti_deployments << deps
+      end
+    end
   end
 
   factory :lti_deployment do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -2054,7 +2054,7 @@ FactoryBot.define do
     subject {"subject"}
     lti_integration {create(:lti_integration)}
     user {create(:student)}
-    
+
     # Let callers optionally pass deployments to attach after creation
     transient do
       attach_deployments {[]} # accept one or many deployments
@@ -2075,7 +2075,7 @@ FactoryBot.define do
 
     # Add multiple deployments
     trait :with_deployments do
-      transient { deployment_count { 2 } }
+      transient {deployment_count {2}}
       after(:create) do |identity, evaluator|
         deps = create_list(:lti_deployment, evaluator.deployment_count, lti_integration: identity.lti_integration)
         identity.lti_deployments << deps

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -3,6 +3,8 @@ require 'user'
 require 'policies/lti'
 
 class Policies::LtiTest < ActiveSupport::TestCase
+  include Minitest::RSpecMocks
+
   setup do
     @ids = ['http://some-iss.com', ['some-aud'], 'some-sub'].freeze
     @roles_key = Policies::Lti::LTI_ROLES_KEY
@@ -216,6 +218,28 @@ class Policies::LtiTest < ActiveSupport::TestCase
       ::PartialRegistration.persist_attributes session, partial_teacher
 
       refute Policies::Lti.lti_registration_in_progress?(session)
+    end
+  end
+
+  describe '.restricted_user?' do
+    let(:user) {create(:user)}
+    let(:deployment) {create(:lti_deployment)}
+    let(:restricted_user?) {described_class.restricted_user?(user)}
+    let(:lti_user_identity) {create(:lti_user_identity, user: user, attach_deployments: [deployment])}
+
+    it 'returns false for normal users' do
+      _(restricted_user?).must_equal false
+    end
+
+    context 'when user is associated with a restricted LTI deployment' do
+      before do
+        lti_user_identity
+        stub_const('Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS', [deployment.id])
+      end
+
+      it 'returns true' do
+        _(restricted_user?).must_equal true
+      end
     end
   end
 end

--- a/dashboard/test/models/lti_deployment_test.rb
+++ b/dashboard/test/models/lti_deployment_test.rb
@@ -19,7 +19,7 @@ class LtiDeploymentTest < ActiveSupport::TestCase
     it 'returns false' do
       _(restricted?).must_equal false
     end
-    
+
     context 'when restricted' do
       before do
         deployment.update(id: restricted_id)

--- a/dashboard/test/models/lti_deployment_test.rb
+++ b/dashboard/test/models/lti_deployment_test.rb
@@ -1,7 +1,33 @@
 require "test_helper"
 
 class LtiDeploymentTest < ActiveSupport::TestCase
-  test "validate required fields" do
-    refute build(:lti_user_identity, lti_integration: nil).valid? "lti_integration is required"
+  include Minitest::RSpecMocks
+
+  test 'validate required fields' do
+    refute build(:lti_user_identity, lti_integration: nil).valid? 'lti_integration is required'
+  end
+
+  describe '#restricted?' do
+    let(:deployment) {build(:lti_deployment)}
+    let(:restricted_id) {SecureRandom.random_number(1_000_000)}
+    let(:restricted?) {deployment.restricted?}
+
+    before do
+      stub_const('Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS', [restricted_id])
+    end
+
+    it 'returns false' do
+      _(restricted?).must_equal false
+    end
+    
+    context 'when restricted' do
+      before do
+        deployment.update(id: restricted_id)
+      end
+
+      it 'returns true' do
+        _(restricted?).must_equal true
+      end
+    end
   end
 end


### PR DESCRIPTION
Short-term, we need to implement special handling for certain LTI deployments. In LTI 1.3, the combination of a deployment ID + issuer uniquely identifies a particular instance of an LMS platform. Unlike the platform instance claim, deployment ID is a required field in launch tokens, and we already have a model in our DB representing deployments.

This PR adds a list of "restricted" deployments, a method in the LtiDeployment model to check an id against the list, and a helper in Policies::Lti to check if a user belongs to a deployment in the list.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1583)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
- Add a uniqueness constraint on `deployment_id` + `issuer` (have to pull from the integration?)



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
