### PR TITLE
Hook up AI differentiation chat to code docs in knowledge base

### DIFF
--- a/dashboard/app/controllers/aidiff_threads_controller.rb
+++ b/dashboard/app/controllers/aidiff_threads_controller.rb
@@ -220,7 +220,8 @@ class AidiffThreadsController < ApplicationController
       {
         context: context_scope,
         course_display_name: course_display_name,
-        course_names: course_names
+        course_names: course_names,
+        section: section
       }
     end
     contexts
@@ -266,6 +267,20 @@ class AidiffThreadsController < ApplicationController
     elsif context_type == SharedConstants::AI_DIFF_CONTEXT[:COURSE]
       @unit_group.default_units.map do |unit|
         unit.levels.map {|level| labs_from_level(level)}
+      end
+    elsif context_type == SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
+      @section_contexts.map do |sc|
+        units =
+          if sc[:section]&.unit_group.present?
+            sc[:section].unit_group.default_units
+          elsif sc[:section]&.script.present?
+            [sc[:section].script]
+          else
+            []
+          end
+        units.map do |unit|
+          unit.levels.map {|level| labs_from_level(level)}
+        end
       end
     else
       []

--- a/dashboard/app/controllers/aidiff_threads_controller.rb
+++ b/dashboard/app/controllers/aidiff_threads_controller.rb
@@ -258,16 +258,12 @@ class AidiffThreadsController < ApplicationController
   # Returns name(s) of programming environment(s) in the chat context
   private def get_labs(context_type)
     if context_type == SharedConstants::AI_DIFF_CONTEXT[:LEVEL]
-      puts 'level context'
       labs_from_level(@level)
     elsif context_type == SharedConstants::AI_DIFF_CONTEXT[:LESSON]
-      puts 'lesson context'
       @lesson.levels.map {|level| labs_from_level(level)}
     elsif context_type == SharedConstants::AI_DIFF_CONTEXT[:UNIT]
-      puts 'unit context'
       @unit.levels.map {|level| labs_from_level(level)}
     elsif context_type == SharedConstants::AI_DIFF_CONTEXT[:COURSE]
-      puts 'unit group context'
       @unit_group.default_units.map do |unit|
         unit.levels.map {|level| labs_from_level(level)}
       end

--- a/dashboard/app/controllers/aidiff_threads_controller.rb
+++ b/dashboard/app/controllers/aidiff_threads_controller.rb
@@ -5,6 +5,17 @@ class AidiffThreadsController < ApplicationController
   before_action :authenticate_user!
   load_and_authorize_resource
 
+  LEVEL_TO_LAB = {
+    'Applab' => 'applab',
+    'Gamelab' => 'gamelab',
+    'GamelabJr' => 'spritelab',
+    'Javalab' => 'javalab',
+    'Weblab' => 'weblab',
+    'Weblab2' => 'weblab',
+    'Music' => 'music',
+    'Pythonlab' => 'pythonlab'
+  }.freeze
+
   # POST /aidiff_threads
   def create
     unless validate_context? && has_required_chat_params?
@@ -186,7 +197,7 @@ class AidiffThreadsController < ApplicationController
       student_code
     )
 
-    response = AiDiffBedrockHelper.request_bedrock_rag_chat(input, prompt, lesson_num, unit_num, course_names, session_id, @section_contexts)
+    response = AiDiffBedrockHelper.request_bedrock_rag_chat(input, prompt, lesson_num, unit_num, course_names, session_id, @section_contexts, get_labs(context_type))
     #TODO: check for profanity/PII in model response
 
     {
@@ -242,6 +253,34 @@ class AidiffThreadsController < ApplicationController
     if context_type == SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
       @section_contexts = get_active_sections
     end
+  end
+
+  # Returns name(s) of programming environment(s) in the chat context
+  private def get_labs(context_type)
+    if context_type == SharedConstants::AI_DIFF_CONTEXT[:LEVEL]
+      puts 'level context'
+      labs_from_level(@level)
+    elsif context_type == SharedConstants::AI_DIFF_CONTEXT[:LESSON]
+      puts 'lesson context'
+      @lesson.levels.map {|level| labs_from_level(level)}
+    elsif context_type == SharedConstants::AI_DIFF_CONTEXT[:UNIT]
+      puts 'unit context'
+      @unit.levels.map {|level| labs_from_level(level)}
+    elsif context_type == SharedConstants::AI_DIFF_CONTEXT[:COURSE]
+      puts 'unit group context'
+      @unit_group.default_units.map do |unit|
+        unit.levels.map {|level| labs_from_level(level)}
+      end
+    else
+      []
+    end.flatten.compact.uniq
+  end
+
+  private def labs_from_level(level)
+    [
+      LEVEL_TO_LAB[level.type],
+      level.try(:sublevels)&.map {|sublevel| LEVEL_TO_LAB[sublevel.type]}
+    ]
   end
 
   private def log_messages(response_body)

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -162,7 +162,7 @@ module AiDiffBedrockHelper
     }
   end
 
