### PR TITLE
Lab2 Dance: read default song from start/exemplar sources

### DIFF
--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -150,7 +150,9 @@ export const setSong = createAsyncThunk(
     }
 
     dispatch(setSelectedSong(songId));
-    unloadSong(lastSongId, songData);
+    if (lastSongId) {
+      unloadSong(lastSongId, songData);
+    }
 
     loadSong(songId, songData, async (status: number) => {
       if (status === 403) {
@@ -182,6 +184,43 @@ async function handleSongSelection(
   const metadata = await loadSongMetadata(songId);
   dispatch(setCurrentSongMetadata(metadata));
 }
+
+interface LoadSongsPayload {
+  useRestrictedSongs: boolean;
+  songSelection?: string[];
+}
+
+/** Loads the song manifest only. Used by Lab2 Dance. */
+export const loadSongs = createAsyncThunk(
+  'dance/loadSongs',
+  async ({useRestrictedSongs, songSelection}: LoadSongsPayload, thunkAPI) => {
+    // Check for a user-specified manifest file.
+    const userManifest = queryParams('manifest') as string;
+
+    // Build up a set from our song selection so we can filter our manifest later.
+    const filteredSongSet = new Set(songSelection || []);
+
+    const unfilteredSongManifest = await getSongManifest(
+      useRestrictedSongs,
+      userManifest
+    );
+
+    // TODO: Cache unfiltered song manifest so it persists across multiple levels for Lab2.
+    // a song should be included if we do NOT have a filtered song set
+    // OR if we do have a set and our song's id is in them.
+    let songManifest = unfilteredSongManifest.filter(
+      (song: {id: string}) =>
+        !filteredSongSet.size || filteredSongSet.has(song.id)
+    );
+    // Handle dev scenario where there's no overlap between
+    // levelbuilder-configured songs and the list of dev-only songs
+    if (!songManifest.length) {
+      songManifest = unfilteredSongManifest;
+    }
+    const songData = parseSongOptions(songManifest) as SongData;
+    thunkAPI.dispatch(setSongData(songData));
+  }
+);
 
 const danceSlice = createSlice({
   name: 'dance',

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -10,7 +10,7 @@ import {
   setupBlocklyEnvironment,
 } from '@cdo/apps/dance/blockly/setup';
 import {
-  initSongs,
+  loadSongs,
   reducers,
   setHasEdited,
   setHasRun,
@@ -222,21 +222,19 @@ const DanceView: React.FunctionComponent<
     dispatch(setHasEdited(false));
   }, [levelProperties.id, dispatch]);
 
-  // Initialize song manifest and load initial song when level loads.
+  // Load or update song manifest when level properties change.
   useEffect(() => {
     dispatch(
-      initSongs({
+      loadSongs({
         useRestrictedSongs: levelProperties.useRestrictedSongs || false,
-        selectSongOptions: {
-          defaultSong: levelProperties.defaultSong,
-          selectedSong: initialSources?.selectedSong,
-          isProjectLevel: levelProperties.isProjectLevel || false,
-          freePlay: levelProperties.freePlay || false,
-        },
-        onAuthError,
+        songSelection: levelProperties.songSelection || [],
       })
     );
-  }, [levelProperties, initialSources, dispatch]);
+  }, [
+    levelProperties.useRestrictedSongs,
+    levelProperties.songSelection,
+    dispatch,
+  ]);
 
   // Set up the Blockly workspace when the level changes
   useEffect(() => {
@@ -250,6 +248,7 @@ const DanceView: React.FunctionComponent<
     }
     workspace.current = Blockly.inject(blocklyDiv, {
       toolbox: levelProperties.toolboxBlocks,
+      readOnly: readonlyWorkspace,
     });
 
     const sources =
@@ -257,7 +256,22 @@ const DanceView: React.FunctionComponent<
     loadBlocksToWorkspace(workspace.current, JSON.stringify(sources.source));
 
     return () => workspace.current?.dispose();
-  }, [dispatch, initialSources, levelProperties]);
+  }, [dispatch, initialSources, readonlyWorkspace, levelProperties]);
+
+  // Set the initial song based on initial sources or level default
+  useEffect(() => {
+    const songKeys = Object.keys(songData);
+    if (songKeys.length === 0) {
+      // Song data has not been loaded yet.
+      return;
+    }
+    const sources =
+      getInitialSources(levelProperties, initialSources) ||
+      (defaultSources as DanceProjectSources);
+    dispatch(
+      setSong({songId: sources.selectedSong || songKeys[0], onAuthError})
+    );
+  }, [dispatch, initialSources, levelProperties, songData]);
 
   useEffect(() => {
     workspace.current?.addChangeListener(onBlockSpaceChange);

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -268,9 +268,10 @@ const DanceView: React.FunctionComponent<
     const sources =
       getInitialSources(levelProperties, initialSources) ||
       (defaultSources as DanceProjectSources);
-    dispatch(
-      setSong({songId: sources.selectedSong || songKeys[0], onAuthError})
-    );
+    const selectedSong = sources.selectedSong || levelProperties.defaultSong;
+    const songToUse =
+      selectedSong && songData[selectedSong] ? selectedSong : songKeys[0];
+    dispatch(setSong({songId: songToUse, onAuthError}));
   }, [dispatch, initialSources, levelProperties, songData]);
 
   useEffect(() => {

--- a/apps/src/dance/types.ts
+++ b/apps/src/dance/types.ts
@@ -34,4 +34,5 @@ export interface DanceProjectSources extends ProjectSources {
 export interface DanceLevelProperties extends LevelProperties {
   defaultSong?: string;
   useRestrictedSongs?: boolean;
+  songSelection?: string[];
 }

--- a/dashboard/app/views/levels/editors/fields/_default_song.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_default_song.html.haml
@@ -14,6 +14,9 @@
   Default Song
 
 #defaultSong.in.collapse
+  %p
+    %b NOTE: If using the Lab2 version of Dance, the default song is assigned in Start Mode. This field will have no effect. Go to Start Mode to select the default song.
+
   %p Please note - If you are limiting songs in the Limit Song Selection input, the Default Song must be one of those songs.
   If not, the first song in the list of selected songs will be used as the default song.
   %p

--- a/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
+++ b/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
@@ -59,11 +59,71 @@
         }
       }
     },
+    "exemplar_sources": {
+      "selectedSong": "good4u_oliviarodrigo",
+      "source": {
+        "blocks": {
+          "languageVersion": 0,
+          "blocks": [
+            {
+              "type": "when_run",
+              "id": "when-run-block",
+              "x": 16,
+              "y": 16,
+              "deletable": false,
+              "movable": false,
+              "next": {
+                "block": {
+                  "type": "Dancelab_makeAnonymousDanceSprite",
+                  "id": "1",
+                  "fields": {
+                    "COSTUME": "<field name=\"COSTUME\" config=\"&quot;CAT&quot;,&quot;SLOTH&quot;\">\"CAT\"</field>",
+                    "LOCATION": "<field name=\"LOCATION\">{x: 300, y: 200}</field>"
+                  },
+                  "next": {
+                    "block": {
+                      "type": "Dancelab_makeAnonymousDanceSprite",
+                      "id": "O3,0evv7cLQ0HPA(8WqE",
+                      "fields": {
+                        "COSTUME": "<field name=\"COSTUME\" config=\"&quot;CAT&quot;,&quot;SLOTH&quot;\">\"SLOTH\"</field>",
+                        "LOCATION": "<field name=\"LOCATION\">{x: 100, y: 200}</field>"
+                      },
+                      "next": {
+                        "block": {
+                          "type": "Dancelab_changeMoveEachLR",
+                          "id": "|y+CWEBlleENO5MU(?yL",
+                          "fields": {
+                            "GROUP": "<field name=\"GROUP\" config=\"&quot;CAT&quot;,&quot;SLOTH&quot;\">\"CAT\"</field>",
+                            "MOVE": "<field name=\"MOVE\">MOVES.ClapHigh</field>",
+                            "DIR": "<field name=\"DIR\">-1</field>"
+                          },
+                          "next": {
+                            "block": {
+                              "type": "Dancelab_changeMoveEachLR",
+                              "id": "Vw/DajSIL)Uf2r!oa7jd",
+                              "fields": {
+                                "GROUP": "<field name=\"GROUP\" config=\"&quot;CAT&quot;,&quot;SLOTH&quot;\">\"SLOTH\"</field>",
+                                "MOVE": "<field name=\"MOVE\">MOVES.Floss</field>",
+                                "DIR": "<field name=\"DIR\">1</field>"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
     "preload_asset_list": null
   },
   "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:08.190-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"},{\"changed_at\":\"2025-08-20 23:36:05 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"skin\",\"validation_code\",\"default_song\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-20 23:41:21 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"free_play\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-22 22:53:47 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-26 21:05:16 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:08.190-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"},{\"changed_at\":\"2025-08-20 23:36:05 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"skin\",\"validation_code\",\"default_song\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-20 23:41:21 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"free_play\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-22 22:53:47 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-26 21:05:16 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-27 22:54:36 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:07:26 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:09:07 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:15:17 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:16:16 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>


### PR DESCRIPTION
Follow-up to: https://github.com/code-dot-org/code-dot-org/pull/67980 which has us read the starting song for a level from start/exemplar sources (instead of the `defaultSong` level property). This allows the default song to be assigned in Start mode and saved to the level exemplar. This was also preferred by curriculum since the list of available songs is reflected in the level in start/exemplar mode.

Did a minor refactor to support this use case which breaks out just the manifest loading portion of the `initSongs` thunk into a new separate thunk so that we don't have to also load the initial song at the same time.

Also added some text to the level edit page to make this clear. Let me know if there's a better way to word this!

<img width="782" height="295" alt="Screenshot 2025-08-28 at 11 44 37 AM" src="https://github.com/user-attachments/assets/57c4bc1e-5656-4e94-846d-ef7bac904ba7" />

Start Mode:

https://github.com/user-attachments/assets/e983ae7d-564a-485d-98dc-d6761ff2d440

Exemplar Mode:

https://github.com/user-attachments/assets/2c0d09ff-501e-40ae-9951-76aa372439b5

## Testing story
- Tested locally on Dance Lab2 allthethings