### PR TITLE
Notifications unread badge

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -3225,6 +3225,7 @@
   "unitVocabulary": "Unit Vocabulary",
   "unitedStates": "United States",
   "unread": "Unread",
+  "unreadNotificationsCount": "{unreadCount} unread notifications",
   "unsubmit": "Unsubmit",
   "unsubmitAssessment": "Unsubmit your assessment",
   "unsubmitYourProject": "Unsubmit your project",

--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -284,6 +284,13 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
 
   React.useEffect(() => {
     if (initialThreadPrompt && threadMessages.length === 0 && threadId === 0) {
+      const newUserMessage = {
+        role: Role.USER,
+        chatMessageText: initialThreadPrompt.prompt,
+        status: Status.OK,
+      };
+
+      setMessageHistory(prevMessages => [...prevMessages, newUserMessage]);
       onPromptSelect(initialThreadPrompt);
       setInitialThreadPrompt(null);
     }

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -92,7 +92,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
   }, [canStartOpen, hasOpened, hasClosed, canDefaultOpen]);
 
   const updateUnreadNotificationCount = React.useCallback(() => {
-    HttpClient.fetchJson<AiDiffNotification[]>('/notifications', {}, undefined)
+    HttpClient.fetchJson<AiDiffNotification[]>('/notifications')
       .then(response => {
         const unreadNotificationCount =
           response?.value?.filter(n => n.readAt === null).length || 0;

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -184,7 +184,16 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
                 unreadCount: unreadNotificationCount,
               })
             }
-            sx={{height: '48px', width: '48px'}}
+            sx={{
+              height: '48px',
+              width: '48px',
+              '& .MuiBadge-badge': {
+                backgroundColor: 'var(--background-error-primary)',
+                top: '8%',
+                right: '8%',
+              },
+            }}
+            className={style.badge}
           >
             <img
               alt="AI bot - unread notifications"
@@ -193,6 +202,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
                 !isFabWithoutTextImageLoaded &&
                 setIsFabWithoutTextImageLoaded(true)
               }
+              className={style.fabImageWithBadge}
             />
           </Badge>
         ) : (

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -1,3 +1,4 @@
+import {Badge} from '@mui/material';
 import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 
@@ -8,6 +9,7 @@ import {
   trySetLocalStorage,
 } from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
+import aiFabWithoutText from '@cdo/static/ai-bot-ta-no-text.png';
 import aiFabWithIcon from '@cdo/static/ai-bot-ta.png';
 
 import {EVENTS, PLATFORMS} from '../metrics/AnalyticsConstants';
@@ -15,6 +17,7 @@ import analyticsReporter from '../metrics/AnalyticsReporter';
 import HttpClient from '../util/HttpClient';
 
 import AiDiffContainer from './AiDiffContainer';
+import {AiDiffNotification} from './notifications/types';
 import {Context} from './types';
 
 import style from './ai-differentiation.module.scss';
@@ -61,6 +64,10 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
       tryGetLocalStorage(LOCAL_STORAGE_CLOSED_KEY, false.toString())
     ) || false;
 
+  const [unreadNotificationCount, setUnreadNotificationCount] = useState<
+    number | 'loading'
+  >('loading');
+
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   React.useEffect(() => {
@@ -83,6 +90,19 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
     }
   }, [canStartOpen, hasOpened, hasClosed, canDefaultOpen]);
 
+  React.useEffect(() => {
+    HttpClient.fetchJson<AiDiffNotification[]>('/notifications', {}, undefined)
+      .then(response => {
+        const unreadNotificationCount =
+          response?.value?.filter(n => n.readAt === null).length || 0;
+        setUnreadNotificationCount(unreadNotificationCount);
+        console.log('lfm', unreadNotificationCount);
+      })
+      .catch(error => {
+        console.error('Error fetching notifications:', error);
+      });
+  }, []);
+
   const [curriculumCourses, setCurriculumCourses] = useState<string[]>();
 
   useEffect(() => {
@@ -103,8 +123,14 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
   }, [context]);
 
   const [isFabImageLoaded, setIsFabImageLoaded] = useState(false);
