### PR TITLE
Remove Temporary Alias for Renamed Rake Task

### DIFF
--- a/lib/rake/infra.rake
+++ b/lib/rake/infra.rake
@@ -121,12 +121,6 @@ namespace :infra do
   end
 end
 
-# Temporarily support invoking this task with either `rake ci` or `rake
-# infra:ci` until the latter method has been deployed everywhere, so our
-# persistent managed servers don't break during the transition.
-# TODO infra: remove this once the `infra:ci` implementation has been deployed
-timed_task_with_logging ci: ['infra:ci']
-
 # Returns true if upgrade succeeded, false if failed.
 def upgrade_frontend(name, hostname)
   ChatClient.log "Upgrading <b>#{name}</b> (#{hostname})..."


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/64843, which added a Rake alias to help smooth the rename of a Rake task from `ci` to `infra:ci`. We needed to support both only for long enough for all of our persistent managed servers to pick up the change, which they now have for quite some time.

## Testing story

I have done no testing beyond verifying that the two references to `ci` which we updated to `infra:ci` in [the original PR](https://github.com/code-dot-org/code-dot-org/pull/64647/files) are still in place. This should be an extremely safe change, so I'm comfortable with that level of testing; please let me know if you think more diligent testing here would be a good use of time, and I'll be happy to do so.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
