### PR TITLE
Only allow Clever account linking for restricted users

### DIFF
--- a/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
+++ b/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
@@ -21,6 +21,11 @@
   margin: auto;
 }
 
+button.oauth-sign-in.with-clever.restricted {
+  // This ensures the button is the same size as the non-restricted version
+  width: 270px;
+}
+
 #email-side {
   margin-right: auto;
 }

--- a/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
+++ b/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
@@ -16,6 +16,11 @@
   margin-left: auto;
 }
 
+#oauth-side-restricted {
+  flex-grow: 0;
+  margin: auto;
+}
+
 #email-side {
   margin-right: auto;
 }

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -223,7 +223,7 @@ class LtiV1Controller < ApplicationController
         user = Services::Lti.initialize_lti_user(decoded_jwt)
         # If this is a restricted deployment, skip the account linking flow and
         # immediately create the user and sign them in.
-        if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(deployment.id)
+        if deployment.restricted?
           user.lms_landing_opted_out = true
           user.save!
           sign_in user

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -221,7 +221,6 @@ class LtiV1Controller < ApplicationController
         redirect_to destination_url
       else
         user = Services::Lti.initialize_lti_user(decoded_jwt)
-
         # PartialRegistration removes the email address, so store it in a local variable first
         email_address = Services::Lti.get_claim(decoded_jwt, :email)
         Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'new', user.user_type)

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -226,7 +226,7 @@ class LtiV1Controller < ApplicationController
         Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'new', user.user_type)
         PartialRegistration.persist_attributes(session, user)
         # Store the deployment ID in the session, so we can check if it's a restricted deployment later
-        session[:deployment_id] = deployment.id
+        session[:lti_deployment_id] = deployment.id
         publish_linking_page_visit(user, integration[:platform_name])
         render 'lti/v1/account_linking/landing', locals: {email: email_address} and return
       end

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -194,12 +194,6 @@ class LtiV1Controller < ApplicationController
           metadata: metadata,
         )
 
-        # Add user's lti_user_identity to deployment if it doesn't exist
-        lti_user_identity = Queries::Lti.lti_user_identity(user, integration)
-        unless deployment.lti_user_identities.include?(lti_user_identity)
-          deployment.lti_user_identities << lti_user_identity
-        end
-
         # If this is the user's first login, send them into the account linking flow
         unless user.lms_landing_opted_out
           Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue', user.user_type)

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -200,6 +200,11 @@ class LtiV1Controller < ApplicationController
           deployment.lti_user_identities << lti_user_identity
         end
 
+        # TODO: We could also do this when creating users during sync_course
+        if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(deployment.id) && !user.lms_landing_opted_out
+          user.update!(lms_landing_opted_out: true)
+        end
+
         # If this is the user's first login, send them into the account linking flow
         unless user.lms_landing_opted_out
           Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue', user.user_type)
@@ -221,6 +226,13 @@ class LtiV1Controller < ApplicationController
         redirect_to destination_url
       else
         user = Services::Lti.initialize_lti_user(decoded_jwt)
+        # If this is a restricted deployment, skip the account linking flow and
+        # immediately create the user and sign them in.
+        if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(deployment.id)
+          user.save!
+          sign_in user
+          redirect_to destination_url and return
+        end
         # PartialRegistration removes the email address, so store it in a local variable first
         email_address = Services::Lti.get_claim(decoded_jwt, :email)
         Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'new', user.user_type)

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -200,10 +200,10 @@ class LtiV1Controller < ApplicationController
           deployment.lti_user_identities << lti_user_identity
         end
 
-        # TODO: We could also do this when creating users during sync_course
-        if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(deployment.id) && !user.lms_landing_opted_out
-          user.update!(lms_landing_opted_out: true)
-        end
+        # If this is a restricted deployment, skip the account linking flow by setting lms_landing_opted_out to true
+        # if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(deployment.id) && !user.lms_landing_opted_out
+        #   user.update!(lms_landing_opted_out: true)
+        # end
 
         # If this is the user's first login, send them into the account linking flow
         unless user.lms_landing_opted_out
@@ -229,6 +229,7 @@ class LtiV1Controller < ApplicationController
         # If this is a restricted deployment, skip the account linking flow and
         # immediately create the user and sign them in.
         if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(deployment.id)
