### PR TITLE
Lab2 Dance: start over

### DIFF
--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,3 +1,4 @@
+import {Button} from '@code-dot-org/component-library/button';
 import {Events, WorkspaceSvg} from 'blockly/core';
 import classNames from 'classnames';
 import {isEqual} from 'lodash';
@@ -71,7 +72,8 @@ const DanceView: React.FunctionComponent<{
   const hasEdited = useAppSelector(state => state.dance.hasEdited);
   const isLoading = useAppSelector(state => state.dance.isLoading);
 
-  const {currentSources, updateSources} = useSources<DanceProjectSources>();
+  const {currentSources, updateSources, showStartOverDialog} =
+    useSources<DanceProjectSources>();
 
   const programExecutor = useRef<ProgramExecutor | null>(null);
   const workspace = useRef<WorkspaceSvg | null>(null);
@@ -183,6 +185,10 @@ const DanceView: React.FunctionComponent<{
     },
     [isRunning, dispatch, saveBlocks]
   );
+
+  const onClickStartOver = useCallback(() => {
+    showStartOverDialog('blocks');
+  }, [showStartOverDialog]);
 
   // Setup Blockly for dance party when first mounting.
   useEffect(setupBlocklyEnvironment, []);
@@ -362,6 +368,17 @@ const DanceView: React.FunctionComponent<{
         headerContent={commonI18n.workspaceHeaderShort()}
         className={moduleStyles.workspaceArea}
         headerClassName={moduleStyles.panelHeader}
+        rightHeaderContent={
+          <Button
+            text={commonI18n.startOver()}
+            iconRight={{iconStyle: 'solid', iconName: 'refresh'}}
+            color={'black'}
+            onClick={onClickStartOver}
+            ariaLabel={commonI18n.startOver()}
+            size={'xs'}
+            type="secondary"
+          />
+        }
       >
         {WorkspaceAlert}
         <div id={BLOCKLY_DIV_ID} />

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -369,15 +369,17 @@ const DanceView: React.FunctionComponent<{
         className={moduleStyles.workspaceArea}
         headerClassName={moduleStyles.panelHeader}
         rightHeaderContent={
-          <Button
-            text={commonI18n.startOver()}
-            iconRight={{iconStyle: 'solid', iconName: 'refresh'}}
-            color={'black'}
-            onClick={onClickStartOver}
-            ariaLabel={commonI18n.startOver()}
-            size={'xs'}
-            type="secondary"
-          />
+          !readonlyWorkspace && (
+            <Button
+              text={commonI18n.startOver()}
+              iconRight={{iconStyle: 'solid', iconName: 'refresh'}}
+              color={'black'}
+              onClick={onClickStartOver}
+              ariaLabel={commonI18n.startOver()}
+              size={'xs'}
+              type="secondary"
+            />
+          )
         }
       >
         {WorkspaceAlert}

--- a/apps/src/dance/lab2/views/SourcesContainer.tsx
+++ b/apps/src/dance/lab2/views/SourcesContainer.tsx
@@ -8,13 +8,17 @@ import React, {
   useState,
 } from 'react';
 
+import {START_BLOCKS} from '@cdo/apps/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {LabProps, ProjectSources} from '@cdo/apps/lab2/types';
 import StartOverDialog, {
   MessageType,
 } from '@cdo/apps/lab2/views/dialogs/dsco/StartOverDialog';
 
 import getInitialSources from '../utils/getInitialSources';
+
+const isStartMode = getAppOptionsEditBlocks() === START_BLOCKS;
 
 interface SourcesContextType<T extends ProjectSources = ProjectSources> {
   currentSources: T;
@@ -70,7 +74,9 @@ const SourcesContainer: React.FC<
 
   const onStartOver = useCallback(() => {
     const {templateSources, startSources} = levelProperties;
-    const startOverSources = templateSources || startSources || defaultSources;
+    const startOverSources = isStartMode
+      ? defaultSources
+      : templateSources || startSources || defaultSources;
     updateSources(startOverSources as ProjectSources, true);
     setStartOverProps(undefined);
   }, [levelProperties, defaultSources, updateSources]);

--- a/apps/src/dance/lab2/views/SourcesContainer.tsx
+++ b/apps/src/dance/lab2/views/SourcesContainer.tsx
@@ -72,10 +72,9 @@ const SourcesContainer: React.FC<
     const {templateSources, startSources} = levelProperties;
     const startOverSources = templateSources || startSources || defaultSources;
     updateSources(startOverSources as ProjectSources, true);
-    setShowStartOver(false);
+    setStartOverProps(undefined);
   }, [levelProperties, defaultSources, updateSources]);
 
-  const [showStartOver, setShowStartOver] = useState(false);
   const [startOverProps, setStartOverProps] = useState<{
     type: MessageType;
     message?: string;
@@ -84,7 +83,6 @@ const SourcesContainer: React.FC<
   const showStartOverDialog = useCallback(
     (type: MessageType, message?: string) => {
       setStartOverProps({type, message});
-      setShowStartOver(true);
     },
     []
   );
@@ -94,10 +92,10 @@ const SourcesContainer: React.FC<
       value={{currentSources, updateSources, showStartOverDialog}}
     >
       {children}
-      {showStartOver && startOverProps && (
+      {startOverProps && (
         <StartOverDialog
           onConfirm={onStartOver}
-          onCancel={() => setShowStartOver(false)}
+          onCancel={() => setStartOverProps(undefined)}
           {...startOverProps}
         />
       )}

--- a/apps/src/dance/lab2/views/SourcesContainer.tsx
+++ b/apps/src/dance/lab2/views/SourcesContainer.tsx
@@ -10,12 +10,16 @@ import React, {
 
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {LabProps, ProjectSources} from '@cdo/apps/lab2/types';
+import StartOverDialog, {
+  MessageType,
+} from '@cdo/apps/lab2/views/dialogs/dsco/StartOverDialog';
 
 import getInitialSources from '../utils/getInitialSources';
 
 interface SourcesContextType<T extends ProjectSources = ProjectSources> {
   currentSources: T;
   updateSources: (newSources: T, forceSave?: boolean) => void;
+  showStartOverDialog: (type: MessageType, message?: string) => void;
 }
 
 const SourcesContext = createContext<SourcesContextType | null>(null);
@@ -64,9 +68,39 @@ const SourcesContainer: React.FC<
     [setCurrentSources]
   );
 
+  const onStartOver = useCallback(() => {
+    const {templateSources, startSources} = levelProperties;
+    const startOverSources = templateSources || startSources || defaultSources;
+    updateSources(startOverSources as ProjectSources, true);
+    setShowStartOver(false);
+  }, [levelProperties, defaultSources, updateSources]);
+
+  const [showStartOver, setShowStartOver] = useState(false);
+  const [startOverProps, setStartOverProps] = useState<{
+    type: MessageType;
+    message?: string;
+  }>();
+
+  const showStartOverDialog = useCallback(
+    (type: MessageType, message?: string) => {
+      setStartOverProps({type, message});
+      setShowStartOver(true);
+    },
+    []
+  );
+
   return (
-    <SourcesContext.Provider value={{currentSources, updateSources}}>
+    <SourcesContext.Provider
+      value={{currentSources, updateSources, showStartOverDialog}}
+    >
       {children}
+      {showStartOver && startOverProps && (
+        <StartOverDialog
+          onConfirm={onStartOver}
+          onCancel={() => setShowStartOver(false)}
+          {...startOverProps}
+        />
+      )}
     </SourcesContext.Provider>
   );
 };

--- a/apps/src/lab2/views/dialogs/dsco/StartOverDialog.tsx
+++ b/apps/src/lab2/views/dialogs/dsco/StartOverDialog.tsx
@@ -20,7 +20,7 @@ const StartOverDialog: React.FC<StartOverDialogProps> = ({
 }) => (
   <Modal
     title={commonI18n.startOverTitle()}
-    customContent={
+    description={
       type === 'text'
         ? commonI18n.startOverWorkspaceText()
         : type === 'blocks'

--- a/apps/src/lab2/views/dialogs/dsco/StartOverDialog.tsx
+++ b/apps/src/lab2/views/dialogs/dsco/StartOverDialog.tsx
@@ -1,0 +1,36 @@
+import Modal from '@code-dot-org/component-library/modal';
+import React from 'react';
+
+import {commonI18n} from '@cdo/apps/types/locale';
+
+export type MessageType = 'text' | 'blocks' | 'custom';
+
+interface StartOverDialogProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+  type: MessageType;
+  message?: string;
+}
+
+const StartOverDialog: React.FC<StartOverDialogProps> = ({
+  onConfirm,
+  onCancel,
+  type,
+  message,
+}) => (
+  <Modal
+    title={commonI18n.startOverTitle()}
+    customContent={
+      type === 'text'
+        ? commonI18n.startOverWorkspaceText()
+        : type === 'blocks'
+        ? commonI18n.startOverWorkspace()
+        : message
+    }
+    primaryButtonProps={{text: commonI18n.startOver(), onClick: onConfirm}}
+    secondaryButtonProps={{text: commonI18n.cancel(), onClick: onCancel}}
+    onClose={onCancel}
+  />
+);
+
+export default StartOverDialog;


### PR DESCRIPTION
Adds Start Over functionality to Lab2 Dance. This makes use of the `SourcesContainer` introduced in https://github.com/code-dot-org/code-dot-org/pull/68065. The SourcesContainer manages computing what the starting sources should be (in this case just `templateSources || startSources || defaultSources`), and updates and saves, so the lab doesn't need to do any of that itself. The lab just receives a function to open the dialog and the value of `currentSources` is automatically updated when starting over.

I also created a new `StartOverDialog` that uses the DSCO `Modal`. I realize this is a bit redundant because we already have a dialog system and an existing `StartOverDialog`. However that dialog system was written pre-DSCO and has some extra complexity that I think we no longer need; moving to DSCO dialogs in general I think will help clean up our shared dialog system and clean up lab code. Happy to discuss further though!

<img width="1512" height="823" alt="Screenshot 2025-09-02 at 11 22 43 AM" src="https://github.com/user-attachments/assets/e2ecd331-9094-4c46-aa6d-508ad0732007" />
<img width="1512" height="823" alt="Screenshot 2025-09-02 at 11 24 38 AM" src="https://github.com/user-attachments/assets/f6c01d10-134b-4193-9377-c42995aecaf0" />


## Testing story
- Tested locally with Lab2 Dance allthethings