-  def self.filter_for_context(lesson_number, unit_num, course_names, section_contexts)
+  def self.filter_for_context(lesson_number, unit_num, course_names, section_contexts, labs)
     filter_config = {}
     and_all_filters = []
     or_all_filters = []
@@ -170,7 +170,8 @@ module AiDiffBedrockHelper
       and_all_filters.push(
         or_all: [
           {equals: {key: "lesson", value: format("L%02d", lesson_number)}},
-          {equals: {key: "lesson", value: "all"}}
+          {equals: {key: "lesson", value: "all"}},
+          {in: {key: 'lab', value: labs}}
         ]
       )
     end
@@ -178,11 +179,19 @@ module AiDiffBedrockHelper
       and_all_filters.push(
         or_all: [
           {equals: {key: "unit", value: format("U%02d", unit_num)}},
-          {equals: {key: "unit", value: "all"}}
+          {equals: {key: "unit", value: "all"}},
+          {in: {key: 'lab', value: labs}}
         ]
       )
     end
-    and_all_filters.push({in: {key: "course", value: course_names}}) unless course_names.nil?
+    unless course_names.nil?
+      and_all_filters.push(
+        or_all: [
+          {in: {key: "course", value: course_names}},
+          {in: {key: 'lab', value: labs}}
+        ]
+      )
+    end
 
     if lesson_number.nil? && unit_num.nil? && course_names.nil?
       or_all_filters.push({equals: {key: "scope", value: "general"}})
@@ -201,6 +210,12 @@ module AiDiffBedrockHelper
                         end
     or_all_filters.push(curriculum_filter) unless curriculum_filter.nil?
 
+    # Ideally we'd be able to include the code docs this way instead of tacking
+    # them onto each of the and_all_filters above, but that causes us to exceed
+    # AWS's two-level nesting limit for filter conditions
+    # TODO: revisit this if/when the filter depth limit changes.
+    # or_all_filters.push({in: {key: 'lab', value: labs}}) unless labs.empty?
+
     #can't use "or_all" if there is only 1 expression to filter on, only 2+
     if or_all_filters.length > 1
       filter_config = {
@@ -212,10 +227,10 @@ module AiDiffBedrockHelper
     filter_config
   end
 
-  def self.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, session_id, section_contexts)
+  def self.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, session_id, section_contexts, labs)
     config = format_inputs_for_bedrock_request(input, prompt)
     config[:session_id] = session_id unless session_id.nil?
-    filter_config = filter_for_context(lesson_number, unit_num, course_name, section_contexts)
+    filter_config = filter_for_context(lesson_number, unit_num, course_name, section_contexts, labs)
     config[:retrieve_and_generate_configuration][:knowledge_base_configuration][:retrieval_configuration][:vector_search_configuration][:filter] = filter_config
 
     response = create_bedrock_client.retrieve_and_generate(

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -202,6 +202,7 @@ module AiDiffBedrockHelper
       section_contexts&.each do |section_context|
         or_all_filters.push({in: {key: "course", value: section_context[:course_names]}})
       end
+      or_all_filters.push({in: {key: 'lab', value: labs}}) unless labs.empty?
     end
 
     #can't use "and_all" if there is only 1 expression to filter on, only 2+

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -162,7 +162,7 @@ module AiDiffBedrockHelper
     }
   end
 
-  def self.filter_for_context(lesson_number, unit_num, course_names, section_contexts, labs)
+  def self.filter_for_context(lesson_number, unit_num, course_names, section_contexts, labs = [])
     filter_config = {}
     and_all_filters = []
     or_all_filters = []
@@ -171,8 +171,8 @@ module AiDiffBedrockHelper
         or_all: [
           {equals: {key: "lesson", value: format("L%02d", lesson_number)}},
           {equals: {key: "lesson", value: "all"}},
-          {in: {key: 'lab', value: labs}}
-        ]
+          labs.empty? ? nil : {in: {key: 'lab', value: labs}}
+        ].compact
       )
     end
     unless unit_num.nil?
@@ -180,17 +180,21 @@ module AiDiffBedrockHelper
         or_all: [
           {equals: {key: "unit", value: format("U%02d", unit_num)}},
           {equals: {key: "unit", value: "all"}},
-          {in: {key: 'lab', value: labs}}
-        ]
+          labs.empty? ? nil : {in: {key: 'lab', value: labs}}
+        ].compact
       )
     end
     unless course_names.nil?
