### PR TITLE
Teach 1792/remove old fields from unit

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -151,7 +151,7 @@ class ScriptsController < ApplicationController
 
       unit = first_cv.content_root
       next unless unit
-      @unit_families_course_types << [cf, {instruction_type: unit.instruction_type, instructor_audience: unit.instructor_audience, participant_audience: unit.participant_audience}]
+      @unit_families_course_types << [cf]
     end
 
     @unit_families_course_types = @unit_families_course_types.compact.to_h
@@ -159,33 +159,8 @@ class ScriptsController < ApplicationController
 
   def create
     return head :bad_request unless general_params[:is_migrated]
-
-    # These fields should be set unless a unit is in a unit group.
-    # When creating a unit it is not yet in a unit group so we
-    # set default values here
-    #
-    # Setting default values for the columns would not work because those
-    # are not used when you call new() just when you call create
-    updated_unit_params = unit_params.merge(
-      {
-        published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development,
-        instructor_audience: general_params[:instructor_audience] ? general_params[:instructor_audience] : Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-        participant_audience: general_params[:participant_audience] ? general_params[:participant_audience] : Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
-        instruction_type: general_params[:instruction_type] ? general_params[:instruction_type] : Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-      }
-    )
-
-    updated_general_params = general_params.merge(
-      {
-        published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development,
-        instructor_audience: general_params[:instructor_audience] ? general_params[:instructor_audience] : Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-        participant_audience: general_params[:participant_audience] ? general_params[:participant_audience] : Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
-        instruction_type: general_params[:instruction_type] ? general_params[:instruction_type] : Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-      }
-    )
-
-    @script = Unit.new(updated_unit_params)
-    if @script.save && @script.update_text(unit_params, i18n_params, updated_general_params)
+    @script = Unit.new(unit_params)
+    if @script.save && @script.update_text(unit_params, i18n_params, general_params)
       redirect_to edit_script_url(@script), notice: I18n.t('crud.created', model: Unit.model_name.human)
     else
       render json: @script.errors
@@ -392,9 +367,6 @@ class ScriptsController < ApplicationController
   private def general_params
     h = params.permit(
       :hide_within_course,
-      :instruction_type,
-      :instructor_audience,
-      :participant_audience,
       :deprecated,
       :curriculum_umbrella,
       :family_name,
@@ -417,7 +389,6 @@ class ScriptsController < ApplicationController
       :weekly_instructional_minutes,
       :is_migrated,
       :announcements,
-      :pilot_experiment,
       :editor_experiment,
       :include_student_lesson_plans,
       :use_legacy_lesson_plans,

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -154,7 +154,7 @@ class ScriptsController < ApplicationController
       @unit_families_course_types << [cf]
     end
 
-    @unit_families_course_types = @unit_families_course_types.compact.to_h
+    @unit_families_course_types = @unit_families_course_types.compact
   end
 
   def create

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -152,13 +152,6 @@ class Unit < ApplicationRecord
     }
 
   validates :link, presence: true
-  validate :deeper_learning_courses_cannot_be_launched
-
-  def deeper_learning_courses_cannot_be_launched
-    if old_professional_learning_course? && (launched? || pilot?)
-      errors.add('can never be pilot, preview or stable for a deeper learning course.')
-    end
-  end
 
   def prevent_new_duplicate_levels(old_dup_level_keys = [])
     new_dup_level_keys = duplicate_level_keys - old_dup_level_keys
@@ -214,7 +207,7 @@ class Unit < ApplicationRecord
       new_published_state = Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
       new_instruction_type = Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
       new_instructor_audience = Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer
-      new_participant_audience =  Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator
+      new_participant_audience = Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator
 
       if unit_group
         # Check if anything needs to be updated on the PL course
@@ -1493,9 +1486,9 @@ class Unit < ApplicationRecord
         course_id: unit_group_unit&.cached_unit_group&.id,
         hide_within_course: hide_within_course,
         publishedState: get_published_state,
-        instructionType: get_instruction_type,
-        instructorAudience: get_instructor_audience,
-        participantAudience: get_participant_audience,
+        instructionType: unit_group_unit&.cached_unit_group&.instruction_type,
+        instructorAudience: unit_group_unit&.cached_unit_group&.instructor_audience,
+        participantAudience: unit_group_unit&.cached_unit_group&.participant_audience,
         loginRequired: login_required,
         plc: old_professional_learning_course?,
         hideable_lessons: hideable_lessons?,
@@ -1880,25 +1873,8 @@ class Unit < ApplicationRecord
   # If a script is in a unit group, use that unit group's published state
   # Otherwise, default to in_development
   def get_published_state(unit_group: get_original_unit_group)
+    unit_group = UnitGroup.find_by_name(professional_learning_course) if old_professional_learning_course?
     unit_group&.published_state || Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
-  end
-
-  # If a script is in a unit group, use that unit group's instruction type.
-  # Otherwise, default to teacher led
-  def get_instruction_type(unit_group: get_original_unit_group)
-    unit_group&.instruction_type || Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-  end
-
-  # If a script is in a unit group, use that unit group's instructor_audience.
-  # Otherwise, default to instructed by teacher
-  def get_instructor_audience(unit_group: get_original_unit_group)
-    unit_group&.instructor_audience || Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
-  end
-
-  # If a script is in a unit group, use that unit group's participant_audience.
-  # Otherwise, default to participated in by students
-  def get_participant_audience(unit_group: get_original_unit_group)
-    unit_group&.participant_audience || Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
   end
 
   # Use the unit group's pilot_experiment if one exists

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -141,17 +141,6 @@ class Unit < ApplicationRecord
 
   include SerializedToFileValidation
 
-  after_save :hide_pilot_units
-
-  # Ideally this would be done in a before_validation hook, to avoid saving twice.
-  # however this is not practical to do given how rails validations work for
-  # activerecord-import during the seed process.
-  def hide_pilot_units
-    if !get_original_unit_group && pilot_experiment.present? && published_state != Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot
-      update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot)
-    end
-  end
-
   # As we read and write to files with the unit name, to prevent directory
   # traversal (for security reasons), we do not allow the name to start with a
   # tilde or dot or contain a slash.
@@ -163,12 +152,11 @@ class Unit < ApplicationRecord
     }
 
   validates :link, presence: true
-  validates :published_state, acceptance: {accept: Curriculum::SharedCourseConstants::PUBLISHED_STATE.to_h.values.push(nil), message: 'must be nil, in_development, pilot, beta, preview or stable'}
   validate :deeper_learning_courses_cannot_be_launched
 
   def deeper_learning_courses_cannot_be_launched
     if old_professional_learning_course? && (launched? || pilot?)
-      errors.add(:published_state, 'can never be pilot, preview or stable for a deeper learning course.')
+      errors.add('can never be pilot, preview or stable for a deeper learning course.')
     end
   end
 
@@ -294,7 +282,6 @@ class Unit < ApplicationRecord
     announcements
     version_year
     supported_locales
-    pilot_experiment
     editor_experiment
     project_sharing
     curriculum_umbrella
@@ -1630,9 +1617,8 @@ class Unit < ApplicationRecord
     include_lessons = false
     summary = summarize(include_lessons, unit_group_unit: original_unit_group_unit)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
-    summary[:coursePublishedState] = original_unit_group ? original_unit_group.published_state : published_state
-    summary[:unitPublishedState] = original_unit_group ? published_state : nil
-    summary[:isCSDCourseOffering] = original_unit_group&.course_version&.course_offering&.csd?
+    summary[:coursePublishedState] = get_original_unit_group&.published_state
+    summary[:isCSDCourseOffering] = get_original_unit_group&.course_version&.course_offering&.csd?
     summary[:allowMajorCurriculumChanges] = allow_major_curriculum_changes?
     summary
   end