+          user.lms_landing_opted_out = true
           user.save!
           sign_in user
           redirect_to destination_url and return

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -221,18 +221,13 @@ class LtiV1Controller < ApplicationController
         redirect_to destination_url
       else
         user = Services::Lti.initialize_lti_user(decoded_jwt)
-        # If this is a restricted deployment, skip the account linking flow and
-        # immediately create the user and sign them in.
-        if deployment.restricted?
-          user.lms_landing_opted_out = true
-          user.save!
-          sign_in user
-          redirect_to destination_url and return
-        end
+
         # PartialRegistration removes the email address, so store it in a local variable first
         email_address = Services::Lti.get_claim(decoded_jwt, :email)
         Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'new', user.user_type)
         PartialRegistration.persist_attributes(session, user)
+        # Store the deployment ID in the session, so we can check if it's a restricted deployment later
+        session[:deployment_id] = deployment.id
         publish_linking_page_visit(user, integration[:platform_name])
         render 'lti/v1/account_linking/landing', locals: {email: email_address} and return
       end

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -200,11 +200,6 @@ class LtiV1Controller < ApplicationController
           deployment.lti_user_identities << lti_user_identity
         end
 
-        # If this is a restricted deployment, skip the account linking flow by setting lms_landing_opted_out to true
-        # if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(deployment.id) && !user.lms_landing_opted_out
-        #   user.update!(lms_landing_opted_out: true)
-        # end
-
         # If this is the user's first login, send them into the account linking flow
         unless user.lms_landing_opted_out
           Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue', user.user_type)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -188,9 +188,11 @@ class RegistrationsController < Devise::RegistrationsController
       if Policies::Lti.lti? current_user
         current_user.verify_teacher! if Policies::Lti.unverified_teacher?(current_user)
         if session[:lti_deployment_id] && current_user.lti_user_identities.any?
