### PR TITLE
rename unit.unit_group to unit.get_original_unit_group

### DIFF
--- a/bin/oneoff/add_course_offering_for_all.rb
+++ b/bin/oneoff/add_course_offering_for_all.rb
@@ -8,7 +8,7 @@ def add_course_offering_for_all
   raise unless Rails.application.config.levelbuilder_mode
 
   Unit.all.each do |script|
-    next if script.unit_group
+    next if script.get_original_unit_group
     next if script.old_professional_learning_course?
     next if script.published_state == "in_development"
 

--- a/bin/oneoff/data_fix/fix_units_in_unit_group_version_year.rb
+++ b/bin/oneoff/data_fix/fix_units_in_unit_group_version_year.rb
@@ -29,7 +29,7 @@ def set_nil_version_year(actual_execution)
       next
     end
 
-    unless unit.unit_group
+    unless unit.get_original_unit_group
       puts "#{unit_name} is not part of unit group. Skipping."
       next
     end

--- a/bin/oneoff/set_course_audiences.rb
+++ b/bin/oneoff/set_course_audiences.rb
@@ -11,7 +11,7 @@ def set_course_audiences
 
   Unit.all.each do |script|
     # scripts in unit_groups get their audiences from their unit group
-    next if script.unit_group
+    next if script.get_original_unit_group
 
     # rubocop:disable Style/WordArray
     # rubocop:disable Performance/CollectionLiteralInLoop

--- a/bin/oneoff/set_instruction_type.rb
+++ b/bin/oneoff/set_instruction_type.rb
@@ -15,7 +15,7 @@ def set_instruction_type
   self_paced_units = ['self-paced-pl-csd5-2021', 'self-paced-pl-csd6-2021', 'self-paced-pl-csd7-2021', 'self-paced-pl-csd8-2021']
   Unit.all.each do |script|
     # scripts in unit_groups get their instruction type from their unit group
-    next if script.unit_group
+    next if script.get_original_unit_group
 
     script.instruction_type = if self_paced_units.include?(script.name)
                                 'self_paced'

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -298,7 +298,7 @@ class ApiController < ApplicationController
       unit_group = UnitGroup.get_from_cache(section.course_id)
     elsif section.script_id
       # Some older Sections only have a script_id defined.
-      unit_group = Unit.get_from_cache(section.script_id)&.unit_group
+      unit_group = Unit.get_from_cache(section.script_id)&.get_original_unit_group
     end
     unit_ids.concat(unit_group.default_units.pluck(:id)).uniq! if unit_group
     render json: CourseVersion.courses_for_unit_selector(unit_ids, current_user)

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -152,7 +152,7 @@ class HomeController < ApplicationController
     script = Queries::ScriptActivity.primary_student_unit(current_user)
     if script
       script_level = current_user.next_unpassed_progression_level(script)
-      unit_group = script.unit_group
+      unit_group = script.get_original_unit_group
       unit_group_unit = script.unit_group_units.find {|ugu| ugu.unit_group == unit_group} if unit_group
     end
     @homepage_data[:topCourse] = nil
@@ -181,7 +181,7 @@ class HomeController < ApplicationController
       pl_unit = Queries::ScriptActivity.primary_pl_unit(current_user)
       if pl_unit
         pl_script_level = current_user.next_unpassed_progression_level(pl_unit)
-        pl_unit_group = pl_unit.unit_group
+        pl_unit_group = pl_unit.get_original_unit_group
         pl_unit_group_unit = pl_unit.unit_group_units.find {|ugu| ugu.unit_group == pl_unit_group} if pl_unit_group
       end
       @homepage_data[:topPlCourse] = nil

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -41,8 +41,8 @@ class ScriptsController < ApplicationController
         end
         return
       end
-      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.id == @course&.id}
-        most_recent_section = current_user.sections_instructed.select {|s| s.script_id == @script.id || s.unit_group&.id == @course.id}.last
+      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.get_original_unit_group&.id == @course&.id}
+        most_recent_section = current_user.sections_instructed.select {|s| s.script_id == @script.id || s.get_original_unit_group&.id == @course.id}.last
         section_id = params[:section_id]
         section_id ||= most_recent_section&.id
         if section_id
