### PR TITLE
Lab2 Resource Panel: Teaching Tips fixes

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -3091,6 +3091,7 @@
   "teaching": "Teaching",
   "teachingGuide": "Teaching Guide",
   "teachingTip": "Teaching Tip",
+  "teachingTips": "Teaching Tips",
   "teachWithCodeOrg": "Teach with Code.org",
   "teachWithCodeOrgDescription": "Volunteer to teach the Hour of Code or be a guest speaker in a local classroom. Sign up to hear about opportunities near you.",
   "tellUsAboutYourself": "Tell us about yourself",

--- a/apps/src/lab2/views/components/Instructions/ForTeachersOnly.tsx
+++ b/apps/src/lab2/views/components/Instructions/ForTeachersOnly.tsx
@@ -1,9 +1,12 @@
+import classNames from 'classnames';
 import React from 'react';
 
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import TeacherOnlyMarkdown from '@cdo/apps/templates/instructions/TeacherOnlyMarkdown';
 
 import PredictSolution from './PredictSolution';
+
+import moduleStyles from './for-teachers-only.module.scss';
 
 const ForTeachersOnly: React.FC<{
   levelProperties: LevelProperties;
@@ -12,7 +15,7 @@ const ForTeachersOnly: React.FC<{
   const {teacherMarkdown, predictSettings} = levelProperties;
 
   return (
-    <div className={className}>
+    <div className={classNames(moduleStyles.teachersOnlyContainer, className)}>
       <PredictSolution predictSettings={predictSettings} />
       <TeacherOnlyMarkdown content={teacherMarkdown} hideContainer={true} />
     </div>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import {kitIcons} from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import classNames from 'classnames';
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import AiTutor2Chat from '@cdo/apps/lab2/views/components/AiTutor2Chat';
@@ -11,6 +11,7 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import StudentRubricView from '@cdo/apps/lab2/views/components/rubrics/StudentRubricView';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {getTypedKeys} from '@cdo/apps/types/utils';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useRubric} from '../../rubrics/RubricWrapper';
 import ForTeachersOnly from '../ForTeachersOnly';
@@ -42,7 +43,7 @@ const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
   [Tabs.Instructions]: {title: commonI18n.instructions(), icon: 'info-circle'},
   [Tabs.AiTutor]: {title: commonI18n.aiTutor(), icon: 'ai-head-solid'},
   [Tabs.TeachersOnly]: {
-    title: commonI18n.forTeachersOnly(),
+    title: commonI18n.teachingTips(),
     icon: 'chalkboard-teacher',
   },
   [Tabs.StudentRubric]: {
@@ -76,6 +77,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   const {showRubric} = useRubric();
   const [currentTab, setCurrentTab] = useState<Tabs>(Tabs.Instructions);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
 
   const levelId = instructionsProps.levelProperties.id;
 
@@ -91,8 +93,9 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     }
 
     if (
-      levelProperties.teacherMarkdown ||
-      levelProperties.predictSettings?.solution
+      isUserTeacher &&
+      (levelProperties.teacherMarkdown ||
+        levelProperties.predictSettings?.solution)
     ) {
       tabMap[Tabs.TeachersOnly] = (
         <ForTeachersOnly
@@ -115,7 +118,14 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     }
 
     return tabMap;
-  }, [instructionsProps, aiTutor2Context, showRubric]);
+  }, [instructionsProps, isUserTeacher, aiTutor2Context, showRubric]);
+
+  useEffect(() => {
+    if (!(currentTab in availableTabs)) {
+      // If the current tab is no longer available, switch to the first available tab.
+      setCurrentTab(getTypedKeys(availableTabs)[0] || Tabs.Instructions);
+    }
+  }, [currentTab, availableTabs]);
 
   return (
     <div className={classNames(styles.resourcePanel, className)}>

--- a/apps/src/lab2/views/components/Instructions/for-teachers-only.module.scss
+++ b/apps/src/lab2/views/components/Instructions/for-teachers-only.module.scss
@@ -1,0 +1,3 @@
+.teachersOnlyContainer {
+  overflow-y: scroll;
+}

--- a/apps/src/templates/instructions/TeacherOnlyMarkdown.jsx
+++ b/apps/src/templates/instructions/TeacherOnlyMarkdown.jsx
@@ -29,7 +29,7 @@ export default class TeacherOnlyMarkdown extends Component {
       return null;
     }
 
-    // CodeBridge does not use the teal container/header, so we just render the content.
+    // Hides the teal container/header (Lab2 does not use the container).
     if (hideContainer) {
       return this.renderMarkdownContent();
     }


### PR DESCRIPTION
4 small fixes to the "Teaching Tips" (formerly "For Teachers Only") tab:
- Hide the tab if the user is not a teacher.
- Change the tab text to "Teaching Tips"
- Make the tab scroll if needed.
- If we switch levels to a level that does not have the currently-active tab, go to the first available tab.

## Level Switching Before
https://github.com/user-attachments/assets/8c0821bb-fd27-4ee1-9393-0d2f64b76776

## Level Switching After
https://github.com/user-attachments/assets/c76de785-73e5-47e5-a056-77eb491d1fe3

## New Scroll behavior
https://github.com/user-attachments/assets/148bbe10-2653-4a9b-a4bf-5b5d02f9f65d


## New Text
<img width="335" height="147" alt="Screenshot 2025-08-27 at 9 27 48 AM" src="https://github.com/user-attachments/assets/96e07d8e-3e6f-4d5e-9ae0-1012bbad8230" />


## Links

- Jira: [SL-1399](https://codedotorg.atlassian.net/browse/SL-1399), [SL-1400](https://codedotorg.atlassian.net/browse/SL-1400), [SL-1411](https://codedotorg.atlassian.net/browse/SL-1411), [SL-1404](https://codedotorg.atlassian.net/browse/SL-1404)

## Testing story
Tested locally.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
