### PR TITLE
feat(workshops): ensure workshop_organizers without an associated regional partner gets all rps

### DIFF
--- a/dashboard/app/controllers/api/v1/regional_partners_controller.rb
+++ b/dashboard/app/controllers/api/v1/regional_partners_controller.rb
@@ -8,7 +8,11 @@ class Api::V1::RegionalPartnersController < ApplicationController
 
   # GET /api/v1/regional_partners
   def index
-    regional_partners = current_user.workshop_admin? ? RegionalPartner.all : current_user.regional_partners
+    regional_partners = if current_user.workshop_admin?
+                          RegionalPartner.all
+                        else
+                          current_user.workshop_organizer? && current_user.regional_partners.empty? ? RegionalPartner.all : current_user.regional_partners
+                        end
 
     render json: regional_partners.order(:name).map {|partner| {id: partner.id, name: partner.name}}
   end

--- a/dashboard/test/controllers/api/v1/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/regional_partners_controller_test.rb
@@ -71,6 +71,32 @@ class Api::V1::RegionalPartnersControllerTest < ActionController::TestCase
     assert_includes(response, {'id' => regional_partner.id, 'name' => regional_partner.name})
   end
 
+  test 'index gets all regional partners for workshop organizers not associated with a regional partner' do
+    regional_partner_1 = create(:regional_partner, name: 'First regional partner')
+    regional_partner_2 = create(:regional_partner, name: 'Second regional partner')
+    sign_in(create(:workshop_organizer))
+
+    get :index
+    response = JSON.parse(@response.body)
+    assert_equal RegionalPartner.count, response.length
+    assert_includes(response, {'id' => regional_partner_1.id, 'name' => regional_partner_1.name})
+    assert_includes(response, {'id' => regional_partner_2.id, 'name' => regional_partner_2.name})
+  end
+
+  test 'index gets only associated regional partners for workshop organizers that are associated with a regional partner' do
+    regional_partner_1 = create(:regional_partner, name: 'First regional partner')
+    regional_partner_2 = create(:regional_partner, name: 'Second regional partner')
+    organizer = create(:workshop_organizer)
+    organizer.regional_partners << regional_partner_1
+    sign_in(organizer)
+
+    get :index
+    response = JSON.parse(@response.body)
+    assert_equal 1, response.length
+    assert_includes(response, {'id' => regional_partner_1.id, 'name' => regional_partner_1.name})
+    refute_includes(response, {'id' => regional_partner_2.id, 'name' => regional_partner_2.name})
+  end
+
   test 'capacity as a workshop organizer returns regional partner cohort capacity for teacher applications' do
     time = Date.new(2017, 3, 15)
 


### PR DESCRIPTION
This pull request updates the logic for fetching regional partners in the `RegionalPartnersController#index` action to better handle workshop organizers, and adds corresponding tests to ensure correct behavior. Now, workshop organizers who are not associated with any regional partners will see all regional partners, while those with associations will only see their assigned partners.

**Controller logic improvements:**

* Updated `index` action in `RegionalPartnersController` to return all regional partners for workshop organizers not associated with any, and only the associated partners otherwise.

**Test coverage enhancements:**

* Added tests to verify that workshop organizers with no associated regional partners receive all partners, and those with associations receive only their assigned partners.…er can access all regional_partners

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/ACQ-3520

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
