### PR TITLE
Add unused MailJet mailer file and info

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
@@ -1,0 +1,70 @@
+require_relative '../../../../lib/cdo/mailjet'
+require 'pd/certificate_renderer'
+
+class Pd::WorkshopMailjetMailer
+  def self.send_teacher_workshop_reminder(enrollment, user, use_alternate_email, days)
+    workshop = enrollment.workshop
+    organizer = workshop.organizer
+    regional_partner = workshop.regional_partner
+    email = use_alternate_email ? user.alternate_email : user.email
+    email_vars = {
+      email_to: email,
+      name: user.given_name || user.name,
+      cancel_registration_link: CDO.studio_url("pd/workshop_enrollment/#{enrollment.code}/cancel", CDO.default_scheme),
+      pre_survey_link: enrollment.pre_workshop_survey_url,
+      facilitator_name: workshop.facilitators&.map(&:name)&.join(', '),
+      rp_email: regional_partner&.contact_email_with_backup,
+      rp_name: regional_partner&.name,
+      organizer_email: organizer&.email,
+      organizer_name: organizer&.name,
+      workshop_notes: workshop.notes,
+      sessions: workshop.sessions.map do |session|
+        {
+          datetime: session.start_date_with_start_and_end_times_us_format,
+          format: session.session_format,
+          meeting_link: session.meeting_link,
+          location: session.formatted_location_details
+        }
+      end,
+      workshop_subjects: workshop.course_offerings.present? ? workshop.course_offerings.map(&:display_name)&.join(', ') : workshop.subject,
+      workshop_name: workshop.name.presence || "#{workshop.course} #{workshop.subject}",
+      num_days: days
+    }
+
+    retryable_send_email('teacher_workshop_reminder', email, user.friendly_name, email_vars)
+  end
+
+  def self.send_teacher_post_workshop_survey(enrollment, user, use_alternate_email)
+    workshop = enrollment.workshop
+    organizer = workshop.organizer
+    regional_partner = workshop.regional_partner
+    email = use_alternate_email ? user.alternate_email : user.email
+    email_vars = {
+      email_to: email,
+      name: user.given_name || user.name,
+      exit_survey_url: enrollment.exit_survey_url,
+      download_certificate_url: CDO.studio_url("/pd/generate_workshop_certificate/#{enrollment.code}", CDO.default_scheme),
+      rp_email: regional_partner&.contact_email_with_backup,
+      rp_name: regional_partner&.name,
+      organizer_email: organizer&.email,
+      organizer_name: organizer&.name
+    }
+
+    retryable_send_email('teacher_post_workshop_survey', email, user.friendly_name, email_vars)
+  end
+
+  private_class_method def self.retryable_send_email(email_name, email, name, vars)
+    Retryable.retryable(
+      on: RestClient::TooManyRequests,
+      tries: MailJet::MAILJET_RETRY_LIMIT,
+      sleep: ->(n) {2 ** n}
+    ) do
+      MailJet.send_email(
+        email_name.to_sym,
+        email,
+        name,
+        vars: vars
+      )
+    end
+  end
+end

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -1,4 +1,6 @@
 module MailJetConstants
+  MAILJET_RETRY_LIMIT = 5
+
   EMAILS = {
     welcome: {
       template_id: {
@@ -28,6 +30,27 @@ module MailJetConstants
         },
         development: {
           default: 6_205_188,
+        }
+      },
+      from_address: 'noreply@code.org',
+      from_name: 'Code.org',
+    },
+    teacher_workshop_reminder: {
+      template_id: {
+        production: {
+          default: 7_182_428,
+        },
+        development: {
+          default: 7_208_545,
+        }
+      },
+      from_address: 'noreply@code.org',
+      from_name: 'Code.org',
+    },
+    teacher_post_workshop_survey: {
+      template_id: {
+        production: {
+          default: 7_192_300,
         }
       },
       from_address: 'noreply@code.org',


### PR DESCRIPTION
Since both PD MailJet PR's had to be reverted ([3-/10-day reminder](https://github.com/code-dot-org/code-dot-org/pull/67975) and [post-workshop survey](https://github.com/code-dot-org/code-dot-org/pull/67974)) but without a clear issue, this PR takes one step towards being able to test why they weren't sending (while other non-PD MailJet emails do send). This just adds the workshop mailjet mailer file that was added in the [3-/10-day reminder PR](https://github.com/code-dot-org/code-dot-org/pull/67554/files#diff-389f943a2a922f0b89451ac3eadf6c14c6ecc01e86ae8aa89bff248ac2338234) (and updated in the [post-workshop survey PR](https://github.com/code-dot-org/code-dot-org/pull/67759/files#diff-389f943a2a922f0b89451ac3eadf6c14c6ecc01e86ae8aa89bff248ac2338234)) and its associated MailJet constants without actually calling it anywhere.

In a followup, I'll add a non-user-facing call to these emails so they can be tested on production without affecting users or disrupting their currnet PD emails. Unfortunately, MailJet appears to work in the PD space locally but not on production so testing on production is required.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3501)