@@ -120,7 +120,7 @@ class ScriptsController < ApplicationController
     @page_title = "Unit: #{@script.localized_title}"
     @page_description = @script.localized_description.truncate(200, separator: '.', omission: '.')
 
-    if @script.unit_group&.single_unit_course?
+    if @script.get_original_unit_group&.single_unit_course?
       canonical_ug = UnitGroup.latest_stable_version(@course.family_name)&.name
       @canonical_url = CDO.studio_url("/courses/#{canonical_ug}/units/1") if canonical_ug
     end

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -41,8 +41,8 @@ class ScriptsController < ApplicationController
         end
         return
       end
-      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.get_original_unit_group&.id == @course&.id}
-        most_recent_section = current_user.sections_instructed.select {|s| s.script_id == @script.id || s.get_original_unit_group&.id == @course.id}.last
+      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.id == @course&.id}
+        most_recent_section = current_user.sections_instructed.select {|s| s.script_id == @script.id || s.unit_group&.id == @course.id}.last
         section_id = params[:section_id]
         section_id ||= most_recent_section&.id
         if section_id

--- a/dashboard/app/models/concerns/curriculum/course_types.rb
+++ b/dashboard/app/models/concerns/curriculum/course_types.rb
@@ -40,7 +40,7 @@ module Curriculum::CourseTypes
 
     if is_a?(UnitGroup)
       all_family_courses = UnitGroup.all.select {|c| c.family_name == family_name}
-    elsif is_a?(Unit) && !unit_group
+    elsif is_a?(Unit) && !get_original_unit_group
       all_family_courses = Unit.get_family_from_cache(family_name)
     end
 
@@ -59,7 +59,7 @@ module Curriculum::CourseTypes
     return false unless user
 
     # If unit is in a unit group then decide based on unit group audience
-    return unit_group.can_be_instructor?(user) if is_a?(Unit) && unit_group
+    return get_original_unit_group.can_be_instructor?(user) if is_a?(Unit) && get_original_unit_group
 
     return false if user.student?
     return true if user.permission?(UserPermission::UNIVERSAL_INSTRUCTOR) || user.permission?(UserPermission::LEVELBUILDER)
@@ -82,7 +82,7 @@ module Curriculum::CourseTypes
   # in student courses.
   def can_be_participant?(user)
     # If unit is in a unit group then decide based on unit group audience
-    return unit_group.can_be_participant?(user) if is_a?(Unit) && unit_group
+    return get_original_unit_group.can_be_participant?(user) if is_a?(Unit) && get_original_unit_group
 
     # Signed out users can only use student facing courses
     return false if !user && participant_audience != 'student'
@@ -107,7 +107,7 @@ module Curriculum::CourseTypes
   # those can be checked for using old_professional_learning_course?
   def pl_course?
     # If unit is in a unit group then decide based on unit group
-    return unit_group.pl_course? if is_a?(Unit) && unit_group
+    return get_original_unit_group.pl_course? if is_a?(Unit) && get_original_unit_group
 
     participant_audience != 'student'
   end

--- a/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
+++ b/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
@@ -14,7 +14,7 @@ module User::AssignedCoursesAndScripts
 
   # Returns the set of courses the user has been assigned to or has progress in.
   def courses_as_participant
-    visible_scripts.filter_map(&:unit_group).concat(section_courses).uniq
+    visible_scripts.filter_map(&:get_original_unit_group).concat(section_courses).uniq
   end
 
   def visible_scripts
@@ -22,7 +22,7 @@ module User::AssignedCoursesAndScripts
   end
 
   def assigned_script?(script)
-    section_scripts.include?(script) || section_courses.include?(script&.unit_group)
+    section_scripts.include?(script) || section_courses.include?(script&.get_original_unit_group)
   end
 
   # Checks if there are any launched scripts assigned to the user.

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -253,8 +253,8 @@ class Lesson < ApplicationRecord
 
   def lesson_feedback_url
     url = "https://studio.code.org/form/teacher_lesson_feedback?survey_data[script_name]=#{script.name}&survey_data[lesson_number]=#{relative_position}&survey_data[lesson_name]=#{CGI.escape(localized_name)}"
