### PR TITLE
Lab2 Dance: generic source management container

### DIFF
--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -42,13 +42,9 @@ export const useInitialSources = (
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const exemplarSources = levelProperties.exemplarSources as MultiFileSource;
   const startSources = levelProperties.startSources as MultiFileSource;
-  const {
-    serializedMaze,
-    miniApp,
-    validationFile,
-    templateSources,
-    predictSettings,
-  } = levelProperties;
+  const templateSources = levelProperties.templateSources as MultiFileSource;
+  const {serializedMaze, miniApp, validationFile, predictSettings} =
+    levelProperties;
 
   const generateMazeFile = (mazeContents: MazeCell[][], fileId: string) => {
     return {

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,5 +1,6 @@
 import {Events, WorkspaceSvg} from 'blockly/core';
 import classNames from 'classnames';
+import {isEqual} from 'lodash';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {loadBlocksToWorkspace} from '@cdo/apps/blockly/addons/cdoUtils';
@@ -38,9 +39,9 @@ import loadingGif from '@cdo/static/dance/DancePartyLoading.gif';
 
 import danceI18n from '../locale';
 import ProgramExecutor from '../ProgramExecutor';
-import getInitialSources from '../utils/getInitialSources';
 
 import DanceControls from './DanceControls';
+import SourcesContainer, {useSources} from './SourcesContainer';
 
 import moduleStyles from './dance-view.module.scss';
 
@@ -53,15 +54,14 @@ registerReducers(reducers);
  * Renders the Lab2 version of Dance Lab. This separate container
  * allows us to support both Lab2 and legacy Dance.
  */
-const DanceView: React.FunctionComponent<
-  LabProps<DanceLevelProperties, DanceProjectSources>
-> = ({levelProperties, initialSources}) => {
+const DanceView: React.FunctionComponent<{
+  levelProperties: DanceLevelProperties;
+}> = ({levelProperties}) => {
   const dispatch = useAppDispatch();
 
   const isRunning = useAppSelector(state => state.dance.isRunning);
   const userType = useAppSelector(state => state.currentUser.userType);
   const under13 = useAppSelector(state => state.currentUser.under13);
-  const selectedSong = useAppSelector(state => state.dance.selectedSong);
   const songData = useAppSelector(state => state.dance.songData);
   const readonlyWorkspace = useAppSelector(isReadOnlyWorkspace);
   const currentSongMetadata = useAppSelector(
@@ -71,19 +71,10 @@ const DanceView: React.FunctionComponent<
   const hasEdited = useAppSelector(state => state.dance.hasEdited);
   const isLoading = useAppSelector(state => state.dance.isLoading);
 
+  const {currentSources, updateSources} = useSources<DanceProjectSources>();
+
   const programExecutor = useRef<ProgramExecutor | null>(null);
   const workspace = useRef<WorkspaceSvg | null>(null);
-
-  const getSourcesToSave = (selectedSong: string) => {
-    if (!workspace.current) {
-      return;
-    }
-    const blocksJson = Blockly.serialization.workspaces.save(workspace.current);
-    return {
-      selectedSong,
-      source: blocksJson,
-    };
-  };
 
   const WorkspaceAlert = useLevelEditMode(
     levelProperties.id,
@@ -94,19 +85,12 @@ const DanceView: React.FunctionComponent<
           // TODO: Support toolbox edit mode (get toolbox definition from workspace)
           return {};
         }
-        if (!selectedSong) {
-          return {};
-        }
-        const sourcesToSave = getSourcesToSave(selectedSong);
-        if (sourcesToSave) {
-          return {
-            [mode === 'start' ? 'start_sources' : 'exemplar_sources']:
-              sourcesToSave,
-          };
-        }
-        return {};
+        return {
+          [mode === 'start' ? 'start_sources' : 'exemplar_sources']:
+            currentSources,
+        };
       },
-      [selectedSong]
+      [currentSources]
     )
   );
 
@@ -126,22 +110,24 @@ const DanceView: React.FunctionComponent<
 
   const onSetSong = useCallback(
     (songId: string) => {
-      dispatch(setSong({songId, onAuthError}));
+      updateSources({...currentSources, selectedSong: songId});
     },
-    [dispatch]
+    [updateSources, currentSources]
   );
 
-  const saveProject = useCallback((selectedSong: string, forceSave = false) => {
-    const sourcesToSave = getSourcesToSave(selectedSong);
-    if (sourcesToSave) {
-      Lab2Registry.getInstance()
-        .getProjectManager()
-        ?.save(sourcesToSave, forceSave);
-    }
-  }, []);
+  const saveBlocks = useCallback(
+    (forceSave = false) => {
+      if (!workspace.current) {
+        return;
+      }
+      const blocks = Blockly.serialization.workspaces.save(workspace.current);
+      updateSources({...currentSources, source: blocks}, forceSave);
+    },
+    [currentSources, updateSources]
+  );
 
   const runProgram = useCallback(async () => {
-    if (!programExecutor.current || !currentSongMetadata || !selectedSong) {
+    if (!programExecutor.current || !currentSongMetadata) {
       return;
     }
 
@@ -156,14 +142,8 @@ const DanceView: React.FunctionComponent<
     dispatch(setRunIsStarting(false));
     dispatch(setIsRunning(true));
     dispatch(setHasRun(true));
-    saveProject(selectedSong, true);
-  }, [
-    programExecutor,
-    currentSongMetadata,
-    selectedSong,
-    saveProject,
-    dispatch,
-  ]);
+    saveBlocks(true);
+  }, [programExecutor, currentSongMetadata, saveBlocks, dispatch]);
 
   const resetProgram = useCallback(() => {
     programExecutor.current?.reset();
@@ -198,23 +178,14 @@ const DanceView: React.FunctionComponent<
       if (!isRunning) {
         programExecutor.current?.staticPreview(Blockly.getWorkspaceCode());
       }
-      if (selectedSong) {
-        saveProject(selectedSong);
-        dispatch(setHasEdited(true));
-      }
+      saveBlocks();
+      dispatch(setHasEdited(true));
     },
-    [selectedSong, isRunning, dispatch, saveProject]
+    [isRunning, dispatch, saveBlocks]
   );
 
   // Setup Blockly for dance party when first mounting.
   useEffect(setupBlocklyEnvironment, []);
-
-  // Save project when selected song changes
-  useEffect(() => {
-    if (selectedSong) {
-      saveProject(selectedSong);
-    }
-  }, [selectedSong, saveProject]);
 
   // Reset hasRun and hasEdited flag when level changes
   useEffect(() => {
@@ -251,28 +222,47 @@ const DanceView: React.FunctionComponent<
       readOnly: readonlyWorkspace,
     });
 
-    const sources =
-      getInitialSources(levelProperties, initialSources) || defaultSources;
-    loadBlocksToWorkspace(workspace.current, JSON.stringify(sources.source));
-
     return () => workspace.current?.dispose();
-  }, [dispatch, initialSources, readonlyWorkspace, levelProperties]);
+  }, [dispatch, readonlyWorkspace, levelProperties]);
 
