### PR TITLE
Eager load dashboard lib

### DIFF
--- a/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
+++ b/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
@@ -70,7 +70,7 @@ module Lti
         end
 
         begin
-          dynamic_registration_client = LtiDynamicRegistrationClient.new(registration_data[:registration_token], registration_data[:registration_endpoint])
+          dynamic_registration_client = Clients::LtiDynamicRegistrationClient.new(registration_data[:registration_token], registration_data[:registration_endpoint])
           registration_response = dynamic_registration_client.make_registration_request
         rescue => exception
           message = 'Error creating registration'
@@ -99,7 +99,7 @@ module Lti
 
       private def init_cache
         cache_namespace = 'lti_v1_dynamic_registration'
-        @cache = CacheClient.new(cache_namespace)
+        @cache = Clients::CacheClient.new(cache_namespace)
       end
 
       private def unauthorized_status

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -49,7 +49,7 @@ class LtiV1Controller < ApplicationController
     begin
       write_cache(state_and_nonce[:state], state_and_nonce, 15.minutes)
     rescue => exception
-      LtiLogger.log_event('Error writing state and nonce to cache', {lti_integration_id: lti_integration[:id], exception: exception})
+      Clients::LtiLogger.log_event('Error writing state and nonce to cache', {lti_integration_id: lti_integration[:id], exception: exception})
       return render status: :internal_server_error
     end
 
@@ -101,7 +101,7 @@ class LtiV1Controller < ApplicationController
     begin
       cached_state_and_nonce = read_cache params[:state]
     rescue => exception
-      LtiLogger.log_event('Error reading state and nonce from cache', {exception: exception})
+      Clients::LtiLogger.log_event('Error reading state and nonce from cache', {exception: exception})
       return render status: :internal_server_error
     end
     if cached_state_and_nonce.nil? || (params[:state] != cached_state_and_nonce[:state]) || (decoded_jwt_no_auth[:nonce] != cached_state_and_nonce[:nonce])
@@ -251,7 +251,7 @@ class LtiV1Controller < ApplicationController
         details: message,
       }
     )