-    url += if script.unit_group
-             "&survey_data[course_name]=#{CGI.escape(script.unit_group.localized_title)}&survey_data[unit_name]=#{CGI.escape(script.localized_title)}&survey_data[unit_number]=#{script.unit_group_units&.first&.position}"
+    url += if script.get_original_unit_group
+             "&survey_data[course_name]=#{CGI.escape(script.get_original_unit_group.localized_title)}&survey_data[unit_name]=#{CGI.escape(script.localized_title)}&survey_data[unit_number]=#{script.unit_group_units&.first&.position}"
            else
              "&survey_data[course_name]=#{CGI.escape(script.localized_title)}"
            end

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -147,7 +147,7 @@ class Unit < ApplicationRecord
   # however this is not practical to do given how rails validations work for
   # activerecord-import during the seed process.
   def hide_pilot_units
-    if !unit_group && pilot_experiment.present? && published_state != Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot
+    if !get_original_unit_group && pilot_experiment.present? && published_state != Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot
       update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot)
     end
   end
@@ -649,13 +649,13 @@ class Unit < ApplicationRecord
     # or the course it belongs to.
     return nil unless can_view_version?(user, locale: locale) && !user.assigned_script?(self)
     # No redirect if unit or its course are not versioned.
-    current_version_year = version_year || unit_group&.version_year
+    current_version_year = version_year || get_original_unit_group&.version_year
     return nil if current_version_year.blank?
 
     # Redirect user to the latest assigned unit in this family,
     # if one exists and it is newer than the current unit.
     latest_assigned_version = Unit.latest_assigned_version(family_name, user)
-    latest_assigned_version_year = latest_assigned_version&.version_year || latest_assigned_version&.unit_group&.version_year
+    latest_assigned_version_year = latest_assigned_version&.version_year || latest_assigned_version&.get_original_unit_group&.version_year
     return nil unless latest_assigned_version_year && latest_assigned_version_year > current_version_year
     latest_assigned_version.link
   end
@@ -672,7 +672,7 @@ class Unit < ApplicationRecord
   # @param locale [String] User or request locale. Optional.
   # @return [Boolean] Whether the user can view the unit.
   def can_view_version?(user, locale: nil, unit_group: nil)
-    unit_group ||= self.unit_group
+    unit_group ||= get_original_unit_group
     return false unless Ability.new(user).can?(:read, self, unit_group)
 
     # Users can view any course not in a family.
@@ -705,8 +705,8 @@ class Unit < ApplicationRecord
   # If it's the last unit in the unit group, returns nil.
   # If it's not in a unit group, returns nil.
   def next_unit(user)
-    return nil unless unit_group
-    other_units = unit_group.units_for_user(user)
+    return nil unless get_original_unit_group
+    other_units = get_original_unit_group.units_for_user(user)
     self_index = other_units.index {|u| u.id == id}
     other_units[self_index + 1] if self_index
   end
@@ -850,7 +850,7 @@ class Unit < ApplicationRecord
   end
 
   def has_standards_associations?
-    curriculum_umbrella == 'CSF' && ((version_year && version_year >= '2019') || (unit_group&.version_year && unit_group.version_year >= '2019'))
+    curriculum_umbrella == 'CSF' && ((version_year && version_year >= '2019') || (get_original_unit_group&.version_year && get_original_unit_group.version_year >= '2019'))
   end
 
   def standards
@@ -1328,9 +1328,9 @@ class Unit < ApplicationRecord
           wrapup_video: general_params[:wrapup_video],
           family_name: general_params[:family_name].presence ? general_params[:family_name] : nil, # default nil
           hide_within_course: general_params[:hide_within_course].nil? ? false : general_params[:hide_within_course], # default false
-          instruction_type: unit_group.present? ? nil : general_params[:instruction_type],
-          participant_audience: unit_group.present? ? nil : general_params[:participant_audience],
-          instructor_audience: unit_group.present? ? nil : general_params[:instructor_audience],
+          instruction_type: get_original_unit_group.present? ? nil : general_params[:instruction_type],
+          participant_audience: get_original_unit_group.present? ? nil : general_params[:participant_audience],
+          instructor_audience: get_original_unit_group.present? ? nil : general_params[:instructor_audience],
           properties: Unit.build_property_hash(general_params)
         },
         unit_data[:lesson_groups]
