### PR TITLE
Lab2 rubrics visibility changes

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -11,7 +11,6 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import StudentRubricView from '@cdo/apps/lab2/views/components/rubrics/StudentRubricView';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {getTypedKeys} from '@cdo/apps/types/utils';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useRubric} from '../../rubrics/RubricWrapper';
 import ForTeachersOnly from '../ForTeachersOnly';
@@ -75,9 +74,6 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
 }) => {
   const {theme} = useTheme();
   const {showRubric} = useRubric();
-  const isParticipant = useAppSelector(
-    state => state.currentUser.userType === 'student'
-  );
   const [currentTab, setCurrentTab] = useState<Tabs>(Tabs.Instructions);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
@@ -114,12 +110,12 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
       tabMap[Tabs.AiTutor] = <AiTutor2Chat hiddenContext={aiTutor2Context} />;
     }
 
-    if (isParticipant && showRubric) {
+    if (showRubric) {
       tabMap[Tabs.StudentRubric] = <StudentRubricView />;
     }
 
     return tabMap;
-  }, [instructionsProps, aiTutor2Context, isParticipant, showRubric]);
+  }, [instructionsProps, aiTutor2Context, showRubric]);
 
   return (
     <div className={classNames(styles.resourcePanel, className)}>

--- a/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
+++ b/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react';
 
 import {isLabLoading} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {isUsingResourcePanel} from '@cdo/apps/lab2/utils';
 import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -28,6 +29,10 @@ const RubricFABContainer: React.FC = () => {
   );
   const courseName = useAppSelector(state => state.progress.courseName);
   const unitName = useAppSelector(state => state.progress.scriptName);
+  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const isProjectLevel = useAppSelector(
+    state => state.lab.levelProperties?.isProjectLevel
+  );
 
   const studentLevelInfo = useMemo(() => {
     const userLevel = levelsWithProgress?.find(
@@ -58,11 +63,14 @@ const RubricFABContainer: React.FC = () => {
   );
 
   if (
+    !appName ||
     !isTeacher ||
     !showRubric ||
     labLoading ||
     isLoadingRubric ||
-    !rubricData
+    !rubricData ||
+    // Only show the rubric FAB is the resource panel is enabled
+    !isUsingResourcePanel(appName, isProjectLevel || false)
   ) {
     return null;
   }


### PR DESCRIPTION
Two changes to rubrics visibility:
- The teacher-facing rubrics FAB is only enabled if the resource panel is enabled (currently behind an experiment flag for Music Lab)
- The student-facing rubrics tab inside the resource panel is always visible, regardless of account type.

Submittable level with resource panel enabled on a teacher account - both FAB and rubric panel are displayed.
<img width="1512" height="943" alt="Screenshot 2025-08-26 at 3 23 46 PM" src="https://github.com/user-attachments/assets/b9820a56-0eef-4933-af97-820792d67910" />

Same level without flag - no FAB
<img width="1512" height="944" alt="Screenshot 2025-08-26 at 3 20 47 PM" src="https://github.com/user-attachments/assets/473c4464-d102-46a2-a96c-208324e7acd9" />

## Links
- https://codedotorg.atlassian.net/browse/SL-1409
- https://codedotorg.atlassian.net/browse/SL-1410 

## Testing story
- Tested locally on Music Lab allthethings