### PR TITLE
TEACH-2154/validate section always has course if assigned script

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -84,6 +84,7 @@ class Section < ApplicationRecord
   accepts_nested_attributes_for :students
 
   validates :name, presence: true, unless: -> {deleted?}
+  validates :course_id, presence: true, if: -> {script_id.present?}
 
   belongs_to :script, class_name: 'Unit', optional: true
   belongs_to :unit_group, foreign_key: 'course_id', optional: true

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -29,14 +29,14 @@ class ApiControllerTest < ActionController::TestCase
     @student_1, @student_2, @student_3, @student_4, @student_5, @student_6, @student_7 = @students
 
     @flappy = create(:text_match, :with_script).script_levels.first.script
-    create(:single_unit_course, unit: @flappy)
-    @flappy_section = create(:section, user: @teacher, script_id: @flappy.id)
+    @flappy_course = create(:single_unit_course, unit: @flappy)
+    @flappy_section = create(:section, user: @teacher, script_id: @flappy.id, course_id: @flappy_course.id)
     @student_flappy_1 = create(:follower, section: @flappy_section).student_user
     @student_flappy_1.reload
 
     @allthings = create(:text_match, :with_script).script_levels.first.script
-    create(:single_unit_course, unit: @allthings)
-    @allthings_section = create(:section, user: @teacher, script_id: @allthings.id)
+    @allthingscourse = create(:single_unit_course, unit: @allthings)
+    @allthings_section = create(:section, user: @teacher, script_id: @allthings.id, course_id: @allthings.original_unit_group_id)
     @student_allthings = create(:student, name: 'student_allthings')
     create(:follower, section: @allthings_section, student_user: @student_allthings)
     @allthings_section.reload

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -68,7 +68,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     @pilot_script_level = create(:script_level, script: pilot_script, lesson: pilot_lesson)
     @pilot_teacher = create(:teacher, pilot_experiment: 'pilot-experiment')
     @pilot_section_owner = create(:teacher, pilot_experiment: 'pilot-experiment')
-    pilot_section = create(:section, user: @pilot_section_owner, script: pilot_script)
+    pilot_section = create(:section, user: @pilot_section_owner, script: pilot_script, course_id: pilot_script.original_unit_group_id)
     create(:section_instructor, instructor: @pilot_teacher, section: pilot_section)
     @pilot_student = create(:follower, section: pilot_section).student_user
 
@@ -78,7 +78,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     @pilot_pl_script_level = create(:script_level, script: pilot_pl_script, lesson: pilot_pl_lesson)
     @pilot_instructor = create(:facilitator, pilot_experiment: 'pl-pilot-experiment')
     @pilot_section_owner = create(:facilitator, pilot_experiment: 'pl-pilot-experiment')
-    pilot_pl_section = create(:section, user: @pilot_section_owner, script: pilot_pl_script)
+    pilot_pl_section = create(:section, user: @pilot_section_owner, script: pilot_pl_script, course_id: pilot_pl_script.original_unit_group_id)
     create(:section_instructor, instructor: @pilot_instructor, section: pilot_pl_section)
     @pilot_participant = create(:teacher)
     create(:follower, section: pilot_pl_section, student_user: @pilot_participant)
@@ -1921,7 +1921,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   def  put_participant_in_section(student, teacher, script)
-    section = create(:section, user_id: teacher.id, script_id: script.id)
+    section = create(:section, user_id: teacher.id, script_id: script.id, course_id: script.original_unit_group_id)
     Follower.create!(section_id: section.id, student_user_id: student.id, user: teacher)
     section
   end

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -16,7 +16,7 @@ class SectionsControllerTest < ActionController::TestCase
 
     @regular_section = create(:section, user: @teacher, login_type: 'email')
 
-    @flappy_section = create(:section, user: @teacher, login_type: 'word', script_id: Unit.flappy_unit.id)
+    @flappy_section = create(:section, user: @teacher, login_type: 'word', script_id: Unit.flappy_unit.id, course_id: Unit.flappy_unit.original_unit_group_id)
     @flappy_user_1 = create(:follower, section: @flappy_section).student_user
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -820,9 +820,9 @@ FactoryBot.define do
 
     initialize_with {Section.new(attributes)}
 
-    after(:create) do |section|
+    after(:build) do |section|
       if section.script_id && section.course_id.nil?
-        section.update!(course_id: section.script.original_unit_group_id)
+        section.course_id = section.script.original_unit_group_id
       end
     end
 

--- a/dashboard/test/lib/policies/unit_test.rb
+++ b/dashboard/test/lib/policies/unit_test.rb
@@ -30,8 +30,8 @@ class Policies::UnitTest < ActiveSupport::TestCase
   end
 
   test 'check deletion unit with section assignment' do