@@ -1843,7 +1829,6 @@ class Unit < ApplicationRecord
       :announcements,
       :version_year,
       :supported_locales,
-      :pilot_experiment,
       :editor_experiment,
       :curriculum_umbrella,
       :weekly_instructional_minutes,
@@ -1892,10 +1877,10 @@ class Unit < ApplicationRecord
     get_original_unit_group&.course_version
   end
 
-  # If a script is in a unit group, use that unit group's published state. If not, use the script's published_state
-  # If both are null, the script is in_development
-  def get_published_state
-    published_state || get_original_unit_group&.published_state || Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
+  # If a script is in a unit group, use that unit group's published state
+  # Otherwise, default to in_development
+  def get_published_state(unit_group: get_original_unit_group)
+    unit_group&.published_state || Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
   end
 
   # If a script is in a unit group, use that unit group's instruction type.
@@ -1917,8 +1902,8 @@ class Unit < ApplicationRecord
   end
 
   # Use the unit group's pilot_experiment if one exists
-  def get_pilot_experiment
-    pilot_experiment || get_original_unit_group&.pilot_experiment
+  def get_pilot_experiment(unit_group: get_original_unit_group)
+    unit_group&.pilot_experiment
   end
 
   def unversioned?

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -223,10 +223,10 @@ class Unit < ApplicationRecord
     if old_professional_learning_course?
       unit_group = UnitGroup.find_by_name(professional_learning_course)
 
-      new_published_state = published_state ? published_state : Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
-      new_instruction_type = instruction_type ? instruction_type : Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-      new_instructor_audience = instructor_audience ? instructor_audience : Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer
-      new_participant_audience = participant_audience ? participant_audience : Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator
+      new_published_state = Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
+      new_instruction_type = Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
+      new_instructor_audience = Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer
+      new_participant_audience =  Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator
 
       if unit_group
         # Check if anything needs to be updated on the PL course
@@ -601,9 +601,6 @@ class Unit < ApplicationRecord
         # to allow the redirect to happen for any user
         return Unit.new(
           redirect_to: unit_name,
-          published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta,
-          instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-          participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
         )
       end
     end
@@ -630,9 +627,6 @@ class Unit < ApplicationRecord
       # to allow the redirect to happen for any user
       Unit.new(
         redirect_to: unit_name,
-        published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta,
-        instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-        participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
       ) : nil
   end
 
@@ -1189,15 +1183,9 @@ class Unit < ApplicationRecord
       ActiveRecord::Base.transaction do
         copied_unit = dup
 
-        copied_unit.pilot_experiment = nil
         copied_unit.tts = false
         copied_unit.announcements = nil
         copied_unit.name = new_name
-
-        copied_unit.published_state = destination_unit_group.nil? ? Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development : nil
-        copied_unit.instruction_type = destination_unit_group.nil? ? get_instruction_type : nil
-        copied_unit.participant_audience = destination_unit_group.nil? ? get_participant_audience : nil
-        copied_unit.instructor_audience = destination_unit_group.nil? ? get_instructor_audience : nil
 
         copied_unit.save!
 
@@ -1328,9 +1316,6 @@ class Unit < ApplicationRecord
           wrapup_video: general_params[:wrapup_video],
           family_name: general_params[:family_name].presence ? general_params[:family_name] : nil, # default nil
           hide_within_course: general_params[:hide_within_course].nil? ? false : general_params[:hide_within_course], # default false
-          instruction_type: get_original_unit_group.present? ? nil : general_params[:instruction_type],
-          participant_audience: get_original_unit_group.present? ? nil : general_params[:participant_audience],
-          instructor_audience: get_original_unit_group.present? ? nil : general_params[:instructor_audience],
           properties: Unit.build_property_hash(general_params)
         },
         unit_data[:lesson_groups]
@@ -1913,22 +1898,22 @@ class Unit < ApplicationRecord
     published_state || get_original_unit_group&.published_state || Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
   end
 
-  # If a script is in a unit group, use that unit group's instruction type. If not, use the units's instruction type
-  # If both are null, the unit should be teacher led
-  def get_instruction_type
-    get_original_unit_group&.instruction_type || instruction_type || Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
+  # If a script is in a unit group, use that unit group's instruction type.
+  # Otherwise, default to teacher led
+  def get_instruction_type(unit_group: get_original_unit_group)
+    unit_group&.instruction_type || Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
   end
 
-  # If a script is in a unit group, use that unit group's instructor_audience. If not, use the units's instructor_audience
-  # If both are null, the unit should be instructed by teacher
-  def get_instructor_audience
-    get_original_unit_group&.instructor_audience || instructor_audience || Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
+  # If a script is in a unit group, use that unit group's instructor_audience.
+  # Otherwise, default to instructed by teacher
+  def get_instructor_audience(unit_group: get_original_unit_group)
+    unit_group&.instructor_audience || Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
   end
 
-  # If a script is in a unit group, use that unit group's participant_audience. If not, use the units's participant_audience
-  # If both are null, the unit should be participated in by students
-  def get_participant_audience
-    get_original_unit_group&.participant_audience || participant_audience || Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
+  # If a script is in a unit group, use that unit group's participant_audience.
+  # Otherwise, default to participated in by students
+  def get_participant_audience(unit_group: get_original_unit_group)
+    unit_group&.participant_audience || Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
   end
 
   # Use the unit group's pilot_experiment if one exists

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -75,6 +75,14 @@ class UnitGroup < ApplicationRecord
     end
   end
 
+  validate :pl_courses_cannot_be_launched
+
+  def pl_courses_cannot_be_launched
+    if plc_course && (launched? || pilot?)
+      errors.add(:published_state, 'can never be pilot, preview or stable for a pl course.')
+    end
+  end
+
   def skip_name_format_validation
     !!plc_course
   end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -75,11 +75,11 @@ class UnitGroup < ApplicationRecord
     end
   end
 
-  validate :pl_courses_cannot_be_launched
+  validate :plc_courses_cannot_be_launched
 
-  def pl_courses_cannot_be_launched
+  def plc_courses_cannot_be_launched
     if plc_course && (launched? || pilot?)
-      errors.add(:published_state, 'can never be pilot, preview or stable for a pl course.')
+      errors.add(:published_state, 'can never be pilot, preview or stable for a plc course.')
     end
   end
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -245,7 +245,6 @@ class UnitGroup < ApplicationRecord
     new_units_objects.each_with_index do |unit, index|
       unit_group_unit = UnitGroupUnit.find_or_create_by!(unit_group: self, script: unit) do |ugu|
         ugu.position = index + 1
-        unit.update!(published_state: nil, instruction_type: nil, participant_audience: nil, instructor_audience: nil, pilot_experiment: nil, skip_name_format_validation: true)
         unit.update!(original_unit_group_id: id, skip_name_format_validation: true) if unit.original_unit_group.nil?
 
         unit.reload
@@ -256,14 +255,7 @@ class UnitGroup < ApplicationRecord
 
     units_to_remove.each do |unit|
       if unit.unit_group_units.count == 1
