### PR TITLE
Ceara/aitt 1132 fix ai diff disable bug

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepagePopups.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepagePopups.tsx
@@ -47,6 +47,10 @@ const TeacherHomepagePopups: React.FC<TeacherHomepagePopupsProps> = () => {
     state => state.currentUser.hasSeenHomepageWelcome
   );
 
+  const aiDifferentiationEnabled = useAppSelector(
+    state => state.currentUser.aiDifferentiationEnabled
+  );
+
   const hasSeenPopupInLastDay = React.useMemo(() => {
     // Allows triggering of drawer with URL params for testing / debugging
     const searchParams = new URLSearchParams(window.location.search);
@@ -150,18 +154,19 @@ const TeacherHomepagePopups: React.FC<TeacherHomepagePopupsProps> = () => {
   return (
     <>
       {popup}
-      {experiments.isEnabled('ai-differentiation') && (
-        <AiDiffFloatingActionButton
-          context={{type: AiDiffContext.GENERAL}}
-          canShowPulse={
-            !isLoading && !hasSeenPopup && !popup && !hasSeenPopupInLastDay
-          }
-          canStartOpen={!isLoading && !hasSeenPopup && !popup}
-          canDefaultOpen={
-            !isLoading && !hasSeenPopup && !popup && !hasSeenPopupInLastDay
-          }
-        />
-      )}
+      {aiDifferentiationEnabled &&
+        experiments.isEnabled('ai-differentiation') && (
+          <AiDiffFloatingActionButton
+            context={{type: AiDiffContext.GENERAL}}
+            canShowPulse={
+              !isLoading && !hasSeenPopup && !popup && !hasSeenPopupInLastDay
+            }
+            canStartOpen={!isLoading && !hasSeenPopup && !popup}
+            canDefaultOpen={
+              !isLoading && !hasSeenPopup && !popup && !hasSeenPopupInLastDay
+            }
+          />
+        )}
     </>
   );
 };

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -48,6 +48,10 @@ const TeacherNavigationBar: React.FC<{
     state => state.teacherSections.isLoadingSectionData
   );
 
+  const aiDifferentiationEnabled = useAppSelector(
+    state => state.currentUser.aiDifferentiationEnabled
+  );
+
   useEffect(() => {
     const updatedSectionArray = sectionOrder
       .map(sectionId => sections[sectionId] || null)
@@ -280,12 +284,13 @@ const TeacherNavigationBar: React.FC<{
         />
         {navbarComponents.map(component => component)}
       </div>
-      {experiments.isEnabled('ai-differentiation') && (
-        <AiDiffFloatingActionButton
-          context={aiContext()}
-          scriptName={selectedSection?.courseVersionName}
-        />
-      )}
+      {aiDifferentiationEnabled &&
+        experiments.isEnabled('ai-differentiation') && (
+          <AiDiffFloatingActionButton
+            context={aiContext()}
+            scriptName={selectedSection?.courseVersionName}
+          />
+        )}
     </nav>
   );
 };

--- a/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
+++ b/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
@@ -115,7 +115,8 @@ describe('TeacherNavigationBar', () => {
   const renderDefault = (
     selectedSectionId = 11,
     selectedRoute = null,
-    showAITutorTab = false
+    showAITutorTab = false,
+    aiDiffEnabled = true
   ) => {
     store = getStore();
     registerReducers({
@@ -128,6 +129,7 @@ describe('TeacherNavigationBar', () => {
         id: 1,
         name: 'test_user',
         has_completed_ai_differentiation_welcome: true,
+        ai_differentiation_enabled: aiDiffEnabled,
       })
     );
 
@@ -330,9 +332,25 @@ describe('TeacherNavigationBar', () => {
   });
 
   test('does not render AiDiffFloatingActionButton component when experiement is not enabled', async () => {
-    // mock experiment is enabled
+    // mock experiment is disabled
     experiments.isEnabled = jest.fn(() => false);
     renderDefault(13, `/teacher_dashboard/sections/13/unit/csd3-2022`);
+
+    expect(
+      screen.queryByRole('button', {name: i18n.openOrCloseTeachingAssistant()})
+    ).toBeNull();
+  });
+
+  test('does not render AiDiffFloatingActionButton component when user pref is not enabled', async () => {
+    // mock experiment is enabled
+    experiments.isEnabled = jest.fn(() => true);
+    // mock user preference disabled
+    renderDefault(
+      13,
+      `/teacher_dashboard/sections/13/unit/csd3-2022`,
+      false,
+      false
+    );
 
     expect(
       screen.queryByRole('button', {name: i18n.openOrCloseTeachingAssistant()})


### PR DESCRIPTION
This addresses a zendesk ticket about the toggle to disable the AI differentiation chat not working.

After investigating: the toggle works to change the user model and current user redux, the issue is that on the new teacher homepage and navigation bar we weren't checking if the user had the chat disabled. On all other pages (e.g. curriculum pages, course catalog, etc) where it appears it's controlled in the haml file by checking `Policies::Ai.ai_differentiation_enabled?` to add the diff chat mount point. On these pages we don't add it using the mount point, so the check didn't occur.

This change checks in the currentUser redux to see if the user has disabled the chat before rendering the AI diff floating action button.

This turned out to be unrelated to threads or ipad work

## Links

- Jira: https://codedotorg.atlassian.net/browse/AITT-1132
- Slack: https://codedotorg.slack.com/archives/C050HE4QDHR/p1756220079880809

## Testing story
Adds a test for this condition in the TeacherNavigationBar unit test


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