-    LtiLogger.log_event(
+    Clients::LtiLogger.log_event(
       message,
       {
         reason: reason,
@@ -324,7 +324,7 @@ class LtiV1Controller < ApplicationController
       nrps_url = params[:nrps_url]
     end
 
-    lti_advantage_client = LtiAdvantageClient.new(lti_integration.client_id, lti_integration.issuer)
+    lti_advantage_client = Clients::LtiAdvantageClient.new(lti_integration.client_id, lti_integration.issuer)
     begin
       nrps_response = lti_advantage_client.get_context_membership(nrps_url, resource_link_id)
     rescue
@@ -505,7 +505,7 @@ class LtiV1Controller < ApplicationController
   end
 
   private def log_unauthorized(event, attributes = {})
-    LtiLogger.log_event(event, attributes)
+    Clients::LtiLogger.log_event(event, attributes)
     unauthorized_status
   end
 

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -185,11 +185,15 @@ module Dashboard
     # structure. Specifically, include a couple of directories for misc library code, as
     # well as some subdirectories of the models dir that we use for organization.
 
-    config.autoload_paths << Rails.root.join('lib')
-    config.autoload_paths << Rails.root.join('app', 'models', 'experiments')
-    config.autoload_paths << Rails.root.join('app', 'models', 'levels')
-    config.autoload_paths << Rails.root.join('app', 'models', 'sections')
-    config.autoload_paths << Rails.root.join('../lib/cdo/shared_constants')
+    runtime_load_paths = [
+      Rails.root.join('lib'),
+      Rails.root.join('app', 'models', 'experiments'),
+      Rails.root.join('app', 'models', 'levels'),
+      Rails.root.join('app', 'models', 'sections'),
+      Rails.root.join('../lib/cdo/shared_constants')
+    ].map(&:to_s)
+
+    config.autoload_paths += runtime_load_paths
 
     # Make sure to explicitly cast all autoload paths to strings; the gem we use to
     # annotate model files with schema descriptions doesn't know how to deal with
@@ -205,13 +209,7 @@ module Dashboard
     #
     # These directories will also be treated as top-level directories by
     # Zeitwerk, rather than as subdirectories which require namspacing.
-    config.eager_load_paths += [
-      Rails.root.join('lib'),
-      Rails.root.join('app', 'models', 'experiments'),
-      Rails.root.join('app', 'models', 'levels'),
-      Rails.root.join('app', 'models', 'sections'),
-      Rails.root.join('../lib/cdo/shared_constants')
-    ].map(&:to_s)
+    config.eager_load_paths += runtime_load_paths
 
     # Ignore certain directories for autoloading and eager loading
     Rails.autoloaders.main.ignore(

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -191,7 +191,7 @@ module Dashboard
       Rails.root.join('app', 'models', 'levels'),
       Rails.root.join('app', 'models', 'sections'),
       Rails.root.join('../lib/cdo/shared_constants')
-    ].map(&:to_s)
+    ]
 
     config.autoload_paths += runtime_load_paths
 
@@ -209,7 +209,7 @@ module Dashboard
     #
     # These directories will also be treated as top-level directories by
     # Zeitwerk, rather than as subdirectories which require namspacing.
-    config.eager_load_paths += runtime_load_paths
+    config.eager_load_paths += runtime_load_paths.map(&:to_s)
 
     # Ignore certain directories for autoloading and eager loading
     Rails.autoloaders.main.ignore(

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -206,9 +206,11 @@ module Dashboard
     # These directories will also be treated as top-level directories by
     # Zeitwerk, rather than as subdirectories which require namspacing.
     config.eager_load_paths += [
+      Rails.root.join('lib'),
       Rails.root.join('app', 'models', 'experiments'),
       Rails.root.join('app', 'models', 'levels'),
-      Rails.root.join('app', 'models', 'sections')
+      Rails.root.join('app', 'models', 'sections'),
+      Rails.root.join('../lib/cdo/shared_constants')
     ].map(&:to_s)
 
     # use https://(*-)studio.code.org urls in mails

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -213,6 +213,12 @@ module Dashboard
       Rails.root.join('../lib/cdo/shared_constants')
     ].map(&:to_s)
 
+    # Ignore certain directories for autoloading and eager loading
+    Rails.autoloaders.main.ignore(
+      Rails.root.join("lib", "tasks"),
+      Rails.root.join("lib", "assets")
+    )
+
     # use https://(*-)studio.code.org urls in mails
     config.action_mailer.default_url_options = {host: CDO.canonical_hostname('studio.code.org'), protocol: 'https'}
     config.action_mailer.delivery_job = 'MailDeliveryJob'

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -204,7 +204,7 @@ module Dashboard
     # this line.
     config.autoload_paths.map!(&:to_s)
 
-    # Also make sure some of these directories are always loaded up front in production
+    # Also make sure these directories are always loaded up front in production
     # environments.
     #
     # These directories will also be treated as top-level directories by

--- a/dashboard/engines/marketing/lib/marketing/engine.rb
+++ b/dashboard/engines/marketing/lib/marketing/engine.rb
@@ -3,6 +3,7 @@ module Marketing
     isolate_namespace Marketing
 
     config.autoload_paths << config.root.join('lib').to_s
+    config.eager_load_paths << config.root.join('lib').to_s
 
     config.to_prepare do
       # Register the Contentful source for notifications in the Dashboard app

--- a/dashboard/lib/clients/cache_client.rb
+++ b/dashboard/lib/clients/cache_client.rb
@@ -1,4 +1,4 @@
-class CacheClient
+class Clients::CacheClient
   def initialize(namespace)
     raise ArgumentError unless namespace
     @namespace = namespace

--- a/dashboard/lib/clients/lti_advantage_client.rb
+++ b/dashboard/lib/clients/lti_advantage_client.rb
@@ -1,4 +1,4 @@
-class LtiAdvantageClient
+class Clients::LtiAdvantageClient
   include LtiAccessToken
 
   def initialize(client_id, issuer)

--- a/dashboard/lib/clients/lti_dynamic_registration_client.rb
+++ b/dashboard/lib/clients/lti_dynamic_registration_client.rb
@@ -1,4 +1,4 @@
-class LtiDynamicRegistrationClient
+class Clients::LtiDynamicRegistrationClient
   def initialize(registration_token, registration_endpoint)
     raise ArgumentError unless registration_token && registration_endpoint
     @registration_token = registration_token

--- a/dashboard/lib/clients/lti_logger.rb
+++ b/dashboard/lib/clients/lti_logger.rb
@@ -1,4 +1,4 @@
-class LtiLogger
+class Clients::LtiLogger
   NAMESPACE = 'LTI'.freeze
 
   def self.log_event(event, attributes = {})

--- a/dashboard/lib/mega_section.rb
+++ b/dashboard/lib/mega_section.rb
@@ -1,6 +1,6 @@
-include FactoryBot::Syntax::Methods
-
 class MegaSection
+  include FactoryBot::Syntax::Methods
+
   SAMPLE_TEACHER_EMAIL = 'mega_section_teacher@code.org'.freeze
   SAMPLE_TEACHER_PASSWORD = 'mega_section_password'.freeze
   SAMPLE_TEACHER_NAME = 'MegaSection_Teacher'.freeze

--- a/dashboard/lib/sample_data.rb
+++ b/dashboard/lib/sample_data.rb
@@ -1,6 +1,6 @@
-include FactoryBot::Syntax::Methods
-
 class SampleData
+  include FactoryBot::Syntax::Methods
+
   SAMPLE_TEACHER_EMAIL = 'testteacher@code.org'.freeze
   SAMPLE_TEACHER_PASSWORD = '00secret'.freeze
   SAMPLE_TEACHER_NAME = 'TestTeacher Codeberg'.freeze

--- a/dashboard/lib/services/lti/auth_id_generator.rb
+++ b/dashboard/lib/services/lti/auth_id_generator.rb
@@ -33,7 +33,7 @@ module Services
             }
             event_name = 'Generate Authentication ID error'
             Honeybadger.notify(event_name, context: attributes)
-            LtiLogger.log_event(event_name, attributes)
+            Clients::LtiLogger.log_event(event_name, attributes)
             raise ArgumentError, "Invalid Audience Claim: #{id_token[:aud]}, with more than 1 client_id. #{id_token[:aud].length} client_ids given."
           else
             id_token[:aud].first

--- a/dashboard/lib/test_section.rb
+++ b/dashboard/lib/test_section.rb
@@ -1,8 +1,8 @@
-include FactoryBot::Syntax::Methods
-
 require 'json'
 
 class TestSection
+  include FactoryBot::Syntax::Methods
+
   @@rng = nil
 
   # Returns a seeded random number generator for consistent test data

--- a/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
@@ -35,9 +35,9 @@ class Lti::V1::DynamicRegistrationControllerTest < ActionController::TestCase
       issuer: Policies::Lti::LMS_PLATFORMS[:canvas_cloud][:issuer],
       lms_account_name: name,
     }
