### PR TITLE
add course levelbuilder files for units assigned to sections without courses

### DIFF
--- a/dashboard/config/course_offerings/csp3-research-mxghyt.json
+++ b/dashboard/config/course_offerings/csp3-research-mxghyt.json
@@ -1,0 +1,21 @@
+{
+  "key": "csp3-research-mxghyt",
+  "display_name": "csp3-research-mxghyt",
+  "is_featured": false,
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null,
+  "image": null,
+  "cs_topic": null,
+  "school_subject": null,
+  "device_compatibility": null,
+  "description": null,
+  "professional_learning_program": null,
+  "video": null,
+  "published_date": null,
+  "self_paced_pl_course_offering_key": null,
+  "ai_teaching_assistant_available": false,
+  "facilitator_course_permissions": null
+}

--- a/dashboard/config/course_offerings/sb-chardev-v1.json
+++ b/dashboard/config/course_offerings/sb-chardev-v1.json
@@ -1,0 +1,21 @@
+{
+  "key": "sb-chardev-v1",
+  "display_name": "sb-chardev-v1",
+  "is_featured": false,
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null,
+  "image": null,
+  "cs_topic": null,
+  "school_subject": null,
+  "device_compatibility": null,
+  "description": null,
+  "professional_learning_program": null,
+  "video": null,
+  "published_date": null,
+  "self_paced_pl_course_offering_key": null,
+  "ai_teaching_assistant_available": false,
+  "facilitator_course_permissions": null
+}

--- a/dashboard/config/courses/csp3-research-mxghyt.course
+++ b/dashboard/config/courses/csp3-research-mxghyt.course
@@ -1,0 +1,23 @@
+{
+  "name": "csp3-research-mxghyt",
+  "script_names": [
+    "csp3-research-mxghyt"
+  ],
+  "original_script_names": [
+    "csp3-research-mxghyt"
+  ],
+  "published_state": "in_development",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "csp3-research-mxghyt",
+    "version_year": "unversioned"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/config/courses/sb-chardev-v1.course
+++ b/dashboard/config/courses/sb-chardev-v1.course
@@ -1,0 +1,23 @@
+{
+  "name": "sb-chardev-v1",
+  "script_names": [
+    "sb-chardev-v1"
+  ],
+  "original_script_names": [
+    "sb-chardev-v1"
+  ],
+  "published_state": "in_development",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "sb-chardev-v1",
+    "version_year": "unversioned"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/config/locales/courses/en.yml
+++ b/dashboard/config/locales/courses/en.yml
@@ -6308,6 +6308,6 @@ en:
         sb-chardev-v1:
           title: Story Board Character Development
           description_short: ''
-          description_student: 'translation missing: en.data.script.name.sb-chardev-v1.student_description'
+          description_student: ''
           description_teacher: ''
           version_title: ''

--- a/dashboard/config/locales/courses/en.yml
+++ b/dashboard/config/locales/courses/en.yml
@@ -6299,3 +6299,15 @@ en:
           description_student: ''
           description_teacher: ''
           version_title: "'25-'26"
+        csp3-research-mxghyt:
+          title: CSP Unit 3 - Intro to Programming (subgoals)
+          description_short: Learn the basics of programming in JavaScript through a top-down design approach using classic turtle drawing.
+          description_student: This unit introduces the foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
+          description_teacher: This unit introduces the foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
+          version_title: ''
+        sb-chardev-v1:
+          title: Story Board Character Development
+          description_short: ''
+          description_student: 'translation missing: en.data.script.name.sb-chardev-v1.student_description'
+          description_teacher: ''
+          version_title: ''


### PR DESCRIPTION
There are about 1100 sections in production assigned to these 2 units (`csp3-research-mxghyt` and `sb-chardev-v1`) that exist on every environment. To avoid complicating the migration process, this PR adds the levelbuilder files needed to add the units to respective unit groups.


## Links
- Jira: [TEACH-2152](https://codedotorg.atlassian.net/browse/TEACH-2152)


## Deployment strategy
This PR needs to be merged before the [backfill](https://github.com/code-dot-org/code-dot-org/pull/67854) is run.


## Follow-up work
Part of this work also includes:
- A validation to ensure no more sections get into this state ([Jira](https://codedotorg.atlassian.net/browse/TEACH-2154), PR to come)