-      and_all_filters.push(
-        or_all: [
-          {in: {key: "course", value: course_names}},
-          {in: {key: 'lab', value: labs}}
-        ]
-      )
+      if labs.empty?
+        and_all_filters.push({in: {key: "course", value: course_names}})
+      else
+        and_all_filters.push(
+          or_all: [
+            {in: {key: "course", value: course_names}},
+            {in: {key: 'lab', value: labs}}
+          ]
+        )
+      end
     end
 
     if lesson_number.nil? && unit_num.nil? && course_names.nil?
@@ -227,7 +231,7 @@ module AiDiffBedrockHelper
     filter_config
   end
 
-  def self.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, session_id, section_contexts, labs)
+  def self.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, session_id, section_contexts, labs = [])
     config = format_inputs_for_bedrock_request(input, prompt)
     config[:session_id] = session_id unless session_id.nil?
     filter_config = filter_for_context(lesson_number, unit_num, course_name, section_contexts, labs)

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -744,6 +744,7 @@ The courses that this teacher may ask you about are:
         course_names: ["fake_b"]
       }
     ]
+    labs = ['javalab', 'pythonlab']
     formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -778,11 +779,12 @@ The courses that this teacher may ask you about are:
       or_all: [
         {equals: {key: "scope", value: "general"}},
         {in: {key: "course", value: ["fake_a"]}},
-        {in: {key: "course", value: ["fake_b"]}}
+        {in: {key: "course", value: ["fake_b"]}},
+        {in: {key: 'lab', value: ['javalab', 'pythonlab']}}
       ]
     }
     assert_equal formatted_input, expected_input
-    filter = AiDiffBedrockHelper.filter_for_context(lesson_number, unit_num, course_names, section_contexts)
+    filter = AiDiffBedrockHelper.filter_for_context(lesson_number, unit_num, course_names, section_contexts, labs)
     assert_equal filter, expected_filter
   end
 

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -525,6 +525,66 @@ The courses that this teacher may ask you about are:
     assert_equal filter, expected_filter
   end
 
+  test 'Testing context filtering for lesson with labs' do
+    input = "Hello there!"
+    prompt = "prompt text"
+    course_names = ["test_course"]
+    unit_num = 2
+    lesson_number = 3
+    section_contexts = nil
+    formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
+    expected_input = {
+      input: {
+        text: "Hello there!"
+      },
+      retrieve_and_generate_configuration: {
+        type: 'KNOWLEDGE_BASE',
+        knowledge_base_configuration: {
+          knowledge_base_id: AiDiffBedrockHelper::KB_ID,
+          model_arn: 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0',
+          generation_configuration: {
+            prompt_template: {
+              text_prompt_template: "prompt text"
+            },
+            inference_config: {
+              text_inference_config: {
+                max_tokens: 1500,
+                temperature: 0.5,
+              }
+            },
+          },
+          retrieval_configuration: {
+            vector_search_configuration: {
+              filter: {},
+              number_of_results: 10,
+            }
+          }
+        }
+      }
+    }
+    expected_filter = {
+      and_all: [
+        {or_all: [
+          {equals: {key: "lesson", value: "L03"}},
+          {equals: {key: "lesson", value: "all"}},
+          {in: {key: 'lab', value: ['weblab', 'gamelab']}}
+        ]},
+        {or_all: [
+          {equals: {key: "unit", value: "U02"}},
+          {equals: {key: "unit", value: "all"}},
+          {in: {key: 'lab', value: ['weblab', 'gamelab']}}
+        ]},
+        {or_all: [
+          {in: {key: "course", value: ["test_course"]}},
+          {in: {key: 'lab', value: ['weblab', 'gamelab']}}
+        ]}
+      ]
+    }
+    assert_equal formatted_input, expected_input
+    filter = AiDiffBedrockHelper.filter_for_context(lesson_number, unit_num, course_names, section_contexts, ['weblab', 'gamelab'])
+    assert_equal filter, expected_filter
+  end
+
   test 'Testing context filtering for unit' do
     input = "Hello there!"
     prompt = "prompt text"


### PR DESCRIPTION
This change looks at the AI differentiation chat context, inspects the relevant course/unit/lesson/level for which lab(s) it uses, and adds relevant code docs to the knowledge base filter for our RetrieveAndGenerate call.

See sample chat below in a Weblab level context: the AI explains how to make lists in HTML and links to https://studio.code.org/docs/ide/weblab/expressions/li and https://studio.code.org/docs/ide/weblab/expressions/ol.

<img width="1573" height="996" alt="image" src="https://github.com/user-attachments/assets/9cc2fff2-1230-4cda-9862-3bd8ad3365ae" />



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AITT-1079

## Testing story
Unit tests for the bedrock helper are updated with the new expected filters.
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