-    unit = create(:script, published_state: PUBLISHED_STATE.in_development)
-    create(:section, script: unit, unit_group: nil)
+    unit = create(:single_unit_course, published_state: PUBLISHED_STATE.in_development).first_unit
+    create(:section, script: unit)
     assert_equal false, Policies::Unit.can_be_deleted?(unit)
   end
 end

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -714,6 +714,7 @@ class AbilityTest < ActiveSupport::TestCase
   test 'student of verified teacher in CSA section can access main javabuilder' do
     teacher = create(:authorized_teacher)
     csa_script = create(:csa_script)
+    create(:single_unit_course, unit: csa_script)
     section = create(:section, user: teacher, login_type: 'word', script: csa_script)
     student = create(:follower, section: section).student_user
 

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -99,7 +99,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
   describe 'assigned and section scripts' do
     let(:user) {create(:student)}
     let(:single_script) {create(:script)}
-    let(:section_1) {create(:section, script: single_script)}
+    let(:section_1) {create(:section, script: single_script, unit_group: unit_group)}
     let(:section_2) {create(:section, unit_group: unit_group)}
     let(:unit_group_unit) {create(:script)}
     before do
@@ -283,7 +283,8 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
       context 'when the script is a pilot and the user has access' do
         let(:pilot_teacher) {create(:teacher, pilot_experiment: 'my-experiment')}
         let(:pilot_script) {create(:script, name: 'pilot-script', pilot_experiment: 'my-experiment')}
-        let(:pilot_section) {create(:section, user: pilot_teacher, script: pilot_script)}
+        let(:pilot_course) {create(:single_unit_course, unit: pilot_script, pilot_experiment: 'my-experiment')}
+        let(:pilot_section) {create(:section, user: pilot_teacher, script: pilot_script, course_id: pilot_course.id)}
         let(:pilot_student) {create(:follower, section: pilot_section).student_user}
         subject(:can_access_pilot?) {pilot_student.can_access_most_recently_assigned_script?}
 

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -200,18 +200,20 @@ class SectionTest < ActiveSupport::TestCase
   end
 
   test 'course_id is required if script_id is set' do
-    section = build(:section, script_id: 1, course_id: nil)
+    script = create(:script)
+    section = Section.new(name: 'test section', script_id: script.id, course_id: nil, user: @teacher)
     refute section.valid?
     assert_equal ['Course is required'], section.errors.full_messages
   end
 
   test 'course_id is not required if script_id is not set' do
-    section = build(:section, script_id: nil, course_id: nil)
+    section = Section.new(name: 'test section', script_id: nil, course_id: nil, user: @teacher)
     assert section.valid?
   end
 
   test 'script_id is not required if course_id is set' do
-    section = build(:section, script_id: nil, course_id: 1)
+    course = create(:unit_group)
+    section = Section.new(name: 'test section', script_id: nil, course_id: course.id, user: @teacher)
     assert section.valid?
   end
 

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -199,6 +199,22 @@ class SectionTest < ActiveSupport::TestCase
     assert_equal ['Name is required'], section.errors.full_messages
   end
 
+  test 'course_id is required if script_id is set' do
+    section = build(:section, script_id: 1, course_id: nil)
+    refute section.valid?
+    assert_equal ['Course is required'], section.errors.full_messages
+  end
+
+  test 'course_id is not required if script_id is not set' do
+    section = build(:section, script_id: nil, course_id: nil)
+    assert section.valid?
+  end
+
+  test 'script_id is not required if course_id is set' do
+    section = build(:section, script_id: nil, course_id: 1)
+    assert section.valid?
+  end
+
   test 'emoji is dropped from section name' do
     section = create(:section, name: "\u{1F600} Test Section A \u{1F600}")
     assert_equal 'Test Section A', section.name
@@ -422,12 +438,6 @@ class SectionTest < ActiveSupport::TestCase
     assert_nil section.default_script
   end
 
-  test 'default_script: script assigned, no course assigned' do
-    script = create(:script, :in_single_unit_course)
-    section = create(:section, script: script)
-    assert_equal script, section.default_script
-  end
-
   test 'default_script: script and course assigned' do
     script1 = create(:script)
     script2 = create(:script)
@@ -478,55 +488,6 @@ class SectionTest < ActiveSupport::TestCase
         course_offering_id: unit_group.course_version.course_offering.id,
         course_version_id: unit_group.course_version.id,
         unit_id: nil,
