### PR TITLE
Fix crash on rubrics edit page when there are no submittable levels

### DIFF
--- a/apps/src/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/levelbuilder/rubrics/RubricsContainer.jsx
@@ -137,7 +137,7 @@ export default function RubricsContainer({
   // TODO-AITT-168: Check that there is at least one submittable programming level here
   const initialLevelForAssessment = !!rubric
     ? rubric.levelId
-    : submittableLevels[0].id;
+    : submittableLevels[0]?.id;
   const [selectedLevelForAssessment, setSelectedLevelForAssessment] = useState(
     initialLevelForAssessment
   );


### PR DESCRIPTION
Currently when trying to add or edit a rubric on a lesson where there are no submittable levels, the page crashes. Fix here is just to make the check optional, since otherwise the edit page is already set up to notify the user that they need to add submittable levels in order to create a rubric.

Before (levelbuilder):
<img width="2113" height="944" alt="Screenshot 2025-09-05 at 2 52 41 PM" src="https://github.com/user-attachments/assets/b6951da0-e02c-4387-8755-d3974af8f877" />

After (localhost):
<img width="2110" height="942" alt="Screenshot 2025-09-05 at 2 53 17 PM" src="https://github.com/user-attachments/assets/6485f783-2d40-4a94-a4dd-16ae1e247b57" />

## Testing story
- Tested with a lesson in allthethings (51) that does not yet have any submittable levels.