@@ -1446,7 +1446,7 @@ class Unit < ApplicationRecord
   def finish_url(unit_group_unit: nil)
     return hoc_finish_url if hoc?
     return csf_finish_url if csf?
-    course = unit_group_unit&.unit_group || unit_group
+    course = unit_group_unit&.unit_group || get_original_unit_group
     if course
       return CDO.code_org_url "/congrats/#{course.name}"
     end
@@ -1653,8 +1653,8 @@ class Unit < ApplicationRecord
   end
 
   def allow_major_curriculum_changes?
-    unit_group.nil? ||
-      [PUBLISHED_STATE.in_development, PUBLISHED_STATE.pilot].include?(unit_group.published_state) ||
+    get_original_unit_group.nil? ||
+      [PUBLISHED_STATE.in_development, PUBLISHED_STATE.pilot].include?(get_original_unit_group.published_state) ||
       hide_within_course
   end
 
@@ -1885,11 +1885,10 @@ class Unit < ApplicationRecord
     result
   end
 
-  # A unit is considered to have a matching course if there is at least one
-  # unit_group for this unit
-  # @deprecated - This method should no longer be used. This from a time when
-  # Units could only be in max 1 UnitGroup.
-  def unit_group
+  # A unit's original_unit_group is the unit group that it was first associated with.
+  # If a unit is in multiple unit groups, this is the first one it was added to.
+  # If a unit is not in any unit group, this will be nil.
+  def get_original_unit_group
     # rubocop:disable Style/ZeroLengthPredicate
     return nil if unit_group_units.length < 1
     # rubocop:enable Style/ZeroLengthPredicate
@@ -1905,36 +1904,36 @@ class Unit < ApplicationRecord
   # if there is one.
   # @return [CourseVersion]
   def get_course_version
-    unit_group&.course_version
+    get_original_unit_group&.course_version
   end
 
   # If a script is in a unit group, use that unit group's published state. If not, use the script's published_state
   # If both are null, the script is in_development
   def get_published_state
-    published_state || unit_group&.published_state || Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
+    published_state || get_original_unit_group&.published_state || Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
   end
 
   # If a script is in a unit group, use that unit group's instruction type. If not, use the units's instruction type
   # If both are null, the unit should be teacher led
   def get_instruction_type
-    unit_group&.instruction_type || instruction_type || Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
+    get_original_unit_group&.instruction_type || instruction_type || Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
   end
 
   # If a script is in a unit group, use that unit group's instructor_audience. If not, use the units's instructor_audience
   # If both are null, the unit should be instructed by teacher
   def get_instructor_audience
-    unit_group&.instructor_audience || instructor_audience || Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
+    get_original_unit_group&.instructor_audience || instructor_audience || Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
   end
 
   # If a script is in a unit group, use that unit group's participant_audience. If not, use the units's participant_audience
   # If both are null, the unit should be participated in by students
   def get_participant_audience
-    unit_group&.participant_audience || participant_audience || Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
+    get_original_unit_group&.participant_audience || participant_audience || Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
   end
 
   # Use the unit group's pilot_experiment if one exists
   def get_pilot_experiment
-    pilot_experiment || unit_group&.pilot_experiment
+    pilot_experiment || get_original_unit_group&.pilot_experiment
   end
 
   def unversioned?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -796,7 +796,7 @@ class User < ApplicationRecord
     return false if sections_as_student.empty?
 
     # Can't hide a unit that isn't part of a course
-    unit_group = unit.try(:unit_group)
+    unit_group = unit.try(:get_original_unit_group)
     return false unless unit_group
 
     get_participant_hidden_ids(unit_group.id, false).include?(unit.id)

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -15,7 +15,7 @@
       %a{href: '#notes-outer'}= I18n.t('video.notes')
 
 - if @script_level
