### PR TITLE
Resource Panel: Make instructions the default panel when switching levels/users

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -179,6 +179,11 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     }
   }, [currentTab, availableTabs]);
 
+  useEffect(() => {
+    // Reset current tab to instructions when switching levels or viewAsUserId
+    setCurrentTab(Tabs.Instructions);
+  }, [levelId, viewAsUserId]);
+
   return (
     <div className={classNames(styles.resourcePanel, className)}>
       <div className={styles.sidebar}>


### PR DESCRIPTION
When we switch levels or a teacher switches to view a student's code, always default to showing the instructions panel rather than whatever panel the user was previously on.

## Links

- Jira: [AFL-127](https://codedotorg.atlassian.net/browse/AFL-127)
- [Slack](https://codedotorg.slack.com/archives/C06JELCAPT9/p1756914810553609)

## Testing story
Tested locally.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