-          deployment = LtiDeployment.find(session[:lti_deployment_id])
-          lti_identity = current_user.lti_user_identities.first
-          deployment.lti_user_identities << lti_identity if deployment && lti_identity
+          deployment = LtiDeployment.find_by(id: session[:lti_deployment_id])
+          lti_identity = current_user.lti_user_identities.find_by(lti_integration_id: deployment.lti_integration_id)
+          if deployment && lti_identity && !deployment.lti_user_identities.exists?(lti_identity.id)
+            deployment.lti_user_identities << lti_identity
+          end
         end
         lms_name = Queries::Lti.get_lms_name_from_user(current_user)
         metadata = {

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -187,6 +187,11 @@ class RegistrationsController < Devise::RegistrationsController
       PartialRegistration.delete session
       if Policies::Lti.lti? current_user
         current_user.verify_teacher! if Policies::Lti.unverified_teacher?(current_user)
+        if session[:lti_deployment_id] && current_user.lti_user_identities.any?
+          deployment = LtiDeployment.find(session[:lti_deployment_id])
+          lti_identity = current_user.lti_user_identities.first
+          deployment.lti_user_identities << lti_identity if deployment && lti_identity
+        end
         lms_name = Queries::Lti.get_lms_name_from_user(current_user)
         metadata = {
           'user_type' => current_user.user_type,

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -2,7 +2,11 @@
 %link{href: "/shared/css/2022-rebrand-update.css", rel: "stylesheet"}
 
 %h2#linking-page-header= t('lti.account_linking.linking_page_header', provider: params[:lms_name])
-%p#linking-page-description= t('lti.account_linking.linking_page_description')
+- if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(session[:lti_deployment_id])
+  - msg = t('lti.account_linking.linking_page_description_restricted')
+- else
+  - msg = t('lti.account_linking.linking_page_description')
+%p#linking-page-description= msg
 %div#flash-messages= show_flashes.html_safe
 
 - if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(session[:lti_deployment_id])
@@ -10,7 +14,7 @@
     .flex-container
       #oauth-side-restricted.devise-links
         %h3= t('lti.account_linking.connect_with')
-        = button_to omniauth_authorize_path(resource_name, 'clever'), id: "clever-sign-in", class: "oauth-sign-in with-clever" do
+        = button_to omniauth_authorize_path(resource_name, 'clever'), id: "clever-sign-in", class: "oauth-sign-in with-clever restricted" do
           = image_tag("oauth/clever.svg")
           = t('lti.account_linking.connect_button', provider: t("auth.clever"))
 

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -5,7 +5,7 @@
 %p#linking-page-description= t('lti.account_linking.linking_page_description')
 %div#flash-messages= show_flashes.html_safe
 
-- if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(session[:deployment_id])
+- if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(session[:lti_deployment_id])
   %div#link-account-restricted
     .flex-container
       #oauth-side-restricted.devise-links

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -1,44 +1,49 @@
+- require 'policies/lti'
 %link{href: "/shared/css/2022-rebrand-update.css", rel: "stylesheet"}
 
 %h2#linking-page-header= t('lti.account_linking.linking_page_header', provider: params[:lms_name])
 %p#linking-page-description= t('lti.account_linking.linking_page_description')
 %div#flash-messages= show_flashes.html_safe
 
+- restricted = Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(session[:deployment_id])
+
 %div#link-account
   .flex-container
     #oauth-side.devise-links
       %h3= t('lti.account_linking.connect_with')
       - [:google_oauth2, :microsoft_v2_auth, :facebook, :clever].each do |provider|
-        = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
-          = image_tag("oauth/#{provider}.svg")
-          = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
+        - if !restricted || provider == :clever
+          = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
+            = image_tag("oauth/#{provider}.svg")
+            = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
+    -# TODO: We should hide all of this if restricted, and have a restricted div with only clever potentially
+    - if !restricted
+      %div.vertical-or
+        %hr
+        = t("or").upcase
+        %hr
 
-    %div.vertical-or
-      %hr
-      = t("or").upcase
-      %hr
+      #email-side
+        %h3= t('lti.account_linking.connect_with_email')
+        = form_with(url: :lti_v1_account_linking_link_email, method: :post) do |f|
 
-    #email-side
-      %h3= t('lti.account_linking.connect_with_email')
-      = form_with(url: :lti_v1_account_linking_link_email, method: :post) do |f|
+          / Email
+          .field
+            = f.label :email
+            - email = params[:email] || ''
+            = f.text_field :email, value: email, autofocus: email == '', required: true
 
-        / Email
-        .field
-          = f.label :email
-          - email = params[:email] || ''
-          = f.text_field :email, value: email, autofocus: email == '', required: true
+          / Password
+          .field#password_field
+            = f.label :password
+            = f.password_field :password, autofocus: email != '', required: true
 
-        / Password
-        .field#password_field
-          = f.label :password
-          = f.password_field :password, autofocus: email != '', required: true
+          / Additional values to be used in redirects on the link_email controller action
+          = f.hidden_field :lti_provider, value: params[:lti_provider]
+          = f.hidden_field :lms_name, value: params[:lms_name]
 
-        / Additional values to be used in redirects on the link_email controller action
-        = f.hidden_field :lti_provider, value: params[:lti_provider]
-        = f.hidden_field :lms_name, value: params[:lms_name]
-
-        / Sign in button
-        %button#signin-connect-button= t('lti.account_linking.sign_in_and_connect')
+          / Sign in button
+          %button#signin-connect-button= t('lti.account_linking.sign_in_and_connect')
 
   %div.call-to-action-container
     %div

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -7,17 +7,26 @@
 
 - restricted = Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(session[:deployment_id])
 
-%div#link-account
-  .flex-container
-    #oauth-side.devise-links
-      %h3= t('lti.account_linking.connect_with')
-      - [:google_oauth2, :microsoft_v2_auth, :facebook, :clever].each do |provider|
-        - if !restricted || provider == :clever
-          = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
-            = image_tag("oauth/#{provider}.svg")
-            = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
-    -# TODO: We should hide all of this if restricted, and have a restricted div with only clever potentially
-    - if !restricted
+- if restricted
+  %div#link-account-restricted
+    .flex-container
+      #oauth-side-restricted.devise-links
+        %h3= t('lti.account_linking.connect_with')
+        = button_to omniauth_authorize_path(resource_name, 'clever'), id: "clever-sign-in", class: "oauth-sign-in with-clever" do
+          = image_tag("oauth/clever.svg")
+          = t('lti.account_linking.connect_button', provider: t("auth.clever"))
+
+- else
+  %div#link-account
+    .flex-container
+      #oauth-side.devise-links
+        %h3= t('lti.account_linking.connect_with')
+        - [:google_oauth2, :microsoft_v2_auth, :facebook, :clever].each do |provider|
+          - if !restricted || provider == :clever
+            = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
+              = image_tag("oauth/#{provider}.svg")
+              = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
+
       %div.vertical-or
         %hr
         = t("or").upcase
@@ -45,14 +54,14 @@
           / Sign in button
           %button#signin-connect-button= t('lti.account_linking.sign_in_and_connect')
 
-  %div.call-to-action-container
-    %div
-      - if params[:lti_provider].present? && params[:email].present?
-        %a.go-back-link{href: lti_v1_account_linking_landing_path(lti_provider: params[:lti_provider], email: params[:email])}
-          %i.fa.fa-arrow-left
-          = t('lti.account_linking.go_back')
+%div.call-to-action-container
+  %div
+    - if params[:lti_provider].present? && params[:email].present?
+      %a.go-back-link{href: lti_v1_account_linking_landing_path(lti_provider: params[:lti_provider], email: params[:email])}
+        %i.fa.fa-arrow-left
+        = t('lti.account_linking.go_back')
 
-    = link_to t('cancel'), users_cancel_path
+  = link_to t('cancel'), users_cancel_path
 
 
 

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -5,9 +5,7 @@
 %p#linking-page-description= t('lti.account_linking.linking_page_description')
 %div#flash-messages= show_flashes.html_safe
 
-- restricted = Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(session[:deployment_id])
-
-- if restricted
+- if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(session[:deployment_id])
   %div#link-account-restricted
     .flex-container
       #oauth-side-restricted.devise-links
@@ -22,10 +20,9 @@
       #oauth-side.devise-links
         %h3= t('lti.account_linking.connect_with')
         - [:google_oauth2, :microsoft_v2_auth, :facebook, :clever].each do |provider|
-          - if !restricted || provider == :clever
-            = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
-              = image_tag("oauth/#{provider}.svg")
-              = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
+          = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
+            = image_tag("oauth/#{provider}.svg")
+            = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
 
       %div.vertical-or
         %hr

--- a/dashboard/config/locales/base/en.yml
+++ b/dashboard/config/locales/base/en.yml
@@ -1491,6 +1491,7 @@ en:
       launch_from_lms: "Please launch from your LMS to link your account."
       linking_page_header: "Link your %{provider} account to your existing Code.org account"
       linking_page_description: "Choose the sign-in method you normally use to access Code.org"
+      linking_page_description_restricted: "Choose the sign-in method allowed by your school"
       sign_in_and_connect: "Sign in and connect"
       successfully_linked: "You have successfully linked your Code.org account!"
       successfully_unlinked: "You have successfully unlinked your Code.org account."

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -16,7 +16,6 @@ class Policies::Lti
 
   module DeploymentConfiguration
     RESTRICTED_DEPLOYMENTS = [
-      2, # TODO: Remove this after testing
       223 # LAUSD
     ]
   end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -16,6 +16,7 @@ class Policies::Lti
 
   module DeploymentConfiguration
     RESTRICTED_DEPLOYMENTS = [
+      2, # TODO: Remove this after testing
       223 # LAUSD
     ]
   end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -212,6 +212,10 @@ module Services
             deployment.lti_user_identities << lti_user_identity
           end
 
+          # TODO: We could check for restricted deployment here and set lms_landing_opted_out accordingly:
+          # if Policies::Lti.restricted_user?(user)
+          #   user.update!(lms_landing_opted_out: true) # will skip account linking
+          # end
           Metrics::Events.log_event(
             user: user,
             event_name: 'lti_user_created',

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -213,7 +213,7 @@ module Services
           end
 
           # Check for restricted deployment here and set lms_landing_opted_out so the user isn't sent through the account linking flow
-          if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(deployment.id) && !user.lms_landing_opted_out
+          if deployment.restricted? && !user.lms_landing_opted_out
             user.update!(lms_landing_opted_out: true) # will skip account linking
           end
 

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -212,11 +212,6 @@ module Services
             deployment.lti_user_identities << lti_user_identity
           end
 
-          # Check for restricted deployment here and set lms_landing_opted_out so the user isn't sent through the account linking flow
-          if deployment.restricted? && !user.lms_landing_opted_out
-            user.update!(lms_landing_opted_out: true) # will skip account linking
-          end
-
           Metrics::Events.log_event(
             user: user,
             event_name: 'lti_user_created',

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -212,10 +212,11 @@ module Services
             deployment.lti_user_identities << lti_user_identity
           end
 
-          # TODO: We could check for restricted deployment here and set lms_landing_opted_out accordingly:
-          # if Policies::Lti.restricted_user?(user)
-          #   user.update!(lms_landing_opted_out: true) # will skip account linking
-          # end
+          # Check for restricted deployment here and set lms_landing_opted_out so the user isn't sent through the account linking flow
+          if Policies::Lti::DeploymentConfiguration::RESTRICTED_DEPLOYMENTS.include?(deployment.id) && !user.lms_landing_opted_out
+            user.update!(lms_landing_opted_out: true) # will skip account linking
+          end
+
           Metrics::Events.log_event(
             user: user,
             event_name: 'lti_user_created',

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -533,17 +533,6 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert deployment.name
   end
 
-  test 'auth - link lti_user_identity with lti_deployment' do
-    payload = get_valid_payload
-    jwt = create_jwt_and_stub(payload)
-    user = create_preexisting_user(payload)
-    deployment = create(:lti_deployment, deployment_id: @deployment_id, lti_integration: @integration)
-    assert_equal deployment.lti_user_identities.count, 0
-    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
-    assert_equal deployment.lti_user_identities.count, 1
-    assert_equal deployment.lti_user_identities.first, user.lti_user_identities.first
-  end
-
   test 'auth - do not link lti_user_identity with lti_deployment if already linked' do
     payload = get_valid_payload
     jwt = create_jwt_and_stub(payload)

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -500,16 +500,6 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     # could confirm more things here
   end
 
-  test 'auth - create new user but skip account linking if user is part of restricted deployment' do
-    payload = get_valid_payload
-    jwt = create_jwt_and_stub(payload)
-    LtiDeployment.any_instance.stubs(:restricted?).returns(true)
-    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
-    assert_response :redirect
-    user = LtiUserIdentity.find_by(subject: @subject).user
-    assert_equal true, user.lms_landing_opted_out
-  end
-
   test 'auth - given a deployment_id not in our system yet, create LtiDeployment' do
     payload = get_valid_payload
     jwt = create_jwt_and_stub(payload)

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -978,9 +978,9 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
   # Create a user with an auth option matching the given JWT.
   # Useful for bypassing the landing/linking flow.
-  private def create_preexisting_user(jwt_payload, user_type = User::TYPE_TEACHER, landing_opt_out = true)
+  private def create_preexisting_user(jwt_payload, user_type = User::TYPE_TEACHER)
     user = user_type == User::TYPE_TEACHER ? create(:teacher) : create(:student)
-    user.update(lms_landing_opted_out: landing_opt_out)
+    user.update(lms_landing_opted_out: true)
     ao = AuthenticationOption.new(
       user: user,
       email: Services::Lti.get_claim(jwt_payload, :email),

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -500,6 +500,16 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     # could confirm more things here
   end
 
+  test 'auth - create new user but skip account linking if user is part of restricted deployment' do
+    payload = get_valid_payload
+    jwt = create_jwt_and_stub(payload)
+    LtiDeployment.any_instance.stubs(:restricted?).returns(true)
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+    assert_response :redirect
+    user = LtiUserIdentity.find_by(subject: @subject).user
+    assert_equal true, user.lms_landing_opted_out
+  end
+
   test 'auth - given a deployment_id not in our system yet, create LtiDeployment' do
     payload = get_valid_payload
     jwt = create_jwt_and_stub(payload)
@@ -968,9 +978,9 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
   # Create a user with an auth option matching the given JWT.
   # Useful for bypassing the landing/linking flow.
-  private def create_preexisting_user(jwt_payload, user_type = User::TYPE_TEACHER)
+  private def create_preexisting_user(jwt_payload, user_type = User::TYPE_TEACHER, landing_opt_out = true)
     user = user_type == User::TYPE_TEACHER ? create(:teacher) : create(:student)
-    user.update(lms_landing_opted_out: true)
+    user.update(lms_landing_opted_out: landing_opt_out)
     ao = AuthenticationOption.new(
       user: user,
       email: Services::Lti.get_claim(jwt_payload, :email),

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -555,6 +555,34 @@ class RegistrationsControllerTest < ActionController::TestCase
     refute assigns(:user).verified_teacher?
   end
 
+  test 'adds LtiUserIdentity to LtiDeployment if LTI user' do
+    integration = create(:lti_integration, issuer: 'test', client_id: '123456')
+    deployment = create(:lti_deployment, deployment_id: '1234', lti_integration: integration)
+    assert_equal 0, deployment.lti_user_identities.count
+
+    lti_auth_id = "#{integration.issuer}|#{integration.client_id}|#{SecureRandom.uuid}"
+    auth_option = AuthenticationOption.new(
+      authentication_id: lti_auth_id,
+      credential_type: AuthenticationOption::LTI_V1,
+      email: @default_params[:email],
+    )
+
+    session[:lti_deployment_id] = deployment.id
+
+    @user = User.new
+    lti_student_params = @default_params.update(provider: User::PROVIDER_MIGRATED, authentication_options: [auth_option])
+    @user.assign_attributes(lti_student_params)
+
+    PartialRegistration.persist_attributes(session, @user)
+
+    post :create, params: {user: lti_student_params}
+
+    student = User.last
+    assert student.lti_user_identities.any?, 'Expected LTI user identity to be created'
+    assert_equal 1, student.lti_user_identities.first.lti_deployments.count
+    assert_equal deployment.lti_user_identities.first, student.lti_user_identities.first
+  end
+
   test 'redirects signed-in user to home if they attempt to access account_type url' do
     # Create a new user and sign them in
     picture_student = create(:student_in_picture_section)

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -518,29 +518,6 @@ class Services::LtiTest < ActiveSupport::TestCase
     assert_equal lti_section.followers.last, user_to_remove
   end
 
-  test 'should set lms_landing_opted_out to true when creating new users who are part of a restricted deployment' do
-    auth_id = "#{@lti_integration[:issuer]}|#{@lti_integration[:client_id]}|user-id-1"
-    user = create(:teacher)
-    create(:lti_authentication_option, user: user, authentication_id: auth_id)
-
-    section = create(:section, user: user)
-
-    lti_course = create(:lti_course, lti_integration: @lti_integration)
-    lti_section = create(:lti_section, lti_course: lti_course, section: section)
-    Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
-    parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
-    nrps_section = parsed_response[@lms_section_ids.first.to_s]
-
-    # Make the deployment restricted
-    LtiDeployment.any_instance.stubs(:restricted?).returns(true)
-
-    Services::Lti.sync_section_roster(@lti_integration, lti_section, nrps_section)
-
-    lti_section.followers.each do |follower|
-      assert_equal true, follower.student_user.lms_landing_opted_out
-    end
-  end
-
   test 'should update a user\'s name when syncing a section' do
     auth_id = "#{@lti_integration[:issuer]}|#{@lti_integration[:client_id]}|user-id-1"
     user = create(:teacher)

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -518,6 +518,29 @@ class Services::LtiTest < ActiveSupport::TestCase
     assert_equal lti_section.followers.last, user_to_remove
   end
 
+  test 'should set lms_landing_opted_out to true when creating new users who are part of a restricted deployment' do
+    auth_id = "#{@lti_integration[:issuer]}|#{@lti_integration[:client_id]}|user-id-1"
+    user = create(:teacher)
+    create(:lti_authentication_option, user: user, authentication_id: auth_id)
+
+    section = create(:section, user: user)
+
+    lti_course = create(:lti_course, lti_integration: @lti_integration)
+    lti_section = create(:lti_section, lti_course: lti_course, section: section)
+    Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
+    parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
+    nrps_section = parsed_response[@lms_section_ids.first.to_s]
+
+    # Make the deployment restricted
+    LtiDeployment.any_instance.stubs(:restricted?).returns(true)
+
+    Services::Lti.sync_section_roster(@lti_integration, lti_section, nrps_section)
+
+    lti_section.followers.each do |follower|
+      assert_equal true, follower.student_user.lms_landing_opted_out
+    end
+  end
+
   test 'should update a user\'s name when syncing a section' do
     auth_id = "#{@lti_integration[:issuer]}|#{@lti_integration[:client_id]}|user-id-1"
     user = create(:teacher)


### PR DESCRIPTION
This PR narrows account linking via LTI launches for LAUSD users to strictly Clever. It checks if the LTI launch is coming from a "restricted" deployment, and only displays a single Clever button and different text instructions if the user choses to link an existing account.

**UI with only Clever**
<img width="2283" height="1285" alt="Screenshot 2025-09-17 at 2 17 26 PM" src="https://github.com/user-attachments/assets/84a1889a-a67f-45ab-a2a3-648ceb8e6db9" />



**UI remains unchanged for non-restricted users**
<img width="2275" height="1292" alt="Screenshot 2025-09-11 at 9 38 12 AM" src="https://github.com/user-attachments/assets/f17b28d8-6093-4251-b99c-9af16ee955e5" />


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
