### PR TITLE
feat(workshops): add breakdown dialog for likert

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -398,29 +398,28 @@ export const isQuestionType = <T extends SurveyQuestion['question_type']>(
   return !!question && question.question_type === type;
 };
 
+export interface Breakdown {
+  count: number;
+  percentage: number;
+  label: string;
+  status?: string;
+}
+
 export interface LikertResults {
   weighted_score: number;
   agreement_count: number;
   agreement_percentage: number;
-  breakdown: Record<string, LikertBreakdown>;
-}
-
-export interface LikertBreakdown {
-  count: number;
-  percentage: number;
-  label: string;
-  weighted_value: number;
+  breakdown: Record<
+    string,
+    Breakdown & {
+      weighted_value: number;
+    }
+  >;
 }
 
 export interface PromoterResults {
   promoter_percentage: number;
-  breakdown: Record<string, PromoterBreakdown>;
-}
-
-export interface PromoterBreakdown {
-  count: number;
-  percentage: number;
-  label: string;
+  breakdown: Record<string, Breakdown>;
 }
 
 export interface TextResults {
@@ -428,23 +427,11 @@ export interface TextResults {
 }
 
 export interface SingleSelectResults {
-  breakdown: Record<string, SingleSelectBreakdown>;
+  breakdown: Record<string, Breakdown>;
   other_answers?: string[];
 }
 
-export interface SingleSelectBreakdown {
-  count: number;
-  percentage: number;
-  label: string;
-}
-
 export interface MultiSelectResults {
-  breakdown: Record<string, MultiSelectBreakdown>;
+  breakdown: Record<string, Breakdown>;
   total_respondents: number;
-}
-
-export interface MultiSelectBreakdown {
-  count: number;
-  percentage: number;
-  label: string;
 }

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FreeResponseCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FreeResponseCard.tsx
@@ -64,9 +64,9 @@ export const FreeResponseCard: FC<FreeResponseCardProps> = ({
               [styles.small]: size === 's',
             })}
           >
