### PR TITLE
Add diff chat FAB to the section create page

### DIFF
--- a/apps/src/sites/studio/pages/sections/new.js
+++ b/apps/src/sites/studio/pages/sections/new.js
@@ -2,6 +2,7 @@ import {Heading1} from '@code-dot-org/component-library/typography';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import {displayDifferentiationChat} from '@cdo/apps/aiDifferentiation/aiDiffUtils';
 import DCDO from '@cdo/apps/dcdo';
 import SectionsSetUpContainer from '@cdo/apps/templates/sectionsRefresh/SectionsSetUpContainer';
 import experiments from '@cdo/apps/util/experiments';
@@ -33,4 +34,5 @@ $(document).ready(() => {
     </div>,
     document.getElementById('form')
   );
+  displayDifferentiationChat();
 });

--- a/dashboard/app/views/sections/new.html.haml
+++ b/dashboard/app/views/sections/new.html.haml
@@ -2,3 +2,5 @@
 
 #form
 
+- if Policies::Ai.ai_differentiation_enabled?(current_user)
+  %div#ai-differentiation-fab-mount-point


### PR DESCRIPTION
Add the AI differentiation chat FAB to the section create page. It uses the `GENERAL` chat context- the same as the home page, so all support articles plus their currently assigned courses are in the context, and the pre-set prompt chips are focused on using the CDO platform

<img width="1267" height="959" alt="Screenshot 2025-08-29 at 11 24 51 AM" src="https://github.com/user-attachments/assets/cdcd6cf0-fb92-4cd2-9f31-300c2083e379" />


## Links
- Jira: https://codedotorg.atlassian.net/browse/AITT-1110

## Testing story
I expect an eyes diff for the section page

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
