### PR TITLE
fix(workshops): add promoter count

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -413,6 +413,7 @@ export interface LikertBreakdown {
 }
 
 export interface PromoterResults {
+  promoter_count: number;
   promoter_percentage: number;
   breakdown: Record<string, PromoterBreakdown>;
 }

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/helpers.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/helpers.ts
@@ -4,6 +4,9 @@ export const getQuestionDescription = (question: SurveyQuestion) => {
   if (isQuestionType(question, 'likert')) {
     return `${question.results.agreement_count} of ${question.results.total_responses} respondents`;
   }
+  if (isQuestionType(question, 'promoter')) {
+    return `${question.results.promoter_count} of ${question.results.total_responses} respondents`;
+  }
   if (
     isQuestionType(question, 'multiSelect') &&
     question.question_name === 'barriers_implementation_curriculum'

--- a/dashboard/lib/pd/foorm/response_processor.rb
+++ b/dashboard/lib/pd/foorm/response_processor.rb
@@ -92,6 +92,7 @@ module Pd::Foorm
 
       {
         total_responses: total_responses,
+        promoter_count: promoter_count,
         promoter_percentage: calculate_percentage(promoter_count, total_responses),
         breakdown: breakdown
       }

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
@@ -395,6 +395,7 @@ module Api::V1::Pd
       assert promoter_question.key?(:question_text)
       assert promoter_question.key?(:question_type)
       assert promoter_question.key?(:results)
+      assert promoter_question[:results][:promoter_count].is_a?(Integer)
       assert promoter_question[:results][:promoter_percentage].is_a?(Integer)
       assert promoter_question[:results][:total_responses].is_a?(Integer)
       assert promoter_question[:results].key?(:breakdown)

--- a/dashboard/test/lib/pd/foorm/response_processor_test.rb
+++ b/dashboard/test/lib/pd/foorm/response_processor_test.rb
@@ -80,6 +80,7 @@ module Pd::Foorm
       expected_promoter_percentage = 80
 
       assert_equal 5, result[:total_responses]
+      assert_equal 4, result[:promoter_count]
       assert_equal expected_promoter_percentage, result[:promoter_percentage]
       assert_equal 4, result[:breakdown].size
     end
@@ -95,6 +96,7 @@ module Pd::Foorm
       result = ResponseProcessor.process_rating_responses(question_summary, choices)
 
       assert_equal 4, result[:total_responses]
+      assert_equal 0, result[:promoter_count]
       assert_equal 0, result[:promoter_percentage]
     end
 
@@ -226,6 +228,7 @@ module Pd::Foorm
       # Test that nil gets converted to empty hash and processed normally
       expected_rating_result = {
         total_responses: 0,
+        promoter_count: 0,
         promoter_percentage: 0,
         breakdown: {}
       }

--- a/dashboard/test/lib/pd/foorm/workshop_categorizer_test.rb
+++ b/dashboard/test/lib/pd/foorm/workshop_categorizer_test.rb
@@ -128,6 +128,8 @@ module Pd::Foorm
       result = WorkshopCategorizer.create_processed_question(question_name, question_data, question_summary)
 
       assert_equal 'promoter', result[:question_type]
+      assert result[:results].key?(:promoter_count)
+      assert_equal 4, result[:results][:promoter_count] # Count of responses >= 7
       assert result[:results].key?(:promoter_percentage)
       assert_equal 100, result[:results][:promoter_percentage] # All responses >= 7
     end


### PR DESCRIPTION
This pull request adds support for tracking and displaying the raw count of "promoter" responses in survey results, alongside the existing promoter percentage. The changes ensure that both backend processing and frontend display include this new metric, and relevant tests are updated to validate the new behavior.

Enhancements to promoter response tracking and display:

* The backend now calculates and includes a `promoter_count` field in the results for promoter-type survey questions.
* The frontend `PromoterResults` TypeScript interface is updated to include the new `promoter_count` field.
* The survey question description helper now uses `promoter_count` when generating descriptions for promoter-type questions.

Test updates:

* Automated tests for response processing and reporting are updated to assert the presence and correctness of the new `promoter_count` field in both backend and frontend logic.



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
