### PR TITLE
TEACH-2054/modularity support for canonical urls

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -120,8 +120,10 @@ class ScriptsController < ApplicationController
     @page_title = "Unit: #{@script.localized_title}"
     @page_description = @script.localized_description.truncate(200, separator: '.', omission: '.')
 
-    link = Unit.latest_stable_version(@script.family_name)&.link(unit_group_unit: @unit_group_unit)
-    @canonical_url = CDO.studio_url(link) if @script.unit_group&.single_unit_course? && link
+    if @script.unit_group&.single_unit_course?
+      canonical_ug = UnitGroup.latest_stable_version(@course.family_name)&.name
+      @canonical_url = CDO.studio_url("/courses/#{canonical_ug}/units/1") if canonical_ug
+    end
 
     if @script.old_professional_learning_course? && current_user && Plc::UserCourseEnrollment.exists?(user: current_user, plc_course: @script.plc_course_unit.plc_course)
       @plc_breadcrumb = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.unit_group)}

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -91,15 +91,16 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'canonical url is added if it is a single unit course' do
-    unit = create(:script, family_name: 'my-script')
-    course = create(:single_unit_course, unit: unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    sign_in create(:teacher)
+    course2024 = create(:single_unit_course, family_name: 'my-family', version_year: '2024', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    course2025 = create(:single_unit_course, family_name: 'my-family', version_year: '2025', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
 
     get :show, params: {
-      course_course_name: course.name,
+      course_course_name: course2024.name,
       position: 1
     }
     assert_response :ok
-    assert_includes(@response.body, "<link rel=\"canonical\" href=\"//test-studio.code.org/courses/#{course.name}/units/1")
+    assert_includes(@response.body, "<link rel=\"canonical\" href=\"//test-studio.code.org/courses/#{course2025.name}/units/1")
   end
 
   test 'canonical url is not added if is not single unit course' do


### PR DESCRIPTION
Before the standalone-unit migration, all course overviews and standalone unit overviews would have a canonical url associated with them. Since migrating standalone units, the single-unit courses no longer have course overview pages or family_names on the unit, so there were no `canonical_urls` for those courses. This PR adds canonical urls back for single-unit courses based on the latest stable version of the course.



## Links
- Jira: [TEACH-2054](https://codedotorg.atlassian.net/browse/TEACH-2054)
- Slack thread with more context: https://codedotorg.slack.com/archives/C068ZAMH7TL/p1750880061806039

## Testing story
Modified tests to reflect changes and manually verified:
- [x] the canonical url is present and correct on single-unit course unit overviews
- [x] the canonical url is not present on "normal" unit overviews

