### PR TITLE
allow teachers to unassign single unit courses

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -152,6 +152,7 @@ class UnitOverview extends React.Component {
       courseVersionId,
       courseId,
       isProfessionalLearningCourse,
+      isSingleUnitCourse,
       publishedState,
       participantAudience,
       showAiAssessmentsAnnouncement,
@@ -202,6 +203,7 @@ class UnitOverview extends React.Component {
               viewAs={viewAs}
               showAssignButton={showAssignButton}
               courseOfferingId={courseOfferingId}
+              isSingleUnitCourse={isSingleUnitCourse}
               currentCourseId={courseId}
               scriptId={scriptId}
               participantAudience={participantAudience}

--- a/apps/src/code-studio/components/progress/UnitOverviewActionRow.tsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewActionRow.tsx
@@ -242,7 +242,7 @@ const UnitOverviewActionRow: React.FC<UnitOverviewActionRowProps> = ({
                 assignmentName={unitTitle}
                 reassignConfirm={onReassignConfirm}
                 isAssigningCourseOnly={false}
-                isAssigningUnitOnly={isSingleUnitCourse}
+                isSingleUnitCourse={isSingleUnitCourse}
                 participantAudience={participantAudience}
               />
             </div>

--- a/apps/src/code-studio/components/progress/UnitOverviewActionRow.tsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewActionRow.tsx
@@ -42,7 +42,7 @@ interface UnitOverviewActionRowProps {
   showAssignButton: boolean;
   currentCourseId: number;
   courseOfferingId: number;
-  courseLink: string;
+  isSingleUnitCourse: boolean;
   participantAudience: string;
   isMigrated: boolean;
   scriptOverviewPdfUrl: string;
@@ -105,7 +105,7 @@ const UnitOverviewActionRow: React.FC<UnitOverviewActionRowProps> = ({
   showAssignButton,
   currentCourseId,
   courseOfferingId,
-  courseLink,
+  isSingleUnitCourse,
   participantAudience,
   isMigrated,
   scriptOverviewPdfUrl,
@@ -242,7 +242,7 @@ const UnitOverviewActionRow: React.FC<UnitOverviewActionRowProps> = ({
                 assignmentName={unitTitle}
                 reassignConfirm={onReassignConfirm}
                 isAssigningCourseOnly={false}
-                isAssigningUnitOnly={courseLink === null}
+                isAssigningUnitOnly={isSingleUnitCourse}
                 participantAudience={participantAudience}
               />
             </div>

--- a/apps/src/templates/MultipleAssignButton.jsx
+++ b/apps/src/templates/MultipleAssignButton.jsx
@@ -21,7 +21,7 @@ class MultipleAssignButton extends React.Component {
     assignmentName: PropTypes.string,
     reassignConfirm: PropTypes.func,
     isAssigningCourseOnly: PropTypes.bool,
-    isAssigningUnitOnly: PropTypes.bool,
+    isSingleUnitCourse: PropTypes.bool,
     participantAudience: PropTypes.string,
     // Redux
     assignToSection: PropTypes.func.isRequired,
@@ -53,7 +53,7 @@ class MultipleAssignButton extends React.Component {
       courseVersionId,
       scriptId,
       assignmentName,
-      isAssigningUnitOnly,
+      isSingleUnitCourse,
       sectionsForDropdown,
       participantAudience,
       isAssigningCourseOnly,
@@ -80,7 +80,7 @@ class MultipleAssignButton extends React.Component {
             courseVersionId={courseVersionId}
             reassignConfirm={reassignConfirm}
             isAssigningCourseOnly={isAssigningCourseOnly}
-            isAssigningUnitOnly={isAssigningUnitOnly}
+            isSingleUnitCourse={isSingleUnitCourse}
             participantAudience={participantAudience}
           />
         )}

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -30,7 +30,7 @@ const MultipleSectionsAssigner = ({
   scriptId,
   reassignConfirm = () => {},
   isAssigningCourseOnly,
-  isAssigningUnitOnly,
+  isSingleUnitCourse,
   participantAudience,
   onAssignSuccess,
   sectionDirections = i18n.chooseSectionsDirections(),
@@ -47,7 +47,7 @@ const MultipleSectionsAssigner = ({
     let initialSectionsAssigned = [];
     // check to see if this is coming from the UNIT landing page - if so add courses featuring this unit
     if (!isAssigningCourseOnly) {
-      if (isAssigningUnitOnly) {
+      if (isSingleUnitCourse) {
         for (let i = 0; i < sections.length; i++) {
           if (courseVersionId === sections[i].courseVersionId) {
             initialSectionsAssigned.push(sections[i]);
@@ -72,7 +72,7 @@ const MultipleSectionsAssigner = ({
     return initialSectionsAssigned;
   }, [
     isAssigningCourseOnly,
-    isAssigningUnitOnly,
+    isSingleUnitCourse,
     sections,
     courseId,
     scriptId,
@@ -126,7 +126,7 @@ const MultipleSectionsAssigner = ({
 
       if (isSectionToBeRemoved) {
         // if on COURSE landing page or a SINGLE-UNIT COURSE unit overview, unassign entirely
-        isAssigningCourseOnly || isAssigningUnitOnly
+        isAssigningCourseOnly || isSingleUnitCourse
           ? unassignSection(initialSectionsAssigned[i].id, '')
           : assignCourseWithoutUnit(initialSectionsAssigned[i]);
       }
@@ -271,7 +271,7 @@ MultipleSectionsAssigner.propTypes = {
   scriptId: PropTypes.number,
   reassignConfirm: PropTypes.func,
   isAssigningCourseOnly: PropTypes.bool.isRequired,
-  isAssigningUnitOnly: PropTypes.bool,
+  isSingleUnitCourse: PropTypes.bool,
   participantAudience: PropTypes.string,
   onAssignSuccess: PropTypes.func,
   sectionDirections: PropTypes.string,

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -125,7 +125,7 @@ const MultipleSectionsAssigner = ({
       );
 
       if (isSectionToBeRemoved) {
-        // if on COURSE landing page or a STANDALONE UNIT, unassign entirely
+        // if on COURSE landing page or a SINGLE-UNIT COURSE unit overview, unassign entirely
         isAssigningCourseOnly || isAssigningUnitOnly
           ? unassignSection(initialSectionsAssigned[i].id, '')
           : assignCourseWithoutUnit(initialSectionsAssigned[i]);

--- a/apps/src/templates/courseOverview/CourseOverviewActionRow.tsx
+++ b/apps/src/templates/courseOverview/CourseOverviewActionRow.tsx
@@ -95,7 +95,7 @@ const CourseOverviewActionRow: React.FC<CourseOverviewActionRowProps> = ({
             assignmentName={title}
             reassignConfirm={() => setConfirmationMessageOpen(true)}
             isAssigningCourseOnly={true}
-            isAssigningUnitOnly={false}
+            isSingleUnitCourse={false}
             participantAudience={participantAudience}
           />
         </div>

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -163,7 +163,7 @@ class CourseScript extends Component {
                   assignmentName={title}
                   reassignConfirm={this.onReassignConfirm}
                   isAssigningCourseOnly={false}
-                  isAssigningUnitOnly={false}
+                  isSingleUnitCourse={false}
                   participantAudience={participantAudience}
                 />
               </div>

--- a/apps/test/unit/templates/MultipleSectionsAssignerTest.js
+++ b/apps/test/unit/templates/MultipleSectionsAssignerTest.js
@@ -39,7 +39,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: false,
       courseId: assignedCourseANDUnitSection.courseId,
-      isAssigningUnitOnly: false,
+      isSingleUnitCourse: false,
       scriptId: assignedCourseANDUnitSection.unitId,
     });
 
@@ -66,7 +66,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: true,
       courseId: assignedCourseANDUnitSection.courseId,
-      isAssigningUnitOnly: false,
+      isSingleUnitCourse: false,
       scriptId: assignedCourseANDUnitSection.unitId,
     });
 
@@ -111,7 +111,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: true,
       courseId: assignedCourseANDUnitSection.courseId,
-      isAssigningUnitOnly: false,
+      isSingleUnitCourse: false,
       scriptId: assignedCourseANDUnitSection.unitId,
       courseOfferingId: assignedCourseANDUnitSection.courseOfferingId,
       courseVersionId: assignedCourseANDUnitSection.courseVersionId,
@@ -144,7 +144,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: true,
       courseId: assignedCourseANDUnitSection.courseId,
-      isAssigningUnitOnly: false,
+      isSingleUnitCourse: false,
       scriptId: assignedCourseANDUnitSection.unitId,
       courseOfferingId: assignedCourseANDUnitSection.courseOfferingId,
       courseVersionId: assignedCourseANDUnitSection.courseVersionId,
@@ -181,7 +181,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: false,
       courseId: assignedCourseANDUnitSection.courseId,
-      isAssigningUnitOnly: false,
+      isSingleUnitCourse: false,
       scriptId: assignedCourseANDUnitSection.unitId,
       assignToSection,
       reassignConfirm,
@@ -223,7 +223,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: false,
       courseId: assignedSingleUnitCourseSection.courseId,
-      isAssigningUnitOnly: true,
+      isSingleUnitCourse: true,
       scriptId: assignedSingleUnitCourseSection.unitId,
       assignToSection,
       reassignConfirm,
@@ -266,7 +266,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: false,
       courseId: assignedSingleUnitCourseSection.courseId,
-      isAssigningUnitOnly: true,
+      isSingleUnitCourse: true,
       scriptId: assignedSingleUnitCourseSection.unitId,
       unassignSection,
       reassignConfirm,
@@ -305,7 +305,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: false,
       courseId: assignedCourseANDUnitSection.courseId,
-      isAssigningUnitOnly: false,
+      isSingleUnitCourse: false,
       scriptId: assignedCourseANDUnitSection.unitId,
       reassignConfirm,
       assignToSection,
@@ -349,7 +349,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: true,
       courseId: assignedCourseANDUnitSection.courseId,
-      isAssigningUnitOnly: false,
+      isSingleUnitCourse: false,
       scriptId: assignedCourseANDUnitSection.unitId,
       unassignSection,
       reassignConfirm,
@@ -388,7 +388,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: true,
       courseId: assignedCourseANDUnitSection.courseId,
-      isAssigningUnitOnly: false,
+      isSingleUnitCourse: false,
       scriptId: assignedCourseANDUnitSection.unitId,
       assignToSection,
       reassignConfirm,
@@ -427,7 +427,7 @@ describe('MultipleSectionsAssigner', () => {
     const wrapper = setUp({
       isAssigningCourseOnly: false,
       courseId: assignedCourseANDUnitSection.courseId,
-      isAssigningUnitOnly: false,
+      isSingleUnitCourse: false,
       scriptId: assignedCourseANDUnitSection.unitId,
     });
 


### PR DESCRIPTION
While cleaning up [references to standalone units](https://github.com/code-dot-org/code-dot-org/pull/67806), I discovered that MultipleSectionsAssigner un-assign single-unit courses properly. This PR fixes the MultipleSectionsAssigner to check for `isSingleUnitCourse` to determine whether or not to assign both unit and course on the unit overview page.

Previously, the MultipleSectionsAssigner checked if courseLink is null to assign/un-assign both unit and course. Since the courseLink was dependent on the unit being a standalone unit, only the unit was being unassigned for single-unit courses. Then, when the update was triggered, the unit was added back to the section:
https://github.com/code-dot-org/code-dot-org/blob/cc6109b9896f6b55c2bce3800a108bbe35702ad6/dashboard/app/controllers/api/v1/sections_controller.rb#L321-L323



<img width="694" height="482" alt="Screenshot 2025-08-27 at 10 36 31 AM" src="https://github.com/user-attachments/assets/b0be801a-2060-4227-93a2-440c251fec36" />


## Links
- Jira: [TEACH-2147](https://codedotorg.atlassian.net/browse/TEACH-2147)

## Testing story

- [x] Can assign and un-assign single-unit courses
- [x] Can assign and un-assign courses
- [x] Can assign and un-assign units


