### PR TITLE
Fixes resetting of experiments when using legacy WebLab.

### DIFF
--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -1,3 +1,5 @@
+import {tryGetLocalStorage, trySetLocalStorage} from '../utils';
+
 import CdoBramble, {BRAMBLE_CONTAINER} from './CdoBramble';
 import {FILE_SYSTEM_ERROR, BRAMBLE_READY_STATE} from './constants';
 
@@ -19,6 +21,8 @@ if (parent.getWebLab) {
 }
 
 function load(Bramble) {
+  // Remember experiments since Bramble will clear localStorage
+  const experiments = tryGetLocalStorage('experimentsList', '[]');
   const api = webLab_.brambleApi();
   const cdoBramble = new CdoBramble(
     Bramble,
@@ -30,7 +34,12 @@ function load(Bramble) {
   );
   cdoBramble
     .on('mountable', () => api.onBrambleMountable(cdoBramble.getInterface()))
-    .on('ready', api.onBrambleReady)
+    .on('ready', () => {
+      // Reset the experiments list after Bramble loads which should restore
+      // the experiment list that existed when the level page loaded.
+      trySetLocalStorage('experimentsList', experiments);
+      api.onBrambleReady();
+    })
     .on('projectChange', api.onProjectChanged)
     .init();
 }


### PR DESCRIPTION
Bramble, a third-party library we use to embed an HTML editor for legecy WebLab, seems to clear localStorage as part of its initialization. That means that experiments suddenly get voided out when somebody goes through a legacy weblab page. This maintains that list during the weblab initialization.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
