### PR TITLE
DOTD: specify url for updating github access tokens in dotd script

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -52,7 +52,7 @@ rescue Octokit::Unauthorized
   puts <<~EOS
 
     Your CDO.github_access_token is out of date. Please update your
-    personal access token at github.com, put the new value in locals.yml,
+    personal access token at https://github.com/settings/tokens, put the new value in locals.yml,
     and rerun this script.
 
   EOS


### PR DESCRIPTION
I'm DOTD today and my github access token expired. This is an easy thing to fix, but fails in the category of "things I don't have do often enough to remember exactly how to do them". Leaving a breadcrumb for future DOTDs in a similar situation to making getting a new access token slightly easier by adding the direct link to that page in the message. 

 