### PR TITLE
Add Statsig event when a user hits the deprecated curriculum page

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -589,6 +589,9 @@ const EVENTS = {
   TEACHER_NAV_COURSE_OVERVIEW_FAILED:
     'Teacher Nav Course Overview Load Failure',
 
+  DEPRECATED_CURRICULUM_ERROR_PAGE_VISITED:
+    'Deprecated Curriculum Error Page Visited',
+
   // Lab2
   SKIP_TO_PROJECT: 'User Skipped To Project From Tutorial Level',
 

--- a/apps/src/sites/studio/pages/errors/deprecated_course.js
+++ b/apps/src/sites/studio/pages/errors/deprecated_course.js
@@ -1,0 +1,10 @@
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import getScriptData from '@cdo/apps/util/getScriptData';
+
+$(() => {
+  const deprecatedCurriculumName = getScriptData('deprecatedCurriculumName');
+  analyticsReporter.sendEvent(EVENTS.DEPRECATED_CURRICULUM_ERROR_PAGE_VISITED, {
+    deprecatedCurriculumName,
+  });
+});

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -65,6 +65,7 @@ const CODE_STUDIO_ENTRIES = {
   'gates/logged_out': './src/sites/studio/pages/gates/logged_out.js',
   'gates/teacher_account_required': './src/sites/studio/pages/gates/teacher_account_required.js',
   'essential': './src/sites/studio/pages/essential.js',
+  'errors/deprecated_course': './src/sites/studio/pages/errors/deprecated_course.js',
   'home/_homepage': './src/sites/studio/pages/home/_homepage.js',
   'layouts/_parent_email_banner': './src/sites/studio/pages/layouts/_parent_email_banner.js',
   'layouts/_race_interstitial': './src/sites/studio/pages/layouts/_race_interstitial.js',

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -29,7 +29,7 @@ class LessonsController < ApplicationController
     return render :forbidden unless script.is_migrated
 
     if script.is_deprecated
-      @deprecated_course_name = script.name
+      @deprecated_curriculum_name = script.name
       return render 'errors/deprecated_course'
     end
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -79,7 +79,7 @@ class ScriptLevelsController < ApplicationController
     # Check if the script or current level is deprecated
     level_is_deprecated = @script_level&.level_deprecated?
     if @script.is_deprecated || level_is_deprecated
-      @deprecated_course_name = @script.name
+      @deprecated_curriculum_name = @script.name
       return render 'errors/deprecated_course'
     end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -19,7 +19,7 @@ class ScriptsController < ApplicationController
 
   def show
     if @script.is_deprecated
-      @deprecated_course_name = @script.name
+      @deprecated_curriculum_name = @script.name
       return render 'errors/deprecated_course'
     end
     #TODO: TEACH-2050 Modularity support redirect to property. Currently this redirects to the script path, which
@@ -215,7 +215,7 @@ class ScriptsController < ApplicationController
   def edit
     # Deprecated scripts should not be edited.
     if @script.is_deprecated
-      @deprecated_course_name = @script.name
+      @deprecated_curriculum_name = @script.name
       return render 'errors/deprecated_course'
     end
     raise "The new unit editor does not support level variants with experiments" if @script.is_migrated && @script.script_levels.any?(&:has_experiment?)

--- a/dashboard/app/views/errors/deprecated_course.html.haml
+++ b/dashboard/app/views/errors/deprecated_course.html.haml
@@ -1,17 +1,19 @@
 :ruby
-  if @deprecated_course_name == Unit::COURSE1_NAME
+  if @deprecated_curriculum_name == Unit::COURSE1_NAME
     description = I18n.t('course_deprecated.course1_retired', coursea_url: course_path('coursea', viewAs: 'Instructor'), pre_reader_express_url: course_path('pre-express', viewAs: 'Instructor'), markdown: :inline)
-    elsif @deprecated_course_name == Unit::COURSE2_NAME
+    elsif @deprecated_curriculum_name == Unit::COURSE2_NAME
       description = I18n.t('course_deprecated.course2_retired', coursec_url: course_path('coursec', viewAs: 'Instructor'), course_d_url: course_path('coursed', viewAs: 'Instructor'), markdown: :inline)
-    elsif @deprecated_course_name == Unit::COURSE3_NAME
+    elsif @deprecated_curriculum_name == Unit::COURSE3_NAME
       description = I18n.t('course_deprecated.course3_retired', course_e_url: course_path('coursee', viewAs: 'Instructor'), course_f_url: course_path('coursef', viewAs: 'Instructor'), markdown: :inline)
-    elsif @deprecated_course_name == Unit::COURSE4_NAME
+    elsif @deprecated_curriculum_name == Unit::COURSE4_NAME
       description = I18n.t('course_deprecated.course4_retired', course_f_url: course_path('coursef', viewAs: 'Instructor'), markdown: :inline)
-    elsif @deprecated_course_name == Unit::TWENTY_HOUR_NAME
+    elsif @deprecated_curriculum_name == Unit::TWENTY_HOUR_NAME
       description = I18n.t('course_deprecated.accelerated_course_retired', express_course_url: course_path('express', viewAs: 'Instructor'), markdown: :inline)
   else
     description = I18n.t('course_deprecated.title', path_type: I18n.t('course_deprecated.curriculum'))
   end
+
+%script{src: webpack_asset_path('js/errors/deprecated_course.js'), data: {deprecatedCurriculumName: @deprecated_curriculum_name.to_json}}
 
 .not-found-page.deprecated-course-page
   .error-parent


### PR DESCRIPTION
Adds an event for when a user visits the deprecated curriculum page so we can track what they do afterwards (eg move to a different course, stop using our platform, etc).

Example event:
```
[STATSIG ANALYTICS EVENT]: Deprecated Curriculum Error Page Visited. Payload: {"payload":{"deprecatedCurriculumName":"course1"}}
```



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
