### PR TITLE
Revert "Setup Post-Workshop Survey email on MailJet"

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -218,6 +218,27 @@ class Pd::WorkshopMailer < ApplicationMailer
       reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
+  # Exit survey email
+  # @param enrollment [Pd::Enrollment]
+  def exit_survey(enrollment, to_email = '')
+    @workshop = enrollment.workshop
+    workshop_title = @workshop.name.presence || @workshop.course
+    @teacher = enrollment.user
+    @enrollment = enrollment
+    @survey_url = enrollment.exit_survey_url
+
+    content_type = 'text/html'
+    if @workshop.course == Pd::Workshop::COURSE_CSF
+      attachments['certificate.jpg'] = generate_csf_certificate
+      content_type = 'multipart/mixed'
+    end
+
+    mail content_type: content_type,
+      from: from_survey,
+      subject: "Help us improve Code.org #{workshop_title} workshops!",
+      to: email_address(@enrollment.full_name, to_email.presence || @enrollment.email)
+  end
+
   def teacher_follow_up(enrollment)
     @enrollment = enrollment
     @workshop = enrollment.workshop

--- a/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
@@ -34,25 +34,6 @@ class Pd::WorkshopMailjetMailer
     retryable_send_email('teacher_workshop_reminder', email, user.friendly_name, email_vars)
   end
 
