### PR TITLE
feat(marketing): add no padding option to Section component

### DIFF
--- a/frontend/apps/marketing-storybook/stories/Section.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/Section.story.tsx
@@ -27,7 +27,7 @@ const backgrounds = [
   'patternPrimary',
   'transparent',
 ] as const;
-const paddings = ['m', 'l'] as const;
+const paddings = ['m', 'l', 'none'] as const;
 const themes = ['Light', 'Dark'] as const;
 const dividers = ['none', 'primary', 'strong'] as const;
 

--- a/frontend/apps/marketing/src/components/common/definitions/index.ts
+++ b/frontend/apps/marketing/src/components/common/definitions/index.ts
@@ -167,6 +167,7 @@ export const sectionPaddingDefinition: Record<
       in: [
         {value: 'm', displayName: 'Medium'},
         {value: 'l', displayName: 'Large'},
+        {value: 'none', displayName: 'None'},
       ],
     },
   },

--- a/frontend/apps/marketing/src/components/contentful/section/Section.tsx
+++ b/frontend/apps/marketing/src/components/contentful/section/Section.tsx
@@ -52,7 +52,7 @@ export interface SectionProps {
   /** Background color */
   background?: SectionBackground;
   /** Vertical padding */
-  padding?: keyof Exclude<SpacingProps, 'none' | 'xs' | 's'>;
+  padding?: keyof Exclude<SpacingProps, 'xs' | 's'>;
   /** Section theme */
   theme?: 'Light' | 'Dark';
   /** Has bottom divider */

--- a/frontend/apps/marketing/src/themes/code.org/styleOverrides/container.ts
+++ b/frontend/apps/marketing/src/themes/code.org/styleOverrides/container.ts
@@ -18,6 +18,10 @@ export const CONTAINER_OVERRIDES: Components<Theme>['MuiContainer'] = {
         paddingTop: theme.spacing(5),
         paddingBottom: theme.spacing(5),
       },
+      '&.MuiContainer-root.container--spacing-none': {
+        paddingTop: theme.spacing(0),
+        paddingBottom: theme.spacing(0),
+      },
       // Divider styles
       '&.MuiContainer-root.container--divider-primary': {
         borderBottom: `1px solid var(--background-neutral-quaternary)`,

--- a/frontend/apps/marketing/src/themes/csforall/styleOverrides/container.ts
+++ b/frontend/apps/marketing/src/themes/csforall/styleOverrides/container.ts
@@ -17,6 +17,10 @@ export const CONTAINER_OVERRIDES: Components<Theme>['MuiContainer'] = {
         paddingTop: theme.spacing(5),
         paddingBottom: theme.spacing(5),
       },
+      '&.MuiContainer-root.container--spacing-none': {
+        paddingTop: theme.spacing(0),
+        paddingBottom: theme.spacing(0),
+      },
       // Background styles
       '.section-background-primary:has(&.MuiContainer-root)': {
         backgroundColor: theme.palette.common.white,


### PR DESCRIPTION
Adds a "None" option to the Section component Padding prop to remove top and bottom padding.

## Links
Jira ticket: [CMS-1017](https://codedotorg.atlassian.net/browse/CMS-1017)

----

## Code.org


https://github.com/user-attachments/assets/7a212286-e7b7-45ca-b0bb-948a3049bc53




## CSforAll


https://github.com/user-attachments/assets/3557c979-9cb2-482d-b436-9c9d95794c5a

