### PR TITLE
[Lab2] Add Blockly settings to Resource Panel

### DIFF
--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -20,6 +20,7 @@ import {
 import {getFilterStatus} from '@cdo/apps/dance/songs';
 import SongSelector from '@cdo/apps/dance/SongSelector';
 import {DanceLevelProperties, DanceProjectSources} from '@cdo/apps/dance/types';
+import {useBlocklySettings} from '@cdo/apps/lab2/hooks/useBlocklySettings';
 import {setPageError} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {getIsShareView} from '@cdo/apps/lab2/projects/utils';
@@ -249,6 +250,7 @@ const DanceView: React.FunctionComponent<
     onPuzzleComplete,
     readonlyWorkspace,
   ]);
+  const settings = useBlocklySettings();
 
   return (
     <div id="dance-lab" className={moduleStyles.danceLab}>
@@ -261,6 +263,7 @@ const DanceView: React.FunctionComponent<
         levelProperties={levelProperties}
         headerClassName={moduleStyles.panelHeader}
         className={moduleStyles.instructionsArea}
+        settings={settings}
       />
       <div className={moduleStyles.divider} />
       <PanelContainer

--- a/apps/src/lab2/hooks/useBlocklySettings.ts
+++ b/apps/src/lab2/hooks/useBlocklySettings.ts
@@ -3,9 +3,9 @@ import {useEffect, useState} from 'react';
 import {BLOCKLY_THEME, Themes} from '@cdo/apps/blockly/constants';
 import {commonI18n} from '@cdo/apps/types/locale';
 
-import {getBaseName, setWorkspaceTheme} from '../blockly/utils';
-import {Setting} from '../lab2/views/components/Settings/SettingsDropdown';
-import UserPreferences from '../lib/util/UserPreferences';
+import {getBaseName, setWorkspaceTheme} from '../../blockly/utils';
+import UserPreferences from '../../lib/util/UserPreferences';
+import {Setting} from '../views/components/Settings/SettingsDropdown';
 
 const blockThemeOptions = [
   {
@@ -30,7 +30,7 @@ const blockThemeOptions = [
   },
 ];
 
-export function useMusicSettings(): Setting[] {
+export function useBlocklySettings(): Setting[] {
   const [selectedTheme, setSelectedTheme] = useState<string | null>(null);
 
   useEffect(() => {

--- a/apps/src/lab2/hooks/useBlocklySettings.ts
+++ b/apps/src/lab2/hooks/useBlocklySettings.ts
@@ -1,11 +1,10 @@
 import {useEffect, useState} from 'react';
 
 import {BLOCKLY_THEME, Themes} from '@cdo/apps/blockly/constants';
+import {getBaseName, setWorkspaceTheme} from '@cdo/apps/blockly/utils';
+import {Setting} from '@cdo/apps/lab2/views/components/Settings/SettingsDropdown';
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {commonI18n} from '@cdo/apps/types/locale';
-
-import {getBaseName, setWorkspaceTheme} from '../../blockly/utils';
-import UserPreferences from '../../lib/util/UserPreferences';
-import {Setting} from '../views/components/Settings/SettingsDropdown';
 
 const blockThemeOptions = [
   {

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -2,18 +2,19 @@ import classNames from 'classnames';
 import React, {memo, useCallback, useContext} from 'react';
 import {useSelector} from 'react-redux';
 
+import {useBlocklySettings} from '@cdo/apps/lab2/hooks/useBlocklySettings';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import SettingsButton from '@cdo/apps/lab2/views/components/Settings/SettingsButton';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {commonI18n} from '@cdo/apps/types/locale';
+import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {getBaseAssetUrl} from '../appConfig';
 import {AnalyticsContext} from '../context';
 import musicI18n from '../locale';
 import MusicLibrary, {SoundFolder} from '../player/MusicLibrary';
-import {useMusicSettings} from '../settings';
 
 import moduleStyles from './HeaderButtons.module.scss';
 
@@ -141,6 +142,8 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
     }
   }, [dialogControl, skipUrl]);
 
+  const settings = useBlocklySettings();
+
   return (
     <div className={moduleStyles.container}>
       {!allowPackSelection && packFolder && (
@@ -178,10 +181,14 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
           </button>
         </>
       )}
-      <SettingsButton
-        settings={useMusicSettings()}
-        className={classNames(moduleStyles.button)}
-      />
+      {!experiments.isEnabledAllowingQueryString(
+        experiments.LAB2_RESOURCE_PANEL
+      ) ? (
+        <SettingsButton
+          settings={settings}
+          className={classNames(moduleStyles.button)}
+        />
+      ) : null}
       {!readOnlyWorkspace && (
         <>
           <button

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -9,6 +9,7 @@ import {
   TOOLBOX_BLOCKS,
   WARNING_BANNER_MESSAGES,
 } from '@cdo/apps/lab2/constants';
+import {useBlocklySettings} from '@cdo/apps/lab2/hooks/useBlocklySettings';
 import {ProgressManagerContext} from '@cdo/apps/lab2/progress/ProgressContainer';
 import {
   getAppOptionsEditBlocks,
@@ -299,6 +300,8 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     AppConfig.getValue('player') === 'tonejs' &&
     AppConfig.getValue('advanced-controls-enabled') === 'true';
 
+  const settings = useBlocklySettings();
+
   if (isPlayView) {
     return <MusicPlayView setPlaying={setPlaying} />;
   }
@@ -364,6 +367,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 includeFooterSpacing={false}
                 levelProperties={levelProperties}
                 headerClassName={moduleStyles.headerWithBorder}
+                settings={settings}
               />
             ) : (
               <PanelContainer


### PR DESCRIPTION
The Lab2 version of Dance now has Blockly workspace editing (https://github.com/code-dot-org/code-dot-org/pull/67914), however there is no way to change themes. In Music Lab and other Blockly labs, theme preferences are currently managed through a settings button in the workspace header. However, with the new Lab2 instructions panel, these settings will be moving to the resource panel. Music Lab doesn't currently use the resource panel by default, but there is an experiment for it. This branch makes the following changes:

1. Show the Blockly theme setting options inside the resource panel for Music and Dance (Lab2 only)
2. Hide the Settings workspace header button if we are using the resource panel
 

New setting in Music Lab:
<img width="1510" height="840" alt="image" src="https://github.com/user-attachments/assets/dcad9d38-52d7-40a3-8eba-ed2abfd92f84" />

New setting in Dance:
<img width="1510" height="840" alt="image" src="https://github.com/user-attachments/assets/4cdf7625-1380-4355-9da5-fd8968c71ce7" />

I've confirmed that the setting persists across levels, page reloads, and between Music and Dance.



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
