### PR TITLE
Evaluate Student Learning: separate skill evaluations from overall evaluations

### DIFF
--- a/apps/src/aiEvaluation/aiEvaluationApi.ts
+++ b/apps/src/aiEvaluation/aiEvaluationApi.ts
@@ -121,7 +121,6 @@ export async function summarizeEvaluations(
 }
 
 const EVALUATE_URL = '/openai/evaluate';
-const EVALUATE_SKILL_URL = '/openai/evaluate_skill';
 
 type ValueOf<T> = T[keyof T];
 type EvaluationType = ValueOf<typeof AiEvaluationTypes>;
@@ -158,11 +157,15 @@ export async function evaluationFromOpenAI(
     evaluationType: evaluationType,
     shouldEvaluateSkills: shouldEvaluateSkills,
   };
-  const url = shouldEvaluateSkills ? EVALUATE_SKILL_URL : EVALUATE_URL;
 
-  const response = await HttpClient.post(url, JSON.stringify(payload), true, {
-    'Content-Type': 'application/json; charset=UTF-8',
-  });
+  const response = await HttpClient.post(
+    EVALUATE_URL,
+    JSON.stringify(payload),
+    true,
+    {
+      'Content-Type': 'application/json; charset=UTF-8',
+    }
+  );
   if (response.ok) {
     return await response.json();
   } else {

--- a/apps/src/aiEvaluation/aiEvaluationApi.ts
+++ b/apps/src/aiEvaluation/aiEvaluationApi.ts
@@ -9,9 +9,7 @@ import {
   logUserLevelEvaluation,
   logUserLevelSkillEvaluations,
 } from './studentWorkEvaluationsApi';
-
 import {UserLevelSkillEvaluation} from './types';
-import {logStudentWorkEvaluations} from './studentWorkEvaluationsApi';
 
 export interface StudentAnswer {
   studentId: number;

--- a/apps/src/aiEvaluation/aiEvaluationApi.ts
+++ b/apps/src/aiEvaluation/aiEvaluationApi.ts
@@ -5,6 +5,12 @@ import {
   AiInteractionStatus,
 } from '@cdo/generated-scripts/sharedConstants';
 
+import {
+  logUserLevelEvaluation,
+  logUserLevelSkillEvaluations,
+} from './studentWorkEvaluationsApi';
+
+import {UserLevelSkillEvaluation} from './types';
 import {logStudentWorkEvaluations} from './studentWorkEvaluationsApi';
 
 export interface StudentAnswer {
@@ -35,7 +41,15 @@ export interface StudentWorkEvaluation extends StudentAnswer, AIResponse {
   id: number;
 }
 
-export async function evaluateStudentWork(
+export async function evaluateFreeResponse(
+  studentAnswer: StudentAnswer,
+  levelId: number,
+  unitId: number
+): Promise<AIResponse> {
+  return evaluateStudentWorkOverall(studentAnswer, levelId, unitId);
+}
+
+export async function evaluateStudentWorkOverall(
   studentWorkSample: StudentAnswer,
   levelId: number,
   unitId: number
@@ -48,14 +62,39 @@ export async function evaluateStudentWork(
   let parsedResponse;
   if (response?.content) {
     parsedResponse = JSON.parse(response?.content);
-    const userLevelEvaluationId = await logStudentWorkEvaluations(
+    const userLevelEvaluationId = await logUserLevelEvaluation(
       studentWorkSample,
       parsedResponse,
       levelId,
       unitId
     );
-
     parsedResponse.id = userLevelEvaluationId;
+  }
+  return parsedResponse;
+}
+
+export async function evaluateStudentWorkSkills(
+  studentWorkSample: StudentAnswer,
+  levelId: number,
+  unitId: number
+): Promise<AIResponse> {
+  const response = await evaluationFromOpenAI(
+    studentWorkSample.studentWork,
+    levelId,
+    AiEvaluationTypes.SINGLE_STUDENT,
+    true
+  );
+  let parsedResponse;
+  if (response?.content) {
+    parsedResponse = JSON.parse(response?.content);
+    const skillEvaluations: UserLevelSkillEvaluation[] =
+      parsedResponse.skillEvaluations || [];
+    await logUserLevelSkillEvaluations(
+      skillEvaluations,
+      studentWorkSample,
+      levelId,
+      unitId
+    );
   }
   return parsedResponse;
 }
@@ -84,6 +123,7 @@ export async function summarizeEvaluations(
 }
 
 const EVALUATE_URL = '/openai/evaluate';
+const EVALUATE_SKILL_URL = '/openai/evaluate_skill';
 
 type ValueOf<T> = T[keyof T];
 type EvaluationType = ValueOf<typeof AiEvaluationTypes>;
@@ -106,7 +146,8 @@ type OpenaiChatCompletionMessage = {
 export async function evaluationFromOpenAI(
   studentWork?: string | Record<string, string>,
   levelId?: number,
-  evaluationType?: EvaluationType
+  evaluationType?: EvaluationType,
+  shouldEvaluateSkills?: boolean
 ): Promise<OpenaiChatCompletionMessage | null> {
   const payload = {
     studentWork:
@@ -117,16 +158,13 @@ export async function evaluationFromOpenAI(
             .join('\n\n'),
     levelId: levelId,
     evaluationType: evaluationType,
+    shouldEvaluateSkills: shouldEvaluateSkills,
   };
+  const url = shouldEvaluateSkills ? EVALUATE_SKILL_URL : EVALUATE_URL;
 
-  const response = await HttpClient.post(
-    EVALUATE_URL,
-    JSON.stringify(payload),
-    true,
-    {
-      'Content-Type': 'application/json; charset=UTF-8',
-    }
-  );
+  const response = await HttpClient.post(url, JSON.stringify(payload), true, {
+    'Content-Type': 'application/json; charset=UTF-8',
+  });
   if (response.ok) {
     return await response.json();
   } else {

--- a/apps/src/aiEvaluation/studentWorkEvaluationsApi.ts
+++ b/apps/src/aiEvaluation/studentWorkEvaluationsApi.ts
@@ -5,7 +5,7 @@ import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import {AIResponse, StudentAnswer} from './aiEvaluationApi';
 import {UserLevelEvaluation, UserLevelSkillEvaluation} from './types';
 
-export async function logStudentWorkEvaluations(
+export async function logUserLevelEvaluation(
   studentWorkSample: StudentAnswer,
   parsedResponse: AIResponse,
   levelId: number,
@@ -22,11 +22,19 @@ export async function logStudentWorkEvaluations(
     evaluation: parsedResponse.aiEvaluation,
     reasoning: parsedResponse.aiReasoning,
   });
-  // For each specific skill-based evaluation, log a UserLevelSkillEvaluation
-  if (parsedResponse.skillEvaluations) {
-    await Promise.all(
-      parsedResponse.skillEvaluations.map(async skillEvaluation => {
-        const ulse = await logStudentWorkEvaluation({
+  return ule;
+}
+
+export async function logUserLevelSkillEvaluations(
+  skillEvaluations: UserLevelSkillEvaluation[],
+  studentWorkSample: StudentAnswer,
+  levelId: number,
+  unitId: number
+) {
+  await Promise.all(
+    skillEvaluations.map(async skillEvaluation => {
+      try {
+        await logStudentWorkEvaluation({
           type: 'UserLevelSkillEvaluation',
           studentId: studentWorkSample.studentId,
           codeVersion: studentWorkSample.codeVersion,
@@ -35,27 +43,19 @@ export async function logStudentWorkEvaluations(
           skillId: skillEvaluation.skillId,
           evaluator: 'AI',
           evaluationCriteria: skillEvaluation.evaluationCriteria,
-          evaluation: skillEvaluation.aiEvaluation,
-          reasoning: skillEvaluation.aiReasoning,
+          evaluation: skillEvaluation.evaluation,
+          reasoning: skillEvaluation.reasoning,
         });
-        try {
-          await logStudentWorkEvaluationSummary({
-            studentWorkEvaluationId: ulse.id,
-            studentWorkEvaluationSummaryId: ule.id,
-          });
-        } catch (error) {
-          MetricsReporter.logError({
-            event: MetricEvent.STUDENT_WORK_EVALUATION_SUMMARY_SAVE_FAIL,
-            errorMessage:
-              (error as Error).message ||
-              `Failed to save StudentWorkEvaluationSummary for ULSE ID ${ulse.id} and ULE ID ${ule.id}`,
-          });
-        }
-      })
-    );
-  }
-
-  return ule.id;
+      } catch (error) {
+        MetricsReporter.logError({
+          event: MetricEvent.STUDENT_WORK_EVALUATION_SAVE_FAIL,
+          errorMessage:
+            (error as Error).message ||
+            `Failed to save UserLevelSkillEvaluation for student ${studentWorkSample.studentId}, level ${levelId}, unit ${unitId}, skill ${skillEvaluation.skillId}`,
+        });
+      }
+    })
+  );
 }
 
 type StudentWorkEvaluation = UserLevelEvaluation | UserLevelSkillEvaluation;
@@ -85,35 +85,6 @@ export async function logStudentWorkEvaluation(
       errorMessage:
         (error as Error).message ||
         `Failed to save StudentWorkEvaluation of type ${evaluationData.type}`,
-    });
-  }
-}
-type SummaryIds = {
-  studentWorkEvaluationId: number;
-  studentWorkEvaluationSummaryId: number;
-};
-
-export async function logStudentWorkEvaluationSummary(summaryData: SummaryIds) {
-  try {
-    const response = await fetch('/student_work_evaluation_summaries', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': await getAuthenticityToken(),
-      },
-      body: JSON.stringify(summaryData),
-    });
-    if (!response.ok) {
-      throw new Error('Failed to save StudentWorkEvaluationSummary');
-    }
-    const data = await response.json();
-    return data;
-  } catch (error) {
-    MetricsReporter.logError({
-      event: MetricEvent.STUDENT_WORK_EVALUATION_SAVE_FAIL,
-      errorMessage:
-        (error as Error).message ||
-        'Failed to save StudentWorkEvaluationSummary',
     });
   }
 }

--- a/apps/src/levelbuilder/ai-iteration-tools/FreeResponseDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/FreeResponseDatasetMaker.tsx
@@ -3,7 +3,7 @@ import TextField from '@code-dot-org/component-library/textField';
 import Papa from 'papaparse';
 import React, {useState} from 'react';
 
-import {evaluateStudentWork} from '@cdo/apps/aiEvaluation/aiEvaluationApi';
+import {evaluateFreeResponse} from '@cdo/apps/aiEvaluation/aiEvaluationApi';
 
 import {fetchFreeResponseAnswers} from './StudentWorkSamplesApi';
 
@@ -68,7 +68,7 @@ const FreeResponseDatasetMaker: React.FC = () => {
   const evaluateStudentResponse = async (
     studentAnswer: StudentFreeResponseAnswer
   ) => {
-    const aiResponse = await evaluateStudentWork(
+    const aiResponse = await evaluateFreeResponse(
       studentAnswer,
       parseInt(levelId),
       parseInt(unitId)

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -13,13 +13,18 @@ import {
 
 import {fetchStudentCodeSamples} from './StudentWorkSamplesApi';
 
-type EvaluatedCodeSample = StudentAnswer &
-  AIResponse & {
-    [key in `skill-${string}${
-      | 'evaluationCriteria'
-      | 'aiEvaluation'
-      | 'aiReasoning'}`]?: string;
-  };
+type EvaluatedCodeSample =
+  | OverallEvaluatedCodeSample
+  | SkillsEvaluatedCodeSample;
+
+type OverallEvaluatedCodeSample = StudentAnswer & AIResponse;
+
+type SkillsEvaluatedCodeSample = StudentAnswer & {
+  [key in `skill-${string}${
+    | 'evaluationCriteria'
+    | 'aiEvaluation'
+    | 'aiReasoning'}`]?: string;
+};
 
 const StudentCodeDatasetMaker: React.FC = () => {
   const [datasetName, setDatasetName] = useState<string>('');
@@ -67,7 +72,7 @@ const StudentCodeDatasetMaker: React.FC = () => {
       levelId: Number(levelId),
     };
     const codeSamples = await fetchStudentCodeSamples(studentWorkRequest);
-    if (!codeSamples) {
+    if (codeSamples?.length === 0) {
       alert('No samples found for the given parameters.');
     } else {
       const fetchedCodeSamples = codeSamples as unknown as StudentAnswer[];
@@ -108,14 +113,13 @@ const StudentCodeDatasetMaker: React.FC = () => {
         parseInt(unitId)
       );
     }
-    const evaluation: EvaluatedCodeSample = {
-      ...studentAnswer,
-      aiEvaluation: aiResponse.aiEvaluation,
-      aiReasoning: aiResponse.aiReasoning,
-      evaluationCriteria: aiResponse.evaluationCriteria,
-      id: aiResponse.id,
-    };
+
+    let evaluation: EvaluatedCodeSample;
+
     if (aiResponse.skillEvaluations) {
+      evaluation = {
+        ...studentAnswer,
+      };
       for (let i = 0; i < aiResponse.skillEvaluations.length; i++) {
         const skillEvaluation = aiResponse.skillEvaluations[i];
         const skillKey = skillEvaluation.skillKey;
@@ -126,6 +130,13 @@ const StudentCodeDatasetMaker: React.FC = () => {
         evaluation[`skill-${skillKey}-aiReasoning`] =
           skillEvaluation.aiReasoning;
       }
+    } else {
+      evaluation = {
+        ...studentAnswer,
+        evaluationCriteria: aiResponse.evaluationCriteria,
+        aiEvaluation: aiResponse.aiEvaluation,
+        aiReasoning: aiResponse.aiReasoning,
+      };
     }
     setEvaluatedSamples(prevSamples => [...prevSamples, evaluation]);
   };

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -188,15 +188,6 @@ const StudentCodeDatasetMaker: React.FC = () => {
           />
         </div>
         <br />
-        <div>
-          <Button
-            text="Evaluate Student Code Samples"
-            onClick={getAIEvaluations}
-            disabled={fetchedSamples.length === 0}
-            isPending={evaluationPending}
-          />
-        </div>
-        <br />
         <Checkbox
           label={'Evaluate skills (if any) associated with the level'}
           name={'evaluateSkills'}
@@ -205,6 +196,15 @@ const StudentCodeDatasetMaker: React.FC = () => {
           onChange={e => setEvaluateSkills(e.target.checked)}
         />
         <br />
+        <br />
+        <div>
+          <Button
+            text="Evaluate Student Code Samples"
+            onClick={getAIEvaluations}
+            disabled={fetchedSamples.length === 0}
+            isPending={evaluationPending}
+          />
+        </div>
         <br />
         <div>
           <Button

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -5,11 +5,13 @@ import React, {useState} from 'react';
 
 import {
   AIResponse,
-  evaluateStudentWork,
+  evaluateStudentWorkOverall,
+  evaluateStudentWorkSkills,
   StudentAnswer,
 } from '@cdo/apps/aiEvaluation/aiEvaluationApi';
 
 import {fetchStudentCodeSamples} from './StudentWorkSamplesApi';
+import Checkbox from '@code-dot-org/component-library/checkbox';
 
 type EvaluatedCodeSample = StudentAnswer &
   AIResponse & {
@@ -23,6 +25,7 @@ const StudentCodeDatasetMaker: React.FC = () => {
   const [datasetName, setDatasetName] = useState<string>('');
   const [levelId, setLevelId] = useState<string>('');
   const [unitId, setUnitId] = useState<string>('');
+  const [evaluateSkills, setEvaluateSkills] = useState<boolean>(false);
   const [studentIds, setStudentIds] = useState<string>('');
   const [pending, setPending] = useState<boolean>(false);
   const [fetchedSamples, setFetchedSamples] = useState<StudentAnswer[]>([]);
@@ -84,18 +87,27 @@ const StudentCodeDatasetMaker: React.FC = () => {
         studentDisplayName: studentResponse.studentDisplayName,
         studentWork: studentResponse.studentWork,
       };
-      return evaluateStudentResponse(studentWorkToEvaluate as StudentAnswer);
+      return evaluateStudentCode(studentWorkToEvaluate as StudentAnswer);
     });
     await Promise.allSettled(responsePromises);
     setEvaluationPending(false);
   };
 
-  const evaluateStudentResponse = async (studentAnswer: StudentAnswer) => {
-    const aiResponse = await evaluateStudentWork(
-      studentAnswer,
-      parseInt(levelId),
-      parseInt(unitId)
-    );
+  const evaluateStudentCode = async (studentAnswer: StudentAnswer) => {
+    let aiResponse;
+    if (evaluateSkills) {
+      aiResponse = await evaluateStudentWorkSkills(
+        studentAnswer,
+        parseInt(levelId),
+        parseInt(unitId)
+      );
+    } else {
+      aiResponse = await evaluateStudentWorkOverall(
+        studentAnswer,
+        parseInt(levelId),
+        parseInt(unitId)
+      );
+    }
     const evaluation: EvaluatedCodeSample = {
       ...studentAnswer,
       aiEvaluation: aiResponse.aiEvaluation,
@@ -173,6 +185,15 @@ const StudentCodeDatasetMaker: React.FC = () => {
             isPending={evaluationPending}
           />
         </div>
+        <br />
+        <Checkbox
+          label={'Evaluate skills (if any) associated with the level'}
+          name={'evaluateSkills'}
+          checked={evaluateSkills}
+          size="s"
+          onChange={e => setEvaluateSkills(e.target.checked)}
+        />
+        <br />
         <br />
         <div>
           <Button

--- a/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
+++ b/apps/src/levelbuilder/ai-iteration-tools/StudentCodeDatasetMaker.tsx
@@ -1,4 +1,5 @@
 import Button from '@code-dot-org/component-library/button';
+import Checkbox from '@code-dot-org/component-library/checkbox';
 import TextField from '@code-dot-org/component-library/textField';
 import Papa from 'papaparse';
 import React, {useState} from 'react';
@@ -11,7 +12,6 @@ import {
 } from '@cdo/apps/aiEvaluation/aiEvaluationApi';
 
 import {fetchStudentCodeSamples} from './StudentWorkSamplesApi';
-import Checkbox from '@code-dot-org/component-library/checkbox';
 
 type EvaluatedCodeSample = StudentAnswer &
   AIResponse & {

--- a/apps/src/levelbuilder/skills/AccuracyCheck.tsx
+++ b/apps/src/levelbuilder/skills/AccuracyCheck.tsx
@@ -95,6 +95,8 @@ const AccuracyCheck: React.FC<{
     setEvaluationPending(false);
   };
 
+  // TODO: This function will need to updated to determine
+  // whether we're asking for a skill-based evaluation or not.
   const evaluateStudentWork = async (example: ExampleAnswer) => {
     const aiResponse = await evaluationFromOpenAI(
       example.studentWork,

--- a/apps/src/levelbuilder/skills/AccuracyCheck.tsx
+++ b/apps/src/levelbuilder/skills/AccuracyCheck.tsx
@@ -14,6 +14,7 @@ import {
 } from '@cdo/generated-scripts/sharedConstants';
 
 import AccuracyDetails from './AccuracyDetails';
+import Checkbox from '@code-dot-org/component-library/checkbox';
 
 type AIEvaluation = {
   aiEvaluation: string;
@@ -37,7 +38,8 @@ type ExampleAnswer = {
 
 const AccuracyCheck: React.FC<{
   levelId: number;
-}> = ({levelId}) => {
+  hasSkills: boolean;
+}> = ({levelId, hasSkills}) => {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [studentAnswers, setStudentAnswers] = useState<ExampleAnswer[]>([]);
   const [evaluationPending, setEvaluationPending] = useState<boolean>(false);
@@ -48,6 +50,7 @@ const AccuracyCheck: React.FC<{
   const datasetName = csvFile
     ? `${csvFile.name}-ai-evaluations.csv`
     : 'ai-evaluations.csv';
+  const [evaluateSkills, setEvaluateSkills] = useState<boolean>(false);
 
   function renderStudentWorkEvaluationStatusCodes() {
     return (
@@ -95,13 +98,12 @@ const AccuracyCheck: React.FC<{
     setEvaluationPending(false);
   };
 
-  // TODO: This function will need to updated to determine
-  // whether we're asking for a skill-based evaluation or not.
   const evaluateStudentWork = async (example: ExampleAnswer) => {
     const aiResponse = await evaluationFromOpenAI(
       example.studentWork,
       levelId,
-      AiEvaluationTypes.SINGLE_STUDENT
+      AiEvaluationTypes.SINGLE_STUDENT,
+      evaluateSkills
     );
     const parsedResponse = JSON.parse(aiResponse?.content || '{}');
     const evaluation: EvaluatedExample = {
@@ -223,6 +225,19 @@ const AccuracyCheck: React.FC<{
           isPending={evaluationPending}
         />
       </div>
+      <br />
+      {hasSkills && (
+        <Checkbox
+          label={
+            'Evaluate skills (if not checked, you will get an overall evaluation based on completeness of the level instructions)'
+          }
+          name={'evaluateSkills'}
+          checked={evaluateSkills}
+          size="s"
+          onChange={e => setEvaluateSkills(e.target.checked)}
+        />
+      )}
+      <br />
       <br />
       <div>
         <Button

--- a/apps/src/levelbuilder/skills/AccuracyCheck.tsx
+++ b/apps/src/levelbuilder/skills/AccuracyCheck.tsx
@@ -1,4 +1,5 @@
 import Button from '@code-dot-org/component-library/button';
+import Checkbox from '@code-dot-org/component-library/checkbox';
 import Link from '@code-dot-org/component-library/link';
 import Papa from 'papaparse';
 import React, {useState} from 'react';
@@ -14,7 +15,6 @@ import {
 } from '@cdo/generated-scripts/sharedConstants';
 
 import AccuracyDetails from './AccuracyDetails';
-import Checkbox from '@code-dot-org/component-library/checkbox';
 
 type AIEvaluation = {
   aiEvaluation: string;

--- a/apps/src/levelbuilder/skills/SkillEvaluationSettings.tsx
+++ b/apps/src/levelbuilder/skills/SkillEvaluationSettings.tsx
@@ -44,7 +44,7 @@ const SkillEvaluationSettings: React.FC<Props> = ({
           size="s"
         />
       </p>
-      <AccuracyCheck levelId={levelId} />
+      <AccuracyCheck levelId={levelId} hasSkills={skills.length > 0} />
       <br />
       <ViewSystemPrompt systemPrompt={systemPrompt} />
       <br />

--- a/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
+++ b/apps/src/templates/levelSummary/FreeResponseAIEvaluation.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from 'react';
 import {
   StudentAnswer,
   StudentWorkEvaluation,
-  evaluateStudentWork,
+  evaluateFreeResponse,
 } from '@cdo/apps/aiEvaluation/aiEvaluationApi';
 import {fetchMostRecentUserLevelEvaluation} from '@cdo/apps/aiEvaluation/studentWorkEvaluationsApi';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -138,7 +138,7 @@ const FreeResponseAIEvaluation: React.FunctionComponent<
   };
 
   const evaluateStudentResponse = async (studentAnswer: StudentAnswer) => {
-    const aiResponse = await evaluateStudentWork(
+    const aiResponse = await evaluateFreeResponse(
       studentAnswer,
       levelData.levelId,
       levelData.unitId

--- a/dashboard/app/controllers/openai_evaluate_controller.rb
+++ b/dashboard/app/controllers/openai_evaluate_controller.rb
@@ -8,6 +8,7 @@ class OpenaiEvaluateController < ApplicationController
     level_id = evaluate_params[:level_id]
     student_work = evaluate_params[:student_work]
     evaluation_type = evaluate_params[:evaluation_type]
+    should_evaluate_skills = evaluate_params[:should_evaluate_skills] || false
 
     begin
       level = Level.find(level_id)
@@ -18,7 +19,8 @@ class OpenaiEvaluateController < ApplicationController
     response = OpenaiEvaluateHelper.evaluate(
       level,
       student_work: student_work,
-      evaluation_type: evaluation_type
+      evaluation_type: evaluation_type,
+      should_evaluate_skills: should_evaluate_skills
     )
 
     return render(status: response[:status], json: response[:json])
@@ -44,7 +46,7 @@ class OpenaiEvaluateController < ApplicationController
   end
 
   private def evaluate_params
-    params.transform_keys(&:underscore).permit(:level_id, :unit_id, :student_work, :evaluation_type)
+    params.transform_keys(&:underscore).permit(:level_id, :unit_id, :student_work, :evaluation_type, :should_evaluate_skills)
   end
 
   private def evaluate_section_params

--- a/dashboard/app/helpers/ai_evaluation_openai_helper.rb
+++ b/dashboard/app/helpers/ai_evaluation_openai_helper.rb
@@ -65,6 +65,7 @@ module AiEvaluationOpenaiHelper
                     type: "object",
                     properties: {
                       skillId: {type: "integer"},
+                      skillKey: {type: "string"},
                       evaluationCriteria: {type: "string"},
                       aiEvaluation: {type: "string"},
                       aiReasoning: {type: "string"}

--- a/dashboard/app/helpers/ai_evaluation_openai_helper.rb
+++ b/dashboard/app/helpers/ai_evaluation_openai_helper.rb
@@ -21,15 +21,57 @@ module AiEvaluationOpenaiHelper
         response_format: {
           type: "json_schema",
           json_schema: {
-            name: "evaluation",
+            name: "overall_evaluation",
             schema: {
               type: "object",
               properties: {
                 evaluationCriteria: {type: "string"},
                 aiEvaluation: {type: "string"},
                 aiReasoning: {type: "string"},
-                skillEvaluations: {type: "array", items: {type: "object"}},
               },
+            }
+          }
+        }
+      }
+
+      HTTParty.post(
+        OPEN_AI_URL,
+        headers: headers,
+        body: data.to_json,
+        open_timeout: DCDO.get('openai_http_open_timeout', 5),
+        read_timeout: DCDO.get('openai_http_read_timeout', 30)
+      )
+    end
+
+    def request_skill_evaluations(student_work)
+      headers = {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer #{api_key}"
+      }
+
+      data = {
+        model: model,
+        messages: student_work,
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "skills_evaluation",
+            schema: {
+              type: "object",
+              properties: {
+                skillEvaluations: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      skillId: {type: "integer"},
+                      evaluationCriteria: {type: "string"},
+                      aiEvaluation: {type: "string"},
+                      aiReasoning: {type: "string"}
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/dashboard/app/helpers/openai_evaluate_helper.rb
+++ b/dashboard/app/helpers/openai_evaluate_helper.rb
@@ -71,7 +71,7 @@ module OpenaiEvaluateHelper
       if user_level.level_source && user_level.level_source.data.present?
         evaluate_free_response(user_level, unit)
       elsif user_level.level.name == 'U4 L03 Variables operator practice 5_2024' || user_level.level.name == 'U4 L03 Variables numbers practice 4_2024'
-        evaluate_code_level(user_level, unit)
+        evaluate_code_level(user_level, unit, true)
       end
     end
 

--- a/dashboard/app/helpers/openai_evaluate_helper.rb
+++ b/dashboard/app/helpers/openai_evaluate_helper.rb
@@ -30,10 +30,7 @@ module OpenaiEvaluateHelper
     aiReasoning: "Dummy data returned for testing purposes."
   }
 
-  def self.evaluate(level, options)
-    student_work = options[:student_work]
-    evaluation_type = options[:evaluation_type]
-
+  def self.evaluate(level, student_work:, evaluation_type:, should_evaluate_skills: false)
     if (level.is_a?(FreeResponse) && student_work.delete(' ').empty?) || (level.upper_grades_programming_level? && level.get_starter_code == student_work)
       response = NO_ATTEMPT_RESPONSE
       # mimic the format of the response from AI
@@ -53,7 +50,7 @@ module OpenaiEvaluateHelper
       system_prompt = AiSystemPrompts::EvaluateSystemPromptHelper.get_system_prompt(level, evaluation_type)
       student_work_message = [{role: "user", content: student_work}]
       messages = prepend_system_prompt(system_prompt, student_work_message)
-      response = client.request_evaluation(messages)
+      response = should_evaluate_skills ? client.request_skill_evaluations(messages) : client.request_evaluation(messages)
       response_body = JSON.parse(response.body)
       response_body = response_body['choices'][0]['message'] if response.code == 200
       evaluation =  {status: response.code, json: response_body}
@@ -93,12 +90,17 @@ module OpenaiEvaluateHelper
     create_ai_evaluations_from_ai_response(user_level.user, user_level, unit, response, {})
   end
 
-  def self.evaluate_code_level(user_level, unit)
+  def self.evaluate_code_level(user_level, unit, should_evaluate_skills)
     helper = ApplicationController.helpers
     student_code = helper.get_student_code(user_level.user.id, user_level.level, unit.id)
 
     unless student_code.nil? || student_code[:student_code].nil?
-      response = evaluate(user_level.level, student_work: student_code[:student_code], evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT])
+      response = evaluate(
+        user_level.level,
+        student_work: student_code[:student_code],
+        evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT],
+        should_evaluate_skills: should_evaluate_skills
+      )
 
       create_ai_evaluations_from_ai_response(user_level.user, user_level, unit, response, code_version: student_code[:code_version])
     end
@@ -162,5 +164,5 @@ module OpenaiEvaluateHelper
     messages
   end
 
-  private_class_method :client, :prepend_system_prompt, :evaluate_free_response
+  private_class_method :client, :prepend_system_prompt
 end

--- a/dashboard/test/helpers/openai_evaluate_helper_test.rb
+++ b/dashboard/test/helpers/openai_evaluate_helper_test.rb
@@ -48,14 +48,14 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
     fr_level_source = create(:level_source, data: "This is my free response answer")
     fr_user_level = create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: fr_level_source)
 
-     mock_response = {
-       status: :ok,
+    mock_response = {
+      status: :ok,
       json: {"content" => {
         aiEvaluation: "Meets",
         evaluationCriteria: "Did student answer the question?",
         aiReasoning: "Student provided a complete answer",
       }.to_json}
-     }
+    }
 
     OpenaiEvaluateHelper.expects(:evaluate).with(
       @fr_user_level.level,

--- a/dashboard/test/helpers/openai_evaluate_helper_test.rb
+++ b/dashboard/test/helpers/openai_evaluate_helper_test.rb
@@ -21,34 +21,58 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
   end
 
   test "evaluate_section evaluates free response levels" do
-    level_source = create(:level_source, data: "This is my free response answer")
-    create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: level_source)
+    fr_level_source = create(:level_source, data: "This is my free response answer")
+    fr_user_level = create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: fr_level_source)
 
-    mock_response = {
-      status: :ok,
+    OpenaiEvaluateHelper.expects(:evaluate_free_response).with(
+      fr_user_level,
+      @unit,
+    )
+
+    OpenaiEvaluateHelper.evaluate_section(@unit, @section)
+  end
+
+  test "evaluate_section evaluates coding levels" do
+    code_user_level = create(:user_level, user: @student1, level: @code_level1, script: @unit)
+
+    OpenaiEvaluateHelper.expects(:evaluate_code_level).with(
+      code_user_level,
+      @unit,
+      should_evaluate_skills: true
+    )
+
+    OpenaiEvaluateHelper.evaluate_section(@unit, @section)
+  end
+
+  test "evaluate_free_response calls evaluate and creates student work evaluation" do
+    fr_level_source = create(:level_source, data: "This is my free response answer")
+    fr_user_level = create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: fr_level_source)
+
+     mock_response = {
+    status: :ok,
       json: {"content" => {
         aiEvaluation: "Meets",
         evaluationCriteria: "Did student answer the question?",
         aiReasoning: "Student provided a complete answer",
-        skillEvaluations: []
       }.to_json}
     }
 
     OpenaiEvaluateHelper.expects(:evaluate).with(
-      @free_response_level,
+      @fr_user_level.level,
       student_work: "This is my free response answer",
-      evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]
+      evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT],
+      should_evaluate_skills: false
     ).returns(mock_response)
 
     StudentWorkEvaluation.expects(:create!).with(
       has_entry(type: 'UserLevelEvaluation')
     ).returns(mock('work_evaluation'))
 
-    OpenaiEvaluateHelper.evaluate_section(@unit, @section)
+    OpenaiEvaluateHelper.evaluate_free_response(fr_user_level, @unit)
   end
 
-  test "evaluate_section evaluates specific code levels with skill evaluation" do
-    create(:user_level, user: @student1, level: @code_level1, script: @unit)
+ test "evaluate_code_level with skills gets student code, calls evaluate and creates student work evaluation" do
+    code_user_level = create(:user_level, user: @student1, level: @code_level1, script: @unit)
 
     helper = mock('helper')
     ApplicationController.expects(:helpers).returns(helper)
@@ -61,9 +85,6 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
     mock_response = {
       status: :ok,
       json: {"content" => {
-        aiEvaluation: "Meets",
-        evaluationCriteria: "Did student write correct code?",
-        aiReasoning: "Student code is correct",
         skillEvaluations: [
           {
             skillId: "skill1",
@@ -78,7 +99,8 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
     OpenaiEvaluateHelper.expects(:evaluate).with(
       @code_level1,
       student_work: "console.log('Hello')",
-      evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]
+      evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT],
+      should_evaluate_skills: true
     ).returns(mock_response)
 
     work_evaluation = mock('work_evaluation')
@@ -96,14 +118,15 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
       student_work_evaluation_summary_id: 1
     ).returns(mock('summary'))
 
-    OpenaiEvaluateHelper.evaluate_section(@unit, @section)
+     OpenaiEvaluateHelper.evaluate_code_level(code_user_level, @unit, true)
   end
 
   test "evaluate_section skips levels with no level_source data" do
     level_source = create(:level_source, data: "")
     create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: level_source)
 
-    OpenaiEvaluateHelper.expects(:evaluate).never
+    OpenaiEvaluateHelper.expects(:evaluate_code_level).never
+    OpenaiEvaluateHelper.expects(:evaluate_free_response).never
 
     OpenaiEvaluateHelper.evaluate_section(@unit, @section)
   end
@@ -111,14 +134,14 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
   test "evaluate_section skips non-targeted levels" do
     create(:user_level, user: @student1, level: @other_level, script: @unit)
 
-    ApplicationController.helpers.expects(:get_student_code).never
-    OpenaiEvaluateHelper.expects(:evaluate).never
+    OpenaiEvaluateHelper.expects(:evaluate_code_level).never
+    OpenaiEvaluateHelper.expects(:evaluate_free_response).never
 
     OpenaiEvaluateHelper.evaluate_section(@unit, @section)
   end
 
-  test "evaluate_section handles nil student code" do
-    create(:user_level, user: @student1, level: @code_level2, script: @unit)
+  test "evaluate_code_level handles nil student code" do
+    nil_code_user_level = create(:user_level, user: @student1, level: @code_level2, script: @unit)
 
     helper = mock('helper')
     ApplicationController.expects(:helpers).returns(helper)
@@ -130,7 +153,7 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
 
     OpenaiEvaluateHelper.expects(:evaluate).never
 
-    OpenaiEvaluateHelper.evaluate_section(@unit, @section)
+    OpenaiEvaluateHelper.evaluate_code_level(nil_code_user_level, @unit, false)
   end
 
   test "evaluate_section processes multiple students and levels" do
@@ -142,29 +165,9 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
 
     create(:user_level, user: @student1, level: @code_level1, script: @unit)
 
-    helper = mock('helper')
-    ApplicationController.expects(:helpers).at_least_once.returns(helper)
-    helper.expects(:get_student_code).with(
-      @student1.id,
-      @code_level1,
-      @unit.id
-    ).returns({student_code: "console.log('Hello')", code_version: "1"})
+    OpenaiEvaluateHelper.expects(:evaluate_free_response).times(2).returns
 
-    mock_response = {
-      status: :ok,
-      json: {"content" => {
-        aiEvaluation: "Meets",
-        evaluationCriteria: "Test criteria",
-        aiReasoning: "Test reasoning",
-        skillEvaluations: []
-      }.to_json}
-    }
-
-    OpenaiEvaluateHelper.expects(:evaluate).times(3).returns(mock_response)
-
-    work_evaluation = mock('work_evaluation')
-    work_evaluation.stubs(:id).returns(1)
-    StudentWorkEvaluation.expects(:create!).times(3).returns(work_evaluation)
+    StudentWorkEvaluation.expects(:evaluate_code_level).times(1)
 
     OpenaiEvaluateHelper.evaluate_section(@unit, @section)
   end

--- a/dashboard/test/helpers/openai_evaluate_helper_test.rb
+++ b/dashboard/test/helpers/openai_evaluate_helper_test.rb
@@ -20,53 +20,20 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
     Level.find_by(id: @other_level.id).update!(name: 'Some other level')
   end
 
-  test "evaluate_section evaluates free response levels" do
+  test "evaluate_free_response calls evaluate" do
     fr_level_source = create(:level_source, data: "This is my free response answer")
     fr_user_level = create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: fr_level_source)
-
-    OpenaiEvaluateHelper.expects(:evaluate_free_response).with(
-      fr_user_level,
-      @unit,
-    )
-
-    OpenaiEvaluateHelper.evaluate_section(@unit, @section)
-  end
-
-  test "evaluate_section evaluates coding levels" do
-    code_user_level = create(:user_level, user: @student1, level: @code_level1, script: @unit)
-
-    OpenaiEvaluateHelper.expects(:evaluate_code_level).with(
-      code_user_level,
-      @unit,
-      should_evaluate_skills: true
-    )
-
-    OpenaiEvaluateHelper.evaluate_section(@unit, @section)
-  end
-
-  test "evaluate_free_response calls evaluate and creates student work evaluation" do
-    fr_level_source = create(:level_source, data: "This is my free response answer")
-    fr_user_level = create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: fr_level_source)
-
-    mock_response = {
-      status: :ok,
-      json: {"content" => {
-        aiEvaluation: "Meets",
-        evaluationCriteria: "Did student answer the question?",
-        aiReasoning: "Student provided a complete answer",
-      }.to_json}
-    }
 
     OpenaiEvaluateHelper.expects(:evaluate).with(
-      @fr_user_level.level,
+      @free_response_level,
       student_work: "This is my free response answer",
-      evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT],
-      should_evaluate_skills: false
-    ).returns(mock_response)
-
-    StudentWorkEvaluation.expects(:create!).with(
-      has_entry(type: 'UserLevelEvaluation')
-    ).returns(mock('work_evaluation'))
+      evaluation_type: SharedConstants::AI_EVALUATION_TYPES[:SINGLE_STUDENT]
+    ).returns({status: 200, json: {"content" => {
+      aiEvaluation: "Meets",
+      evaluationCriteria: "Did student answer the question?",
+      aiReasoning: "Student provided a complete answer",
+    }.to_json}}
+)
 
     OpenaiEvaluateHelper.evaluate_free_response(fr_user_level, @unit)
   end
@@ -121,6 +88,30 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
     OpenaiEvaluateHelper.evaluate_code_level(code_user_level, @unit, true)
   end
 
+  test "evaluate_section evaluates free response levels" do
+    fr_level_source = create(:level_source, data: "This is my free response answer")
+    fr_user_level = create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: fr_level_source)
+
+    OpenaiEvaluateHelper.expects(:evaluate_free_response).with(
+      fr_user_level,
+      @unit,
+    )
+
+    OpenaiEvaluateHelper.evaluate_section(@unit, @section)
+  end
+
+  test "evaluate_section evaluates coding levels" do
+    code_user_level = create(:user_level, user: @student1, level: @code_level1, script: @unit)
+
+    OpenaiEvaluateHelper.expects(:evaluate_code_level).with(
+      code_user_level,
+      @unit,
+      true
+    )
+
+    OpenaiEvaluateHelper.evaluate_section(@unit, @section)
+  end
+
   test "evaluate_section skips levels with no level_source data" do
     level_source = create(:level_source, data: "")
     create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: level_source)
@@ -167,7 +158,7 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
 
     OpenaiEvaluateHelper.expects(:evaluate_free_response).times(2).returns
 
-    StudentWorkEvaluation.expects(:evaluate_code_level).times(1)
+    OpenaiEvaluateHelper.expects(:evaluate_code_level).times(1)
 
     OpenaiEvaluateHelper.evaluate_section(@unit, @section)
   end

--- a/dashboard/test/helpers/openai_evaluate_helper_test.rb
+++ b/dashboard/test/helpers/openai_evaluate_helper_test.rb
@@ -49,13 +49,13 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
     fr_user_level = create(:user_level, user: @student1, level: @free_response_level, script: @unit, level_source: fr_level_source)
 
      mock_response = {
-    status: :ok,
+       status: :ok,
       json: {"content" => {
         aiEvaluation: "Meets",
         evaluationCriteria: "Did student answer the question?",
         aiReasoning: "Student provided a complete answer",
       }.to_json}
-    }
+     }
 
     OpenaiEvaluateHelper.expects(:evaluate).with(
       @fr_user_level.level,
@@ -71,7 +71,7 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
     OpenaiEvaluateHelper.evaluate_free_response(fr_user_level, @unit)
   end
 
- test "evaluate_code_level with skills gets student code, calls evaluate and creates student work evaluation" do
+  test "evaluate_code_level with skills gets student code, calls evaluate and creates student work evaluation" do
     code_user_level = create(:user_level, user: @student1, level: @code_level1, script: @unit)
 
     helper = mock('helper')
@@ -118,7 +118,7 @@ class OpenaiEvaluateHelperTest < ActionView::TestCase
       student_work_evaluation_summary_id: 1
     ).returns(mock('summary'))
 
-     OpenaiEvaluateHelper.evaluate_code_level(code_user_level, @unit, true)
+    OpenaiEvaluateHelper.evaluate_code_level(code_user_level, @unit, true)
   end
 
   test "evaluate_section skips levels with no level_source data" do


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/TEACH-2140

To increase accuracy of AI validation (see https://github.com/code-dot-org/code-dot-org/pull/67382) we needed to separate the skills-specific evaluations from the overall evaluation of the student's work. In order to do that, we needed to separate out the API endpoint for calling OpenAI into `request_evaluation` and `request_skill_evaluations`. Which had a cascade effect on upstream code that was also updated. 

Tidy re-do of https://github.com/code-dot-org/code-dot-org/pull/67681
