### PR TITLE
Use color prop for segmented buttons in Web Lab 2 desktop/mobile toggle

### DIFF
--- a/apps/src/codebridge/FilePreview/HTMLPreviewHeader.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreviewHeader.tsx
@@ -43,6 +43,7 @@ export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({
     }
   };
   const previewViewModeButtonsProps: SegmentedButtonsProps = {
+    color: 'strong',
     buttons: [
       {
         label: weblab2I18n.desktop(),

--- a/apps/src/codebridge/FilePreview/styles/html-preview-header.module.scss
+++ b/apps/src/codebridge/FilePreview/styles/html-preview-header.module.scss
@@ -100,22 +100,7 @@ $url-bar-content-height: calc($url-bar-height - $vertical-padding-offset);
   
   // Target all buttons within segmented buttons container
   :global(button) {
-    border: 1px solid var(--borders-neutral-strong) !important;
     height: $url-bar-height; // Match the input bar height including borders
     box-sizing: border-box;
-    
-    &:hover {
-      // Using secondary instead of tertiary because the preview header already uses background-neutral-tertiary color.
-      background-color: var(--background-neutral-secondary) !important;
-    }
-  }
-  
-  // Override for selected buttons to keep their original styling
-  :global(button[class*="selectedSegmentedButton"]) {
-    border: 1px solid transparent !important;
-    
-    &:hover {
-      background-color: var(--background-brand-teal-primary) !important;
-    }
   }
 }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/68095 - replaces custom styling of  `SegmentedButtons` with assigning `color` prop.

There is no visual change from this PR.

 
<img width="633" height="103" alt="Screenshot 2025-09-04 at 2 03 30 PM" src="https://github.com/user-attachments/assets/50e8ea27-d4d4-4ab6-94cc-3f748d22c405" />



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira:  https://codedotorg.atlassian.net/browse/AFL-95

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally in `weblab2` levels.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
