### PR TITLE
feat(link): auto-detect external links

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "turbo": "^2.3.0",
     "typescript": "5.5.4"
   },
-  "packageManager": "yarn@4.6.0+sha512.5383cc12567a95f1d668fbe762dfe0075c595b4bfff433be478dbbe24e05251a8e8c3eb992a986667c1d53b6c3a9c85b8398c35a960587fbd9fa3a0915406728",
+  "packageManager": "yarn@4.6.0",
   "engines": {
     "node": ">=20"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "turbo": "^2.3.0",
     "typescript": "5.5.4"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.6.0+sha512.5383cc12567a95f1d668fbe762dfe0075c595b4bfff433be478dbbe24e05251a8e8c3eb992a986667c1d53b6c3a9c85b8398c35a960587fbd9fa3a0915406728",
   "engines": {
     "node": ">=20"
   }

--- a/frontend/packages/component-library/src/link/Link.tsx
+++ b/frontend/packages/component-library/src/link/Link.tsx
@@ -109,44 +109,30 @@ const Link: React.FunctionComponent<LinkProps> = ({
  */
 const ABSOLUTE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
 
-/**
- * Checks if a given URL is external
- *
- * Taken from https://github.com/remix-run/react-router/blob/20d8307d4a51c219f6e13e0b66461e7162d944e4/packages/react-router/lib/dom/lib.tsx#L1292-L1322
- *
- * Note: this currently only works client-side (because it uses window.location.href)
- */
+const INTERNAL_URL_REGEX_LIST = [
+  // Matches "https://code.org", "https://studio.code.org", "http://localhost-studio.code.org:3000/"
+  /^(?:https?:\/\/)?(?:[a-z0-9-]+\.)?code\.org(:\d+)?/i,
+  // Storybooks
+  /^(?:https?:\/\/)?localhost(:\d+)?/i,
+  // dev-code.org
+  /^(?:https?:\/\/)?dev-code.org(:\d+)?/i,
+  // hourofcode.com
+  /^(?:https?:\/\/)?hourofcode.com(:\d+)?/i,
+  // csedweek.org
+  /^(?:https?:\/\/)?csedweek.org(:\d+)?/i,
+];
+
 const isExternalUrl = (href: string) => {
   const isAbsolute = ABSOLUTE_URL_REGEX.test(href);
 
-  if (typeof href !== 'string' || !isAbsolute) {
+  if (!isAbsolute) {
     return false;
   }
 
-  const isBrowser =
-    typeof window !== 'undefined' &&
-    typeof window.document !== 'undefined' &&
-    typeof window.document.createElement !== 'undefined';
+  // Tests the absolute URL (e.g. "https://example.com") against our list of internal URLs
+  const isInternal = INTERNAL_URL_REGEX_LIST.some(regex => regex.test(href));
 
-  if (!isBrowser) {
-    return false;
-  }
-
-  // Only check for external origins client-side
-  try {
-    const currentUrl = new URL(window.location.href);
-    const targetUrl = /^\/\//.test(href)
-      ? new URL(currentUrl.protocol + href)
-      : new URL(href);
-
-    if (targetUrl.origin !== currentUrl.origin) {
-      return true;
-    }
-  } catch {
-    // invalid URL
-  }
-
-  return false;
+  return !isInternal;
 };
 
 export default Link;

--- a/frontend/packages/component-library/src/link/Link.tsx
+++ b/frontend/packages/component-library/src/link/Link.tsx
@@ -74,11 +74,7 @@ const Link: React.FunctionComponent<LinkProps> = ({
   ...HTMLAttributes
 }) => {
   // Determine if link is external: use external prop if provided, otherwise auto-detect
-  let isExternal = external !== undefined ? external : false;
-
-  if (external === undefined) {
-    isExternal = isExternalUrl(href);
-  }
+  const isExternal = external !== undefined ? external : isExternalUrl(href);
 
   return (
     <a

--- a/frontend/packages/component-library/src/link/Link.tsx
+++ b/frontend/packages/component-library/src/link/Link.tsx
@@ -72,26 +72,86 @@ const Link: React.FunctionComponent<LinkProps> = ({
   type = 'primary',
   role,
   ...HTMLAttributes
-}) => (
-  <a
-    className={classNames(
-      moduleStyles.link,
-      moduleStyles[`link-${type}`],
-      moduleStyles[`link-${size}`],
-      className,
-    )}
-    href={!disabled ? href : undefined}
-    id={id}
-    onClick={!disabled ? onClick : undefined}
-    rel={openInNewTab || external ? 'noopener noreferrer' : undefined}
-    target={(openInNewTab || undefined) && '_blank'}
-    role={role}
-    {...(disabled ? {'aria-disabled': true} : {})}
-    {...HTMLAttributes}
-  >
-    {text || children}
-    {external && <FontAwesomeV6Icon {...externalLinkIconProps} />}
-  </a>
-);
+}) => {
+  // Determine if link is external: use external prop if provided, otherwise auto-detect
+  let isExternal = external !== undefined ? external : false;
+
+  if (external === undefined) {
+    isExternal = isExternalUrl(href);
+  }
+
+  return (
+    <a
+      className={classNames(
+        moduleStyles.link,
+        moduleStyles[`link-${type}`],
+        moduleStyles[`link-${size}`],
+        className,
+      )}
+      href={!disabled ? href : undefined}
+      id={id}
+      onClick={!disabled ? onClick : undefined}
+      rel={openInNewTab || isExternal ? 'noopener noreferrer' : undefined}
+      target={(openInNewTab || undefined) && '_blank'}
+      role={role}
+      {...(disabled ? {'aria-disabled': true} : {})}
+      {...HTMLAttributes}
+    >
+      {text || children}
+      {isExternal && <FontAwesomeV6Icon {...externalLinkIconProps} />}
+    </a>
+  );
+};
+
+/**
+ * Regex to check if a given URL starts with a protocol or double slash.
+ *
+ *  e.g.:
+ * - https://example.com
+ * - //example.com
+ * - ftp://example.com
+ * - mailto:example@example.com
+ */
+const ABSOLUTE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
+/**
+ * Checks if a given URL is external
+ *
+ * Taken from https://github.com/remix-run/react-router/blob/20d8307d4a51c219f6e13e0b66461e7162d944e4/packages/react-router/lib/dom/lib.tsx#L1292-L1322
+ *
+ * Note: this currently only works client-side (because it uses window.location.href)
+ */
+const isExternalUrl = (href: string) => {
+  const isAbsolute = ABSOLUTE_URL_REGEX.test(href);
+
+  if (typeof href !== 'string' || !isAbsolute) {
+    return false;
+  }
+
+  const isBrowser =
+    typeof window !== 'undefined' &&
+    typeof window.document !== 'undefined' &&
+    typeof window.document.createElement !== 'undefined';
+
+  if (!isBrowser) {
+    return false;
+  }
+
+  // Only check for external origins client-side
+  try {
+    const currentUrl = new URL(window.location.href);
+    const targetUrl = /^\/\//.test(href)
+      ? new URL(currentUrl.protocol + href)
+      : new URL(href);
+
+    if (targetUrl.origin !== currentUrl.origin) {
+      return true;
+    }
+  } catch {
+    // invalid URL
+  }
+
+  return false;
+};
 
 export default Link;

--- a/frontend/packages/component-library/src/link/Link.tsx
+++ b/frontend/packages/component-library/src/link/Link.tsx
@@ -73,7 +73,6 @@ const Link: React.FunctionComponent<LinkProps> = ({
   role,
   ...HTMLAttributes
 }) => {
-  // Determine if link is external: use external prop if provided, otherwise auto-detect
   const isExternal = external !== undefined ? external : isExternalUrl(href);
 
   return (

--- a/frontend/packages/component-library/src/link/__tests__/Link.test.tsx
+++ b/frontend/packages/component-library/src/link/__tests__/Link.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, cleanup} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -85,25 +85,6 @@ describe('Design System - Link', () => {
   });
 
   describe('automatic external link detection', () => {
-    const originalWindow = window;
-
-    beforeEach(() => {
-      Object.defineProperty(window, 'location', {
-        value: {
-          origin: 'https://studio.code.org',
-          href: 'https://studio.code.org/home',
-        },
-        writable: true,
-      });
-    });
-
-    afterEach(() => {
-      Object.defineProperty(window, 'location', {
-        value: originalWindow.location,
-        writable: true,
-      });
-    });
-
     it('automatically detects external links and shows external icon', () => {
       render(<Link href="https://google.com">External Link</Link>);
 
@@ -142,16 +123,32 @@ describe('Design System - Link', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('treats same-origin links as internal', () => {
-      render(
-        <Link href="https://studio.code.org/different-path">Same Origin</Link>,
-      );
+    it('treats internal links correctly', () => {
+      const paths = [
+        'https://code.org',
+        'https://studio.code.org',
+        'https://studio.code.org/teacher_dashboard/home',
+        'https://localhost-studio.code.org:3000',
+        'https://localhost-studio.code.org:3000/teacher_dashboard/home',
+        'https://localhost',
+        'https://localhost:3000',
+        'http://localhost:6006/?path=/story/designsystem-link--external-link-auto-detected',
+        'https://dev-code.org',
+        'https://hourofcode.com',
+        'https://csedweek.org',
+      ];
 
-      const link = screen.getByRole('link', {name: 'Same Origin'});
-      expect(link).not.toHaveAttribute('rel');
-      expect(
-        screen.queryByTestId('font-awesome-v6-icon'),
-      ).not.toBeInTheDocument();
+      for (const path of paths) {
+        render(<Link href={path}>{path}</Link>);
+
+        const link = screen.getByRole('link', {name: path});
+        expect(link).not.toHaveAttribute('rel');
+        expect(
+          screen.queryByTestId('font-awesome-v6-icon'),
+        ).not.toBeInTheDocument();
+
+        cleanup();
+      }
     });
 
     it('allows external prop to override automatic detection (external=true)', () => {

--- a/frontend/packages/component-library/src/link/__tests__/Link.test.tsx
+++ b/frontend/packages/component-library/src/link/__tests__/Link.test.tsx
@@ -83,4 +83,111 @@ describe('Design System - Link', () => {
     const link = screen.getByText('Disabled');
     expect(link).not.toHaveAttribute('href');
   });
+
+  describe('automatic external link detection', () => {
+    const originalWindow = window;
+
+    beforeEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          origin: 'https://studio.code.org',
+          href: 'https://studio.code.org/home',
+        },
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: originalWindow.location,
+        writable: true,
+      });
+    });
+
+    it('automatically detects external links and shows external icon', () => {
+      render(<Link href="https://google.com">External Link</Link>);
+
+      const link = screen.getByRole('link', {name: 'External Link'});
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(screen.getByTestId('font-awesome-v6-icon')).toBeInTheDocument();
+    });
+
+    it('treats relative paths as internal links', () => {
+      render(<Link href="/about">About</Link>);
+
+      const link = screen.getByRole('link', {name: 'About'});
+      expect(link).not.toHaveAttribute('rel');
+      expect(
+        screen.queryByTestId('font-awesome-v6-icon'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('treats hash links as internal', () => {
+      render(<Link href="#section">Section</Link>);
+
+      const link = screen.getByRole('link', {name: 'Section'});
+      expect(link).not.toHaveAttribute('rel');
+      expect(
+        screen.queryByTestId('font-awesome-v6-icon'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('treats query-only links as internal', () => {
+      render(<Link href="?param=value">Query Link</Link>);
+
+      const link = screen.getByRole('link', {name: 'Query Link'});
+      expect(link).not.toHaveAttribute('rel');
+      expect(
+        screen.queryByTestId('font-awesome-v6-icon'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('treats same-origin links as internal', () => {
+      render(
+        <Link href="https://studio.code.org/different-path">Same Origin</Link>,
+      );
+
+      const link = screen.getByRole('link', {name: 'Same Origin'});
+      expect(link).not.toHaveAttribute('rel');
+      expect(
+        screen.queryByTestId('font-awesome-v6-icon'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('allows external prop to override automatic detection (external=true)', () => {
+      render(
+        <Link href="https://studio.code.org/same-origin" external={true}>
+          Override External
+        </Link>,
+      );
+
+      const link = screen.getByRole('link', {name: 'Override External'});
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(screen.getByTestId('font-awesome-v6-icon')).toBeInTheDocument();
+    });
+
+    it('allows external prop to override automatic detection (external=false)', () => {
+      render(
+        <Link href="https://google.com" external={false}>
+          Override Internal
+        </Link>,
+      );
+
+      const link = screen.getByRole('link', {name: 'Override Internal'});
+      expect(link).not.toHaveAttribute('rel');
+      expect(
+        screen.queryByTestId('font-awesome-v6-icon'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('handles malformed URLs gracefully', () => {
+      render(<Link href="not-a-valid-url">Invalid URL</Link>);
+
+      const link = screen.getByRole('link', {name: 'Invalid URL'});
+      expect(link).not.toHaveAttribute('rel');
+      expect(
+        screen.queryByTestId('font-awesome-v6-icon'),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/packages/component-library/src/link/stories/Link.story.tsx
+++ b/frontend/packages/component-library/src/link/stories/Link.story.tsx
@@ -55,11 +55,40 @@ ExternalLink.args = {
   external: true,
 };
 
+export const ExternalLinkAutoDetected = SingleTemplate.bind({});
+ExternalLinkAutoDetected.args = {
+  text: 'Auto-detected External Link',
+  href: 'https://google.com',
+};
+
 export const OpenInNewTabLink = SingleTemplate.bind({});
 OpenInNewTabLink.args = {
   text: 'Open in New Tab',
   href: 'https://google.com',
   openInNewTab: true,
+};
+
+export const InternalVsExternalAutoDetection = MultipleTemplate.bind({});
+InternalVsExternalAutoDetection.args = {
+  components: [
+    {
+      text: 'Internal Link (relative)',
+      href: '/about',
+    },
+    {
+      text: 'Internal Link (hash)',
+      href: '#section',
+    },
+    {
+      text: 'External Link (auto-detected)',
+      href: 'https://google.com',
+    },
+    {
+      text: 'external=false using external URL',
+      href: 'https://google.com',
+      external: false,
+    },
+  ],
 };
 
 export const LinkWithTextPropVsLinkWithChildrenProp = MultipleTemplate.bind({});


### PR DESCRIPTION
Closes https://github.com/code-dot-org/code-dot-org/issues/66095 by adding external link detection to the Link component.

This implementation takes inspiration from [`react-router`](https://github.com/remix-run/react-router/blob/20d8307d4a51c219f6e13e0b66461e7162d944e4/packages/react-router/lib/dom/lib.tsx#L1292-L1322).

One thing that should be noted is that there's no SSR support for it because I'm not able to tell what the incoming URL is, so we're just using window.location.href client-side to determine this. I'm still just getting familiar with the codebase but I don't think the project does javascript-based SSR anyways so it shouldn't be much of an issue.

## Links

N/A

## Testing story

I've added an 'automatic external link detection' test suite under `Link.test.tsx` that covers test cases for the Link component specifically on how it treats external links, but haven't added any tests for the `isExternalUrl` function because I didn't find it that necessary.

I have also added two stories to `Link.story.tsx`:

<details>
  <summary>Internal Vs External Auto Detection story</summary>
<img width="1286" height="782" alt="Screenshot 2025-09-02 at 6 07 54 PM" src="https://github.com/user-attachments/assets/738922fe-19ce-45f6-badb-86709b0613dc" />
</details>

<details>
  <summary>External Link Auto Detected story</summary>
  <img width="1287" height="765" alt="Screenshot 2025-09-02 at 6 08 14 PM" src="https://github.com/user-attachments/assets/bb87dfe8-19a1-454f-9901-1db457978cd5" />
</details>

## Deployment strategy
N/A

## Follow-up work

Please just verify whether the current external links that use the Link component are intended to use this icon by default. Because if this gets merged we'll see the icons being added to some of the interfaces which weren't previously there.

e.g. I'm seeing codesites like this:

```tsx
// LevelsSkillsCreator.tsx
<Link
  openInNewTab
  href="https://docs.google.com/spreadsheets/d/1avXwCQ2qK5V3hhmFm_yk1IHzF-tUA30Tm2ZA5rq31ww/edit?usp=sharing"
>
  template
 </Link>
```

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Creation Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy impacts have been documented
- [x] Security impacts have been documented
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Follow-up work items (including potential tech debt) are tracked and linked
