### PR TITLE
Shorten session to 24 hours for restricted users

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -436,7 +436,7 @@ class User < ApplicationRecord
   # Include default Devise modules. Others available are:
   # :token_authenticatable, :confirmable
   devise :invitable, :database_authenticatable, :registerable, :omniauthable,
-    :recoverable, :rememberable, :trackable, :lockable
+    :recoverable, :rememberable, :trackable, :lockable, :timeoutable
 
   # Make sure to include these Concerns after we include the default Devise
   # modules, since it's trying to extend some methods added by those modules

--- a/dashboard/lib/devise/models/custom_timeoutable.rb
+++ b/dashboard/lib/devise/models/custom_timeoutable.rb
@@ -12,11 +12,7 @@ module Devise
       # Devise provides the timeout_in method. Override this functionality here
       # to set custom session timeout values for different users.
       def timeout_in
-        if Policies::Lti.restricted_user?(self)
-          return RESTRICTED_USER_TIMEOUT
-        end
-
-        self.class.timeout_in
+        Policies::Lti.restricted_user?(self) ? RESTRICTED_USER_TIMEOUT : super
       end
     end
   end

--- a/dashboard/lib/devise/models/custom_timeoutable.rb
+++ b/dashboard/lib/devise/models/custom_timeoutable.rb
@@ -7,11 +7,13 @@ module Devise
     module CustomTimeoutable
       extend ActiveSupport::Concern
 
+      RESTRICTED_USER_TIMEOUT = 24.hours
+
       # Devise provides the timeout_in method. Override this functionality here
       # to set custom session timeout values for different users.
       def timeout_in
         if Policies::Lti.restricted_user?(self)
-          return 24.hours
+          return RESTRICTED_USER_TIMEOUT
         end
 
         self.class.timeout_in

--- a/dashboard/lib/devise/models/custom_timeoutable.rb
+++ b/dashboard/lib/devise/models/custom_timeoutable.rb
@@ -7,13 +7,13 @@ module Devise
     module CustomTimeoutable
       extend ActiveSupport::Concern
 
-      included do
-        devise :timeoutable
-      end
-
       # Devise provides the timeout_in method. Override this functionality here
       # to set custom session timeout values for different users.
       def timeout_in
+        if Policies::Lti.restricted_user?(self)
+          return 24.hours
+        end
+
         self.class.timeout_in
       end
     end

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -856,7 +856,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
       create(:teacher_feedback, script: script, level: weblab_level, student: student, teacher: @teacher)
     end
 
-    assert_queries 13 do
+    assert_queries 14 do
       get :section_feedback, params: {section_id: @section.id, script_id: script.id}
     end
 

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -147,7 +147,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: score}]}
 
-    assert_queries 6 do
+    assert_queries 7 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
 
@@ -159,7 +159,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal section.students.count, 11
 
-    assert_queries 6 do
+    assert_queries 7 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1143,7 +1143,7 @@ class ApiControllerTest < ActionController::TestCase
   test "should get progress for section with section script" do
     Unit.stubs(:should_cache?).returns true
 
-    assert_queries 7 do
+    assert_queries 8 do
       get :section_progress, params: {section_id: @flappy_section.id}
     end
     assert_response :success

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -53,9 +53,9 @@ class CoursesControllerTest < ActionController::TestCase
       @unit_group_regular = create(:unit_group, name: 'non-plc-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
     end
 
-    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 10
+    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 11
 
-    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 2
+    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 3
   end
 
   class CachedQueryCounts < ActionController::TestCase

--- a/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
@@ -45,7 +45,7 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
 
     assert_equal TeacherFeedback.all.count, 4
     sign_in student
-    assert_queries 24 do
+    assert_queries 25 do
       get :index
       assert_response :success
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -23,7 +23,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level_source: create(:level_source, level: level)
 )
 
-    assert_cached_queries(17) do
+    assert_cached_queries(18) do
       get course_unit_lesson_script_level_path(
         course_course_name: script.original_unit_group.name,
         unit_position: 1,
@@ -56,7 +56,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level.id
     )
 
