### PR TITLE
Require educator_role to sign up for workshop

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopJoin.tsx
@@ -111,6 +111,7 @@ const WorkshopJoin: React.FunctionComponent<WorkshopJoinProps> = ({
             givenName={userInfo.givenName}
             familyName={userInfo.familyName}
             email={userInfo.email}
+            educatorRole={userInfo.educatorRole}
             schoolName={userInfo.schoolInfo?.schoolName}
             schoolType={userInfo.schoolInfo?.schoolType}
             returnToHref={`/pd/workshops/${workshopInfo.id}/join`}

--- a/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
+++ b/apps/src/code-studio/pd/workshops/components/EnrollInWorkshop.tsx
@@ -134,6 +134,7 @@ const EnrollInWorkshop: React.FC<EnrollInWorkshopProps> = ({
             givenName={userInfo.givenName}
             familyName={userInfo.familyName}
             email={userInfo.email}
+            educatorRole={userInfo.educatorRole}
             schoolName={userInfo.schoolInfo?.schoolName}
             schoolType={userInfo.schoolInfo?.schoolType}
             returnToHref={`/professional-learning/workshops/${id}`}

--- a/apps/src/code-studio/pd/workshops/components/UserPassport.tsx
+++ b/apps/src/code-studio/pd/workshops/components/UserPassport.tsx
@@ -21,6 +21,7 @@ export const isMissingUserInfo = (
     !userInfo.givenName ||
     !userInfo.familyName ||
     !userInfo.email ||
+    !userInfo.educatorRole ||
     (!userInfo.schoolInfo?.schoolName && !userInfo.schoolInfo?.schoolType)
   );
 };
@@ -30,6 +31,7 @@ const UserPassport: React.FunctionComponent<{
   givenName?: string;
   familyName?: string;
   email: string;
+  educatorRole?: string;
   schoolName?: string;
   schoolType?: string;
   returnToHref: string;
@@ -39,6 +41,7 @@ const UserPassport: React.FunctionComponent<{
   givenName,
   familyName,
   email,
+  educatorRole,
   schoolName,
   schoolType,
   returnToHref,
@@ -63,7 +66,7 @@ const UserPassport: React.FunctionComponent<{
       returnToHref
     )}`;
 
-    if (!givenName || !familyName) {
+    if (!givenName || !familyName || !educatorRole) {
       editLink += `&${AccountSettingsSectionUrlParams.AccountInformation}=true`;
     }
     if (!schoolName && !schoolType) {
@@ -104,6 +107,16 @@ const UserPassport: React.FunctionComponent<{
             Email
           </OverlineThreeText>
           <BodyThreeText>{email}</BodyThreeText>
+        </div>
+        <div className={style.userInfoRow}>
+          <OverlineThreeText className={style.userInfoLabel}>
+            Role
+          </OverlineThreeText>
+          {educatorRole ? (
+            <BodyThreeText>{educatorRole}</BodyThreeText>
+          ) : (
+            RenderErrorMessage('Add your role')
+          )}
         </div>
         <div className={style.userInfoRow}>
           <OverlineThreeText className={style.userInfoLabel}>

--- a/apps/src/code-studio/pd/workshops/types.ts
+++ b/apps/src/code-studio/pd/workshops/types.ts
@@ -105,6 +105,7 @@ export interface GetUserInfoForWorkshopResponse {
   is_student?: boolean;
   given_name?: string;
   family_name?: string;
+  educator_role?: string;
   school_info?: {
     school_id?: number;
     country?: string;
@@ -122,6 +123,7 @@ export type UserInfoForWorkshop = {
     isStudent?: boolean;
     givenName?: string;
     familyName?: string;
+    educatorRole?: string;
     schoolInfo?: {
       schoolId?: number;
       country?: string;
@@ -145,6 +147,7 @@ export const userInfoDataResponseToParams = (
       isStudent: response.is_student,
       givenName: response.given_name,
       familyName: response.family_name,
+      educatorRole: response.educator_role,
       schoolInfo: {
         schoolId: response.school_info?.school_id,
         country: response.school_info?.country,

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/WorkshopJoinTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/WorkshopJoinTest.tsx
@@ -26,6 +26,7 @@ const DEFAULT_PROPS = {
     givenName: 'Reba',
     familyName: 'McEntire',
     email: 'reba@mcentire.com',
+    educatorRole: 'Homeschool Teacher',
     schoolInfo: {
       schoolId: 1,
       country: 'United States',
@@ -115,6 +116,7 @@ describe('WorkshopJoin', () => {
     renderDefault({
       userInfo: {
         givenName: '',
+        educatorRole: '',
         schoolInfo: {},
       },
     });

--- a/apps/test/unit/code-studio/pd/workshops/components/EnrollInWorkshopTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshops/components/EnrollInWorkshopTest.tsx
@@ -12,6 +12,7 @@ const baseUserInfo = {
   displayName: 'Mr. Doe',
   givenName: 'John',
   familyName: 'Doe',
+  educatorRole: 'Homeschool Teacher',
   schoolInfo: {
     schoolId: 1,
     country: 'United States',

--- a/apps/test/unit/code-studio/pd/workshops/components/UserPassportTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshops/components/UserPassportTest.tsx
@@ -10,6 +10,7 @@ const DEFAULT_PROPS = {
   givenName: 'Reba',
   familyName: 'McEntire',
   email: 'reba@mcentire.com',
+  educatorRole: 'Homeschool Teacher',
   schoolName: 'Sample School Name',
   schoolType: undefined,
   returnToHref: '/fake-return-url',
@@ -33,11 +34,18 @@ describe('UserPassport', () => {
     screen.getByText(DEFAULT_PROPS.schoolName);
   });
 
-  it('missing name or school shows error messages', () => {
-    renderDefault({givenName: '', schoolName: '', schoolType: ''});
+  it('missing name or role or school shows error messages', () => {
+    renderDefault({
+      givenName: '',
+      educatorRole: '',
+      schoolName: '',
+      schoolType: '',
+    });
 
     screen.getByText('Full name');
     screen.getByText('Add your full name');
+    screen.getByText('Role');
+    screen.getByText('Add your role');
     screen.getByText('School');
     screen.getByText('Add your school');
   });
@@ -51,6 +59,21 @@ describe('UserPassport', () => {
     screen.getByText('School');
     screen.getByText('Non-School Setting');
     expect(screen.queryByText('Add your school')).toBe(null);
+  });
+
+  it('edit link adds missing info params to url: missing role', () => {
+    renderDefault({educatorRole: ''});
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Edit',
+      })
+    ).toHaveAttribute(
+      'href',
+      `/users/edit?user_return_to=${encodeURIComponent(
+        DEFAULT_PROPS.returnToHref
+      )}&accountInformation=true`
+    );
   });
 
   it('edit link adds missing info params to url: missing full name', () => {

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1005,6 +1005,7 @@ class User < ApplicationRecord
       display_name: name,
       given_name: given_name,
       family_name: family_name,
+      educator_role: educator_role ? SharedConstants::EDUCATOR_ROLES.find {|role| role[:value] == educator_role}&.dig(:label) : nil,
       school_info: Queries::SchoolInfo.current_school(self),
     }
   end

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -310,7 +310,7 @@ Given(/^I am a "([^"]*)" user enrolling in workshop with "([^"]*)" status$/) do 
 
            school_info = FactoryBot.create(:school_info)
            teacher = find_test_user_by_name(random_name)
-           teacher.update!(school_info: school_info)
+           teacher.update!(educator_role: 'classroom_teacher', school_info: school_info)
            teacher
          else
            nil


### PR DESCRIPTION
Adds `educator_role` as a required field in the `UserPassport` to enroll in a workshop (used on the workshop marketing page and the /join page).

### Enrolling is disabled if `educator_role` is missing
![role is required](https://github.com/user-attachments/assets/3d08e506-e2cc-455b-8752-6c75993316c8)

### Enrolling is enabled once `educator_role` is present
![with role](https://github.com/user-attachments/assets/43a6cb7b-8786-4cc5-8ce9-7c76f09f950b)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3453)
Figma: [here](https://www.figma.com/design/Km9JCLNbayBlTrlnKenumq/New-PL-Program?node-id=3814-28887&t=IK3rXIEqom97JZmT-0)

## Testing story
Local testing and updating unit tests.
