### PR TITLE
feat: explicitly categorize "other" questions

### DIFF
--- a/dashboard/lib/pd/foorm/workshop_categorizer.rb
+++ b/dashboard/lib/pd/foorm/workshop_categorizer.rb
@@ -46,7 +46,6 @@ module Pd::Foorm
 
       # Always ensure these core categories exist
       categories.add(:facilitators)
-      categories.add(:other)
 
       categories.to_a.sort
     end
@@ -61,7 +60,7 @@ module Pd::Foorm
     end
 
     def self.determine_category(category_string)
-      return :other unless category_string.is_a?(String) && !category_string.empty?
+      return unless category_string.is_a?(String) && !category_string.empty?
       category_string.downcase.to_sym
     end
 
@@ -96,6 +95,9 @@ module Pd::Foorm
               # since they should stay grouped under the facilitator, not split by category
               process_facilitator_matrix_question(question_name, question_data, question_summary, categories, facilitator_id, facilitator_name)
             else
+              category = determine_category(question_data[:category])
+              next unless category
+
               processed_question = create_processed_question(question_name, question_data, question_summary, facilitator_name)
               categories[:facilitators][facilitator_id][:questions][question_name] = processed_question
             end
@@ -109,6 +111,7 @@ module Pd::Foorm
         row_summary = question_summary&.dig(row_key)
 
         category = determine_category(row_data[:category])
+        next unless category
 
         # Replace facilitator name placeholder in text if provided
         row_text = row_data[:text]
@@ -126,7 +129,7 @@ module Pd::Foorm
           question_text: row_text,
           question_short_text: row_short_text,
           question_type: 'likert',
-          category: row_data[:category],
+          category: category,
           results: Pd::Foorm::ResponseProcessor.process_likert_responses(row_summary, question_data[:columns])
         }
 
@@ -136,12 +139,17 @@ module Pd::Foorm
 
     def self.process_regular_question_by_category(question_name, question_data, question_summary, categories)
       category = determine_category(question_data[:category])
+      return unless category
+
       processed_question = create_processed_question(question_name, question_data, question_summary)
       categories[category][:questions][question_name] = processed_question
     end
 
     def self.process_facilitator_matrix_question(question_name, question_data, question_summary, categories, facilitator_id, facilitator_name)
       question_data[:matrix_rows].each do |row_key, row_data|
+        category = determine_category(row_data[:category])
+        next unless category
+
         row_summary = question_summary&.dig(row_key)
 
         # Replace facilitator name placeholder in text
@@ -160,7 +168,7 @@ module Pd::Foorm
           question_text: row_text,
           question_short_text: row_short_text,
           question_type: 'likert',
-          category: row_data[:category],
+          category: category,
           results: Pd::Foorm::ResponseProcessor.process_likert_responses(row_summary, question_data[:columns])
         }
 

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
@@ -418,7 +418,7 @@ module Api::V1::Pd
       assert single_select_question[:results].key?(:breakdown)
 
       # Verify response structure for text questions
-      text_question = categories[:other][:questions][:uncategorized_feedback]
+      text_question = categories[:other][:questions][:other_feedback]
       assert text_question.key?(:question_name)
       assert text_question.key?(:question_text)
       assert text_question.key?(:question_type)

--- a/dashboard/test/factories/foorm_factories.rb
+++ b/dashboard/test/factories/foorm_factories.rb
@@ -1037,6 +1037,7 @@ FactoryBot.define do
                  ],
                  "rows": [
                    {
+                     "category": "facilitators",
                      "value": "demonstrated_knowledge",
                      "text": "Demonstrated knowledge of the curriculum."
                    },
@@ -1063,11 +1064,13 @@ FactoryBot.define do
                  ]
                },
                {
+                 "category": "facilitators",
                  "type": "comment",
                  "name": "k5_facilitator_did_well",
                  "title": "What were two things {panel.facilitator_name} did well?"
                },
                {
+                "category": "facilitators",
                  "type": "comment",
                  "name": "k5_facilitator_could_improve",
                  "title": "What were two things {panel.facilitator_name} could do better?"
@@ -1283,7 +1286,7 @@ FactoryBot.define do
             "modality_met_needs": "1"
           },
           "barriers_implementation_curriculum":["needs_more_preparation","lack_admin_support"],
-          "uncategorized_feedback": "Overall experience was okay"
+          "other_feedback": "Overall experience was okay"
         }'
       end
     end
@@ -1303,7 +1306,7 @@ FactoryBot.define do
             "modality_met_needs": "7"
           },
           "barriers_implementation_curriculum":["none"],
-          "uncategorized_feedback": "Amazing workshop experience!"
+          "other_feedback": "Amazing workshop experience!"
         }'
       end
     end
@@ -1429,8 +1432,9 @@ FactoryBot.define do
                 ]
               },
               {
+                "category": "other",
                 "type": "comment",
-                "name": "uncategorized_feedback",
+                "name": "other_feedback",
                 "title": "Any other feedback about the workshop?"
               }
             ]

