### PR TITLE
feat(workshops): add categories and shortText to byo pre survey questions

### DIFF
--- a/dashboard/config/foorm/forms/surveys/pd/build_your_own_workshop_teachers_pre_survey.0.json
+++ b/dashboard/config/foorm/forms/surveys/pd/build_your_own_workshop_teachers_pre_survey.0.json
@@ -84,35 +84,49 @@
           ],
           "rows": [
             {
+              "category": "readiness_expectations",
               "value": "feel_prepared",
-              "text": "I am prepared to participate in this workshop."
+              "text": "I am prepared to participate in this workshop.",
+              "shortText": "Prepared to participate (%)"
             },
             {
+              "category": "readiness_expectations",
               "value": "understand_cs_concepts",
-              "text": "I am confident in my understanding of computer science concepts."
+              "text": "I am confident in my understanding of computer science concepts.",
+              "shortText": "Confidence in CS concepts (%)"
             },
             {
+              "category": "readiness_expectations",
               "value": "know_where_to_get_help",
-              "text": "I know where to find help when preparing to teach computer science content."
+              "text": "I know where to find help when preparing to teach computer science content.",
+              "shortText": "Know where to find help (%)"
             },
             {
+              "category": "readiness_expectations",
               "value": "community_cs_educators",
-              "text": "I have a community of educators I can turn to for support with computer science."
+              "text": "I have a community of educators I can turn to for support with computer science.",
+              "shortText": "Have a CS educator community (%)"
             },
             {
+              "category": "readiness_expectations",
               "value": "confindent_use_cdo_resources",
-              "text": "I am confident using the Code.org platform and resources."
+              "text": "I am confident using the Code.org platform and resources.",
+              "shortText": "Confidence using Code.org (%)"
             },
             {
+              "category": "readiness_expectations",
               "value": "strategies_support_all_learners",
-              "text": "I have strategies to support the engagement and success of all learners in a computer science classroom."
+              "text": "I have strategies to support the engagement and success of all learners in a computer science classroom.",
+              "shortText": "Have strategies to support learners (%)"
             }
           ]
         },
         {
+          "category": "readiness_expectations",
           "type": "comment",
           "name": "learning_expectations",
-          "title": "What are you hoping to learn or take away from this specific workshop?  What questions or topics do you hope this workshop will cover?."
+          "title": "What are you hoping to learn or take away from this specific workshop?  What questions or topics do you hope this workshop will cover?.",
+          "shortText": "Expectations for this workshop"
         },
         {
           "type": "html",

--- a/dashboard/config/foorm/forms/surveys/pd/build_your_own_workshop_teachers_pre_survey.0.json
+++ b/dashboard/config/foorm/forms/surveys/pd/build_your_own_workshop_teachers_pre_survey.0.json
@@ -93,7 +93,7 @@
               "category": "readiness_expectations",
               "value": "understand_cs_concepts",
               "text": "I am confident in my understanding of computer science concepts.",
-              "shortText": "Confidence in CS concepts (%)"
+              "shortText": "Confident in CS concepts (%)"
             },
             {
               "category": "readiness_expectations",
@@ -111,7 +111,7 @@
               "category": "readiness_expectations",
               "value": "confindent_use_cdo_resources",
               "text": "I am confident using the Code.org platform and resources.",
-              "shortText": "Confidence using Code.org (%)"
+              "shortText": "Confident using Code.org (%)"
             },
             {
               "category": "readiness_expectations",

--- a/dashboard/config/foorm/library/surveys/pd/demographic_items.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/demographic_items.0.json
@@ -14,9 +14,11 @@
           "placeHolder": "enter a number"
         },
         {
+          "category": "cohort_profile",
           "type": "radiogroup",
           "name": "cdo_teaching_experience",
           "title": "Which of the following options best captures your previous experience using Code.org in the classroom?",
+          "shortText": "Previous experience with Code.org in the classroom",
           "choices": [
             {
               "value": "cs_teaching",
@@ -64,9 +66,11 @@
           ]
         },
         {
+          "category": "cohort_profile",
           "type": "checkbox",
           "name": "grade",
           "title": "What grade levels do you currently support or work with?",
+          "shortText": "Grade levels currently teaching",
           "description": " (Select all that apply)",
           "choices": [
             {
@@ -132,9 +136,11 @@
           ]
         },
         {
+          "category": "cohort_profile",
           "type": "radiogroup",
           "name": "highest_level_cs_education",
           "title": "Which most accurately describes the highest level of formal computer science education you have completed? ",
+          "shortText": "Highest level of formal computer science education",
           "otherPlaceHolder": "Other CS Education",
           "choices": [
             {
@@ -209,17 +215,21 @@
           ]
         },
         {
+          "category": "cohort_profile",
           "type": "text",
           "name": "years_teaching",
           "title": "How many years have you taught at the K-12 level (any subject)?",
+          "shortText": "Years teaching at K-12 level (any subject)",
           "description": "Please enter a whole number. If you are about to start your first year teaching, enter 0.",
           "inputType": "number",
           "min": 0
         },
         {
+          "category": "cohort_profile",
           "type": "text",
           "name": "years_teaching_cs",
           "title": "How many years have you taught COMPUTER SCIENCE at the K-12 level?",
+          "shortText": "Years teaching at K-12 level (CS only)",
           "description": "Please enter a whole number. Enter 0 if it's your first year teaching computer science.",
           "inputType": "number",
           "min": 0

--- a/dashboard/config/foorm/library/surveys/pd/workshop_elements.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/workshop_elements.0.json
@@ -75,9 +75,11 @@
           ]
         },
         {
+          "category": "cohort_profile",
           "type": "radiogroup",
           "name": "cdo_pd_experience",
           "title": "What is your previous experience with Code.org professional learning?",
+          "shortText": "Previous experience with Code.org professional learning",
           "choices": [
             {
               "value": "first",

--- a/dashboard/lib/pd/foorm/response_processor.rb
+++ b/dashboard/lib/pd/foorm/response_processor.rb
@@ -165,7 +165,7 @@ module Pd::Foorm
       # Filter responses
       responses = question_summary.compact_blank.filter do |response|
         sanitized_response = response.downcase.gsub(/\W/, '') # Remove spaces and non-word characters and then downcase
-        response.length >= 3 && useless_answers.exclude?(sanitized_response) # Exclude short and useless answers
+        useless_answers.exclude?(sanitized_response) # Exclude useless answers
       end
 
       # Sort responses by length, longest first

--- a/dashboard/lib/pd/foorm/response_processor.rb
+++ b/dashboard/lib/pd/foorm/response_processor.rb
@@ -149,6 +149,8 @@ module Pd::Foorm
         none
         na
         no
+        n
+        nope
         nothing
         noneoftheabove
         notapplicable

--- a/dashboard/test/lib/pd/foorm/response_processor_test.rb
+++ b/dashboard/test/lib/pd/foorm/response_processor_test.rb
@@ -228,6 +228,7 @@ module Pd::Foorm
                                                           'n/a',
                                                           'NA',
                                                           'Not applicable',
+                                                          'NOPE',
                                                           '',
                                                           'No',
                                                           'no',


### PR DESCRIPTION
Adds `readiness_expectations` and `cohort_profile` question categories for the pre-workshop survey, along with `shortText`


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
