### PR TITLE
TEACH-2155/fix unit overview for levelbuilders with sections

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -41,7 +41,7 @@ class ScriptsController < ApplicationController
         end
         return
       end
-      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.id == @course.id}
+      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.id == @course&.id}
         most_recent_section = current_user.sections_instructed.select {|s| s.script_id == @script.id || s.unit_group&.id == @course.id}.last
         section_id = params[:section_id]
         section_id ||= most_recent_section&.id


### PR DESCRIPTION
It was recently discovered that a levelbuilder user gets a sad bee on the unit overview page for a unit that doesn't have a course. This PR fixes that problem by adding a safe navigation operator



## Links

- Jira: [TEACH-2155](https://codedotorg.atlassian.net/browse/TEACH-2155)

## Testing story
Verified
- [x] Levelbuilder with sections can view the unit overview
- [x] User without access to a unit cannot view the unit overview