-  - level_data = {redirect_script_url: @redirect_unit_url, script_name: @script_level.script&.name, course_name: @script_level.script&.unit_group&.name, level_name: @level.name, tts_autoplay_enabled: @tts_autoplay_enabled, code_review_enabled: @code_review_enabled_for_level}
+  - level_data = {redirect_script_url: @redirect_unit_url, script_name: @script_level.script&.name, course_name: @script_level.script&.get_original_unit_group&.name, level_name: @level.name, tts_autoplay_enabled: @tts_autoplay_enabled, code_review_enabled: @code_review_enabled_for_level}
   - ai_diff_data = {levelId: @level&.id, scriptId: @script_level.script&.id}
   %link{href: asset_path('css/levels.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/levels/show.js'), data: { aiDiffData: ai_diff_data.to_json, level: level_data.to_json, rubricData: @rubric_data&.to_json }}

--- a/dashboard/app/views/scripts/_hidden_script.html.haml
+++ b/dashboard/app/views/scripts/_hidden_script.html.haml
@@ -2,6 +2,6 @@
   #hidden-script
     %div{style: 'margin-bottom: 15px' }
       =t('hidden_script')
-    %a{href: course_path(@script.unit_group)}
+    %a{href: course_path(@script.get_original_unit_group)}
       %button.btn.btn-large.btn-primary
         =t('return_course_overview')

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -230,9 +230,9 @@ class CertificateImage
 
       # When we have a unit within a unit_group, we want to display both the unit and unit_group titles.
       # When we have a unit group, we only display the localized title of unit_or_unit_group.
-      if unit_or_unit_group.is_a?(Unit) && unit_or_unit_group.unit_group.present?
+      if unit_or_unit_group.is_a?(Unit) && unit_or_unit_group.get_original_unit_group.present?
         unit = unit_or_unit_group
-        unit_group = unit.unit_group
+        unit_group = unit.get_original_unit_group
 
         course_titles_constants = cert_text_constants[:two_titles]
 

--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -182,7 +182,7 @@ module Services
     end
 
     def self.generate_metadata_for_ai(script, lesson)