-        # Units that are not in a unit group need to have these fields set in order to determine course type and visibility of course
-        # If this is the last unit group unit, then we need to set those fields and set the original_unit_group_id to nil
-        unit.update!(
-          published_state: (unit.published_state ? unit.published_state : published_state),
-          instruction_type: instruction_type,
-          participant_audience: participant_audience,
-          instructor_audience: instructor_audience
-        )
+        # If this is the last unit group unit, then we need to set the original_unit_group_id to nil
         unit.update!(original_unit_group_id: nil, skip_name_format_validation: true)
       end
       UnitGroupUnit.where(unit_group: self, script: unit).destroy_all

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -23,12 +23,12 @@ class CoursesControllerTest < ActionController::TestCase
 
     @unit_group_regular = create(:unit_group, name: 'non-plc-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
 
-    @migrated_pl_unit = create(:script, is_migrated: true, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
+    @migrated_pl_unit = create(:script, is_migrated: true)
     @pl_unit_group_migrated = create(:unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
     create(:unit_group_unit, unit_group: @pl_unit_group_migrated, script: @migrated_pl_unit, position: 1)
     @migrated_pl_unit.reload
 
-    @unmigrated_unit = create(:script, is_migrated: false, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
+    @unmigrated_unit = create(:script, is_migrated: false)
     @unit_group_unmigrated = create(:unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
     create(:unit_group_unit, unit_group: @unit_group_unmigrated, script: @unmigrated_unit, position: 1)
   end
@@ -36,7 +36,7 @@ class CoursesControllerTest < ActionController::TestCase
   setup do
     sign_in @teacher
 
-    @migrated_unit = create(:script, is_migrated: true, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
+    @migrated_unit = create(:script, is_migrated: true)
     @unit_group_migrated = create(:unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
     create(:unit_group_unit, unit_group: @unit_group_migrated, script: @migrated_unit, position: 1)
 

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -169,8 +169,7 @@ class HomeControllerTest < ActionController::TestCase
   end
 
   test "student without pilot access will go to index" do
-    pilot_script = create(:script, pilot_experiment: 'pilot-experiment')
-    create(:single_unit_course, unit: pilot_script, pilot_experiment: 'pilot-experiment')
+    pilot_script = create(:script, :in_single_unit_course, pilot_experiment: 'pilot-experiment')
     section = create(:section, script: pilot_script)
     student = create(:follower, section: section).student_user
     sign_in student
@@ -180,16 +179,14 @@ class HomeControllerTest < ActionController::TestCase
   end
 
   test "student with pilot access will go to pilot script" do
-    unit_group = create(:unit_group)
-    pilot_unit = create(:unit, pilot_experiment: 'pilot-experiment', original_unit_group: unit_group)
-    create(:unit_group_unit, unit_group: unit_group, script: pilot_unit, position: 1)
+    pilot_unit = create(:unit, :in_single_unit_course, pilot_experiment: 'pilot-experiment')
     pilot_teacher = create(:teacher, pilot_experiment: 'pilot-experiment')
     section = create(:section, script: pilot_unit, user: pilot_teacher)
     student = create(:follower, section: section).student_user
     sign_in student
     get :index
 
-    assert_redirected_to course_unit_path(unit_group, 1)
+    assert_redirected_to course_unit_path(pilot_unit.original_unit_group, 1)
   end
 
   test "redirect index when signed out" do

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -62,14 +62,14 @@ class LessonsControllerTest < ActionController::TestCase
     @in_development_unit.reload
 
     @pilot_teacher = create(:teacher, pilot_experiment: 'my-experiment')
-    @pilot_script = create(:script, :with_lessons, lessons_count: 1, name: 'pilot-script', pilot_experiment: 'my-experiment', include_student_lesson_plans: true)
+    @pilot_script = create(:script, :with_lessons, lessons_count: 1, name: 'pilot-script', include_student_lesson_plans: true)
     @pilot_course = create(:single_unit_course, unit: @pilot_script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, pilot_experiment: 'my-experiment')
     @pilot_script.reload
     @pilot_section = create(:section, user: @pilot_teacher, script: @pilot_script)
     @pilot_student = create(:follower, section: @pilot_section).student_user
 
     @pilot_instructor = create(:teacher, pilot_experiment: 'pl-my-experiment')
-    @pilot_pl_script = create(:script, :with_lessons, lessons_count: 1, name: 'pl-pilot-script', pilot_experiment: 'pl-my-experiment', include_student_lesson_plans: true)
+    @pilot_pl_script = create(:script, :with_lessons, lessons_count: 1, name: 'pl-pilot-script', include_student_lesson_plans: true)
     @pilot_pl_course = create(:single_unit_course, unit: @pilot_pl_script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, pilot_experiment: 'pl-my-experiment')
     @pilot_pl_script.reload
     @pilot_pl_section = create(:section, user: @pilot_instructor, script: @pilot_pl_script)

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -751,14 +751,6 @@ class LevelsControllerTest < ActionController::TestCase
     assert_includes @response.body, level.name
     assert_includes @response.body, 'level cannot be renamed'
 
-    script.pilot_experiment = 'platformization-partners'
-    script.published_state = 'pilot'
-    script.save!
-    get :edit, params: {id: level.id}
-    assert_response :success
-    assert_includes @response.body, level.name
-    assert_includes @response.body, 'level cannot be renamed'
-
     script_level.destroy!
     get :edit, params: {id: level.id}
     assert_response :success

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -104,11 +104,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'canonical url is not added if is not single unit course' do
-    course = create(:unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-    unit = create(:script, published_state: nil)
-    create(:unit_group_unit, unit_group: course, script: unit, position: 1)
-    unit2 = create(:script, published_state: nil)
-    create(:unit_group_unit, unit_group: course, script: unit2, position: 2)
+    course = create(:unit_group, :with_units, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
 
     get :show, params: {
       course_course_name: course.name,
@@ -570,39 +566,6 @@ class ScriptsControllerTest < ActionController::TestCase
     unit = Unit.find_by_name(unit_name)
     assert_equal unit_name, unit.name
     assert unit.is_migrated
-    assert_equal unit.published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
-    assert_equal unit.instruction_type, Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-    assert_equal unit.instructor_audience, Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
-    assert_equal unit.participant_audience, Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
-  end
-
-  test 'create: sets course type if provided' do
-    unit_name = 'test-pl-unit-create'
-    @request.host = CDO.dashboard_hostname
-    File.stubs(:write).with {|filename, _| filename.end_with? 'scripts/en.yml'}.once
-    File.stubs(:write).with do |filename, contents|
-      filename == "#{Rails.root}/config/scripts_json/#{unit_name}.script_json" && JSON.parse(contents)['script']['name'] == unit_name
-    end
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in create(:levelbuilder)
-
-    post :create, params: {
-      script: {name: unit_name},
-      lesson_groups: '[]',
-      is_migrated: true,
-      instruction_type: 'self_paced',
-      instructor_audience: 'universal_instructor',
-      participant_audience: 'teacher'
-    }
-    assert_redirected_to edit_script_path id: unit_name
-
-    unit = Unit.find_by_name(unit_name)
-    assert_equal unit_name, unit.name
-    assert unit.is_migrated
-    assert_equal unit.published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
-    assert_equal unit.instruction_type, Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.self_paced
-    assert_equal unit.instructor_audience, Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.universal_instructor
-    assert_equal unit.participant_audience, Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher
   end
 
   test 'cannot create legacy unit' do
@@ -685,27 +648,6 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :success
     unit.reload
     assert unit.login_required
-  end
-
-  test "update instruction_type" do
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in create(:levelbuilder)
-
-    unit = create(:script, instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led)
-    File.stubs(:write).with {|filename, _| filename.end_with? 'scripts/en.yml'}.once
-    File.stubs(:write).with do |filename, contents|
-      filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
-    end
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      is_migrated: true,
-      lesson_groups: '[]',
-      instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.self_paced
-    }
-    assert_response :success
-    unit.reload
-    assert_equal unit.get_instruction_type, Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.self_paced
   end
 
   test "can update on test without modifying filesystem" do
@@ -921,29 +863,6 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_equal(student_resources.map(&:key), Unit.find_by_name(unit.name).student_resources.pluck(:key))
   end
 
-  test 'updates pilot_experiment' do
-    sign_in create(:levelbuilder)
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-
-    unit = create(:script)
-    stub_file_writes(unit.name)
-
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      is_migrated: true,
-      lesson_groups: '[]',
-      pilot_experiment: 'pilot-experiment',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot
-    }
-
-    assert_response :success
-
-    assert_equal 'pilot-experiment', Unit.find_by_name(unit.name).pilot_experiment
-    # pilot units are always marked with the pilot published state
-    assert_equal Unit.find_by_name(unit.name).get_published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot
-  end
-
   test 'update: can update general_params' do
     sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
@@ -996,17 +915,12 @@ class ScriptsControllerTest < ActionController::TestCase
       student_detail_progress_view: 'on',
       lesson_extras_available: 'on',
       has_verified_resources: 'on',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot,
-      instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led,
-      participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
-      instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
       tts: 'on',
       project_sharing: 'on',
       peer_reviews_to_complete: 1,
       curriculum_path: 'fake_curriculum_path',
       family_name: 'fake-family-z',
       version_year: '2020',
-      pilot_experiment: 'fake-pilot-experiment',
       editor_experiment: 'fake-editor-experiment',
       curriculum_umbrella: 'CSF',
       content_area: 'k-5',
@@ -1040,8 +954,6 @@ class ScriptsControllerTest < ActionController::TestCase
       lesson_groups: '[]',
       curriculum_path: '',
       version_year: '',
-      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta,
-      pilot_experiment: '',
       editor_experiment: '',
       curriculum_umbrella: '',
       content_area: '',
@@ -1499,17 +1411,15 @@ class ScriptsControllerTest < ActionController::TestCase
     setup do
       @pilot_section_owner = create(:teacher, pilot_experiment: 'my-experiment')
       @pilot_teacher = create(:teacher, pilot_experiment: 'my-experiment')
-      @pilot_unit = create(:script, pilot_experiment: 'my-experiment')
-      @pilot_course = create(:single_unit_course, unit: @pilot_unit, pilot_experiment: 'my-experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot)
-      @pilot_section = create(:section, user: @pilot_section_owner, script: @pilot_unit)
+      @pilot_course = create(:single_unit_course, pilot_experiment: 'my-experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot)
+      @pilot_section = create(:section, user: @pilot_section_owner, course_id: @pilot_course.id)
       create(:section_instructor, instructor: @pilot_teacher, section: @pilot_section, status: :active)
       @pilot_student = create(:follower, section: @pilot_section).student_user
 
       @pilot_pl_section_owner = create(:teacher, pilot_experiment: 'my-pl-experiment')
       @pilot_instructor = create(:facilitator, pilot_experiment: 'my-pl-experiment')
-      @pilot_pl_unit = create(:script, pilot_experiment: 'my-pl-experiment')
-      @pilot_pl_course = create(:single_unit_course, :pl_course, unit: @pilot_pl_unit, pilot_experiment: 'my-pl-experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot)
-      @pilot_pl_section = create(:section, user: @pilot_pl_section_owner, script: @pilot_pl_unit)
+      @pilot_pl_course = create(:single_unit_course, :pl_course, pilot_experiment: 'my-pl-experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot)
+      @pilot_pl_section = create(:section, user: @pilot_pl_section_owner, course_id: @pilot_pl_course.id)
       create(:section_instructor, instructor: @pilot_instructor, section: @pilot_pl_section, status: :active)
       @pilot_pl_participant = create(:facilitator)
       create(:follower, section: @pilot_pl_section, student_user: @pilot_pl_participant)
@@ -1858,7 +1768,7 @@ class ScriptsControllerTest < ActionController::TestCase
   describe '#redirect_to_canonical_path' do
     let!(:user) {create(:teacher)}
     let(:course) {create(:unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
-    let(:unit) {create(:unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+    let(:unit) {create(:unit)}
     let(:unit_position) {1}
     let!(:unit_group_unit) {create(:unit_group_unit, unit_group: course, script: unit, position: unit_position)}
     let(:modularity_enabled) {false}

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1163,12 +1163,22 @@ FactoryBot.define do
     published_state {nil}
 
     trait :in_single_unit_course do
-      published_state {nil}
-      instruction_type {nil}
-      participant_audience {nil}
-      instructor_audience {nil}
-      after(:create) do |unit|
-        create(:single_unit_course, unit: unit)
+      transient do
+        published_state {nil}
+        instruction_type {nil}
+        participant_audience {nil}
+        instructor_audience {nil}
+        pilot_experiment {nil}
+      end
+      after(:create) do |unit, evaluator|
+        attributes = {
+          published_state: evaluator.published_state,
+          instruction_type: evaluator.instruction_type,
+          participant_audience: evaluator.participant_audience,
+          instructor_audience: evaluator.instructor_audience,
+          pilot_experiment: evaluator.pilot_experiment
+        }.compact
+        create(:single_unit_course, unit: unit, **attributes)
       end
     end
 

--- a/dashboard/test/lib/policies/ai_test.rb
+++ b/dashboard/test/lib/policies/ai_test.rb
@@ -162,7 +162,7 @@ class Policies::AiTest < ActiveSupport::TestCase
 
     context 'the unit is an actual unit' do
       context 'the unit name is stable' do
-        let(:unit) {build(:unit, name: unit_name, published_state: 'stable')}
+        let(:unit) {create(:unit, :in_single_unit_course, name: unit_name, published_state: 'stable')}
         it 'returns true' do
           _(ai_differentiation_enabled_for_unit?).must_equal true
         end
@@ -201,7 +201,7 @@ class Policies::AiTest < ActiveSupport::TestCase
     let(:lesson) {build(:lesson, script: unit)}
 
     context 'the unit of the lesson is stable' do
-      let(:unit) {build(:unit, name: unit_name, published_state: 'stable')}
+      let(:unit) {create(:unit, :in_single_unit_course, name: unit_name, published_state: 'stable')}
       it 'returns true' do
         _(ai_differentiation_enabled_for_lesson?).must_equal true
       end
@@ -216,7 +216,7 @@ class Policies::AiTest < ActiveSupport::TestCase
     context 'the lesson belongs to a real unit we are specifically allowing' do
       ['csd3-2023'].each do |real_unit_name|
         context(real_unit_name) do
-          let(:unit) {build(:unit, name: real_unit_name, published_state: 'stable')}
+          let(:unit) {create(:unit, :in_single_unit_course, name: real_unit_name, published_state: 'stable')}
 
           it 'returns true' do
             _(ai_differentiation_enabled_for_lesson?).must_equal true

--- a/dashboard/test/lib/policies/unit_test.rb
+++ b/dashboard/test/lib/policies/unit_test.rb
@@ -14,16 +14,8 @@ class Policies::UnitTest < ActiveSupport::TestCase
   end
 
   test 'check deletion for unit (nil published state) in unit group with in_development' do
-    unit = create(:script, published_state: nil)
+    unit = create(:script)
     unit_gp = create(:unit_group, published_state: PUBLISHED_STATE.in_development)
-    create(:unit_group_unit, unit_group: unit_gp, script: unit, position: 1)
-
-    assert_equal true, Policies::Unit.can_be_deleted?(unit)
-  end
-
-  test 'check deletion published state unit in_development and unit group stable' do
-    unit = create(:script, published_state: PUBLISHED_STATE.in_development)
-    unit_gp = create(:unit_group, published_state: PUBLISHED_STATE.stable)
     create(:unit_group_unit, unit_group: unit_gp, script: unit, position: 1)
 
     assert_equal true, Policies::Unit.can_be_deleted?(unit)

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -1157,21 +1157,6 @@ module Services
       assert_equal 'Validation failed: Module type is not included in the list', e.message
     end
 
-    test 'published state set to pilot when pilot_experiment is present' do
-      unit = create(:script)
-      assert_nil unit.pilot_experiment
-      assert_equal Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development, unit.get_published_state
-
-      json = ScriptSeed.serialize_seeding_json(unit)
-      unit_data = JSON.parse(json)
-      unit_data['script']['properties']['pilot_experiment'] = 'my-experiment'
-
-      ScriptSeed.seed_from_json(unit_data.to_json)
-      unit.reload
-      assert_equal 'my-experiment', unit.pilot_experiment
-      assert_equal 'pilot', unit.get_published_state
-    end
-
     def get_script_and_json_with_change_and_rollback(script, &db_write_block)
       script_with_change = json = nil
       Unit.transaction do

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -308,7 +308,6 @@ class AbilityTest < ActiveSupport::TestCase
 
     assert ability.can?(:read, Section)
 
-    # TODO: figure out plc!!
     assert ability.can?(:read, Unit.find_by_name('ECSPD'))
     assert ability.can?(:read, Unit.find_by_name('flappy'))
 

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -40,18 +40,18 @@ class AbilityTest < ActiveSupport::TestCase
       end
     end
 
-    @pilot_course = create(:unit, pilot_experiment: 'my-experiment').tap do |script|
+    @pilot_course = create(:unit).tap do |script|
       create(:single_unit_course, unit: script, pilot_experiment: 'my-experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot)
       @pilot_course_script_level = create(:script_level, script: script)
     end
 
-    @pl_pilot_course = create(:unit, pilot_experiment: 'my-experiment').tap do |script|
+    @pl_pilot_course = create(:unit).tap do |script|
       create(:single_unit_course, unit: script, pilot_experiment: 'my-experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer)
       @pl_pilot_course_script_level = create(:script_level, script: script)
     end
 
     @in_development_unit_group = create(:unit_group, published_state: 'in_development')
-    @in_development_script = create(:script, published_state: 'in_development').tap do |script|
+    @in_development_script = create(:script).tap do |script|
       @in_development_lesson = create(:lesson, script: script, has_lesson_plan: true)
       @in_development_script_level = create(:script_level, script: script)
     end
@@ -308,6 +308,7 @@ class AbilityTest < ActiveSupport::TestCase
 
     assert ability.can?(:read, Section)
 
+    # TODO: figure out plc!!
     assert ability.can?(:read, Unit.find_by_name('ECSPD'))
     assert ability.can?(:read, Unit.find_by_name('flappy'))
 

--- a/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
+++ b/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
@@ -41,16 +41,22 @@ class AssignableCourseTests < ActiveSupport::TestCase
   end
 
   test 'course_assignable? is true if user has editor experiment access' do
-    partner_pilot_unit = create(:course_version, :with_single_unit_course).content_root.first_unit
-    partner_pilot_unit.update!(pilot_experiment: 'my-experiment', editor_experiment: 'ed-experiment')
+    partner_pilot_course = create(:course_version, :with_single_unit_course).content_root
+    partner_pilot_unit = partner_pilot_course.first_unit
+
+    partner_pilot_course.update!(pilot_experiment: 'my-experiment')
+    partner_pilot_unit.update!(editor_experiment: 'ed-experiment')
     partner = create(:teacher, editor_experiment: 'ed-experiment')
 
     assert partner_pilot_unit.course_assignable?(partner)
   end
 
   test 'course_assignable? is false if user does not have editor experiment access' do
-    partner_pilot_unit = create(:course_version, :with_single_unit_course).content_root.first_unit
-    partner_pilot_unit.update!(pilot_experiment: 'my-experiment', editor_experiment: 'ed-experiment')
+    partner_pilot_course = create(:course_version, :with_single_unit_course).content_root
+    partner_pilot_unit = partner_pilot_course.first_unit
+
+    partner_pilot_course.update!(pilot_experiment: 'my-experiment')
+    partner_pilot_unit.update!(editor_experiment: 'ed-experiment')
 
     refute partner_pilot_unit.course_assignable?(@teacher)
   end

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -50,8 +50,8 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
 
   describe '#visible_scripts' do
     subject(:visible_scripts) {student.visible_scripts}
-    let(:visible_script) {create(:script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
-    let(:hidden_script) {create(:script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)}
+    let(:visible_script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+    let(:hidden_script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)}
 
     context 'when the student is assigned scripts' do
       before do
@@ -68,8 +68,8 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
 
   describe '#any_visible_assigned_scripts?' do
     subject(:any_visible_assigned_scripts?) {student.any_visible_assigned_scripts?}
-    let(:visible_script) {create(:script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
-    let(:hidden_script) {create(:script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)}
+    let(:visible_script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+    let(:hidden_script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)}
 
     context 'when the student has no assigned scripts' do
       it 'returns false' do
@@ -167,8 +167,8 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
   end
 
   describe 'visible assigned scripts' do
-    let(:hidden_script) {create(:script, name: 'hidden-script', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)}
-    let(:visible_script) {create(:script, name: 'visible-script', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+    let(:hidden_script) {create(:script, :in_single_unit_course, name: 'hidden-script', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)}
+    let(:visible_script) {create(:script, :in_single_unit_course, name: 'visible-script', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
 
     describe '#visible_assigned_scripts' do
       let(:user) {create(:student)}
@@ -218,8 +218,8 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
 
   describe 'recently assigned script' do
     let(:user) {create(:student)}
-    let(:script1) {create(:script, name: 'script1', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
-    let(:script2) {create(:script, name: 'script2', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+    let(:script1) {create(:script, :in_single_unit_course, name: 'script1', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+    let(:script2) {create(:script, :in_single_unit_course, name: 'script2', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
 
     before do
       Timecop.freeze(Time.now) do
@@ -246,7 +246,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
 
   describe '#can_access_most_recently_assigned_script?' do
     let(:user) {create(:student)}
-    let(:script) {create(:script, name: 'recent-script', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+    let(:script) {create(:script, :in_single_unit_course, name: 'recent-script', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
     subject(:can_access_most_recently_assigned_script?) {user.can_access_most_recently_assigned_script?}
 
     context 'when the user has no assigned scripts' do
@@ -264,7 +264,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
 
     describe '#can_access_most_recently_assigned_script?' do
       let(:user) {create(:student)}
-      let(:script) {create(:script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+      let(:script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
       subject(:can_access?) {user.can_access_most_recently_assigned_script?}
 
       context 'when the user has no assigned scripts' do
@@ -282,7 +282,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
 
       context 'when the script is a pilot and the user has access' do
         let(:pilot_teacher) {create(:teacher, pilot_experiment: 'my-experiment')}
-        let(:pilot_script) {create(:script, name: 'pilot-script', pilot_experiment: 'my-experiment')}
+        let(:pilot_script) {create(:script, name: 'pilot-script')}
         let(:pilot_course) {create(:single_unit_course, unit: pilot_script, pilot_experiment: 'my-experiment')}
         let(:pilot_section) {create(:section, user: pilot_teacher, script: pilot_script, course_id: pilot_course.id)}
         let(:pilot_student) {create(:follower, section: pilot_section).student_user}
@@ -294,7 +294,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
       end
 
       context 'when the script is a pilot and the user does NOT have access' do
-        let(:pilot_script) {create(:script, pilot_experiment: 'test_experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+        let(:pilot_script) {create(:script, :in_single_unit_course, pilot_experiment: 'test_experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
         before {user.assign_script(pilot_script)}
         it 'returns false' do
           _(can_access?).must_equal false
@@ -305,8 +305,8 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
 
   describe 'recent progress in scripts' do
     let(:user) {create(:student)}
-    let(:script_1) {create(:script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
-    let(:script_2) {create(:script, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+    let(:script_1) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+    let(:script_2) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
     subject(:user_script_with_most_recent_progress) {user.user_script_with_most_recent_progress}
 
     before do
@@ -532,12 +532,12 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
         let(:teacher) {create(:teacher)}
 
         let(:unit_group) {create(:unit_group, name: 'testcourse', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
-        let(:unit_group_unit1) {create(:unit_group_unit, unit_group: unit_group, script: (create(:script, name: 'testscript1', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)), position: 1)}
-        let(:other_script) {create(:script, name: 'otherscript', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
+        let(:unit_group_unit1) {create(:unit_group_unit, unit_group: unit_group, script: (create(:script, name: 'testscript1')), position: 1)}
+        let(:other_script) {create(:script, name: 'otherscript')}
         let(:section) {create(:section, user_id: teacher.id, unit_group: unit_group)}
 
         before do
-          create(:unit_group_unit, unit_group: unit_group, script: (create(:script, name: 'testscript2', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)), position: 2)
+          create(:unit_group_unit, unit_group: unit_group, script: (create(:script, name: 'testscript2')), position: 2)
           create(:user_script, user: student, script: unit_group_unit1.script, started_at: (Time.now - 1.day))
           create(:user_script, user: student, script: other_script, started_at: (Time.now - 1.hour))
           Follower.create!(section_id: section.id, student_user_id: student.id, user: teacher)

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -34,10 +34,10 @@ class CourseVersionTest < ActiveSupport::TestCase
     CourseOffering.add_course_offering(@unit_group)
 
     @pilot_teacher = create(:teacher, pilot_experiment: 'my-experiment')
-    @pilot_unit = create(:single_unit_course, :with_course_offering, unit: @pilot_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-42', pilot_experiment: 'my-experiment').first_unit
+    @pilot_unit = create(:single_unit_course, :with_course_offering, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-42', pilot_experiment: 'my-experiment').first_unit
 
     @pilot_instructor = create(:facilitator, pilot_experiment: 'my-pl-experiment')
-    @pilot_pl_unit = create(:single_unit_course, :with_course_offering, :pl_course, unit: @pilot_pl_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-52', pilot_experiment: 'my-pl-experiment').first_unit
+    @pilot_pl_unit = create(:single_unit_course, :with_course_offering, :pl_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-52', pilot_experiment: 'my-pl-experiment').first_unit
 
     @partner = create(:teacher, pilot_experiment: 'my-editor-experiment', editor_experiment: 'ed-experiment')
     @partner_unit = create(:script, editor_experiment: 'ed-experiment')

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -34,15 +34,13 @@ class CourseVersionTest < ActiveSupport::TestCase
     CourseOffering.add_course_offering(@unit_group)
 
     @pilot_teacher = create(:teacher, pilot_experiment: 'my-experiment')
-    @pilot_unit = create(:script, pilot_experiment: 'my-experiment')
-    create(:single_unit_course, :with_course_offering, unit: @pilot_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-42', pilot_experiment: 'my-experiment')
+    @pilot_unit = create(:single_unit_course, :with_course_offering, unit: @pilot_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-42', pilot_experiment: 'my-experiment').first_unit
 
     @pilot_instructor = create(:facilitator, pilot_experiment: 'my-pl-experiment')
-    @pilot_pl_unit = create(:script, pilot_experiment: 'my-pl-experiment')
-    create(:single_unit_course, :with_course_offering, :pl_course, unit: @pilot_pl_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-52', pilot_experiment: 'my-pl-experiment')
+    @pilot_pl_unit = create(:single_unit_course, :with_course_offering, :pl_course, unit: @pilot_pl_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-52', pilot_experiment: 'my-pl-experiment').first_unit
 
     @partner = create(:teacher, pilot_experiment: 'my-editor-experiment', editor_experiment: 'ed-experiment')
-    @partner_unit = create(:script, pilot_experiment: 'my-editor-experiment', editor_experiment: 'ed-experiment')
+    @partner_unit = create(:script, editor_experiment: 'ed-experiment')
     create(:single_unit_course, :with_course_offering, unit: @partner_unit, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, version_year: '1991', family_name: 'family-112', pilot_experiment: 'my-editor-experiment')
   end
 

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -72,6 +72,19 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should raise error if deeper learning course is being launched' do
+    unit_group = create(:unit_group, family_name: 'plc')
+    unit_group.plc_course = Plc::Course.new(unit_group: unit_group)
+    unit_group.save
+
+    error = assert_raises do
+      unit_group.published_state = 'stable'
+      unit_group.save!
+    end
+
+    assert_includes error.message, 'Validation failed: Published state can never be pilot, preview or stable for a deeper learning course.'
+  end
+
   test "should serialize to json" do
     unit_group = create(:unit_group, name: 'my-unit-group', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led)
     create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "unit1", published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable))

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -72,17 +72,17 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should raise error if deeper learning course is being launched' do
+  test 'should raise error if plc course is being launched' do
     unit_group = create(:unit_group, family_name: 'plc')
     unit_group.plc_course = Plc::Course.new(unit_group: unit_group)
-    unit_group.save
+    unit_group.save!
 
     error = assert_raises do
       unit_group.published_state = 'stable'
       unit_group.save!
     end
 
-    assert_includes error.message, 'Validation failed: Published state can never be pilot, preview or stable for a pl course.'
+    assert_includes error.message, 'Validation failed: Published state can never be pilot, preview or stable for a plc course.'
   end
 
   test "should serialize to json" do

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -82,7 +82,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       unit_group.save!
     end
 
-    assert_includes error.message, 'Validation failed: Published state can never be pilot, preview or stable for a deeper learning course.'
+    assert_includes error.message, 'Validation failed: Published state can never be pilot, preview or stable for a pl course.'
   end
 
   test "should serialize to json" do

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -110,9 +110,9 @@ class UnitGroupTest < ActiveSupport::TestCase
 
   test "can seed unit group from hash" do
     unit_group = create(:unit_group, name: 'my-unit-group', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.self_paced, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator)
-    create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "unit1", published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable))
-    create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "unit2", published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable))
-    create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "unit3", published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable))
+    create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "unit1"))
+    create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "unit2"))
+    create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "unit3"))
 
     serialization = unit_group.serialize
     unit_group.original_units.each {|u| u.update!(original_unit_group: nil)}
@@ -404,88 +404,6 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_equal unit_group1, unit1.original_unit_group
     end
 
-    test "set pilot experiment to nil for new UnitGroupUnits" do
-      unit_group = create(:unit_group)
-
-      unit1 = create(:script, name: 'unit1', published_state: 'pilot', pilot_experiment: 'unit-going-to-unit-group-pilot')
-
-      unit_group.update_scripts(['unit1'])
-
-      unit1.reload
-      assert_nil unit1.published_state
-      assert_nil unit1.pilot_experiment
-    end
-
-    test "set published state to nil for new UnitGroupUnits" do
-      unit_group = create(:unit_group)
-
-      unit1 = create(:script, name: 'unit1')
-      unit2 = create(:script, name: 'unit2')
-
-      unit_group.update_scripts(['unit1'])
-
-      unit1.reload
-      unit2.reload
-      assert_nil unit1.published_state
-
-      unit1.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview)
-      unit2.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview)
-
-      unit_group.update_scripts(['unit1', 'unit2'])
-
-      unit1.reload
-      unit2.reload
-      assert_equal Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview, unit1.published_state
-      assert_nil unit2.published_state
-    end
-
-    test "set instructor and participant audience to nil for new UnitGroupUnits" do
-      unit_group = create(:unit_group)
-
-      unit1 = create(:script, name: 'unit1')
-      unit2 = create(:script, name: 'unit2')
-
-      unit_group.update_scripts(['unit1'])
-
-      unit1.reload
-      unit2.reload
-      assert_nil unit1.instructor_audience
-      assert_nil unit1.participant_audience
-
-      unit2.update!(instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
-
-      unit_group.update_scripts(['unit1', 'unit2'])
-
-      unit1.reload
-      unit2.reload
-      assert_nil unit1.instructor_audience
-      assert_nil unit1.participant_audience
-      assert_nil unit2.instructor_audience
-      assert_nil unit2.participant_audience
-    end
-
-    test "set instruction type to nil for new UnitGroupUnits" do
-      unit_group = create(:unit_group)
-
-      unit1 = create(:script, name: 'unit1')
-      unit2 = create(:script, name: 'unit2')
-
-      unit_group.update_scripts(['unit1'])
-
-      unit1.reload
-      unit2.reload
-      assert_nil unit1.instruction_type
-
-      unit2.update!(instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led)
-
-      unit_group.update_scripts(['unit1', 'unit2'])
-
-      unit1.reload
-      unit2.reload
-      assert_nil unit1.instruction_type
-      assert_nil unit2.instruction_type
-    end
-
     test "cannot remove UnitGroupUnits from their original course that cannot change course version" do
       course_version = create(:course_version)
       unit_group = create(:unit_group, course_version: course_version)
@@ -518,24 +436,11 @@ class UnitGroupTest < ActiveSupport::TestCase
         instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
         participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
       )
-      unit1 = create(
-        :script,
-        name: 'unit1',
-        published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development,
-        instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led,
-        instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-        participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
-      )
+      unit1 = create(:script, name: 'unit1')
       create(:script, name: 'unit2')
 
       unit_group.update_scripts(['unit1', 'unit2'])
-
-      unit1.reload
-
-      assert_nil unit1.published_state
-      assert_nil unit1.instruction_type
-      assert_nil unit1.instructor_audience
-      assert_nil unit1.participant_audience
+      assert_equal 2, unit_group.default_unit_group_units.length
 
       unit_group.update_scripts(['unit2'])
 
@@ -545,10 +450,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_equal 1, unit_group.default_unit_group_units.length
       assert_equal 1, unit_group.default_unit_group_units[0].position
       assert_equal 'unit2', unit_group.default_unit_group_units[0].script.name
-      assert_equal unit1.published_state, Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
-      assert_equal unit1.instruction_type, Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-      assert_equal unit1.instructor_audience, Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
-      assert_equal unit1.participant_audience, Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
+      assert_empty unit1.unit_groups
     end
 
     test "remove UnitGroupUnits from original unit group" do
@@ -606,89 +508,6 @@ class UnitGroupTest < ActiveSupport::TestCase
 
       new_unit_group.update_scripts([])
       assert_equal 0, new_unit_group.default_unit_group_units.length
-    end
-
-    test "removed units have their published state instruction type participant audience and instructor audience reset" do
-      unit_group = create(:unit_group)
-      unit1 = create(:script, name: 'unit1')
-      unit2 = create(:script, name: 'unit2')
-
-      unit_group.update_scripts(['unit1', 'unit2'])
-
-      unit_group.reload
-      unit1.reload
-      unit2.reload
-
-      assert_nil unit1.published_state
-      assert_nil unit1.instruction_type
-      assert_nil unit1.instructor_audience
-      assert_nil unit1.participant_audience
-
-      assert_nil unit2.published_state
-      assert_nil unit2.instruction_type
-      assert_nil unit2.instructor_audience
-      assert_nil unit2.participant_audience
-
-      unit_group.update_scripts(['unit2'])
-
-      unit_group.reload
-      unit1.reload
-      unit2.reload
-
-      assert_equal unit_group.published_state, unit1.published_state
-      refute_nil unit1.published_state
-      assert_equal unit_group.instruction_type, unit1.instruction_type
-      refute_nil unit1.instruction_type
-      assert_equal unit_group.instructor_audience, unit1.instructor_audience
-      refute_nil unit1.instructor_audience
-      assert_equal unit_group.participant_audience, unit1.participant_audience
-      refute_nil unit1.participant_audience
-
-      assert_nil unit2.published_state
-      assert_nil unit2.instruction_type
-      assert_nil unit2.instructor_audience
-      assert_nil unit2.participant_audience
-    end
-
-    test "units with published state set independent of the unit group maintain that published state when removed" do
-      unit_group = create(:unit_group)
-      unit1 = create(:script, name: 'unit1')
-      unit2 = create(:script, name: 'unit2')
-
-      unit_group.update_scripts(['unit1', 'unit2'])
-
-      unit_group.reload
-      unit1.reload
-      unit2.reload
-
-      assert_nil unit1.published_state
-      assert_nil unit1.instruction_type
-      assert_nil unit1.instructor_audience
-      assert_nil unit1.participant_audience
-
-      assert_nil unit2.published_state
-      assert_nil unit2.instruction_type
-      assert_nil unit2.instructor_audience
-      assert_nil unit2.participant_audience
-
-      unit2.published_state = Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
-      unit2.save!
-
-      assert_equal Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development, unit2.published_state
-
-      unit_group.update_scripts(['unit1'])
-
-      unit_group.reload
-      unit2.reload
-
-      refute_equal unit_group.published_state, unit2.published_state
-      assert_equal Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development, unit2.published_state
-      assert_equal unit_group.instruction_type, unit2.instruction_type
-      refute_nil unit2.instruction_type
-      assert_equal unit_group.instructor_audience, unit2.instructor_audience
-      refute_nil unit2.instructor_audience
-      assert_equal unit_group.participant_audience, unit2.participant_audience
-      refute_nil unit2.participant_audience
     end
   end
 

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -581,7 +581,7 @@ class UnitTest < ActiveSupport::TestCase
 
   test 'self.latest_stable_version returns latest stable version for user locale' do
     create(:script, :in_single_unit_course, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, supported_locales: ["it-it"])
-    unit_2018 = create(:script, :in_single_unit_course,  name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, supported_locales: ["it-it"])
+    unit_2018 = create(:script, :in_single_unit_course, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, supported_locales: ["it-it"])
 
     assert_equal unit_2018, Unit.latest_stable_version('fake-family', locale: 'it-it')
   end
@@ -2420,17 +2420,6 @@ class UnitTest < ActiveSupport::TestCase
         @single_unit.clone_migrated_unit('coursename2-2021', destination_unit_group_name: versionless_unit_group.name)
       end
     end
-  end
-
-  test 'should raise error if deeper learning course is being launched' do
-    unit = create(:unit, professional_learning_course: 'my-deeper-learning-course')
-
-    error = assert_raises do
-      unit.published_state = 'stable'
-      unit.save!
-    end
-
-    assert_includes error.message, 'Validation failed: Published state can never be pilot, preview or stable for a deeper learning course.'
   end
 
   test 'finish_url returns unit group finish url if in a unit group' do

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -20,7 +20,7 @@ class UnitTest < ActiveSupport::TestCase
     @unit_group.reload
 
     @pl_unit_group = create(:unit_group)
-    @pl_unit_in_unit_group = create(:script, name: 'pl-unit-in-unit-group', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
+    @pl_unit_in_unit_group = create(:script, name: 'pl-unit-in-unit-group', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
     create(:unit_group_unit, position: 1, unit_group: @pl_unit_group, script: @pl_unit_in_unit_group)
     @pl_unit_in_unit_group.reload
     @pl_unit_group.reload
@@ -1354,30 +1354,8 @@ class UnitTest < ActiveSupport::TestCase
     assert_equal Plc::LearningModule::CONTENT_MODULE, lm.module_type
   end
 
-  test 'updating plc unit updates its unit group' do
-    Unit.stubs(:unit_json_directory).returns(self.class.fixture_path)
-    unit = Unit.seed_from_json_file('test-plc')
-
-    unit_group = unit.plc_course_unit.plc_course.unit_group
-
-    assert_equal 'plc_reviewer', unit_group.instructor_audience
-    assert_equal 'facilitator', unit_group.participant_audience
-    assert_equal 'teacher_led', unit_group.instruction_type
-    assert_equal 'beta', unit_group.published_state
-
-    unit.update!(instructor_audience: 'universal_instructor', participant_audience: 'teacher', instruction_type: 'self_paced', published_state: 'in_development')
-
-    unit.reload
-    unit_group = unit.plc_course_unit.plc_course.unit_group
-
-    assert_equal 'universal_instructor', unit_group.instructor_audience
-    assert_equal 'teacher', unit_group.participant_audience
-    assert_equal 'self_paced', unit_group.instruction_type
-    assert_equal 'in_development', unit_group.published_state
-  end
-
   test 'generate plc objects will use defaults if script has null values' do
-    unit = create(:script, professional_learning_course: 'my-plc-course', published_state: nil, instruction_type: nil, instructor_audience: nil, participant_audience: nil)
+    unit = create(:script, professional_learning_course: 'my-plc-course', published_state: nil)
 
     unit_group = unit.plc_course_unit.plc_course.unit_group
 
@@ -2254,7 +2232,7 @@ class UnitTest < ActiveSupport::TestCase
       @single_unit_course = create(:single_unit_course, version_year: '2021', family_name: 'csf', name: 'single-unit-course-2021', unit: @single_unit)
       create(:course_version, content_root: @single_unit_course)
 
-      @deeper_learning_unit = create(:script, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer, professional_learning_course: 'DLP 2021', instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led)
+      @deeper_learning_unit = create(:script, professional_learning_course: 'DLP 2021')
 
       @unit_group = create(:unit_group)
       @ug_course_version = create(:course_version, content_root: @unit_group)
@@ -2280,9 +2258,6 @@ class UnitTest < ActiveSupport::TestCase
       cloned_unit = @deeper_learning_unit.clone_migrated_unit('dlp-2022', destination_professional_learning_course: 'Deeper Learning 2022', new_level_suffix: '2022')
       assert_equal 'dlp-2022', cloned_unit.name
       assert_equal 'Deeper Learning 2022', cloned_unit.professional_learning_course
-      assert_equal cloned_unit.instruction_type, @deeper_learning_unit.instruction_type
-      assert_equal cloned_unit.instructor_audience, @deeper_learning_unit.instructor_audience
-      assert_equal cloned_unit.participant_audience, @deeper_learning_unit.participant_audience
       refute_equal [level1, level2], cloned_unit.levels
     end
 
@@ -2341,10 +2316,6 @@ class UnitTest < ActiveSupport::TestCase
       assert_equal 2, @unit_group.default_units.count
       assert_equal 'single-unit-2022', @unit_group.default_units[1].name
       assert_equal cloned_unit.get_original_unit_group, @unit_group
-      assert_nil cloned_unit.published_state
-      assert_nil cloned_unit.instruction_type
-      assert_nil cloned_unit.instructor_audience
-      assert_nil cloned_unit.participant_audience
     end
 
     test 'can copy unit with lessons without copying levels' do

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -580,31 +580,31 @@ class UnitTest < ActiveSupport::TestCase
   end
 
   test 'self.latest_stable_version returns latest stable version for user locale' do
-    create(:script, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, supported_locales: ["it-it"])
-    unit_2018 = create(:script, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, supported_locales: ["it-it"])
+    create(:script, :in_single_unit_course, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, supported_locales: ["it-it"])
+    unit_2018 = create(:script, :in_single_unit_course,  name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, supported_locales: ["it-it"])
 
     assert_equal unit_2018, Unit.latest_stable_version('fake-family', locale: 'it-it')
   end
 
   test 'self.latest_stable_version returns latest stable version for English locales' do
-    create(:script, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-    unit_2018 = create(:script, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    create(:script, :in_single_unit_course, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    unit_2018 = create(:script, :in_single_unit_course, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
 
     assert_equal unit_2018, Unit.latest_stable_version('fake-family')
     assert_equal unit_2018, Unit.latest_stable_version('fake-family', locale: 'en-ca')
   end
 
   test 'self.latest_stable_version returns correct unit version in family if version_year is supplied' do
-    unit_2017 = create(:script, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-    create(:script, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    unit_2017 = create(:script, :in_single_unit_course, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    create(:script, :in_single_unit_course, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
 
     assert_equal unit_2017, Unit.latest_stable_version('fake-family', version_year: '2017')
   end
 
   test 'self.lastest_stable_version supports some family members having nil version_years' do
-    unit_2017 = create(:script, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-    create(:script, name: 's-unknown', family_name: 'fake-family', version_year: nil, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-    create(:script, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    unit_2017 = create(:script, :in_single_unit_course, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    create(:script, :in_single_unit_course, name: 's-unknown', family_name: 'fake-family', version_year: nil, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    create(:script, :in_single_unit_course, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
 
     assert_equal unit_2017, Unit.latest_stable_version('fake-family', version_year: '2017')
   end
@@ -1844,7 +1844,7 @@ class UnitTest < ActiveSupport::TestCase
 
   test 'has pilot access' do
     unit = create(:script, :in_single_unit_course)
-    pilot_unit = create(:script, :in_single_unit_course, pilot_experiment: 'my-experiment')
+    pilot_unit = create(:single_unit_course, pilot_experiment: 'my-experiment').first_unit
 
     student = create(:student)
     teacher = create(:teacher)
@@ -1904,7 +1904,7 @@ class UnitTest < ActiveSupport::TestCase
     student = create(:student)
     teacher = create(:teacher)
     pilot_teacher = create(:teacher, pilot_experiment: 'my-experiment')
-    create(:script, :in_single_unit_course, pilot_experiment: 'my-experiment')
+    create(:single_unit_course, pilot_experiment: 'my-experiment')
     levelbuilder = create(:levelbuilder)
 
     refute Unit.has_any_pilot_access?
@@ -1916,7 +1916,7 @@ class UnitTest < ActiveSupport::TestCase
 
   test 'platformization partner has pilot access' do
     unit = create(:script, :in_single_unit_course)
-    partner_pilot_unit = create(:script, :in_single_unit_course, pilot_experiment: 'my-experiment', editor_experiment: 'ed-experiment')
+    partner_pilot_unit = create(:script, :in_single_unit_course, editor_experiment: 'ed-experiment', pilot_experiment: 'my-experiment', published_state: 'pilot')
 
     student = create(:student)
     teacher = create(:teacher)


### PR DESCRIPTION
This PR removes `instruction_type`, `instructor_audience`, `participant_audience`, `pilot_experiment`, and `published_state` references in the unit model. These fields are no longer necessary now that all units will be in a course.



## Links
- Jira: [TEACH-2157](https://codedotorg.atlassian.net/browse/TEACH-2157)

## Testing story
Manually verified: 

- [x] New units have nil-ed out fields (except `published_state` is default `in_development`)
- [x] Can edit units
- [x] Units still have nil-ed out fields after being added to a unit group
- [x] Can assign the new unit to a section as a teacher
- [x] Can navigate in the new unit and complete lessons as a student


## Follow-up work
- Remove `family_name` and `version_year` references ([TEACH-2157](https://codedotorg.atlassian.net/browse/TEACH-2157))
- Remove these columns from the model ([TEACH-2158](https://codedotorg.atlassian.net/browse/TEACH-2158))