-            {items.map(item => (
+            {items.map((item, i) => (
               <Box
-                key={item}
+                key={`${item}-${i}`}
                 className={classNames(
                   styles.textCard,
                   statusColor && styles[statusColor]

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/MultiSelectCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/MultiSelectCard.tsx
@@ -3,15 +3,16 @@ import {
   Heading2,
   StrongText,
 } from '@code-dot-org/component-library/typography';
-import {Card, CardContent, Box, CardHeader} from '@mui/material';
+import {Card, CardContent, CardHeader} from '@mui/material';
 import classNames from 'classnames';
-import React, {FC, useEffect, useState} from 'react';
+import React, {FC} from 'react';
 
 import noResponsesBars from '@cdo/static/pd/no-responses-bars.png';
 
 import {Breakdown} from '../../../WorkshopFormTemplate/types';
 
 import {EmptyState} from './EmptyState';
+import {PercentageBarGroup} from './PercentageBarGroup';
 
 import styles from '../../workshop.module.scss';
 
@@ -20,10 +21,6 @@ interface MultiSelectCardProps {
   description: string;
   items: Breakdown[];
   barLabel?: string;
-}
-
-interface PercentageBarProps {
-  percentage: number;
 }
 
 export const MultiSelectCard: FC<MultiSelectCardProps> = ({
@@ -55,21 +52,7 @@ export const MultiSelectCard: FC<MultiSelectCardProps> = ({
       />
       <CardContent className={styles.cardContent}>
         {items.length > 0 ? (
-          <Box className={styles.column}>
-            {items.map(item => (
-              <Box key={item.label}>
-                <BodyThreeText noMargin>
-                  <StrongText>{item.label}</StrongText>
-                </BodyThreeText>
-                <Box className={styles.barRow}>
-                  <PercentageBar percentage={item.percentage} />
-                  <BodyThreeText noMargin className={styles.barLabel}>{`${
-                    item.count
-                  }${barLabel ? ` ${barLabel}` : ''}`}</BodyThreeText>
-                </Box>
-              </Box>
-            ))}
-          </Box>
+          <PercentageBarGroup items={items} barLabel={barLabel} />
         ) : (
           <EmptyState
             title="No data available yet."
@@ -79,30 +62,5 @@ export const MultiSelectCard: FC<MultiSelectCardProps> = ({
         )}
       </CardContent>
     </Card>
-  );
-};
-
-const PercentageBar: FC<PercentageBarProps> = ({percentage}) => {
-  const [width, setWidth] = useState(0);
-
-  useEffect(() => {
-    // A tiny delay ensures the browser has painted the initial 0% width
-    // before transitioning to the final percentage.
-    const timer = setTimeout(() => {
-      setWidth(percentage);
-    }, 10);
-
-    return () => clearTimeout(timer);
-  }, [percentage]);
-
-  return (
-    <Box className={styles.barContainer}>
-      <Box
-        className={styles.indicator}
-        style={{
-          width: `${width}%`,
-        }}
-      />
-    </Box>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/MultiSelectCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/MultiSelectCard.tsx
@@ -9,7 +9,7 @@ import React, {FC, useEffect, useState} from 'react';
 
 import noResponsesBars from '@cdo/static/pd/no-responses-bars.png';
 
-import {MultiSelectBreakdown} from '../../../WorkshopFormTemplate/types';
+import {Breakdown} from '../../../WorkshopFormTemplate/types';
 
 import {EmptyState} from './EmptyState';
 
@@ -18,7 +18,7 @@ import styles from '../../workshop.module.scss';
 interface MultiSelectCardProps {
   title: string;
   description: string;
-  items: MultiSelectBreakdown[];
+  items: Breakdown[];
   barLabel?: string;
 }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/PercentageBarGroup.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/PercentageBarGroup.tsx
@@ -8,7 +8,7 @@ import React, {FC, useEffect, useState} from 'react';
 
 import {Breakdown} from '../../../WorkshopFormTemplate/types';
 
-import componentStyles from './PercentageBarGroupStyles.module.scss';
+import styles from './PercentageBarGroupStyles.module.scss';
 import commonStyles from '../../workshop.module.scss';
 
 interface PercentageBarGroupProps {
@@ -34,12 +34,12 @@ export const PercentageBarGroup: FC<PercentageBarGroupProps> = ({
           <BodyThreeText noMargin>
             <StrongText>{item.label}</StrongText>
           </BodyThreeText>
-          <Box className={componentStyles.barRow}>
+          <Box className={styles.barRow}>
             <PercentageBar
               percentage={item.percentage}
-              className={item.status && componentStyles[item.status]}
+              className={item.status && styles[item.status]}
             />
-            <BodyThreeText noMargin className={componentStyles.barLabel}>{`${
+            <BodyThreeText noMargin className={styles.barLabel}>{`${
               item.count
             }${barLabel ? ` ${barLabel}` : ''}`}</BodyThreeText>
           </Box>
@@ -63,9 +63,9 @@ const PercentageBar: FC<PercentageBarProps> = ({percentage, className}) => {
   }, [percentage]);
 
   return (
-    <Box className={componentStyles.barContainer}>
+    <Box className={styles.barContainer}>
       <Box
-        className={classNames(componentStyles.indicator, className)}
+        className={classNames(styles.indicator, className)}
         style={{
           width: `${width}%`,
         }}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/PercentageBarGroup.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/PercentageBarGroup.tsx
@@ -1,0 +1,75 @@
+import {
+  BodyThreeText,
+  StrongText,
+} from '@code-dot-org/component-library/typography';
+import {Box} from '@mui/material';
+import classNames from 'classnames';
+import React, {FC, useEffect, useState} from 'react';
+
+import {Breakdown} from '../../../WorkshopFormTemplate/types';
+
+import componentStyles from './PercentageBarGroupStyles.module.scss';
+import commonStyles from '../../workshop.module.scss';
+
+interface PercentageBarGroupProps {
+  items: Breakdown[];
+  barLabel?: string;
+  className?: string;
+}
+
+interface PercentageBarProps {
+  percentage: number;
+  className?: string;
+}
+
+export const PercentageBarGroup: FC<PercentageBarGroupProps> = ({
+  items,
+  barLabel,
+  className,
+}) => {
+  return (
+    <Box className={classNames(commonStyles.column, className)}>
+      {items.map(item => (
+        <Box key={item.label}>
+          <BodyThreeText noMargin>
+            <StrongText>{item.label}</StrongText>
+          </BodyThreeText>
+          <Box className={componentStyles.barRow}>
+            <PercentageBar
+              percentage={item.percentage}
+              className={item.status && componentStyles[item.status]}
+            />
+            <BodyThreeText noMargin className={componentStyles.barLabel}>{`${
+              item.count
+            }${barLabel ? ` ${barLabel}` : ''}`}</BodyThreeText>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+const PercentageBar: FC<PercentageBarProps> = ({percentage, className}) => {
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    // A tiny delay ensures the browser has painted the initial 0% width
+    // before transitioning to the final percentage.
+    const timer = setTimeout(() => {
+      setWidth(percentage);
+    }, 10);
+
+    return () => clearTimeout(timer);
+  }, [percentage]);
+
+  return (
+    <Box className={componentStyles.barContainer}>
+      <Box
+        className={classNames(componentStyles.indicator, className)}
+        style={{
+          width: `${width}%`,
+        }}
+      />
+    </Box>
+  );
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/PercentageBarGroupStyles.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/PercentageBarGroupStyles.module.scss
@@ -1,0 +1,42 @@
+.barRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+
+  .barLabel {
+    min-width: 5rem;
+    flex-shrink: 0;
+    text-align: left;
+    color: var(--text-neutral-tertiary);
+  }
+
+  .barContainer {
+    position: relative;
+    flex: 1;
+    flex-shrink: 0;
+    height: 0.625rem;
+    border-radius: 6.25rem;
+    background: var(--background-neutral-tertiary);
+    overflow: hidden;
+
+    .indicator {
+      background: var(--background-brand-teal-primary);
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      transition: width 0.6s ease-out;
+
+      &.neutral {
+        background: var(--background-neutral-septenary);
+      }
+      &.agree {
+        background: var(--background-success-primary);
+      }
+      &.disagree {
+        background: var(--background-error-primary);
+      }
+    }
+  }
+}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
@@ -1,36 +1,53 @@
+import {Button} from '@code-dot-org/component-library/button';
+import {CustomDialog} from '@code-dot-org/component-library/dialog';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {
   BodyFourText,
   BodyThreeText,
+  Heading3,
   OverlineTwoText,
   StrongText,
 } from '@code-dot-org/component-library/typography';
 import {Card, CardContent, Box} from '@mui/material';
 import classNames from 'classnames';
-import {CRITICAL_CONCERN_LIMIT, NEEDS_ATTENTION_LIMIT} from '../constants';
+import React, {FC, useMemo, useState} from 'react';
 
-import styles from '../../workshop.module.scss';
+import {Breakdown} from '../../../WorkshopFormTemplate/types';
+import {CRITICAL_CONCERN_LIMIT, NEEDS_ATTENTION_LIMIT} from '../constants';
+import {PercentageBarGroup} from './PercentageBarGroup';
+
+import componentStyles from './ScoreCardStyles.module.scss';
+import commonStyles from '../../workshop.module.scss';
 
 interface ScoreCardProps {
   title: string;
+  longTitle: string;
   description: string;
   footer: string | null;
+  questionType: 'likert' | 'promoter';
   score?: number | null;
   responseCount?: number;
   minResponseCount?: number;
+  breakdown?: Breakdown[];
 }
 
-export const ScoreCard: React.FC<ScoreCardProps> = ({
+export const ScoreCard: FC<ScoreCardProps> = ({
   title,
+  longTitle,
   description,
   footer,
+  questionType,
   score,
   responseCount,
   minResponseCount,
+  breakdown,
 }) => {
+  const [showBreakdown, setShowBreakdown] = useState(false);
   const insufficientData = useMemo(
     () =>
-      (responseCount && minResponseCount && responseCount < minResponseCount) ||
+      (typeof responseCount === 'number' &&
+        typeof minResponseCount === 'number' &&
+        responseCount < minResponseCount) ||
       score === null ||
       score === undefined,
     [responseCount, minResponseCount, score]
@@ -74,28 +91,76 @@ export const ScoreCard: React.FC<ScoreCardProps> = ({
   }, [score, responseCount, insufficientData]);
 
   return (
-    <Card className={classNames(styles.card, styles.questionCard)}>
-      <CardContent className={styles.cardContent}>
-        <Box>
-          <OverlineTwoText noMargin>
-            <StrongText>{title}</StrongText>
-          </OverlineTwoText>
-          <BodyFourText className={styles.description} noMargin>
-            {responseBasedDescription}
-          </BodyFourText>
-        </Box>
+    <>
+      <Card
+        className={classNames(commonStyles.card, commonStyles.questionCard)}
+      >
+        <CardContent className={commonStyles.cardContent}>
+          <Box>
+            <OverlineTwoText noMargin>
+              <StrongText>{title}</StrongText>
+            </OverlineTwoText>
+            <BodyFourText className={commonStyles.description} noMargin>
+              {responseBasedDescription}
+            </BodyFourText>
+          </Box>
 
-        <Box
-          className={classNames(styles.scoreBox, styles[status])}
-          data-status={status}
-        >
-          {responseBasedScore}
+          <Box
+            className={classNames(
+              componentStyles.scoreBox,
+              componentStyles[status]
+            )}
+            data-status={status}
+          >
+            {responseBasedScore}
+          </Box>
+        </CardContent>
+        <Box className={componentStyles.scoreCardFooter}>
+          <Box className={componentStyles.scoreCardFooterText}>
+            <FontAwesomeV6Icon iconName="info-circle" />
+            <BodyFourText noMargin>{footer}</BodyFourText>
+          </Box>
+          {breakdown && !insufficientData && (
+            <Button
+              className={componentStyles.breakdownButton}
+              text="See breakdown"
+              type="tertiary"
+              size="s"
+              onClick={() => setShowBreakdown(true)}
+            />
+          )}
         </Box>
-      </CardContent>
-      <Box className={styles.scoreCardFooter}>
-        <FontAwesomeV6Icon iconName="info-circle" />
-        <BodyFourText noMargin>{footer}</BodyFourText>
-      </Box>
-    </Card>
+      </Card>
+      {showBreakdown && breakdown && (
+        <CustomDialog
+          className={commonStyles.customDialog}
+          onClose={() => setShowBreakdown(false)}
+        >
+          <Heading3 noMargin>Response breakdown</Heading3>
+          <Box className={componentStyles.breakdownContentContainer}>
+            <Box className={componentStyles.longTitleContainer}>
+              <BodyThreeText noMargin>
+                <StrongText>{longTitle}</StrongText>
+              </BodyThreeText>
+              <BodyFourText
+                noMargin
+              >{`${responseCount} responses received`}</BodyFourText>
+            </Box>
+            {questionType === 'likert' && (
+              <PercentageBarGroup
+                className={componentStyles.breakdownBarGroup}
+                items={breakdown}
+                barLabel="Teachers"
+              />
+            )}
+          </Box>
+          <Button
+            className={componentStyles.breakdownCloseButton}
+            text="Return to dashboard"
+            onClick={() => setShowBreakdown(false)}
+          />
+        </CustomDialog>
+      )}
+    </>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
@@ -14,9 +14,10 @@ import React, {FC, useMemo, useState} from 'react';
 
 import {Breakdown} from '../../../WorkshopFormTemplate/types';
 import {CRITICAL_CONCERN_LIMIT, NEEDS_ATTENTION_LIMIT} from '../constants';
+
 import {PercentageBarGroup} from './PercentageBarGroup';
 
-import componentStyles from './ScoreCardStyles.module.scss';
+import styles from './ScoreCardStyles.module.scss';
 import commonStyles from '../../workshop.module.scss';
 
 interface ScoreCardProps {
@@ -106,23 +107,20 @@ export const ScoreCard: FC<ScoreCardProps> = ({
           </Box>
 
           <Box
-            className={classNames(
-              componentStyles.scoreBox,
-              componentStyles[status]
-            )}
+            className={classNames(styles.scoreBox, styles[status])}
             data-status={status}
           >
             {responseBasedScore}
           </Box>
         </CardContent>
-        <Box className={componentStyles.scoreCardFooter}>
-          <Box className={componentStyles.scoreCardFooterText}>
+        <Box className={styles.scoreCardFooter}>
+          <Box className={styles.scoreCardFooterText}>
             <FontAwesomeV6Icon iconName="info-circle" />
             <BodyFourText noMargin>{footer}</BodyFourText>
           </Box>
           {breakdown && !insufficientData && (
             <Button
-              className={componentStyles.breakdownButton}
+              className={styles.breakdownButton}
               text="See breakdown"
               type="tertiary"
               size="s"
@@ -133,12 +131,18 @@ export const ScoreCard: FC<ScoreCardProps> = ({
       </Card>
       {showBreakdown && breakdown && (
         <CustomDialog
+          aria-labelledby="response-breakdown"
           className={commonStyles.customDialog}
           onClose={() => setShowBreakdown(false)}
         >
-          <Heading3 noMargin>Response breakdown</Heading3>
-          <Box className={componentStyles.breakdownContentContainer}>
-            <Box className={componentStyles.longTitleContainer}>
+          <Heading3 id="response-breakdown" noMargin>
+            Response breakdown
+          </Heading3>
+          <Box className={styles.breakdownContentContainer}>
+            <Box
+              id="dsco-dialog-description"
+              className={styles.longTitleContainer}
+            >
               <BodyThreeText noMargin>
                 <StrongText>{longTitle}</StrongText>
               </BodyThreeText>
@@ -148,14 +152,14 @@ export const ScoreCard: FC<ScoreCardProps> = ({
             </Box>
             {questionType === 'likert' && (
               <PercentageBarGroup
-                className={componentStyles.breakdownBarGroup}
+                className={styles.breakdownBarGroup}
                 items={breakdown}
                 barLabel="Teachers"
               />
             )}
           </Box>
           <Button
-            className={componentStyles.breakdownCloseButton}
+            className={styles.breakdownCloseButton}
             text="Return to dashboard"
             onClick={() => setShowBreakdown(false)}
           />

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
@@ -7,7 +7,7 @@ import {
 } from '@code-dot-org/component-library/typography';
 import {Card, CardContent, Box} from '@mui/material';
 import classNames from 'classnames';
-import React, {useMemo} from 'react';
+import {CRITICAL_CONCERN_LIMIT, NEEDS_ATTENTION_LIMIT} from '../constants';
 
 import styles from '../../workshop.module.scss';
 
@@ -19,9 +19,6 @@ interface ScoreCardProps {
   responseCount?: number;
   minResponseCount?: number;
 }
-
-export const CRITICAL_CONCERN_LIMIT = 50;
-export const NEEDS_ATTENTION_LIMIT = 70;
 
 export const ScoreCard: React.FC<ScoreCardProps> = ({
   title,

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCardStyles.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCardStyles.module.scss
@@ -1,0 +1,100 @@
+.scoreBox {
+  height: 3rem;
+  width: 3rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--background-success-primary);
+  border-radius: 4px;
+  flex-shrink: 0;
+  margin-left: 0.75rem;
+
+  p {
+    color: var(--text-neutral-white-fixed);
+  }
+
+  &.insufficientData {
+    background-color: var(--background-neutral-tertiary);
+    p,
+    i {
+      color: var(--text-neutral-quaternary);
+    }
+
+    i {
+      font-size: 1.75rem;
+    }
+  }
+
+  &.needsAttention {
+    background-color: var(--background-warning-primary);
+    p {
+      color: var(--text-neutral-black-fixed);
+    }
+  }
+
+  &.criticalConcern {
+    background-color: var(--background-error-primary);
+  }
+}
+
+.scoreCardFooter {
+  background-color: var(--background-neutral-secondary);
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
+  border-top: 1px solid var(--borders-neutral-primary);
+  padding: 0.5rem;
+  padding-left: 1rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: space-between;
+
+  .scoreCardFooterText {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .breakdownButton {
+    padding: 0;
+  }
+
+  * {
+    white-space: nowrap;
+  }
+
+  i,
+  p {
+    color: var(--text-neutral-quaternary);
+  }
+
+  i {
+    margin-right: 0.375rem;
+  }
+}
+
+.breakdownContentContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  padding: 1rem 0;
+  border-top: 1px solid var(--borders-neutral-primary);
+  border-bottom: 1px solid var(--borders-neutral-primary);
+
+  .longTitleContainer {
+    border-radius: 4px;
+    background-color: var(--background-neutral-secondary);
+    padding: 0.75rem;
+  }
+
+  .breakdownBarGroup {
+    min-width: 37.5rem;
+  }
+}
+
+.breakdownCloseButton {
+  margin-left: auto;
+}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/constants.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/constants.ts
@@ -2,3 +2,6 @@ export const MIN_RESPONSE_COUNT = 5;
 
 export const LIKERT_QUESTION_FOOTER = 'Based on a 7-point agreement scale';
 export const PROMOTER_QUESTION_FOOTER = 'Based on a 10-point rating';
+
+export const CRITICAL_CONCERN_LIMIT = 50;
+export const NEEDS_ATTENTION_LIMIT = 70;

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/helpers.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/helpers.ts
@@ -1,4 +1,8 @@
-import {isQuestionType, SurveyQuestion} from '../../WorkshopFormTemplate/types';
+import {
+  isQuestionType,
+  LikertResults,
+  SurveyQuestion,
+} from '../../WorkshopFormTemplate/types';
 
 export const getQuestionDescription = (question: SurveyQuestion) => {
   if (isQuestionType(question, 'likert')) {
@@ -18,3 +22,12 @@ export const getQuestionDescription = (question: SurveyQuestion) => {
   }
   return '';
 };
+
+export const prepLikertBreakdown = (breakdown: LikertResults['breakdown']) =>
+  Object.entries(breakdown)
+    .map(([key, value]) => ({
+      ...value,
+      className:
+        Number(key) === 4 ? 'neutral' : Number(key) > 4 ? 'success' : 'error',
+    }))
+    .reverse();

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Engagement.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Engagement.tsx
@@ -13,7 +13,7 @@ import {
   MIN_RESPONSE_COUNT,
   PROMOTER_QUESTION_FOOTER,
 } from '../../constants';
-import {getQuestionDescription} from '../../helpers';
+import {getQuestionDescription, prepLikertBreakdown} from '../../helpers';
 
 import styles from '../../../workshop.module.scss';
 
@@ -44,6 +44,8 @@ export const Engagement = () => {
               likelyToRecommend.question_short_text ??
               likelyToRecommend.question_text
             }
+            longTitle={likelyToRecommend.question_text}
+            questionType={likelyToRecommend.question_type}
             description={getQuestionDescription(likelyToRecommend)}
             footer={PROMOTER_QUESTION_FOOTER}
             score={likelyToRecommend.results.promoter_percentage}
@@ -56,11 +58,14 @@ export const Engagement = () => {
             <ScoreCard
               key={question.question_name}
               title={question.question_short_text ?? question.question_text}
+              longTitle={question.question_text}
+              questionType={question.question_type}
               description={getQuestionDescription(question)}
               footer={LIKERT_QUESTION_FOOTER}
               score={question.results.weighted_score}
               responseCount={question.results.total_responses}
               minResponseCount={MIN_RESPONSE_COUNT}
+              breakdown={prepLikertBreakdown(question.results.breakdown)}
             />
           ) : null
         )}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/FacilitatorFeedback.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/FacilitatorFeedback.tsx
@@ -10,7 +10,7 @@ import {useWorkshopContext} from '../../../WorkshopLayout';
 import {FreeResponseCard} from '../../components/FreeResponseCard';
 import {ScoreCard} from '../../components/ScoreCard';
 import {LIKERT_QUESTION_FOOTER, MIN_RESPONSE_COUNT} from '../../constants';
-import {getQuestionDescription} from '../../helpers';
+import {getQuestionDescription, prepLikertBreakdown} from '../../helpers';
 
 import styles from '../../../workshop.module.scss';
 
@@ -65,11 +65,14 @@ export const FacilitatorFeedback = () => {
               <ScoreCard
                 key={question.question_name}
                 title={question.question_short_text ?? question.question_text}
+                longTitle={question.question_text}
                 description={getQuestionDescription(question)}
+                questionType={question.question_type}
                 footer={LIKERT_QUESTION_FOOTER}
                 score={question.results.weighted_score}
                 responseCount={question.results.total_responses}
                 minResponseCount={MIN_RESPONSE_COUNT}
+                breakdown={prepLikertBreakdown(question.results.breakdown)}
               />
             ) : null
           )}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
@@ -11,7 +11,7 @@ import {FreeResponseCard} from '../../components/FreeResponseCard';
 import {MultiSelectCard} from '../../components/MultiSelectCard';
 import {ScoreCard} from '../../components/ScoreCard';
 import {LIKERT_QUESTION_FOOTER, MIN_RESPONSE_COUNT} from '../../constants';
-import {getQuestionDescription} from '../../helpers';
+import {getQuestionDescription, prepLikertBreakdown} from '../../helpers';
 
 import styles from '../../../workshop.module.scss';
 
@@ -62,11 +62,14 @@ export const Implementation = () => {
             <ScoreCard
               key={question.question_name}
               title={question.question_short_text ?? question.question_text}
+              longTitle={question.question_text}
               description={getQuestionDescription(question)}
+              questionType={question.question_type}
               footer={LIKERT_QUESTION_FOOTER}
               score={question.results.weighted_score}
               responseCount={question.results.total_responses}
               minResponseCount={MIN_RESPONSE_COUNT}
+              breakdown={prepLikertBreakdown(question.results.breakdown)}
             />
           ) : null
         )}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Logistics.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Logistics.tsx
@@ -9,7 +9,7 @@ import {useWorkshopContext} from '../../../WorkshopLayout';
 import {FreeResponseCard} from '../../components/FreeResponseCard';
 import {ScoreCard} from '../../components/ScoreCard';
 import {LIKERT_QUESTION_FOOTER, MIN_RESPONSE_COUNT} from '../../constants';
-import {getQuestionDescription} from '../../helpers';
+import {getQuestionDescription, prepLikertBreakdown} from '../../helpers';
 
 import styles from '../../../workshop.module.scss';
 
@@ -42,11 +42,14 @@ export const Logistics = () => {
             <ScoreCard
               key={question.question_name}
               title={question.question_short_text ?? question.question_text}
+              longTitle={question.question_text}
               description={getQuestionDescription(question)}
+              questionType={question.question_type}
               footer={LIKERT_QUESTION_FOOTER}
               score={question.results.weighted_score}
               responseCount={question.results.total_responses}
               minResponseCount={MIN_RESPONSE_COUNT}
+              breakdown={prepLikertBreakdown(question.results.breakdown)}
             />
           ) : null
         )}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Other.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Other.tsx
@@ -8,7 +8,7 @@ import {
 import {useWorkshopContext} from '../../../WorkshopLayout';
 import {ScoreCard} from '../../components/ScoreCard';
 import {LIKERT_QUESTION_FOOTER, MIN_RESPONSE_COUNT} from '../../constants';
-import {getQuestionDescription} from '../../helpers';
+import {getQuestionDescription, prepLikertBreakdown} from '../../helpers';
 
 import styles from '../../../workshop.module.scss';
 
@@ -37,11 +37,14 @@ export const Other = () => {
             <ScoreCard
               key={question.question_name}
               title={question.question_short_text ?? question.question_text}
+              longTitle={question.question_text}
               description={getQuestionDescription(question)}
+              questionType={question.question_type}
               footer={LIKERT_QUESTION_FOOTER}
               score={question.results.weighted_score}
               responseCount={question.results.total_responses}
               minResponseCount={MIN_RESPONSE_COUNT}
+              breakdown={prepLikertBreakdown(question.results.breakdown)}
             />
           ) : null
         )}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
@@ -361,66 +361,6 @@ div.card {
         color: var(--text-neutral-tertiary);
         margin-top: 0.313rem;
       }
-
-      .scoreBox {
-        height: 3rem;
-        width: 3rem;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        background-color: var(--background-success-primary);
-        border-radius: 4px;
-        flex-shrink: 0;
-        margin-left: 0.75rem;
-
-        p {
-          color: var(--text-neutral-white-fixed);
-        }
-
-        &.insufficientData {
-          background-color: var(--background-neutral-tertiary);
-          p,
-          i {
-            color: var(--text-neutral-quaternary);
-          }
-
-          i {
-            font-size: 1.75rem;
-          }
-        }
-
-        &.needsAttention {
-          background-color: var(--background-warning-primary);
-          p {
-            color: var(--text-neutral-black-fixed);
-          }
-        }
-
-        &.criticalConcern {
-          background-color: var(--background-error-primary);
-        }
-      }
-    }
-
-    .scoreCardFooter {
-      background-color: var(--background-neutral-secondary);
-      border-bottom-left-radius: inherit;
-      border-bottom-right-radius: inherit;
-      border-top: 1px solid var(--borders-neutral-primary);
-      padding: 0.5rem;
-      padding-left: 1rem;
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-
-      i,
-      p {
-        color: var(--text-neutral-quaternary);
-      }
-
-      i {
-        margin-right: 0.375rem;
-      }
     }
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
@@ -400,39 +400,6 @@ div.card {
           background-color: var(--background-error-primary);
         }
       }
-
-      .barRow {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        gap: 0.5rem;
-
-        .barLabel {
-          min-width: 5rem;
-          flex-shrink: 0;
-          text-align: left;
-          color: var(--text-neutral-tertiary);
-        }
-
-        .barContainer {
-          position: relative;
-          flex: 1;
-          flex-shrink: 0;
-          height: 0.625rem;
-          border-radius: 6.25rem;
-          background: var(--background-neutral-tertiary);
-          overflow: hidden;
-
-          .indicator {
-            background: var(--background-brand-teal-primary);
-            position: absolute;
-            left: 0;
-            top: 0;
-            bottom: 0;
-            transition: width 0.6s ease-out;
-          }
-        }
-      }
     }
 
     .scoreCardFooter {

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/surveys/components/MultiSelectCardTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/surveys/components/MultiSelectCardTest.tsx
@@ -2,11 +2,11 @@ import '@testing-library/jest-dom';
 import {render, screen, waitFor} from '@testing-library/react';
 import React from 'react';
 
-import {MultiSelectBreakdown} from '@cdo/apps/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types';
+import {Breakdown} from '@cdo/apps/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types';
 import {MultiSelectCard} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshops/surveys/components/MultiSelectCard';
 
 describe('MultiSelectCard', () => {
-  const defaultItems: MultiSelectBreakdown[] = [
+  const defaultItems: Breakdown[] = [
     {label: 'Option A', count: 15, percentage: 50},
     {label: 'Option B', count: 10, percentage: 33.3},
     {label: 'Option C', count: 5, percentage: 16.7},

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCardTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCardTest.tsx
@@ -2,11 +2,11 @@ import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 
+import {ScoreCard} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard';
 import {
-  ScoreCard,
   CRITICAL_CONCERN_LIMIT,
   NEEDS_ATTENTION_LIMIT,
-} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard';
+} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshops/surveys/constants';
 
 // Mock the FontAwesomeV6Icon component to make it testable.
 // It will render a span with the iconName as its text content.

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCardTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCardTest.tsx
@@ -20,7 +20,9 @@ jest.mock(
 describe('ScoreCard', () => {
   const defaultProps = {
     title: 'Test Score Card',
+    longTitle: 'Test Score Card Long',
     description: 'This is a test description',
+    questionType: 'likert' as const,
     footer: 'Test footer information',
     score: 85,
     responseCount: 10,


### PR DESCRIPTION
This pull request refactors and enhances the survey results UI components in the workshop dashboard. The main improvements include consolidating breakdown types, introducing a reusable `PercentageBarGroup` component for displaying breakdowns, and updating the `ScoreCard` to support a breakdown dialog. Additionally, several style improvements and code cleanups were made for consistency and maintainability.

**Type and Data Structure Consolidation:**

- Unified multiple breakdown interfaces (`LikertBreakdown`, `PromoterBreakdown`, etc.) into a single `Breakdown` interface, simplifying type usage across survey result types like `LikertResults`, `PromoterResults`, `SingleSelectResults`, and `MultiSelectResults`.

**Component Refactoring and Feature Enhancements:**

- Added a new `PercentageBarGroup` component to render breakdown bars with labels and status-based coloring, replacing individual percentage bar logic in `MultiSelectCard` and enabling reuse.
- Updated `MultiSelectCard` to use the new `PercentageBarGroup` and refactored its props to accept the consolidated `Breakdown` type.

**ScoreCard Improvements:**

- Enhanced `ScoreCard` to support displaying a breakdown dialog with detailed response breakdowns using the `PercentageBarGroup` component. Added support for `longTitle`, `questionType`, and `breakdown` props.
- Moved score thresholds (`CRITICAL_CONCERN_LIMIT`, `NEEDS_ATTENTION_LIMIT`) to a shared constants file for reuse.

**Helper and Usage Updates:**

- Added a `prepLikertBreakdown` helper to prepare Likert breakdown data for display, and updated relevant survey post components (`Engagement`, `FacilitatorFeedback`) to use this helper and pass breakdown data to `ScoreCard`. 

**Styling Improvements:**

- Added new SCSS modules for `ScoreCard` and `PercentageBarGroup` to improve visual consistency and support status-based coloring for breakdown bars.

These changes collectively improve code maintainability, UI consistency, and the user experience when viewing survey response breakdowns.<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

<img width="744" height="597" alt="Screenshot 2025-08-28 at 11 55 51 AM" src="https://github.com/user-attachments/assets/4453fae2-5757-4b2c-b792-13f78cf56796" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3510

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
