### PR TITLE
Lab2 Dance: toolbox mode

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -652,7 +652,10 @@ export function getSimplifiedStateForFlyout(
 
   // Replace variable ids with names and simplify state for flyout.
   blocksCopy.blocks?.forEach(block => {
-    updateVariableFields(block, serializedVariableMap);
+    updateVariableFields(
+      block as {fields: SerializedFields},
+      serializedVariableMap
+    );
     blocksList.push(simplifyBlockState(block));
   });
 

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -352,3 +352,8 @@ export const COLOURS: string[] = [
   '#663366',
   '#330033',
 ];
+
+export const DYNAMIC_CATEGORY_OPTIONS: {[key: string]: string} = {
+  Functions: 'PROCEDURE',
+  Variables: 'VARIABLE',
+};

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -361,7 +361,7 @@ export interface JsonBlockConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extraState?: any;
   type: string;
-  fields: {[key: string]: {name: string; type: string; id?: string}};
+  fields: {[key: string]: {name: string; type: string; id?: string} | string};
   inputs: {[key: string]: {block: JsonBlockConfig}};
   next: {block: JsonBlockConfig};
   kind: string;
@@ -508,7 +508,28 @@ export interface BlockJson<BlockType extends string = string> {
   helpUrl?: string;
 }
 
-export interface ArgumentJson {
+// Add more field/input definitions as needed
+type ArgumentJson = FieldJson | FieldInput | FieldDropdown;
+
+interface FieldJson {
   type: string;
   name: string;
+}
+
+interface FieldInput extends FieldJson {
+  type: 'field_input';
+}
+
+interface FieldDropdown extends FieldJson {
+  type: 'field_dropdown';
+  options: [string, string][];
+}
+
+export interface SerializedBlock {
+  id?: string;
+  type: string;
+  fields?: {[key: string]: string};
+  next?: {
+    block: SerializedBlock;
+  };
 }

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -524,12 +524,3 @@ interface FieldDropdown extends FieldJson {
   type: 'field_dropdown';
   options: [string, string][];
 }
-
-export interface SerializedBlock {
-  id?: string;
-  type: string;
-  fields?: {[key: string]: string};
-  next?: {
-    block: SerializedBlock;
-  };
-}

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -19,7 +19,12 @@ import {
   BLOCK_TYPES,
   BLOCKLY_THEME,
 } from './constants';
-import {ExtendedBlock} from './types';
+import {
+  BlocklyWrapperType,
+  ExtendedBlock,
+  JsonBlockConfig,
+  WorkspaceSerialization,
+} from './types';
 
 type xmlAttribute = string | null;
 type InputTuple = [string, string, number];
@@ -445,4 +450,70 @@ export function setAllWorkspacesTheme(
     const workspace = baseWorkspace as GoogleBlockly.WorkspaceSvg;
     setThemeAndRenderBlocks(workspace, newTheme, previousTheme);
   });
+}
+
+/**
+ * Adds a warning to blocks that are not positioned under a static category block,
+ * except when there are no categories at all. If warnings are ignored, we will
+ * still save the blocks into a "DEFAULT" category.
+ */
+export function validateBlockCategories(workspace: GoogleBlockly.WorkspaceSvg) {
+  const topBlocks = workspace.getTopBlocks(true);
+
+  const noCategoryBlocks =
+    !workspace.getBlocksByType(BLOCK_TYPES.category).length &&
+    !workspace.getBlocksByType(BLOCK_TYPES.categoryDynamic).length;
+
+  let currentCategoryBlock: GoogleBlockly.BlockSvg | null = null;
+  let warningText = 'This block is not positioned under a category.';
+
+  topBlocks.forEach(block => {
+    // If there are no categories, remove all warnings.
+    if (noCategoryBlocks) {
+      block.setWarningText(null);
+      return;
+    }
+    if (block.type === BLOCK_TYPES.category) {
+      // Update the current category to this block
+      currentCategoryBlock = block;
+    } else if (block.type === BLOCK_TYPES.categoryDynamic) {
+      // Reset the current category since dynamic categories can't include static blocks
+      currentCategoryBlock = null;
+      warningText = 'Auto-populated categories cannot include static blocks.';
+    } else {
+      // All non-category blocks
+      if (!currentCategoryBlock) {
+        // No static category block above this block
+        block.setWarningText(warningText);
+      } else {
+        // Valid placement under a static category block
+        block.setWarningText(null);
+      }
+    }
+  });
+}
+
+export function applyBlockIdOverrides(
+  workspaceJson: WorkspaceSerialization,
+  overrides: BlocklyWrapperType['blockIdOverrides']
+) {
+  function walkBlocks(block: JsonBlockConfig) {
+    if (block.id && overrides[block.id]) {
+      block.id = overrides[block.id];
+    }
+    if (block.next?.block) {
+      walkBlocks(block.next.block);
+    }
+    if (block.inputs) {
+      for (const stmt of Object.values(block.inputs)) {
+        if (stmt?.block) {
+          walkBlocks(stmt.block);
+        }
+      }
+    }
+  }
+
+  if (Array.isArray(workspaceJson.blocks?.blocks)) {
+    workspaceJson.blocks.blocks.forEach(walkBlocks);
+  }
 }

--- a/apps/src/blockly/utils/toolbox/generateToolboxDefinition.ts
+++ b/apps/src/blockly/utils/toolbox/generateToolboxDefinition.ts
@@ -1,0 +1,34 @@
+import type * as GoogleBlockly from 'blockly/core';
+
+/**
+ * Generates a toolbox definition from a map of blocks by category.
+ */
+export default function (
+  blocksByCategory: {[category: string]: string[]},
+  kind: 'categoryToolbox' | 'flyoutToolbox'
+): GoogleBlockly.utils.toolbox.ToolboxInfo {
+  const categories = Object.keys(blocksByCategory);
+  if (kind === 'categoryToolbox') {
+    return {
+      kind,
+      contents: categories.map(categoryName => ({
+        kind: 'category',
+        name: categoryName,
+        contents: blocksByCategory[categoryName].map(type => ({
+          kind: 'block',
+          type,
+        })),
+      })),
+    };
+  }
+
+  return {
+    kind,
+    contents: categories.flatMap(categoryName =>
+      blocksByCategory[categoryName].map(type => ({
+        kind: 'block',
+        type,
+      }))
+    ),
+  };
+}

