### PR TITLE
Lab2 Settings: Focus language dropdown on open

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
@@ -28,9 +28,16 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
   );
 
   useEffect(() => {
+    // Set up a listener for localization changes.
     localization.on('change', info => {
       setLocaleOptions(localization.locales);
     });
+
+    // On load, focus the language dropdown.
+    const languageDropdown = document.getElementById(
+      'settings-language-dropdown'
+    );
+    languageDropdown?.focus();
   }, []);
 
   const handleLanguageChange = (
@@ -74,6 +81,7 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
             color={dropdownColor}
             dropdownTextThickness="thin"
             className={styles.dropdown}
+            id={'settings-language-dropdown'}
           />
         </form>
         {settings.map(setting => (


### PR DESCRIPTION
This focuses the language dropdown when the new settings panel is opened, for accessibility purposes.

@hannahbergam I did not add an escape on close yet, since I wasn't sure how we wanted to manage the scope of that keybinding. The panel could be open but the user's focus could be elsewhere on the page, in which case we probably wouldn't want escape to close the panel. You can also escape to close the dropdowns in the panel. Let me know what the best path forward is here, or we can rely on using the 'x' button to close, which works with the keyboard already. You can also navigate back to the settings button in the tab bar to close as well.

## Screen recording

https://github.com/user-attachments/assets/94dc7ab0-d17f-4deb-b826-2e45a4e4f8d6



## Links

- Jira: [AFL-110](https://codedotorg.atlassian.net/browse/AFL-110)

## Testing story
Tested locally.




## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