-    assert_cached_queries(4) do
+    assert_cached_queries(5) do
       get user_app_options_path,
         headers: {HTTP_USER_AGENT: 'test'}
       assert_response :success
@@ -73,7 +73,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(9) do
+    assert_cached_queries(10) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id,
@@ -93,7 +93,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(7) do
+    assert_cached_queries(8) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id,
@@ -112,7 +112,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sl = script.script_levels[2]
     params = {program: 'fake program', testResult: 0, result: 'false'}
 
-    assert_cached_queries(7) do
+    assert_cached_queries(8) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id,
@@ -138,7 +138,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(script)
     sign_in student
 
-    assert_cached_queries(9) do
+    assert_cached_queries(10) do
       get "/courses/#{course.name}/units/1/"
       assert_response :success
     end
@@ -146,12 +146,12 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     # Simulate all the ajax requests which the unit overview page sends to the
     # server on page load.
 
-    assert_cached_queries(6) do
+    assert_cached_queries(7) do
       get "/api/user_progress/#{script.name}"
       assert_response :success
     end
 
-    assert_cached_queries(2) do
+    assert_cached_queries(3) do
       get "/api/v1/teacher_feedbacks/count?student_id=#{student.id}"
       assert_response :success
     end
@@ -178,7 +178,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(unit)
     sign_in student
 
-    assert_cached_queries(19) do
+    assert_cached_queries(20) do
       get "/courses/#{course.name}/units/1/lessons/1/levels/1"
       assert_response :success
     end
@@ -186,12 +186,12 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     # Simulate all the ajax requests which the level page sends to the
     # server on page load.
 
-    assert_cached_queries(2) do
+    assert_cached_queries(3) do
       get "/api/user_app_options/#{unit.name}/1/1/#{level.id}"
       assert_response :success
     end
 
-    assert_cached_queries(2) do
+    assert_cached_queries(3) do
       get "/levels/#{level.id}/get_rubric"
       assert_response :success
     end

--- a/dashboard/test/lib/devise/custom_timeoutable_test.rb
+++ b/dashboard/test/lib/devise/custom_timeoutable_test.rb
@@ -25,7 +25,7 @@ class Devise::Models::CustomTimeoutableTest < ActiveSupport::TestCase
       end
 
       it 'returns 24 hours' do
-        _(timeout_in).must_equal 24.hours
+        _(timeout_in).must_equal Devise::Models::CustomTimeoutable::RESTRICTED_USER_TIMEOUT
       end
     end
   end

--- a/dashboard/test/lib/devise/custom_timeoutable_test.rb
+++ b/dashboard/test/lib/devise/custom_timeoutable_test.rb
@@ -2,14 +2,31 @@ require 'test_helper'
 
 class Devise::Models::CustomTimeoutableTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::TimeHelpers
+  include Minitest::RSpecMocks
 
   subject(:user) {build_stubbed(:user)}
   let(:timeout) {Devise.timeout_in}
   let(:last_activity_at) {Time.current}
 
   describe '#timeout_in' do
+    subject(:timeout_in) {user.timeout_in}
+
+    it 'sets the value based on CDO config' do
+      _(timeout).must_equal CDO.dashboard_session_ttl_days.days
+    end
+
     it 'returns the correct default value' do
-      _(user.timeout_in).must_equal timeout
+      _(timeout_in).must_equal timeout
+    end
+
+    context 'when restricted user' do
+      before do
+        expect(Policies::Lti).to receive(:restricted_user?).with(user).and_return(true)
+      end
+
+      it 'returns 24 hours' do
+        _(timeout_in).must_equal 24.hours
+      end
     end
   end
 
@@ -19,6 +36,7 @@ class Devise::Models::CustomTimeoutableTest < ActiveSupport::TestCase
     it 'returns false' do
       _(timedout?).must_equal false
     end
+
     context 'when timed out' do
       around do |test|
         travel_to(last_activity_at + timeout + 1.minute) {test.call}


### PR DESCRIPTION
Overrides the Devise `timeout_in` method to return 24 hours for LAUSD.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1584)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
