### PR TITLE
Remove deprecated course from some UI tests 

### DIFF
--- a/dashboard/test/ui/features/star_labs/maze.feature
+++ b/dashboard/test/ui/features/star_labs/maze.feature
@@ -2,10 +2,10 @@ Feature: Complete a complicated maze level
 
 Background:
   Given I am on "http://studio.code.org/reset_session"
-  Given I am on "http://studio.code.org/courses/20-hour/units/1/lessons/2/levels/15?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/5?noautoplay=true"
   And I wait for the lab page to fully load
   And I dismiss the login reminder
-  And element ".csf-top-instructions p" has text "Ok, this is just like the last puzzle, but you need to remember how you used the \"if\" block and the \"repeat\" block together."
+  And element ".csf-top-instructions p" has text "Use the if block to help me decide when to turn. "
 
 @no_mobile
 Scenario: Submit an invalid solution
@@ -15,10 +15,6 @@ Scenario: Submit an invalid solution
   Then element "#runButton" is hidden
   And element "#resetButton" is visible
   Then I wait until element ".uitest-topInstructions-inline-feedback" is visible
-  # Skipping due to failing on test.studio.code.org environment
-  #   TODO (espertus/bjordan): fix or change level this applies to
-  # And element ".congrats" has text "You need an \"if\" block inside a \"repeat\" block. If you're having trouble, try the previous level again to see how it worked."
-  # could also try the back button, and validate that clicking outside of the dialog closes it
   And I press "resetButton"
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
@@ -30,16 +26,16 @@ Scenario: Submit a valid solution
   Then I've initialized the workspace with valid maze blocks
   Then I press "runButton"
   Then I wait until element ".congrats" is visible
-  And element ".congrats" has text "Congratulations! You completed Puzzle 15."
+  And element ".congrats" has text "Congratulations! You completed Puzzle 5."
 
   And I press "continue-button"
-  Then I wait until I am on "http://studio.code.org/courses/20-hour/units/1/lessons/2/levels/16"
-  Then check that level 16 on this lesson is done
-  Then check that level 15 on this lesson is not done
+  Then I wait until I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/6"
+  Then check that level 6 on this lesson is done
+  Then check that level 5 on this lesson is not done
 
-  # Make sure the work on level 15 was saved.
-  When I am on "http://studio.code.org/courses/20-hour/units/1/lessons/2/levels/15?noautoplay=true"
+  # Make sure the work on level 5 was saved.
+  When I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/5?noautoplay=true"
   And I wait for the lab page to fully load
   Then I press "runButton"
   Then I wait until element ".congrats" is visible
-  And element ".congrats" has text "Congratulations! You completed Puzzle 15."
+  And element ".congrats" has text "Congratulations! You completed Puzzle 5."

--- a/dashboard/test/ui/features/step_definitions/blockly_initialization_blocks.rb
+++ b/dashboard/test/ui/features/step_definitions/blockly_initialization_blocks.rb
@@ -51,7 +51,7 @@ And /^I've initialized the workspace with level 2 flappy blocks$/ do
 end
 
 And /^I've initialized the workspace with valid maze blocks$/ do
-  load_json_blocks('{"blocks":{"languageVersion":0,"blocks":[{"type":"when_run","x":16,"y":16,"next":{"block":{"type":"maze_forever","inputs":{"DO":{"block":{"type":"maze_moveForward","next":{"block":{"type":"maze_if","fields":{"DIR":"<field name=\"DIR\">isPathRight</field>"},"inputs":{"DO":{"block":{"type":"maze_turn","fields":{"DIR":"<field name=\"DIR\">turnRight</field>"}}}}}}}}}}}}]}}')
+  load_json_blocks('{"blocks":{"languageVersion":0,"blocks":[{"type":"when_run","x":16,"y":16,"next":{"block":{"type":"maze_forever","inputs":{"DO":{"block":{"type":"maze_moveForward","next":{"block":{"type":"maze_if","fields":{"DIR":"<field name=\"DIR\">isPathLeft</field>"},"inputs":{"DO":{"block":{"type":"maze_turn","fields":{"DIR":"<field name=\"DIR\">turnLeft</field>"}}}}}}}}}}}}]}}')
 end
 
 And /^I've initialized the workspace with incorrect maze blocks$/ do

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1245,6 +1245,13 @@ And /^I dismiss the hoc guide dialog$/ do
   GHERKIN
 end
 
