### PR TITLE
chore(i18n): add locale codes for chinese

### DIFF
--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -822,6 +822,8 @@ const SUPPORTED_LOCALES = new Set([
   'sq',
   'tl',
   'he',
+  'zh-Hans',
+  'zh-Hant',
 ]);
 
 // Remove the localized portion of paths, if there is a localized portion.

--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -832,7 +832,7 @@ const SUPPORTED_LOCALES = new Set([
 // 2. /engineering/all-the-things remains unchanged
 function extractPaths(uri) {
   const parts = uri.split('/').filter(Boolean); // Remove empty segments
-  const localeRegex = /^[a-z]{2}(-[A-Z]{2})?$/;
+  const localeRegex = /^[a-z]{2}(?:-(?:[A-Z]{2}|[A-Z][a-z]{3}))?$/;
 
   if (parts.length && localeRegex.test(parts[0]) && SUPPORTED_LOCALES.has(parts[0])) {
     // Has locale, return everything after locale


### PR DESCRIPTION
This adds the `zh-Hans` and `zh-Hant` locale codes as supported ones for Chinese on the marketing router.