### PR TITLE
feat: create new enrollments serializer that flattens user info

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
         render json: @workshop.enrollments, each_serializer: Api::V1::Pd::WorkshopEnrollmentSerializer
       end
       format.csv do
-        response = render_to_json @workshop.enrollments, each_serializer: Api::V1::Pd::WorkshopEnrollmentSerializer
+        response = render_to_json @workshop.enrollments, each_serializer: Api::V1::Pd::WorkshopEnrollmentCsvSerializer
         send_as_csv_attachment response, 'workshop_enrollments.csv'
       end
     end

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_csv_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_csv_serializer.rb
@@ -55,7 +55,7 @@ class Api::V1::Pd::WorkshopEnrollmentCsvSerializer < ActiveModel::Serializer
   end
 
   def pre_workshop_survey
-    object.pre_workshop_survey&.try do |survey|
+    object.pre_workshop_survey&.then do |survey|
       survey.form_data_hash.merge({unitLessonShortName: survey.unit_lesson_short_name})
     end
   end
@@ -73,10 +73,10 @@ class Api::V1::Pd::WorkshopEnrollmentCsvSerializer < ActiveModel::Serializer
   end
 
   def user_school_info
-    resolved_user&.try(:school_info)
+    resolved_user&.school_info
   end
 
   def enrollment_school_info
-    object.try(:school_info)
+    object&.school_info
   end
 end

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_csv_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_csv_serializer.rb
@@ -1,0 +1,82 @@
+class Api::V1::Pd::WorkshopEnrollmentCsvSerializer < ActiveModel::Serializer
+  attributes :id, :first_name, :last_name, :email, :alternate_email, :application_id, :district_name, :school, :role,
+    :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
+    :csf_courses_planned, :user_id, :attended,
+    :pre_workshop_survey, :previous_courses, :attendances,
+    :scholarship_status, :enrolled_date, :years_teaching, :years_teaching_cs, :taught_ap_before, :planning_to_teach_ap
+
+  # Prefer resolved_user fields when present; fall back to enrollment values.
+
+  def first_name
+    resolved_user&.given_name.presence || object.first_name
+  end
+
+  def last_name
+    resolved_user&.family_name.presence || object.last_name
+  end
+
+  def email
+    resolved_user&.email.presence || object.email
+  end
+
+  def role
+    resolved_user&.educator_role.presence || object.role
+  end
+
+  def school
+    # Prefer user school_info first, then enrollment school_info, then enrollment.school string
+    if user_school_info.present?
+      user_school_info.effective_school_name || "Does not teach in a school setting"
+    else
+      enrollment_school_info&.school&.name || enrollment_school_info&.school_name || object.school
+    end
+  end
+
+  def district_name
+    user_school_info&.school_district&.name.presence ||
+      enrollment_school_info&.school_district&.name
+  end
+
+  def user_id
+    resolved_user&.id
+  end
+
+  def application_id
+    object&.application&.id
+  end
+
+  def alternate_email
+    # RuboCop-friendly: dig after safe-nav
+    object&.application&.sanitized_form_data_hash&.dig(:alternate_email)
+  end
+
+  def attended
+    object.attendances.exists?
+  end
+
+  def pre_workshop_survey
+    object.pre_workshop_survey&.try do |survey|
+      survey.form_data_hash.merge({unitLessonShortName: survey.unit_lesson_short_name})
+    end
+  end
+
+  def attendances
+    object.attendances.count
+  end
+
+  def enrolled_date
+    object.created_at&.to_date&.iso8601
+  end
+
+  def resolved_user
+    @resolved_user ||= object.resolve_user
+  end
+
+  def user_school_info
+    resolved_user&.try(:school_info)
+  end
+
+  def enrollment_school_info
+    object.try(:school_info)
+  end
+end

