### PR TITLE
Lab2 Resource Panel: Use DSCO Buttons

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
@@ -1,5 +1,5 @@
+import {Button} from '@code-dot-org/component-library/button';
 import {Theme} from '@code-dot-org/component-library/common/contexts';
-import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import React from 'react';
 
@@ -33,14 +33,13 @@ const ButtonWithDialog: React.FunctionComponent<ButtonWithDialogProps> = ({
           'data-theme': theme,
         }}
       >
-        <button
-          type="button"
+        <Button
           className={styles.bottomButton}
           onClick={() => setIsDialogOpen(true)}
           id={`uitest-${id}-button`}
-        >
-          <FontAwesomeV6Icon iconName={iconName} />
-        </button>
+          isIconOnly={true}
+          icon={{iconName: iconName}}
+        />
       </WithTooltip>
       {Dialog}
     </>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
@@ -39,6 +39,8 @@ const ButtonWithDialog: React.FunctionComponent<ButtonWithDialogProps> = ({
           id={`uitest-${id}-button`}
           isIconOnly={true}
           icon={{iconName: iconName}}
+          color={'gray'}
+          type={'tertiary'}
         />
       </WithTooltip>
       {Dialog}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -1,8 +1,6 @@
+import {Button} from '@code-dot-org/component-library/button';
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
-import {
-  default as FontAwesomeV6Icon,
-  kitIcons,
-} from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {kitIcons} from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import classNames from 'classnames';
 import React, {useMemo, useState} from 'react';
@@ -138,22 +136,21 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
               }}
               key={`tooltip-${tab}`}
             >
-              <button
-                type="button"
+              <Button
                 className={classNames(
                   styles.tabButton,
                   tab === currentTab && styles.selected
                 )}
                 onClick={() => setCurrentTab(tab)}
                 key={tab}
-              >
-                <FontAwesomeV6Icon
-                  iconName={tabInfo[tab].icon}
-                  iconFamily={
-                    kitIcons.has(tabInfo[tab].icon) ? 'kit' : undefined
-                  }
-                />
-              </button>
+                isIconOnly={true}
+                icon={{
+                  iconName: tabInfo[tab].icon,
+                  iconFamily: kitIcons.has(tabInfo[tab].icon)
+                    ? 'kit'
+                    : undefined,
+                }}
+              />
             </WithTooltip>
           ))}
         </div>
@@ -168,15 +165,14 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
               'data-theme': theme,
             }}
           >
-            <button
-              type="button"
+            <Button
               className={styles.bottomButton}
               onClick={() => {
                 setIsSettingsOpen(!isSettingsOpen);
               }}
-            >
-              <FontAwesomeV6Icon iconName={'gear'} />
-            </button>
+              isIconOnly={true}
+              icon={{iconName: 'gear'}}
+            />
           </WithTooltip>
           <CopyrightButton theme={theme} />
         </div>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -143,6 +143,8 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
                 )}
                 onClick={() => setCurrentTab(tab)}
                 key={tab}
+                color={'gray'}
+                type={'tertiary'}
                 isIconOnly={true}
                 icon={{
                   iconName: tabInfo[tab].icon,
@@ -172,6 +174,8 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
               }}
               isIconOnly={true}
               icon={{iconName: 'gear'}}
+              color={'gray'}
+              type={'tertiary'}
             />
           </WithTooltip>
           <CopyrightButton theme={theme} />

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -18,8 +18,8 @@
     flex-direction: column;
   }
 