--- a/dashboard/test/lib/pd/foorm/workshop_categorizer_test.rb
+++ b/dashboard/test/lib/pd/foorm/workshop_categorizer_test.rb
@@ -33,14 +33,9 @@ module Pd::Foorm
       assert_equal :logistics, WorkshopCategorizer.determine_category('LOGISTICS')
     end
 
-    test 'determine_category handles dynamic categories and falls back to other for nil or invalid values' do
+    test 'determine_category handles dynamic categories' do
       # Any string category should be converted to symbol
       assert_equal :custom_category, WorkshopCategorizer.determine_category('custom_category')
-
-      # Invalid inputs should fall back to :other
-      assert_equal :other, WorkshopCategorizer.determine_category('')
-      assert_equal :other, WorkshopCategorizer.determine_category(nil)
-      assert_equal :other, WorkshopCategorizer.determine_category(123)
     end
 
     test 'promoter_percentage_scale? correctly identifies Promoter percentage vs Likert scales' do
@@ -199,6 +194,12 @@ module Pd::Foorm
               type: 'singleSelect',
               category: 'logistics',
               choices: {'high' => 'High', 'low' => 'Low'}
+            },
+            'other_question' => {
+              title: 'Other Question',
+              type: 'singleSelect',
+              category: 'other',
+              choices: {'1' => 'Strongly Disagree', '7' => 'Strongly Agree'}
             }
           }
         },
@@ -212,7 +213,8 @@ module Pd::Foorm
             'form1' => {
               'impl_question' => {'yes' => 8, 'no' => 2},
               'engage_question' => {'high' => 6, 'low' => 4},
-              'log_question' => {'high' => 7, 'low' => 3}
+              'log_question' => {'high' => 7, 'low' => 3},
+              'other_question' => {'1' => 4, '7' => 10}
             }
           }
         }
@@ -247,8 +249,13 @@ module Pd::Foorm
       assert_equal 'log_question', engage_questions['log_question'][:question_name]
       assert_equal 'Logistics Question', engage_questions['log_question'][:question_text]
 
-      # Other categories should be empty
-      assert_equal({}, result[:other][:questions])
+      # Check other category has the right question
+      other_questions = result[:other][:questions]
+      assert_equal 1, other_questions.length
+      assert_equal 'other_question', other_questions['other_question'][:question_name]
+      assert_equal 'Other Question', other_questions['other_question'][:question_text]
+
+      # Facilitators categories should be empty
       assert_equal({}, result[:facilitators])
     end
 
@@ -354,39 +361,6 @@ module Pd::Foorm
       fac2_questions = result[:facilitators]['fac2'][:questions]
       assert_equal 1, fac2_questions.length
       assert_equal 'Jane Doe was helpful', fac2_questions['fac_question'][:question_text]
-    end
-
-    test 'categorize_survey_data handles uncategorized questions in other' do
-      parsed_forms_with_categories = {
-        general: {
-          'form1' => {
-            'uncategorized_question' => {
-              title: 'Uncategorized Question',
-              type: 'singleSelect',
-              choices: {'option1' => 'Option 1'}
-            }
-          }
-        },
-        facilitator: {}
-      }
-
-      summarized_answers = {
-        'Survey1' => {
-          general: {
-            'form1' => {
-              'uncategorized_question' => {'option1' => 5}
-            }
-          }
-        }
-      }
-
-      result = WorkshopCategorizer.categorize_survey_data(parsed_forms_with_categories, summarized_answers, nil)
-
-      # Question should end up in 'other' category
-      other_questions = result[:other][:questions]
-      assert_equal 1, other_questions.length
-      assert_equal 'uncategorized_question', other_questions['uncategorized_question'][:question_name]
-      assert_equal 'Uncategorized Question', other_questions['uncategorized_question'][:question_text]
     end
   end
 end


### PR DESCRIPTION
This pull request refines how survey questions are categorized in the `Pd::Foorm::WorkshopCategorizer` by improving category assignment logic, removing the catch-all `:other` fallback for invalid or missing categories, and updating related tests and test data to match these changes. The main focus is to ensure that only valid, explicit categories are used, and that questions without a valid category are ignored rather than defaulted to `:other`.

**Category assignment improvements:**

* The `determine_category` method no longer falls back to `:other` for invalid or missing categories; it now returns `nil` for such cases, and calling code skips questions without a valid category. 
* The core category `:other` is no longer always added by default in `get_form_categories`, meaning it will only appear if there are actually questions with that category.

**Bug fixes and consistency:**

* When processing matrix and regular questions, the assigned category is now always the resolved symbol (or skipped if invalid), ensuring consistent handling throughout the categorization logic.

**Test and fixture updates:**

* Test factories and test data have been updated to use `other_feedback` instead of `uncategorized_feedback` and to assign explicit categories to all questions, including new "other" and "facilitators" categories where appropriate.
* Tests for `determine_category` and categorization logic have been updated to reflect the removal of the `:other` fallback and to check that only explicitly categorized questions are included.
* Controller tests now reference the updated question name and category.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