--- a/dashboard/test/serializers/api/v1/pd/workshop_enrollment_csv_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/workshop_enrollment_csv_serializer_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+
+class Api::V1::Pd::WorkshopEnrollmentCsvSerializerTest < ActionController::TestCase
+  include Pd::Application::ActiveApplicationModels
+  include Pd::EnrollmentConstants
+
+  test 'serialized workshop enrollment has expected attributes' do
+    enrollment = create(:pd_enrollment)
+
+    expected_attributes = [
+      :id, :first_name, :last_name, :email, :alternate_email, :application_id, :district_name, :school, :role,
+      :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
+      :csf_courses_planned, :user_id, :attended,
+      :pre_workshop_survey, :previous_courses, :attendances,
+      :scholarship_status, :enrolled_date, :years_teaching, :years_teaching_cs,
+      :taught_ap_before, :planning_to_teach_ap
+    ]
+
+    serialized = ::Api::V1::Pd::WorkshopEnrollmentCsvSerializer.new(enrollment).attributes
+    assert_equal expected_attributes, serialized.keys
+  end
+
+  test 'prefers user fields over enrollment when present' do
+    user = create(:teacher, given_name: "Given", family_name: "Family", educator_role: 'classroom_teacher')
+    district = create(:school_district, name: "User District")
+    school   = create(:school, name: "User School", school_district: district)
+    user_si  = create(:school_info, school: school)
+    user.update!(school_info: user_si)
+
+    # Enrollment has different values that should be overridden by the user fields
+    enrollment_district = create(:school_district, name: "Enrollment District")
+    enrollment_school   = create(:school, name: "Enrollment School", school_district: enrollment_district)
+    enrollment_si       = create(:school_info, school: enrollment_school)
+
+    enrollment = create(
+      :pd_enrollment,
+      first_name: "EnrollFirst",
+      last_name: "EnrollLast",
+      email: "enroll@example.com",
+      role: "facilitator",
+      school_info: enrollment_si,
+      user: user
+    )
+
+    serialized = ::Api::V1::Pd::WorkshopEnrollmentCsvSerializer.new(enrollment).attributes
+
+    assert_equal "Given", serialized[:first_name]
+    assert_equal "Family", serialized[:last_name]
+    # Prefers the user's email over enrollment email
+    assert_equal user.email, serialized[:email]
+    # Prefers the user's educator_role over enrollment role
+    assert_equal user.educator_role, serialized[:role]
+    # Prefers the user's school/district
+    assert_equal "User School", serialized[:school]
+    assert_equal "User District", serialized[:district_name]
+    assert_equal user.id, serialized[:user_id]
+  end
+
+  test 'falls back to enrollment data when user name fields are blank' do
+    # Keep user valid (email/role present), but make names blank/nil which should cause fallback.
+    user = create(:teacher, given_name: "", family_name: nil, educator_role: 'classroom_teacher')
+
+    enrollment = create(
+      :pd_enrollment,
+      first_name: "EnrollFirst",
+      last_name: "EnrollLast",
+      email: "enroll@example.com",
+      role: "other",
+      user: user
+    )
+
+    serialized = ::Api::V1::Pd::WorkshopEnrollmentCsvSerializer.new(enrollment).attributes
+
+    assert_equal "EnrollFirst", serialized[:first_name]
+    assert_equal "EnrollLast", serialized[:last_name]
+    # Email and role still prefer the user's valid values
+    assert_equal user.email, serialized[:email]
+    assert_equal user.educator_role, serialized[:role]
+  end
+
+  test 'attendances count' do
+    workshop   = create(:workshop, num_sessions: 5)
+    user       = create(:teacher, given_name: "Firstname", family_name: "Lastname")
+    enrollment = create(:pd_enrollment, workshop: workshop, user: user)
+    create(:pd_attendance, session: workshop.sessions.first, enrollment: enrollment)
+
+    serialized = ::Api::V1::Pd::WorkshopEnrollmentCsvSerializer.new(workshop.enrollments.first).attributes
+    assert_equal enrollment.attendances.count, serialized[:attendances]
+  end
+end


### PR DESCRIPTION
This pull request adds a new serializer for exporting workshop enrollments as CSV, ensuring that user-related fields are preferred over enrollment data when available. It also updates the controller to use this new serializer for CSV exports and introduces comprehensive tests for the serializer's behavior.

**CSV Export Functionality Improvements:**

* Added a new serializer `Api::V1::Pd::WorkshopEnrollmentCsvSerializer` that defines all the fields to be included in the CSV export and ensures user fields are preferred over enrollment fields when present.
* Updated the `index` action in `WorkshopEnrollmentsController` to use the new CSV serializer when rendering CSV responses.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3470

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
