### PR TITLE
Evaluate Student Learning: only levelbuilders can see skill editing UI

### DIFF
--- a/apps/src/levelbuilder/skills/SkillsByConcept.tsx
+++ b/apps/src/levelbuilder/skills/SkillsByConcept.tsx
@@ -8,9 +8,13 @@ import {SkillsByConcept} from './types';
 
 interface SkillsByConceptTableProps {
   skills: SkillsByConcept;
+  canEditSkills: boolean;
 }
 
-const SkillsByConcept: React.FC<SkillsByConceptTableProps> = ({skills}) => {
+const SkillsByConcept: React.FC<SkillsByConceptTableProps> = ({
+  skills,
+  canEditSkills,
+}) => {
   const [selectedConcept, setSelectedConcept] = useState('');
   const concepts = Object.keys(skills)
     .sort((a, b) => a.localeCompare(b))
@@ -40,7 +44,7 @@ const SkillsByConcept: React.FC<SkillsByConceptTableProps> = ({skills}) => {
       {skillsToShow.length === 0 && (
         <h3>There are no skills for the selected concept.</h3>
       )}
-      <SkillsTable skills={skillsToShow} canModifySkill />
+      <SkillsTable skills={skillsToShow} canModifySkill={canEditSkills} />
     </div>
   );
 };

--- a/apps/src/levelbuilder/skills/SkillsContainer.tsx
+++ b/apps/src/levelbuilder/skills/SkillsContainer.tsx
@@ -24,7 +24,7 @@ const SkillsContainer: React.FC<SkillsContainerProps> = ({
         <h3>You need levelbuilder permissions to edit Skills.</h3>
       )}
       {canEditSkills && <SkillsCreator skills={skills} />}
-      <SkillsByConceptTable skills={skills} />
+      <SkillsByConceptTable skills={skills} canEditSkills={canEditSkills} />
       {canEditSkills && <LevelsSkillsCreator />}
       <LevelsSkillsTable levels={levels} />
     </div>

--- a/dashboard/app/views/skills/index.html.haml
+++ b/dashboard/app/views/skills/index.html.haml
@@ -1,6 +1,6 @@
 :ruby
     skills_data = {}
-    skills_data[:canEditSkills] = current_user.levelbuilder?
+    skills_data[:canEditSkills] = current_user.levelbuilder? && !Rails.env.production?
     skills_data[:skills] = @skills_by_concept
     skills_data[:levels] = @levels_skills
 


### PR DESCRIPTION
Small quality of life improvement for editing & deleting skills. Only those with levelbuilder permissions can edit or delete skills. Previously, anyone, regardless of permissions, could still see the edit and delete columns on the skills table. You would get a 403 forbidden error if you didn't have levelbuilder permissions, but it's a better experience to just hide that UI if you don't have permission to use it. 

BEFORE (without levelbuilder permissions)
<img width="1506" height="775" alt="Screenshot 2025-09-04 at 11 47 41 AM" src="https://github.com/user-attachments/assets/fff73d3e-d0c5-41b6-a3e0-994792bc2208" />

AFTER (without levelbuilder permissions)
<img width="1350" height="757" alt="Screenshot 2025-09-04 at 11 43 02 AM" src="https://github.com/user-attachments/assets/f2356d74-40e0-44eb-82c5-380fc1d38572" />

NO CHANGE (with levelbuilder permissions)
<img width="1311" height="915" alt="Screenshot 2025-09-04 at 11 52 00 AM" src="https://github.com/user-attachments/assets/490a73b4-efec-44a6-84bb-a212374b6a45" />