+  const [isFabWithoutTextImageLoaded, setIsFabWithoutTextImageLoaded] =
+    useState(false);
 
-  const showPulse = canShowPulse && !hasOpened && isFabImageLoaded;
+  const showPulse =
+    canShowPulse &&
+    !hasOpened &&
+    isFabImageLoaded &&
+    !isFabWithoutTextImageLoaded;
   const classes = showPulse
     ? classNames(style.floatingActionButton, style.pulse, 'unittest-fab-pulse')
     : style.floatingActionButton;
@@ -136,11 +162,39 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
         onClick={handleClick}
         type="button"
       >
-        <img
-          alt="AI bot"
-          src={aiFabWithIcon}
-          onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
-        />
+        {unreadNotificationCount === 'loading' ||
+        unreadNotificationCount > 0 ? (
+          <Badge
+            badgeContent={
+              unreadNotificationCount === 'loading'
+                ? 0
+                : unreadNotificationCount
+            }
+            color="error"
+            overlap="circular"
+            aria-label={
+              unreadNotificationCount &&
+              i18n.unreadNotificationsCount({
+                unreadCount: unreadNotificationCount,
+              })
+            }
+          >
+            <img
+              alt="AI bot - unread notifications"
+              src={aiFabWithoutText}
+              onLoad={() =>
+                !isFabWithoutTextImageLoaded &&
+                setIsFabWithoutTextImageLoaded(true)
+              }
+            />
+          </Badge>
+        ) : (
+          <img
+            alt="AI bot"
+            src={aiFabWithIcon}
+            onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
+          />
+        )}
       </button>
       <AiDiffContainer
         open={isOpen}

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -2,6 +2,7 @@ import {Badge} from '@mui/material';
 import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 
+import experiments from '@cdo/apps/util/experiments';
 import {
   tryGetSessionStorage,
   trySetSessionStorage,
@@ -90,18 +91,21 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
     }
   }, [canStartOpen, hasOpened, hasClosed, canDefaultOpen]);
 