-    CacheClient.any_instance.stubs(:read).with(registration_id).returns(registration_data)
+    Clients::CacheClient.any_instance.stubs(:read).with(registration_id).returns(registration_data)
     response = {client_id: client_id}
-    LtiDynamicRegistrationClient.any_instance.stubs(:make_registration_request).returns(response)
+    Clients::LtiDynamicRegistrationClient.any_instance.stubs(:make_registration_request).returns(response)
 
     post :create_registration, params: {email: email, registration_id: registration_id}
     assert_response :created
@@ -54,7 +54,7 @@ class Lti::V1::DynamicRegistrationControllerTest < ActionController::TestCase
     post :create_registration, params: {registration_id: SecureRandom.uuid}
     assert_response :bad_request
     # missing registration_id
-    CacheClient.any_instance.stubs(:read).with(nil).returns(nil)
+    Clients::CacheClient.any_instance.stubs(:read).with(nil).returns(nil)
 
     post :create_registration, params: {email: 'example@test.com'}
     assert_response :unauthorized
@@ -66,7 +66,7 @@ class Lti::V1::DynamicRegistrationControllerTest < ActionController::TestCase
     registration_data = {
       issuer: 'fake'
     }
-    CacheClient.any_instance.stubs(:read).with(registration_id).returns(registration_data)
+    Clients::CacheClient.any_instance.stubs(:read).with(registration_id).returns(registration_data)
 
     post :create_registration, params: {email: email, registration_id: registration_id}
     assert_response :unprocessable_entity
