### PR TITLE
feat(workshops): complete follow up requested component

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopFormTemplate/types.ts
@@ -332,11 +332,17 @@ export interface SurveySummary {
   name: string;
   facilitators: Record<string, string>;
   surveys: Record<string, SurveyTypeSummary>;
+  follow_up_requested: FollowUpRequestedItem[];
 }
 
 export interface SurveyTypeSummary {
   total_responses: number;
   categories: SurveyCategories;
+}
+
+export interface FollowUpRequestedItem {
+  name: string;
+  email: string;
 }
 
 export interface SurveyCategories {
@@ -366,7 +372,7 @@ type SurveyQuestionBase = {
 };
 
 type ResultsBase = {
-  total_responses: number;
+  total_responses?: number;
 };
 
 export type SurveyQuestion =
@@ -406,10 +412,10 @@ export interface Breakdown {
 }
 
 export interface LikertResults {
-  weighted_score: number;
-  agreement_count: number;
-  agreement_percentage: number;
-  breakdown: Record<
+  weighted_score?: number;
+  agreement_count?: number;
+  agreement_percentage?: number;
+  breakdown?: Record<
     string,
     Breakdown & {
       weighted_value: number;
@@ -418,20 +424,20 @@ export interface LikertResults {
 }
 
 export interface PromoterResults {
-  promoter_percentage: number;
-  breakdown: Record<string, Breakdown>;
+  promoter_percentage?: number;
+  breakdown?: Record<string, Breakdown>;
 }
 
 export interface TextResults {
-  responses: string[];
+  responses?: string[];
 }
 
 export interface SingleSelectResults {
-  breakdown: Record<string, Breakdown>;
+  breakdown?: Record<string, Breakdown>;
   other_answers?: string[];
 }
 
 export interface MultiSelectResults {
-  breakdown: Record<string, Breakdown>;
-  total_respondents: number;
+  breakdown?: Record<string, Breakdown>;
+  total_respondents?: number;
 }

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/components/CopyButton.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/components/CopyButton.tsx
@@ -3,15 +3,17 @@ import React, {useState, useEffect} from 'react';
 
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 
-interface CopyLinkButtonProps {
-  link: string;
+interface CopyButtonProps {
+  buttonText: string;
+  textToCopy: string;
   ariaLabel?: string;
 }
 
 const RESET_TIMEOUT = 2000;
 
-export const CopyLinkButton: React.FC<CopyLinkButtonProps> = ({
-  link,
+export const CopyButton: React.FC<CopyButtonProps> = ({
+  textToCopy,
+  buttonText,
   ariaLabel,
 }) => {
   const [icon, setIcon] = useState<'copy' | 'check'>('copy');
@@ -31,12 +33,12 @@ export const CopyLinkButton: React.FC<CopyLinkButtonProps> = ({
 
   return (
     <Button
-      text={icon === 'copy' ? 'Copy link' : 'Copied!'}
+      text={icon === 'copy' ? buttonText : 'Copied!'}
       type="secondary"
       size="xs"
       color={buttonColors.gray}
       iconLeft={{iconName: icon, iconStyle: 'solid'}}
-      onClick={() => copyToClipboard(link, () => setIcon('check'))}
+      onClick={() => copyToClipboard(textToCopy, () => setIcon('check'))}
       ariaLabel={ariaLabel}
     />
   );

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopLinksSection.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopLinksSection.tsx
@@ -16,7 +16,7 @@ import {
 import classNames from 'classnames';
 import React from 'react';
 
-import {CopyLinkButton} from '../../components/CopyLinkButton';
+import {CopyButton} from '../../components/CopyButton';
 import {WorkshopData} from '../../types';
 
 import styles from '../../workshop.module.scss';
@@ -91,8 +91,9 @@ export const WorkshopLinksSection: React.FC<WorkshopLinksSectionProps> = ({
               </Link>
             </Box>
             <Box>
-              <CopyLinkButton
-                link={fullMarketingPageUrl}
+              <CopyButton
+                buttonText="Copy link"
+                textToCopy={fullMarketingPageUrl}
                 ariaLabel="Copy marketing page link to clipboard"
               />
             </Box>
@@ -129,8 +130,9 @@ export const WorkshopLinksSection: React.FC<WorkshopLinksSectionProps> = ({
                   </Link>
                 </Box>
                 <Box>
-                  <CopyLinkButton
-                    link={fullJoinWorkshopUrl}
+                  <CopyButton
+                    buttonText="Copy link"
+                    textToCopy={fullJoinWorkshopUrl}
                     ariaLabel="Copy join workshop link to clipboard"
                   />
                 </Box>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FollowUpRequestedCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FollowUpRequestedCard.tsx
@@ -9,19 +9,18 @@ import React, {FC} from 'react';
 
 import noResponsesEmail from '@cdo/static/pd/no-responses-email.png';
 
+import {FollowUpRequestedItem} from '../../../WorkshopFormTemplate/types';
+import {CopyButton} from '../../components/CopyButton';
+
 import {EmptyState} from './EmptyState';
 
-import styles from '../../workshop.module.scss';
-
-interface FollowUp {
-  name: string;
-  email: string;
-}
+import styles from './FollowUpRequestedCardStyles.module.scss';
+import commonStyles from '../../workshop.module.scss';
 
 interface FollowUpRequestedCardProps {
   title: string;
   description: string;
-  items: FollowUp[];
+  items: FollowUpRequestedItem[];
 }
 
 export const FollowUpRequestedCard: FC<FollowUpRequestedCardProps> = ({
@@ -30,32 +29,36 @@ export const FollowUpRequestedCard: FC<FollowUpRequestedCardProps> = ({
   items,
 }) => {
   return (
-    <Card
-      className={classNames(
-        styles.card,
-        styles.questionCard,
-        styles.multiSelect
-      )}
-    >
+    <Card className={classNames(commonStyles.card, styles.followUpCard)}>
       <CardHeader
-        className={styles.cardHeader}
+        className={commonStyles.cardHeader}
         title={
           <>
             <Heading2 visualAppearance="body-one" noMargin>
               <StrongText>{title}</StrongText>
             </Heading2>
-            <BodyThreeText noMargin className={styles.subHeader}>
+            <BodyThreeText noMargin className={commonStyles.subHeader}>
               {description}
             </BodyThreeText>
           </>
         }
       />
-      <CardContent className={styles.cardContent}>
+      <CardContent className={classNames(styles.cardContent)}>
         {items.length > 0 ? (
-          <Box className={styles.column}>
+          <Box
+            className={classNames(commonStyles.column, styles.emailContainer)}
+          >
             {items.map(item => (
-              <Box key={item.email}>
-                {/* TODO: https://codedotorg.atlassian.net/browse/ACQ-3460 render result rows */}
+              <Box key={item.email} className={styles.emailRow}>
+                <BodyThreeText noMargin>
+                  <StrongText>{item.name}</StrongText>
+                </BodyThreeText>
+                <BodyThreeText noMargin>{item.email}</BodyThreeText>
+                <CopyButton
+                  buttonText="Copy email"
+                  textToCopy={item.email}
+                  ariaLabel={`copy ${item.email}`}
+                />
               </Box>
             ))}
           </Box>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FollowUpRequestedCardStyles.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FollowUpRequestedCardStyles.module.scss
@@ -1,0 +1,38 @@
+div.followUpCard {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+
+  @media (min-width: 900px) {
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: calc(50% - 0.75rem);
+  }
+
+  div.cardContent {
+    padding: 0;
+    overflow: auto;
+
+    &:last-child {
+      padding: 0;
+    }
+
+    .emailContainer {
+      gap: 0;
+
+      .emailRow {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+        border-bottom: 1px solid var(--borders-neutral-primary);
+        padding: 1rem 1.25rem;
+
+        button {
+          margin-left: auto;
+        }
+      }
+    }
+  }
+}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FreeResponseCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FreeResponseCard.tsx
@@ -17,7 +17,7 @@ import styles from '../../workshop.module.scss';
 interface FreeResponseCardProps {
   title: string;
   tagText?: string;
-  items: string[];
+  items?: string[];
   statusColor?: 'success' | 'warning';
   size?: 's' | 'l';
 }
@@ -25,7 +25,7 @@ interface FreeResponseCardProps {
 export const FreeResponseCard: FC<FreeResponseCardProps> = ({
   title,
   tagText,
-  items,
+  items = [],
   statusColor,
   size = 'l',
 }) => {

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
@@ -26,8 +26,8 @@ interface ScoreCardProps {
   description: string;
   footer: string | null;
   questionType: 'likert' | 'promoter';
-  score: number;
-  responseCount: number;
+  score?: number;
+  responseCount?: number;
   minResponseCount: number;
   breakdown?: Breakdown[];
 }
@@ -38,8 +38,8 @@ export const ScoreCard: FC<ScoreCardProps> = ({
   description,
   footer,
   questionType,
-  score,
-  responseCount,
+  score = 0,
+  responseCount = 0,
   minResponseCount,
   breakdown,
 }) => {

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/SelectCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/SelectCard.tsx
@@ -17,7 +17,7 @@ interface SelectCardProps {
   title: string;
   description: string;
   items: Breakdown[];
-  totalRespondents: number;
+  totalRespondents?: number;
   barLabel?: string;
 }
 
@@ -25,7 +25,7 @@ export const SelectCard: FC<SelectCardProps> = ({
   title,
   description,
   items,
-  totalRespondents,
+  totalRespondents = 0,
   barLabel = '',
 }) => {
   if (!totalRespondents) {

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/SelectCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/SelectCard.tsx
@@ -36,7 +36,7 @@ export const SelectCard: FC<SelectCardProps> = ({
       className={classNames(
         styles.card,
         styles.questionCard,
-        styles.multiSelect
+        styles.selectCard
       )}
     >
       <CardHeader

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/helpers.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/helpers.ts
@@ -15,19 +15,19 @@ export const getQuestionDescription = (question: SurveyQuestion) => {
     isQuestionType(question, 'multiSelect') &&
     question.question_name === 'barriers_implementation_curriculum'
   ) {
-    if (question.results.total_respondents === 0) {
+    if (!question.results.total_respondents) {
       return '';
     }
     const numWithBarriers =
       question.results.total_respondents -
-      (question.results.breakdown.none?.count ?? 0);
+      (question.results.breakdown?.none?.count ?? 0);
     return `${numWithBarriers} teachers reported at least 1 or more barriers to implementation`;
   }
   return '';
 };
 
 export const prepLikertBreakdown = (breakdown: LikertResults['breakdown']) =>
-  Object.entries(breakdown)
+  Object.entries(breakdown ?? {})
     .map(([key, value]) => ({
       ...value,
       className:

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Engagement.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Engagement.tsx
@@ -79,7 +79,9 @@ export const Engagement = () => {
               otherQuestionsEngagement.question_text
             }
             items={otherQuestionsEngagement.results.responses}
-            tagText={`${otherQuestionsEngagement.results.total_responses} Submitted`}
+            tagText={`${
+              otherQuestionsEngagement.results.total_responses ?? 0
+            } Submitted`}
           />
         )}
       </Box>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/FacilitatorFeedback.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/FacilitatorFeedback.tsx
@@ -87,7 +87,9 @@ export const FacilitatorFeedback = () => {
               facilitatorDidWell.question_text
             }
             items={facilitatorDidWell.results.responses}
-            tagText={`${facilitatorDidWell.results.total_responses} Submitted`}
+            tagText={`${
+              facilitatorDidWell.results.total_responses ?? 0
+            } Submitted`}
             statusColor="success"
             size="s"
           />
@@ -99,7 +101,9 @@ export const FacilitatorFeedback = () => {
               facilitatorCouldImprove.question_text
             }
             items={facilitatorCouldImprove.results.responses}
-            tagText={`${facilitatorCouldImprove.results.total_responses} Submitted`}
+            tagText={`${
+              facilitatorCouldImprove.results.total_responses ?? 0
+            } Submitted`}
             statusColor="warning"
             size="s"
           />

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
@@ -112,7 +112,9 @@ export const Implementation = () => {
               otherQuestionsImplementation.question_text
             }
             items={otherQuestionsImplementation.results.responses ?? []}
-            tagText={`${otherQuestionsImplementation.results.total_responses} Submitted`}
+            tagText={`${
+              otherQuestionsImplementation.results.total_responses ?? 0
+            } Submitted`}
           />
         )}
       </Box>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
@@ -47,10 +47,12 @@ export const Implementation = () => {
     if (!isQuestionType(barriersToImplementation, 'multiSelect')) {
       return [];
     }
-    return Object.entries(barriersToImplementation.results.breakdown)
+    return Object.entries(barriersToImplementation.results.breakdown ?? {})
       .filter(([key]) => key !== 'none')
       .map(([_, value]) => value);
   }, [barriersToImplementation]);
+
+  const followUpRequestedItems = surveys?.follow_up_requested ?? [];
 
   if (!questions) return null;
 
@@ -104,7 +106,7 @@ export const Implementation = () => {
               otherQuestionsImplementation.question_short_text ??
               otherQuestionsImplementation.question_text
             }
-            items={otherQuestionsImplementation.results.responses}
+            items={otherQuestionsImplementation.results.responses ?? []}
             tagText={`${otherQuestionsImplementation.results.total_responses} Submitted`}
           />
         )}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Implementation.tsx
@@ -1,4 +1,5 @@
 import {Box} from '@mui/material';
+import classNames from 'classnames';
 import React, {useMemo} from 'react';
 
 import {
@@ -77,7 +78,7 @@ export const Implementation = () => {
         )}
       </Box>
 
-      <Box className={styles.cardRow}>
+      <Box className={classNames(styles.cardRow, styles.scrollContainerRow)}>
         {isQuestionType(barriersToImplementation, 'multiSelect') && (
           <SelectCard
             title={
@@ -93,9 +94,13 @@ export const Implementation = () => {
           />
         )}
         <FollowUpRequestedCard
-          items={[]}
+          items={followUpRequestedItems}
           title="Follow-up requested"
-          description=""
+          description={
+            followUpRequestedItems.length
+              ? `${followUpRequestedItems.length} teachers requested additional support with implementation.`
+              : ''
+          }
         />
       </Box>
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Logistics.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/post/components/Logistics.tsx
@@ -63,7 +63,9 @@ export const Logistics = () => {
               otherQuestionsLogistics.question_text
             }
             items={otherQuestionsLogistics.results.responses}
-            tagText={`${otherQuestionsLogistics.results.total_responses} Submitted`}
+            tagText={`${
+              otherQuestionsLogistics.results.total_responses ?? 0
+            } Submitted`}
           />
         )}
       </Box>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
@@ -328,9 +328,21 @@ div.card {
   flex: 1;
   gap: 1.5rem;
   flex-direction: column;
+  position: relative;
 
   @media (min-width: 900px) {
     flex-direction: row;
+  }
+
+  &.scrollContainerRow {
+    @media (min-width: 900px) {
+      // empty element to take space of absolutely positioned scrollable card
+      &::after {
+        content: '';
+        display: block;
+        flex: 1;
+      }
+    }
   }
 
   .questionCard {
@@ -338,29 +350,29 @@ div.card {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+  }
 
-    .cardHeader,
+  .cardHeader,
+  .cardContent {
+    padding: 1rem 1.25rem;
+  }
+
+  &.selectCard {
     .cardContent {
-      padding: 1rem 1.25rem;
+      padding-right: 0.5rem;
+      padding-bottom: 1.25rem;
     }
+  }
 
-    &.selectCard {
-      .cardContent {
-        padding-right: 0.5rem;
-        padding-bottom: 1.25rem;
-      }
-    }
+  .cardContent {
+    padding-top: 1rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
 
-    .cardContent {
-      padding-top: 1rem;
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-
-      .description {
-        color: var(--text-neutral-tertiary);
-        margin-top: 0.313rem;
-      }
+    .description {
+      color: var(--text-neutral-tertiary);
+      margin-top: 0.313rem;
     }
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/workshop.module.scss
@@ -344,7 +344,7 @@ div.card {
       padding: 1rem 1.25rem;
     }
 
-    &.multiSelect {
+    &.selectCard {
       .cardContent {
         padding-right: 0.5rem;
         padding-bottom: 1.25rem;

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/components/CopyButtonTest.tsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshops/components/CopyButtonTest.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {UserEvent} from 'node_modules/@testing-library/user-event/dist/types/setup/setup';
 import React from 'react';
 
-import {CopyLinkButton} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshops/components/CopyLinkButton';
+import {CopyButton} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshops/components/CopyButton';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 
 jest.mock('@cdo/apps/util/copyToClipboard', () => jest.fn());
@@ -12,7 +12,7 @@ const mockCopyToClipboard = copyToClipboard as jest.MockedFunction<
   typeof copyToClipboard
 >;
 
-describe('CopyLinkButton', () => {
+describe('CopyButton', () => {
   let user: UserEvent;
   const advanceTimers = () => {
     // Fast-forward time by 2 seconds
@@ -43,11 +43,12 @@ describe('CopyLinkButton', () => {
   });
 
   const defaultProps = {
-    link: 'https://example.com/test-link',
+    buttonText: 'Copy link',
+    textToCopy: 'https://example.com/test-link',
   };
 
   it('renders with correct text and initial icon', () => {
-    render(<CopyLinkButton {...defaultProps} />);
+    render(<CopyButton {...defaultProps} />);
 
     expect(screen.getByRole('button', {name: 'Copy link'})).toBeInTheDocument();
     expect(screen.getByText('Copy link')).toBeInTheDocument();
@@ -55,7 +56,7 @@ describe('CopyLinkButton', () => {
 
   it('renders with custom aria-label when provided', () => {
     const customAriaLabel = 'Copy workshop marketing page link';
-    render(<CopyLinkButton {...defaultProps} ariaLabel={customAriaLabel} />);
+    render(<CopyButton {...defaultProps} ariaLabel={customAriaLabel} />);
 
     expect(
       screen.getByRole('button', {name: customAriaLabel})
@@ -63,7 +64,7 @@ describe('CopyLinkButton', () => {
   });
 
   it('calls copyToClipboard with correct link when clicked', async () => {
-    render(<CopyLinkButton {...defaultProps} />);
+    render(<CopyButton {...defaultProps} />);
 
     const button = screen.getByRole('button', {name: 'Copy link'});
     await act(async () => {
@@ -72,13 +73,13 @@ describe('CopyLinkButton', () => {
     advanceTimers();
 
     expect(mockCopyToClipboard).toHaveBeenCalledWith(
-      defaultProps.link,
+      defaultProps.textToCopy,
       expect.any(Function)
     );
   });
 
   it('changes text to "Copied!" when copy is successful', async () => {
-    render(<CopyLinkButton {...defaultProps} />);
+    render(<CopyButton {...defaultProps} />);
 
     const button = screen.getByRole('button', {name: 'Copy link'});
     await act(async () => {
@@ -94,7 +95,7 @@ describe('CopyLinkButton', () => {
   });
 
   it('resets text back to "Copy link" after 2 seconds', async () => {
-    render(<CopyLinkButton {...defaultProps} />);
+    render(<CopyButton {...defaultProps} />);
 
     const button = screen.getByRole('button', {name: 'Copy link'});
     await act(async () => {
@@ -115,7 +116,7 @@ describe('CopyLinkButton', () => {
   it('handles link values correctly', async () => {
     const customLink = 'https://code.org/workshops/123/join';
 
-    render(<CopyLinkButton link={customLink} />);
+    render(<CopyButton {...defaultProps} textToCopy={customLink} />);
 
     const button = screen.getByRole('button', {name: 'Copy link'});
     await act(async () => {
@@ -130,7 +131,7 @@ describe('CopyLinkButton', () => {
   });
 
   it('cleans up timeout when component unmounts', async () => {
-    const {unmount} = render(<CopyLinkButton {...defaultProps} />);
+    const {unmount} = render(<CopyButton {...defaultProps} />);
 
     // Click to trigger the timeout
     const button = screen.getByRole('button', {name: 'Copy link'});


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This pull request introduces several improvements and refactors to the workshop survey dashboard, focusing on better handling of optional survey data, enhanced UI for follow-up requests, and reusable copy-to-clipboard functionality. The most notable changes include making survey result fields optional to match the api data, adding a new follow-up requested card with copyable emails, and generalizing the copy button component for broader use.

**Survey data model and type safety improvements:**

* Made various fields in survey result types (e.g., `total_responses`, `weighted_score`, `breakdown`, etc.) optional to handle incomplete or missing data gracefully in the UI. This includes updates to `SurveySummary`, `LikertResults`, `PromoterResults`, `TextResults`, `SingleSelectResults`, and `MultiSelectResults` interfaces.
* Updated code throughout the survey dashboard to use safe access patterns (e.g., nullish coalescing and default values) when reading these potentially undefined fields, ensuring the UI remains stable even with partial data.

**Follow-up requested card and styling:**

* Added a new `FollowUpRequestedCard` component to display a list of teachers who requested follow-up, including their names and emails, with a "Copy email" button for each entry. This uses a new `FollowUpRequestedItem` type and pulls data from the survey summary.
* Introduced new styling for the follow-up card and improved layout for better usability and responsiveness, including a new SCSS module.

**Reusable copy-to-clipboard button:**

* Refactored the `CopyLinkButton` component into a more generic `CopyButton`, allowing it to be used for copying any text (not just links). Updated all usages and related tests to use the new component and props.

These changes collectively improve the resilience, usability, and maintainability of the workshop survey dashboard.



<img width="1647" height="1110" alt="Screenshot 2025-09-04 at 9 35 13 AM" src="https://github.com/user-attachments/assets/6230b4b4-3a7f-424f-aff5-4306a1b87ab9" />
## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3519

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