+And /^I dismiss the match instructions dialog$/ do
+  steps <<~GHERKIN
+    And I click selector ".x-close" if I see it
+    And I wait until I don't see selector ".dash_modal"
+  GHERKIN
+end
+
 # Call `execute_async_script` on the provided `js` code.
 # Provides a workaround for Appium (mobile) which doesn't support execute_async_script on HTTPS.
 # For Appium, wrap `execute_script` with a polling wait on a window variable that records the result.

--- a/dashboard/test/ui/features/teacher_tools/level_types/match.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/match.feature
@@ -1,12 +1,13 @@
 Feature: Playing match levels
 
 Background:
-  Given I am on "http://studio.code.org/courses/course1/units/1/lessons/14/levels/13?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/11/levels/1?noautoplay=true"
+  And I dismiss the match instructions dialog
   Then I wait to see ".submitButton"
   And element ".submitButton" is visible
 
 Scenario: Loading the level
-  And element ".match .content2" has text "Match the blocks"
+  And element ".match .content2" has text "Match the puzzles and blocks"
 
 @no_mobile
 Scenario: Solving puzzle

--- a/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
@@ -1,13 +1,13 @@
 Feature: Playing multi levels
 
 Scenario: Loading the level
-  Given I am on "http://studio.code.org/courses/course1/units/1/lessons/2/levels/2?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/9/levels/1?noautoplay=true"
   Then I wait to see ".submitButton"
   And element ".submitButton" is visible
-  And element ".multi-question" has text "Which algorithm gets the Flurb to the flowers?"
+  And element ".multi-question" has text "Which arrow gets the Flurb to the treasure?"
 
 Scenario: Clicking an option enables submit and submitting the correct answer wins
-  Given I am on "http://studio.code.org/courses/course1/units/1/lessons/2/levels/2?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/9/levels/1?noautoplay=true"
   Then I rotate to landscape
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
@@ -20,7 +20,7 @@ Scenario: Clicking an option enables submit and submitting the correct answer wi
   And I wait to see ".modal"
 
 Scenario: Submitting an incorrect option
-  Given I am on "http://studio.code.org/courses/course1/units/1/lessons/2/levels/2/lang/en-US?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/9/levels/1/lang/en-US?noautoplay=true"
   Then I rotate to landscape
   And I wait to see ".submitButton"
   And element ".submitButton" is visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/multi3.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multi3.feature
@@ -1,10 +1,10 @@
 Feature: Playing multi levels 3
 
   Scenario: Rendering in another language
-    Given I am on "http://studio.code.org/courses/course1/units/1/lessons/2/levels/2/lang/es-MX"
+    Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/9/levels/1/lang/es-MX"
     Then I wait to see ".submitButton"
     And element ".submitButton" is visible
-    Then element ".multi h1" has "es-MX" text from key "data.dsls.2-3 Algorithms Multi 1.title"
+    Then element ".multi h1" has "es-MX" text from key "data.dsls.K-1 Happy Maps Multi 1.title"
 
   Scenario: Does not scroll horizontally
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/9/levels/2?noautoplay=true"


### PR DESCRIPTION
As part of deprecating courses 1-4 and Accelerated, we need to remove our UI test dependencies on these courses. This doesn't remove all of our dependencies, but is a good start. For all of these, I found a very similar corresponding level that already existed in allthethings and just used that.

This is the list of tests that we need to fix in order from Drone to pass, for the curious:

<img width="1341" height="528" alt="Screenshot 2025-09-04 140659" src="https://github.com/user-attachments/assets/b3f1923c-01a4-41ea-b5dc-53c1cd4b518d" />