-      course_name = script.unit_group ? script.unit_group.name : script.name
+      course_name = script.get_original_unit_group ? script.get_original_unit_group.name : script.name
       metadata ={
         course: course_name,
         unit_fullname: script.name,

--- a/dashboard/lib/services/unit_group_creator.rb
+++ b/dashboard/lib/services/unit_group_creator.rb
@@ -10,7 +10,7 @@ module Services
     end
 
     def call
-      if @unit.unit_group
+      if @unit.get_original_unit_group
         log "Unit already has a UnitGroup: #{@unit.name}", type: "error"
         return false
       end
@@ -56,7 +56,7 @@ module Services
     def rollback
       log "Rolling back migration for unit #{@unit.name}"
 
-      @unit_group ||= @unit.unit_group
+      @unit_group ||= @unit.get_original_unit_group
       if @unit_group.nil?
         log "Unit's unit_group not found: #{@unit.name}", type: "error"
         return false
@@ -214,7 +214,7 @@ module Services
       checks = {
         "UnitGroup is destroyed" => UnitGroup.find_by(id: unit_group_id).nil?,
         "Unit is valid" => @unit.valid? || @name_changed,
-        "Unit does not have a unit_group" => @unit.unit_group.nil?,
+        "Unit does not have a unit_group" => @unit.get_original_unit_group.nil?,
       }
 
       # Determine if all checks passed

--- a/dashboard/lib/version_redirect_overrider.rb
+++ b/dashboard/lib/version_redirect_overrider.rb
@@ -37,7 +37,7 @@ module VersionRedirectOverrider
     script_overrides = script_version_overrides(session)
     course_overrides = course_version_overrides(session)
 
-    script_overrides.include?(script.name) || course_overrides.include?(script.unit_group&.name)
+    script_overrides.include?(script.name) || course_overrides.include?(script.get_original_unit_group&.name)
   end
 
   def self.override_course_redirect?(session, course)

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -122,13 +122,13 @@ class ScriptsControllerTest < ActionController::TestCase
     not_admin = create(:user)
     sign_in not_admin
     @migrated_unit.update!(login_required: true)
-    get :show, params: {course_course_name: @migrated_unit.unit_group.name, position: 1}
+    get :show, params: {course_course_name: @migrated_unit.get_original_unit_group.name, position: 1}
     assert_response :success
   end
 
   test "should get show if login required and not signed in" do
     @migrated_unit.update!(login_required: true)
-    get :show, params: {course_course_name: @migrated_unit.unit_group.name, position: 1}
+    get :show, params: {course_course_name: @migrated_unit.get_original_unit_group.name, position: 1}
     assert_response :success
   end
 
@@ -139,21 +139,21 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test "should get show if not signed in" do
-    get :show, params: {course_course_name: @migrated_unit.unit_group.name, position: 1}
+    get :show, params: {course_course_name: @migrated_unit.get_original_unit_group.name, position: 1}
     assert_response :success
   end
 
   test "should get show if not admin" do
     not_admin = create(:user)
     sign_in not_admin
-    get :show, params: {course_course_name: @migrated_unit.unit_group.name, position: 1}
+    get :show, params: {course_course_name: @migrated_unit.get_original_unit_group.name, position: 1}
     assert_response :success
   end
 
   test 'should not get show if admin' do
     admin = create(:admin)
     sign_in admin
-    get :show, params: {course_course_name: @migrated_unit.unit_group.name, position: 1}
+    get :show, params: {course_course_name: @migrated_unit.get_original_unit_group.name, position: 1}
     assert_response :forbidden
   end
 

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -92,7 +92,7 @@ module Services
     # a particular machine.
     test 'seed script not yet in unit group' do
       script = create_script_tree
-      assert script.unit_group.course_version
+      assert script.get_original_unit_group.course_version
 
       # Capture the json while resources are still present. This test checks
       # that these resources do not get added back during the seed process.
@@ -102,14 +102,14 @@ module Services
       script.resources.destroy_all
       script.student_resources.destroy_all
       script.freeze
-      script.unit_group.course_version.resources.destroy_all
-      script.unit_group.course_version.vocabularies.destroy_all
+      script.get_original_unit_group.course_version.resources.destroy_all
+      script.get_original_unit_group.course_version.vocabularies.destroy_all
       expected_counts = get_counts
 
       # destroy the script and its unit group, so that no course version will
       # be available during seed.
       script_to_destroy = Unit.find(script.id)
-      unit_group_to_destroy = script_to_destroy.unit_group
+      unit_group_to_destroy = script_to_destroy.get_original_unit_group
       script_to_destroy.original_unit_group.course_version.destroy!
       script_to_destroy.destroy!
       unit_group_to_destroy.destroy!

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -110,7 +110,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
     describe '#assigned_script?' do
       context 'when the user is assigned a script' do
         subject(:assigned_script?) {user.assigned_script?(single_script)}
-        subject(:assigned_script_course?) {user.assigned_script?(section_2)}
+        subject(:assigned_script_course?) {user.assigned_script?(unit_group.first_unit)}
 
         it 'returns true' do
           _(assigned_script?).must_equal true

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -554,7 +554,7 @@ class SectionTest < ActiveSupport::TestCase
     script = Unit.find_by_name('jigsaw')
 
     Timecop.freeze(Time.zone.now) do
-      section = create(:section, script: script, unit_group: script.unit_group)
+      section = create(:section, script: script, unit_group: script.get_original_unit_group)
 
       expected = {
         id: section.id,
@@ -571,11 +571,11 @@ class SectionTest < ActiveSupport::TestCase
         sharing_disabled: false,
         studentCount: 0,
         code: section.code,
-        course_display_name: script.unit_group.course_version.localized_title,
-        course_offering_id: script.unit_group.course_version.course_offering.id,
-        course_version_id: script.unit_group.course_version.id,
+        course_display_name: script.get_original_unit_group.course_version.localized_title,
+        course_offering_id: script.get_original_unit_group.course_version.course_offering.id,
+        course_version_id: script.get_original_unit_group.course_version.id,
         unit_id: script.id,
-        course_id: script.unit_group.id,
+        course_id: script.get_original_unit_group.id,
         hidden: false,
         restrict_section: false,
         post_milestone_disabled: false,
@@ -815,7 +815,7 @@ class SectionTest < ActiveSupport::TestCase
     script = Unit.find_by_name('jigsaw')
 
     Timecop.freeze(Time.zone.now) do
-      section = create(:section, script: script, unit_group: script.unit_group)
+      section = create(:section, script: script, unit_group: script.get_original_unit_group)
 
       expected = {
         id: section.id,
@@ -826,8 +826,8 @@ class SectionTest < ActiveSupport::TestCase
         any_student_has_progress: false,
         is_assigned_single_unit_course: true,
         course: {
-          course_offering_id: script.unit_group.course_version.course_offering.id,
-          version_id: script.unit_group.course_version.id,
+          course_offering_id: script.get_original_unit_group.course_version.course_offering.id,
+          version_id: script.get_original_unit_group.course_version.id,
           lesson_extras_available: script.lesson_extras_available,
           text_to_speech_enabled: script.text_to_speech_enabled?,
           unit_id: section.unit_group ? section.script_id : nil,
@@ -1058,7 +1058,7 @@ class SectionTest < ActiveSupport::TestCase
     script = Unit.find_by_name('jigsaw')
 
     Timecop.freeze(Time.zone.now) do
-      section = create(:section, script: script, unit_group: script.unit_group)
+      section = create(:section, script: script, unit_group: script.get_original_unit_group)
 
       expected = {
         id: section.id,
@@ -1080,12 +1080,12 @@ class SectionTest < ActiveSupport::TestCase
         login_type: "email",
         login_type_name: "Email",
         participant_type: 'student',
-        course_display_name: script.unit_group.course_version.localized_title,
-        course_offering_id: script.unit_group.course_version.course_offering.id,
-        course_version_id: script.unit_group.course_version.id,
+        course_display_name: script.get_original_unit_group.course_version.localized_title,
+        course_offering_id: script.get_original_unit_group.course_version.course_offering.id,
+        course_version_id: script.get_original_unit_group.course_version.id,
         unit_id: script.id,
         unitPosition: 1,
-        course_id: script.unit_group.id,
+        course_id: script.get_original_unit_group.id,
         script: {id: script.id, name: script.name, project_sharing: nil},
         studentCount: 0,
         grades: nil,

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2339,7 +2339,7 @@ class UnitTest < ActiveSupport::TestCase
       cloned_unit = @single_unit.clone_migrated_unit('single-unit-2022', destination_unit_group_name: @unit_group.name)
       assert_equal 2, @unit_group.default_units.count
       assert_equal 'single-unit-2022', @unit_group.default_units[1].name
-      assert_equal cloned_unit.unit_group, @unit_group
+      assert_equal cloned_unit.get_original_unit_group, @unit_group
       assert_nil cloned_unit.published_state
       assert_nil cloned_unit.instruction_type
       assert_nil cloned_unit.instructor_audience
@@ -2415,7 +2415,7 @@ class UnitTest < ActiveSupport::TestCase
       ReferenceGuide.any_instance.expects(:write_serialization).once
       File.stubs(:write)
       cloned_unit = @unit_in_course.clone_migrated_unit('refguidetest-ug-coursename-2021', destination_unit_group_name: @unit_group.name)
-      assert_equal cloned_unit.unit_group, @unit_group
+      assert_equal cloned_unit.get_original_unit_group, @unit_group
       assert_equal 1, cloned_unit.get_course_version.reference_guides.count
     end
 


### PR DESCRIPTION
After the standalone unit migration, there is a lot of code in the unit model that needs to be updated or removed. The first step in this is renaming `unit.unit_group` to `unit.get_original_unit_group` to add more clarity to the method function. 



## Links

- Jira: [TEACH-1792](https://codedotorg.atlassian.net/browse/TEACH-1792)

## Testing story
Manually verified some major pathways:

- [x] Create and update units and unit groups as a levelbuilder
- [x] Assign courses and units to sections as a teacher
- [x] Make progress in units as a student


## Follow-up work
- Remove dead code in the unit model and use this method as needed ( [TEACH-1792](https://codedotorg.atlassian.net/browse/TEACH-1792))