-        course_id: unit_group.id,
-        hidden: false,
-        restrict_section: false,
-        post_milestone_disabled: false,
-        code_review_expires_at: nil,
-        is_assigned_csa: false,
-        participant_type: 'student',
-        sectionInstructors: [{id: section.section_instructors[0].id, status: "active", instructor_name: section.teacher.name, instructor_email: section.teacher.email}],
-        sync_enabled: nil,
-        ai_tutor_enabled: false,
-        avatar_color: nil,
-        avatar_emoji: nil,
-        at_risk_age_gated_date: nil,
-        at_risk_age_gated_us_state: nil
-      }
-      # Compare created_at separately because the object's created_at microseconds
-      # don't match Time.zone.now's microseconds (different levels of precision)
-      assert_equal Time.zone.now.change(sec: 0), section.created_at.change(sec: 0)
-      assert_equal expected, section.concise_summarize.except!(:createdAt)
-    end
-  end
-
-  test 'concise_summarize: deprecated section with a script assigned but no course' do
-    unit_group = create(:single_unit_course, name: 'somecourse', version_year: '1991', family_name: 'some-family')
-    unit = unit_group.first_unit
-    CourseOffering.add_course_offering(unit_group)
-
-    Timecop.freeze(Time.zone.now) do
-      section = create(:section, script: unit, unit_group: nil)
-
-      expected = {
-        id: section.id,
-        name: section.name,
-        courseVersionName: 'somecourse',
-        unitName: unit.name,
-        unitPosition: 1,
-        login_type: "email",
-        grades: nil,
-        providerManaged: false,
-        lesson_extras: false,
-        pairing_allowed: true,
-        tts_autoplay_enabled: false,
-        sharing_disabled: false,
-        studentCount: 0,
-        code: section.code,
-        course_display_name: unit_group.course_version.localized_title,
-        course_offering_id: unit_group.course_version.course_offering.id,
-        course_version_id: unit_group.course_version.id,
-        unit_id: unit.id,
         course_id: unit_group.id,
         hidden: false,
         restrict_section: false,
@@ -771,7 +732,7 @@ class SectionTest < ActiveSupport::TestCase
 
   test 'concise_summarize: section with sharing disabled and script with project sharing' do
     script = create(:script, :in_single_unit_course, project_sharing: true)
-    section = create(:section, sharing_disabled: true, script: script, unit_group: nil)
+    section = create(:section, sharing_disabled: true, script: script, unit_group: script.original_unit_group)
     summarized_section = section.concise_summarize
 
     assert summarized_section[:sharing_disabled]
@@ -861,24 +822,6 @@ class SectionTest < ActiveSupport::TestCase
     assert_equal true, summarized_section[:is_assigned_single_unit_course]
   end
 
-  test 'selected_section_summarize: deprecated section with a script assigned but no course' do
-    single_unit_course = create(:single_unit_course)
-    single_unit = single_unit_course.first_unit
-    section = create(:section, script: single_unit)
-    CourseOffering.add_course_offering(single_unit_course)
-
-    summarized_section = section.selected_section_summarize
-    expected_script_info = {
-      id: single_unit.id,
-      name: single_unit.name,
-      project_sharing: single_unit.project_sharing
-    }
-
-    assert_equal single_unit_course.course_version.course_offering.id, summarized_section[:course][:course_offering_id]
-    assert_equal expected_script_info, summarized_section[:script]
-    assert_equal true, summarized_section[:is_assigned_single_unit_course]
-  end
-
   test 'selected_section_summarize: section with students' do
     section = create(:section, script: nil, unit_group: nil)
     student1 = create(:follower, section: section).student_user
@@ -903,7 +846,7 @@ class SectionTest < ActiveSupport::TestCase
 
   test 'selected_section_summarize: section with sharing disabled and script with project sharing' do
     script = create(:script, :in_single_unit_course, project_sharing: true)
-    section = create(:section, sharing_disabled: true, script: script, unit_group: nil)
+    section = create(:section, sharing_disabled: true, script: script, unit_group: script.original_unit_group)
     summarized_section = section.selected_section_summarize
 
     assert summarized_section[:script][:project_sharing]
@@ -974,67 +917,6 @@ class SectionTest < ActiveSupport::TestCase
         restrict_section: false,
         is_assigned_csa: false,
         is_assigned_single_unit_course: false,
-        post_milestone_disabled: false,
-        code_review_expires_at: nil,
-        sectionInstructors: [{id: section.section_instructors[0].id, status: "active", instructor_name: section.teacher.name, instructor_email: section.teacher.email}],
-        primaryInstructor: {email: section.teacher.email, name: section.teacher.name, ltiRosterSyncEnabled: nil},
-        sync_enabled: nil,
-        ai_tutor_enabled: false,
-        at_risk_age_gated_date: nil,
-        at_risk_age_gated_us_state: nil,
-        avatar_color: nil,
-        avatar_emoji: nil,
-      }
-      # Compare created_at separately because the object's created_at microseconds
-      # don't match Time.zone.now's microseconds (different levels of precision)
-      assert_equal Time.zone.now.change(sec: 0), section.created_at.change(sec: 0)
-      assert_equal expected, section.summarize.except!(:createdAt)
-    end
-  end
-
-  test 'summarize: deprecated section with a script assigned but no course' do
-    unit_group = create(:single_unit_course, name: 'somecourse', version_year: '1991', family_name: 'some-family')
-    unit = unit_group.first_unit
-    CourseOffering.add_course_offering(unit_group)
-
-    Timecop.freeze(Time.zone.now) do
-      section = create(:section, script: unit, unit_group: nil)
-
-      expected = {
-        id: section.id,
-        name: section.name,
-        teacherName: section.teacher.name,
-        linkToProgress: "//test-studio.code.org/teacher_dashboard/sections/#{section.id}/progress",
-        assignedTitle: 'somecourse',
-        linkToAssigned: '/courses/somecourse',
-        currentUnitTitle: unit.name,
-        linkToCurrentUnit: "/courses/somecourse/units/1",
-        courseVersionName: 'somecourse',
-        numberOfStudents: 0,
-        linkToStudents: "//test-studio.code.org/teacher_dashboard/sections/#{section.id}/manage_students",
-        code: section.code,
-        lesson_extras: false,
-        pairing_allowed: true,
-        tts_autoplay_enabled: false,
-        sharing_disabled: false,
-        login_type: "email",
-        login_type_name: "Email",
-        participant_type: 'student',
-        course_display_name: unit_group.course_version.localized_title,
-        course_offering_id: unit_group.course_version.course_offering.id,
-        course_version_id: unit_group.course_version.id,
-        unit_id: unit.id,
-        unitPosition: 1,
-        course_id: unit_group.id,
-        script: {id: unit.id, name: unit.name, project_sharing: nil},
-        studentCount: 0,
-        grades: nil,
-        providerManaged: false,
-        hidden: false,
-        students: [],
-        restrict_section: false,
-        is_assigned_csa: false,
-        is_assigned_single_unit_course: true,
         post_milestone_disabled: false,
         code_review_expires_at: nil,
         sectionInstructors: [{id: section.section_instructors[0].id, status: "active", instructor_name: section.teacher.name, instructor_email: section.teacher.email}],
@@ -1329,7 +1211,7 @@ class SectionTest < ActiveSupport::TestCase
 
   test 'summarize: section with sharing disabled and script with project sharing' do
     script = create(:script, :in_single_unit_course, project_sharing: true)
-    section = create(:section, sharing_disabled: true, script: script, unit_group: nil)
+    section = create(:section, sharing_disabled: true, script: script, unit_group: script.original_unit_group)
     summarized_section = section.summarize
 
     assert summarized_section[:script][:project_sharing]

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -635,6 +635,7 @@ class UnitTest < ActiveSupport::TestCase
   test 'self.latest_assigned_version returns latest assigned unit in family if unit is not in course family' do
     student = create(:student)
     courseg_2017 = create(:script, name: 'courseg-2017', family_name: 'courseg', version_year: '2017')
+    create(:single_unit_course, unit: courseg_2017, family_name: 'courseg', version_year: '2017')
     create(:script, name: 'courseg-2018', family_name: 'courseg', version_year: '2018')
     section = create(:section, script: courseg_2017)
     section.students << student

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4029,7 +4029,9 @@ class UserTest < ActiveSupport::TestCase
   test 'marketing_segment_data returns expected curriculums for teacher with sections' do
     teacher = create(:teacher)
     csf_script = create(:csf_script)
+    create(:single_unit_course, unit: csf_script)
     csd_script = create(:csd_script)
+    create(:single_unit_course, unit: csd_script)
     create(:section, user: teacher, script: csf_script)
     create(:section, user: teacher, script: csd_script)
 


### PR DESCRIPTION
NOTE: This cannot be merged until the unit migration and backfill have been performed! 

This is the last part required to make sure that sections are assigned courses if they are assigned scripts. 

## Links

- Jira: [TEACH-2154](https://codedotorg.atlassian.net/browse/TEACH-2154)

## Testing story
Some tests were updated to make sure that test sections had both script and course assigned 


## Deployment strategy
This must not be merged before the [unit migration](https://github.com/code-dot-org/code-dot-org/pull/67935) and [backfill](https://github.com/code-dot-org/code-dot-org/pull/67854) are run. 
