### PR TITLE
feat: use same description for likert and promoter questions

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/helpers.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/helpers.ts
@@ -1,8 +1,11 @@
 import {isQuestionType, SurveyQuestion} from '../../WorkshopFormTemplate/types';
 
 export const getQuestionDescription = (question: SurveyQuestion) => {
-  if (isQuestionType(question, 'likert')) {
-    return `${question.results.agreement_count} of ${question.results.total_responses} respondents`;
+  if (
+    isQuestionType(question, 'likert') ||
+    isQuestionType(question, 'promoter')
+  ) {
+    return `${question.results.total_responses} responses`;
   }
   if (
     isQuestionType(question, 'multiSelect') &&


### PR DESCRIPTION
This pull request updates the logic for generating question descriptions in the survey helpers. The main change is to unify how response counts are displayed for both 'likert' and 'promoter' question types.

Survey question description updates:

* Updated `getQuestionDescription` in `helpers.ts` to show the total number of responses (e.g., "5 responses") for both 'likert' and 'promoter' question types, instead of showing agreement count for 'likert'.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3505

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