@@ -82,8 +82,8 @@ class Lti::V1::DynamicRegistrationControllerTest < ActionController::TestCase
       issuer: Policies::Lti::LMS_PLATFORMS[:canvas_cloud][:issuer],
       lms_account_name: name,
     }
-    CacheClient.any_instance.stubs(:read).with(registration_id).returns(registration_data)
-    LtiDynamicRegistrationClient.any_instance.stubs(:make_registration_request).raises RuntimeError
+    Clients::CacheClient.any_instance.stubs(:read).with(registration_id).returns(registration_data)
+    Clients::LtiDynamicRegistrationClient.any_instance.stubs(:make_registration_request).raises RuntimeError
 
     post :create_registration, params: {email: email, registration_id: registration_id}
     assert_response :internal_server_error

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -671,7 +671,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     sign_in user
     lti_integration = create(:lti_integration)
     lti_course = create(:lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps')
-    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id).returns({})
+    Clients::LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id).returns({})
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
     Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_with_changes)
 
@@ -685,7 +685,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     lti_integration = create(:lti_integration)
     lti_course = create(:lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps')
     new_resource_id = SecureRandom.uuid
-    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, new_resource_id).returns({})
+    Clients::LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, new_resource_id).returns({})
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
     Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_with_changes)
 
@@ -711,7 +711,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
       nrps_url: lti_course_nrps_url
     )
 
-    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course_nrps_url, lti_course_resource_link_id).returns({})
+    Clients::LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course_nrps_url, lti_course_resource_link_id).returns({})
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
     Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_no_changes)
 
@@ -742,7 +742,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     user = create(:teacher, :with_lti_auth)
     lti_integration = create(:lti_integration)
 
-    LtiAdvantageClient.
+    Clients::LtiAdvantageClient.
       any_instance.
       expects(:get_context_membership).
       with(lti_course_nrps_url, lti_course_resource_link_id).
@@ -787,7 +787,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     user = create(:teacher, :with_lti_auth)
     lti_integration = create(:lti_integration)
 
-    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course_nrps_url, lti_course_resource_link_id).returns({})
+    Clients::LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course_nrps_url, lti_course_resource_link_id).returns({})
     Policies::Lti.expects(:issuer_accepts_resource_link?).with(lti_integration.issuer).returns(false)
     Services::Lti::NRPSResponseValidator.expects(:call).never
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
@@ -813,7 +813,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     sign_in user
     lti_integration = create(:lti_integration)
     lti_course = create(:lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps')
-    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id).returns({})
+    Clients::LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id).returns({})
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
     Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_no_changes)
 
@@ -827,7 +827,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     lti_integration = create(:lti_integration)
     lti_course = create(:lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps')
     lti_section = create(:lti_section, lti_course: lti_course)
-    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id).returns({})
+    Clients::LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id).returns({})
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
     Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_with_changes)
 
@@ -842,7 +842,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     lti_course = create(:lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps')
     create(:lti_user_identity, lti_integration: lti_integration, user: user, subject: 'f2a16942-ed81-4c98-96dc-5cac16e354ec')
 
-    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id)
+    Clients::LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id)
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
 
     # Set up a situation where a sync has partially progressed, including saving some objects, but then
