### PR TITLE
feat(workshops): filter out useless text survey responses and sort by length

### DIFF
--- a/dashboard/lib/pd/foorm/response_processor.rb
+++ b/dashboard/lib/pd/foorm/response_processor.rb
@@ -145,11 +145,35 @@ module Pd::Foorm
     def self.process_text_responses(question_summary)
       return {} unless question_summary.is_a?(Array)
 
-      responses = question_summary.compact_blank
+      useless_answers = %w(
+        none
+        na
+        no
+        nothing
+        noneoftheabove
+        notapplicable
+        noopinion
+        noidea
+        nada
+        idk
+        idc
+        idontknow
+        dontknow
+        dunno
+      )
+
+      # Filter responses
+      responses = question_summary.compact_blank.filter do |response|
+        sanitized_response = response.downcase.gsub(/\W/, '') # Remove spaces and non-word characters and then downcase
+        response.length >= 3 && useless_answers.exclude?(sanitized_response) # Exclude short and useless answers
+      end
+
+      # Sort responses by length, longest first
+      sorted_responses = responses.sort_by {|response| -response.length}
 
       {
-        total_responses: responses.length,
-        responses: responses
+        total_responses: sorted_responses.length,
+        responses: sorted_responses
       }
     end
 

--- a/dashboard/test/lib/pd/foorm/response_processor_test.rb
+++ b/dashboard/test/lib/pd/foorm/response_processor_test.rb
@@ -187,17 +187,17 @@ module Pd::Foorm
 
     test 'process_text_responses handles text array correctly' do
       question_summary = [
-        'First response',
-        'Second response',
+        'Response 1',
+        'Response 2',
         '',  # Should be filtered out by compact_blank
-        'Third response'
+        'Response 3'
       ]
 
       result = ResponseProcessor.process_text_responses(question_summary)
 
       expected = {
         total_responses: 3,
-        responses: ['First response', 'Second response', 'Third response']
+        responses: ['Response 1', 'Response 2', 'Response 3']
       }
 
       assert_equal expected, result
@@ -209,6 +209,67 @@ module Pd::Foorm
       expected = {
         total_responses: 0,
         responses: []
+      }
+
+      assert_equal expected.with_indifferent_access, result.with_indifferent_access
+    end
+
+    test 'process_text_responses filters useless responses' do
+      result = ResponseProcessor.process_text_responses([
+                                                          'none',
+                                                          'None',
+                                                          'None of the above',
+                                                          'nothing',
+                                                          'Nothing',
+                                                          'Nothing!',
+                                                          'Nothing.',
+                                                          'N/A',
+                                                          'N/a',
+                                                          'n/a',
+                                                          'NA',
+                                                          'Not applicable',
+                                                          '',
+                                                          'No',
+                                                          'no',
+                                                          'no opinion',
+                                                          'no idea',
+                                                          'n',
+                                                          'nada',
+                                                          'idc',
+                                                          'idk',
+                                                          "i don't know",
+                                                          "don't know",
+                                                          'dunno',
+                                                          'This is valid',
+                                                          'Another valid response'
+                                                        ]
+)
+
+      expected = {
+        total_responses: 2,
+        responses: ['Another valid response', 'This is valid']
+      }
+
+      assert_equal expected.with_indifferent_access, result.with_indifferent_access
+    end
+
+    test 'process_text_responses sorts responses by length' do
+      result = ResponseProcessor.process_text_responses([
+                                                          'it was okay',
+                                                          'this was the best workshop ever!',
+                                                          'meh',
+                                                          'solid ws'
+                                                        ]
+)
+
+      expected = {
+        total_responses: 4,
+        responses: [
+          'this was the best workshop ever!',
+          'it was okay',
+          'solid ws',
+          'meh',
+        ]
       }
 
       assert_equal expected.with_indifferent_access, result.with_indifferent_access


### PR DESCRIPTION
This pull request updates the logic for processing free-text survey responses in `ResponseProcessor`, focusing on filtering out unhelpful answers and improving the order of reported responses. It also adds comprehensive tests to ensure the new behavior is correct.

**Improvements to text response processing:**

* Updated `process_text_responses` in `response_processor.rb` to filter out common useless answers (like "none", "n/a", "no", "nothing", and their variants) and ignore blank responses. The method now also sorts remaining responses by length, showing the longest first.

**Testing enhancements:**

* Added new tests in `response_processor_test.rb` to verify that useless responses are filtered, and that the remaining responses are sorted by length.
* Updated existing tests to match the new expected output and ensure correct handling of filtered and sorted responses.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
