### PR TITLE
Provide string backups for possible empty fields in PD MailJet emails

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
@@ -12,18 +12,18 @@ class Pd::WorkshopMailjetMailer
       name: user.given_name || user.name,
       cancel_registration_link: CDO.studio_url("pd/workshop_enrollment/#{enrollment.code}/cancel", CDO.default_scheme),
       pre_survey_link: enrollment.pre_workshop_survey_url,
-      facilitator_name: workshop.facilitators&.map(&:name)&.join(', '),
-      rp_email: regional_partner&.contact_email_with_backup,
-      rp_name: regional_partner&.name,
-      organizer_email: organizer&.email,
-      organizer_name: organizer&.name,
-      workshop_notes: workshop.notes,
+      facilitator_name: workshop.facilitators&.map(&:name)&.join(', ') || 'None',
+      rp_email: regional_partner&.contact_email_with_backup || 'support@code.org',
+      rp_name: regional_partner&.name || 'Code.org',
+      organizer_email: organizer&.email || 'support@code.org',
+      organizer_name: organizer&.name || 'Code.org',
+      workshop_notes: workshop.notes || '',
       sessions: workshop.sessions.map do |session|
         {
           datetime: session.start_date_with_start_and_end_times_us_format,
           format: session.session_format,
-          meeting_link: session.meeting_link,
-          location: session.formatted_location_details
+          meeting_link: session.meeting_link || '',
+          location: session.formatted_location_details || ''
         }
       end,
       workshop_subjects: workshop.course_offerings.present? ? workshop.course_offerings.map(&:display_name)&.join(', ') : workshop.subject,
@@ -44,10 +44,10 @@ class Pd::WorkshopMailjetMailer
       name: user.given_name || user.name,
       exit_survey_url: enrollment.exit_survey_url,
       download_certificate_url: CDO.studio_url("/pd/generate_workshop_certificate/#{enrollment.code}", CDO.default_scheme),
-      rp_email: regional_partner&.contact_email_with_backup,
-      rp_name: regional_partner&.name,
-      organizer_email: organizer&.email,
-      organizer_name: organizer&.name
+      rp_email: regional_partner&.contact_email_with_backup || 'support@code.org',
+      rp_name: regional_partner&.name || 'Code.org',
+      organizer_email: organizer&.email || 'support@code.org',
+      organizer_name: organizer&.name || 'Code.org'
     }
 
     retryable_send_email('teacher_post_workshop_survey', email, user.friendly_name, email_vars)


### PR DESCRIPTION
The issue of why certain MailJet emails weren't sending was likely that `nil` fields weren't able to be processed by MailJet, which expects string values. Since I was testing the 3-/10-day reminder and the post-workshop survey emails locally, I always included the test regional partner and test facilitator I created locally out of habit since I knew they wouldn't actually receive emails (since the emails were fake). However, when I tested on production, I didn't use a regional partner or facilitator in the workshops because I didn't want to send real RP's and facilitators test emails, and I believe this caused the `rp_name`, `facilitator_names`, etc. variables to be `nil` rather than empty strings which threw an error in the email.

### Production investigation
I was able to confirm this on production and locally when manually triggering `send_exit_surveys`. When there was an empty field (such as `rp_name`), MailJet threw an error:
<img width="3025" height="670" alt="null values" src="https://github.com/user-attachments/assets/563e11a6-7ebe-4b8c-bea6-02c4e62dcf13" />

However, once those fields were filled in and I tried again, I saw a success (and an email in my inbox):
<img width="2476" height="1107" alt="successful send after setting rp values" src="https://github.com/user-attachments/assets/638ab44e-eb0b-4b67-ac02-67e4d2b1cff3" />

### Test locally
I created a workshop with the bare minimum fields it would let me create it with to test.

I first confirmed that locally I would see the same error with missing fields:
![confirm locally](https://github.com/user-attachments/assets/d98713a8-8591-414f-93fd-6eac1296723d)

Then, I added fallback string values for fields that could possibly be `nil` and tested again (this time, seeing the email):
![sent email TADA](https://github.com/user-attachments/assets/02449804-4ab6-4ac9-87c6-9ba166960a21)

### This PR's changes
This PR adds in the fallback values but still keeps sending the post-workshop survey [behind the DCDO flag](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/pd/enrollment.rb#L209-L216) just to be safe. Once I can confirm that it's working on production as expected, we can do the rollout of the new MailJet email for all users.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3521)

## Testing story
Local testing.

## Follow-up work
Once I confirm this works on production as well, we can start rolling out the new PD MailJet emails.
