### PR TITLE
Add level name and id to Level Activity event

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2179,7 +2179,12 @@ StudioApp.prototype.configureDom = function (config) {
     if (!runButtonWasClicked) {
       analyticsReporter.sendEvent(
         eventName,
-        {signedIn: config.isSignedIn, unitName: config.scriptName},
+        {
+          signedIn: config.isSignedIn,
+          unitName: config.scriptName,
+          levelId: config.serverLevelId,
+          levelName: config.level.name,
+        },
         PLATFORMS.BOTH
       );
       runButtonWasClicked = true;


### PR DESCRIPTION
Add level info to the Level Activity event that fires in (most) Lab 1 labs.


This is the updated event:
```
[STATSIG ANALYTICS EVENT]: Level Activity. Payload: {"payload":{"signedIn":true,"unitName":"elem-game-design-2024","levelId":63094,"levelName":"game_design_event_touch_independent"}}
```



