### PR TITLE
Allow fetching rubric data on non-levelbuilder environments

### DIFF
--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -2,7 +2,7 @@ class RubricsController < ApplicationController
   include Rails.application.routes.url_helpers
   include SharedConstants
 
-  before_action :require_levelbuilder_mode_or_test_env, except: [:submit_evaluations, :get_ai_evaluations, :get_teacher_evaluations, :get_teacher_evaluations_for_all, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all, :get_ai_rubrics_tour_seen, :update_ai_rubrics_tour_seen]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :submit_evaluations, :get_ai_evaluations, :get_teacher_evaluations, :get_teacher_evaluations_for_all, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all, :get_ai_rubrics_tour_seen, :update_ai_rubrics_tour_seen]
   load_resource only: [:show, :get_teacher_evaluations, :get_teacher_evaluations_for_all, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all, :get_ai_rubrics_tour_seen, :update_ai_rubrics_tour_seen]
   load_and_authorize_resource except: [:submit_evaluations, :get_ai_evaluations, :get_teacher_evaluations, :get_teacher_evaluations_for_all, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all, :get_ai_rubrics_tour_seen, :update_ai_rubrics_tour_seen]
 


### PR DESCRIPTION
While implementing loading rubrics in Lab2 (https://github.com/code-dot-org/code-dot-org/pull/67364), I missed that I had to allow-list the `show` action to work on non-levelbuilder and non-test environments. As a result, rubrics were not being loaded on production.

## Links
Slack: https://codedotorg.slack.com/archives/C07UT279KM1/p1757089467080029

## Testing story
- Tested locally by disabling levelbuilder mode and confirming that once I added the `show` action to the exception list, rubrics data was loaded successfully.