-  .tabButton {
-    @include remove-button-styles;
+  // Doubling class name to increase specificity and override default button styles.
+  .tabButton.tabButton {
     height: 2rem;
     width: 2rem;
     min-width: 2rem;
@@ -27,13 +27,6 @@
     border: 1px solid var(--borders-neutral-primary);
     border-right: none;
     border-radius: 4px 0 0 4px;
-    background-color: var(--background-neutral-secondary);
-
-    // Overwrite default button styles.
-    &:active {
-      border: 1px solid var(--borders-neutral-primary) !important;
-      border-right: none !important;
-    }
 
     &.selected {
       background-color: var(--background-neutral-primary);
@@ -54,21 +47,16 @@
     padding: 8px 0;
   }
 
-  .bottomButton {
-    @include remove-button-styles;
+
+  // Doubling class name to increase specificity and override default button styles.
+  .bottomButton.bottomButton {
     height: 2rem;
     width: 2rem;
     min-width: 2rem;
 
     i {
-      color: var(--text-neutral-secondary);
       font-size: 14px;
     }
-
-    &:active, &:hover, &.selected {
-      background-color: var(--background-neutral-tertiary);
-    }
-
   }
 }
 

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -22,6 +22,7 @@
     @include remove-button-styles;
     height: 2rem;
     width: 2rem;
+    min-width: 2rem;
     margin-left: 5px;
     border: 1px solid var(--borders-neutral-primary);
     border-right: none;
@@ -57,6 +58,7 @@
     @include remove-button-styles;
     height: 2rem;
     width: 2rem;
+    min-width: 2rem;
 
     i {
       color: var(--text-neutral-secondary);

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -1,6 +1,3 @@
-@import 'color.scss';
-@import '../../../../../mixins.scss';
-
 .resourcePanel {
   display: flex;
   background-color: var(--background-neutral-secondary);


### PR DESCRIPTION
This updates the lab2 resource panel to use dsco buttons rather than standard html `button` components. There are only 2 slight visual changes here:
- The bottom buttons (settings/copyright) are now "gray", which means their icons are gray rather than white/black depending on theme. This is in line with the mocks.
- When you hover over a non-active tab, there is now a highlight color where there wasn't before.

We are still moving towards the final desired mocks (the desired tab styling has changed since the original work was done here), I didn't change the sizes/spacing of the tabs as is in the mocks yet. That was out of scope for this change.

## Before

<img width="329" height="816" alt="Screenshot 2025-08-25 at 1 41 08 PM" src="https://github.com/user-attachments/assets/a1a38f7d-dc5c-45a1-b7cc-94a7fea9fbb1" />
<img width="329" height="95" alt="Screenshot 2025-08-25 at 1 40 56 PM" src="https://github.com/user-attachments/assets/e78988eb-e217-4535-9ae7-705ea240262b" />
<img width="329" height="817" alt="Screenshot 2025-08-25 at 1 40 39 PM" src="https://github.com/user-attachments/assets/8d2ee1f7-76ed-4405-8500-34e85aed362b" />
<img width="329" height="156" alt="Screenshot 2025-08-25 at 1 40 49 PM" src="https://github.com/user-attachments/assets/f2058fdb-f6ab-48d5-99c3-5137d1b58cf6" />

## After
Ignore the existence of the extra links button, that was due to taking screenshots on a different account type.


<img width="329" height="796" alt="Screenshot 2025-08-25 at 1 39 20 PM" src="https://github.com/user-attachments/assets/5f91ea46-d8de-47a3-a738-1ea26749afa4" />
<img width="329" height="133" alt="Screenshot 2025-08-25 at 1 39 14 PM" src="https://github.com/user-attachments/assets/77640e46-a263-453c-ae34-d5b1874fb02a" />
<img width="329" height="133" alt="Screenshot 2025-08-25 at 1 39 06 PM" src="https://github.com/user-attachments/assets/3289abab-d6a5-4765-8308-6e7f34cc7b44" />
<img width="329" height="133" alt="Screenshot 2025-08-25 at 1 38 51 PM" src="https://github.com/user-attachments/assets/fe39cfe5-7a40-4b11-a79d-6c4e154be44a" />
<img width="329" height="133" alt="Screenshot 2025-08-25 at 1 38 32 PM" src="https://github.com/user-attachments/assets/a36985c9-d71a-4e39-9c2a-321b99d839ca" />
<img width="329" height="822" alt="Screenshot 2025-08-25 at 1 38 24 PM" src="https://github.com/user-attachments/assets/055669d4-d1a7-469d-ad73-ba30fb15647f" />

## Links

- Jira: [AFL-110](https://codedotorg.atlassian.net/browse/AFL-110)

## Testing story
Tested locally.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