-  def self.send_teacher_post_workshop_survey(enrollment, user, use_alternate_email)
-    workshop = enrollment.workshop
-    organizer = workshop.organizer
-    regional_partner = workshop.regional_partner
-    email = use_alternate_email ? user.alternate_email : user.email
-    email_vars = {
-      email_to: email,
-      name: user.given_name || user.name,
-      exit_survey_url: enrollment.exit_survey_url,
-      download_certificate_url: CDO.studio_url("/pd/generate_workshop_certificate/#{enrollment.code}", CDO.default_scheme),
-      rp_email: regional_partner&.contact_email_with_backup,
-      rp_name: regional_partner&.name,
-      organizer_email: organizer&.email,
-      organizer_name: organizer&.name
-    }
-
-    retryable_send_email('teacher_post_workshop_survey', email, user.friendly_name, email_vars)
-  end
-
   private_class_method def self.retryable_send_email(email_name, email, name, vars)
     Retryable.retryable(
       on: RestClient::TooManyRequests,

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -175,6 +175,38 @@ class Pd::Enrollment < ApplicationRecord
     end
   end
 
+  def should_send_exit_survey?
+    !(workshop.fit_weekend? || workshop.course == Pd::Workshop::COURSE_ADMIN_COUNSELOR)
+  end
+
+  def send_exit_survey
+    # In case the workshop is reprocessed, do not send duplicate exit surveys.
+    if survey_sent_at
+      CDO.log.warn "Skipping attempt to send a duplicate workshop survey email. Enrollment: #{id}"
+      return
+    end
+
+    return unless should_send_exit_survey?
+
+    # Don't send if there's no associated survey
+    return unless exit_survey_url
+
+    return unless (mailer = Pd::WorkshopMailer.exit_survey(self))
+
+    mailer.deliver_now
+
+    # Also send to the user's alternate summer email if they entered it in their application and
+    # it's for a summer workshop.
+    if workshop.subject == SUBJECT_SUMMER_WORKSHOP
+      alt_summer_email = user&.alternate_email
+      if alt_summer_email.present?
+        Pd::WorkshopMailer.exit_survey(self, alt_summer_email).deliver_now
+      end
+    end
+
+    update!(survey_sent_at: Time.zone.now)
+  end
+
   # TODO: Once we're satisfied with the first/last name split data,
   # remove the name field entirely.
   def name=(value)

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -630,7 +630,7 @@ class Pd::Workshop < ApplicationRecord
   end
 
   # Called at the very end of the async close-workshop workflow, to actually send exit
-  # surveys to attended teachers. Note that logic here is more-or-less independent
+  # surveys to attended teachers.  Note that logic here is more-or-less independent
   # from other logic deciding whether a workshop should have exit surveys.
   def send_exit_surveys
     # FiT workshops should not send exit surveys
@@ -640,29 +640,13 @@ class Pd::Workshop < ApplicationRecord
 
     # Send the emails
     enrollments.each do |enrollment|
-      user = enrollment.user
-
-      if enrollment.survey_sent_at
-        CDO.log.warn "Skipping attempt to send a duplicate workshop survey email. Enrollment: #{id}"
-        next
-      end
-
       if account_required_for_attendance?
-        next unless user
+        next unless enrollment.user
 
-        next unless attending_teachers.include?(user)
+        next unless attending_teachers.include?(enrollment.user)
       end
 
-      Pd::WorkshopMailjetMailer.send_teacher_post_workshop_survey(enrollment, user, false)
-
-      # Also send to the user's alternate summer email if they entered it in their application and it's for a summer workshop.
-      if enrollment.workshop.subject == SUBJECT_SUMMER_WORKSHOP && user.alternate_email.present?
-        Pd::WorkshopMailjetMailer.send_teacher_post_workshop_survey(enrollment, user, true)
-      end
-
-      enrollment.update!(survey_sent_at: Time.zone.now)
-    rescue => exception
-      raise "teacher enrollment #{enrollment.id} - #{exception.message}"
+      enrollment.send_exit_survey
     end
   end
 

--- a/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
@@ -1,0 +1,65 @@
+:css
+  body {
+    font-family: Figtree, sans-serif;
+  }
+
+- code_org_link = link_to 'Code.org', 'http://code.org'
+- pl_page_link = link_to 'My Professional Learning Page', 'https://studio.code.org/my-professional-learning'
+
+%p
+  Hi
+  = @enrollment.first_name + ','
+
+%p
+  Thank you for attending
+  - if @workshop.name.present?
+    = 'the Code.org ' + @workshop.name
+  - elsif @workshop.course == Pd::Workshop::COURSE_CSF
+    = 'a Code.org ' + @workshop.course + ' ' + @workshop.subject + ' workshop'
+  - else
+    = 'a Code.org ' + @workshop.course + ' workshop'
+  on
+  = @workshop.sessions.first.start_date_us_format + '.'
+
+%p
+  Please tell us about your experience by filling out this 5 minute
+  = link_to('survey', @survey_url) + '.'
+
+%p
+  We are committed to continually improving our programs. We want our teachers to have the best workshops possible
+  and your feedback helps us build the experience that teachers have in the future!
+
+%p
+  %a{href: @survey_url,
+    style: 'width: 240px; height: 36px; border: 0; color: white; background-color: #FFA400; font: bolder 18px Arial; display: block; text-align: center; line-height: 36px; text-decoration: none; border-radius: 5px;'}
+    Take the 5 minute survey
+
+%p
+  Please note that your responses will be shared
+  %strong anonymously
+  with the facilitator of your workshop and your Regional Partner. Your responses are confidential
+  and your name and email will not be shared with your facilitator or Regional Partner. However,
+  it's possible your facilitator or Regional Partner could identify you from your written responses.
+
+  %p
+    There is a personalized certificate of completion available on your
+    = pl_page_link
+    to print.
+  %p
+    You've taken the first steps to making CS available to your students. We can't wait to see where you all go from here!
+    Remember to keep us posted on Twitter @TeachCode.
+
+  %p
+    If you have any questions, feel free to reach out to us at
+    = link_to('teacher@code.org', 'mailto:teacher@code.org')
+    or connect with other teachers on our
+    = link_to('teacher forum', 'https://forum.code.org/') + '.'
+
+  %p
+    Thank you,
+    %br
+    Karim Meghji
+    %br
+    Chief Product Officer
+    = code_org_link
+

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -45,6 +45,16 @@ class WorkshopMailerTest < ActionMailer::TestCase
     end
   end
 
+  test 'exit survey emails are sent for workshops with exit surveys' do
+    workshop = create(:workshop, :ended)
+    enrollment = create(:pd_enrollment, workshop: workshop)
+    Pd::Enrollment.any_instance.expects(:exit_survey_url).returns('a url')
+
+    assert_emails 1 do
+      Pd::WorkshopMailer.exit_survey(enrollment).deliver_now
+    end
+  end
+
   test 'reminders are not sent for workshops with suppress_email attribute' do
     workshop = create(:csp_summer_workshop, suppress_email: true)
     facilitator = workshop.facilitators.first
@@ -60,12 +70,13 @@ class WorkshopMailerTest < ActionMailer::TestCase
     workshop = create(:csp_summer_workshop, suppress_email: true)
     enrollment = create(:pd_enrollment, workshop: workshop)
 
-    assert_emails 5 do
+    assert_emails 6 do
       Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
       Pd::WorkshopMailer.detail_change_notification(enrollment).deliver_now
 
       # Still send cancellation receipt and exit survey to teachers
       Pd::WorkshopMailer.teacher_cancel_receipt(enrollment).deliver_now
+      Pd::WorkshopMailer.exit_survey(enrollment).deliver_now
 
       # Organizers want to stay informed of who has enrolled, even if
       # email is suppressed
@@ -85,6 +96,37 @@ class WorkshopMailerTest < ActionMailer::TestCase
       workshop.save(validate: false)
       enrollment = create(:pd_enrollment, workshop: workshop)
       mail = Pd::WorkshopMailer.detail_change_notification(enrollment)
+
+      assert links_are_complete_urls?(mail)
+    end
+  end
+
+  test 'survey emails send to email stored in enrollment.email' do
+    teacher = create(:teacher, email: 'personal@email.com')
+    workshop = create(:workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD)
+    enrollment = create(:pd_enrollment, user: teacher, workshop: workshop, email: 'enrollment@email.com')
+
+    mail = Pd::WorkshopMailer.exit_survey(enrollment)
+
+    refute mail.to_s.include? 'personal@email.com'
+    assert_equal mail.to, ['enrollment@email.com']
+  end
+
+  test 'exit survey email links are complete urls' do
+    test_cases = [
+      {course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP},
+      {course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_WORKSHOP_1},
+      {course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1},
+    ]
+
+    test_cases.each do |test_case|
+      workshop = create(:workshop,
+        :ended,
+        course: test_case[:course],
+        subject: test_case[:subject]
+)
+      enrollment = create(:pd_enrollment, workshop: workshop)
+      mail = Pd::WorkshopMailer.exit_survey(enrollment)
 
       assert links_are_complete_urls?(mail)
     end

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -187,6 +187,15 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
     mail :detail_change_notification, Pd::Workshop::COURSE_ADMIN_COUNSELOR, Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_SLP_CALL1
   end
 
+  # Exit survey has variations for CSF and for CSP for returning teachers. It's the same for all other courses.
+  def exit_survey__general
+    mail :exit_survey
+  end
+
+  def exit_survey__csp_for_returning_teachers
+    mail :exit_survey, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
+  end
+
   private def mail(method, course = nil, subject = nil, options: nil, target: :enrollment, workshop_params: {})
     unless course
       course = DEFAULT_COURSE

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -126,6 +126,88 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert_equal studio_url["/pd/workshop_survey/post/#{byo_enrollment.code}"], byo_enrollment.exit_survey_url
   end
 
+  test 'should_send_exit_survey' do
+    normal_workshop = create(:workshop, :ended)
+    normal_enrollment = create(:pd_enrollment, workshop: normal_workshop)
+
+    assert normal_enrollment.should_send_exit_survey?
+
+    fit_workshop = build(:fit_workshop, :ended)
+    # workshop subject is deprecated so validation must be skipped
+    fit_workshop.save(validate: false)
+    fit_enrollment = create(:pd_enrollment, user: create(:teacher), workshop: fit_workshop)
+
+    refute fit_enrollment.should_send_exit_survey?
+  end
+
+  test 'send_exit_survey does not send mail when the survey was already sent' do
+    enrollment = create(:pd_enrollment, user: create(:teacher), survey_sent_at: Time.now)
+    Pd::WorkshopMailer.expects(:exit_survey).never
+
+    enrollment.send_exit_survey
+  end
+
+  test 'send_exit_survey does not send mail for FIT Weekend workshops' do
+    workshop = build(:fit_workshop, :ended)
+    # workshop subject is deprecated so validation must be skipped
+    workshop.save(validate: false)
+    enrollment = create(:pd_enrollment, user: create(:teacher), workshop: workshop)
+    Pd::WorkshopMailer.expects(:exit_survey).never
+
+    enrollment.send_exit_survey
+  end
+
+  test 'send_exit_survey does not send mail for EIR:Admin/Counselor workshops' do
+    workshop = create(:admin_counselor_workshop, :ended)
+    enrollment = create(:pd_enrollment, user: create(:teacher), workshop: workshop)
+    Pd::WorkshopMailer.expects(:exit_survey).never
+
+    enrollment.send_exit_survey
+  end
+
+  test 'send_exit_survey does not send mail for workshops without exit survey URL' do
+    enrollment = create(:pd_enrollment, user: create(:teacher))
+
+    Pd::Enrollment.any_instance.expects(:exit_survey_url).returns(nil)
+    Pd::WorkshopMailer.expects(:exit_survey).never
+
+    enrollment.send_exit_survey
+  end
+
+  test 'send_exit_survey tries to send email and, if successful, updates survey_sent_at ' do
+    enrollment = create(:pd_enrollment, user: create(:teacher))
+
+    mock_mail = stub(deliver_now: nil)
+    Pd::WorkshopMailer.expects(:exit_survey).once.returns(mock_mail)
+
+    enrollment.send_exit_survey
+    refute_nil enrollment.reload.survey_sent_at
+  end
+
+  test 'send_exit_survey tries to send email and, if unsuccessful, does not update survey_sent_at' do
+    enrollment = create(:pd_enrollment, user: create(:teacher))
+
+    Pd::WorkshopMailer.expects(:exit_survey).once.returns(nil)
+
+    enrollment.send_exit_survey
+    assert_nil enrollment.reload.survey_sent_at
+  end
+
+  test 'send_exit_survey sends email to both the users email and alternate email if available and for a summer workshop' do
+    mock_mail = stub(deliver_now: nil)
+
+    teacher = create(:teacher)
+    workshop = create(:summer_workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD)
+    application = create(:pd_teacher_application, course: 'csd', application_year: workshop.school_year, user: teacher, status: 'accepted')
+    enrollment = create(:pd_enrollment, application_id: application.id, user: teacher, workshop: workshop)
+
+    Pd::WorkshopMailer.expects(:exit_survey).with(enrollment).returns(mock_mail)
+    Pd::WorkshopMailer.expects(:exit_survey).with(enrollment, teacher.alternate_email).returns(mock_mail)
+
+    enrollment.send_exit_survey
+    refute_nil enrollment.reload.survey_sent_at
+  end
+
   test 'name is deprecated and calls through to full_name' do
     enrollment = create(:pd_enrollment)
     enrollment.expects(:full_name)

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -372,7 +372,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop = create(:workshop, :ended)
 
     create(:pd_workshop_participant, workshop: workshop, enrolled: true)
-    Pd::WorkshopMailjetMailer.expects(:send_teacher_post_workshop_survey).never
+    Pd::Enrollment.any_instance.expects(:send_exit_survey).never
 
     workshop.send_exit_surveys
   end
@@ -381,24 +381,32 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop = create(:workshop, :ended)
     workshop.update_columns(course: Pd::Workshop::COURSE_COUNSELOR, subject: nil)
 
-    user = create(:teacher)
-    enrollment = create(:pd_enrollment, workshop: workshop, user: user)
+    enrollment = create(:pd_enrollment, workshop: workshop)
+    create(:pd_attendance_no_account, session: workshop.sessions.first, enrollment: enrollment)
+    refute workshop.account_required_for_attendance?
+    Pd::Enrollment.any_instance.expects(:send_exit_survey)
+    workshop.send_exit_surveys
+  end
+
+  test 'send_exit_surveys with attendance but no account gets email for admin/counselor' do
+    workshop = create(:admin_counselor_workshop, :ended)
+
+    enrollment = create(:pd_enrollment, workshop: workshop)
     create(:pd_attendance_no_account, session: workshop.sessions.first, enrollment: enrollment)
 
     refute workshop.account_required_for_attendance?
-    Pd::WorkshopMailjetMailer.expects(:send_teacher_post_workshop_survey).times(1)
+    Pd::Enrollment.any_instance.expects(:send_exit_survey).never
 
     workshop.send_exit_surveys
   end
 
   test 'send_exit_surveys teachers with attendance get emails' do
     workshop = create(:workshop, :ended)
-
     create(:pd_workshop_participant, workshop: workshop, enrolled: true)
     create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
 
     assert workshop.account_required_for_attendance?
-    Pd::WorkshopMailjetMailer.expects(:send_teacher_post_workshop_survey).times(1)
+    Pd::Enrollment.any_instance.expects(:send_exit_survey).times(1)
 
     workshop.send_exit_surveys
   end
@@ -412,7 +420,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
 
     # Ensure no exit surveys are sent
-    Pd::WorkshopMailjetMailer.expects(:send_teacher_post_workshop_survey).never
+    Pd::Enrollment.any_instance.expects(:send_exit_survey).never
     workshop.send_exit_surveys
   end
 
@@ -423,7 +431,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
 
     # Ensure no exit surveys are sent
-    Pd::WorkshopMailjetMailer.expects(:send_teacher_post_workshop_survey).never
+    Pd::Enrollment.any_instance.expects(:send_exit_survey).never
     workshop.send_exit_surveys
   end
 
@@ -434,30 +442,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
 
     # Ensure no exit surveys are sent
-    Pd::WorkshopMailjetMailer.expects(:send_teacher_post_workshop_survey).never
+    Pd::Enrollment.any_instance.expects(:send_exit_survey).never
     workshop.send_exit_surveys
-  end
-
-  test 'send_exit_surveys sends no survey if already sent' do
-    workshop = create(:workshop, :ended)
-    create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
-    workshop.enrollments.first.update!(survey_sent_at: Time.zone.today)
-
-    Pd::WorkshopMailjetMailer.expects(:send_teacher_post_workshop_survey).never
-
-    workshop.send_exit_surveys
-  end
-
-  test 'send_exit_surveys sends to alternate email as well if available for summer workshops' do
-    teacher = create(:teacher)
-    application = create(:pd_teacher_application, :csp, user: teacher, status: 'accepted')
-    summer_workshop = create(:csp_summer_workshop, :ended, num_sessions: 1)
-    enrollment = create(:pd_enrollment, application_id: application.id, user: teacher, workshop: summer_workshop)
-    create(:pd_attendance, session: summer_workshop.sessions.first, teacher: teacher, enrollment: enrollment)
-
-    Pd::WorkshopMailjetMailer.expects(:send_teacher_post_workshop_survey).times(2)
-
-    summer_workshop.send_exit_surveys
   end
 
   # an issue with this test failing is fixed by prepending TZ=UTC to the test command

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -46,15 +46,6 @@ module MailJetConstants
       },
       from_address: 'noreply@code.org',
       from_name: 'Code.org',
-    },
-    teacher_post_workshop_survey: {
-      template_id: {
-        production: {
-          default: 7_192_300,
-        }
-      },
-      from_address: 'noreply@code.org',
-      from_name: 'Code.org',
     }
   }.freeze
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#67759

Emails are not sending so reverting until this is debugged