### PR TITLE
Lab2 student rubric panel updates

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2990,7 +2990,7 @@
   "studentResources": "Student Resources",
   "studentResponses": "Student Responses",
   "studentResponse": "Student Response",
-  "studentRubricNoFeedback": "No feedback yet!",
+  "studentRubricNoFeedback": "No teacher feedback yet!",
   "studentRubricTeacherFeedback": "Your teacher wrote:",
   "studentTableTeacherDemo": "Me",
   "studentUsStateUpdatesModal_title": "Set state for all students",

--- a/apps/src/lab2/views/components/rubrics/StudentRubricView.tsx
+++ b/apps/src/lab2/views/components/rubrics/StudentRubricView.tsx
@@ -52,34 +52,41 @@ const StudentRubricView: React.FC = () => {
     return null;
   }
 
+  // Sort from highest to lowest understanding level
+  const sortedEvidenceLevels = currentLearningGoal.evidenceLevels?.sort(
+    (a, b) => b!.understanding - a!.understanding
+  );
+
   return (
     <div className={styles.rubricContainer}>
-      <div className={styles.goalSwitcher}>
-        <button
-          className={styles.goalSwitcherButton}
-          type="button"
-          onClick={() => switchGoal(-1)}
-        >
-          <FontAwesomeV6Icon iconName="angle-left" />
-        </button>
-        <ProgressRing
-          className={styles.progressRing}
-          learningGoals={learningGoals}
-          currentLearningGoal={currentGoalIndex}
-          understandingLevels={teacherEvaluations?.map(evaluation =>
-            evaluation.understanding === null ? -1 : evaluation.understanding
-          )}
-          radius={30}
-          stroke={4}
-        />
-        <button
-          className={styles.goalSwitcherButton}
-          type="button"
-          onClick={() => switchGoal(1)}
-        >
-          <FontAwesomeV6Icon iconName="angle-right" />
-        </button>
-      </div>
+      {learningGoals.length > 1 && (
+        <div className={styles.goalSwitcher}>
+          <button
+            className={styles.goalSwitcherButton}
+            type="button"
+            onClick={() => switchGoal(-1)}
+          >
+            <FontAwesomeV6Icon iconName="angle-left" />
+          </button>
+          <ProgressRing
+            className={styles.progressRing}
+            learningGoals={learningGoals}
+            currentLearningGoal={currentGoalIndex}
+            understandingLevels={teacherEvaluations?.map(evaluation =>
+              evaluation.understanding === null ? -1 : evaluation.understanding
+            )}
+            radius={30}
+            stroke={4}
+          />
+          <button
+            className={styles.goalSwitcherButton}
+            type="button"
+            onClick={() => switchGoal(1)}
+          >
+            <FontAwesomeV6Icon iconName="angle-right" />
+          </button>
+        </div>
+      )}
       <BodyTwoText className={styles.learningGoalHeader}>
         {currentLearningGoal.learningGoal}
       </BodyTwoText>
@@ -99,15 +106,19 @@ const StudentRubricView: React.FC = () => {
           )}
         </div>
         <div className={styles.evidenceLevelsContainer}>
-          {currentLearningGoal.evidenceLevels?.map((evidenceLevel, index) => {
+          {sortedEvidenceLevels?.map((evidenceLevel, index) => {
             // InferProps allows evidenceLevel to be null, but if the array is defined
             // we can assume evidenceLevel is not null.
             const el = evidenceLevel as EvidenceLevel;
+            const selected =
+              currentEvaluation?.understanding === el.understanding;
             return (
               <EvidenceLevelView
                 key={index}
                 {...el}
-                selected={currentEvaluation?.understanding === el.understanding}
+                selected={selected}
+                // If a teacher evaluation exists, only expand the corresponding evidence level. Otherwise show all by default.
+                startExpanded={!currentEvaluation || selected}
               />
             );
           })}
@@ -119,18 +130,20 @@ const StudentRubricView: React.FC = () => {
 
 interface EvidenceLevelViewProps extends EvidenceLevel {
   selected: boolean;
+  startExpanded: boolean;
 }
 
 const EvidenceLevelView: React.FC<EvidenceLevelViewProps> = ({
   understanding,
   teacherDescription,
   selected,
+  startExpanded,
 }) => {
-  const [collapsed, setCollapsed] = useState(!selected);
+  const [collapsed, setCollapsed] = useState(!startExpanded);
 
   useEffect(() => {
-    setCollapsed(!selected);
-  }, [selected]);
+    setCollapsed(!startExpanded);
+  }, [startExpanded]);
 
   return (
     <div


### PR DESCRIPTION
A few minor updates to the student-facing rubric panel in Lab2:
- Display learning objectives from highest to lowest (Extensive -> No)
- Rubric fields are expanded by default if there is no feedback
- Don't show progress circle if there is only one objective
- Update copy to "No teacher feedback yet!"

Example level with a single learning objective and no feedback (no progress circle, learning objectives ordered correctly, expanded by default, updated copy)
<img width="1512" height="945" alt="Screenshot 2025-08-26 at 3 58 17 PM" src="https://github.com/user-attachments/assets/c4fbb5c4-9384-4b35-8928-db51a0ea20b9" />

## Links
- https://codedotorg.atlassian.net/browse/SL-1406
- https://codedotorg.atlassian.net/browse/SL-1401
- https://codedotorg.atlassian.net/browse/SL-1403
- https://codedotorg.atlassian.net/browse/SL-1402

## Testing story
Tested locally on Music Lab allthethings