-  // Set the initial song based on initial sources or level default
+  useEffect(() => {
+    if (!workspace.current) {
+      return;
+    }
+    const blocks = Blockly.serialization.workspaces.save(workspace.current);
+    if (isEqual(blocks, currentSources.source)) {
+      return;
+    }
+    loadBlocksToWorkspace(
+      workspace.current,
+      JSON.stringify(currentSources.source)
+    );
+  }, [currentSources.source]);
+
   useEffect(() => {
     const songKeys = Object.keys(songData);
     if (songKeys.length === 0) {
       // Song data has not been loaded yet.
       return;
     }
-    const sources =
-      getInitialSources(levelProperties, initialSources) ||
-      (defaultSources as DanceProjectSources);
-    const selectedSong = sources.selectedSong || levelProperties.defaultSong;
-    const songToUse =
-      selectedSong && songData[selectedSong] ? selectedSong : songKeys[0];
-    dispatch(setSong({songId: songToUse, onAuthError}));
-  }, [dispatch, initialSources, levelProperties, songData]);
+    // In case there is no song set in the current sources, set it to the default.
+    if (!currentSources.selectedSong) {
+      updateSources({...currentSources, selectedSong: songKeys[0]});
+    }
+  }, [songData, currentSources, updateSources]);
+
+  // Load the selected song whenever it changes in project sources.
+  useEffect(() => {
+    const songKeys = Object.keys(songData);
+    if (songKeys.length === 0 || !currentSources.selectedSong) {
+      return;
+    }
+    // Make sure the song is available
+    const songId = songData[currentSources.selectedSong]
+      ? currentSources.selectedSong
+      : songKeys[0];
+    dispatch(setSong({songId, onAuthError}));
+  }, [dispatch, currentSources.selectedSong, levelProperties, songData]);
 
   useEffect(() => {
     workspace.current?.addChangeListener(onBlockSpaceChange);
@@ -334,11 +324,11 @@ const DanceView: React.FunctionComponent<
         className={moduleStyles.visualizationArea}
       >
         <div className={moduleStyles.visualizationColumn}>
-          {selectedSong && (
+          {currentSources.selectedSong && (
             <SongSelector
               enableSongSelection={!isRunning}
               setSong={onSetSong}
-              selectedSong={selectedSong}
+              selectedSong={currentSources.selectedSong}
               songData={songData}
               filterOn={filterOn}
               levelIsRunning={isRunning}
@@ -378,4 +368,14 @@ const DanceView: React.FunctionComponent<
   );
 };
 
-export default DanceView;
+const DanceLab: React.FC<
+  LabProps<DanceLevelProperties, DanceProjectSources>
+> = props => {
+  return (
+    <SourcesContainer {...props} defaultSources={defaultSources}>
+      <DanceView levelProperties={props.levelProperties} />
+    </SourcesContainer>
+  );
+};
+
+export default DanceLab;

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -230,13 +230,12 @@ const DanceView: React.FunctionComponent<{
       return;
     }
     const blocks = Blockly.serialization.workspaces.save(workspace.current);
-    if (isEqual(blocks, currentSources.source)) {
-      return;
+    if (!isEqual(blocks, currentSources.source)) {
+      loadBlocksToWorkspace(
+        workspace.current,
+        JSON.stringify(currentSources.source)
+      );
     }
-    loadBlocksToWorkspace(
-      workspace.current,
-      JSON.stringify(currentSources.source)
-    );
   }, [currentSources.source]);
 
   useEffect(() => {
@@ -247,9 +246,12 @@ const DanceView: React.FunctionComponent<{
     }
     // In case there is no song set in the current sources, set it to the default.
     if (!currentSources.selectedSong) {
-      updateSources({...currentSources, selectedSong: songKeys[0]});
+      const defaultSong = levelProperties.defaultSong;
+      const songToUse =
+        defaultSong && songData[defaultSong] ? defaultSong : songKeys[0];
+      updateSources({...currentSources, selectedSong: songToUse});
     }
-  }, [songData, currentSources, updateSources]);
+  }, [songData, currentSources, updateSources, levelProperties.defaultSong]);
 
   // Load the selected song whenever it changes in project sources.
   useEffect(() => {
@@ -368,14 +370,8 @@ const DanceView: React.FunctionComponent<{
   );
 };
 
-const DanceLab: React.FC<
-  LabProps<DanceLevelProperties, DanceProjectSources>
-> = props => {
-  return (
-    <SourcesContainer {...props} defaultSources={defaultSources}>
-      <DanceView levelProperties={props.levelProperties} />
-    </SourcesContainer>
-  );
-};
-
-export default DanceLab;
+export default (props: LabProps<DanceLevelProperties, DanceProjectSources>) => (
+  <SourcesContainer {...props} defaultSources={defaultSources}>
+    <DanceView levelProperties={props.levelProperties} />
+  </SourcesContainer>
+);

--- a/apps/src/dance/lab2/views/SourcesContainer.tsx
+++ b/apps/src/dance/lab2/views/SourcesContainer.tsx
@@ -1,0 +1,74 @@
+import {isEqual} from 'lodash';
+import React, {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {LabProps, ProjectSources} from '@cdo/apps/lab2/types';
+
+import getInitialSources from '../utils/getInitialSources';
+
+interface SourcesContextType<T extends ProjectSources = ProjectSources> {
+  currentSources: T;
+  updateSources: (newSources: T, forceSave?: boolean) => void;
+}
+
+const SourcesContext = createContext<SourcesContextType | null>(null);
+
+export function useSources<T extends ProjectSources = ProjectSources>() {
+  const context = useContext(SourcesContext);
+  if (context === null) {
+    throw new Error('useSources must be used within a SourcesProvider');
+  }
+  // The SourcesContext object has to be created without a specific type,
+  // so TS complains about casting context to a parameterized type.
+  // Cast to unknown to get the correctly typed object.
+  return context as unknown as SourcesContextType<T>;
+}
+
+/**
+ * Manages sources for a Lab. Currently used by Dance Lab2, but is intentionally
+ * designed to be lab-agnostic so that it can be used by other labs in the future.
+ */
+const SourcesContainer: React.FC<
+  LabProps & {children: ReactNode; defaultSources: ProjectSources}
+> = ({levelProperties, initialSources, defaultSources, children}) => {
+  const [currentSources, setCurrentSources] = useState<ProjectSources>(
+    () => getInitialSources(levelProperties, initialSources) || defaultSources
+  );
+
+  useEffect(() => {
+    setCurrentSources(
+      getInitialSources(levelProperties, initialSources) || defaultSources
+    );
+  }, [levelProperties, initialSources, defaultSources]);
+
+  const updateSources = useCallback(
+    (newSources: ProjectSources, forceSave = false) => {
+      setCurrentSources(prev => {
+        // Perform a deep equality check to prevent unnecessary re-renders
+        if (isEqual(prev, newSources)) {
+          return prev;
+        }
+        return newSources;
+      });
+      Lab2Registry.getInstance()
+        .getProjectManager()
+        ?.save(newSources, forceSave);
+    },
+    [setCurrentSources]
+  );
+
+  return (
+    <SourcesContext.Provider value={{currentSources, updateSources}}>
+      {children}
+    </SourcesContext.Provider>
+  );
+};
+
+export default SourcesContainer;

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -167,8 +167,10 @@ export interface LevelProperties {
   isK1?: boolean;
   skin?: string;
   toolboxBlocks?: string;
-  startSources?: Source;
-  templateSources?: MultiFileSource;
+  // Dance stores the full main.json source structure (ProjectSources) in start/template/exemplar sources,
+  // while PythonLab/Weblab2 stores just the source code (MultiFileSource). TODO: Can we reconcile these?
+  startSources?: ProjectSources | MultiFileSource;
+  templateSources?: ProjectSources | MultiFileSource;
   sharedBlocks?: BlockDefinition[];
   validations?: Validation[];
   baseAssetUrl?: string;
@@ -182,7 +184,7 @@ export interface LevelProperties {
   helpVideos?: VideoData[];
   // Exemplars
   exampleSolutions?: string[];
-  exemplarSources?: Source;
+  exemplarSources?: ProjectSources | MultiFileSource;
   exemplarSettings?: ExemplarSettings;
   // For Teachers Only value
   teacherMarkdown?: string;

--- a/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
+++ b/apps/test/unit/codebridge/hooks/useInitialSourcesTest.tsx
@@ -216,7 +216,7 @@ describe('useInitialSources', () => {
       '1'
     );
     const expectedTemplateSources = getExpectedMazeSources(
-      levelProperties.templateSources,
+      levelProperties.templateSources as MultiFileSource,
       levelProperties.serializedMaze!,
       '1'
     );


### PR DESCRIPTION
This is a minor pre-factor I've been wanting to do to test out a new paradigm for source management in Lab2 (along the lines of https://github.com/code-dot-org/code-dot-org/pull/67276). It's somewhat similar to what Codebridge already does in abstracting away source management from the core lab code, and I'm hoping to keep it generic enough that we can eventually adapt it for other labs, if/when we have time.

This moves project source **loading** and **updating** into a wrapper component (called `SourcesContainer`). SourceContainer exposes a hook that the lab can use to grab 1) the current sources for the project and 2) a function to update sources whenever they change. In its current form it's pretty simple, but provides a few key benefits that I think will help unlock future scenarios more easily. These are:
- Single source of truth for the current sources, i.e. "what code is currently in the workspace". No more need to manage `initialSources`, `startSources`, `exemplarSources`, etc, plus the current state of the workspace, all separately.

  - In Dance, one interesting side effect is that we no longer need to rely on the `selectedSong` value in redux. Instead, the `selectedSong` in the `currentSources` is _always_ one and only source of truth for the selected song on the level. There might be minor quirks to this such as when a song is unavailable/deprecated, but for the most part this helps clean up the component logic.

- One function to both update and save sources. The lab doesn't need to manually call `ProjectManager.save()` directly as this is handled by the wrapper whenever sources update. Again, this isn't a huge change for now since `ProjectManager.save()` is just one function call, but it helps maintain the single source of truth mentioned above, and also has benefits for scenarios like Start Over (coming soon)

Again, not too much going on its current state here (and no functional changes to the lab), but hoping to lay some groundwork, especially for some more interesting future use cases (such as no-reload start/exemplar mode). Happy to discuss in more details and/or walk through in person if anyone would like!

## Testing story
- Tested with allthethings lab2 dance party