### PR TITLE
Lab 2: new panel header font and size

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -10,7 +10,7 @@
   justify-content: space-between;
 
   .tabs {
-    margin-top: 2rem;
+    margin-top: calc(2.5rem - 1px);
     display: flex;
     flex-direction: column;
   }

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -1,6 +1,6 @@
 .resourcePanel {
   display: flex;
-  background-color: var(--background-neutral-secondary);
+  background-color: var(--background-neutral-primary);
   height: 100%;
 }
 
@@ -13,6 +13,7 @@
     margin-top: calc(2.5rem - 1px);
     display: flex;
     flex-direction: column;
+    background-color: var(--background-neutral-secondary);
   }
 
   // Doubling class name to increase specificity and override default button styles.

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -1,6 +1,6 @@
 .resourcePanel {
   display: flex;
-  background-color: var(--background-neutral-primary);
+  background-color: var(--background-neutral-secondary);
   height: 100%;
 }
 
@@ -13,7 +13,6 @@
     margin-top: calc(2.5rem - 1px);
     display: flex;
     flex-direction: column;
-    background-color: var(--background-neutral-secondary);
   }
 
   // Doubling class name to increase specificity and override default button styles.

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -22,6 +22,7 @@
   line-height: 1.5;
   display: flex;
   overflow: hidden;
