### PR TITLE
[Notifications] Add caching for contentful notifications

### DIFF
--- a/dashboard/engines/marketing/lib/marketing/dashboard_notifications/contentful_notification_source.rb
+++ b/dashboard/engines/marketing/lib/marketing/dashboard_notifications/contentful_notification_source.rb
@@ -4,7 +4,7 @@ module Marketing
       NOTIFICATION_CONTENTFUL_CONTENT_TYPE = 'dashboard-notification'
 
       CONTENTFUL_SOURCE_NAME = 'contentful'
-      CACHE_EXPIRATION = 2.hours
+      CACHE_EXPIRATION = 1.hour
 
       def get(user_id:, locale:)
         contentful_entries = cached_contentful_entries(locale.to_s)
@@ -30,7 +30,7 @@ module Marketing
       end
 
       private def cached_contentful_entries(locale)
-        Rails.cache.fetch("contentful-#{NOTIFICATION_CONTENTFUL_CONTENT_TYPE}:#{locale}", expires_in: CACHE_EXPIRATION) do
+        CDO.shared_cache.fetch("contentful-#{NOTIFICATION_CONTENTFUL_CONTENT_TYPE}:#{locale}", expires_in: CACHE_EXPIRATION) do
           Marketing::ContentfulClient.entries(locale, NOTIFICATION_CONTENTFUL_CONTENT_TYPE)
         end
       end

--- a/dashboard/engines/marketing/lib/marketing/dashboard_notifications/contentful_notification_source.rb
+++ b/dashboard/engines/marketing/lib/marketing/dashboard_notifications/contentful_notification_source.rb
@@ -4,9 +4,10 @@ module Marketing
       NOTIFICATION_CONTENTFUL_CONTENT_TYPE = 'dashboard-notification'
 
       CONTENTFUL_SOURCE_NAME = 'contentful'
+      CACHE_EXPIRATION = 2.hours
 
       def get(user_id:, locale:)
-        contentful_entries = Marketing::ContentfulClient.entries(locale.to_s, NOTIFICATION_CONTENTFUL_CONTENT_TYPE)
+        contentful_entries = cached_contentful_entries(locale.to_s)
         contentful_result = contentful_entries.filter_map do |notification|
           Services::ContentfulNotificationFormatter.call(notification)
         end
@@ -25,6 +26,12 @@ module Marketing
           read_at = rails_notification&.read_at&.iso8601 || nil
 
           notification.merge(read_at: read_at, source: CONTENTFUL_SOURCE_NAME)
+        end
+      end
+
+      private def cached_contentful_entries(locale)
+        Rails.cache.fetch("contentful-#{NOTIFICATION_CONTENTFUL_CONTENT_TYPE}:#{locale}", expires_in: CACHE_EXPIRATION) do
+          Marketing::ContentfulClient.entries(locale, NOTIFICATION_CONTENTFUL_CONTENT_TYPE)
         end
       end
     end

--- a/dashboard/engines/marketing/test/dashboard_notifications/contentful_notification_source_test.rb
+++ b/dashboard/engines/marketing/test/dashboard_notifications/contentful_notification_source_test.rb
@@ -51,6 +51,7 @@ class ContentfulNotificationSourceTest < ActionDispatch::IntegrationTest
   end
 
   before do
+    CDO.shared_cache.clear
     sign_in user
   end
 
@@ -146,12 +147,12 @@ class ContentfulNotificationSourceTest < ActionDispatch::IntegrationTest
         _(results_es[0][:external_id]).must_equal entry_id_2
       end
 
-      it 'cache expires after 2 hours' do
+      it 'cache expires after 1 hour' do
         Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_1]).once
         results1 = contentful_source.get(user_id: user.id, locale: 'en-US')
         _(results1.length).must_equal 1
 
-        travel 3.hours do
+        travel 2.hours do
           Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_2]).once
           results2 = contentful_source.get(user_id: user.id, locale: 'en-US')
           _(results2.length).must_equal 1

--- a/dashboard/engines/marketing/test/dashboard_notifications/contentful_notification_source_test.rb
+++ b/dashboard/engines/marketing/test/dashboard_notifications/contentful_notification_source_test.rb
@@ -14,6 +14,7 @@ class ContentfulNotificationSourceTest < ActionDispatch::IntegrationTest
   let(:later) {2.days.from_now}
   let(:user) {create(:user)}
   let(:other_user) {create(:user)}
