### PR TITLE
Remove Some Psych 3 to 4 Transitional Logic

### DIFF
--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -14,15 +14,10 @@ module Cdo
     end
 
     # Return +nil+ if file not found.
+    # Also load aliases by default, to mirror pre-Ruby-3.1 behavior
+    # See: https://stackoverflow.com/a/71192990/1810460
     def load_file(path)
-      # Temporarily accommodate both Psych 3 and Psych 4 syntax while we
-      # navigate the transition from Ruby 3.0 to Ruby 3.1.
-      # See: https://stackoverflow.com/a/71192990/1810460
-      # TODO infra: simplify down to just the Psych 4 case once we're fully
-      # upgraded to Ruby 3.1.
       super(path, aliases: true)
-    rescue ArgumentError
-      super
     rescue Errno::ENOENT
       nil
     end
@@ -35,19 +30,8 @@ module Cdo
     # dangerous things in the various `config.yml.erb` files loaded by this
     # method, we need to do so.
     def load_erb_file(path, binding = nil)
-      # Temporarily accommodate both Psych 3 and Psych 4 syntax while we
-      # navigate the transition from Ruby 3.0 to Ruby 3.1.
-      # See: https://stackoverflow.com/a/71192990/1810460
-      # TODO infra: simplify down to just the Psych 4 case once we're fully
-      # upgraded to Ruby 3.1.
       # rubocop:disable Security/YAMLLoad
-      begin
-        # Psych 4 compatibility
-        YAML.load(erb_file_to_string(path, binding), aliases: true)
-      rescue ArgumentError
-        # Psych 3 compatibility
-        YAML.load(erb_file_to_string(path, binding))
-      end
+      YAML.load(erb_file_to_string(path, binding), aliases: true)
       # rubocop:enable Security/YAMLLoad
     rescue Errno::ENOENT
       nil

--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -17,7 +17,7 @@ module Cdo
     # Also load aliases by default, to mirror pre-Ruby-3.1 behavior
     # See: https://stackoverflow.com/a/71192990/1810460
     def load_file(path)
-      super(path)
+      super(path, aliases: true)
     rescue Errno::ENOENT
       nil
     end
@@ -31,7 +31,7 @@ module Cdo
     # method, we need to do so.
     def load_erb_file(path, binding = nil)
       # rubocop:disable Security/YAMLLoad
-      YAML.load(erb_file_to_string(path, binding))
+      YAML.load(erb_file_to_string(path, binding), aliases: true)
       # rubocop:enable Security/YAMLLoad
     rescue Errno::ENOENT
       nil

--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -17,7 +17,7 @@ module Cdo
     # Also load aliases by default, to mirror pre-Ruby-3.1 behavior
     # See: https://stackoverflow.com/a/71192990/1810460
     def load_file(path)
-      super(path, aliases: true)
+      super(path)
     rescue Errno::ENOENT
       nil
     end
@@ -31,7 +31,7 @@ module Cdo
     # method, we need to do so.
     def load_erb_file(path, binding = nil)
       # rubocop:disable Security/YAMLLoad
-      YAML.load(erb_file_to_string(path, binding), aliases: true)
+      YAML.load(erb_file_to_string(path, binding))
       # rubocop:enable Security/YAMLLoad
     rescue Errno::ENOENT
       nil


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/66218, which added some temporary logic to simultaneously support both Psych 3 (embedded by Ruby 3.0) and Psych 4 (embedded by Ruby 3.1). Now that we're fully upgraded to Ruby 3.1, and therefore also to Psych 4, we can safely remove this support!

## Links

- https://stackoverflow.com/a/71192990/1810460

## Testing story

I verified that with these changes in place we can still complete a build and successfully run the server locally and on an adhoc. I also verified that our existing tests still exercise this logic and fail if it's broken, and so am comfortable relying on CI/CD for thorough testing.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