--- a/apps/src/blockly/utils/toolbox/index.ts
+++ b/apps/src/blockly/utils/toolbox/index.ts
@@ -1,0 +1,3 @@
+export {default as getToolboxDefinition} from './generateToolboxDefinition';
+export {default as toolboxToWorkspaceBlocks} from './toolboxToWorkspaceBlocks';
+export {default as workspaceToToolboxDefinition} from './workspaceToToolboxDefinition';

--- a/apps/src/blockly/utils/toolbox/toolboxToWorkspaceBlocks.ts
+++ b/apps/src/blockly/utils/toolbox/toolboxToWorkspaceBlocks.ts
@@ -1,0 +1,78 @@
+import type * as GoogleBlockly from 'blockly/core';
+
+import {BLOCK_TYPES} from '../../constants';
+import {JsonBlockConfig} from '../../types';
+
+import {DEFAULT_CATEGORY_NAME} from './workspaceToToolboxDefinition';
+
+/**
+ * Converts a toolbox definition into workspace blocks for toolbox editing mode.
+ *
+ * Adapted from {@link @cdo/apps/music/blockly/toolbox} addToolboxBlocksToWorkspace().
+ * TODO: Consolidate
+ */
+export default function (
+  toolbox: GoogleBlockly.utils.toolbox.ToolboxInfo | undefined
+) {
+  if (!toolbox) {
+    return {};
+  }
+
+  return {blocks: {blocks: contentsToBlocks(toolbox.contents)}};
+}
+
+function contentsToBlocks(
+  contents: GoogleBlockly.utils.toolbox.ToolboxItemInfo[]
+) {
+  const blocks: Partial<JsonBlockConfig>[] = [];
+  for (const item of contents) {
+    if (item.kind === 'block') {
+      // Add toolbox blocks directly to the workspace.
+      const blockInfo = item as GoogleBlockly.utils.toolbox.BlockInfo;
+      if (!blockInfo.type) {
+        console.warn('Missing block type: ', item);
+      } else {
+        blocks.push(blockInfo as JsonBlockConfig);
+      }
+    } else if (item.kind === 'category' && 'custom' in item) {
+      // For dynamic categories, create a custom category block..
+      const dynamicCategoryName = (
+        item as GoogleBlockly.utils.toolbox.DynamicCategoryInfo
+      ).id;
+      if (!dynamicCategoryName) {
+        console.warn('Missing dynamic category name: ', item);
+      } else {
+        blocks.push({
+          type: BLOCK_TYPES.categoryDynamic,
+          fields: {
+            CUSTOM: dynamicCategoryName,
+          },
+        });
+      }
+    } else if (item.kind === 'category') {
+      const categoryInfo =
+        item as GoogleBlockly.utils.toolbox.StaticCategoryInfo;
+      // For a localized category, like "Sounds", get the category type, like "Play".
+      const categoryName = categoryInfo.id;
+      // 'DEFAULT' categories are intentionally skipped.
+      if (categoryName && categoryName !== DEFAULT_CATEGORY_NAME) {
+        blocks.push({
+          type: BLOCK_TYPES.category,
+          fields: {
+            CATEGORY: categoryName,
+          },
+        });
+      } else {
+        // We shouldn't hit this point, but theoretically could if a toolbox
+        // contained unsupported items like buttons or labels.
+        console.warn('Unsupported category found:', item);
+      }
+
+      if (categoryInfo.contents) {
+        blocks.push(...contentsToBlocks(categoryInfo.contents));
+      }
+    }
+  }
+
+  return blocks;
+}

