### PR TITLE
Add "music" Course Offering Topic

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -821,6 +821,7 @@
   "courseOfferingCsTopicGamesAndAnimations": "Games and Animations",
   "courseOfferingCsTopicHardware": "Hardware",
   "courseOfferingCsTopicInternet": "Internet",
+  "courseOfferingCsTopicMusic": "Music",
   "courseOfferingCsTopicPhysicalComputing": "Physical Computing",
   "courseOfferingCsTopicWebDesign": "Web Design",
   "courseOfferingCsTopicProgramming": "Programming",

--- a/apps/src/templates/teacherDashboard/CourseOfferingHelpers.jsx
+++ b/apps/src/templates/teacherDashboard/CourseOfferingHelpers.jsx
@@ -11,6 +11,7 @@ export const translatedCourseOfferingCsTopics = {
   games_and_animations: i18n.courseOfferingCsTopicGamesAndAnimations(),
   hardware: i18n.courseOfferingCsTopicHardware(),
   internet: i18n.courseOfferingCsTopicInternet(),
+  music: i18n.courseOfferingCsTopicMusic(),
   physical_computing: i18n.courseOfferingCsTopicPhysicalComputing(),
   programming: i18n.courseOfferingCsTopicProgramming(),
   web_design: i18n.courseOfferingCsTopicWebDesign(),

--- a/apps/src/templates/teacherDashboard/CourseOfferingHelpers.jsx
+++ b/apps/src/templates/teacherDashboard/CourseOfferingHelpers.jsx
@@ -121,6 +121,7 @@ export const subjectsAndTopicsOrder = [
   'cybersecurity',
   'physical_computing',
   'internet',
+  'music',
   'app_design',
   'games_and_animations',
   'art_and_design',

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -164,6 +164,7 @@ module Curriculum
       games_and_animations
       hardware
       internet
+      music
       physical_computing
       web_design
       programming


### PR DESCRIPTION
Adds "music" as a Course Offering Topic.

### Can add "Music" in the Course Offering Editor
![can add music as topic](https://github.com/user-attachments/assets/d7d8759f-f9f3-4e60-a96a-f4e7c1fd72c7)

### Can filter for "Music" on the Curriculum Catalog
![can filter for music](https://github.com/user-attachments/assets/7f719d07-b184-4002-9630-2026221ea540)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3508)

## Testing story
Local testing.