+  border: 1px solid var(--borders-neutral-primary);
 
   &.vertical {
     flex-direction: column;
@@ -29,7 +30,7 @@
 }
 
 .fixedDarkBackground {
-  background-color: var( --background-neutral-black-fixed);
+  background-color: var(--background-neutral-black-fixed);
 }
 
 .standardBackground {

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -22,7 +22,6 @@
   line-height: 1.5;
   display: flex;
   overflow: hidden;
-  border: 1px solid var(--borders-neutral-primary);
 
   &.vertical {
     flex-direction: column;
@@ -30,7 +29,7 @@
 }
 
 .fixedDarkBackground {
-  background-color: var(--background-neutral-black-fixed);
+  background-color: var( --background-neutral-black-fixed);
 }
 
 .standardBackground {

--- a/apps/src/lab2/views/components/PanelContainer.tsx
+++ b/apps/src/lab2/views/components/PanelContainer.tsx
@@ -1,4 +1,4 @@
-import {Heading2} from '@code-dot-org/component-library/typography';
+import {OverlineTwoText} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -59,20 +59,19 @@ const PanelContainer: React.FunctionComponent<PanelContainerProps> = ({
             {leftHeaderContent}
           </div>
 
-          <Heading2
+          <OverlineTwoText
             className={classNames(
               'panelContainerHeaderItemText',
               moduleStyles.panelContainerHeaderItem,
               moduleStyles.panelContainerHeaderItemCenter
             )}
-            visualAppearance={'body-three'}
           >
             <span
               className={classNames(moduleStyles.panelContainerHeaderItemText)}
             >
               {headerContent}
             </span>
-          </Heading2>
+          </OverlineTwoText>
           <div
             className={classNames(
               'panelContainerHeaderItemRight',

--- a/apps/src/lab2/views/components/layout/layout.module.scss
+++ b/apps/src/lab2/views/components/layout/layout.module.scss
@@ -63,7 +63,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 40px;
+  height: 2.5rem;
   padding: 4px 8px;
   box-sizing: border-box;
   border-bottom: 1px solid var(--borders-neutral-primary);

--- a/apps/src/lab2/views/components/layout/layout.module.scss
+++ b/apps/src/lab2/views/components/layout/layout.module.scss
@@ -70,10 +70,6 @@
   background-color: var(--background-neutral-secondary);
 }
 
-.headerText {
-  color: var(--text-neutral-quaternary);
-}
-
 .editorAndPreviewContainer {
   display: flex;
   flex-grow: 1;

--- a/apps/src/lab2/views/components/layout/layout.module.scss
+++ b/apps/src/lab2/views/components/layout/layout.module.scss
@@ -67,7 +67,7 @@
   padding: 4px 8px;
   box-sizing: border-box;
   border-bottom: 1px solid var(--borders-neutral-primary);
-  background-color: var(--background-neutral-primary);
+  background-color: var(--background-neutral-secondary);
 }
 
 .headerText {

--- a/apps/src/lab2/views/components/layout/layout.module.scss
+++ b/apps/src/lab2/views/components/layout/layout.module.scss
@@ -67,7 +67,7 @@
   padding: 4px 8px;
   box-sizing: border-box;
   border-bottom: 1px solid var(--borders-neutral-primary);
-  background-color: var(--background-neutral-secondary);
+  background-color: var(--background-neutral-primary);
 }
 
 .headerText {

--- a/apps/src/lab2/views/components/layout/layout.module.scss
+++ b/apps/src/lab2/views/components/layout/layout.module.scss
@@ -70,6 +70,10 @@
   background-color: var(--background-neutral-secondary);
 }
 
+.headerText {
+  color: var(--text-neutral-quaternary);
+}
+
 .editorAndPreviewContainer {
   display: flex;
   flex-grow: 1;

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -17,7 +17,7 @@
     padding-left: 4px;
     padding-right: 4px;
     flex-shrink: 0;
-    background-color: var(--background-neutral-primary);
+    background-color: var(--background-neutral-secondary);
     color: var(--text-neutral-primary);
 
     &Item {

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -8,7 +8,7 @@
   position: relative;
 
   .panelContainerHeader {
-    height: 40px;
+    height: 2.5rem;
     box-sizing: border-box;
     display: grid;
     grid-template-columns: 1fr auto 1fr;

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -17,7 +17,7 @@
     padding-left: 4px;
     padding-right: 4px;
     flex-shrink: 0;
-    background-color: var(--background-neutral-secondary);
+    background-color: var(--background-neutral-primary);
     color: var(--text-neutral-primary);
 
     &Item {

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -31,6 +31,7 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        color: var(--text-neutral-quaternary);
       }
 
       &Center {

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -8,7 +8,8 @@
   position: relative;
 
   .panelContainerHeader {
-    height: 2rem;
+    height: 40px;
+    box-sizing: border-box;
     display: grid;
     grid-template-columns: 1fr auto 1fr;
     position: relative;

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -31,7 +31,6 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        color: var(--text-neutral-quaternary);
       }
 
       &Center {

--- a/apps/src/templates/ProjectTemplateWorkspaceIconV2.tsx
+++ b/apps/src/templates/ProjectTemplateWorkspaceIconV2.tsx
@@ -10,7 +10,6 @@ import styles from './project-template-workspace-icon-v2.module.scss';
 interface ProjectTemplateWorkspaceIconV2Props {
   tooltipPlace?: ComponentPlacementDirection;
   darkMode?: boolean;
-  className?: string;
 }
 
 /**
@@ -22,12 +21,11 @@ interface ProjectTemplateWorkspaceIconV2Props {
  * the DSCO ComponentPlacementDirection enum.
  * @param darkMode - boolean to indicate if the workspace is in dark mode. This is only
  * used to style the tooltip. The icon will inherit its color from the parent component.
- * @param className - Additional class name to apply to the icon container.
  * @returns
  */
 const ProjectTemplateWorkspaceIconV2: React.FunctionComponent<
   ProjectTemplateWorkspaceIconV2Props
-> = ({tooltipPlace, darkMode, className}) => {
+> = ({tooltipPlace, darkMode}) => {
   return (
     <WithTooltip
       tooltipProps={{
@@ -36,7 +34,7 @@ const ProjectTemplateWorkspaceIconV2: React.FunctionComponent<
         tooltipId: 'project-template-workspace-icon-tooltip',
         size: 'xs',
       }}
-      tooltipOverlayClassName={className}
+      tooltipOverlayClassName={styles.flexContainer}
     >
       {/* Wrap the icon in a button so that the tooltip is tabbable. */}
       <button type="button" className={styles.iconButton}>

--- a/apps/src/templates/project-template-workspace-icon-v2.module.scss
+++ b/apps/src/templates/project-template-workspace-icon-v2.module.scss
@@ -4,9 +4,12 @@
 .iconButton {
   @include remove-button-styles;
   font-size: 13px;
-  margin-bottom: 1px;
 }
 
 .icon {
   color: $light_gray_500;
+}
+
+.flexContainer {
+  display: flex;
 }

--- a/apps/src/templates/project-template-workspace-icon-v2.module.scss
+++ b/apps/src/templates/project-template-workspace-icon-v2.module.scss
@@ -4,6 +4,7 @@
 .iconButton {
   @include remove-button-styles;
   font-size: 13px;
+  margin-bottom: 2px;
 }
 
 .icon {

--- a/apps/src/templates/project-template-workspace-icon-v2.module.scss
+++ b/apps/src/templates/project-template-workspace-icon-v2.module.scss
@@ -4,7 +4,7 @@
 .iconButton {
   @include remove-button-styles;
   font-size: 13px;
-  margin-bottom: 2px;
+  margin-bottom: 1px;
 }
 
 .icon {

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -160,7 +160,7 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
             ) : (
               <SegmentedButtons {...viewModeButtonsProps} />
             )}
-            <OverlineTwoText noMargin>
+            <OverlineTwoText noMargin className={moduleStyles.headerText}>
               {weblab2I18n.workspace()}
             </OverlineTwoText>
             <HeaderButtons />

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -160,7 +160,7 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
             ) : (
               <SegmentedButtons {...viewModeButtonsProps} />
             )}
-            <OverlineTwoText noMargin className={moduleStyles.headerText}>
+            <OverlineTwoText noMargin>
               {weblab2I18n.workspace()}
             </OverlineTwoText>
             <HeaderButtons />


### PR DESCRIPTION
In order to standardize the headers of the panels in Web Lab 2, this PR introduces a change to the headers in all panel containers in Lab 2 labs to use new designs from our design team.

The headers as implemented in this PR feel a bit LOUD, so the plan is to use a less bright color for the header text color. To use a lighter text color, we need to lighten the background of the headers as well as make some changes to borders, etc. in several components, so I think we should do that separately.

## Links

- [Figma](https://www.figma.com/design/tDzVjyvhfkF8lyGROENOAD/Web-Lab-2?node-id=3772-11298&t=FKUKxaLpsn3NVxm7-0)
- [Slack discussion](https://codedotorg.slack.com/archives/C06JELCAPT9/p1756918023797789?thread_ts=1755894346.111439&cid=C06JELCAPT9)
- [Jira](https://codedotorg.atlassian.net/browse/AFL-128)

**Web Lab 2**

| Dark | Light |
| - | - |
| <img width="1680" height="891" alt="image" src="https://github.com/user-attachments/assets/42f0fd1f-29b1-47f1-a77d-723630ecd11b" /> | <img width="1680" height="890" alt="image" src="https://github.com/user-attachments/assets/dd3f8a7f-35c4-43db-9814-36587195ddbd" /> |

**Music Lab**

<img width="1680" height="889" alt="image" src="https://github.com/user-attachments/assets/58ccb741-0d52-4064-b0a5-e1799c027ad9" />

**AI Chat Lab**

<img width="1680" height="889" alt="image" src="https://github.com/user-attachments/assets/6b216a84-63a7-4fd1-8348-379591db3cfa" />

**Python Lab**

| Dark | Light |
| - | - |
| <img width="1680" height="889" alt="image" src="https://github.com/user-attachments/assets/ffda68f7-6a5e-4db6-9ed1-ba608c03173b" /> | <img width="1680" height="889" alt="image" src="https://github.com/user-attachments/assets/2abcf6e6-5d1d-4a0a-997e-0e77c4fdc8de" /> |

| Dark Vertical |
| - |
| <img width="1680" height="889" alt="image" src="https://github.com/user-attachments/assets/86094f6e-0c38-4ab7-ac25-8097b84b432f" /> | |