### PR TITLE
Dance Lab2: add enable checkbox to level edit page

### DIFF
--- a/dashboard/app/views/levels/editors/_dance.html.haml
+++ b/dashboard/app/views/levels/editors/_dance.html.haml
@@ -13,6 +13,7 @@
 = render partial: 'levels/editors/fields/control_buttons', locals: {f: f}
 
 = render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: 'dance'}
+= render partial: 'levels/editors/fields/lab2', locals: {f: f, level_type: 'dance'}
 
 = render partial: 'levels/editors/fields/preload_assets', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_lab2.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_lab2.html.haml
@@ -1,0 +1,9 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#lab2_area"}}
+  [EXPERIMENTAL] Lab 2
+
+#lab2_area.in.collapse
+  - if @level.respond_to? :uses_lab2
+    %p If enabled, this level will use the Lab2 version of #{level_type}.
+    Note that the Lab2 version of #{level_type} is still in development so some features may not be available.
+    Contact the Student Learning team for more information.
+    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :uses_lab2, description: "Enable Lab 2"}


### PR DESCRIPTION
Adds a levelbuilder option to enable Lab2 for a Dance Party level. As noted in the description, this is very experimental since Dance Lab2 is not fully-featured yet and we are explicitly not supporting legacy features, but this will allow us to start putting together new progressions, namely for Hour of AI.

Very much open to better naming/clearer wording!

<img width="796" height="171" alt="Screenshot 2025-08-25 at 3 13 23 PM" src="https://github.com/user-attachments/assets/8cb1ccfc-02ce-46b4-92f0-99c0d9c1c4c7" />

## Testing story

Tested locally on allthethings