+  let!(:contentful_source) {Marketing::DashboardNotifications::ContentfulNotificationSource.new}
 
   let(:entry_1) do
     TestEntry.new(
@@ -56,9 +57,9 @@ class ContentfulNotificationSourceTest < ActionDispatch::IntegrationTest
   describe 'get_contentful_notifications_for_user' do
     context 'with contentful data' do
       it 'returns user external notifications' do
-        Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_1, entry_2])
+        Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_1, entry_2]).once
 
-        results = Marketing::DashboardNotifications::ContentfulNotificationSource.new.get(user_id: user.id, locale: 'en-US')
+        results = contentful_source.get(user_id: user.id, locale: 'en-US')
 
         _(results.length).must_equal 2
 
@@ -77,21 +78,21 @@ class ContentfulNotificationSourceTest < ActionDispatch::IntegrationTest
 
       it 'only returns active external notifications' do
         create_external_notification(user, external_id: entry_id_2, is_dismissed: true)
-        Marketing::ContentfulClient.any_instance.expects(:entries).with('other-locale', 'dashboard-notification').returns([entry_1, entry_2])
+        Marketing::ContentfulClient.any_instance.expects(:entries).with('other-locale', 'dashboard-notification').returns([entry_1, entry_2]).once
 
-        results = Marketing::DashboardNotifications::ContentfulNotificationSource.new.get(user_id: user.id, locale: 'other-locale')
+        results = contentful_source.get(user_id: user.id, locale: 'other-locale')
 
         _(results.length).must_equal 1
         _(results[0][:external_id]).must_equal entry_id_1
       end
 
       it 'adds read_at timestamps' do
-        Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_1, entry_2])
+        Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_1, entry_2]).once
 
         create_external_notification(user, external_id: entry_id_1, read_at: tomorrow)
         create_external_notification(user, external_id: entry_id_2, read_at: later)
 
-        results = Marketing::DashboardNotifications::ContentfulNotificationSource.new.get(user_id: user.id, locale: 'en-US')
+        results = contentful_source.get(user_id: user.id, locale: 'en-US')
 
         _(results.length).must_equal 2
         _(results[0][:external_id]).must_equal entry_id_1
@@ -115,11 +116,47 @@ class ContentfulNotificationSourceTest < ActionDispatch::IntegrationTest
           },
           )
 
-        Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([expired_entry])
+        Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([expired_entry]).once
 
-        results = Marketing::DashboardNotifications::ContentfulNotificationSource.new.get(user_id: user.id, locale: 'en-US')
+        results = contentful_source.get(user_id: user.id, locale: 'en-US')
 
         _(results.length).must_equal 0
+      end
+
+      it 'caches contentful entries for 2 hours per locale' do
+        Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_1]).once
+
+        results1 = contentful_source.get(user_id: user.id, locale: 'en-US')
+        _(results1.length).must_equal 1
+
+        results2 = contentful_source.get(user_id: user.id, locale: 'en-US')
+        _(results2.length).must_equal 1
+      end
+
+      it 'uses separate cache keys for different locales' do
+        Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_1]).once
+        Marketing::ContentfulClient.any_instance.expects(:entries).with('es-ES', 'dashboard-notification').returns([entry_2]).once
+
+        results_en = contentful_source.get(user_id: user.id, locale: 'en-US')
+        results_es = contentful_source.get(user_id: user.id, locale: 'es-ES')
+
+        _(results_en.length).must_equal 1
+        _(results_es.length).must_equal 1
+        _(results_en[0][:external_id]).must_equal entry_id_1
+        _(results_es[0][:external_id]).must_equal entry_id_2
+      end
+
+      it 'cache expires after 2 hours' do
+        Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_1]).once
+        results1 = contentful_source.get(user_id: user.id, locale: 'en-US')
+        _(results1.length).must_equal 1
+
+        travel 3.hours do
+          Marketing::ContentfulClient.any_instance.expects(:entries).with('en-US', 'dashboard-notification').returns([entry_2]).once
+          results2 = contentful_source.get(user_id: user.id, locale: 'en-US')
+          _(results2.length).must_equal 1
+          _(results2[0][:external_id]).must_equal entry_id_2
+        end
       end
     end
   end


### PR DESCRIPTION
Adds caching so that we don't need to call contentful all the time. I went with 2 hours, but we can decrease or increase without any issues.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AITT-1113