### PR TITLE
Fix date text wrapping issue

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2637,6 +2637,7 @@
   "sessionLockoutHeaderThanksDescription": "An image of a penguin happily dancing.",
   "sessionLockoutPendingPrompt": "We sent an email to {pendingEmail}. Didn't receive anything? Update your parent or guardian's email below or send another request.",
   "sessionLockoutNote": "Note: Your account will be deleted if we do not receive your parent or guardian's permission by {deleteDate}.",
+  "sessionLockoutByDateNote": "Note: Your account will be deleted if we do not receive your parent or guardian's permission by:",
   "sessionLockoutLastEmailSent": "Last email sent:",
   "sessionLockoutParentEmailField": "Parent/Guardian Email:",
   "sessionLockoutParentStatusField": "Permission Request:",

--- a/apps/src/templates/sessions/LockoutPanel.tsx
+++ b/apps/src/templates/sessions/LockoutPanel.tsx
@@ -256,12 +256,14 @@ const LockoutPanel: React.FC<LockoutPanelProps> = props => {
 
         {/* The timezone is set to UTC to ensure that the exact date renders. */}
         <p>
-          {i18n.sessionLockoutNote({
-            deleteDate: props.deleteDate.toLocaleDateString(locale, {
+          {i18n.sessionLockoutByDateNote()}
+          <br />
+          <b>
+            {props.deleteDate.toLocaleDateString(locale, {
               ...dateOptions,
               timeZone: 'UTC',
-            }),
-          })}
+            })}
+          </b>
         </p>
 
         {/* This field shows the current status of the validation. */}

--- a/dashboard/test/ui/features/platform/policy_compliance/parental_permission.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance/parental_permission.feature
@@ -23,7 +23,7 @@ Feature: Policy Compliance and Parental Permission
     Then I wait until element "#permission-status" contains text "Pending"
     And element ".lockout-panel h2" contains text "Thanks! We've contacted your parent/guardian."
     And element "#lockout-panel-form > p:nth-child(1)" contains text "We sent an email to parent@example.com. Didn't receive anything? Update your parent or guardian's email below or send another request."
-    And element "#lockout-panel-form > p:nth-child(2)" contains text "Note: Your account will be deleted if we do not receive your parent or guardian's permission by "
+    And element "#lockout-panel-form > p:nth-child(2)" contains text "Note: Your account will be deleted if we do not receive your parent or guardian's permission by:"
 
   Scenario: New under 13 account should be able to provide state and see lockout page to send parental request.
     Given I am on "http://studio.code.org"

--- a/dashboard/test/ui/features/platform/policy_compliance/parental_permission.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance/parental_permission.feature
@@ -12,7 +12,7 @@ Feature: Policy Compliance and Parental Permission
     Then I wait until element "#permission-status" contains text "Not Submitted"
     And element ".lockout-panel h2" contains text "Just one more thing!"
     And element "#lockout-panel-form > p:nth-child(1)" contains text "We need your parent or guardian to approve your account before you can get started. Please supply us with your parent or guardian's email address so they can grant you permission."
-    And element "#lockout-panel-form > p:nth-child(2)" contains text "Note: Your account will be deleted if we do not receive your parent or guardian's permission by "
+    And element "#lockout-panel-form > p:nth-child(2)" contains text "Note: Your account will be deleted if we do not receive your parent or guardian's permission by:"
 
     # Type in the email do re-enable the button
     And I press keys "parent@example.com" for element "#parent-email"


### PR DESCRIPTION
This PR moves the Lockout date to its own line to prevent eyes test failures. Previously, change in month names would shift the content below it down everytime the lockout date month changed from a shorter to longer month. Vice versa shifitng content up if going from a longer to shorter month. This caused visual diffs, making us accept a new baseline. This fix prevents us from constantly having to update the baseline.


## Date on its own line in bold
<img width="755" height="520" alt="Screenshot 2025-08-28 at 10 11 52 AM" src="https://github.com/user-attachments/assets/f03e5800-07b3-45d3-8807-ac5693730fdf" />


## Eyes difference before
<img width="1698" height="909" alt="Screenshot 2025-08-28 at 10 01 31 AM" src="https://github.com/user-attachments/assets/db5a2a82-1816-47a8-b6b1-a9367209d79b" />

## Links

- Jira: [here](https://codedotorg.atlassian.net/browse/P20-1591)
- Slack thread: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1756143746243409)


