### PR TITLE
Use bitnamilegacy/git instead of bitnami/git

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -353,6 +353,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: d706a958430c49a672f3c7c5a42209f54dd4cc1aada7d68e2489307e2d98b275
+hmac: 00ca47ae7662acfdeaa0032ce47719f2f003245624d2da2ba08753165ca57af0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -52,7 +52,7 @@ steps:
         - .
 
   - name: checkout
-    image: bitnami/git
+    image: bitnamilegacy/git
     commands:
       - git lfs install --skip-repo
       # We should be in a cached git repo, but clone if the cache failed
@@ -185,7 +185,7 @@ steps:
         - .
 
   - name: checkout
-    image: bitnami/git
+    image: bitnamilegacy/git
     commands:
       - git lfs install --skip-repo
       # We should be in a cached git repo, but clone if the cache failed
@@ -288,7 +288,7 @@ clone:
 
 steps:
   - name: clone
-    image: bitnami/git
+    image: bitnamilegacy/git
     commands:
       - git lfs install
       - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 


### PR DESCRIPTION
Bitnami has begun a deprecation process of the `bitnami/git` docker image, which we use for our Drone runs. As part of that process, they're doing rolling brownouts; today is one of the brownout days and has caused all Drone runs to fail at the checkout step. Using `bitnamilegacy/git` is a short-term mitigation for this issue.

More info: 
- [Bitnami issue](https://github.com/bitnami/containers/issues/83267)
- [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1756823091181729)



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
