### PR TITLE
Fix TTS icon in Panels

### DIFF
--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -234,7 +234,12 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
               textLayoutClass
             )}
           >
-            {offerBrowserTts && <TextToSpeech text={panel.text} />}
+            {offerBrowserTts && (
+              // Override the theme since the text container is always white.
+              <div className={styles.ttsContainer} data-theme="Light">
+                <TextToSpeech text={panel.text} />
+              </div>
+            )}
             {showTyping ? (
               <div>
                 <div className={styles.invisiblePlaceholder}>{plainText}</div>

--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -168,6 +168,14 @@ $text-horizontal-padding: 2.6cqw;
         bottom: $text-offset-y;
         right: $text-offset-x;
       }
+
+      .ttsContainer {
+        position: absolute;
+        display: flex;
+        justify-content: flex-end;
+        right: 7px;
+        bottom: 7px;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes TTS position and color in panels levels. This was an accidental regression introduced in https://github.com/code-dot-org/code-dot-org/pull/67213 (at least for the positioning issue).


| Before | After |
| -------- | ------- |
| <img width="1510" height="824" alt="Screenshot 2025-08-29 at 2 51 21 PM" src="https://github.com/user-attachments/assets/2feec0b2-d883-493e-8c35-1eff041257ed" />  | <img width="1511" height="824" alt="Screenshot 2025-08-29 at 2 51 01 PM" src="https://github.com/user-attachments/assets/94139684-ac50-430e-a408-5e6464a4344f" /> |
| <img width="1512" height="825" alt="Screenshot 2025-08-29 at 2 55 09 PM" src="https://github.com/user-attachments/assets/5f7473cd-8b3b-48d3-a007-cc40cc37dc6d" />  | <img width="1512" height="828" alt="Screenshot 2025-08-29 at 2 55 42 PM" src="https://github.com/user-attachments/assets/4c4afde1-f3e4-4b97-b3fd-b310ad653d1f" /> |
| <img width="1513" height="824" alt="Screenshot 2025-08-29 at 3 00 38 PM" src="https://github.com/user-attachments/assets/3059e9e8-019d-4525-b2b5-2c38045363e9" />  | <img width="1512" height="824" alt="Screenshot 2025-08-29 at 3 02 06 PM" src="https://github.com/user-attachments/assets/5a7d82c0-439e-44b5-b0b2-51003ffbd7bd" /> |