-  React.useEffect(() => {
+  const updateUnreadNotificationCount = React.useCallback(() => {
     HttpClient.fetchJson<AiDiffNotification[]>('/notifications', {}, undefined)
       .then(response => {
         const unreadNotificationCount =
           response?.value?.filter(n => n.readAt === null).length || 0;
         setUnreadNotificationCount(unreadNotificationCount);
-        console.log('lfm', unreadNotificationCount);
       })
       .catch(error => {
         console.error('Error fetching notifications:', error);
       });
   }, []);
+
+  React.useEffect(() => {
+    updateUnreadNotificationCount();
+  }, [updateUnreadNotificationCount]);
 
   const [curriculumCourses, setCurriculumCourses] = useState<string[]>();
 
@@ -151,6 +155,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
     }
     setIsOpen(!isOpen);
     trySetSessionStorage(SESSION_STORAGE_KEY, (!isOpen).toString());
+    updateUnreadNotificationCount();
   };
 
   return (
@@ -162,8 +167,9 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
         onClick={handleClick}
         type="button"
       >
-        {unreadNotificationCount === 'loading' ||
-        unreadNotificationCount > 0 ? (
+        {experiments.isEnabled('teacher-notifications') &&
+        (unreadNotificationCount === 'loading' ||
+          unreadNotificationCount > 0) ? (
           <Badge
             badgeContent={
               unreadNotificationCount === 'loading'
@@ -178,6 +184,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
                 unreadCount: unreadNotificationCount,
               })
             }
+            sx={{height: '48px', width: '48px'}}
           >
             <img
               alt="AI bot - unread notifications"

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -127,14 +127,8 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
   }, [context]);
 
   const [isFabImageLoaded, setIsFabImageLoaded] = useState(false);
-  const [isFabWithoutTextImageLoaded, setIsFabWithoutTextImageLoaded] =
-    useState(false);
 
-  const showPulse =
-    canShowPulse &&
-    !hasOpened &&
-    isFabImageLoaded &&
-    !isFabWithoutTextImageLoaded;
+  const showPulse = canShowPulse && !hasOpened && isFabImageLoaded;
   const classes = showPulse
     ? classNames(style.floatingActionButton, style.pulse, 'unittest-fab-pulse')
     : style.floatingActionButton;
@@ -167,14 +161,14 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
         onClick={handleClick}
         type="button"
       >
-        {experiments.isEnabled('teacher-notifications') &&
-        (unreadNotificationCount === 'loading' ||
-          unreadNotificationCount > 0) ? (
+        {experiments.isEnabled('teacher-notifications') ? (
           <Badge
             badgeContent={
               unreadNotificationCount === 'loading'
                 ? 0
-                : unreadNotificationCount
+                : unreadNotificationCount > 0
+                ? unreadNotificationCount
+                : 'TA'
             }
             color="error"
             overlap="circular"
@@ -188,9 +182,18 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
               height: '48px',
               width: '48px',
               '& .MuiBadge-badge': {
-                backgroundColor: 'var(--background-error-primary)',
-                top: '8%',
-                right: '8%',
+                backgroundColor:
+                  unreadNotificationCount === 'loading' ||
+                  unreadNotificationCount > 0
+                    ? 'var(--background-error-primary)'
+                    : '#3CFFF8',
+                color:
+                  unreadNotificationCount === 'loading' ||
+                  unreadNotificationCount > 0
+                    ? 'var(--text-neutral-white-fixed)'
+                    : 'var(--text-neutral-black-fixed)',
+                top: '5%',
+                right: '5%',
               },
             }}
             className={style.badge}
@@ -198,10 +201,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
             <img
               alt="AI bot - unread notifications"
               src={aiFabWithoutText}
-              onLoad={() =>
-                !isFabWithoutTextImageLoaded &&
-                setIsFabWithoutTextImageLoaded(true)
-              }
+              onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
               className={style.fabImageWithBadge}
             />
           </Badge>

--- a/apps/src/aiDifferentiation/notifications/Notification.tsx
+++ b/apps/src/aiDifferentiation/notifications/Notification.tsx
@@ -35,13 +35,11 @@ const getRelativeTimeString = (date: Date): string => {
 };
 
 interface NotificationProps {
-  key: string;
   notification: AiDiffNotification | null;
   aiPromptClick?: (label: string, prompt: string) => void;
 }
 
 const Notification: React.FC<NotificationProps> = ({
-  key,
   notification,
   aiPromptClick,
 }) => {
@@ -60,7 +58,7 @@ const Notification: React.FC<NotificationProps> = ({
   };
 
   return (
-    <div className={styles.notification} key={key}>
+    <div className={styles.notification}>
       <FontAwesomeV6Icon
         iconName={notificationOrPlaceholder.iconName}
         iconStyle="solid"
@@ -89,8 +87,8 @@ const Notification: React.FC<NotificationProps> = ({
         </BodyThreeText>
         <ol className={styles.links}>
           {notificationOrPlaceholder.hrefLinks?.length > 0 &&
-            notificationOrPlaceholder.hrefLinks.map(link => (
-              <li key={link.url}>
+            notificationOrPlaceholder.hrefLinks.map((link, index) => (
+              <li key={'url-' + index}>
                 <a
                   href={link.url}
                   target="_blank"
@@ -102,8 +100,8 @@ const Notification: React.FC<NotificationProps> = ({
               </li>
             ))}
           {notificationOrPlaceholder.aiPrompts?.length > 0 &&
-            notificationOrPlaceholder.aiPrompts.map(prompt => (
-              <li key={prompt.prompt}>
+            notificationOrPlaceholder.aiPrompts.map((prompt, index) => (
+              <li key={'ai-' + index}>
                 <button
                   onClick={() => {
                     if (aiPromptClick) {

--- a/apps/src/aiDifferentiation/notifications/Notification.tsx
+++ b/apps/src/aiDifferentiation/notifications/Notification.tsx
@@ -74,20 +74,19 @@ const Notification: React.FC<NotificationProps> = ({
         data-testid={'icon-' + notificationOrPlaceholder.iconName}
       />
       <div className={styles.textAndLinks}>
-        <div
+        <BodyThreeText
+          noMargin
           className={classNames(
             styles.text,
             isLoading && skeletonizeContent.skeletonizeContent
           )}
         >
-          <BodyThreeText noMargin>
-            <StrongText>
-              {notificationOrPlaceholder.title}
-              {': '}
-            </StrongText>
-            {notificationOrPlaceholder.description}
-          </BodyThreeText>
-        </div>
+          <StrongText>
+            {notificationOrPlaceholder.title}
+            {': '}
+          </StrongText>
+          {notificationOrPlaceholder.description}
+        </BodyThreeText>
         <ol className={styles.links}>
           {notificationOrPlaceholder.hrefLinks?.length > 0 &&
             notificationOrPlaceholder.hrefLinks.map(link => (

--- a/apps/src/aiDifferentiation/notifications/notifications.module.scss
+++ b/apps/src/aiDifferentiation/notifications/notifications.module.scss
@@ -55,16 +55,10 @@
 }
 
 p.text {
-  font-size: 14px;
-  font-weight: 600;
   margin-inline-end: 16px;
-  margin-bottom: 0;
+  margin-bottom: 4px;
   flex-grow: 1;
   height: fit-content;
-
-  p {
-    color: inherit;
-  }
 }
 
 .links {

--- a/apps/src/aiDifferentiation/notifications/notifications.module.scss
+++ b/apps/src/aiDifferentiation/notifications/notifications.module.scss
@@ -84,6 +84,11 @@ p.text {
   height: 24px;
   font-weight: 600;
 
+  &:hover {
+    text-decoration: none;
+    color: var(--text-neutral-black-fixed);
+  }
+
   & i {
     margin-inline-start: 4px;
   }

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepagePopups.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepagePopups.tsx
@@ -80,7 +80,6 @@ const TeacherHomepagePopups: React.FC<TeacherHomepagePopupsProps> = () => {
   React.useEffect(() => {
     HttpClient.fetchJson<DrawerData>('/teacher_dashboard/get_drawer_data')
       .then(data => {
-        console.log(data.value);
         setExistingSchoolInfo(data.value.existingSchoolInfo);
         setSchoolInfoInterstitialOpen(data.value.showSchoolInfoInterstitial);
         setSchoolInfoConfirmationOpen(data.value.showSchoolInfoConfirmation);

--- a/apps/static/ai-bot-ta-no-text.png
+++ b/apps/static/ai-bot-ta-no-text.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d8cd825149692b3838aac8d8d8d871ffd2398c3d498150f67181376f1ae2f31
+size 10066

--- a/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
+++ b/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
@@ -37,6 +37,7 @@ jest.mock('@cdo/apps/util/HttpClient', () => ({
       json: () => Promise.resolve({}),
     })
   ),
+  fetchJson: jest.fn(() => Promise.resolve({})),
 }));
 
 const LocationElement = () => {


### PR DESCRIPTION
Adds a unread notification badge to the TA FAB


https://github.com/user-attachments/assets/e4778a41-df7a-49b1-964d-deeee93f142d

No unread messages:
<img width="148" height="168" alt="image" src="https://github.com/user-attachments/assets/fc9047af-baaf-4992-bf5c-ce458d903079" />

2 unread messages:
<img width="140" height="146" alt="image" src="https://github.com/user-attachments/assets/b358ced5-20db-4838-82b1-51afd8b1a206" />

Loading messages:
<img width="140" height="144" alt="image" src="https://github.com/user-attachments/assets/9d109171-09eb-41f1-aef1-7ce6f19003e6" />

Also fixes some bugs with the loading screen, the notification description font weight and others.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AITT-1102
