### PR TITLE
feat(segmentedButton): Tweak segmented button background, fix disabled states

### DIFF
--- a/frontend/packages/component-library/src/segmentedButtons/segmentedButtons.module.scss
+++ b/frontend/packages/component-library/src/segmentedButtons/segmentedButtons.module.scss
@@ -45,11 +45,12 @@
     &:focus-visible {
       outline: none;
       background-color: var(--background-brand-teal-light);
+      border-color: var(--borders-brand-teal-primary);
     }
 
     // Pressed styles
     &:active {
-      color: var(--text-neutral-primary);
+      color: var(--text-neutral-secondary);
     }
 
     // Disabled styles
@@ -77,15 +78,13 @@
 
     // Focus styles
     &:focus-visible {
-      background-color: var(--background-brand-teal-light);
-      color: var(--text-neutral-primary);
+      background-color: var(--background-brand-teal-primary);
+      color: var(--text-neutral-white-fixed);
     }
 
     // Pressed styles
     &:active {
-      background-color: var(--background-brand-teal-primary);
-      border-color: var(--borders-brand-teal-primary);
-      color: var(--text-neutral-white-fixed);
+      background-color: var(--background-brand-teal-strong);
     }
   }
 }
@@ -101,33 +100,14 @@
       border-color: var(--borders-neutral-primary);
     }
 
-    // Focus styles
-    &:focus-visible {
-      border-color: var(--borders-neutral-primary);
-    }
-
     // Pressed styles
-    &:not(:disabled):active {
+    &:active {
       background-color: var(--background-neutral-tertiary);
       border-color: var(--borders-neutral-primary);
-      color: var(--text-neutral-secondary);
-    }
-
-    // Disabled styles
-    &:disabled {
-      background-color: var(--background-neutral-primary);
-      border-color: var(--borders-neutral-primary);
     }
 
   }
 
-  // Selected styles
-  .selectedSegmentedButton.segmentedButton {
-    // Focus styles
-    &:focus-visible {
-      border-color: var(--borders-neutral-primary);
-    }
-  }
 }
 
 .segmentedButtons-strong {
@@ -140,26 +120,13 @@
       border-color: var(--borders-neutral-strong);
     }
 
-    // Focus styles
-    &:focus-visible {
-      border-color: var(--borders-neutral-strong);
-    }
-
     // Pressed styles
     &:active {
       background-color: var(--background-neutral-quaternary);
       border-color: var(--borders-neutral-strong);
-      color: var(--text-neutral-secondary);
     }
   }
 
-  // Selected styles
-  .selectedSegmentedButton.segmentedButton {
-    // Focus styles
-    &:focus-visible {
-      border-color: var(--borders-neutral-strong);
-    }
-  }
 }
 
 // Sizes

--- a/frontend/packages/component-library/src/segmentedButtons/segmentedButtons.module.scss
+++ b/frontend/packages/component-library/src/segmentedButtons/segmentedButtons.module.scss
@@ -105,9 +105,7 @@
       background-color: var(--background-neutral-tertiary);
       border-color: var(--borders-neutral-primary);
     }
-
   }
-
 }
 
 .segmentedButtons-strong {
@@ -126,7 +124,6 @@
       border-color: var(--borders-neutral-strong);
     }
   }
-
 }
 
 // Sizes

--- a/frontend/packages/component-library/src/segmentedButtons/segmentedButtons.module.scss
+++ b/frontend/packages/component-library/src/segmentedButtons/segmentedButtons.module.scss
@@ -17,7 +17,7 @@
       color 0.15s ease-in-out,
       background-color 0.15s ease-in-out;
 
-    background-color: transparent;
+    background-color: var(--background-neutral-primary);
     border: 1px solid transparent;
     color: var(--text-neutral-primary);
 
@@ -55,7 +55,7 @@
     // Disabled styles
     &:disabled {
       border-color: var(--borders-neutral-disabled);
-      background-color: transparent;
+      background-color: var(--background-neutral-primary);
       color: var(--text-neutral-disabled);
       cursor: not-allowed;
     }
@@ -107,11 +107,18 @@
     }
 
     // Pressed styles
-    &:active {
+    &:not(:disabled):active {
       background-color: var(--background-neutral-tertiary);
       border-color: var(--borders-neutral-primary);
       color: var(--text-neutral-secondary);
     }
+
+    // Disabled styles
+    &:disabled {
+      background-color: var(--background-neutral-primary);
+      border-color: var(--borders-neutral-primary);
+    }
+
   }
 
   // Selected styles


### PR DESCRIPTION
**What's changed:**
- We noticed in a weblab2 pr that segmented buttons were missing a primary bg in their default/unselected states (the pattern we take with other components like buttons, fields, etc). This pr adds that fill.
- Separately I noticed that our hover and press interactions still get applied when an item is disabled in the segmented button group. This enforces no change in fill and text color on hover/press.

**In latest commit:**
- Some more styles clean up and tweaks, deduped some previous variant/state-specific overrides that are now unified styles.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
