### PR TITLE
backfill section course id migration

### DIFF
--- a/dashboard/db/migrate/20250828171244_backfill_section_course_id.rb
+++ b/dashboard/db/migrate/20250828171244_backfill_section_course_id.rb
@@ -1,0 +1,39 @@
+class BackfillSectionCourseId < ActiveRecord::Migration[6.1]
+  BATCH_SIZE = 100
+  INFO_INTERVAL = 1_000
+  def up
+    return if Rails.env.production?
+    CDO.log = Logger.new($stdout)
+    ActiveRecord::Base.record_timestamps = false
+
+    sections_processed = 0
+    sections_not_processed = 0
+
+    Section.with_deleted.where(course_id: nil).where.not(script_id: nil).find_each(batch_size: BATCH_SIZE) do |section|
+      # Be kind to the database by limiting to 1000 sections processed per second
+      sleep 0.001
+
+      ActiveRecord::Base.transaction do
+        CDO.log.info "Processing section #{section.id}" if section.id % INFO_INTERVAL == 0
+
+        # Find the script associated with the section and add the course_id
+        unit = Unit.find_by(id: section.script_id)
+        if unit&.original_unit_group_id
+          section.update_columns(course_id: unit.original_unit_group_id)
+        else
+          # unassign if the section's script_id does not correspond to a valid unit or course
+          section.update_columns(script_id: nil)
+        end
+
+        sections_processed += 1
+      end
+    rescue => exception
+      CDO.log.error "Could not process section #{section.id}"
+      CDO.log.error exception
+      sections_not_processed += 1
+    end
+
+    CDO.log.info "backfill completed"
+    CDO.log.info "#{sections_processed} sections were processed, #{sections_not_processed} experienced errors"
+  end
+end

--- a/dashboard/db/migrate/20250828171244_backfill_section_course_id.rb
+++ b/dashboard/db/migrate/20250828171244_backfill_section_course_id.rb
@@ -2,7 +2,8 @@ class BackfillSectionCourseId < ActiveRecord::Migration[6.1]
   BATCH_SIZE = 100
   INFO_INTERVAL = 1_000
   def up
-    return if Rails.env.production?
+    return if Rails.env.production? || Rails.env.test?
+
     CDO.log = Logger.new($stdout)
     ActiveRecord::Base.record_timestamps = false
 

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_08_21_182723) do
+ActiveRecord::Schema.define(version: 2025_08_28_171244) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
Puts the [section backfill](https://github.com/code-dot-org/code-dot-org/pull/67854) in a rails migration to run in all environments except production and test.

Expected sections to backfill:
- Staging: 15
- Levelbuilder: 40

## Testing story
Ran the migration locally and verified correct functionality

## Deployment Strategy
After the migration is completed, there should be 0 sections 
```
Section.with_deleted.where(course_id: nil).where.not(script_id: nil).count
```

After Merge:
Confirmed migration successfully ran in staging:
```ruby
[staging] dashboard > Section.with_deleted.where(course_id: nil).where.not(script_id: nil).count
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
   (0.7ms)  SELECT COUNT(*) FROM `sections` WHERE `sections`.`course_id` IS NULL AND `sections`.`script_id` IS NOT NULL
=> 0
```

and in levelbuilder: 
```ruby
[levelbuilder] dashboard > Section.with_deleted.where(course_id: nil).where.not(script_id: nil).count
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
=> 0
```
