### PR TITLE
hardcode 2019 unit redirects 

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -95,10 +95,6 @@ class ScriptLevelsController < ApplicationController
       new_script = Unit.get_from_cache(@script.redirect_to)
       new_path = request.fullpath.sub(%r{^/s/#{params[:script_id]}/}, "/s/#{new_script.name}/")
 
-      if Unit.family_names.include?(params[:script_id])
-        Unit.log_redirect(params[:script_id], new_script.name, request, 'unversioned-script-level-redirect', current_user&.user_type)
-      end
-
       # avoid a redirect loop if the string substitution failed
       # TODO: TEACH-2050 Modularity support for redirects. This redirects to the current script. Redirect to the new script's
       # original unit group for now.

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -341,12 +341,6 @@ class ScriptsController < ApplicationController
 
     return {script: script} if script
 
-    if Unit.family_names.include?(unit_name)
-      script = Unit.get_unit_family_redirect_for_user(unit_name, user: current_user, locale: request.locale)
-      Unit.log_redirect(unit_name, script.redirect_to, request, 'unversioned-script-redirect', current_user&.user_type) if script.present?
-      return {script: script}
-    end
-
     # Redirect to the latest version or the assigned version of a single-unit course
     if UnitGroup.family_names.include?(unit_name)
       unit_group = UnitGroup.latest_stable_version(unit_name, locale: request.locale) ||

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -636,25 +636,6 @@ class Unit < ApplicationRecord
       ) : nil
   end
 
-  def self.log_redirect(old_unit_name, new_unit_name, request, event_name, user_type)
-    FirehoseClient.instance.put_record(
-      :analysis,
-      {
-        study: 'script-family-redirect',
-        event: event_name,
-        data_string: request.path,
-        data_json: {
-          old_script_name: old_unit_name,
-          new_script_name: new_unit_name,
-          method: request.method,
-          url: request.url,
-          referer: request.referer,
-          user_type: user_type
-        }.to_json
-      }
-    )
-  end
-
   # @param user [User]
   # @param locale [String] User or request locale. Optional.
   # @return [String|nil] URL to the unit overview page the user should be redirected to (if any).

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -524,21 +524,19 @@ Dashboard::Application.routes.draw do
     get '/s/csp10-2020/lockable/1(*all)', to: redirect(path: '/s/csp10-2020/lessons/14%{all}')
 
     # Hardcoded redirects for old courses that used unit family names
-    get '/s/csd1', to: redirect('/courses/csd-2019/units/1')
-    get '/s/csd2', to: redirect('/courses/csd-2019/units/2')
-    get '/s/csd3', to: redirect('/courses/csd-2019/units/3')
-    get '/s/csd4', to: redirect('/courses/csd-2019/units/4')
-    get '/s/csd5', to: redirect('/courses/csd-2019/units/5')
-    get '/s/csd6', to: redirect('/courses/csd-2019/units/6')
+    get '/s/csd:unit', to: redirect('/courses/csd-2019/units/%{unit}'), constraints: {unit: /[1-6]/}
+    get '/s/csd:unit/(*all)', to: redirect('/courses/csd-2019/units/%{unit}/%{all}'), constraints: {unit: /[1-6]/}
 
-    get '/s/csp1', to: redirect('/courses/csp-2019/units/1')
-    get '/s/csp2', to: redirect('/courses/csp-2019/units/2')
-    get '/s/csp3', to: redirect('/courses/csp-2019/units/3')
-    get '/s/csp4', to: redirect('/courses/csp-2019/units/4')
+    get '/s/csp:unit', to: redirect('/courses/csp-2019/units/%{unit}'), constraints: {unit: /[1-4]/}
+    get '/s/csp:unit/(*all)', to: redirect('/courses/csp-2019/units/%{unit}/%{all}'), constraints: {unit: /[1-4]/}
     get '/s/csp-explore', to: redirect('/courses/csp-2019/units/5')
+    get '/s/csp-explore/(*all)', to: redirect('/courses/csp-2019/units/5/%{all}')
     get '/s/csp5', to: redirect('/courses/csp-2019/units/6')
+    get '/s/csp5/(*all)', to: redirect('/courses/csp-2019/units/6/%{all}')
     get '/s/csp-create', to: redirect('/courses/csp-2019/units/7')
+    get '/s/csp-create/(*all)', to: redirect('/courses/csp-2019/units/7/%{all}')
     get '/s/csppostap', to: redirect('/courses/csp-2019/units/8')
+    get '/s/csppostap/(*all)', to: redirect('/courses/csp-2019/units/8/%{all}')
 
     resources :data_docs, param: :key do
       collection do

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -523,6 +523,23 @@ Dashboard::Application.routes.draw do
     get '/s/csp9-2020/lockable/1(*all)', to: redirect(path: '/s/csp9-2020/lessons/9%{all}')
     get '/s/csp10-2020/lockable/1(*all)', to: redirect(path: '/s/csp10-2020/lessons/14%{all}')
 
+    # Hardcoded redirects for old courses that used unit family names
+    get '/s/csd1', to: redirect('/courses/csd-2019/units/1')
+    get '/s/csd2', to: redirect('/courses/csd-2019/units/2')
+    get '/s/csd3', to: redirect('/courses/csd-2019/units/3')
+    get '/s/csd4', to: redirect('/courses/csd-2019/units/4')
+    get '/s/csd5', to: redirect('/courses/csd-2019/units/5')
+    get '/s/csd6', to: redirect('/courses/csd-2019/units/6')
+
+    get '/s/csp1', to: redirect('/courses/csp-2019/units/1')
+    get '/s/csp2', to: redirect('/courses/csp-2019/units/2')
+    get '/s/csp3', to: redirect('/courses/csp-2019/units/3')
+    get '/s/csp4', to: redirect('/courses/csp-2019/units/4')
+    get '/s/csp-explore', to: redirect('/courses/csp-2019/units/5')
+    get '/s/csp5', to: redirect('/courses/csp-2019/units/6')
+    get '/s/csp-create', to: redirect('/courses/csp-2019/units/7')
+    get '/s/csppostap', to: redirect('/courses/csp-2019/units/8')
+
     resources :data_docs, param: :key do
       collection do
         get '/edit', to: 'data_docs#edit_all'

--- a/dashboard/test/integration/redirects_test.rb
+++ b/dashboard/test/integration/redirects_test.rb
@@ -181,8 +181,18 @@ class RedirectsTest < ActionDispatch::IntegrationTest
   test 'redirect old courses that used unit family names' do
     get '/s/csp1'
     assert_redirected_to '/courses/csp-2019/units/1'
+    get '/s/csp1/lessons/1/levels/1'
+    assert_redirected_to '/courses/csp-2019/units/1/lessons/1/levels/1'
 
     get '/s/csd1'
     assert_redirected_to '/courses/csd-2019/units/1'
+    get '/s/csd1/lessons/1/levels/1'
+    assert_redirected_to '/courses/csd-2019/units/1/lessons/1/levels/1'
+
+    get '/s/csp5'
+    assert_redirected_to '/courses/csp-2019/units/6'
+
+    get '/s/csd11'
+    assert_response :not_found
   end
 end

--- a/dashboard/test/integration/redirects_test.rb
+++ b/dashboard/test/integration/redirects_test.rb
@@ -177,4 +177,12 @@ class RedirectsTest < ActionDispatch::IntegrationTest
     get "/s/#{multi_unit_course.default_units.last.name}"
     assert_redirected_to "/courses/#{multi_unit_course.name}/units/#{multi_unit_course.default_unit_group_units.last.position}"
   end
+
+  test 'redirect old courses that used unit family names' do
+    get '/s/csp1'
+    assert_redirected_to '/courses/csp-2019/units/1'
+
+    get '/s/csd1'
+    assert_redirected_to '/courses/csd-2019/units/1'
+  end
 end


### PR DESCRIPTION
Currently, unit `family_name` and `version_year` are still being used by some deprecated code which redirects to the 2019 versions of the following units, which are all in multi unit courses:
<img width="588" height="347" alt="image" src="https://github.com/user-attachments/assets/655a22f3-6aa5-41e3-a2b1-6b0599d1fcb6" />

We are trying to get rid of the deprecated unit `family_name` and `version_year`, so we also needed to remove or update the 2019 redirects, since they are still in use. We decided to just hardcode these redirects.

## Links
- Jira: [TEACH-1790](https://codedotorg.atlassian.net/browse/TEACH-1790)

## Testing story
Verified: 
- [x] http://localhost-studio.code.org:3000/s/csd1 -> http://localhost-studio.code.org:3000/courses/csd-2019/units/1
- [x] http://localhost-studio.code.org:3000/s/csd2 -> http://localhost-studio.code.org:3000/courses/csd-2019/units/2
- [x] http://localhost-studio.code.org:3000/s/csd3 -> http://localhost-studio.code.org:3000/courses/csd-2019/units/3
- [x] http://localhost-studio.code.org:3000/s/csd4 -> http://localhost-studio.code.org:3000/courses/csd-2019/units/4
- [x] http://localhost-studio.code.org:3000/s/csd5 -> http://localhost-studio.code.org:3000/courses/csd-2019/units/5
- [x] http://localhost-studio.code.org:3000/s/csd6 -> http://localhost-studio.code.org:3000/courses/csd-2019/units/6
- [x] http://localhost-studio.code.org:3000/s/csp1 -> http://localhost-studio.code.org:3000/courses/csp-2019/units/1
- [x] http://localhost-studio.code.org:3000/s/csp2 -> http://localhost-studio.code.org:3000/courses/csp-2019/units/2
- [x] http://localhost-studio.code.org:3000/s/csp3 -> http://localhost-studio.code.org:3000/courses/csp-2019/units/3
- [x] http://localhost-studio.code.org:3000/s/csp4 -> http://localhost-studio.code.org:3000/courses/csp-2019/units/4
- [x] http://localhost-studio.code.org:3000/s/csp-explore -> http://localhost-studio.code.org:3000/courses/csp-2019/units/5
- [x] http://localhost-studio.code.org:3000/s/csp5 -> http://localhost-studio.code.org:3000/courses/csp-2019/units/6
- [x] http://localhost-studio.code.org:3000/s/csp-create -> http://localhost-studio.code.org:3000/courses/csp-2019/units/7
- [x] http://localhost-studio.code.org:3000/s/csppostap -> http://localhost-studio.code.org:3000/courses/csp-2019/units/8
- [x] http://localhost-studio.code.org:3000/s/virtual-pl-csp-summer-day1 -> http://localhost-studio.code.org:3000/courses/virtual-pl-csp-summer-2024/units/1
- [x] http://localhost-studio.code.org:3000/s/csa-software-engineering -> http://localhost-studio.code.org:3000/courses/csa-software-engineering/units/1