@@ -958,7 +958,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     sign_in user
     lti_integration = create(:lti_integration)
     lti_course = create(:lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps')
-    LtiAdvantageClient.any_instance.expects(:get_context_membership).never
+    Clients::LtiAdvantageClient.any_instance.expects(:get_context_membership).never
     Services::Lti.expects(:parse_nrps_response).never
     Services::Lti.expects(:sync_course_roster).never
 

--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 require_relative '../../../lib/clients/lti_advantage_client'
 
-class LtiAdvantageClientTest < ActiveSupport::TestCase
+class Clients::LtiAdvantageClientTest < ActiveSupport::TestCase
   setup do
     @client_id = 'expected_client_id'
     @issuer = 'expected_issuer'
     @rlid = 'expected_rlid'
 
-    @lti_client = LtiAdvantageClient.new(@client_id, @issuer)
+    @lti_client = Clients::LtiAdvantageClient.new(@client_id, @issuer)
     @lti_client.stubs(:get_access_token).returns('fake_access_token')
     @page_2_url = 'https://example.com/api/lti/courses/1234/memberships?rlid=1234&page=2'
     @page_3_url = 'https://example.com/api/lti/courses/1234/memberships?rlid=1234&page=3'
@@ -59,7 +59,7 @@ class LtiAdvantageClientTest < ActiveSupport::TestCase
 
   test 'throws an error if no client_id or issuer is provided' do
     assert_raises ArgumentError do
-      LtiAdvantageClient.new(nil, nil)
+      Clients::LtiAdvantageClient.new(nil, nil)
     end
   end
 

--- a/dashboard/test/lib/clients/lti_dynamic_registration_client_test.rb
+++ b/dashboard/test/lib/clients/lti_dynamic_registration_client_test.rb
@@ -10,7 +10,7 @@ module Lti
       registration_token = SecureRandom.uuid
       @registration_endpoint = 'https://example.com'
       @client_id = SecureRandom.alphanumeric(10)
-      @registration_client = LtiDynamicRegistrationClient.new(registration_token, @registration_endpoint)
+      @registration_client = Clients::LtiDynamicRegistrationClient.new(registration_token, @registration_endpoint)
     end
 
     test 'Returns response body with client_id when successful response from the registration_endpoint' do
@@ -36,7 +36,7 @@ module Lti
 
     test 'throws an error if no registration_token or registration_endpoint is provided' do
       assert_raises ArgumentError do
-        LtiDynamicRegistrationClient.new(nil, nil)
+        Clients::LtiDynamicRegistrationClient.new(nil, nil)
       end
     end
   end

--- a/docker/ci/scripts/prepare_ui_tests.sh
+++ b/docker/ci/scripts/prepare_ui_tests.sh
@@ -54,6 +54,8 @@ echo "Wrote settings and secrets from env vars into locals.yml."
 set -x
 
 bundle exec rake install
+# catch any code loader errors before starting any rails environment
+bundle exec rake lint:zeitwerk
 bundle exec rake build
 
 bundle exec rake ci:seed_ui_test

--- a/docker/ci/scripts/prepare_unit_tests.sh
+++ b/docker/ci/scripts/prepare_unit_tests.sh
@@ -40,4 +40,6 @@ echo "Wrote settings and secrets from env vars into locals.yml."
 set -x
 
 bundle exec rake install
+# catch any code loader errors before starting any rails environment
+bundle exec rake lint:zeitwerk
 bundle exec rake build

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -4,7 +4,7 @@ require 'honeybadger/ruby'
 require_relative './shared_constants/mailjet_constants'
 
 module MailJet
-  include MailJetConstants
+  include MailjetConstants
 
   API_KEY = CDO.try(:mailjet_api_key).freeze
   SECRET_KEY = CDO.try(:mailjet_secret_key).freeze

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -1,4 +1,4 @@
-module MailJetConstants
+module MailjetConstants
   MAILJET_RETRY_LIMIT = 5
 
   EMAILS = {

--- a/lib/rake/lint.rake
+++ b/lib/rake/lint.rake
@@ -48,7 +48,14 @@ namespace :lint do
     end
   end
 
-  timed_task_with_logging all: [:ruby, :haml, :scss, :javascript, :python]
+  desc 'Check for Rails code loader errors.'
+  timed_task_with_logging :zeitwerk do
+    Dir.chdir(dashboard_dir) do
+      RakeUtils.rake_stream_output('zeitwerk:check')
+    end
+  end
+
+  timed_task_with_logging all: [:ruby, :haml, :scss, :javascript, :python, :zeitwerk]
 end
 desc 'Lints all code.'
 timed_task_with_logging lint: ['lint:all']


### PR DESCRIPTION
We've been seeing intermittent errors when resolving constants in the `Policies` namespace in production (see [slack](https://codedotorg.slack.com/archives/C03CK49G9/p1756815700304659)). One explanation is that `dashboard/lib` is in  `autoload_paths`, but not `eager_load_paths`, which could cause nondeterministic behavior in production when those paths are lazy-loaded. Rails recommends eager-loading code in production here:  https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#eager-loading

For context, the `eager_load` flag is set in `test` and `production`, but not `development`. therefore paths which are marked as both autoload and eager load will be lazy loaded in development and eagerly loaded in test and production. paths which are marked only as autoload will also be lazy loaded in production, which is the suspected cause for the constant errors linked above.

This PR attempts to mitigate the issue as follows:
1. include `dashboard/lib` in the list of `eager_load_paths`
2. fix any resulting errors produced by `bundle exec rake zeitwerk:check`
3. explicitly run `zeitwerk:check` during CI, so that developers can see how to test their fix locally. otherwise it shows up as an error while starting active job or dashboard server in drone but not locally, which is confusing and hard to debug
4. the new task will also run as part of the staging deploy:
  - https://github.com/code-dot-org/code-dot-org/blob/b0b7ca8322af939b47cf9a0eab0b80b6ea756c21/lib/rake/infra.rake#L52
  - https://github.com/code-dot-org/code-dot-org/blob/b0b7ca8322af939b47cf9a0eab0b80b6ea756c21/config/staging.yml.erb#L4

## Caveats

This PR does cause some code to be loaded on production which might not have been loaded before. e35d08286bd15a513f14a4a54ac212eb97cf0edc shows a fix for some unintended consequences of this. I'm generally relying on existing test coverage to ensure there are no regressions caused by this, and assuming there isn't enough previously-unused code that's now being loaded to cause any big slowdowns. If we wanted to try harder to keep code not needed by web servers out of the eager load, that could be done as a follow-up, for example by splitting `dashboard/lib` into `dashboard/lib/lazy` and `dashboard/lib/eager`.


## Testing story

- verified new rake task locally: 
```
Dave-MBP:~/src/cdo (eager-load-dashboard-lib)$ bundle exec rake lint:zeitwerk
RAILS_ENV=development RACK_ENV=development bundle exec rake zeitwerk:check
...
Hold on, I am eager loading the application.
...
WARNING: The following directories will only be checked if you configure
them to be eager loaded:

  /Users/dsb/src/cdo/dashboard/test/mailers/previews
  /Users/dsb/src/cdo/dashboard/test/mailers/previews

You may verify them manually, or add them to config.eager_load_paths
in config/application.rb and run zeitwerk:check again.

Otherwise, all is good!
Finished lint:zeitwerk (1 minute)
```
- [intermediate drone results](https://drone.cdn-code.org/code-dot-org/code-dot-org/39323) show that any issues with `bundle exec rake zeitwerk:check` will be surfaced when the `lint:zeitwerk` task fails
- no noticeable difference in run time for either of the following commands:
```
spring stop ; time RAILS_ENV=test RACK_ENV=test bundle exec rails runner 'puts "boot ok"'
spring stop ; time bundle exec spring testunit test/controllers/projects_controller_test.rb --name test_submit_project_returns_forbidden_if_project_already_submitted
```
- `adhoc-load-rails-lib` started cleanly

## Deployment strategy

## Follow-up work
- revert https://github.com/code-dot-org/code-dot-org/pull/43733 as it is no longer needed now that we use zeitwerk
- stop running active job in drone unit tests