--- a/apps/src/blockly/utils/toolbox/workspaceToToolboxDefinition.ts
+++ b/apps/src/blockly/utils/toolbox/workspaceToToolboxDefinition.ts
@@ -27,9 +27,6 @@ export function getNewStaticCategory(
 ): GoogleBlockly.utils.toolbox.StaticCategoryInfo {
   return {
     kind: 'category',
-    // name is not localized upon saving, because levelbuilder is English only.
-    // Instead, we localize the category names when loading the toolbox.
-    // See prepareToolboxCategories().
     name,
     cssconfig: undefined,
     contents: [] as GoogleBlockly.utils.toolbox.ToolboxItemInfo[],
@@ -51,9 +48,6 @@ export function getNewDynamicCategory(
   return {
     kind: 'category',
     custom: DYNAMIC_CATEGORY_OPTIONS[name],
-    // name is not localized upon saving, because levelbuilder is English only.
-    // Instead, we localize the category names when loading the toolbox.
-    // See prepareToolboxCategories().
     name,
     cssconfig: undefined,
     id: name,

--- a/apps/src/blockly/utils/toolbox/workspaceToToolboxDefinition.ts
+++ b/apps/src/blockly/utils/toolbox/workspaceToToolboxDefinition.ts
@@ -1,0 +1,139 @@
+import type * as GoogleBlockly from 'blockly/core';
+
+import {BLOCK_TYPES, DYNAMIC_CATEGORY_OPTIONS} from '../../constants';
+
+export const DEFAULT_CATEGORY_NAME = 'DEFAULT';
+
+/**
+ * Determines if a category is valid. Used to filter out
+ * empty "DEFAULT" categories when saving in toolbox mode.
+ * @param category
+ */
+export function isValidCategory(
+  category: GoogleBlockly.utils.toolbox.StaticCategoryInfo
+): boolean {
+  return !!(
+    category.contents.length || category.name !== DEFAULT_CATEGORY_NAME
+  );
+}
+
+/**
+ * Creates a new static category. Used to convert workspace
+ * blocks into a toolbox definition in levelbuilder's toolbox mode.
+ * @returns JSON representation of a new static category.
+ */
+export function getNewStaticCategory(
+  name: string = DEFAULT_CATEGORY_NAME
+): GoogleBlockly.utils.toolbox.StaticCategoryInfo {
+  return {
+    kind: 'category',
+    // name is not localized upon saving, because levelbuilder is English only.
+    // Instead, we localize the category names when loading the toolbox.
+    // See prepareToolboxCategories().
+    name,
+    cssconfig: undefined,
+    contents: [] as GoogleBlockly.utils.toolbox.ToolboxItemInfo[],
+    id: name,
+    categorystyle: undefined,
+    colour: undefined,
+    hidden: undefined,
+  };
+}
+
+/**
+ * Creates a new dynamic category. Used to convert workspace
+ * blocks into a toolbox definition in levelbuilder's toolbox mode.
+ * @returns JSON representation of a new dynamic category.
+ */
+export function getNewDynamicCategory(
+  name: string
+): GoogleBlockly.utils.toolbox.ToolboxItemInfo {
+  return {
+    kind: 'category',
+    custom: DYNAMIC_CATEGORY_OPTIONS[name],
+    // name is not localized upon saving, because levelbuilder is English only.
+    // Instead, we localize the category names when loading the toolbox.
+    // See prepareToolboxCategories().
+    name,
+    cssconfig: undefined,
+    id: name,
+    categorystyle: undefined,
+    colour: undefined,
+    hidden: undefined,
+  };
+}
+
+/**
+ * Serialize the top blocks of the workspace as a toolbox.
+ * @returns a toolbox definition that can be handled directly by Blockly.
+ *
+ * Adapted from {@link @cdo/apps/music/blockly/MusicBlocklyWorkspace} workspaceToToolboxDefinition().
+ * TODO: Consolidate
+ */
+export default function (workspace: GoogleBlockly.WorkspaceSvg) {
+  const topBlocks = workspace.getTopBlocks(true);
+
+  // This will be the final toolbox returned by this function, either a
+  // flyout toolbox or a category toolbox.
+  const fullToolbox: GoogleBlockly.utils.toolbox.ToolboxInfo = {
+    contents: [],
+  };
+  // Temporary storage for blocks that will be added to the next category,
+  // if categories exist, or the final flyout toolbox.
+  let flyoutItems: GoogleBlockly.utils.toolbox.FlyoutItemInfo[] = [];
+
+  // Temporary storage for a category, containing a name, type, list of contents.
+  let currentCategory = getNewStaticCategory();
+
+  topBlocks.forEach(block => {
+    if (block.type === BLOCK_TYPES.category) {
+      fullToolbox.kind = 'categoryToolbox';
+      if (isValidCategory(currentCategory)) {
+        // Add the previous category to toolbox.
+        fullToolbox.contents.push({...currentCategory});
+      }
+
+      // Begin a new category for the blocks that follow.
+      currentCategory = getNewStaticCategory(block.getFieldValue('CATEGORY'));
+      flyoutItems = [];
+    } else if (block.type === BLOCK_TYPES.categoryDynamic) {
+      fullToolbox.kind = 'categoryToolbox';
+      if (isValidCategory(currentCategory)) {
+        // Add previous category to toolbox
+        fullToolbox.contents.push({...currentCategory});
+      }
+      // Create and immediately add a new dynamic category to the toolbox,
+      // because dynamic categories cannot include other static blocks.
+      fullToolbox.contents.push(
+        getNewDynamicCategory(block.getFieldValue('CUSTOM'))
+      );
+
+      // Begin a new "DEFAULT" category in case any non-category block follows.
+      currentCategory = getNewStaticCategory();
+      flyoutItems = [];
+    } else {
+      // Add the current block to the flyout and category.
+      flyoutItems.push({
+        kind: 'block',
+        ...Blockly.serialization.blocks.save(block, {saveIds: false}),
+        id: Blockly.blockIdOverrides?.[block.id] || block.id,
+        enabled: true,
+      });
+      currentCategory.contents = flyoutItems;
+    }
+  });
+
+  // Finalize the toolbox.
+  if (
+    !fullToolbox.contents.length &&
+    currentCategory.name === DEFAULT_CATEGORY_NAME
+  ) {
+    // If no categories have been used, create a flyout toolbox.
+    fullToolbox.kind = 'flyoutToolbox';
+    fullToolbox.contents = flyoutItems;
+  } else if (isValidCategory(currentCategory)) {
+    // Add the final category to the toolbox.
+    fullToolbox.contents.push({...currentCategory});
+  }
+  return fullToolbox;
+}

--- a/apps/src/dance/blockly/blockDefinitions/category.ts
+++ b/apps/src/dance/blockly/blockDefinitions/category.ts
@@ -1,0 +1,21 @@
+import {BLOCK_TYPES, BlockStyles} from '@cdo/apps/blockly/constants';
+import {BlockJson, GeneratorFunction} from '@cdo/apps/blockly/types';
+
+const definition: BlockJson = {
+  type: BLOCK_TYPES.category,
+  message0: 'Category %1',
+  args0: [
+    {
+      type: 'field_input',
+      name: 'CATEGORY',
+    },
+  ],
+  inputsInline: true,
+  style: BlockStyles.LOOP,
+  tooltip:
+    'Indicates the start of a new category. All blocks below this point will be contained in this category.',
+};
+
+const generator: GeneratorFunction = () => '\n';
+
+export default {definition, generator};

--- a/apps/src/dance/blockly/blockDefinitions/custom_category.ts
+++ b/apps/src/dance/blockly/blockDefinitions/custom_category.ts
@@ -1,0 +1,26 @@
+import {
+  BLOCK_TYPES,
+  BlockStyles,
+  DYNAMIC_CATEGORY_OPTIONS,
+} from '@cdo/apps/blockly/constants';
+import {BlockJson, GeneratorFunction} from '@cdo/apps/blockly/types';
+
+const definition: BlockJson = {
+  type: BLOCK_TYPES.categoryDynamic,
+  message0: 'Auto-populated Category %1',
+  args0: [
+    {
+      type: 'field_dropdown',
+      name: 'CUSTOM',
+      options: Object.keys(DYNAMIC_CATEGORY_OPTIONS).map(key => [key, key]),
+    },
+  ],
+  inputsInline: true,
+  style: BlockStyles.LOOP,
+  tooltip:
+    'Indicates an auto-populated (dynamic) category. Cannot include other static blocks.',
+};
+
+const generator: GeneratorFunction = () => '\n';
+
+export default {definition, generator};

--- a/apps/src/dance/blockly/blockDefinitions/index.ts
+++ b/apps/src/dance/blockly/blockDefinitions/index.ts
@@ -1,3 +1,17 @@
+import {
+  BlockJson,
+  ExtendedBlock,
+  GeneratorFunction,
+} from '@cdo/apps/blockly/types';
+
+import category from './category';
+import custom_category from './custom_category';
 import whenRun from './when_run';
 
-export default [whenRun];
+const blockDefinitions: {
+  definition: BlockJson;
+  generator: GeneratorFunction;
+  extendedOptions?: Partial<ExtendedBlock>;
+}[] = [whenRun, category, custom_category];
+
+export default blockDefinitions;

--- a/apps/src/dance/blockly/setup.ts
+++ b/apps/src/dance/blockly/setup.ts
@@ -28,9 +28,11 @@ export function setupBlocklyEnvironment() {
   isBlocklyEnvironmentSetup = true;
 }
 
-export function installSharedBlocks(sharedBlocks: BlockDefinition[]) {
+export function installSharedBlocks(sharedBlocks: BlockDefinition[]): {
+  [category: string]: string[];
+} {
   // @ts-expect-error needed to handle CommonJS export. Eventually this may be replaced by using Blockly JSON directly
-  blockUtils.installCustomBlocks({
+  return blockUtils.installCustomBlocks({
     blockly: Blockly,
     blockDefinitions: sharedBlocks,
     customInputTypes: danceBlocks.customInputTypes,

--- a/apps/src/dance/lab2/utils/getInitialSources.ts
+++ b/apps/src/dance/lab2/utils/getInitialSources.ts
@@ -1,12 +1,18 @@
-import {START_BLOCKS} from '@cdo/apps/constants';
+import {toolboxToWorkspaceBlocks} from '@cdo/apps/blockly/utils/toolbox';
+import {START_SOURCES, TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
 import {
   getAppOptionsEditBlocks,
   getAppOptionsEditingExemplar,
   getAppOptionsViewingExemplar,
 } from '@cdo/apps/lab2/projects/utils';
-import {LevelProperties, ProjectSources} from '@cdo/apps/lab2/types';
+import {
+  BlocklyLevelProperties,
+  LevelProperties,
+  ProjectSources,
+} from '@cdo/apps/lab2/types';
 
-const isStartMode = getAppOptionsEditBlocks() === START_BLOCKS;
+const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
 const isEditingExemplar = getAppOptionsEditingExemplar();
 const isViewingExemplar = getAppOptionsViewingExemplar();
 
@@ -24,6 +30,14 @@ export default function <T extends ProjectSources>(
 
   if (isStartMode) {
     return startSources;
+  }
+
+  if (isToolboxMode) {
+    return {
+      source: toolboxToWorkspaceBlocks(
+        (levelProperties as BlocklyLevelProperties).toolboxDefinition
+      ),
+    };
   }
 
   if (isEditingExemplar || isViewingExemplar) {

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,10 +1,20 @@
 import {Button} from '@code-dot-org/component-library/button';
-import {Events, WorkspaceSvg} from 'blockly/core';
+import {BlocklyOptions, Events, WorkspaceSvg} from 'blockly/core';
 import classNames from 'classnames';
 import {isEqual} from 'lodash';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {loadBlocksToWorkspace} from '@cdo/apps/blockly/addons/cdoUtils';
+import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
+import {WorkspaceSerialization} from '@cdo/apps/blockly/types';
+import {
+  applyBlockIdOverrides,
+  validateBlockCategories,
+} from '@cdo/apps/blockly/utils';
+import {
+  getToolboxDefinition,
+  workspaceToToolboxDefinition,
+} from '@cdo/apps/blockly/utils/toolbox';
 import {saveReplayLog} from '@cdo/apps/code-studio/components/shareDialogRedux';
 import defaultSources from '@cdo/apps/dance/blockly/defaultSources.json';
 import {
@@ -23,13 +33,17 @@ import {
 import {getFilterStatus} from '@cdo/apps/dance/songs';
 import SongSelector from '@cdo/apps/dance/SongSelector';
 import {DanceLevelProperties, DanceProjectSources} from '@cdo/apps/dance/types';
+import {TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
 import {useBlocklySettings} from '@cdo/apps/lab2/hooks/useBlocklySettings';
 import useLevelEditMode from '@cdo/apps/lab2/hooks/useLevelEditMode';
 import {setPageError} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {getIsShareView} from '@cdo/apps/lab2/projects/utils';
+import {
+  getAppOptionsEditBlocks,
+  getIsShareView,
+} from '@cdo/apps/lab2/projects/utils';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
-import {LabProps} from '@cdo/apps/lab2/types';
+import {BlocklySource, LabProps} from '@cdo/apps/lab2/types';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {registerReducers} from '@cdo/apps/redux';
@@ -50,6 +64,8 @@ const DANCE_VISUALIZATION_ID = 'dance-visualization';
 const BLOCKLY_DIV_ID = 'dance-blockly-div';
 
 registerReducers(reducers);
+
+const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
 
 /**
  * Renders the Lab2 version of Dance Lab. This separate container
@@ -78,14 +94,26 @@ const DanceView: React.FunctionComponent<{
   const programExecutor = useRef<ProgramExecutor | null>(null);
   const workspace = useRef<WorkspaceSvg | null>(null);
 
-  const WorkspaceAlert = useLevelEditMode(
+  const WorkspaceAlert = useLevelEditMode<DanceLevelProperties>(
     levelProperties.id,
     !!levelProperties.projectTemplateLevelName,
     useCallback(
       mode => {
         if (mode === 'toolbox') {
-          // TODO: Support toolbox edit mode (get toolbox definition from workspace)
-          return {};
+          if (workspace.current) {
+            return {
+              toolbox_definition: workspaceToToolboxDefinition(
+                workspace.current
+              ),
+            };
+          }
+        }
+
+        if (mode === 'start' && Blockly.blockIdOverrides) {
+          applyBlockIdOverrides(
+            currentSources.source as WorkspaceSerialization,
+            Blockly.blockIdOverrides
+          );
         }
         return {
           [mode === 'start' ? 'start_sources' : 'exemplar_sources']:
@@ -122,7 +150,9 @@ const DanceView: React.FunctionComponent<{
       if (!workspace.current) {
         return;
       }
-      const blocks = Blockly.serialization.workspaces.save(workspace.current);
+      const blocks = Blockly.serialization.workspaces.save(
+        workspace.current
+      ) as BlocklySource;
       updateSources({...currentSources, source: blocks}, forceSave);
     },
     [currentSources, updateSources]
@@ -169,6 +199,14 @@ const DanceView: React.FunctionComponent<{
 
   const onBlockSpaceChange = useCallback(
     (e: Events.Abstract) => {
+      if (
+        isToolboxMode &&
+        workspace.current &&
+        e.type === Blockly.Events.BLOCK_MOVE
+      ) {
+        validateBlockCategories(workspace.current);
+      }
+
       if (e.type !== Events.BLOCK_DRAG && e.type !== Events.BLOCK_CHANGE) {
         return;
       }
@@ -220,13 +258,22 @@ const DanceView: React.FunctionComponent<{
       dispatch(setPageError({errorMessage: 'Blockly div not found'}));
       return;
     }
-    if (levelProperties.sharedBlocks) {
-      installSharedBlocks(levelProperties.sharedBlocks);
-    }
+    const blocksByCategory = installSharedBlocks(
+      levelProperties.sharedBlocks || []
+    );
+    const toolboxModeBlocks = {
+      Categories: [BLOCK_TYPES.category, BLOCK_TYPES.categoryDynamic],
+      ...blocksByCategory,
+    };
+    const toolbox = isToolboxMode
+      ? getToolboxDefinition(toolboxModeBlocks, 'categoryToolbox')
+      : levelProperties.toolboxDefinition;
+
     workspace.current = Blockly.inject(blocklyDiv, {
-      toolbox: levelProperties.toolboxBlocks,
+      toolbox,
       readOnly: readonlyWorkspace,
-    });
+      editBlocks: getAppOptionsEditBlocks(),
+    } as BlocklyOptions);
 
     return () => workspace.current?.dispose();
   }, [dispatch, readonlyWorkspace, levelProperties]);
@@ -279,6 +326,10 @@ const DanceView: React.FunctionComponent<{
 
   // Set up the ProgramExecutor
   useEffect(() => {
+    // Skip setting up the ProgramExecutor in toolbox mode as we are not running code.
+    if (isToolboxMode) {
+      return;
+    }
     const {isProjectLevel, freePlay, customHelperLibrary, validationCode} =
       levelProperties;
     // record a replay log (and generate a video) for both project levels and any
@@ -325,43 +376,45 @@ const DanceView: React.FunctionComponent<{
         settings={settings}
       />
       <div className={moduleStyles.divider} />
-      <PanelContainer
-        id="visualization"
-        headerContent="Dance Party!"
-        headerClassName={moduleStyles.panelHeader}
-        className={moduleStyles.visualizationArea}
-      >
-        <div className={moduleStyles.visualizationColumn}>
-          {currentSources.selectedSong && (
-            <SongSelector
-              enableSongSelection={!isRunning}
-              setSong={onSetSong}
-              selectedSong={currentSources.selectedSong}
-              songData={songData}
-              filterOn={filterOn}
-              levelIsRunning={isRunning}
-            />
-          )}
-          <div
-            id={DANCE_VISUALIZATION_ID}
-            className={moduleStyles.visualization}
-          >
-            <div
-              className={classNames(
-                moduleStyles.loading,
-                isLoading && moduleStyles.loadingShow
-              )}
-            >
-              <img
-                src={loadingGif}
-                className={moduleStyles.loadingGif}
-                alt={danceI18n.dancePartyLoading()}
+      {!isToolboxMode && (
+        <PanelContainer
+          id="visualization"
+          headerContent="Dance Party!"
+          headerClassName={moduleStyles.panelHeader}
+          className={moduleStyles.visualizationArea}
+        >
+          <div className={moduleStyles.visualizationColumn}>
+            {currentSources.selectedSong && (
+              <SongSelector
+                enableSongSelection={!isRunning}
+                setSong={onSetSong}
+                selectedSong={currentSources.selectedSong}
+                songData={songData}
+                filterOn={filterOn}
+                levelIsRunning={isRunning}
               />
+            )}
+            <div
+              id={DANCE_VISUALIZATION_ID}
+              className={moduleStyles.visualization}
+            >
+              <div
+                className={classNames(
+                  moduleStyles.loading,
+                  isLoading && moduleStyles.loadingShow
+                )}
+              >
+                <img
+                  src={loadingGif}
+                  className={moduleStyles.loadingGif}
+                  alt={danceI18n.dancePartyLoading()}
+                />
+              </div>
             </div>
+            <DanceControls onRun={runProgram} onReset={resetProgram} />
           </div>
-          <DanceControls onRun={runProgram} onReset={resetProgram} />
-        </div>
-      </PanelContainer>
+        </PanelContainer>
+      )}
       <div className={moduleStyles.divider} />
       <PanelContainer
         id="dance-workspace-panel"

--- a/apps/src/dance/lab2/views/SourcesContainer.tsx
+++ b/apps/src/dance/lab2/views/SourcesContainer.tsx
@@ -5,20 +5,27 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 
-import {START_BLOCKS} from '@cdo/apps/constants';
+import {toolboxToWorkspaceBlocks} from '@cdo/apps/blockly/utils/toolbox';
+import {START_SOURCES, TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
-import {LabProps, ProjectSources} from '@cdo/apps/lab2/types';
+import {
+  BlocklyLevelProperties,
+  LabProps,
+  ProjectSources,
+} from '@cdo/apps/lab2/types';
 import StartOverDialog, {
   MessageType,
 } from '@cdo/apps/lab2/views/dialogs/dsco/StartOverDialog';
 
 import getInitialSources from '../utils/getInitialSources';
 
-const isStartMode = getAppOptionsEditBlocks() === START_BLOCKS;
+const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
 
 interface SourcesContextType<T extends ProjectSources = ProjectSources> {
   currentSources: T;
@@ -56,6 +63,21 @@ const SourcesContainer: React.FC<
     );
   }, [levelProperties, initialSources, defaultSources]);
 
+  // Sources to reset to when starting over. Depends on the level edit mode.
+  const startOverSources: ProjectSources = useMemo(() => {
+    const {templateSources, startSources} = levelProperties;
+    if (isToolboxMode) {
+      return {
+        source: toolboxToWorkspaceBlocks(
+          (levelProperties as BlocklyLevelProperties).toolboxDefinition
+        ),
+      };
+    }
+    return isStartMode
+      ? defaultSources
+      : ((templateSources || startSources || defaultSources) as ProjectSources);
+  }, [defaultSources, levelProperties]);
+
   const updateSources = useCallback(
     (newSources: ProjectSources, forceSave = false) => {
       setCurrentSources(prev => {
@@ -73,13 +95,9 @@ const SourcesContainer: React.FC<
   );
 
   const onStartOver = useCallback(() => {
-    const {templateSources, startSources} = levelProperties;
-    const startOverSources = isStartMode
-      ? defaultSources
-      : templateSources || startSources || defaultSources;
     updateSources(startOverSources as ProjectSources, true);
     setStartOverProps(undefined);
-  }, [levelProperties, defaultSources, updateSources]);
+  }, [startOverSources, updateSources]);
 
   const [startOverProps, setStartOverProps] = useState<{
     type: MessageType;

--- a/apps/src/dance/types.ts
+++ b/apps/src/dance/types.ts
@@ -1,4 +1,4 @@
-import {LevelProperties, ProjectSources} from '../lab2/types';
+import {BlocklyLevelProperties, ProjectSources} from '../lab2/types';
 
 export type SongData = {
   [key: string]: {
@@ -31,7 +31,7 @@ export interface DanceProjectSources extends ProjectSources {
   selectedSong?: string;
 }
 
-export interface DanceLevelProperties extends LevelProperties {
+export interface DanceLevelProperties extends BlocklyLevelProperties {
   defaultSong?: string;
   useRestrictedSongs?: boolean;
   songSelection?: string[];

--- a/apps/src/lab2/hooks/useLevelEditMode.tsx
+++ b/apps/src/lab2/hooks/useLevelEditMode.tsx
@@ -18,18 +18,20 @@ const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
 const isEditingExemplar = getAppOptionsEditingExemplar();
 
-export type GetUpdatedProperties = (mode: 'start' | 'exemplar' | 'toolbox') => {
-  [key in keyof LevelProperties]?: LevelProperties[keyof LevelProperties];
+export type GetUpdatedProperties<T extends LevelProperties> = (
+  mode: 'start' | 'exemplar' | 'toolbox'
+) => {
+  [key: string]: T[keyof T];
 };
 
 /**
  * Hook that displays the save button for levelbuilder workspaces editing and
  * returns a workspace alert if a workspace edit mode is active.
  */
-export default function (
+export default function <T extends LevelProperties>(
   levelId: number,
   isProjectTemplateLevel: boolean,
-  getUpdatedProperties: GetUpdatedProperties
+  getUpdatedProperties: GetUpdatedProperties<T>
 ) {
   useEffect(() => {
     if (isStartMode) {

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -8,6 +8,7 @@
 // The library data should definitely live elsewhere.
 
 import {Theme} from '@code-dot-org/component-library/common/contexts';
+import type * as GoogleBlockly from 'blockly/core';
 import {ComponentType, LazyExoticComponent} from 'react';
 
 import {BlockDefinition} from '@cdo/apps/blockly/types';
@@ -166,12 +167,10 @@ export interface LevelProperties {
   edit_blocks?: string;
   isK1?: boolean;
   skin?: string;
-  toolboxBlocks?: string;
   // Dance stores the full main.json source structure (ProjectSources) in start/template/exemplar sources,
   // while PythonLab/Weblab2 stores just the source code (MultiFileSource). TODO: Can we reconcile these?
   startSources?: ProjectSources | MultiFileSource;
   templateSources?: ProjectSources | MultiFileSource;
-  sharedBlocks?: BlockDefinition[];
   validations?: Validation[];
   baseAssetUrl?: string;
   // An optional URL that allows the user to skip the progression.
@@ -212,6 +211,11 @@ export interface LevelProperties {
   showRubric?: boolean;
   customHelperLibrary?: string;
   validationCode?: string;
+}
+
+export interface BlocklyLevelProperties extends LevelProperties {
+  toolboxDefinition?: GoogleBlockly.utils.toolbox.ToolboxInfo;
+  sharedBlocks?: BlockDefinition[];
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -7,7 +7,10 @@ import {
   ExtendedBlock,
   ExtendedWorkspaceSvg,
 } from '@cdo/apps/blockly/types';
-import {disableOrphanBlocks} from '@cdo/apps/blockly/utils';
+import {
+  disableOrphanBlocks,
+  validateBlockCategories,
+} from '@cdo/apps/blockly/utils';
 import {TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -26,7 +29,6 @@ import AdvancedSequencer from '../player/sequencer/AdvancedSequencer';
 import Simple2Sequencer from '../player/sequencer/Simple2Sequencer';
 
 import {BlockTypes} from './blockTypes';
-import {validateBlockCategories} from './blockUtils';
 import {
   FIELD_TRIGGER_START_NAME,
   TriggerStart,

--- a/apps/src/music/blockly/blockUtils.js
+++ b/apps/src/music/blockly/blockUtils.js
@@ -179,69 +179,6 @@ export function findParentStatementInputTypes(id) {
 }
 
 /**
- * Adds a warning to blocks that are not positioned under a static category block,
- * except when there are no categories at all. If warnings are ignored, we will
- * still save the blocks into a "DEFAULT" category.
- */
-export function validateBlockCategories(workspace) {
-  const topBlocks = workspace.getTopBlocks(true);
-
-  const noCategoryBlocks =
-    !workspace.getBlocksByType(BlockTypes.CATEGORY).length &&
-    !workspace.getBlocksByType(BlockTypes.CUSTOM_CATEGORY).length;
-
-  let currentCategoryBlock = null;
-  let warningText = 'This block is not positioned under a category.';
-
-  topBlocks.forEach(block => {
-    // If there are no categories, remove all warnings.
-    if (noCategoryBlocks) {
-      block.setWarningText(null);
-      return;
-    }
-    if (block.type === BlockTypes.CATEGORY) {
-      // Update the current category to this block
-      currentCategoryBlock = block;
-    } else if (block.type === BlockTypes.CUSTOM_CATEGORY) {
-      // Reset the current category since dynamic categories can't include static blocks
-      currentCategoryBlock = null;
-      warningText = 'Auto-populated categories cannot include static blocks.';
-    } else {
-      // All non-category blocks
-      if (!currentCategoryBlock) {
-        // No static category block above this block
-        block.setWarningText(warningText);
-      } else {
-        // Valid placement under a static category block
-        block.setWarningText(null);
-      }
-    }
-  });
-}
-
-export function applyBlockIdOverrides(workspaceJson, overrides) {
-  function walkBlocks(block) {
-    if (block.id && overrides[block.id]) {
-      block.id = overrides[block.id];
-    }
-    if (block.next?.block) {
-      walkBlocks(block.next.block);
-    }
-    if (block.inputs) {
-      for (const stmt of Object.values(block.inputs)) {
-        if (stmt?.block) {
-          walkBlocks(stmt.block);
-        }
-      }
-    }
-  }
-
-  if (Array.isArray(workspaceJson.blocks?.blocks)) {
-    workspaceJson.blocks.blocks.forEach(walkBlocks);
-  }
-}
-
-/**
  * Recursively collects block IDs starting from the given block, following
  * both child connections and function calls/definitions. The result preserves traversal
  * order and avoids revisiting blocks (e.g., in case of shared or recursive procedures).

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -3,6 +3,8 @@ import classNames from 'classnames';
 import React, {memo, useCallback, useContext, useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
+import {WorkspaceSerialization} from '@cdo/apps/blockly/types';
+import {applyBlockIdOverrides} from '@cdo/apps/blockly/utils';
 import header from '@cdo/apps/code-studio/header';
 import {
   START_SOURCES,
@@ -30,10 +32,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import AnalyticsReporter from '../analytics/AnalyticsReporter';
 import AppConfig from '../appConfig';
-import {
-  applyBlockIdOverrides,
-  installFunctionBlocks,
-} from '../blockly/blockUtils';
+import {installFunctionBlocks} from '../blockly/blockUtils';
 import MusicBlocklyWorkspace from '../blockly/MusicBlocklyWorkspace';
 import {Trigger} from '../constants';
 import musicI18n from '../locale';
@@ -168,7 +167,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
         const workspaceSerialization = blocklyWorkspace.getCode();
         if (Blockly.blockIdOverrides) {
           applyBlockIdOverrides(
-            workspaceSerialization,
+            workspaceSerialization as WorkspaceSerialization,
             Blockly.blockIdOverrides
           );
         }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -8,6 +8,7 @@ import {connect} from 'react-redux';
 
 import './small-footer-music-overrides.scss';
 
+import {validateBlockCategories} from '@cdo/apps/blockly/utils';
 import DCDO from '@cdo/apps/dcdo';
 import {START_SOURCES, TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
 import {setIsLoading, setPageError} from '@cdo/apps/lab2/lab2Redux';
@@ -24,7 +25,6 @@ import {setExtraCopyrightContent} from '@cdo/apps/sharedComponents/footer/Copyri
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 
 import AppConfig from '../appConfig';
-import {validateBlockCategories} from '../blockly/blockUtils';
 import {TRIGGER_FIELD} from '../blockly/constants';
 import MusicBlocklyWorkspace from '../blockly/MusicBlocklyWorkspace';
 import {

--- a/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
+++ b/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
@@ -119,27 +119,99 @@
         }
       }
     },
+    "toolbox_definition": {
+      "contents": [
+        {
+          "kind": "block",
+          "type": "Dancelab_makeAnonymousDanceSprite",
+          "id": "O$O.bva_1Ph7~Y.~iux-",
+          "fields": {
+            "COSTUME": "<field name=\"COSTUME\">\"ALIEN\"</field>",
+            "LOCATION": "<field name=\"LOCATION\">{x: 200, y: 100}</field>"
+          },
+          "enabled": true
+        },
+        {
+          "kind": "block",
+          "type": "Dancelab_makeNewDanceSpriteGroup",
+          "id": "ec$AvzNAC~[ZY0!CH~OW",
+          "fields": {
+            "N": "<field name=\"N\">2</field>",
+            "COSTUME": "<field name=\"COSTUME\">\"ALIEN\"</field>",
+            "LAYOUT": "<field name=\"LAYOUT\">\"border\"</field>"
+          },
+          "enabled": true
+        },
+        {
+          "kind": "block",
+          "type": "Dancelab_changeMoveEachLR_slothcat",
+          "id": ")ib*n^o5OYR}R[mXad51",
+          "fields": {
+            "GROUP": "<field name=\"GROUP\">\"CAT\"</field>",
+            "MOVE": "<field name=\"MOVE\">MOVES.Roll</field>",
+            "DIR": "<field name=\"DIR\">-1</field>"
+          },
+          "enabled": true
+        },
+        {
+          "kind": "block",
+          "type": "Dancelab_doMoveEachLR",
+          "id": "xTmotz3im4nyO3t9)1fD",
+          "fields": {
+            "GROUP": "<field name=\"GROUP\">sprites</field>",
+            "MOVE": "<field name=\"MOVE\">\"rand\"</field>",
+            "DIR": "<field name=\"DIR\">-1</field>"
+          },
+          "enabled": true
+        },
+        {
+          "kind": "block",
+          "type": "Dancelab_ai",
+          "id": "*G.#js[A?o~Mn!Gw]Zol",
+          "fields": {
+            "VALUE": null
+          },
+          "enabled": true
+        },
+        {
+          "kind": "block",
+          "type": "Dancelab_setBackgroundEffectWithPaletteAI",
+          "id": "hoz1N{ey~x7z%f;]^{?N",
+          "fields": {
+            "PALETTE": "<field name=\"PALETTE\">\"autumn\"</field>",
+            "EFFECT": "<field name=\"EFFECT\">\"none\"</field>"
+          },
+          "enabled": true
+        },
+        {
+          "kind": "block",
+          "type": "Dancelab_setForegroundEffect",
+          "id": "E.myuB4`,-!iO9hQ_j/#",
+          "fields": {
+            "EFFECT": "<field name=\"EFFECT\">\"none\"</field>"
+          },
+          "enabled": true
+        },
+        {
+          "kind": "block",
+          "type": "Dancelab_atTimestampNotAfter",
+          "id": "AiJxd[T6gt9E_shE?WE$",
+          "fields": {
+            "TIMESTAMP": 0,
+            "UNIT": "<field name=\"UNIT\">\"measures\"</field>"
+          },
+          "enabled": true
+        }
+      ],
+      "kind": "flyoutToolbox"
+    },
     "preload_asset_list": null
   },
   "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:08.190-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"},{\"changed_at\":\"2025-08-20 23:36:05 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"skin\",\"validation_code\",\"default_song\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-20 23:41:21 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"free_play\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-22 22:53:47 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-26 21:05:16 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-27 22:54:36 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:07:26 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:09:07 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:15:17 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:16:16 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:08.190-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"},{\"changed_at\":\"2025-08-20 23:36:05 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"skin\",\"validation_code\",\"default_song\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-20 23:41:21 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"free_play\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-22 22:53:47 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-26 21:05:16 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-27 22:54:36 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:07:26 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:09:07 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:15:17 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:16:16 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-09-03 23:34:57 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-09-03 23:36:58 +0000\",\"changed\":[\"toolbox_definition\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>
-  <blocks>
-    <toolbox_blocks>
-      <xml>
-        <block type="Dancelab_makeAnonymousDanceSprite" id="1" x="54" y="185">
-          <field name="COSTUME" config="&quot;CAT&quot;,&quot;SLOTH&quot;">"CAT"</field>
-          <field name="LOCATION">{x: 200, y: 200}</field>
-        </block>
-        <block type="Dancelab_changeMoveEachLR" id="|y+CWEBlleENO5MU(?yL" x="67" y="265">
-          <field name="GROUP" config="&quot;CAT&quot;,&quot;SLOTH&quot;">"CAT"</field>
-          <field name="MOVE">MOVES.Roll</field>
-          <field name="DIR">-1</field>
-        </block>
-      </xml>
-    </toolbox_blocks>
-  </blocks>
+  <blocks/>
 </Dancelab>


### PR DESCRIPTION
Adds toolbox mode editing to Lab2 Dance Party. Most of this is adapted or copied from the toolbox implementation for Music Lab (which is also a blockly lab2 lab). There are a few core functions that I copied over instead of factoring out because the music versions make a few reference to music-specific constants (like categories and localized strings), so we'll need to think a bit more about how to solve those cases (particularly localization). Ideally though, it would be great to share the code as it's doing mostly the same thing. There were a few other utils that I did go ahead and pull out.

<img width="1517" height="829" alt="Screenshot 2025-09-03 at 4 38 10 PM" src="https://github.com/user-attachments/assets/fd8b4083-1bf3-4c20-b26a-61343d0eb466" />

<img width="1513" height="827" alt="Screenshot 2025-09-03 at 4 38 35 PM" src="https://github.com/user-attachments/assets/998bd790-03a4-4808-a493-dac58c492994" />


https://github.com/user-attachments/assets/0d1eb47f-7ec0-4985-93da-2c616c3e0b3b

## Testing story
- Tested on Dance Lab2 allthethings