### PR TITLE
Lab2 Dance: JSON when run block

### DIFF
--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -45,6 +45,7 @@ export enum BlockStyles {
   TEXT = 'text_blocks',
   COLOR = 'colour_blocks',
   BEHAVIOR = 'behavior_blocks',
+  LAB_BLOCKS = 'lab_blocks',
 }
 
 export const BlockColors = {

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -26,6 +26,7 @@ import WorkspaceSvgFrame from './addons/workspaceSvgFrame';
 import {
   BLOCK_TYPES,
   BlocklyVersion,
+  BlockStyles,
   Themes,
   WORKSPACE_EVENTS,
 } from './constants';
@@ -497,17 +498,17 @@ export interface ExtendedJavascriptGenerator
 export interface BlockJson<BlockType extends string = string> {
   type: BlockType;
   [key: `message${number}`]: string;
-  [key: `args${number}`]: FieldJson[];
-  style?: string;
+  [key: `args${number}`]: ArgumentJson[];
+  style?: BlockStyles;
   inputsInline?: boolean;
-  previousStatement?: null;
-  nextStatement?: string | null;
-  output?: string | null;
+  previousStatement?: string | string[] | null;
+  nextStatement?: string | string[] | null;
+  output?: string | string[] | null;
   tooltip?: string;
   helpUrl?: string;
 }
 
-export interface FieldJson {
+export interface ArgumentJson {
   type: string;
   name: string;
 }

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -481,16 +481,33 @@ export type PointerMetadataMap = {
 
 export type BlockColor = [number, number, number];
 
+export type GeneratorFunction = (
+  block: GoogleBlockly.Block,
+  generator: GoogleBlockly.CodeGenerator
+) => string | [string, number] | null;
+
 export type JavascriptGeneratorType = typeof javascriptGenerator;
 export interface ExtendedJavascriptGenerator
   extends ExtendedCodeGenerator,
     JavascriptGeneratorType {
   nameDB_: GoogleBlockly.Names | undefined;
-  forBlock: Record<
-    string,
-    (
-      block: GoogleBlockly.Block,
-      generator: GoogleBlockly.CodeGenerator
-    ) => string | [string, number] | null
-  >;
+  forBlock: Record<string, GeneratorFunction>;
+}
+
+export interface BlockJson<BlockType extends string = string> {
+  type: BlockType;
+  [key: `message${number}`]: string;
+  [key: `args${number}`]: FieldJson[];
+  style?: string;
+  inputsInline?: boolean;
+  previousStatement?: null;
+  nextStatement?: string | null;
+  output?: string | null;
+  tooltip?: string;
+  helpUrl?: string;
+}
+
+export interface FieldJson {
+  type: string;
+  name: string;
 }

--- a/apps/src/dance/blockly/blockDefinitions/index.ts
+++ b/apps/src/dance/blockly/blockDefinitions/index.ts
@@ -1,0 +1,3 @@
+import whenRun from './when_run';
+
+export default [whenRun];

--- a/apps/src/dance/blockly/blockDefinitions/when_run.ts
+++ b/apps/src/dance/blockly/blockDefinitions/when_run.ts
@@ -12,9 +12,9 @@ const definition: BlockJson = {
   style: 'setup_blocks',
 };
 
-const generator: GeneratorFunction = block => {
+const generator: GeneratorFunction = (block, generator) => {
   return `whenSetup(function() {
-    ${Blockly.getGenerator().blockToCode(block.getNextBlock())}
+    ${generator.blockToCode(block.getNextBlock())}
   });`;
 };
 

--- a/apps/src/dance/blockly/blockDefinitions/when_run.ts
+++ b/apps/src/dance/blockly/blockDefinitions/when_run.ts
@@ -1,3 +1,4 @@
+import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {
   BlockJson,
   ExtendedBlock,
@@ -9,7 +10,7 @@ const definition: BlockJson = {
   type: 'when_run',
   message0: commonI18n.whenRun(),
   nextStatement: null,
-  style: 'setup_blocks',
+  style: BlockStyles.SETUP,
 };
 
 const generator: GeneratorFunction = (block, generator) => {

--- a/apps/src/dance/blockly/blockDefinitions/when_run.ts
+++ b/apps/src/dance/blockly/blockDefinitions/when_run.ts
@@ -1,0 +1,25 @@
+import {
+  BlockJson,
+  ExtendedBlock,
+  GeneratorFunction,
+} from '@cdo/apps/blockly/types';
+import {commonI18n} from '@cdo/apps/types/locale';
+
+const definition: BlockJson = {
+  type: 'when_run',
+  message0: commonI18n.whenRun(),
+  nextStatement: null,
+  style: 'setup_blocks',
+};
+
+const generator: GeneratorFunction = block => {
+  return `whenSetup(function() {
+    ${Blockly.getGenerator().blockToCode(block.getNextBlock())}
+  });`;
+};
+
+const extendedOptions: Partial<ExtendedBlock> = {
+  skipNextBlockGeneration: true,
+};
+
+export default {definition, generator, extendedOptions};

--- a/apps/src/dance/blockly/defaultSources.json
+++ b/apps/src/dance/blockly/defaultSources.json
@@ -3,7 +3,8 @@
     "blocks": {
       "blocks": [
         {
-          "type": "Dancelab_whenSetup",
+          "id": "when-run-block",
+          "type": "when_run",
           "deletable": false,
           "movable": false
         }

--- a/apps/src/dance/blockly/setup.ts
+++ b/apps/src/dance/blockly/setup.ts
@@ -2,6 +2,8 @@ import * as blockUtils from '@cdo/apps/block_utils';
 import {BlockDefinition} from '@cdo/apps/blockly/types';
 import danceBlocks from '@cdo/apps/dance/blockly/blocks';
 
+import blockDefinitions from './blockDefinitions';
+
 let isBlocklyEnvironmentSetup = false;
 
 export function setupBlocklyEnvironment() {
@@ -12,6 +14,17 @@ export function setupBlocklyEnvironment() {
   delete Blockly.Blocks.procedures_defreturn;
   delete Blockly.Blocks.procedures_ifreturn;
   Blockly.setInfiniteLoopTrap();
+
+  for (const {definition, generator, extendedOptions} of blockDefinitions) {
+    Blockly.Blocks[definition.type] = {
+      init: function () {
+        this.jsonInit(definition);
+      },
+      ...extendedOptions,
+    };
+    Blockly.getGenerator().forBlock[definition.type] = generator;
+  }
+
   isBlocklyEnvironmentSetup = true;
 }
 

--- a/apps/src/music/blockly/blocks/samples.ts
+++ b/apps/src/music/blockly/blocks/samples.ts
@@ -3,12 +3,12 @@ import {Order} from 'blockly/javascript';
 import {BlockTypes} from '../blockTypes';
 import {FIELD_SOUNDS_NAME, SOUND_VALUE_TYPE} from '../constants';
 import {fieldSoundsDefinition} from '../fields';
-import {BlockConfig} from '../types';
+import {MusicBlockConfig} from '../types';
 
 /**
  * Value block for a sample
  */
-export const valueSample: BlockConfig = {
+export const valueSample: MusicBlockConfig = {
   definition: {
     type: BlockTypes.VALUE_SAMPLE,
     message0: '%1',

--- a/apps/src/music/blockly/blocks/samples.ts
+++ b/apps/src/music/blockly/blocks/samples.ts
@@ -1,5 +1,7 @@
 import {Order} from 'blockly/javascript';
 
+import {BlockStyles} from '@cdo/apps/blockly/constants';
+
 import {BlockTypes} from '../blockTypes';
 import {FIELD_SOUNDS_NAME, SOUND_VALUE_TYPE} from '../constants';
 import {fieldSoundsDefinition} from '../fields';
@@ -13,7 +15,7 @@ export const valueSample: MusicBlockConfig = {
     type: BlockTypes.VALUE_SAMPLE,
     message0: '%1',
     args0: [fieldSoundsDefinition],
-    style: 'lab_blocks',
+    style: BlockStyles.LAB_BLOCKS,
     output: SOUND_VALUE_TYPE,
   },
   generator: block => [block.getFieldValue(FIELD_SOUNDS_NAME), Order.ATOMIC],

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -29,7 +29,7 @@ import FieldPatternAi from './FieldPatternAi';
 import FieldSounds from './FieldSounds';
 import FieldTune from './FieldTune';
 import {MUSIC_BLOCKS} from './musicBlocks';
-import {BlockConfig} from './types';
+import {MusicBlockConfig} from './types';
 
 /**
  * Set up the global Blockly environment for Music Lab. This should
@@ -52,16 +52,16 @@ export function setUpBlocklyForMusicLab() {
 
   // Needed for TypeScript to recognize the type of the MUSIC_BLOCKS. Remove
   // after converting musicBlocks to TypeScript.
-  const typedMusicBlocks = MUSIC_BLOCKS as {[key: string]: BlockConfig};
+  const typedMusicBlocks = MUSIC_BLOCKS as {[key: string]: MusicBlockConfig};
   for (const blockType of Object.keys(typedMusicBlocks)) {
-    const blockConfig = typedMusicBlocks[blockType] as BlockConfig;
+    const blockConfig = typedMusicBlocks[blockType] as MusicBlockConfig;
     Blockly.Blocks[blockType] = {
       init: function () {
         this.jsonInit(blockConfig.definition);
       },
     };
 
-    Blockly.JavaScript.forBlock[blockType] = blockConfig.generator;
+    Blockly.getGenerator().forBlock[blockType] = blockConfig.generator;
   }
 
   Blockly.JavaScript.addReservedWords(

--- a/apps/src/music/blockly/types.ts
+++ b/apps/src/music/blockly/types.ts
@@ -1,32 +1,9 @@
-import * as GoogleBlockly from 'blockly/core';
-
-import {JavascriptGeneratorType} from '@cdo/apps/blockly/types';
+import {BlockJson, GeneratorFunction} from '@cdo/apps/blockly/types';
 
 import {BlockTypes} from './blockTypes';
 
-// Configuration data for a block.
-export interface BlockConfig {
-  definition: BlockJson;
-  generator: (
-    block: GoogleBlockly.Block,
-    generator: JavascriptGeneratorType
-  ) => string | [string, number] | null;
-}
-
-export interface BlockJson {
-  type: BlockTypes;
-  [key: `message${number}`]: string;
-  [key: `args${number}`]: FieldJson[];
-  style?: string;
-  inputsInline?: boolean;
-  previousStatement?: null;
-  nextStatement?: string | null;
-  output?: string | null;
-  tooltip?: string;
-  helpUrl?: string;
-}
-
-export interface FieldJson {
-  type: string;
-  name: string;
+// Configuration data for a Music Lab block.
+export interface MusicBlockConfig {
+  definition: BlockJson<BlockTypes>;
+  generator: GeneratorFunction;
 }


### PR DESCRIPTION
This adds a `when run` block to Lab2 Dance Party, to be used in place of the `setup` block. The internal code is the same.

This came out of discussions with @mikeharv. Using "when run" makes this lab consistent with other blockly based labs, but it also also gives us an opportunity to define a more modern block definition paradigm, built off how we define blocks in JSON for Music Lab today. For now, the block definition and generator functions are defined directly in code, but ideally we would store these definitions in a place that levelbuilders could also edit and access them (though traditionally the when run block for other labs is defined in code, so this specific block may stay the way it is). The `definition`/`generator` setup gives us a blueprint of how we might build and convert other blocks.

## Testing story

- Tested with Lab2 Dance - confirmed that it acts like the setup block.

<img width="1512" height="827" alt="Screenshot 2025-08-26 at 2 33 22 PM" src="https://github.com/user-attachments/assets/51d3cf9d-8cbf-428d-b081-cd0e3b8b6dba" />
